### PR TITLE
Implement ZodUnion.distribute()

### DIFF
--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -22,6 +22,10 @@ export class ZodUnion<T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>
     options: this._def.options.map(x => x.toJSON()),
   });
 
+  distribute = <U extends z.ZodTypeAny>(f: (option: T[number]) => U): ZodUnion<[U, U, ...U[]]> => {
+    return ZodUnion.create(this._def.options.map(f) as [U, U, ...U[]]);
+  }
+
   static create = <T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>(types: T): ZodUnion<T> => {
     return new ZodUnion({
       t: z.ZodTypes.union,


### PR DESCRIPTION
Minimal implementation needed to create generic type schemas.

Usage:
```typescript
const $Cat = z.object({
  type: z.literal('cat'),
  ability: z.literal('meow'),
});
const $Dog = z.object({
  type: z.literal('dog'),
  ability: z.literal('bark'),
});
const $AnimalAbility = z.union([$Cat, $Dog]).distribute($A => $A.shape.ability);
type Ability = z.infer<typeof $AnimalAbility>; // "meow" | "bark"
```