### PR TITLE
Reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/cjs/index.js",
   "types": "./lib/cjs/index.d.ts",
   "files": [
-    "lib"
+    "/lib"
   ],
   "repository": {
     "type": "git",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,4 +28,8 @@
   "include": [
     "./src/**/*",
   ],
+  "exclude": [
+    "./src/**/__tests__",
+    "./src/playground.ts",
+  ]
 }


### PR DESCRIPTION
Excludes tests & playground from the published package. Also, use `/lib` instead of `lib` in `files` of `package.json` based on feedback in [this comment](https://github.com/colinhacks/zod/issues/225#issuecomment-739468062).

Relates to #225.