### PR TITLE
✨ Feature: First-Class Optional Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@types/jest": "^25.1.4",
+    "@types/node": "14.10.3",
     "jest": "^25.1.0",
     "make-coverage-badge": "^1.2.0",
     "nodemon": "^2.0.2",
@@ -54,6 +55,7 @@
     "ts-jest": "^25.2.1",
     "tslint": "^6.1.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "3.7"
+    "typescript": "4.0.2",
+    "ts-node": "9.0.0"
   }
 }

--- a/src/__tests__/optional.test.ts
+++ b/src/__tests__/optional.test.ts
@@ -1,0 +1,56 @@
+import * as z from '../index';
+
+function checkSameOptional(a: z.ZodTypeAny) {
+  expect(JSON.stringify(z.optional(a).toJSON())).toMatch(
+    JSON.stringify(a.optional().toJSON()),
+  );
+}
+
+it('Should be the same optional as anywhere else', () => {
+  checkSameOptional(z.string());
+  checkSameOptional(z.number());
+  checkSameOptional(z.null());
+  checkSameOptional(z.undefined());
+  checkSameOptional(z.object({}));
+  checkSameOptional(z.tuple([]));
+  checkSameOptional(z.boolean());
+  checkSameOptional(z.string().min(3));
+  checkSameOptional(z.unknown());
+  checkSameOptional(z.union([z.number(), z.boolean()]));
+  checkSameOptional(z.union([z.number(), z.undefined()]));
+  checkSameOptional(z.any());
+
+  checkSameOptional(z.object({ a: z.string() }));
+  checkSameOptional(z.object({ a: z.string() }).partial());
+  checkSameOptional(z.object({ a: z.string().optional() }));
+  checkSameOptional(z.object({ a: z.string().optional() }).partial());
+});
+
+function checkErrors(
+  a: z.ZodTypeAny,
+  bad: any,
+) {
+  let expected;
+  expected = expected;
+  try {
+    a.parse(bad);
+  } catch (error) {
+    expected = error.formErrors;
+  }
+  try {
+    a.optional().parse(bad);
+  } catch (error) {
+    expect(error.formErrors).toStrictEqual(expected);
+  }
+}
+
+it('Should have error messages appropriate for the underlying type', () => {
+  checkErrors(z.string().min(2), 1)
+  checkErrors(z.number().min(2), 1)
+  checkErrors(z.boolean(), "")
+  checkErrors(z.undefined(), null)
+  checkErrors(z.null(), {})
+  checkErrors(z.object({}), 1)
+  checkErrors(z.tuple([]), 1)
+  checkErrors(z.unknown(), 1)
+});

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -45,11 +45,11 @@ test('deep partial inference', () => {
 
 test('deep partial parse', () => {
   const deep = nested.deepPartial();
-  expect(deep.shape.name instanceof z.ZodUnion).toBe(true);
-  expect(deep.shape.outer instanceof z.ZodUnion).toBe(true);
-  expect(deep.shape.outer._def.options[0] instanceof z.ZodObject).toBe(true);
-  expect(deep.shape.outer._def.options[0].shape.inner instanceof z.ZodUnion).toBe(true);
-  expect(deep.shape.outer._def.options[0].shape.inner._def.options[0] instanceof z.ZodString).toBe(true);
+  expect(deep.shape.name instanceof z.ZodOptional).toBe(true);
+  expect(deep.shape.outer instanceof z.ZodOptional).toBe(true);
+  expect(deep.shape.outer._def.realType instanceof z.ZodObject).toBe(true);
+  expect(deep.shape.outer._def.realType.shape.inner instanceof z.ZodOptional).toBe(true);
+  expect(deep.shape.outer._def.realType.shape.inner._def.realType instanceof z.ZodString).toBe(true);
 });
 
 test('deep partial runtime tests', () => {

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -4,14 +4,16 @@ import { util } from './helpers/util';
 type TypeResult = { schema: any; id: string; type: string };
 
 const isOptional = (schema: z.ZodType<any, any>): boolean => {
-  const def: z.ZodDef = schema._def;
-  if (def.t === z.ZodTypes.undefined) return true;
-  else if (def.t === z.ZodTypes.intersection) {
-    return isOptional(def.right) && isOptional(def.left);
-  } else if (def.t === z.ZodTypes.union) {
-    return def.options.map(isOptional).some(x => x === true);
-  }
-  return false;
+  // const def: z.ZodDef = schema._def;
+  // if (def.t === z.ZodTypes.undefined) return true;
+  // else if (def.t === z.ZodTypes.intersection) {
+  //   return isOptional(def.right) && isOptional(def.left);
+  // } else if (def.t === z.ZodTypes.union) {
+  //   return def.options.map(isOptional).some(x => x === true);
+  // }
+  // return false;
+
+  return schema.isOptional();
 };
 
 export class ZodCodeGenerator {
@@ -136,8 +138,10 @@ ${this.seen.map(item => `type ${item.id} = Identity<${item.type}>;`).join('\n\n'
       case z.ZodTypes.nativeEnum:
         // const lazyType = def.getter();
         return this.setType(id, 'asdf');
+      case z.ZodTypes.optional:
+        return this.setType(id, `${this.generate(def.realType).id}?`)
       default:
-        util.assertNever(def);
+        util.assertNever(def); 
     }
     return this.findById(id);
   };

--- a/src/helpers/partialUtil.ts
+++ b/src/helpers/partialUtil.ts
@@ -2,18 +2,20 @@ import * as z from '../index';
 
 export namespace partialUtil {
   export type RootDeepPartial<T extends z.ZodTypeAny> = {
+    optional: T extends z.ZodOptional<z.ZodTypeAny> ? T : z.ZodOptional<T>
     // array: T extends z.ZodArray<infer Type> ? z.ZodArray<DeepPartial<Type>> : never;
     object: T extends z.ZodObject<infer Shape, infer Params>
       ? z.ZodObject<{ [k in keyof Shape]: DeepPartial<Shape[k]> }, Params>
       : never;
-    rest: z.ZodUnion<[T, z.ZodUndefined]>;
-  }[T extends z.ZodObject<any> ? 'object' : 'rest'];
+    rest: z.ZodOptional<T>;
+  }[T extends z.ZodObject<any> ? 'object' : T extends z.ZodOptional<z.ZodTypeAny> ? 'optional' : 'rest'];
 
   export type DeepPartial<T extends z.ZodTypeAny> = {
+    optional: T extends z.ZodOptional<z.ZodTypeAny> ? T : z.ZodOptional<T>
     // array: T extends z.ZodArray<infer Type> ? z.ZodArray<DeepPartial<Type>> : never;
     object: T extends z.ZodObject<infer Shape, infer Params>
-      ? z.ZodUnion<[z.ZodObject<{ [k in keyof Shape]: DeepPartial<Shape[k]> }, Params>, z.ZodUndefined]>
+      ? z.ZodOptional<z.ZodObject<{ [k in keyof Shape]: DeepPartial<Shape[k]> }, Params>>
       : never;
-    rest: z.ZodUnion<[T, z.ZodUndefined]>;
-  }[T extends z.ZodObject<any> ? 'object' : 'rest'];
+    rest: z.ZodOptional<T>;
+  }[T extends z.ZodObject<any> ? 'object' : T extends z.ZodOptional<z.ZodTypeAny> ? 'optional' : 'rest'];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import { ZodParsedType } from './parser';
 import { ZodErrorMap } from './defaultErrorMap';
 
 import { ZodCodeGenerator } from './codegen';
+import { ZodOptional, ZodOptionalDef } from "./types/optional";
 
 export { ZodTypeDef, ZodTypes };
 type ZodDef =
@@ -65,6 +66,7 @@ type ZodDef =
   | ZodLiteralDef
   | ZodEnumDef
   | ZodNativeEnumDef
+  | ZodOptionalDef
   | ZodPromiseDef;
 
 const stringType = ZodString.create;
@@ -89,6 +91,7 @@ const literalType = ZodLiteral.create;
 const enumType = ZodEnum.create;
 const nativeEnumType = ZodNativeEnum.create;
 const promiseType = ZodPromise.create;
+const optionalType = ZodOptional.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -127,6 +130,7 @@ export {
   nativeEnumType as nativeEnum,
   promiseType as promise,
   instanceOfType as instanceof,
+  optionalType as optional,
   ostring,
   onumber,
   oboolean,
@@ -168,6 +172,7 @@ export {
   ZodErrorMap,
   ZodParsedType,
   ZodCodeGenerator,
+  ZodOptional,
 };
 
 export * from './ZodError';

--- a/src/isScalar.ts
+++ b/src/isScalar.ts
@@ -73,7 +73,9 @@ export const isScalar = (schema: z.ZodType<any, any>, params: { root: boolean } 
     case z.ZodTypes.promise:
       returnValue = false;
       break;
-
+    case z.ZodTypes.optional:
+      returnValue = isScalar(def.realType);
+      break;
     default:
       util.assertNever(def);
     // returnValue = false; break;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,6 +4,7 @@ import { ZodError, ZodErrorCode, ZodSuberror, ZodSuberrorOptionalMessage } from 
 import { util } from './helpers/util';
 import { ZodErrorMap, defaultErrorMap } from './defaultErrorMap';
 
+
 export type ParseParams = {
   seen?: { schema: any; objects: { data: any; error?: any; times: number }[] }[];
   path?: (string | number)[];
@@ -61,6 +62,8 @@ export const find = (arr: any[], checker: (arg: any) => any) => {
   }
   return undefined;
 };
+
+const UNDEFINED = () => require("./types/undefined").ZodUndefined.create();
 
 // conditional required to distribute union
 type stripPath<T extends object> = T extends any ? util.OmitKeys<T, 'path'> : never;
@@ -298,6 +301,20 @@ export const ZodParser = (schemaDef: z.ZodTypeDef) => (
         }
       }
       break;
+      case z.ZodTypes.optional:
+        try {
+          UNDEFINED().parse(obj, params);
+          break;
+        } catch {}
+
+        try {
+          def.realType.parse(obj, params);
+          break;
+        } catch (err) {
+          const zerr: ZodError = err;
+          error.addErrors(zerr.errors);          
+        }
+        break;      
     case z.ZodTypes.intersection:
       try {
         def.left.parse(obj, params);

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,0 +1,22 @@
+import * as z from "./"
+
+const os = z.optional(z.string());
+
+console.log(os)
+console.log(os.safeParse(1))
+console.log(os.safeParse({}))
+console.log(os.safeParse(undefined))
+
+const oo = z.object({
+    s: z.string().optional()
+})
+//type _ts = z.infer<typeof os> 
+console.log(oo)
+console.log(oo.safeParse(1))
+console.log(oo.safeParse({}))
+console.log(oo.safeParse(undefined))
+
+
+ 
+ 
+ 

--- a/src/switcher.ts
+++ b/src/switcher.ts
@@ -48,6 +48,8 @@ export const visitor = (schema: z.ZodType<any, any>) => {
       break;
     case z.ZodTypes.promise:
       break;
+    case z.ZodTypes.optional:
+      break;
     default:
       util.assertNever(def);
   }

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -10,7 +10,8 @@ export interface ZodArrayDef<T extends z.ZodTypeAny = z.ZodTypeAny> extends z.Zo
   nonempty: boolean;
 }
 
-export class ZodArray<T extends z.ZodTypeAny> extends z.ZodType<T['_type'][], ZodArrayDef<T>> {
+
+export class ZodArray<T extends z.ZodTypeAny> extends z.ZodType<T['_type'][], ZodArrayDef<z.ZodTypeAny>> {
   toJSON = () => {
     return {
       t: this._def.t,
@@ -49,16 +50,16 @@ export class ZodArray<T extends z.ZodTypeAny> extends z.ZodType<T['_type'][], Zo
 
   length = (len: number, message?: string) => this.min(len, { message }).max(len, { message });
 
-  nonempty: () => ZodNonEmptyArray<T> = () => {
-    return new ZodNonEmptyArray({ ...this._def, nonempty: true });
+  nonempty: () => ZodNonEmptyArray<T> = <T extends z.ZodTypeAny>() => {
+    return new ZodNonEmptyArray<T> ({ ...this._def, nonempty: true } as any);
   };
 
-  static create = <T extends z.ZodTypeAny>(schema: T): ZodArray<T> => {
+  static create = <T extends z.ZodTypeAny>(schema: T): T extends ZodArray<z.ZodTypeAny> ? ZodArray<ZodArray<z.ZodTypeAny>> : ZodArray<T> => {
     return new ZodArray({
       t: z.ZodTypes.array,
       type: schema,
       nonempty: false,
-    });
+    }) as any;
   };
 }
 

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,6 +1,7 @@
 import { ZodParser, ParseParams, MakeErrorData } from '../parser';
 import { util } from '../helpers/util';
-import { ZodErrorCode, ZodArray, ZodUnion, ZodNull, ZodUndefined, ZodError } from '../index';
+import { ZodErrorCode, ZodArray, ZodUnion, ZodNull, ZodError, ZodOptional } from '../index';
+import { ZodOptionalType } from "./optional";
 
 export enum ZodTypes {
   string = 'string',
@@ -25,6 +26,7 @@ export enum ZodTypes {
   any = 'any',
   unknown = 'unknown',
   void = 'void',
+  optional = 'optional'
 }
 
 export type ZodTypeAny = ZodType<any, any>;
@@ -141,10 +143,11 @@ export abstract class ZodType<Type, Def extends ZodTypeDef = ZodTypeDef> {
 
   abstract toJSON: () => object;
   //  abstract // opt optional: () => any;
-  optional: () => ZodUnion<[this, ZodUndefined]> = () => ZodUnion.create([this, ZodUndefined.create()]);
+  optional: () => ZodOptionalType<this> = () => ZodOptional.create(this);
   nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
   array: () => ZodArray<this> = () => ZodArray.create(this);
   or: <U extends ZodType<any>>(arg: U) => ZodUnion<[this, U]> = arg => {
     return ZodUnion.create([this, arg]);
   };
+  isOptional: () => boolean = () => this._def.t === ZodTypes.optional;
 }

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,7 +1,6 @@
 import { ZodParser, ParseParams, MakeErrorData } from '../parser';
 import { util } from '../helpers/util';
 import { ZodErrorCode, ZodArray, ZodUnion, ZodNull, ZodError, ZodOptional } from '../index';
-import { ZodOptionalType } from "./optional";
 
 export enum ZodTypes {
   string = 'string',
@@ -143,10 +142,10 @@ export abstract class ZodType<Type, Def extends ZodTypeDef = ZodTypeDef> {
 
   abstract toJSON: () => object;
   //  abstract // opt optional: () => any;
-  optional: () => ZodOptionalType<this> = () => ZodOptional.create(this);
-  nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
-  array: () => ZodArray<this> = () => ZodArray.create(this);
-  or: <U extends ZodType<any>>(arg: U) => ZodUnion<[this, U]> = arg => {
+  optional: () => this extends ZodOptional<ZodTypeAny> ? this : ZodOptional<this> = () => ZodOptional.create(this);
+  nullable: () => ZodUnion<readonly [this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
+  array: () => this extends ZodArray<ZodTypeAny> ? this : ZodArray<this>  = () => ZodArray.create(this) as any;
+  or: <U extends ZodType<any>>(arg: U) => ZodUnion<readonly[this, U]> = arg => {
     return ZodUnion.create([this, arg]);
   };
   isOptional: () => boolean = () => this._def.t === ZodTypes.optional;

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -1,10 +1,11 @@
 import * as z from './base';
-import { ZodUndefined } from './undefined';
+// import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
-import { ZodUnion } from './union';
+// import { ZodUnion } from './union';
 import { objectUtil } from '../helpers/objectUtil';
 import { partialUtil } from '../helpers/partialUtil';
 import { isScalar } from '../isScalar';
+import { ZodOptional } from "..";
 
 const AugmentFactory = <Def extends ZodObjectDef>(def: Def) => <Augmentation extends z.ZodRawShape>(
   augmentation: Augmentation,
@@ -140,10 +141,11 @@ export class ZodObject<
     });
   };
 
-  partial = (): ZodObject<{ [k in keyof T]: ZodUnion<[T[k], ZodUndefined]> }, Params> => {
+  partial = (): ZodObject<{ [k in keyof T]: ZodOptional<T[k]>}, Params> => {
     const newShape: any = {};
     for (const key in this.shape) {
-      newShape[key] = this.shape[key].optional();
+      const fieldSchema = this.shape[key];
+      newShape[key] = fieldSchema.isOptional() ? fieldSchema : fieldSchema.optional();
     }
     return new ZodObject({
       ...this._def,
@@ -189,9 +191,9 @@ export class ZodObject<
     for (const key in this.shape) {
       const fieldSchema = this.shape[key];
       if (fieldSchema instanceof ZodObject) {
-        newShape[key] = fieldSchema.deepPartial().optional();
+        newShape[key] = fieldSchema.isOptional() ? fieldSchema : (fieldSchema.deepPartial() as any).optional() ;
       } else {
-        newShape[key] = this.shape[key].optional();
+        newShape[key] = fieldSchema.isOptional() ? fieldSchema : fieldSchema.optional();
       }
     }
     return new ZodObject({

--- a/src/types/optional.ts
+++ b/src/types/optional.ts
@@ -1,0 +1,44 @@
+import * as z from './base';
+// import { ZodUndefined } from './undefined';
+
+// import { ZodNull } from './null';
+
+
+
+export interface ZodOptionalDef<
+  T extends z.ZodTypeAny = z.ZodTypeAny
+> extends z.ZodTypeDef {
+  t: z.ZodTypes.optional;
+  realType: T;
+}
+
+// This type allows for optional flattening
+export type ZodOptionalType<T extends z.ZodTypeAny> = T extends ZodOptional<z.ZodTypeAny> ? T : ZodOptional<T>;
+
+export class ZodOptional<T extends z.ZodTypeAny> extends z.ZodType<
+  T["_type"] | undefined,
+  ZodOptionalDef<T>
+> {
+  optional: () => ZodOptionalType<this> = () => this as ZodOptionalType<this>; // An optional optional is the original optional
+
+  // null nullable: () => ZodOptional<[this, ZodNull]> = () => ZodOptional.create([this, ZodNull.create()]);
+
+  toJSON = () => ({
+    t: this._def.t,
+    realType: this._def.realType
+  });
+
+  // distribute = would only need to delegate to the realType i think
+
+  // distribute = <F extends (arg: T[number]) => z.ZodTypeAny>(f: F): ZodOptional<{ [k in keyof T]: ReturnType<F> }> => {
+  //   return ZodOptional.create(this._def.options.map(f) as any);
+  // };
+  static create = <T extends z.ZodTypeAny>(type: T): ZodOptionalType<T> => {
+    if (type.isOptional()) return type as ZodOptionalType<T>;
+
+    return new ZodOptional({
+      t: z.ZodTypes.optional,
+      realType: type
+    }) as ZodOptionalType<T>;
+  };
+}

--- a/src/types/optional.ts
+++ b/src/types/optional.ts
@@ -9,17 +9,14 @@ export interface ZodOptionalDef<
   T extends z.ZodTypeAny = z.ZodTypeAny
 > extends z.ZodTypeDef {
   t: z.ZodTypes.optional;
-  realType: T;
+  realType: T
 }
-
-// This type allows for optional flattening
-export type ZodOptionalType<T extends z.ZodTypeAny> = T extends ZodOptional<z.ZodTypeAny> ? T : ZodOptional<T>;
 
 export class ZodOptional<T extends z.ZodTypeAny> extends z.ZodType<
   T["_type"] | undefined,
   ZodOptionalDef<T>
 > {
-  optional: () => ZodOptionalType<this> = () => this as ZodOptionalType<this>; // An optional optional is the original optional
+  optional = () => ZodOptional.create(this); // An optional optional is the original optional
 
   // null nullable: () => ZodOptional<[this, ZodNull]> = () => ZodOptional.create([this, ZodNull.create()]);
 
@@ -33,12 +30,12 @@ export class ZodOptional<T extends z.ZodTypeAny> extends z.ZodType<
   // distribute = <F extends (arg: T[number]) => z.ZodTypeAny>(f: F): ZodOptional<{ [k in keyof T]: ReturnType<F> }> => {
   //   return ZodOptional.create(this._def.options.map(f) as any);
   // };
-  static create = <T extends z.ZodTypeAny>(type: T): ZodOptionalType<T> => {
-    if (type.isOptional()) return type as ZodOptionalType<T>;
+  static create = <T extends z.ZodTypeAny>(type: T): T extends ZodOptional<z.ZodTypeAny> ? T : ZodOptional<T> => {
+    if (type.isOptional()) return (type as any);
 
     return new ZodOptional({
       t: z.ZodTypes.optional,
       realType: type
-    }) as ZodOptionalType<T>;
+    }) as any
   };
 }

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -19,9 +19,7 @@ export interface ZodTupleDef<
 
 export class ZodTuple<
   T extends readonly [z.ZodTypeAny, ...z.ZodTypeAny[]] | readonly [] = readonly [z.ZodTypeAny, ...z.ZodTypeAny[]]
-    z.ZodTypeAny,
-    ...z.ZodTypeAny[],
-  ]
+
 > extends z.ZodType<TypeOfTuple<T>, ZodTupleDef<T>> {
   toJSON = () => ({
     t: this._def.t,
@@ -32,7 +30,7 @@ export class ZodTuple<
 
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
 
-  static create = <T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | []>(schemas: T): ZodTuple<T> => {
+  static create = <T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | []>(
     schemas: T,
   ): ZodTuple<T> => {
     return new ZodTuple({

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -3,29 +3,29 @@ import * as z from './base';
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 
-export type TypeOfTuple<T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | []> = {
+export type TypeOfTuple<T extends readonly[z.ZodTypeAny, ...z.ZodTypeAny[]] | readonly []> = {
   [k in keyof T]: T[k] extends z.ZodType<infer U> ? U : never;
 };
 
-export interface ZodTupleDef<T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | [] = [z.ZodTypeAny, ...z.ZodTypeAny[]]>
+export interface ZodTupleDef<T extends readonly [z.ZodTypeAny, ...z.ZodTypeAny[]] | readonly [] = readonly [z.ZodTypeAny, ...z.ZodTypeAny[]]>
   extends z.ZodTypeDef {
   t: z.ZodTypes.tuple;
   items: T;
 }
 
 export class ZodTuple<
-  T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | [] = [z.ZodTypeAny, ...z.ZodTypeAny[]]
+  T extends readonly [z.ZodTypeAny, ...z.ZodTypeAny[]] | readonly [] = readonly [z.ZodTypeAny, ...z.ZodTypeAny[]]
 > extends z.ZodType<TypeOfTuple<T>, ZodTupleDef<T>> {
   toJSON = () => ({
     t: this._def.t,
-    items: (this._def.items as any[]).map(item => item.toJSON()),
+    items: (this._def.items as readonly any[]).map(item => item.toJSON()),
   });
 
   // opt optional: () => ZodUnion<[this, ZodUndefined]> = () => ZodUnion.create([this, ZodUndefined.create()]);
 
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
 
-  static create = <T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | []>(schemas: T): ZodTuple<T> => {
+  static create = <T extends readonly [z.ZodTypeAny, ...z.ZodTypeAny[]] | readonly []>(schemas: T): ZodTuple<T> => {
     return new ZodTuple({
       t: z.ZodTypes.tuple,
       items: schemas,

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -3,13 +3,13 @@ import * as z from './base';
 // import { ZodNull } from './null';
 
 export interface ZodUnionDef<
-  T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]] = [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]
+  T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]] = [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]
 > extends z.ZodTypeDef {
   t: z.ZodTypes.union;
   options: T;
 }
 
-export class ZodUnion<T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]> extends z.ZodType<
+export class ZodUnion<T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]> extends z.ZodType<
   T[number]['_type'],
   ZodUnionDef<T>
 > {
@@ -26,7 +26,7 @@ export class ZodUnion<T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>
   //   return ZodUnion.create(this._def.options.map(f) as any);
   // };
 
-  static create = <T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>(types: T): ZodUnion<T> => {
+  static create = <T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>(types: T): ZodUnion<T> => {
     return new ZodUnion({
       t: z.ZodTypes.union,
       options: types,

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -3,18 +3,17 @@ import * as z from './base';
 // import { ZodNull } from './null';
 
 export interface ZodUnionDef<
-  T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]] = [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]
+  T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]] = readonly [
     z.ZodTypeAny,
     z.ZodTypeAny,
-    ...z.ZodTypeAny[],
-  ]
+    ...z.ZodTypeAny[]
+]
 > extends z.ZodTypeDef {
   t: z.ZodTypes.union;
   options: T;
 }
 
-export class ZodUnion<
-export class ZodUnion<T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]> extends z.ZodType<
+export class ZodUnion<T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]
 > extends z.ZodType<T[number]['_type'], ZodUnionDef<T>> {
   // opt optional: () => ZodUnion<[this, ZodUndefined]> = () => ZodUnion.create([this, ZodUndefined.create()]);
 
@@ -29,7 +28,7 @@ export class ZodUnion<T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTy
   //   return ZodUnion.create(this._def.options.map(f) as any);
   // };
 
-  static create = <T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>(types: T): ZodUnion<T> => {
+  static create = <T extends readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>(
     types: T,
   ): ZodUnion<T> => {
     return new ZodUnion({

--- a/yarn.lock
+++ b/yarn.lock
@@ -398,6 +398,11 @@
     jest-diff "^25.1.0"
     pretty-format "^25.1.0"
 
+"@types/node@14.10.3":
+  version "14.10.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.3.tgz#5ae1f119c96643fc9b19b2d1a83bfa2ec3dbb7ea"
+  integrity sha512-zdN0hor7TLkjAdKTnYW+Y22oIhUUpil5ZD1V1OFq0CR0CLKw+NdR6dkziTfkWRLo6sKzisayoj/GNpNbe4LY9Q==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -517,6 +522,11 @@ anymatch@^3.0.3, anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2494,7 +2504,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -3318,6 +3328,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.5.6:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
@@ -3623,6 +3641,17 @@ ts-jest@^25.2.1:
     semver "^5.5"
     yargs-parser "^16.1.0"
 
+ts-node@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
+  integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 tslib@^1.10.0, tslib@^1.8.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -3695,10 +3724,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@3.7:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 undefsafe@^2.0.2:
   version "2.0.3"
@@ -3985,3 +4014,8 @@ yargs@^15.0.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
This feature introduces a first class optional type. Described more fully in #152 

This is a WIP - mostly done except for some typing issues having to do with infinite recursion on `ZodAnyType` All tests pass in TS 4.0 - but on 3.7 errors are present,

I would like feedback on the PR before I call it complete - hence it is a draft.

1. The existing union type with undefined had some shortcomings. It did not capture whether something could be missing as well as undefined. These issues can be important in objects and tuples.
2. The error messages returned from the union based optionals were generic and confusing.
3. An optional of an optional returned a union of a union before - with this pr it returns the original optional

