### PR TITLE
Code formatting enhancements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 80,
-  "trailingComma": "all",
-  "singleQuote": true
-}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build": "yarn run clean && tsc --p tsconfig.json",
     "buildall": "yarn add typescript@3.4 && yarn build && yarn add typescript@3.5 && yarn build && yarn add typescript@3.6 && yarn build && yarn add typescript@3.7 && yarn build && yarn add typescript@3.8 && yarn build && yarn add typescript@3.9 && yarn build && yarn add typescript@4 && yarn build && yarn add typescript@3.4",
     "buildallv2": "yarn add typescript@3.7 && yarn build && yarn add typescript@3.8 && yarn build && yarn add typescript@3.9 && yarn build && yarn add typescript@4.0 && yarn build && yarn add typescript@4.1 && yarn build && yarn add typescript@3.7",
-    "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
+    "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
     "test": "jest --coverage && yarn run badge",
     "testone": "jest",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lint-staged": "^10.5.3",
     "make-coverage-badge": "^1.2.0",
     "nodemon": "^2.0.2",
-    "prettier": "^1.19.1",
+    "prettier": "^2.2.1",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.0",
     "tslint": "^6.1.0",

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -1,21 +1,21 @@
-import { util } from './helpers/util';
-import { ZodParsedType } from './parser';
+import { util } from "./helpers/util";
+import { ZodParsedType } from "./parser";
 
 export const ZodIssueCode = util.arrayToEnum([
-  'invalid_type',
-  'nonempty_array_is_empty',
-  'custom',
-  'invalid_union',
-  'invalid_literal_value',
-  'invalid_enum_value',
-  'unrecognized_keys',
-  'invalid_arguments',
-  'invalid_return_type',
-  'invalid_date',
-  'invalid_string',
-  'too_small',
-  'too_big',
-  'invalid_intersection_types',
+  "invalid_type",
+  "nonempty_array_is_empty",
+  "custom",
+  "invalid_union",
+  "invalid_literal_value",
+  "invalid_enum_value",
+  "unrecognized_keys",
+  "invalid_arguments",
+  "invalid_return_type",
+  "invalid_date",
+  "invalid_string",
+  "too_small",
+  "too_big",
+  "invalid_intersection_types",
 ]);
 
 export type ZodIssueCode = keyof typeof ZodIssueCode;
@@ -70,7 +70,7 @@ export interface ZodInvalidDateIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_date;
 }
 
-export type StringValidation = 'email' | 'url' | 'uuid' | 'regex';
+export type StringValidation = "email" | "url" | "uuid" | "regex";
 
 export interface ZodInvalidStringIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_string;
@@ -81,14 +81,14 @@ export interface ZodTooSmallIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_small;
   minimum: number;
   inclusive: boolean;
-  type: 'array' | 'string' | 'number';
+  type: "array" | "string" | "number";
 }
 
 export interface ZodTooBigIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_big;
   maximum: number;
   inclusive: boolean;
-  type: 'array' | 'string' | 'number';
+  type: "array" | "string" | "number";
 }
 
 export interface ZodInvalidIntersectionTypesIssue extends ZodIssueBase {
@@ -120,7 +120,7 @@ export type ZodIssue = ZodIssueOptionalMessage & { message: string };
 
 export const quotelessJson = (obj: any) => {
   const json = JSON.stringify(obj, null, 2); // {"name":"John Smith"}
-  return json.replace(/"([^"]+)":/g, '$1:');
+  return json.replace(/"([^"]+)":/g, "$1:");
 };
 
 export class ZodError extends Error {

--- a/src/__tests__/all-errors.test.ts
+++ b/src/__tests__/all-errors.test.ts
@@ -1,6 +1,6 @@
-import * as z from '../index';
+import * as z from "../index";
 
-test('all errors', () => {
+test("all errors", () => {
   const propertySchema = z.string();
   const schema = z.object({
     a: propertySchema,
@@ -16,8 +16,8 @@ test('all errors', () => {
     expect(error.flatten()).toStrictEqual({
       formErrors: [],
       fieldErrors: {
-        a: ['Expected string, received null'],
-        b: ['Expected string, received null'],
+        a: ["Expected string, received null"],
+        b: ["Expected string, received null"],
       },
     });
   }

--- a/src/__tests__/anyunknown.test.ts
+++ b/src/__tests__/anyunknown.test.ts
@@ -1,7 +1,7 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
-test('check any inference', () => {
+test("check any inference", () => {
   const t1 = z.any();
   t1.optional();
   t1.nullable();
@@ -11,7 +11,7 @@ test('check any inference', () => {
   f1;
 });
 
-test('check unknown inference', () => {
+test("check unknown inference", () => {
   const t1 = z.unknown();
   t1.optional();
   t1.nullable();
@@ -21,9 +21,9 @@ test('check unknown inference', () => {
   f1;
 });
 
-test('check never inference', () => {
+test("check never inference", () => {
   const t1 = z.never();
   expect(() => t1.parse(undefined)).toThrow();
-  expect(() => t1.parse('asdf')).toThrow();
+  expect(() => t1.parse("asdf")).toThrow();
   expect(() => t1.parse(null)).toThrow();
 });

--- a/src/__tests__/array.test.ts
+++ b/src/__tests__/array.test.ts
@@ -1,61 +1,45 @@
-import * as z from '../index';
+import * as z from "../index";
 
-const minTwo = z
-  .string()
-  .array()
-  .min(2);
+const minTwo = z.string().array().min(2);
 
-const maxTwo = z
-  .string()
-  .array()
-  .max(2);
+const maxTwo = z.string().array().max(2);
 
-const justTwo = z
-  .string()
-  .array()
-  .length(2);
+const justTwo = z.string().array().length(2);
 
-const intNum = z
-  .string()
-  .array()
-  .nonempty();
+const intNum = z.string().array().nonempty();
 
-const nonEmptyMax = z
-  .string()
-  .array()
-  .nonempty()
-  .max(2);
+const nonEmptyMax = z.string().array().nonempty().max(2);
 
-test('passing validations', () => {
-  minTwo.parse(['a', 'a']);
-  minTwo.parse(['a', 'a', 'a']);
-  maxTwo.parse(['a', 'a']);
-  maxTwo.parse(['a']);
-  justTwo.parse(['a', 'a']);
-  intNum.parse(['a']);
-  nonEmptyMax.parse(['a']);
+test("passing validations", () => {
+  minTwo.parse(["a", "a"]);
+  minTwo.parse(["a", "a", "a"]);
+  maxTwo.parse(["a", "a"]);
+  maxTwo.parse(["a"]);
+  justTwo.parse(["a", "a"]);
+  intNum.parse(["a"]);
+  nonEmptyMax.parse(["a"]);
 });
 
-test('failing validations', () => {
-  expect(() => minTwo.parse(['a'])).toThrow();
-  expect(() => maxTwo.parse(['a', 'a', 'a'])).toThrow();
-  expect(() => justTwo.parse(['a'])).toThrow();
-  expect(() => justTwo.parse(['a', 'a', 'a'])).toThrow();
+test("failing validations", () => {
+  expect(() => minTwo.parse(["a"])).toThrow();
+  expect(() => maxTwo.parse(["a", "a", "a"])).toThrow();
+  expect(() => justTwo.parse(["a"])).toThrow();
+  expect(() => justTwo.parse(["a", "a", "a"])).toThrow();
   expect(() => intNum.parse([])).toThrow();
   expect(() => nonEmptyMax.parse([])).toThrow();
-  expect(() => nonEmptyMax.parse(['a', 'a', 'a'])).toThrow();
+  expect(() => nonEmptyMax.parse(["a", "a", "a"])).toThrow();
 });
 
-test('parse empty array in nonempty', () => {
+test("parse empty array in nonempty", () => {
   expect(() =>
     z
       .array(z.string())
       .nonempty()
-      .parse([] as any),
+      .parse([] as any)
   ).toThrow();
 });
 
-test('get element', () => {
-  justTwo.element.parse('asdf');
+test("get element", () => {
+  justTwo.element.parse("asdf");
   expect(() => justTwo.element.parse(12)).toThrow();
 });

--- a/src/__tests__/async-parsing.test.ts
+++ b/src/__tests__/async-parsing.test.ts
@@ -1,15 +1,15 @@
-import * as z from '..';
+import * as z from "..";
 
 const stringToNumber = z.transformer(
   z.string(),
   z.number(),
-  v => v.length + 10,
+  (v) => v.length + 10
 );
 
 /// string
 const stringSchema = z.string();
-test('string async parse', async () => {
-  const goodData = 'XXX';
+test("string async parse", async () => {
+  const goodData = "XXX";
   const badData = 12;
 
   const goodResult = await stringSchema.safeParseAsync(goodData);
@@ -23,9 +23,9 @@ test('string async parse', async () => {
 
 /// number
 const numberSchema = z.number();
-test('number async parse', async () => {
+test("number async parse", async () => {
   const goodData = 1234.2353;
-  const badData = '1234';
+  const badData = "1234";
 
   const goodResult = await numberSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
@@ -38,7 +38,7 @@ test('number async parse', async () => {
 
 /// bigInt
 const bigIntSchema = z.bigint();
-test('bigInt async parse', async () => {
+test("bigInt async parse", async () => {
   const goodData = BigInt(145);
   const badData = 134;
 
@@ -53,7 +53,7 @@ test('bigInt async parse', async () => {
 
 /// boolean
 const booleanSchema = z.boolean();
-test('boolean async parse', async () => {
+test("boolean async parse", async () => {
   const goodData = true;
   const badData = 1;
 
@@ -68,7 +68,7 @@ test('boolean async parse', async () => {
 
 /// date
 const dateSchema = z.date();
-test('date async parse', async () => {
+test("date async parse", async () => {
   const goodData = new Date();
   const badData = new Date().toISOString();
 
@@ -83,9 +83,9 @@ test('date async parse', async () => {
 
 /// undefined
 const undefinedSchema = z.undefined();
-test('undefined async parse', async () => {
+test("undefined async parse", async () => {
   const goodData = undefined;
-  const badData = 'XXX';
+  const badData = "XXX";
 
   const goodResult = await undefinedSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
@@ -98,7 +98,7 @@ test('undefined async parse', async () => {
 
 /// null
 const nullSchema = z.null();
-test('null async parse', async () => {
+test("null async parse", async () => {
   const goodData = null;
   const badData = undefined;
 
@@ -113,7 +113,7 @@ test('null async parse', async () => {
 
 /// any
 const anySchema = z.any();
-test('any async parse', async () => {
+test("any async parse", async () => {
   const goodData = [{}];
   // const badData = 'XXX';
 
@@ -128,8 +128,8 @@ test('any async parse', async () => {
 
 /// unknown
 const unknownSchema = z.unknown();
-test('unknown async parse', async () => {
-  const goodData = ['asdf', 124, () => {}];
+test("unknown async parse", async () => {
+  const goodData = ["asdf", 124, () => {}];
   // const badData = 'XXX';
 
   const goodResult = await unknownSchema.safeParseAsync(goodData);
@@ -143,7 +143,7 @@ test('unknown async parse', async () => {
 
 /// void
 const voidSchema = z.void();
-test('void async parse', async () => {
+test("void async parse", async () => {
   const goodData = undefined;
   const badData = 0;
 
@@ -158,9 +158,9 @@ test('void async parse', async () => {
 
 /// array
 const arraySchema = z.array(z.string());
-test('array async parse', async () => {
-  const goodData = ['XXX'];
-  const badData = 'XXX';
+test("array async parse", async () => {
+  const goodData = ["XXX"];
+  const badData = "XXX";
 
   const goodResult = await arraySchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
@@ -173,8 +173,8 @@ test('array async parse', async () => {
 
 /// object
 const objectSchema = z.object({ string: z.string() });
-test('object async parse', async () => {
-  const goodData = { string: 'XXX' };
+test("object async parse", async () => {
+  const goodData = { string: "XXX" };
   const badData = { string: 12 };
 
   const goodResult = await objectSchema.safeParseAsync(goodData);
@@ -188,7 +188,7 @@ test('object async parse', async () => {
 
 /// union
 const unionSchema = z.union([z.string(), z.undefined()]);
-test('union async parse', async () => {
+test("union async parse", async () => {
   const goodData = undefined;
   const badData = null;
 
@@ -203,8 +203,8 @@ test('union async parse', async () => {
 
 /// tuple
 const tupleSchema = z.tuple([stringToNumber, z.object({})]);
-test('tuple async parse', async () => {
-  const goodData = ['XXX', {}];
+test("tuple async parse", async () => {
+  const goodData = ["XXX", {}];
   const badData = [12, {}];
 
   const goodResult = await tupleSchema.safeParseAsync(goodData);
@@ -218,7 +218,7 @@ test('tuple async parse', async () => {
 
 /// record
 const recordSchema = z.record(z.object({}));
-test('record async parse', async () => {
+test("record async parse", async () => {
   const goodData = { adsf: {}, asdf: {} };
   const badData = [{}];
 
@@ -233,13 +233,13 @@ test('record async parse', async () => {
 
 /// function
 const functionSchema = z.function();
-test('function async parse', async () => {
+test("function async parse", async () => {
   const goodData = () => {};
-  const badData = 'XXX';
+  const badData = "XXX";
 
   const goodResult = await functionSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
-  if (goodResult.success) expect(typeof goodResult.data).toEqual('function');
+  if (goodResult.success) expect(typeof goodResult.data).toEqual("function");
 
   const badResult = await functionSchema.safeParseAsync(badData);
   expect(badResult.success).toBe(false);
@@ -247,10 +247,10 @@ test('function async parse', async () => {
 });
 
 /// literal
-const literalSchema = z.literal('asdf');
-test('literal async parse', async () => {
-  const goodData = 'asdf';
-  const badData = 'asdff';
+const literalSchema = z.literal("asdf");
+test("literal async parse", async () => {
+  const goodData = "asdf";
+  const badData = "asdff";
 
   const goodResult = await literalSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
@@ -262,10 +262,10 @@ test('literal async parse', async () => {
 });
 
 /// enum
-const enumSchema = z.enum(['fish', 'whale']);
-test('enum async parse', async () => {
-  const goodData = 'whale';
-  const badData = 'leopard';
+const enumSchema = z.enum(["fish", "whale"]);
+test("enum async parse", async () => {
+  const goodData = "whale";
+  const badData = "leopard";
 
   const goodResult = await enumSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
@@ -278,13 +278,13 @@ test('enum async parse', async () => {
 
 /// nativeEnum
 enum nativeEnumTest {
-  asdf = 'qwer',
+  asdf = "qwer",
 }
 // @ts-ignore
 const nativeEnumSchema = z.nativeEnum(nativeEnumTest);
-test('nativeEnum async parse', async () => {
+test("nativeEnum async parse", async () => {
   const goodData = nativeEnumTest.asdf;
-  const badData = 'asdf';
+  const badData = "asdf";
 
   const goodResult = await nativeEnumSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
@@ -297,9 +297,9 @@ test('nativeEnum async parse', async () => {
 
 /// promise
 const promiseSchema = z.promise(z.number());
-test('promise async parse', async () => {
+test("promise async parse", async () => {
   const goodData = Promise.resolve(123);
-  const badData = Promise.resolve('XXX');
+  const badData = Promise.resolve("XXX");
 
   const goodResult = await promiseSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
@@ -314,56 +314,56 @@ test('promise async parse', async () => {
 const transformerSchema = z.transformer(
   z.number(),
   z.string(),
-  async val => `${Math.pow(val, 2)}`,
+  async (val) => `${Math.pow(val, 2)}`
 );
-test('transformer async parse', async () => {
+test("transformer async parse", async () => {
   const goodData = 5;
-  const badData = '5';
+  const badData = "5";
 
   const goodResult = await transformerSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);
-  if (goodResult.success) expect(goodResult.data).toEqual('25');
+  if (goodResult.success) expect(goodResult.data).toEqual("25");
 
   const badResult = await transformerSchema.safeParseAsync(badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
 
-test('async validation non-empty strings', async () => {
+test("async validation non-empty strings", async () => {
   const base = z.object({
-    hello: z.string().refine(x => x && x.length > 0),
-    foo: z.string().refine(x => x && x.length > 0),
+    hello: z.string().refine((x) => x && x.length > 0),
+    foo: z.string().refine((x) => x && x.length > 0),
   });
 
-  const testval = { hello: '', foo: '' };
+  const testval = { hello: "", foo: "" };
   const result1 = base.safeParse(testval);
   const result2 = base.safeParseAsync(testval);
 
   const r1 = result1;
-  return result2.then(r2 => {
+  return result2.then((r2) => {
     if (r1.success === false && r2.success === false)
       expect(r1.error.issues.length).toBe(r2.error.issues.length); // <--- r1 has length 2, r2 has length 1
   });
 });
 
-test('async validation multiple errors 1', async () => {
+test("async validation multiple errors 1", async () => {
   const base = z.object({
     hello: z.string(),
     foo: z.number(),
   });
 
-  const testval = { hello: 3, foo: 'hello' };
+  const testval = { hello: 3, foo: "hello" };
   const result1 = base.safeParse(testval);
   const result2 = base.safeParseAsync(testval);
 
   const r1 = result1;
-  return result2.then(r2 => {
+  return result2.then((r2) => {
     if (r1.success === false && r2.success === false)
       expect(r2.error.issues.length).toBe(r1.error.issues.length);
   });
 });
 
-test('async validation multiple errors 2', async () => {
+test("async validation multiple errors 2", async () => {
   const base = (is_async?: boolean) =>
     z.object({
       hello: z.string(),
@@ -377,13 +377,13 @@ test('async validation multiple errors 2', async () => {
   const result2 = base(true).safeParseAsync(testval);
 
   const r1 = result1;
-  return result2.then(r2 => {
+  return result2.then((r2) => {
     if (r1.success === false && r2.success === false)
       expect(r2.error.issues.length).toBe(r1.error.issues.length);
   });
 });
 
-test('ensure early async failure prevents follow-up refinement checks', async () => {
+test("ensure early async failure prevents follow-up refinement checks", async () => {
   let count = 0;
   const base = z.object({
     hello: z.string(),
@@ -399,10 +399,10 @@ test('ensure early async failure prevents follow-up refinement checks', async ()
       }),
   });
 
-  const testval = { hello: 'bye', foo: 3 };
+  const testval = { hello: "bye", foo: 3 };
   const result = base.safeParseAsync(testval);
 
-  return result.then(r => {
+  return result.then((r) => {
     if (r.success === false) expect(r.error.issues.length).toBe(1);
     expect(count).toBe(2);
   });

--- a/src/__tests__/async-refinements.test.ts
+++ b/src/__tests__/async-refinements.test.ts
@@ -1,43 +1,43 @@
-import * as z from '..';
+import * as z from "..";
 
-test('parse async test', async () => {
-  const schema1 = z.string().refine(async _val => false);
-  expect(() => schema1.parse('asdf')).toThrow();
+test("parse async test", async () => {
+  const schema1 = z.string().refine(async (_val) => false);
+  expect(() => schema1.parse("asdf")).toThrow();
 
-  const schema2 = z.string().refine(_val => Promise.resolve(true));
-  return await expect(() => schema2.parse('asdf')).toThrow();
+  const schema2 = z.string().refine((_val) => Promise.resolve(true));
+  return await expect(() => schema2.parse("asdf")).toThrow();
 });
 
-test('parseAsync async test', async () => {
-  const schema1 = z.string().refine(async _val => true);
-  await schema1.parseAsync('asdf');
+test("parseAsync async test", async () => {
+  const schema1 = z.string().refine(async (_val) => true);
+  await schema1.parseAsync("asdf");
 
-  const schema2 = z.string().refine(async _val => false);
-  return await expect(schema2.parseAsync('asdf')).rejects.toBeDefined();
+  const schema2 = z.string().refine(async (_val) => false);
+  return await expect(schema2.parseAsync("asdf")).rejects.toBeDefined();
   // expect(async () => await schema2.parseAsync('asdf')).toThrow();
 });
 
-test('parseAsync async test', async () => {
+test("parseAsync async test", async () => {
   // expect.assertions(2);
 
-  const schema1 = z.string().refine(_val => Promise.resolve(true));
-  const v1 = await schema1.parseAsync('asdf');
-  expect(v1).toEqual('asdf');
+  const schema1 = z.string().refine((_val) => Promise.resolve(true));
+  const v1 = await schema1.parseAsync("asdf");
+  expect(v1).toEqual("asdf");
 
-  const schema2 = z.string().refine(_val => Promise.resolve(false));
-  await expect(schema2.parseAsync('asdf')).rejects.toBeDefined();
+  const schema2 = z.string().refine((_val) => Promise.resolve(false));
+  await expect(schema2.parseAsync("asdf")).rejects.toBeDefined();
 
-  const schema3 = z.string().refine(_val => Promise.resolve(true));
-  await expect(schema3.parseAsync('asdf')).resolves.toEqual('asdf');
-  return await expect(schema3.parseAsync('qwer')).resolves.toEqual('qwer');
+  const schema3 = z.string().refine((_val) => Promise.resolve(true));
+  await expect(schema3.parseAsync("asdf")).resolves.toEqual("asdf");
+  return await expect(schema3.parseAsync("qwer")).resolves.toEqual("qwer");
 });
 
-test('parseAsync async with value', async () => {
-  const schema1 = z.string().refine(async val => {
+test("parseAsync async with value", async () => {
+  const schema1 = z.string().refine(async (val) => {
     return val.length > 5;
   });
-  expect(schema1.parseAsync('asdf')).rejects.toBeDefined();
+  expect(schema1.parseAsync("asdf")).rejects.toBeDefined();
 
-  const v = await schema1.parseAsync('asdf123');
-  return await expect(v).toEqual('asdf123');
+  const v = await schema1.parseAsync("asdf123");
+  return await expect(v).toEqual("asdf123");
 });

--- a/src/__tests__/base.test.ts
+++ b/src/__tests__/base.test.ts
@@ -1,28 +1,28 @@
-import * as z from '..';
-import { util } from '../helpers/util';
+import * as z from "..";
+import { util } from "../helpers/util";
 
-test('type guard', () => {
-  const stringToNumber = z.string().transform(z.number(), arg => arg.length);
+test("type guard", () => {
+  const stringToNumber = z.string().transform(z.number(), (arg) => arg.length);
 
   const s1 = z.object({
     stringToNumber,
   });
   type t1 = z.input<typeof s1>;
 
-  const data: any = 'asdf';
+  const data: any = "asdf";
   if (s1.check(data)) {
     const f1: util.AssertEqual<typeof data, t1> = true;
     f1;
   }
 });
 
-test('test this binding', () => {
+test("test this binding", () => {
   const callback = (predicate: (val: string) => boolean) => {
-    return predicate('hello');
+    return predicate("hello");
   };
 
   expect(callback(z.string().is)).toBe(true); // true
-  expect(callback(value => z.string().is(value))).toBe(true); // true
+  expect(callback((value) => z.string().is(value))).toBe(true); // true
   expect(callback(z.string().check)).toBe(true); // true
-  expect(callback(value => z.string().check(value))).toBe(true); // true
+  expect(callback((value) => z.string().check(value))).toBe(true); // true
 });

--- a/src/__tests__/codegen.test.ts
+++ b/src/__tests__/codegen.test.ts
@@ -1,7 +1,7 @@
-import * as z from '../index';
-import { crazySchema } from '../crazySchema';
+import * as z from "../index";
+import { crazySchema } from "../crazySchema";
 
-test('ZodCodeGenerator', () => {
+test("ZodCodeGenerator", () => {
   const gen = new z.ZodCodeGenerator();
   gen.generate(crazySchema);
   gen.dump();

--- a/src/__tests__/complex.test.ts
+++ b/src/__tests__/complex.test.ts
@@ -1,50 +1,50 @@
-import * as z from '../index';
-import { crazySchema } from '../crazySchema';
+import * as z from "../index";
+import { crazySchema } from "../crazySchema";
 
-test('parse', () => {
+test("parse", () => {
   const value = crazySchema.parse({
-    tuple: ['asdf', 1234, true, null, undefined, '1234'],
-    merged: { k1: 'asdf', k2: 12 },
-    union: ['asdf', 12, 'asdf', 12, 'asdf', 12],
+    tuple: ["asdf", 1234, true, null, undefined, "1234"],
+    merged: { k1: "asdf", k2: 12 },
+    union: ["asdf", 12, "asdf", 12, "asdf", 12],
     array: [12, 15, 16],
     sumTransformer: [12, 15, 16],
     sumMinLength: [12, 15, 16, 98, 24, 63],
     intersection: {},
-    enum: 'one',
+    enum: "one",
     nonstrict: { points: 1234 },
     numProm: Promise.resolve(12),
     lenfun: (x: string) => x.length,
   });
-  expect(typeof value.sumTransformer).toEqual('number');
+  expect(typeof value.sumTransformer).toEqual("number");
 });
 
-test('to JSON', () => {
+test("to JSON", () => {
   crazySchema.toJSON();
 });
 
 const stringSchema = z.string();
 
-test('type guard', () => {
-  if (stringSchema.check('adsf' as any)) {
+test("type guard", () => {
+  if (stringSchema.check("adsf" as any)) {
   }
 });
 
-test('type guard fail', () => {
-  if (crazySchema.check('asdf' as any)) {
+test("type guard fail", () => {
+  if (crazySchema.check("asdf" as any)) {
   }
 });
 
-test('type guard (is)', () => {
-  if (stringSchema.is('asdf' as any)) {
+test("type guard (is)", () => {
+  if (stringSchema.is("asdf" as any)) {
   }
 });
 
-test('type guard failure (is)', () => {
-  if (crazySchema.is('asdf' as any)) {
+test("type guard failure (is)", () => {
+  if (crazySchema.is("asdf" as any)) {
   }
 });
 
-test('ZodCodeGenerator', () => {
+test("ZodCodeGenerator", () => {
   const gen = new z.ZodCodeGenerator();
   gen.generate(crazySchema);
 });

--- a/src/__tests__/deepmasking.test.ts
+++ b/src/__tests__/deepmasking.test.ts
@@ -1,6 +1,6 @@
-import * as z from '../index';
+import * as z from "../index";
 
-test('', () => {
+test("", () => {
   z;
 });
 

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -1,20 +1,20 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
-test('create enum', () => {
-  const MyEnum = z.enum(['Red', 'Green', 'Blue']);
-  expect(MyEnum.Values.Red).toEqual('Red');
-  expect(MyEnum.Enum.Red).toEqual('Red');
-  expect(MyEnum.enum.Red).toEqual('Red');
+test("create enum", () => {
+  const MyEnum = z.enum(["Red", "Green", "Blue"]);
+  expect(MyEnum.Values.Red).toEqual("Red");
+  expect(MyEnum.Enum.Red).toEqual("Red");
+  expect(MyEnum.enum.Red).toEqual("Red");
 });
 
-test('infer enum', () => {
-  const MyEnum = z.enum(['Red', 'Green', 'Blue']);
+test("infer enum", () => {
+  const MyEnum = z.enum(["Red", "Green", "Blue"]);
   type MyEnum = z.infer<typeof MyEnum>;
-  const t1: util.AssertEqual<MyEnum, 'Red' | 'Green' | 'Blue'> = true;
+  const t1: util.AssertEqual<MyEnum, "Red" | "Green" | "Blue"> = true;
   [t1];
 });
 
-test('get options', () => {
-  expect(z.enum(['tuna', 'trout']).options).toEqual(['tuna', 'trout']);
+test("get options", () => {
+  expect(z.enum(["tuna", "trout"]).options).toEqual(["tuna", "trout"]);
 });

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -1,15 +1,15 @@
-import * as z from '../index';
-import { ZodError, ZodIssueCode } from '../ZodError';
-import { ZodParsedType } from '../parser';
+import * as z from "../index";
+import { ZodError, ZodIssueCode } from "../ZodError";
+import { ZodParsedType } from "../parser";
 
-test('error creation', () => {
+test("error creation", () => {
   const err1 = ZodError.create([]);
   err1.addIssue({
     code: ZodIssueCode.invalid_type,
     expected: ZodParsedType.object,
     received: ZodParsedType.string,
     path: [],
-    message: '',
+    message: "",
   });
   err1.isEmpty;
 
@@ -24,8 +24,8 @@ test('error creation', () => {
 
 const errorMap: z.ZodErrorMap = (error, ctx) => {
   if (error.code === ZodIssueCode.invalid_type) {
-    if (error.expected === 'string') {
-      return { message: 'bad type!' };
+    if (error.expected === "string") {
+      return { message: "bad type!" };
     }
   }
   if (error.code === ZodIssueCode.custom) {
@@ -34,9 +34,9 @@ const errorMap: z.ZodErrorMap = (error, ctx) => {
   return { message: ctx.defaultError };
 };
 
-test('type error with custom error map', () => {
+test("type error with custom error map", () => {
   try {
-    z.string().parse('asdf', { errorMap });
+    z.string().parse("asdf", { errorMap });
   } catch (err) {
     const zerr: z.ZodError = err;
 
@@ -45,10 +45,10 @@ test('type error with custom error map', () => {
   }
 });
 
-test('refinement fail with params', () => {
+test("refinement fail with params", () => {
   try {
     z.number()
-      .refine(val => val >= 3, {
+      .refine((val) => val >= 3, {
         params: { minimum: 3 },
       })
       .parse(2, { errorMap });
@@ -59,72 +59,68 @@ test('refinement fail with params', () => {
   }
 });
 
-test('custom error with custom errormap', () => {
+test("custom error with custom errormap", () => {
   try {
     z.string()
-      .refine(val => val.length > 12, {
+      .refine((val) => val.length > 12, {
         params: { minimum: 13 },
-        message: 'override',
+        message: "override",
       })
-      .parse('asdf', { errorMap });
+      .parse("asdf", { errorMap });
   } catch (err) {
     const zerr: z.ZodError = err;
-    expect(zerr.issues[0].message).toEqual('override');
+    expect(zerr.issues[0].message).toEqual("override");
   }
 });
 
-test('default error message', () => {
+test("default error message", () => {
   try {
     z.number()
-      .refine(x => x > 3)
+      .refine((x) => x > 3)
       .parse(2);
   } catch (err) {
     const zerr: z.ZodError = err;
     expect(zerr.issues.length).toEqual(1);
-    expect(zerr.issues[0].message).toEqual('Invalid value.');
+    expect(zerr.issues[0].message).toEqual("Invalid value.");
   }
 });
 
-test('override error in refine', () => {
+test("override error in refine", () => {
   try {
     z.number()
-      .refine(x => x > 3, 'override')
+      .refine((x) => x > 3, "override")
       .parse(2);
   } catch (err) {
     const zerr: z.ZodError = err;
     expect(zerr.issues.length).toEqual(1);
-    expect(zerr.issues[0].message).toEqual('override');
+    expect(zerr.issues[0].message).toEqual("override");
   }
 });
 
-test('override error in refinement', () => {
+test("override error in refinement", () => {
   try {
     z.number()
-      .refine(x => x > 3, {
-        message: 'override',
+      .refine((x) => x > 3, {
+        message: "override",
       })
       .parse(2);
   } catch (err) {
     const zerr: z.ZodError = err;
     expect(zerr.issues.length).toEqual(1);
-    expect(zerr.issues[0].message).toEqual('override');
+    expect(zerr.issues[0].message).toEqual("override");
   }
 });
 
-test('array minimum', () => {
+test("array minimum", () => {
   try {
-    z.array(z.string())
-      .min(3, 'tooshort')
-      .parse(['asdf', 'qwer']);
+    z.array(z.string()).min(3, "tooshort").parse(["asdf", "qwer"]);
   } catch (err) {
     const zerr: ZodError = err;
     expect(zerr.issues[0].code).toEqual(ZodIssueCode.too_small);
-    expect(zerr.issues[0].message).toEqual('tooshort');
+    expect(zerr.issues[0].message).toEqual("tooshort");
   }
   try {
-    z.array(z.string())
-      .min(3)
-      .parse(['asdf', 'qwer']);
+    z.array(z.string()).min(3).parse(["asdf", "qwer"]);
   } catch (err) {
     const zerr: ZodError = err;
     expect(zerr.issues[0].code).toEqual(ZodIssueCode.too_small);
@@ -133,11 +129,11 @@ test('array minimum', () => {
 });
 
 // implement test for semi-smart union logic that checks for type error on either left or right
-test('union smart errors', () => {
+test("union smart errors", () => {
   // expect.assertions(2);
 
   const p1 = z
-    .union([z.string(), z.number().refine(x => x > 0)])
+    .union([z.string(), z.number().refine((x) => x > 0)])
     .safeParse(-3.2);
 
   if (p1.success === true) throw new Error();
@@ -151,37 +147,37 @@ test('union smart errors', () => {
   expect(p2.error.issues[0].code).toEqual(ZodIssueCode.invalid_union);
 });
 
-test('custom path in custom error map', () => {
+test("custom path in custom error map", () => {
   const schema = z.object({
-    items: z.array(z.string()).refine(data => data.length > 3, {
-      path: ['items-too-few'],
+    items: z.array(z.string()).refine((data) => data.length > 3, {
+      path: ["items-too-few"],
     }),
   });
 
-  const errorMap: z.ZodErrorMap = error => {
+  const errorMap: z.ZodErrorMap = (error) => {
     expect(error.path.length).toBe(2);
-    return { message: 'doesnt matter' };
+    return { message: "doesnt matter" };
   };
-  const result = schema.safeParse({ items: ['first'] }, { errorMap });
+  const result = schema.safeParse({ items: ["first"] }, { errorMap });
   expect(result.success).toEqual(false);
   if (!result.success) {
-    expect(result.error.issues[0].path).toEqual(['items', 'items-too-few']);
+    expect(result.error.issues[0].path).toEqual(["items", "items-too-few"]);
   }
 });
 
-test('error metadata from value', () => {
+test("error metadata from value", () => {
   const dynamicRefine = z.string().refine(
-    val => val === val.toUpperCase(),
-    val => ({ params: { val } }),
+    (val) => val === val.toUpperCase(),
+    (val) => ({ params: { val } })
   );
 
-  const result = dynamicRefine.safeParse('asdf');
+  const result = dynamicRefine.safeParse("asdf");
   expect(result.success).toEqual(false);
   if (!result.success) {
     const sub = result.error.issues[0];
-    expect(result.error.issues[0].code).toEqual('custom');
-    if (sub.code === 'custom') {
-      expect(sub.params!.val).toEqual('asdf');
+    expect(result.error.issues[0].code).toEqual("custom");
+    if (sub.code === "custom") {
+      expect(sub.params!.val).toEqual("asdf");
     }
   }
 });
@@ -190,11 +186,11 @@ test("don't call refine after validation failed", () => {
   const asdf = z
     .union([
       z.number(),
-      z.string().transform(z.number(), val => {
+      z.string().transform(z.number(), (val) => {
         return parseFloat(val);
       }),
     ])
-    .refine(v => v >= 1);
+    .refine((v) => v >= 1);
 
-  expect(() => asdf.safeParse('foo')).not.toThrow();
+  expect(() => asdf.safeParse("foo")).not.toThrow();
 });

--- a/src/__tests__/function.test.ts
+++ b/src/__tests__/function.test.ts
@@ -1,32 +1,32 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
 const args1 = z.tuple([z.string()]);
 const returns1 = z.number();
 const func1 = z.function(args1, returns1);
 
-test('function parsing', () => {
+test("function parsing", () => {
   const parsed = func1.parse((arg: any) => arg.length);
-  parsed('asdf');
+  parsed("asdf");
 });
 
-test('parsed function fail 1', () => {
+test("parsed function fail 1", () => {
   const parsed = func1.parse((x: string) => x);
-  expect(() => parsed('asdf')).toThrow();
+  expect(() => parsed("asdf")).toThrow();
 });
 
-test('parsed function fail 2', () => {
+test("parsed function fail 2", () => {
   const parsed = func1.parse((x: string) => x);
   expect(() => parsed(13 as any)).toThrow();
 });
 
-test('function inference 1', () => {
+test("function inference 1", () => {
   type func1 = z.TypeOf<typeof func1>;
   const t1: util.AssertEqual<func1, (k: string) => number> = true;
   [t1];
 });
 
-test('args method', () => {
+test("args method", () => {
   const t1 = z.function();
   type t1 = z.infer<typeof t1>;
   const f1: util.AssertEqual<t1, () => void> = true;
@@ -55,7 +55,7 @@ const returns2 = z.union([z.string(), z.number()]);
 
 const func2 = z.function(args2, returns2);
 
-test('function inference 2', () => {
+test("function inference 2", () => {
   type func2 = z.TypeOf<typeof func2>;
   const t2: util.AssertEqual<
     func2,
@@ -68,15 +68,15 @@ test('function inference 2', () => {
   [t2];
 });
 
-test('valid function run', () => {
-  const validFunc2Instance = func2.validate(_x => {
-    return 'adf' as any;
+test("valid function run", () => {
+  const validFunc2Instance = func2.validate((_x) => {
+    return "adf" as any;
   });
 
   const checker = () => {
     validFunc2Instance({
       f1: 21,
-      f2: 'asdf',
+      f2: "asdf",
       f3: [true, false],
     });
   };
@@ -84,27 +84,27 @@ test('valid function run', () => {
   checker();
 });
 
-test('input validation error', () => {
-  const invalidFuncInstance = func2.validate(_x => {
-    return 'adf' as any;
+test("input validation error", () => {
+  const invalidFuncInstance = func2.validate((_x) => {
+    return "adf" as any;
   });
 
   const checker = () => {
-    invalidFuncInstance('Invalid_input' as any);
+    invalidFuncInstance("Invalid_input" as any);
   };
 
   expect(checker).toThrow();
 });
 
-test('output validation error', () => {
-  const invalidFuncInstance = func2.validate(_x => {
-    return ['this', 'is', 'not', 'valid', 'output'] as any;
+test("output validation error", () => {
+  const invalidFuncInstance = func2.validate((_x) => {
+    return ["this", "is", "not", "valid", "output"] as any;
   });
 
   const checker = () => {
     invalidFuncInstance({
       f1: 21,
-      f2: 'asdf',
+      f2: "asdf",
       f3: [true, false],
     });
   };
@@ -112,14 +112,14 @@ test('output validation error', () => {
   expect(checker).toThrow();
 });
 
-test('special function error codes', () => {
+test("special function error codes", () => {
   const checker = z
     .function(z.tuple([z.string()]), z.boolean())
-    .implement(arg => {
+    .implement((arg) => {
       return arg.length as any;
     });
   try {
-    checker('12' as any);
+    checker("12" as any);
   } catch (err) {
     const zerr: z.ZodError = err;
     const first = zerr.issues[0];
@@ -138,47 +138,47 @@ test('special function error codes', () => {
   }
 });
 
-test('function with async refinements', async () => {
+test("function with async refinements", async () => {
   const func = z
     .function()
-    .args(z.string().refine(async val => val.length > 10))
-    .returns(z.promise(z.number().refine(async val => val > 10)))
-    .implement(async val => {
+    .args(z.string().refine(async (val) => val.length > 10))
+    .returns(z.promise(z.number().refine(async (val) => val > 10)))
+    .implement(async (val) => {
       return val.length;
     });
   let results = [];
   try {
-    await func('asdfasdf');
-    results.push('success');
+    await func("asdfasdf");
+    results.push("success");
   } catch (err) {
-    results.push('fail');
+    results.push("fail");
   }
   try {
-    await func('asdflkjasdflkjsf');
-    results.push('success');
+    await func("asdflkjasdflkjsf");
+    results.push("success");
   } catch (err) {
-    results.push('fail');
+    results.push("fail");
   }
 
-  expect(results).toEqual(['fail', 'success']);
+  expect(results).toEqual(["fail", "success"]);
 });
 
-test('non async function with async refinements should fail', async () => {
+test("non async function with async refinements should fail", async () => {
   const func = z
     .function()
-    .args(z.string().refine(async val => val.length > 10))
-    .returns(z.number().refine(async val => val > 10))
-    .implement(val => {
+    .args(z.string().refine(async (val) => val.length > 10))
+    .returns(z.number().refine(async (val) => val > 10))
+    .implement((val) => {
       return val.length;
     });
 
   let results = [];
   try {
-    await func('asdasdfasdffasdf');
-    results.push('success');
+    await func("asdasdfasdffasdf");
+    results.push("success");
   } catch (err) {
-    results.push('fail');
+    results.push("fail");
   }
 
-  expect(results).toEqual(['fail']);
+  expect(results).toEqual(["fail"]);
 });

--- a/src/__tests__/instanceof.test.ts
+++ b/src/__tests__/instanceof.test.ts
@@ -1,7 +1,7 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
-test('instanceof', async () => {
+test("instanceof", async () => {
   class Test {}
   class Subtest extends Test {}
 
@@ -16,11 +16,11 @@ test('instanceof', async () => {
   expect(() => SubtestSchema.parse(new Test())).toThrow();
   expect(() => TestSchema.parse(12)).toThrow();
 
-  await TestSchema.parseAsync(12).catch(err => {
-    expect(err.issues[0].message).toEqual('Input not instance of Test');
+  await TestSchema.parseAsync(12).catch((err) => {
+    expect(err.issues[0].message).toEqual("Input not instance of Test");
   });
-  await SubtestSchema.parseAsync(12).catch(err => {
-    expect(err.issues[0].message).toEqual('Input not instance of Subtest');
+  await SubtestSchema.parseAsync(12).catch((err) => {
+    expect(err.issues[0].message).toEqual("Input not instance of Subtest");
   });
 
   const f1: util.AssertEqual<Test, z.infer<typeof TestSchema>> = true;

--- a/src/__tests__/intersection.test.ts
+++ b/src/__tests__/intersection.test.ts
@@ -1,6 +1,6 @@
-import * as z from '..';
+import * as z from "..";
 
-test('object intersection', () => {
+test("object intersection", () => {
   const BaseTeacher = z.object({
     subjects: z.array(z.string()),
   });
@@ -8,14 +8,14 @@ test('object intersection', () => {
 
   const Teacher = z.intersection(BaseTeacher.passthrough(), HasID); // BaseTeacher.merge(HasID);
   const data = {
-    subjects: ['math'],
-    id: 'asdfasdf',
+    subjects: ["math"],
+    id: "asdfasdf",
   };
   expect(Teacher.parse(data)).toEqual(data);
   expect(() => Teacher.parse({ subject: data.subjects })).toThrow();
   expect(Teacher.parse({ ...data, extra: 12 })).toEqual({ ...data, extra: 12 });
 
   expect(() =>
-    z.intersection(BaseTeacher.strict(), HasID).parse({ ...data, extra: 12 }),
+    z.intersection(BaseTeacher.strict(), HasID).parse({ ...data, extra: 12 })
   ).toThrow();
 });

--- a/src/__tests__/map.tests.ts
+++ b/src/__tests__/map.tests.ts
@@ -1,26 +1,26 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
-import { ZodIssueCode } from '../index';
+import * as z from "../index";
+import { util } from "../helpers/util";
+import { ZodIssueCode } from "../index";
 
 const stringMap = z.map(z.string(), z.string());
 type stringMap = z.infer<typeof stringMap>;
 
-test('type inference', () => {
+test("type inference", () => {
   const f1: util.AssertEqual<stringMap, Map<string, string>> = true;
   f1;
 });
 
-test('doesn’t throw when a valid value is given', () => {
+test("doesn’t throw when a valid value is given", () => {
   const result = stringMap.safeParse(
     new Map([
-      ['first', 'foo'],
-      ['second', 'bar'],
-    ]),
+      ["first", "foo"],
+      ["second", "bar"],
+    ])
   );
   expect(result.success).toEqual(true);
 });
 
-test('throws when a Set is given', () => {
+test("throws when a Set is given", () => {
   const result = stringMap.safeParse(new Set([]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
@@ -29,26 +29,26 @@ test('throws when a Set is given', () => {
   }
 });
 
-test('throws when the given map has invalid key and invalid value', () => {
+test("throws when the given map has invalid key and invalid value", () => {
   const result = stringMap.safeParse(new Map([[42, Symbol()]]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(2);
     expect(result.error.issues[0].code).toEqual(ZodIssueCode.invalid_type);
-    expect(result.error.issues[0].path).toEqual([0, 'key']);
+    expect(result.error.issues[0].path).toEqual([0, "key"]);
     expect(result.error.issues[1].code).toEqual(ZodIssueCode.invalid_type);
-    expect(result.error.issues[1].path).toEqual([0, 'value']);
+    expect(result.error.issues[1].path).toEqual([0, "value"]);
   }
 });
 
-test('throws when the given map has multiple invalid entries', () => {
+test("throws when the given map has multiple invalid entries", () => {
   // const result = stringMap.safeParse(new Map([[42, Symbol()]]));
 
   const result = stringMap.safeParse(
     new Map([
-      [1, 'foo'],
-      ['bar', 2],
-    ] as [any, any][]) as Map<any, any>,
+      [1, "foo"],
+      ["bar", 2],
+    ] as [any, any][]) as Map<any, any>
   );
 
   // const result = stringMap.safeParse(new Map([[42, Symbol()]]));
@@ -56,8 +56,8 @@ test('throws when the given map has multiple invalid entries', () => {
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(2);
     expect(result.error.issues[0].code).toEqual(ZodIssueCode.invalid_type);
-    expect(result.error.issues[0].path).toEqual([0, 'key']);
+    expect(result.error.issues[0].path).toEqual([0, "key"]);
     expect(result.error.issues[1].code).toEqual(ZodIssueCode.invalid_type);
-    expect(result.error.issues[1].path).toEqual([1, 'value']);
+    expect(result.error.issues[1].path).toEqual([1, "value"]);
   }
 });

--- a/src/__tests__/masking.test.ts
+++ b/src/__tests__/masking.test.ts
@@ -1,8 +1,8 @@
-import * as z from '..';
+import * as z from "..";
 
-test('masking test', () => {});
+test("masking test", () => {});
 
-test('require', () => {
+test("require", () => {
   const baseSchema = z.object({
     firstName: z.string(),
     middleName: z.string().optional(),

--- a/src/__tests__/mocker.test.ts
+++ b/src/__tests__/mocker.test.ts
@@ -1,6 +1,6 @@
-import { Mocker } from '../helpers/Mocker';
+import { Mocker } from "../helpers/Mocker";
 
-test('mocker', () => {
+test("mocker", () => {
   const mocker = new Mocker();
   mocker.string;
   mocker.number;

--- a/src/__tests__/nativeEnum.test.ts
+++ b/src/__tests__/nativeEnum.test.ts
@@ -1,35 +1,38 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
-test('nativeEnum test with consts', () => {
-  const Fruits: { Apple: 'apple'; Banana: 'banana' } = { Apple: 'apple', Banana: 'banana' };
+test("nativeEnum test with consts", () => {
+  const Fruits: { Apple: "apple"; Banana: "banana" } = {
+    Apple: "apple",
+    Banana: "banana",
+  };
   const fruitEnum = z.nativeEnum(Fruits);
   type fruitEnum = z.infer<typeof fruitEnum>;
-  fruitEnum.parse('apple');
-  fruitEnum.parse('banana');
+  fruitEnum.parse("apple");
+  fruitEnum.parse("banana");
   fruitEnum.parse(Fruits.Apple);
   fruitEnum.parse(Fruits.Banana);
-  const t1: util.AssertEqual<fruitEnum, 'apple' | 'banana'> = true;
+  const t1: util.AssertEqual<fruitEnum, "apple" | "banana"> = true;
   [t1];
 });
 
-test('nativeEnum test with real enum', () => {
+test("nativeEnum test with real enum", () => {
   enum Fruits {
-    Apple = 'apple',
-    Banana = 'banana',
+    Apple = "apple",
+    Banana = "banana",
   }
   // @ts-ignore
   const fruitEnum = z.nativeEnum(Fruits);
   type fruitEnum = z.infer<typeof fruitEnum>;
-  fruitEnum.parse('apple');
-  fruitEnum.parse('banana');
+  fruitEnum.parse("apple");
+  fruitEnum.parse("banana");
   fruitEnum.parse(Fruits.Apple);
   fruitEnum.parse(Fruits.Banana);
   const t1: util.AssertEqual<fruitEnum, Fruits> = true;
   [t1];
 });
 
-test('nativeEnum test with const with numeric keys', () => {
+test("nativeEnum test with const with numeric keys", () => {
   const FruitValues = {
     Apple: 10,
     Banana: 20,
@@ -45,38 +48,38 @@ test('nativeEnum test with const with numeric keys', () => {
   [t1];
 });
 
-test('from enum', () => {
+test("from enum", () => {
   enum Fruits {
     Cantaloupe,
-    Apple = 'apple',
-    Banana = 'banana',
+    Apple = "apple",
+    Banana = "banana",
   }
 
   const FruitEnum = z.nativeEnum(Fruits as any);
   type FruitEnum = z.infer<typeof FruitEnum>;
   FruitEnum.parse(Fruits.Cantaloupe);
   FruitEnum.parse(Fruits.Apple);
-  FruitEnum.parse('apple');
+  FruitEnum.parse("apple");
   FruitEnum.parse(0);
   expect(() => FruitEnum.parse(1)).toThrow();
-  expect(() => FruitEnum.parse('Apple')).toThrow();
-  expect(() => FruitEnum.parse('Cantaloupe')).toThrow();
+  expect(() => FruitEnum.parse("Apple")).toThrow();
+  expect(() => FruitEnum.parse("Cantaloupe")).toThrow();
 });
 
-test('from const', () => {
+test("from const", () => {
   const Greek = {
-    Alpha: 'a',
-    Beta: 'b',
+    Alpha: "a",
+    Beta: "b",
     Gamma: 3,
     // @ts-ignore
   } as const;
 
   const GreekEnum = z.nativeEnum(Greek);
   type GreekEnum = z.infer<typeof GreekEnum>;
-  GreekEnum.parse('a');
-  GreekEnum.parse('b');
+  GreekEnum.parse("a");
+  GreekEnum.parse("b");
   GreekEnum.parse(3);
-  expect(() => GreekEnum.parse('v')).toThrow();
-  expect(() => GreekEnum.parse('Alpha')).toThrow();
+  expect(() => GreekEnum.parse("v")).toThrow();
+  expect(() => GreekEnum.parse("Alpha")).toThrow();
   expect(() => GreekEnum.parse(2)).toThrow();
 });

--- a/src/__tests__/number.test.ts
+++ b/src/__tests__/number.test.ts
@@ -1,10 +1,10 @@
-import * as z from '../index';
+import * as z from "../index";
 
-const minFive = z.number().min(5, 'min5');
-const maxFive = z.number().max(5, 'max5');
+const minFive = z.number().min(5, "min5");
+const maxFive = z.number().max(5, "max5");
 const intNum = z.number().int();
 
-test('passing validations', () => {
+test("passing validations", () => {
   minFive.parse(5);
   minFive.parse(6);
   maxFive.parse(5);
@@ -12,12 +12,12 @@ test('passing validations', () => {
   intNum.parse(4);
 });
 
-test('failing validations', () => {
+test("failing validations", () => {
   expect(() => minFive.parse(4)).toThrow();
   expect(() => maxFive.parse(6)).toThrow();
   expect(() => intNum.parse(3.14)).toThrow();
 });
 
-test('parse NaN', () => {
+test("parse NaN", () => {
   expect(() => z.number().parse(NaN)).toThrow();
 });

--- a/src/__tests__/object-augmentation.test.ts
+++ b/src/__tests__/object-augmentation.test.ts
@@ -1,6 +1,6 @@
-import * as z from '../index';
+import * as z from "../index";
 
-test('object augmentation', () => {
+test("object augmentation", () => {
   const Animal = z
     .object({
       species: z.string(),
@@ -13,13 +13,13 @@ test('object augmentation', () => {
     species: z.array(z.string()),
   });
   ModifiedAnimal.parse({
-    species: ['asd'],
+    species: ["asd"],
     population: 1324,
   });
 
   const bad = () =>
     ModifiedAnimal.parse({
-      species: 'asdf',
+      species: "asdf",
       population: 1324,
     } as any);
   expect(bad).toThrow();

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -1,5 +1,5 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
 const Test = z.object({
   f1: z.number(),
@@ -9,7 +9,7 @@ const Test = z.object({
 });
 type Test = z.infer<typeof Test>;
 
-test('object type inference', () => {
+test("object type inference", () => {
   type TestType = {
     f1: number;
     f2?: string | undefined;
@@ -21,19 +21,19 @@ test('object type inference', () => {
   [t1];
 });
 
-test('unknown throw', () => {
+test("unknown throw", () => {
   const asdf: unknown = 35;
   expect(() => Test.parse(asdf)).toThrow();
 });
 
-test('correct parsing', () => {
+test("correct parsing", () => {
   Test.parse({
     f1: 12,
-    f2: 'string',
-    f3: 'string',
+    f2: "string",
+    f3: "string",
     f4: [
       {
-        t: 'string',
+        t: "string",
       },
     ],
   });
@@ -49,11 +49,11 @@ test('correct parsing', () => {
   });
 });
 
-test('incorrect #1', () => {
+test("incorrect #1", () => {
   expect(() => Test.parse({} as any)).toThrow();
 });
 
-test('inference', () => {
+test("inference", () => {
   const t1 = z.object({
     name: z.string(),
     obj: z.object({}),
@@ -70,29 +70,29 @@ test('inference', () => {
 
   f1;
   f2;
-  i1.parse({ name: 'name' });
-  i2.parse({ obj: {}, arrayarray: [['asdf']] });
+  i1.parse({ name: "name" });
+  i2.parse({ obj: {}, arrayarray: [["asdf"]] });
   expect(() => i1.parse({} as any)).toThrow();
 });
 
-test('nonstrict by default', () => {
+test("nonstrict by default", () => {
   z.object({ points: z.number() }).parse({
     points: 2314,
-    unknown: 'asdf',
+    unknown: "asdf",
   });
 });
 
 const data = {
   points: 2314,
-  unknown: 'asdf',
+  unknown: "asdf",
 };
 
-test('strip by default', () => {
+test("strip by default", () => {
   const val = z.object({ points: z.number() }).parse(data);
   expect(val).toEqual({ points: 2314 });
 });
 
-test('unknownkeys override', () => {
+test("unknownkeys override", () => {
   const val = z
     .object({ points: z.number() })
     .strict()
@@ -104,34 +104,25 @@ test('unknownkeys override', () => {
   expect(val).toEqual(data);
 });
 
-test('passthrough unknown', () => {
-  const val = z
-    .object({ points: z.number() })
-    .passthrough()
-    .parse(data);
+test("passthrough unknown", () => {
+  const val = z.object({ points: z.number() }).passthrough().parse(data);
 
   expect(val).toEqual(data);
 });
 
-test('strip unknown', () => {
-  const val = z
-    .object({ points: z.number() })
-    .strip()
-    .parse(data);
+test("strip unknown", () => {
+  const val = z.object({ points: z.number() }).strip().parse(data);
 
   expect(val).toEqual({ points: 2314 });
 });
 
-test('strict', () => {
-  const val = z
-    .object({ points: z.number() })
-    .strict()
-    .safeParse(data);
+test("strict", () => {
+  const val = z.object({ points: z.number() }).strict().safeParse(data);
 
   expect(val.success).toEqual(false);
 });
 
-test('primitives', () => {
+test("primitives", () => {
   const baseObj = z.object({
     stringPrimitive: z.string(),
     stringArrayPrimitive: z.array(z.string()),
@@ -146,8 +137,8 @@ test('primitives', () => {
     primitiveUnion: z.union([z.string(), z.number()]),
     primitiveIntersection: z.intersection(z.string(), z.string()),
     lazyPrimitive: z.lazy(() => z.string()),
-    literalPrimitive: z.literal('sup'),
-    enumPrimitive: z.enum(['asdf', 'qwer']),
+    literalPrimitive: z.literal("sup"),
+    enumPrimitive: z.enum(["asdf", "qwer"]),
     datePrimitive: z.date(),
     primitiveTuple: z.tuple([z.string(), z.number()]),
 
@@ -159,49 +150,49 @@ test('primitives', () => {
   });
 
   expect(Object.keys(baseObj.primitives().shape)).toEqual([
-    'stringPrimitive',
-    'stringArrayPrimitive',
-    'numberPrimitive',
-    'numberArrayPrimitive',
-    'booleanPrimitive',
-    'booleanArrayPrimitive',
-    'bigintPrimitive',
-    'bigintArrayPrimitive',
-    'undefinedPrimitive',
-    'nullPrimitive',
-    'primitiveUnion',
-    'primitiveIntersection',
-    'lazyPrimitive',
-    'literalPrimitive',
-    'enumPrimitive',
-    'datePrimitive',
-    'primitiveTuple',
+    "stringPrimitive",
+    "stringArrayPrimitive",
+    "numberPrimitive",
+    "numberArrayPrimitive",
+    "booleanPrimitive",
+    "booleanArrayPrimitive",
+    "bigintPrimitive",
+    "bigintArrayPrimitive",
+    "undefinedPrimitive",
+    "nullPrimitive",
+    "primitiveUnion",
+    "primitiveIntersection",
+    "lazyPrimitive",
+    "literalPrimitive",
+    "enumPrimitive",
+    "datePrimitive",
+    "primitiveTuple",
   ]);
 
   expect(Object.keys(baseObj.nonprimitives().shape)).toEqual([
-    'nonprimitiveUnion',
-    'object',
-    'objectArray',
-    'arrayarray',
-    'nonprimitiveTuple',
+    "nonprimitiveUnion",
+    "object",
+    "objectArray",
+    "arrayarray",
+    "nonprimitiveTuple",
   ]);
 });
 
-test('catchall inference', () => {
+test("catchall inference", () => {
   const o1 = z
     .object({
       first: z.string(),
     })
     .catchall(z.number());
 
-  const d1 = o1.parse({ first: 'asdf', num: 1243 });
-  const f1: util.AssertEqual<number, typeof d1['asdf']> = true;
-  const f2: util.AssertEqual<string, typeof d1['first']> = true;
+  const d1 = o1.parse({ first: "asdf", num: 1243 });
+  const f1: util.AssertEqual<number, typeof d1["asdf"]> = true;
+  const f2: util.AssertEqual<string, typeof d1["first"]> = true;
   f1;
   f2;
 });
 
-test('catchall overrides strict', () => {
+test("catchall overrides strict", () => {
   const o1 = z
     .object({ first: z.string().optional() })
     .strict()
@@ -216,12 +207,12 @@ test('catchall overrides strict', () => {
   // should only run catchall validation
   // against unknown keys
   o1.parse({
-    first: 'asdf',
+    first: "asdf",
     asdf: 1234,
   });
 });
 
-test('catchall overrides strict', () => {
+test("catchall overrides strict", () => {
   const o1 = z
     .object({
       first: z.string(),
@@ -232,42 +223,42 @@ test('catchall overrides strict', () => {
   // should run fine
   // setting a catchall overrides the unknownKeys behavior
   o1.parse({
-    first: 'asdf',
+    first: "asdf",
     asdf: 1234,
   });
 });
 
-test('test that optional keys are unset', async () => {
+test("test that optional keys are unset", async () => {
   const SNamedEntity = z.object({
     id: z.string(),
     set: z.string().optional(),
     unset: z.string().optional(),
   });
   const result = await SNamedEntity.parse({
-    id: 'asdf',
+    id: "asdf",
     set: undefined,
   });
-  expect(Object.keys(result)).toEqual(['id', 'set']);
+  expect(Object.keys(result)).toEqual(["id", "set"]);
 });
 
-test('test catchall parsing', async () => {
+test("test catchall parsing", async () => {
   const result = z
     .object({ name: z.string() })
     .catchall(z.number())
-    .parse({ name: 'Foo', validExtraKey: 61 });
+    .parse({ name: "Foo", validExtraKey: 61 });
 
-  expect(result).toEqual({ name: 'Foo', validExtraKey: 61 });
+  expect(result).toEqual({ name: "Foo", validExtraKey: 61 });
 
   const result2 = z
     .object({ name: z.string() })
     .catchall(z.number())
-    .safeParse({ name: 'Foo', validExtraKey: 61, invalid: 'asdf' });
+    .safeParse({ name: "Foo", validExtraKey: 61, invalid: "asdf" });
 
   expect(result2.success).toEqual(false);
   return result2;
 });
 
-test('test nonexistent keys', async () => {
+test("test nonexistent keys", async () => {
   const Schema = z.union([
     z.object({
       a: z.string(),
@@ -276,13 +267,13 @@ test('test nonexistent keys', async () => {
       b: z.number(),
     }),
   ]);
-  const obj = { a: 'A' };
+  const obj = { a: "A" };
   const result = await Schema.spa(obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
   expect(result.success).toBe(true);
   return result;
 });
 
-test('test async PseudoPromise.all', async () => {
+test("test async PseudoPromise.all", async () => {
   const Schema2 = z.union([
     z.object({
       ty: z.string(),
@@ -292,7 +283,7 @@ test('test async PseudoPromise.all', async () => {
     }),
   ]);
 
-  const obj = { ty: 'A' };
+  const obj = { ty: "A" };
   const result = await Schema2.spa(obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
   expect(result.success).toEqual(true);
   return result;

--- a/src/__tests__/optional.test.ts
+++ b/src/__tests__/optional.test.ts
@@ -1,4 +1,4 @@
-import * as z from '../index';
+import * as z from "../index";
 
 function checkErrors(a: z.ZodTypeAny, bad: any) {
   let expected;
@@ -14,39 +14,21 @@ function checkErrors(a: z.ZodTypeAny, bad: any) {
   }
 }
 
-it('Should have error messages appropriate for the underlying type', () => {
+it("Should have error messages appropriate for the underlying type", () => {
   checkErrors(z.string().min(2), 1);
-  z.string()
-    .min(2)
-    .optional()
-    .parse(undefined);
+  z.string().min(2).optional().parse(undefined);
   checkErrors(z.number().min(2), 1);
-  z.number()
-    .min(2)
-    .optional()
-    .parse(undefined);
-  checkErrors(z.boolean(), '');
-  z.boolean()
-    .optional()
-    .parse(undefined);
+  z.number().min(2).optional().parse(undefined);
+  checkErrors(z.boolean(), "");
+  z.boolean().optional().parse(undefined);
   checkErrors(z.undefined(), null);
-  z.undefined()
-    .optional()
-    .parse(undefined);
+  z.undefined().optional().parse(undefined);
   checkErrors(z.null(), {});
-  z.null()
-    .optional()
-    .parse(undefined);
+  z.null().optional().parse(undefined);
   checkErrors(z.object({}), 1);
-  z.object({})
-    .optional()
-    .parse(undefined);
+  z.object({}).optional().parse(undefined);
   checkErrors(z.tuple([]), 1);
-  z.tuple([])
-    .optional()
-    .parse(undefined);
+  z.tuple([]).optional().parse(undefined);
   checkErrors(z.unknown(), 1);
-  z.unknown()
-    .optional()
-    .parse(undefined);
+  z.unknown().optional().parse(undefined);
 });

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -1,44 +1,44 @@
-import * as z from '../index';
+import * as z from "../index";
 
-test('parse strict object with unknown keys', () => {
+test("parse strict object with unknown keys", () => {
   expect(() =>
     z
       .object({ name: z.string() })
       .strict()
-      .parse({ name: 'bill', unknownKey: 12 } as any),
+      .parse({ name: "bill", unknownKey: 12 } as any)
   ).toThrow();
 });
 
-test('parse nonstrict object with unknown keys', () => {
+test("parse nonstrict object with unknown keys", () => {
   z.object({ name: z.string() })
     .nonstrict()
-    .parse({ name: 'bill', unknownKey: 12 });
+    .parse({ name: "bill", unknownKey: 12 });
 });
 
-test('invalid left side of intersection', () => {
+test("invalid left side of intersection", () => {
   expect(() =>
-    z.intersection(z.string(), z.number()).parse(12 as any),
+    z.intersection(z.string(), z.number()).parse(12 as any)
   ).toThrow();
 });
 
-test('invalid right side of intersection', () => {
+test("invalid right side of intersection", () => {
   expect(() =>
-    z.intersection(z.string(), z.number()).parse('12' as any),
+    z.intersection(z.string(), z.number()).parse("12" as any)
   ).toThrow();
 });
 
-test('parsing non-array in tuple schema', () => {
-  expect(() => z.tuple([]).parse('12' as any)).toThrow();
+test("parsing non-array in tuple schema", () => {
+  expect(() => z.tuple([]).parse("12" as any)).toThrow();
 });
 
-test('incorrect num elements in tuple', () => {
-  expect(() => z.tuple([]).parse(['asdf'] as any)).toThrow();
+test("incorrect num elements in tuple", () => {
+  expect(() => z.tuple([]).parse(["asdf"] as any)).toThrow();
 });
 
-test('invalid enum value', () => {
-  expect(() => z.enum(['Blue']).parse('Red' as any)).toThrow();
+test("invalid enum value", () => {
+  expect(() => z.enum(["Blue"]).parse("Red" as any)).toThrow();
 });
 
-test('parsing unknown', () => {
-  z.string().parse('Red' as unknown);
+test("parsing unknown", () => {
+  z.string().parse("Red" as unknown);
 });

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -1,5 +1,5 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
 const nested = z.object({
   name: z.string(),
@@ -9,7 +9,7 @@ const nested = z.object({
   }),
 });
 
-test('shallow inference', () => {
+test("shallow inference", () => {
   const shallow = nested.partial();
   type shallow = z.infer<typeof shallow>;
   type correct = {
@@ -21,16 +21,16 @@ test('shallow inference', () => {
   t1;
 });
 
-test('shallow partial parse', () => {
+test("shallow partial parse", () => {
   const shallow = nested.partial();
   shallow.parse({});
   shallow.parse({
-    name: 'asdf',
+    name: "asdf",
     age: 23143,
   });
 });
 
-test('deep partial inference', () => {
+test("deep partial inference", () => {
   const deep = nested.deepPartial();
   type deep = z.infer<typeof deep>;
   type correct = {
@@ -43,31 +43,31 @@ test('deep partial inference', () => {
   t1;
 });
 
-test('deep partial parse', () => {
+test("deep partial parse", () => {
   const deep = nested.deepPartial();
   expect(deep.shape.name instanceof z.ZodOptional).toBe(true);
   expect(deep.shape.outer instanceof z.ZodOptional).toBe(true);
   expect(deep.shape.outer._def.innerType instanceof z.ZodObject).toBe(true);
   expect(
-    deep.shape.outer._def.innerType.shape.inner instanceof z.ZodOptional,
+    deep.shape.outer._def.innerType.shape.inner instanceof z.ZodOptional
   ).toBe(true);
   expect(
     deep.shape.outer._def.innerType.shape.inner._def.innerType instanceof
-      z.ZodString,
+      z.ZodString
   ).toBe(true);
 });
 
-test('deep partial runtime tests', () => {
+test("deep partial runtime tests", () => {
   const deep = nested.deepPartial();
   deep.parse({});
   deep.parse({
     outer: {},
   });
   deep.parse({
-    name: 'asdf',
+    name: "asdf",
     age: 23143,
     outer: {
-      inner: 'adsf',
+      inner: "adsf",
     },
   });
 });

--- a/src/__tests__/pickomit.test.ts
+++ b/src/__tests__/pickomit.test.ts
@@ -1,5 +1,5 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
 const fish = z.object({
   name: z.string(),
@@ -7,26 +7,26 @@ const fish = z.object({
   nested: z.object({}),
 });
 
-test('pick type inference', () => {
+test("pick type inference", () => {
   const nameonlyFish = fish.pick({ name: true });
   type nameonlyFish = z.infer<typeof nameonlyFish>;
   const f1: util.AssertEqual<nameonlyFish, { name: string }> = true;
   f1;
 });
 
-test('pick parse - success', () => {
+test("pick parse - success", () => {
   const nameonlyFish = fish.pick({ name: true });
-  nameonlyFish.parse({ name: 'bob' });
+  nameonlyFish.parse({ name: "bob" });
 });
 
-test('pick parse - fail', () => {
-  fish.pick({ name: true }).parse({ name: '12' } as any);
-  fish.pick({ name: true }).parse({ name: 'bob', age: 12 } as any);
+test("pick parse - fail", () => {
+  fish.pick({ name: true }).parse({ name: "12" } as any);
+  fish.pick({ name: true }).parse({ name: "bob", age: 12 } as any);
   fish.pick({ age: true }).parse({ age: 12 } as any);
 
   const nameonlyFish = fish.pick({ name: true }).strict();
   const bad1 = () => nameonlyFish.parse({ name: 12 } as any);
-  const bad2 = () => nameonlyFish.parse({ name: 'bob', age: 12 } as any);
+  const bad2 = () => nameonlyFish.parse({ name: "bob", age: 12 } as any);
   const bad3 = () => nameonlyFish.parse({ age: 12 } as any);
 
   expect(bad1).toThrow();
@@ -34,19 +34,19 @@ test('pick parse - fail', () => {
   expect(bad3).toThrow();
 });
 
-test('omit type inference', () => {
+test("omit type inference", () => {
   const nonameFish = fish.omit({ name: true });
   type nonameFish = z.infer<typeof nonameFish>;
   const f1: util.AssertEqual<nonameFish, { age: number; nested: {} }> = true;
   f1;
 });
 
-test('omit parse - success', () => {
+test("omit parse - success", () => {
   const nonameFish = fish.omit({ name: true });
   nonameFish.parse({ age: 12, nested: {} });
 });
 
-test('omit parse - fail', () => {
+test("omit parse - fail", () => {
   const nonameFish = fish.omit({ name: true });
   const bad1 = () => nonameFish.parse({ name: 12 } as any);
   const bad2 = () => nonameFish.parse({ age: 12 } as any);
@@ -57,7 +57,7 @@ test('omit parse - fail', () => {
   expect(bad3).toThrow();
 });
 
-test('nonstrict inference', () => {
+test("nonstrict inference", () => {
   const laxfish = fish.nonstrict().pick({ name: true });
   type laxfish = z.infer<typeof laxfish>;
   const f1: util.AssertEqual<
@@ -67,14 +67,14 @@ test('nonstrict inference', () => {
   f1;
 });
 
-test('nonstrict parsing - pass', () => {
+test("nonstrict parsing - pass", () => {
   const laxfish = fish.nonstrict().pick({ name: true });
-  laxfish.parse({ name: 'asdf', whatever: 'asdf' });
-  laxfish.parse({ name: 'asdf', age: 12, nested: {} });
+  laxfish.parse({ name: "asdf", whatever: "asdf" });
+  laxfish.parse({ name: "asdf", age: 12, nested: {} });
 });
 
-test('nonstrict parsing - fail', () => {
+test("nonstrict parsing - fail", () => {
   const laxfish = fish.nonstrict().pick({ name: true });
-  const bad = () => laxfish.parse({ whatever: 'asdf' } as any);
+  const bad = () => laxfish.parse({ whatever: "asdf" } as any);
   expect(bad).toThrow();
 });

--- a/src/__tests__/primitive.test.ts
+++ b/src/__tests__/primitive.test.ts
@@ -1,7 +1,7 @@
-import * as z from '../index';
-import { Mocker } from '../helpers/Mocker';
+import * as z from "../index";
+import { Mocker } from "../helpers/Mocker";
 
-const literalStringSchema = z.literal('asdf');
+const literalStringSchema = z.literal("asdf");
 const literalNumberSchema = z.literal(12);
 const literalBooleanSchema = z.literal(true);
 const stringSchema = z.string();
@@ -24,273 +24,273 @@ const dateSchemaNullable = z.date().nullable();
 
 const val = new Mocker();
 
-test('literal string correct', () => {
-  expect(literalStringSchema.parse('asdf')).toBe('asdf');
+test("literal string correct", () => {
+  expect(literalStringSchema.parse("asdf")).toBe("asdf");
 });
 
-test('literal string incorrect', () => {
-  const f = () => literalStringSchema.parse('not_asdf');
+test("literal string incorrect", () => {
+  const f = () => literalStringSchema.parse("not_asdf");
   expect(f).toThrow();
 });
 
-test('literal string number', () => {
+test("literal string number", () => {
   const f = () => literalStringSchema.parse(123);
   expect(f).toThrow();
 });
 
-test('literal string boolean', () => {
+test("literal string boolean", () => {
   const f = () => literalStringSchema.parse(true);
   expect(f).toThrow();
 });
 
-test('literal string boolean', () => {
+test("literal string boolean", () => {
   const f = () => literalStringSchema.parse(true);
   expect(f).toThrow();
 });
 
-test('literal string object', () => {
+test("literal string object", () => {
   const f = () => literalStringSchema.parse({});
   expect(f).toThrow();
 });
 
-test('literal number correct', () => {
+test("literal number correct", () => {
   expect(literalNumberSchema.parse(12)).toBe(12);
 });
 
-test('literal number incorrect', () => {
+test("literal number incorrect", () => {
   const f = () => literalNumberSchema.parse(13);
   expect(f).toThrow();
 });
 
-test('literal number number', () => {
+test("literal number number", () => {
   const f = () => literalNumberSchema.parse(val.string);
   expect(f).toThrow();
 });
 
-test('literal number boolean', () => {
+test("literal number boolean", () => {
   const f = () => literalNumberSchema.parse(val.boolean);
   expect(f).toThrow();
 });
 
-test('literal number object', () => {
+test("literal number object", () => {
   const f = () => literalStringSchema.parse({});
   expect(f).toThrow();
 });
 
-test('literal boolean correct', () => {
+test("literal boolean correct", () => {
   expect(literalBooleanSchema.parse(true)).toBe(true);
 });
 
-test('literal boolean incorrect', () => {
+test("literal boolean incorrect", () => {
   const f = () => literalBooleanSchema.parse(false);
   expect(f).toThrow();
 });
 
-test('literal boolean number', () => {
-  const f = () => literalBooleanSchema.parse('asdf');
+test("literal boolean number", () => {
+  const f = () => literalBooleanSchema.parse("asdf");
   expect(f).toThrow();
 });
 
-test('literal boolean boolean', () => {
+test("literal boolean boolean", () => {
   const f = () => literalBooleanSchema.parse(123);
   expect(f).toThrow();
 });
 
-test('literal boolean object', () => {
+test("literal boolean object", () => {
   const f = () => literalBooleanSchema.parse({});
   expect(f).toThrow();
 });
 
-test('parse stringSchema string', () => {
+test("parse stringSchema string", () => {
   stringSchema.parse(val.string);
 });
 
-test('parse stringSchema number', () => {
+test("parse stringSchema number", () => {
   const f = () => stringSchema.parse(val.number);
   expect(f).toThrow();
 });
 
-test('parse stringSchema boolean', () => {
+test("parse stringSchema boolean", () => {
   const f = () => stringSchema.parse(val.boolean);
   expect(f).toThrow();
 });
 
-test('parse stringSchema undefined', () => {
+test("parse stringSchema undefined", () => {
   const f = () => stringSchema.parse(val.undefined);
   expect(f).toThrow();
 });
 
-test('parse stringSchema null', () => {
+test("parse stringSchema null", () => {
   const f = () => stringSchema.parse(val.null);
   expect(f).toThrow();
 });
 
-test('parse numberSchema string', () => {
+test("parse numberSchema string", () => {
   const f = () => numberSchema.parse(val.string);
   expect(f).toThrow();
 });
 
-test('parse numberSchema number', () => {
+test("parse numberSchema number", () => {
   numberSchema.parse(val.number);
 });
 
-test('parse numberSchema bigint', () => {
+test("parse numberSchema bigint", () => {
   const f = () => numberSchema.parse(val.bigint);
   expect(f).toThrow();
 });
 
-test('parse numberSchema boolean', () => {
+test("parse numberSchema boolean", () => {
   const f = () => numberSchema.parse(val.boolean);
   expect(f).toThrow();
 });
 
-test('parse numberSchema undefined', () => {
+test("parse numberSchema undefined", () => {
   const f = () => numberSchema.parse(val.undefined);
   expect(f).toThrow();
 });
 
-test('parse numberSchema null', () => {
+test("parse numberSchema null", () => {
   const f = () => numberSchema.parse(val.null);
   expect(f).toThrow();
 });
 
-test('parse bigintSchema string', () => {
+test("parse bigintSchema string", () => {
   const f = () => bigintSchema.parse(val.string);
   expect(f).toThrow();
 });
 
-test('parse bigintSchema number', () => {
+test("parse bigintSchema number", () => {
   const f = () => bigintSchema.parse(val.number);
   expect(f).toThrow();
 });
 
-test('parse bigintSchema bigint', () => {
+test("parse bigintSchema bigint", () => {
   bigintSchema.parse(val.bigint);
 });
 
-test('parse bigintSchema boolean', () => {
+test("parse bigintSchema boolean", () => {
   const f = () => bigintSchema.parse(val.boolean);
   expect(f).toThrow();
 });
 
-test('parse bigintSchema undefined', () => {
+test("parse bigintSchema undefined", () => {
   const f = () => bigintSchema.parse(val.undefined);
   expect(f).toThrow();
 });
 
-test('parse bigintSchema null', () => {
+test("parse bigintSchema null", () => {
   const f = () => bigintSchema.parse(val.null);
   expect(f).toThrow();
 });
 
-test('parse booleanSchema string', () => {
+test("parse booleanSchema string", () => {
   const f = () => booleanSchema.parse(val.string);
   expect(f).toThrow();
 });
 
-test('parse booleanSchema number', () => {
+test("parse booleanSchema number", () => {
   const f = () => booleanSchema.parse(val.number);
   expect(f).toThrow();
 });
 
-test('parse booleanSchema boolean', () => {
+test("parse booleanSchema boolean", () => {
   booleanSchema.parse(val.boolean);
 });
 
-test('parse booleanSchema undefined', () => {
+test("parse booleanSchema undefined", () => {
   const f = () => booleanSchema.parse(val.undefined);
   expect(f).toThrow();
 });
 
-test('parse booleanSchema null', () => {
+test("parse booleanSchema null", () => {
   const f = () => booleanSchema.parse(val.null);
   expect(f).toThrow();
 });
 
 // ==============
 
-test('parse dateSchema string', () => {
+test("parse dateSchema string", () => {
   const f = () => dateSchema.parse(val.string);
   expect(f).toThrow();
 });
 
-test('parse dateSchema number', () => {
+test("parse dateSchema number", () => {
   const f = () => dateSchema.parse(val.number);
   expect(f).toThrow();
 });
 
-test('parse dateSchema boolean', () => {
+test("parse dateSchema boolean", () => {
   const f = () => dateSchema.parse(val.boolean);
   expect(f).toThrow();
 });
 
-test('parse dateSchema date', () => {
+test("parse dateSchema date", () => {
   dateSchema.parse(val.date);
 });
 
-test('parse dateSchema undefined', () => {
+test("parse dateSchema undefined", () => {
   const f = () => dateSchema.parse(val.undefined);
   expect(f).toThrow();
 });
 
-test('parse dateSchema null', () => {
+test("parse dateSchema null", () => {
   const f = () => dateSchema.parse(val.null);
   expect(f).toThrow();
 });
 
-test('parse dateSchema invalid date', async () => {
+test("parse dateSchema invalid date", async () => {
   expect.assertions(1);
-  return await dateSchema.parseAsync(new Date('invalid')).catch(err => {
+  return await dateSchema.parseAsync(new Date("invalid")).catch((err) => {
     expect(err.issues[0].code).toEqual(z.ZodIssueCode.invalid_date);
   });
 });
 // ==============
 
-test('parse undefinedSchema string', () => {
+test("parse undefinedSchema string", () => {
   const f = () => undefinedSchema.parse(val.string);
   expect(f).toThrow();
 });
 
-test('parse undefinedSchema number', () => {
+test("parse undefinedSchema number", () => {
   const f = () => undefinedSchema.parse(val.number);
   expect(f).toThrow();
 });
 
-test('parse undefinedSchema boolean', () => {
+test("parse undefinedSchema boolean", () => {
   const f = () => undefinedSchema.parse(val.boolean);
   expect(f).toThrow();
 });
 
-test('parse undefinedSchema undefined', () => {
+test("parse undefinedSchema undefined", () => {
   undefinedSchema.parse(val.undefined);
 });
 
-test('parse undefinedSchema null', () => {
+test("parse undefinedSchema null", () => {
   const f = () => undefinedSchema.parse(val.null);
   expect(f).toThrow();
 });
 
-test('parse nullSchema string', () => {
+test("parse nullSchema string", () => {
   const f = () => nullSchema.parse(val.string);
   expect(f).toThrow();
 });
 
-test('parse nullSchema number', () => {
+test("parse nullSchema number", () => {
   const f = () => nullSchema.parse(val.number);
   expect(f).toThrow();
 });
 
-test('parse nullSchema boolean', () => {
+test("parse nullSchema boolean", () => {
   const f = () => nullSchema.parse(val.boolean);
   expect(f).toThrow();
 });
 
-test('parse nullSchema undefined', () => {
+test("parse nullSchema undefined", () => {
   const f = () => nullSchema.parse(val.undefined);
   expect(f).toThrow();
 });
 
-test('parse nullSchema null', () => {
+test("parse nullSchema null", () => {
   nullSchema.parse(val.null);
 });
 
@@ -306,10 +306,10 @@ type AssertEqual<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
   ? true
   : never;
 
-test('primitive inference', () => {
+test("primitive inference", () => {
   const literalStringSchemaTest: AssertEqual<
     z.TypeOf<typeof literalStringSchema>,
-    'asdf'
+    "asdf"
   > = true;
   const literalNumberSchemaTest: AssertEqual<
     z.TypeOf<typeof literalNumberSchema>,

--- a/src/__tests__/promise.test.ts
+++ b/src/__tests__/promise.test.ts
@@ -1,14 +1,14 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
 const promSchema = z.promise(
   z.object({
     name: z.string(),
     age: z.number(),
-  }),
+  })
 );
 
-test('promise inference', () => {
+test("promise inference", () => {
   type promSchemaType = z.infer<typeof promSchema>;
   const t1: util.AssertEqual<
     promSchemaType,
@@ -17,36 +17,36 @@ test('promise inference', () => {
   t1;
 });
 
-test('promise parsing success', async () => {
-  const pr = promSchema.parse(Promise.resolve({ name: 'Bobby', age: 10 }));
+test("promise parsing success", async () => {
+  const pr = promSchema.parse(Promise.resolve({ name: "Bobby", age: 10 }));
   expect(pr).toBeInstanceOf(Promise);
   const result = await pr;
-  expect(typeof result).toBe('object');
-  expect(typeof result.age).toBe('number');
-  expect(typeof result.name).toBe('string');
+  expect(typeof result).toBe("object");
+  expect(typeof result.age).toBe("number");
+  expect(typeof result.name).toBe("string");
   return result;
 });
 
-test('promise parsing success 2', () => {
+test("promise parsing success 2", () => {
   promSchema.parse({ then: () => {}, catch: () => {} });
 });
 
-test('promise parsing fail', async () => {
-  const bad = promSchema.parse(Promise.resolve({ name: 'Bobby', age: '10' }));
+test("promise parsing fail", async () => {
+  const bad = promSchema.parse(Promise.resolve({ name: "Bobby", age: "10" }));
   // return await expect(bad).resolves.toBe({ name: 'Bobby', age: '10' });
   return await expect(bad).rejects.toBeInstanceOf(Error);
   // done();
 });
 
-test('promise parsing fail 2', async () => {
+test("promise parsing fail 2", async () => {
   const failPromise = promSchema.parse(
-    Promise.resolve({ name: 'Bobby', age: '10' }),
+    Promise.resolve({ name: "Bobby", age: "10" })
   );
   return await expect(failPromise).rejects.toBeInstanceOf(Error);
   // done();/z
 });
 
-test('promise parsing fail', () => {
+test("promise parsing fail", () => {
   const bad = () => promSchema.parse({ then: () => {}, catch: {} });
   expect(bad).toThrow();
 });
@@ -57,24 +57,24 @@ test('promise parsing fail', () => {
 
 const asyncFunction = z.function(z.tuple([]), promSchema);
 
-test('async function pass', async () => {
+test("async function pass", async () => {
   const validatedFunction = asyncFunction.implement(async () => {
-    return { name: 'jimmy', age: 14 };
+    return { name: "jimmy", age: 14 };
   });
   return await expect(validatedFunction()).resolves.toEqual({
-    name: 'jimmy',
+    name: "jimmy",
     age: 14,
   });
 });
 
-test('async function fail', async () => {
+test("async function fail", async () => {
   const validatedFunction = asyncFunction.implement(() => {
-    return Promise.resolve('asdf' as any);
+    return Promise.resolve("asdf" as any);
   });
   return await expect(validatedFunction()).rejects.toBeInstanceOf(Error);
 });
 
-test('async promise parsing', () => {
+test("async promise parsing", () => {
   const res = z.promise(z.number()).parseAsync(Promise.resolve(12));
   expect(res).toBeInstanceOf(Promise);
 });

--- a/src/__tests__/pseudopromise.test.ts
+++ b/src/__tests__/pseudopromise.test.ts
@@ -1,19 +1,19 @@
 // import * as z from '.';
-import { PseudoPromise } from '../PseudoPromise';
+import { PseudoPromise } from "../PseudoPromise";
 
-test('sync pass', () => {
+test("sync pass", () => {
   const myProm = new PseudoPromise()
     .then(() => 15)
-    .then(arg => arg.toString())
-    .then(arg => arg.length);
+    .then((arg) => arg.toString())
+    .then((arg) => arg.length);
   expect(myProm.getValueSync()).toEqual(2);
 });
 
-test('sync fail', async () => {
+test("sync fail", async () => {
   const myProm = new PseudoPromise()
     .then(async () => 15)
-    .then(arg => arg.toString())
-    .then(arg => {
+    .then((arg) => arg.toString())
+    .then((arg) => {
       return arg.length;
     });
 
@@ -26,51 +26,51 @@ test('sync fail', async () => {
   // (myProm.getValue() as Promise<any>).then(val => expect(val).toEqual(2));
 });
 
-test('pseudopromise all', async () => {
+test("pseudopromise all", async () => {
   const myProm = PseudoPromise.all([
-    new PseudoPromise().then(() => 'asdf'),
+    new PseudoPromise().then(() => "asdf"),
     PseudoPromise.resolve(12),
   ]).getValueAsync();
   expect.assertions(1);
   const val = await myProm;
-  expect(val).toEqual(['asdf', 12]);
+  expect(val).toEqual(["asdf", 12]);
   return val;
 });
 
-test('.resolve sync ', () => {
+test(".resolve sync ", () => {
   expect(PseudoPromise.resolve(12).getValueSync()).toEqual(12);
 });
 
-test('.resolve async', () => {
+test(".resolve async", () => {
   expect.assertions(1);
 
   return PseudoPromise.resolve(Promise.resolve(12))
     .getValueAsync()
-    .then(val => expect(val).toEqual(12));
+    .then((val) => expect(val).toEqual(12));
 });
 
-test('sync and async', () => {
+test("sync and async", () => {
   expect.assertions(2);
   expect(PseudoPromise.resolve(15).getValueSync()).toEqual(15);
   return PseudoPromise.resolve(15)
     .getValueAsync()
-    .then(val => expect(val).toEqual(15));
+    .then((val) => expect(val).toEqual(15));
 });
 
-test('object', async () => {
+test("object", async () => {
   const prom = PseudoPromise.object({
     asdf: PseudoPromise.resolve(15),
-    qwer: new PseudoPromise().then(async () => 'asdfadsf'),
+    qwer: new PseudoPromise().then(async () => "asdfadsf"),
   });
 
-  expect(await prom.getValueAsync()).toEqual({ asdf: 15, qwer: 'asdfadsf' });
-  return 'asdf';
+  expect(await prom.getValueAsync()).toEqual({ asdf: 15, qwer: "asdfadsf" });
+  return "asdf";
 });
 
-test('all', async () => {
-  const asdf = new PseudoPromise().then(async () => 'asdf');
+test("all", async () => {
+  const asdf = new PseudoPromise().then(async () => "asdf");
   await PseudoPromise.all([asdf])
     .getValueAsync()
-    .then(val => expect(val).toEqual(['asdf']));
-  return 'asdf';
+    .then((val) => expect(val).toEqual(["asdf"]));
+  return "asdf";
 });

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -1,21 +1,21 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { util } from "../helpers/util";
 
 const booleanRecord = z.record(z.boolean());
 type booleanRecord = z.infer<typeof booleanRecord>;
 
-test('type inference', () => {
+test("type inference", () => {
   const f1: util.AssertEqual<booleanRecord, Record<string, boolean>> = true;
   f1;
 });
 
-test('methods', () => {
+test("methods", () => {
   booleanRecord.toJSON();
   booleanRecord.optional();
   booleanRecord.nullable();
 });
 
-test('string record parse - pass', () => {
+test("string record parse - pass", () => {
   booleanRecord.parse({
     k1: true,
     k2: false,
@@ -23,17 +23,17 @@ test('string record parse - pass', () => {
   });
 });
 
-test('string record parse - fail', () => {
+test("string record parse - fail", () => {
   const badCheck = () =>
     booleanRecord.parse({
       asdf: 1234,
     } as any);
   expect(badCheck).toThrow();
 
-  expect(() => booleanRecord.parse('asdf')).toThrow();
+  expect(() => booleanRecord.parse("asdf")).toThrow();
 });
 
-test('string record parse - fail', () => {
+test("string record parse - fail", () => {
   const badCheck = () =>
     booleanRecord.parse({
       asdf: {},
@@ -41,7 +41,7 @@ test('string record parse - fail', () => {
   expect(badCheck).toThrow();
 });
 
-test('string record parse - fail', () => {
+test("string record parse - fail", () => {
   const badCheck = () =>
     booleanRecord.parse({
       asdf: [],

--- a/src/__tests__/recursive.test.ts
+++ b/src/__tests__/recursive.test.ts
@@ -1,4 +1,4 @@
-test('', () => {});
+test("", () => {});
 // import * as z from '../index';
 
 // interface A {

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -1,7 +1,7 @@
-import * as z from '../index';
-import { ZodIssueCode } from '../ZodError';
+import * as z from "../index";
+import { ZodIssueCode } from "../ZodError";
 
-test('refinement', () => {
+test("refinement", () => {
   const obj1 = z.object({
     first: z.string(),
     second: z.string(),
@@ -9,22 +9,22 @@ test('refinement', () => {
   const obj2 = obj1.partial().strict();
 
   const obj3 = obj2.refine(
-    data => data.first || data.second,
-    'Either first or second should be filled in.',
+    (data) => data.first || data.second,
+    "Either first or second should be filled in."
   );
 
   expect(obj1 === (obj2 as any)).toEqual(false);
   expect(obj2 === obj3).toEqual(false);
 
   expect(() => obj1.parse({})).toThrow();
-  expect(() => obj2.parse({ third: 'adsf' })).toThrow();
+  expect(() => obj2.parse({ third: "adsf" })).toThrow();
   expect(() => obj3.parse({})).toThrow();
-  obj3.parse({ first: 'a' });
-  obj3.parse({ second: 'a' });
-  obj3.parse({ first: 'a', second: 'a' });
+  obj3.parse({ first: "a" });
+  obj3.parse({ second: "a" });
+  obj3.parse({ first: "a", second: "a" });
 });
 
-test('refinement 2', () => {
+test("refinement 2", () => {
   const validationSchema = z
     .object({
       email: z.string().email(),
@@ -32,40 +32,40 @@ test('refinement 2', () => {
       confirmPassword: z.string(),
     })
     .refine(
-      data => data.password === data.confirmPassword,
-      'Both password and confirmation must match',
+      (data) => data.password === data.confirmPassword,
+      "Both password and confirmation must match"
     );
 
   expect(() =>
     validationSchema.parse({
-      email: 'aaaa@gmail.com',
-      password: 'aaaaaaaa',
-      confirmPassword: 'bbbbbbbb',
-    }),
+      email: "aaaa@gmail.com",
+      password: "aaaaaaaa",
+      confirmPassword: "bbbbbbbb",
+    })
   ).toThrow();
 });
 
-test('custom path', async () => {
+test("custom path", async () => {
   expect.assertions(1);
   await z
     .object({
       password: z.string(),
       confirm: z.string(),
     })
-    .refine(data => data.confirm === data.password, { path: ['confirm'] })
-    .parseAsync({ password: 'asdf', confirm: 'qewr' })
-    .catch(err => {
-      expect(err.issues[0].path).toEqual(['confirm']);
+    .refine((data) => data.confirm === data.password, { path: ["confirm"] })
+    .parseAsync({ password: "asdf", confirm: "qewr" })
+    .catch((err) => {
+      expect(err.issues[0].path).toEqual(["confirm"]);
     });
-  return 'asdf';
+  return "asdf";
 });
 
-test('use path in refinement context', async () => {
+test("use path in refinement context", async () => {
   const noNested = z.string()._refinement((_val, ctx) => {
     if (ctx.path.length > 0) {
       ctx.addIssue({
         code: ZodIssueCode.custom,
-        message: `schema cannot be nested. path: ${ctx.path.join('.')}`,
+        message: `schema cannot be nested. path: ${ctx.path.join(".")}`,
       });
     }
   });
@@ -74,14 +74,14 @@ test('use path in refinement context', async () => {
     foo: noNested,
   });
 
-  const t1 = await noNested.spa('asdf');
-  const t2 = await data.spa({ foo: 'asdf' });
+  const t1 = await noNested.spa("asdf");
+  const t2 = await data.spa({ foo: "asdf" });
 
   expect(t1.success).toBe(true);
   expect(t2.success).toBe(false);
   if (t2.success === false) {
     expect(t2.error.issues[0].message).toEqual(
-      'schema cannot be nested. path: foo',
+      "schema cannot be nested. path: foo"
     );
   }
   return t2;

--- a/src/__tests__/safeparse.test.ts
+++ b/src/__tests__/safeparse.test.ts
@@ -1,24 +1,24 @@
-import * as z from '../index';
+import * as z from "../index";
 const stringSchema = z.string();
 
-test('safeparse fail', () => {
+test("safeparse fail", () => {
   const safe = stringSchema.safeParse(12);
   expect(safe.success).toEqual(false);
   expect((safe as any).error).toBeInstanceOf(z.ZodError);
 });
 
-test('safeparse pass', () => {
-  const safe = stringSchema.safeParse('12');
+test("safeparse pass", () => {
+  const safe = stringSchema.safeParse("12");
   expect(safe.success).toEqual(true);
-  expect((safe as any).data).toEqual('12');
+  expect((safe as any).data).toEqual("12");
 });
 
-test('safeparse unexpected error', () => {
+test("safeparse unexpected error", () => {
   expect(() =>
     stringSchema
-      .refine(data => {
+      .refine((data) => {
         throw new Error(data);
       })
-      .safeParse('12'),
+      .safeParse("12")
   ).toThrow();
 });

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -1,111 +1,90 @@
-import * as z from '../index';
+import * as z from "../index";
 
-const minFive = z.string().min(5, 'min5');
-const maxFive = z.string().max(5, 'max5');
+const minFive = z.string().min(5, "min5");
+const maxFive = z.string().max(5, "max5");
 const justFive = z.string().length(5);
-const nonempty = z.string().nonempty('nonempty');
+const nonempty = z.string().nonempty("nonempty");
 
-test('passing validations', () => {
-  minFive.parse('12345');
-  minFive.parse('123456');
-  maxFive.parse('12345');
-  maxFive.parse('1234');
-  nonempty.parse('1');
-  justFive.parse('12345');
+test("passing validations", () => {
+  minFive.parse("12345");
+  minFive.parse("123456");
+  maxFive.parse("12345");
+  maxFive.parse("1234");
+  nonempty.parse("1");
+  justFive.parse("12345");
 });
 
-test('failing validations', () => {
-  expect(() => minFive.parse('1234')).toThrow();
-  expect(() => maxFive.parse('123456')).toThrow();
-  expect(() => nonempty.parse('')).toThrow();
-  expect(() => justFive.parse('1234')).toThrow();
-  expect(() => justFive.parse('123456')).toThrow();
+test("failing validations", () => {
+  expect(() => minFive.parse("1234")).toThrow();
+  expect(() => maxFive.parse("123456")).toThrow();
+  expect(() => nonempty.parse("")).toThrow();
+  expect(() => justFive.parse("1234")).toThrow();
+  expect(() => justFive.parse("123456")).toThrow();
 });
 
-test('email validations', () => {
+test("email validations", () => {
   const email = z.string().email();
-  email.parse('mojojojo@example.com');
-  expect(() => email.parse('asdf')).toThrow();
-  expect(() => email.parse('@lkjasdf.com')).toThrow();
-  expect(() => email.parse('asdf@sdf.')).toThrow();
+  email.parse("mojojojo@example.com");
+  expect(() => email.parse("asdf")).toThrow();
+  expect(() => email.parse("@lkjasdf.com")).toThrow();
+  expect(() => email.parse("asdf@sdf.")).toThrow();
 });
 
-test('url validations', () => {
+test("url validations", () => {
   const url = z.string().url();
   try {
-    url.parse('http://google.com');
-    url.parse('https://google.com/asdf?asdf=ljk3lk4&asdf=234#asdf');
-    expect(() => url.parse('asdf')).toThrow();
-    expect(() => url.parse('https:/')).toThrow();
-    expect(() => url.parse('asdfj@lkjsdf.com')).toThrow();
+    url.parse("http://google.com");
+    url.parse("https://google.com/asdf?asdf=ljk3lk4&asdf=234#asdf");
+    expect(() => url.parse("asdf")).toThrow();
+    expect(() => url.parse("https:/")).toThrow();
+    expect(() => url.parse("asdfj@lkjsdf.com")).toThrow();
   } catch (err) {
     // console.log(JSON.stringify(err, null, 2));
   }
 });
 
-test('url error overrides', () => {
+test("url error overrides", () => {
   try {
-    z.string()
-      .url()
-      .parse('https');
+    z.string().url().parse("https");
   } catch (err) {
-    expect(err.issues[0].message).toEqual('Invalid url');
+    expect(err.issues[0].message).toEqual("Invalid url");
   }
   try {
-    z.string()
-      .url('badurl')
-      .parse('https');
+    z.string().url("badurl").parse("https");
   } catch (err) {
-    expect(err.issues[0].message).toEqual('badurl');
+    expect(err.issues[0].message).toEqual("badurl");
   }
   try {
-    z.string()
-      .url({ message: 'badurl' })
-      .parse('https');
+    z.string().url({ message: "badurl" }).parse("https");
   } catch (err) {
-    expect(err.issues[0].message).toEqual('badurl');
+    expect(err.issues[0].message).toEqual("badurl");
   }
 });
 
-test('uuid', () => {
-  z.string()
-    .uuid()
-    .parse('9491d710-3185-4e06-bea0-6a2f275345e0');
+test("uuid", () => {
+  z.string().uuid().parse("9491d710-3185-4e06-bea0-6a2f275345e0");
   expect(() =>
-    z
-      .string()
-      .uuid()
-      .parse('9491d710-3185-4e06-bea0-6a2f275345e'),
+    z.string().uuid().parse("9491d710-3185-4e06-bea0-6a2f275345e")
   ).toThrow();
 });
 
-test('regex', () => {
+test("regex", () => {
   z.string()
     .regex(/^moo+$/)
-    .parse('mooooo');
-  expect(() =>
-    z
-      .string()
-      .uuid()
-      .parse('purr'),
-  ).toThrow();
+    .parse("mooooo");
+  expect(() => z.string().uuid().parse("purr")).toThrow();
 });
 
-test('regexp error message', () => {
+test("regexp error message", () => {
   const result = z
     .string()
     .regex(/^moo+$/)
-    .safeParse('boooo');
+    .safeParse("boooo");
   if (!result.success) {
-    expect(result.error.issues[0].message).toEqual('Invalid');
+    expect(result.error.issues[0].message).toEqual("Invalid");
   } else {
-    throw new Error('validation should have failed');
+    throw new Error("validation should have failed");
   }
 
-  expect(() =>
-    z
-      .string()
-      .uuid()
-      .parse('purr'),
-  ).toThrow();
+  expect(() => z.string().uuid().parse("purr")).toThrow();
 });

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -1,33 +1,35 @@
-import * as z from '..';
-import { util } from '../helpers/util';
+import * as z from "..";
+import { util } from "../helpers/util";
 
-const stringToNumber = z.string().transform(z.number(), arg => parseFloat(arg));
-const numberToString = z.transformer(z.number(), z.string(), n => String(n));
-const asyncNumberToString = z.transformer(z.number(), z.string(), async n =>
-  String(n),
+const stringToNumber = z
+  .string()
+  .transform(z.number(), (arg) => parseFloat(arg));
+const numberToString = z.transformer(z.number(), z.string(), (n) => String(n));
+const asyncNumberToString = z.transformer(z.number(), z.string(), async (n) =>
+  String(n)
 );
 
-test('basic transformations', () => {
+test("basic transformations", () => {
   const r1 = z
-    .transformer(z.string(), z.number(), data => data.length)
-    .parse('asdf');
+    .transformer(z.string(), z.number(), (data) => data.length)
+    .parse("asdf");
   expect(r1).toEqual(4);
 });
 
-test('coercion', () => {
-  const numToString = z.transformer(z.number(), z.string(), n => String(n));
+test("coercion", () => {
+  const numToString = z.transformer(z.number(), z.string(), (n) => String(n));
   const data = z
     .object({
       id: numToString,
     })
     .parse({ id: 5 });
 
-  expect(data).toEqual({ id: '5' });
+  expect(data).toEqual({ id: "5" });
 });
 
-test('async coercion', async () => {
-  const numToString = z.transformer(z.number(), z.string(), async n =>
-    String(n),
+test("async coercion", async () => {
+  const numToString = z.transformer(z.number(), z.string(), async (n) =>
+    String(n)
   );
   const data = await z
     .object({
@@ -35,45 +37,39 @@ test('async coercion', async () => {
     })
     .parseAsync({ id: 5 });
 
-  expect(data).toEqual({ id: '5' });
-  return 'asdf';
+  expect(data).toEqual({ id: "5" });
+  return "asdf";
 });
 
-test('sync coercion async error', async () => {
+test("sync coercion async error", async () => {
   expect(() =>
     z
       .object({
         id: asyncNumberToString,
       })
-      .parse({ id: 5 }),
+      .parse({ id: 5 })
   ).toThrow();
-  return 'asdf';
+  return "asdf";
   // expect(data).toEqual({ id: '5' });
 });
 
-test('default', () => {
-  const data = z
-    .string()
-    .default('asdf')
-    .parse(undefined); // => "asdf"
-  expect(data).toEqual('asdf');
+test("default", () => {
+  const data = z.string().default("asdf").parse(undefined); // => "asdf"
+  expect(data).toEqual("asdf");
 });
 
-test('dynamic default', () => {
+test("dynamic default", () => {
   const data = z
     .string()
-    .default(s => s._def.t)
+    .default((s) => s._def.t)
     .parse(undefined); // => "asdf"
-  expect(data).toEqual('string');
+  expect(data).toEqual("string");
 });
 
-test('default when property is null or undefined', () => {
+test("default when property is null or undefined", () => {
   const data = z
     .object({
-      foo: z
-        .boolean()
-        .nullable()
-        .default(true),
+      foo: z.boolean().nullable().default(true),
       bar: z.boolean().default(true),
     })
     .parse({ foo: null });
@@ -81,19 +77,19 @@ test('default when property is null or undefined', () => {
   expect(data).toEqual({ foo: null, bar: true });
 });
 
-test('default with falsy values', () => {
+test("default with falsy values", () => {
   const schema = z.object({
-    emptyStr: z.string().default('def'),
+    emptyStr: z.string().default("def"),
     zero: z.number().default(5),
     falseBoolean: z.boolean().default(true),
   });
-  const input = { emptyStr: '', zero: 0, falseBoolean: true };
+  const input = { emptyStr: "", zero: 0, falseBoolean: true };
   const output = schema.parse(input);
   // defaults are not supposed to be used
   expect(output).toEqual(input);
 });
 
-test('object typing', () => {
+test("object typing", () => {
   const t1 = z.object({
     stringToNumber,
   });
@@ -107,17 +103,17 @@ test('object typing', () => {
   f2;
 });
 
-test('transform method overloads', () => {
-  const t1 = z.string().transform(val => val.toUpperCase());
-  expect(t1.parse('asdf')).toEqual('ASDF');
+test("transform method overloads", () => {
+  const t1 = z.string().transform((val) => val.toUpperCase());
+  expect(t1.parse("asdf")).toEqual("ASDF");
 
-  const t2 = z.string().transform(z.number(), val => val.length);
-  expect(t2.parse('asdf')).toEqual(4);
+  const t2 = z.string().transform(z.number(), (val) => val.length);
+  expect(t2.parse("asdf")).toEqual(4);
 });
 
-test('multiple transformers', () => {
-  const doubler = z.transformer(stringToNumber, numberToString, val => {
+test("multiple transformers", () => {
+  const doubler = z.transformer(stringToNumber, numberToString, (val) => {
     return val * 2;
   });
-  expect(doubler.parse('5')).toEqual('10');
+  expect(doubler.parse("5")).toEqual("10");
 });

--- a/src/__tests__/tuple.test.ts
+++ b/src/__tests__/tuple.test.ts
@@ -1,16 +1,16 @@
-import * as z from '../index';
-import { ZodError } from '../ZodError';
-import { util } from '../helpers/util';
+import * as z from "../index";
+import { ZodError } from "../ZodError";
+import { util } from "../helpers/util";
 
 const testTuple = z.tuple([
   z.string(),
-  z.object({ name: z.literal('Rudy') }),
-  z.array(z.literal('blue')),
+  z.object({ name: z.literal("Rudy") }),
+  z.array(z.literal("blue")),
 ]);
-const testData = ['asdf', { name: 'Rudy' }, ['blue']];
-const badData = [123, { name: 'Rudy2' }, ['blue', 'red']];
+const testData = ["asdf", { name: "Rudy" }, ["blue"]];
+const badData = [123, { name: "Rudy2" }, ["blue", "red"]];
 
-test('tuple inference', () => {
+test("tuple inference", () => {
   const args1 = z.tuple([z.string()]);
   const returns1 = z.number();
   const func1 = z.function(args1, returns1);
@@ -19,19 +19,19 @@ test('tuple inference', () => {
   [t1];
 });
 
-test('successful validation', () => {
+test("successful validation", () => {
   const val = testTuple.parse(testData);
-  expect(val).toEqual(['asdf', { name: 'Rudy' }, ['blue']]);
+  expect(val).toEqual(["asdf", { name: "Rudy" }, ["blue"]]);
 });
 
-test('successful async validation', async () => {
+test("successful async validation", async () => {
   const val = await testTuple.parseAsync(testData);
   return expect(val).toEqual(testData);
 });
 
-test('failed validation', () => {
+test("failed validation", () => {
   const checker = () => {
-    testTuple.parse([123, { name: 'Rudy2' }, ['blue', 'red']] as any);
+    testTuple.parse([123, { name: "Rudy2" }, ["blue", "red"]] as any);
   };
   try {
     checker();
@@ -42,7 +42,7 @@ test('failed validation', () => {
   }
 });
 
-test('failed async validation', async () => {
+test("failed async validation", async () => {
   const res = await testTuple.safeParse(badData);
   expect(res.success).toEqual(false);
   if (!res.success) {
@@ -57,8 +57,8 @@ test('failed async validation', async () => {
   // }
 });
 
-test('tuple with transformers', () => {
-  const stringToNumber = z.string().transform(z.number(), val => val.length);
+test("tuple with transformers", () => {
+  const stringToNumber = z.string().transform(z.number(), (val) => val.length);
   const val = z.tuple([stringToNumber]);
 
   type t1 = z.input<typeof val>;

--- a/src/__tests__/validations.test.ts
+++ b/src/__tests__/validations.test.ts
@@ -1,145 +1,145 @@
-import * as z from '../index';
+import * as z from "../index";
 
-test('array min', async () => {
+test("array min", async () => {
   expect.assertions(1);
   await z
     .array(z.string())
     .min(4)
     .parseAsync([])
-    .catch(err => {
-      expect(err.issues[0].message).toEqual('Should have at least 4 items');
+    .catch((err) => {
+      expect(err.issues[0].message).toEqual("Should have at least 4 items");
     });
 });
 
-test('array max', async () => {
+test("array max", async () => {
   expect.assertions(1);
   const result = await z
     .array(z.string())
     .max(2)
-    .parseAsync(['asdf', 'asdf', 'asdf'])
-    .catch(err => {
-      expect(err.issues[0].message).toEqual('Should have at most 2 items');
+    .parseAsync(["asdf", "asdf", "asdf"])
+    .catch((err) => {
+      expect(err.issues[0].message).toEqual("Should have at most 2 items");
     });
   return result;
 });
 
-test('string min', async () => {
+test("string min", async () => {
   expect.assertions(1);
   const result = await z
     .string()
     .min(4)
-    .parseAsync('asd')
-    .catch(err => {
-      expect(err.issues[0].message).toEqual('Should be at least 4 characters');
+    .parseAsync("asd")
+    .catch((err) => {
+      expect(err.issues[0].message).toEqual("Should be at least 4 characters");
     });
   return result;
 });
 
-test('string max', async () => {
+test("string max", async () => {
   expect.assertions(1);
   await z
     .string()
     .max(4)
-    .parseAsync('aasdfsdfsd')
-    .catch(err => {
+    .parseAsync("aasdfsdfsd")
+    .catch((err) => {
       expect(err.issues[0].message).toEqual(
-        'Should be at most 4 characters long',
+        "Should be at most 4 characters long"
       );
     });
-  return 'asdf';
+  return "asdf";
 });
 
-test('number min', async () => {
+test("number min", async () => {
   expect.assertions(1);
   await z
     .number()
     .min(3)
     .parseAsync(2)
-    .catch(err => {
+    .catch((err) => {
       expect(err.issues[0].message).toEqual(
-        'Value should be greater than or equal to 3',
+        "Value should be greater than or equal to 3"
       );
     });
-  return 'asdf';
+  return "asdf";
 });
 
-test('number max', async () => {
+test("number max", async () => {
   expect.assertions(1);
   await z
     .number()
     .max(3)
     .parseAsync(4)
-    .catch(err => {
+    .catch((err) => {
       expect(err.issues[0].message).toEqual(
-        'Value should be less than or equal to 3',
+        "Value should be less than or equal to 3"
       );
     });
-  return 'asdf';
+  return "asdf";
 });
 
-test('number nonnegative', async () => {
+test("number nonnegative", async () => {
   expect.assertions(1);
   await z
     .number()
     .nonnegative()
     .parseAsync(-1)
-    .catch(err => {
+    .catch((err) => {
       expect(err.issues[0].message).toEqual(
-        'Value should be greater than or equal to 0',
+        "Value should be greater than or equal to 0"
       );
     });
-  return 'asdf';
+  return "asdf";
 });
 
-test('number nonpositive', async () => {
+test("number nonpositive", async () => {
   expect.assertions(1);
   await z
     .number()
     .nonpositive()
     .parseAsync(1)
-    .catch(err => {
+    .catch((err) => {
       expect(err.issues[0].message).toEqual(
-        'Value should be less than or equal to 0',
+        "Value should be less than or equal to 0"
       );
     });
-  return 'asdf';
+  return "asdf";
 });
 
-test('number negative', async () => {
+test("number negative", async () => {
   expect.assertions(1);
   await z
     .number()
     .negative()
     .parseAsync(1)
-    .catch(err => {
-      expect(err.issues[0].message).toEqual('Value should be less than 0');
+    .catch((err) => {
+      expect(err.issues[0].message).toEqual("Value should be less than 0");
     });
-  return 'asdf';
+  return "asdf";
 });
 
-test('number positive', async () => {
+test("number positive", async () => {
   expect.assertions(1);
   await z
     .number()
     .positive()
     .parseAsync(-1)
-    .catch(err => {
-      expect(err.issues[0].message).toEqual('Value should be greater than 0');
+    .catch((err) => {
+      expect(err.issues[0].message).toEqual("Value should be greater than 0");
     });
-  return 'asdf';
+  return "asdf";
 });
 
-test('instantiation', () => {
+test("instantiation", () => {
   z.string().min(5);
   z.string().max(5);
   z.string().length(5);
   z.string().email();
   z.string().url();
   z.string().uuid();
-  z.string().min(5, { message: 'Must be 5 or more characters long' });
-  z.string().max(5, { message: 'Must be 5 or fewer characters long' });
-  z.string().length(5, { message: 'Must be exactly 5 characters long' });
-  z.string().email({ message: 'Invalid email address.' });
-  z.string().url({ message: 'Invalid url' });
-  z.string().uuid({ message: 'Invalid UUID' });
+  z.string().min(5, { message: "Must be 5 or more characters long" });
+  z.string().max(5, { message: "Must be 5 or fewer characters long" });
+  z.string().length(5, { message: "Must be exactly 5 characters long" });
+  z.string().email({ message: "Invalid email address." });
+  z.string().url({ message: "Invalid url" });
+  z.string().uuid({ message: "Invalid UUID" });
 });

--- a/src/__tests__/void.test.ts
+++ b/src/__tests__/void.test.ts
@@ -1,11 +1,11 @@
-import * as z from '../index';
-import { util } from '../helpers/util';
-test('void', () => {
+import * as z from "../index";
+import { util } from "../helpers/util";
+test("void", () => {
   const v = z.void();
   v.parse(null);
   v.parse(undefined);
 
-  expect(() => v.parse('')).toThrow();
+  expect(() => v.parse("")).toThrow();
 
   type v = z.infer<typeof v>;
   const t1: util.AssertEqual<v, void> = true;

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -1,7 +1,7 @@
 // import * as z from './index';
-import { ZodDef } from '.';
-import { util } from './helpers/util';
-import { ZodType, ZodTypes } from './types/base';
+import { ZodDef } from ".";
+import { util } from "./helpers/util";
+import { ZodType, ZodTypes } from "./types/base";
 
 type TypeResult = { schema: any; id: string; type: string };
 
@@ -27,11 +27,11 @@ export class ZodCodeGenerator {
   };
 
   findBySchema = (schema: ZodType<any, any>) => {
-    return this.seen.find(s => s.schema === schema);
+    return this.seen.find((s) => s.schema === schema);
   };
 
   findById = (id: string) => {
-    const found = this.seen.find(s => s.id === id);
+    const found = this.seen.find((s) => s.id === id);
     if (!found) throw new Error(`Unfound ID: ${id}`);
     return found;
   };
@@ -41,8 +41,8 @@ export class ZodCodeGenerator {
 type Identity<T> = T;
 
 ${this.seen
-  .map(item => `type ${item.id} = Identity<${item.type}>;`)
-  .join('\n\n')}
+  .map((item) => `type ${item.id} = Identity<${item.type}>;`)
+  .join("\n\n")}
 `;
   };
 
@@ -93,10 +93,10 @@ ${this.seen
         return this.setType(id, `void`);
       case ZodTypes.literal:
         const val = def.value;
-        const literalType = typeof val === 'string' ? `"${val}"` : `${val}`;
+        const literalType = typeof val === "string" ? `"${val}"` : `${val}`;
         return this.setType(id, literalType);
       case ZodTypes.enum:
-        return this.setType(id, def.values.map(v => `"${v}"`).join(' | '));
+        return this.setType(id, def.values.map((v) => `"${v}"`).join(" | "));
       case ZodTypes.object:
         const objectLines: string[] = [];
         const shape = def.shape();
@@ -104,12 +104,12 @@ ${this.seen
         for (const key in shape) {
           const childSchema = shape[key];
           const childType = this.generate(childSchema);
-          const OPTKEY = isOptional(childSchema) ? '?' : '';
+          const OPTKEY = isOptional(childSchema) ? "?" : "";
           objectLines.push(`${key}${OPTKEY}: ${childType.id}`);
         }
         const baseStruct = `{\n${objectLines
-          .map(line => `  ${line};`)
-          .join('\n')}\n}`;
+          .map((line) => `  ${line};`)
+          .join("\n")}\n}`;
         this.setType(id, `${baseStruct}`);
         break;
       case ZodTypes.tuple:
@@ -119,8 +119,8 @@ ${this.seen
           tupleLines.push(elType.id);
         }
         const baseTuple = `[\n${tupleLines
-          .map(line => `  ${line},`)
-          .join('\n')}\n]`;
+          .map((line) => `  ${line},`)
+          .join("\n")}\n]`;
         return this.setType(id, `${baseTuple}`);
       case ZodTypes.array:
         return this.setType(id, `${this.generate(def.type).id}[]`);
@@ -141,12 +141,12 @@ ${this.seen
       case ZodTypes.intersection:
         return this.setType(
           id,
-          `${this.generate(def.left).id} & ${this.generate(def.right).id}`,
+          `${this.generate(def.left).id} & ${this.generate(def.right).id}`
         );
       case ZodTypes.record:
         return this.setType(
           id,
-          `{[k:string]: ${this.generate(def.valueType).id}}`,
+          `{[k:string]: ${this.generate(def.valueType).id}}`
         );
       case ZodTypes.transformer:
         return this.setType(id, this.generate(def.output).id);
@@ -155,18 +155,18 @@ ${this.seen
           id,
           `Map<${this.generate(def.keyType).id}, ${
             this.generate(def.valueType).id
-          }>`,
+          }>`
         );
       case ZodTypes.lazy:
         const lazyType = def.getter();
         return this.setType(id, this.generate(lazyType).id);
       case ZodTypes.nativeEnum:
         // const lazyType = def.getter();
-        return this.setType(id, 'asdf');
+        return this.setType(id, "asdf");
       case ZodTypes.optional:
         return this.setType(
           id,
-          `${this.generate(def.innerType).id} | undefined`,
+          `${this.generate(def.innerType).id} | undefined`
         );
       case ZodTypes.nullable:
         return this.setType(id, `${this.generate(def.innerType).id} | null`);

--- a/src/crazySchema.ts
+++ b/src/crazySchema.ts
@@ -1,56 +1,42 @@
-import * as z from './index';
+import * as z from "./index";
 
 export const crazySchema = z.object({
   tuple: z.tuple([
-    z
-      .string()
-      .nullable()
-      .optional(),
-    z
-      .number()
-      .nullable()
-      .optional(),
-    z
-      .boolean()
-      .nullable()
-      .optional(),
-    z
-      .null()
-      .nullable()
-      .optional(),
-    z
-      .undefined()
-      .nullable()
-      .optional(),
-    z
-      .literal('1234')
-      .nullable()
-      .optional(),
+    z.string().nullable().optional(),
+    z.number().nullable().optional(),
+    z.boolean().nullable().optional(),
+    z.null().nullable().optional(),
+    z.undefined().nullable().optional(),
+    z.literal("1234").nullable().optional(),
   ]),
   merged: z
     .object({
       k1: z.string().optional(),
     })
     .merge(z.object({ k1: z.string().nullable(), k2: z.number() })),
-  union: z.array(z.union([z.literal('asdf'), z.literal(12)])).nonempty(),
+  union: z.array(z.union([z.literal("asdf"), z.literal(12)])).nonempty(),
   array: z.array(z.number()),
-  sumTransformer: z.transformer(z.array(z.number()), z.number(), arg => {
+  sumTransformer: z.transformer(z.array(z.number()), z.number(), (arg) => {
     return arg.reduce((a, b) => a + b, 0);
   }),
-  sumMinLength: z.array(z.number()).refine(arg => arg.length > 5),
+  sumMinLength: z.array(z.number()).refine((arg) => arg.length > 5),
   intersection: z.intersection(
     z.object({ p1: z.string().optional() }),
-    z.object({ p1: z.number().optional() }),
+    z.object({ p1: z.number().optional() })
   ),
-  enum: z.intersection(z.enum(['zero', 'one']), z.enum(['one', 'two'])),
+  enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
   nonstrict: z.object({ points: z.number() }).nonstrict(),
   numProm: z.promise(z.number()),
   lenfun: z.function(z.tuple([z.string()]), z.boolean()),
 });
 
 export const asyncCrazySchema = crazySchema.extend({
-  async_transform: z.transformer(z.array(z.number()), z.number(), async arg => {
-    return arg.reduce((a, b) => a + b, 0);
-  }),
-  async_refine: z.array(z.number()).refine(async arg => arg.length > 5),
+  async_transform: z.transformer(
+    z.array(z.number()),
+    z.number(),
+    async (arg) => {
+      return arg.reduce((a, b) => a + b, 0);
+    }
+  ),
+  async_refine: z.array(z.number()).refine(async (arg) => arg.length > 5),
 });

--- a/src/defaultErrorMap.ts
+++ b/src/defaultErrorMap.ts
@@ -1,5 +1,5 @@
-import { ZodIssueCode, ZodIssueOptionalMessage } from './ZodError';
-import { util } from './helpers/util';
+import { ZodIssueCode, ZodIssueOptionalMessage } from "./ZodError";
+import { util } from "./helpers/util";
 
 type ErrorMapCtx = {
   // path: (string | number)[];
@@ -12,13 +12,13 @@ type ErrorMapCtx = {
 export type ZodErrorMap = typeof defaultErrorMap;
 export const defaultErrorMap = (
   error: ZodIssueOptionalMessage,
-  _ctx: ErrorMapCtx,
+  _ctx: ErrorMapCtx
 ): { message: string } => {
   let message: string;
   switch (error.code) {
     case ZodIssueCode.invalid_type:
-      if (error.received === 'undefined') {
-        message = 'Required';
+      if (error.received === "undefined") {
+        message = "Required";
       } else {
         message = `Expected ${error.expected}, received ${error.received}`;
       }
@@ -28,8 +28,8 @@ export const defaultErrorMap = (
       break;
     case ZodIssueCode.unrecognized_keys:
       message = `Unrecognized key(s) in object: ${error.keys
-        .map(k => `'${k}'`)
-        .join(', ')}`;
+        .map((k) => `'${k}'`)
+        .join(", ")}`;
       break;
     case ZodIssueCode.invalid_union:
       message = `Invalid input`;
@@ -42,7 +42,7 @@ export const defaultErrorMap = (
       break;
     case ZodIssueCode.invalid_enum_value:
       message = `Input must be one of these values: ${error.options.join(
-        ', ',
+        ", "
       )}`;
       break;
     case ZodIssueCode.invalid_arguments:
@@ -63,8 +63,8 @@ export const defaultErrorMap = (
     //   message = `Too short, should be at most ${error.maximum} ${tooLongNoun}`;
     //   break;
     case ZodIssueCode.invalid_string:
-      if (error.validation !== 'regex') message = `Invalid ${error.validation}`;
-      else message = 'Invalid';
+      if (error.validation !== "regex") message = `Invalid ${error.validation}`;
+      else message = "Invalid";
       break;
     // case ZodIssueCode.invalid_url:
     //   message = 'Invalid URL.';
@@ -73,34 +73,34 @@ export const defaultErrorMap = (
     //   message = 'Invalid UUID.';
     //   break;
     case ZodIssueCode.too_small:
-      if (error.type === 'array')
+      if (error.type === "array")
         message = `Should have ${error.inclusive ? `at least` : `more than`} ${
           error.minimum
         } items`;
-      else if (error.type === 'string')
+      else if (error.type === "string")
         message = `Should be ${error.inclusive ? `at least` : `over`} ${
           error.minimum
         } characters`;
-      else if (error.type === 'number')
+      else if (error.type === "number")
         message = `Value should be greater than ${
           error.inclusive ? `or equal to ` : ``
         }${error.minimum}`;
-      else message = 'Invalid input';
+      else message = "Invalid input";
       break;
     case ZodIssueCode.too_big:
-      if (error.type === 'array')
+      if (error.type === "array")
         message = `Should have ${error.inclusive ? `at most` : `less than`} ${
           error.maximum
         } items`;
-      else if (error.type === 'string')
+      else if (error.type === "string")
         message = `Should be ${error.inclusive ? `at most` : `under`} ${
           error.maximum
         } characters long`;
-      else if (error.type === 'number')
+      else if (error.type === "number")
         message = `Value should be less than ${
           error.inclusive ? `or equal to ` : ``
         }${error.maximum}`;
-      else message = 'Invalid input';
+      else message = "Invalid input";
       break;
     case ZodIssueCode.custom:
       message = `Invalid input.`;

--- a/src/helpers/Mocker.ts
+++ b/src/helpers/Mocker.ts
@@ -8,9 +8,7 @@ export class Mocker {
   };
 
   get string() {
-    return Math.random()
-      .toString(36)
-      .substring(7);
+    return Math.random().toString(36).substring(7);
   }
   get number() {
     return Math.random() * 100;

--- a/src/helpers/errorUtil.ts
+++ b/src/helpers/errorUtil.ts
@@ -1,4 +1,5 @@
 export namespace errorUtil {
   export type ErrMessage = string | { message?: string };
-  export const errToObj = (message?: ErrMessage) => (typeof message === 'string' ? { message } : message || {});
+  export const errToObj = (message?: ErrMessage) =>
+    typeof message === "string" ? { message } : message || {};
 }

--- a/src/helpers/maskUtil.ts
+++ b/src/helpers/maskUtil.ts
@@ -1,4 +1,4 @@
-import { Primitive } from './primitive';
+import { Primitive } from "./primitive";
 
 type AnyObject = { [k: string]: any };
 type IsAny<T> = any extends T ? (T extends any ? true : false) : false;
@@ -23,22 +23,22 @@ export namespace maskUtil {
     rest: never;
     never: never;
   }[T extends null | undefined | Primitive | Array<Primitive>
-    ? 'never'
+    ? "never"
     : any extends T
-    ? 'never'
+    ? "never"
     : T extends Array<AnyObject>
-    ? 'array'
+    ? "array"
     : IsObject<T> extends true
-    ? 'object'
-    : 'rest'];
+    ? "object"
+    : "rest"];
 
   export type PickTest<T, P extends any> = P extends true
-    ? 'true'
+    ? "true"
     : true extends IsObject<T>
-    ? 'object'
+    ? "object"
     : true extends IsObjectArray<T>
-    ? 'array'
-    : 'rest';
+    ? "array"
+    : "rest";
 
   export type Pick<T, P> = null extends T
     ? undefined extends T
@@ -57,16 +57,16 @@ export namespace maskUtil {
     never: never;
     any: any;
   }[IsAny<T> extends true
-    ? 'any'
+    ? "any"
     : IsNever<T> extends true
-    ? 'never'
+    ? "never"
     : IsNever<P> extends true
-    ? 'true'
+    ? "true"
     : IsTrue<P> extends true
-    ? 'true'
+    ? "true"
     : true extends IsObject<T>
-    ? 'object'
+    ? "object"
     : true extends IsObjectArray<T>
-    ? 'array'
-    : 'any'];
+    ? "array"
+    : "any"];
 }

--- a/src/helpers/objectUtil.ts
+++ b/src/helpers/objectUtil.ts
@@ -1,6 +1,6 @@
-import { ZodRawShape, ZodTypes } from '../types/base';
-import { ZodIntersection } from '../types/intersection';
-import { ZodObject, AnyZodObject } from '../types/object';
+import { ZodRawShape, ZodTypes } from "../types/base";
+import { ZodIntersection } from "../types/intersection";
+import { ZodObject, AnyZodObject } from "../types/object";
 
 export namespace objectUtil {
   // export interface ZodObjectParams {
@@ -85,11 +85,11 @@ export namespace objectUtil {
 
   export const mergeShapes = <U extends ZodRawShape, T extends ZodRawShape>(
     first: U,
-    second: T,
+    second: T
   ): T & U => {
     const firstKeys = Object.keys(first);
     const secondKeys = Object.keys(second);
-    const sharedKeys = firstKeys.filter(k => secondKeys.indexOf(k) !== -1);
+    const sharedKeys = firstKeys.filter((k) => secondKeys.indexOf(k) !== -1);
 
     const sharedShape: any = {};
     for (const k of sharedKeys) {
@@ -105,11 +105,11 @@ export namespace objectUtil {
   export const mergeObjects = <First extends AnyZodObject>(first: First) => <
     Second extends AnyZodObject
   >(
-    second: Second,
+    second: Second
   ): ZodObject<
-    First['_shape'] & Second['_shape'],
-    First['_unknownKeys'],
-    First['_catchall']
+    First["_shape"] & Second["_shape"],
+    First["_unknownKeys"],
+    First["_catchall"]
     // MergeObjectParams<First['_params'], Second['_params']>,
     // First['_input'] & Second['_input'],
     // First['_output'] & Second['_output']

--- a/src/helpers/partialUtil.ts
+++ b/src/helpers/partialUtil.ts
@@ -1,5 +1,5 @@
-import * as z from '../index';
-import { AnyZodObject } from '../types/object';
+import * as z from "../index";
+import { AnyZodObject } from "../types/object";
 
 export namespace partialUtil {
   export type RootDeepPartial<T extends z.ZodTypeAny> = {
@@ -7,15 +7,15 @@ export namespace partialUtil {
     // array: T extends z.ZodArray<infer Type> ? z.ZodArray<DeepPartial<Type>> : never;
     object: T extends AnyZodObject
       ? z.ZodObject<
-          { [k in keyof T['_shape']]: DeepPartial<T['_shape'][k]> },
-          T['_unknownKeys'],
-          T['_catchall']
+          { [k in keyof T["_shape"]]: DeepPartial<T["_shape"][k]> },
+          T["_unknownKeys"],
+          T["_catchall"]
         >
       : never;
-    rest: ReturnType<T['optional']>; // z.ZodOptional<T>;
+    rest: ReturnType<T["optional"]>; // z.ZodOptional<T>;
   }[T extends AnyZodObject
-    ? 'object' // T extends z.ZodOptional<any> // ? 'optional' // :
-    : 'rest'];
+    ? "object" // T extends z.ZodOptional<any> // ? 'optional' // :
+    : "rest"];
 
   export type DeepPartial<T extends z.ZodTypeAny> = {
     // optional: T extends z.ZodOptional<z.ZodTypeAny> ? T : z.ZodOptional<T>;
@@ -29,8 +29,8 @@ export namespace partialUtil {
           >
         >
       : never;
-    rest: ReturnType<T['optional']>;
+    rest: ReturnType<T["optional"]>;
   }[T extends z.ZodObject<any>
-    ? 'object' // T extends z.ZodOptional<any> // ? 'optional' // :
-    : 'rest'];
+    ? "object" // T extends z.ZodOptional<any> // ? 'optional' // :
+    : "rest"];
 }

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,4 +1,4 @@
-export const INVALID = Symbol('invalid_data');
+export const INVALID = Symbol("invalid_data");
 export namespace util {
   export type AssertEqual<T, Expected> = T extends Expected
     ? Expected extends T
@@ -16,7 +16,7 @@ export namespace util {
     Partial<Pick<T, K>>;
 
   export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
-    items: U,
+    items: U
   ): { [k in U[number]]: k } => {
     const obj: any = {};
     for (const item of items) {
@@ -27,7 +27,7 @@ export namespace util {
 
   export const getValidEnumValues = (obj: any) => {
     const validKeys = Object.keys(obj).filter(
-      (k: any) => typeof obj[obj[k]] !== 'number',
+      (k: any) => typeof obj[obj[k]] !== "number"
     );
     const filtered: any = {};
     for (const k of validKeys) {
@@ -37,20 +37,20 @@ export namespace util {
   };
 
   export const getValues = (obj: any) => {
-    return Object.keys(obj).map(function(e) {
+    return Object.keys(obj).map(function (e) {
       return obj[e];
     });
   };
 
   export const objectValues = (obj: any) => {
-    return Object.keys(obj).map(function(e) {
+    return Object.keys(obj).map(function (e) {
       return obj[e];
     });
   };
 
   export const find = <T>(
     arr: T[],
-    checker: (arg: T) => any,
+    checker: (arg: T) => any
   ): T | undefined => {
     for (const item of arr) {
       if (checker(item)) return item;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,32 @@
 /* ZOD */
 
-import { ZodString, ZodStringDef } from './types/string';
-import { ZodNumber, ZodNumberDef } from './types/number';
-import { ZodBigInt, ZodBigIntDef } from './types/bigint';
-import { ZodBoolean, ZodBooleanDef } from './types/boolean';
-import { ZodDate, ZodDateDef } from './types/date';
-import { ZodUndefined, ZodUndefinedDef } from './types/undefined';
-import { ZodNull, ZodNullDef } from './types/null';
-import { ZodAny, ZodAnyDef } from './types/any';
-import { ZodUnknown, ZodUnknownDef } from './types/unknown';
-import { ZodNever, ZodNeverDef } from './types/never';
-import { ZodVoid, ZodVoidDef } from './types/void';
-import { ZodArray, ZodArrayDef } from './types/array';
-import { ZodObject, ZodObjectDef } from './types/object';
-import { ZodUnion, ZodUnionDef } from './types/union';
-import { ZodIntersection, ZodIntersectionDef } from './types/intersection';
-import { ZodTuple, ZodTupleDef } from './types/tuple';
-import { ZodRecord, ZodRecordDef } from './types/record';
-import { ZodMap, ZodMapDef } from './types/map';
-import { ZodFunction, ZodFunctionDef } from './types/function';
-import { ZodLazy, ZodLazyDef } from './types/lazy';
-import { ZodLiteral, ZodLiteralDef } from './types/literal';
-import { ZodEnum, ZodEnumDef } from './types/enum';
-import { ZodNativeEnum, ZodNativeEnumDef } from './types/nativeEnum';
-import { ZodPromise, ZodPromiseDef } from './types/promise';
-import { ZodTransformer, ZodTransformerDef } from './types/transformer';
-import { ZodOptional, ZodOptionalDef } from './types/optional';
-import { ZodNullable, ZodNullableDef } from './types/nullable';
+import { ZodString, ZodStringDef } from "./types/string";
+import { ZodNumber, ZodNumberDef } from "./types/number";
+import { ZodBigInt, ZodBigIntDef } from "./types/bigint";
+import { ZodBoolean, ZodBooleanDef } from "./types/boolean";
+import { ZodDate, ZodDateDef } from "./types/date";
+import { ZodUndefined, ZodUndefinedDef } from "./types/undefined";
+import { ZodNull, ZodNullDef } from "./types/null";
+import { ZodAny, ZodAnyDef } from "./types/any";
+import { ZodUnknown, ZodUnknownDef } from "./types/unknown";
+import { ZodNever, ZodNeverDef } from "./types/never";
+import { ZodVoid, ZodVoidDef } from "./types/void";
+import { ZodArray, ZodArrayDef } from "./types/array";
+import { ZodObject, ZodObjectDef } from "./types/object";
+import { ZodUnion, ZodUnionDef } from "./types/union";
+import { ZodIntersection, ZodIntersectionDef } from "./types/intersection";
+import { ZodTuple, ZodTupleDef } from "./types/tuple";
+import { ZodRecord, ZodRecordDef } from "./types/record";
+import { ZodMap, ZodMapDef } from "./types/map";
+import { ZodFunction, ZodFunctionDef } from "./types/function";
+import { ZodLazy, ZodLazyDef } from "./types/lazy";
+import { ZodLiteral, ZodLiteralDef } from "./types/literal";
+import { ZodEnum, ZodEnumDef } from "./types/enum";
+import { ZodNativeEnum, ZodNativeEnumDef } from "./types/nativeEnum";
+import { ZodPromise, ZodPromiseDef } from "./types/promise";
+import { ZodTransformer, ZodTransformerDef } from "./types/transformer";
+import { ZodOptional, ZodOptionalDef } from "./types/optional";
+import { ZodNullable, ZodNullableDef } from "./types/nullable";
 import {
   TypeOf,
   input,
@@ -35,13 +35,13 @@ import {
   ZodTypeAny,
   ZodTypeDef,
   ZodTypes,
-} from './types/base';
+} from "./types/base";
 
 // export { ZodIssueCode } from './ZodError';
 
-import { ZodParsedType } from './parser';
-import { ZodErrorMap } from './defaultErrorMap';
-import { ZodCodeGenerator } from './codegen';
+import { ZodParsedType } from "./parser";
+import { ZodErrorMap } from "./defaultErrorMap";
+import { ZodCodeGenerator } from "./codegen";
 
 export { ZodTypeDef, ZodTypes };
 
@@ -80,7 +80,7 @@ const codegen = ZodCodeGenerator.create;
 
 export const custom = <T>(
   check?: (data: unknown) => any,
-  params?: Parameters<ZodTypeAny['refine']>[1],
+  params?: Parameters<ZodTypeAny["refine"]>[1]
 ): ZodType<T> => {
   if (check) return anyType().refine(check, params);
   return anyType();
@@ -88,10 +88,10 @@ export const custom = <T>(
 
 const instanceOfType = <T extends new (...args: any[]) => any>(
   cls: T,
-  params: Parameters<ZodTypeAny['refine']>[1] = {
+  params: Parameters<ZodTypeAny["refine"]>[1] = {
     message: `Input not instance of ${cls.name}`,
-  },
-) => custom<InstanceType<T>>(data => data instanceof cls, params);
+  }
+) => custom<InstanceType<T>>((data) => data instanceof cls, params);
 
 export {
   stringType as string,
@@ -170,7 +170,7 @@ export {
 
 export { TypeOf, TypeOf as infer, input, output };
 
-export * from './ZodError';
+export * from "./ZodError";
 
 export type ZodDef =
   | ZodStringDef

--- a/src/isScalar.ts
+++ b/src/isScalar.ts
@@ -1,10 +1,10 @@
-import { ZodDef } from '.';
-import { util } from './helpers/util';
-import { ZodType, ZodTypes } from './types/base';
+import { ZodDef } from ".";
+import { util } from "./helpers/util";
+import { ZodType, ZodTypes } from "./types/base";
 
 export const isScalar = (
   schema: ZodType<any, any>,
-  params: { root: boolean } = { root: true },
+  params: { root: boolean } = { root: true }
 ): boolean => {
   const def = schema._def as ZodDef;
 
@@ -48,13 +48,13 @@ export const isScalar = (
       returnValue = false;
       break;
     case ZodTypes.union:
-      returnValue = def.options.every(x => isScalar(x));
+      returnValue = def.options.every((x) => isScalar(x));
       break;
     case ZodTypes.intersection:
       returnValue = isScalar(def.left) && isScalar(def.right);
       break;
     case ZodTypes.tuple:
-      returnValue = def.items.every(x => isScalar(x, { root: false }));
+      returnValue = def.items.every((x) => isScalar(x, { root: false }));
       break;
     case ZodTypes.lazy:
       returnValue = isScalar(def.getter());

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,74 +1,74 @@
-import * as z from './types/base';
+import * as z from "./types/base";
 
 import {
   ZodError,
   ZodIssueCode,
   ZodIssue,
   ZodIssueOptionalMessage,
-} from './ZodError';
-import { INVALID, util } from './helpers/util';
-import { ZodErrorMap, defaultErrorMap } from './defaultErrorMap';
-import { NOSET, PseudoPromise } from './PseudoPromise';
-import { ZodDef, ZodNever, ZodPromise } from './index';
+} from "./ZodError";
+import { INVALID, util } from "./helpers/util";
+import { ZodErrorMap, defaultErrorMap } from "./defaultErrorMap";
+import { NOSET, PseudoPromise } from "./PseudoPromise";
+import { ZodDef, ZodNever, ZodPromise } from "./index";
 
 export const getParsedType = (data: any): ZodParsedType => {
-  if (typeof data === 'string') return 'string';
-  if (typeof data === 'number') {
-    if (Number.isNaN(data)) return 'nan';
-    return 'number';
+  if (typeof data === "string") return "string";
+  if (typeof data === "number") {
+    if (Number.isNaN(data)) return "nan";
+    return "number";
   }
-  if (typeof data === 'boolean') return 'boolean';
-  if (typeof data === 'bigint') return 'bigint';
-  if (typeof data === 'symbol') return 'symbol';
-  if (data instanceof Date) return 'date';
-  if (typeof data === 'function') return 'function';
-  if (data === undefined) return 'undefined';
-  if (typeof data === 'undefined') return 'undefined';
-  if (typeof data === 'object') {
-    if (Array.isArray(data)) return 'array';
-    if (data === null) return 'null';
+  if (typeof data === "boolean") return "boolean";
+  if (typeof data === "bigint") return "bigint";
+  if (typeof data === "symbol") return "symbol";
+  if (data instanceof Date) return "date";
+  if (typeof data === "function") return "function";
+  if (data === undefined) return "undefined";
+  if (typeof data === "undefined") return "undefined";
+  if (typeof data === "object") {
+    if (Array.isArray(data)) return "array";
+    if (data === null) return "null";
     if (
       data.then &&
-      typeof data.then === 'function' &&
+      typeof data.then === "function" &&
       data.catch &&
-      typeof data.catch === 'function'
+      typeof data.catch === "function"
     ) {
-      return 'promise';
+      return "promise";
     }
     if (data instanceof Map) {
-      return 'map';
+      return "map";
     }
-    return 'object';
+    return "object";
   }
-  return 'unknown';
+  return "unknown";
 };
 
 export const ZodParsedType = util.arrayToEnum([
-  'string',
-  'nan',
-  'number',
-  'integer',
-  'boolean',
-  'date',
-  'bigint',
-  'symbol',
-  'function',
-  'undefined',
-  'null',
-  'array',
-  'object',
-  'unknown',
-  'promise',
-  'void',
-  'never',
-  'map',
+  "string",
+  "nan",
+  "number",
+  "integer",
+  "boolean",
+  "date",
+  "bigint",
+  "symbol",
+  "function",
+  "undefined",
+  "null",
+  "array",
+  "object",
+  "unknown",
+  "promise",
+  "void",
+  "never",
+  "map",
 ]);
 
 export type ZodParsedType = keyof typeof ZodParsedType;
 
 // conditional required to distribute union
 type stripPath<T extends object> = T extends any
-  ? util.OmitKeys<T, 'path'>
+  ? util.OmitKeys<T, "path">
   : never;
 export type MakeErrorData = stripPath<ZodIssueOptionalMessage> & {
   path?: (string | number)[];
@@ -77,7 +77,7 @@ export type MakeErrorData = stripPath<ZodIssueOptionalMessage> & {
 const makeError = (
   params: Required<ParseParams>,
   data: any,
-  errorData: MakeErrorData,
+  errorData: MakeErrorData
 ): ZodIssue => {
   const errorArg = {
     ...errorData,
@@ -117,7 +117,7 @@ export type ParseParams = {
 
 export const ZodParser = (schema: z.ZodType<any>) => (
   data: any,
-  baseParams: ParseParams = { seen: [], errorMap: defaultErrorMap, path: [] },
+  baseParams: ParseParams = { seen: [], errorMap: defaultErrorMap, path: [] }
 ) => {
   const params: Required<ParseParams> = {
     seen: baseParams.seen || [],
@@ -165,7 +165,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.string,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -180,7 +180,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.number,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -191,7 +191,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.number,
             received: ZodParsedType.nan,
-          }),
+          })
         );
 
         THROW();
@@ -205,7 +205,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.bigint,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -219,7 +219,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.boolean,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -233,7 +233,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.undefined,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -247,7 +247,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.null,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -266,7 +266,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
           code: ZodIssueCode.invalid_type,
           expected: ZodParsedType.never,
           received: parsedType,
-        }),
+        })
       );
       PROMISE = PseudoPromise.resolve(INVALID);
       break;
@@ -280,7 +280,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.void,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -295,7 +295,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.array,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -305,7 +305,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
         ERROR.addIssue(
           makeError(params, data, {
             code: ZodIssueCode.nonempty_array_is_empty,
-          }),
+          })
         );
         THROW();
       }
@@ -317,16 +317,16 @@ export const ZodParser = (schema: z.ZodType<any>) => (
               def.type.parse(item, {
                 ...params,
                 path: [...params.path, i],
-              }),
+              })
             )
-            .catch(err => {
+            .catch((err) => {
               if (!(err instanceof ZodError)) {
                 throw err;
               }
               ERROR.addIssues(err.issues);
               return INVALID;
             });
-        }),
+        })
       );
 
       break;
@@ -337,7 +337,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.map,
             received: parsedType,
-          }),
+          })
         );
         THROW();
       }
@@ -352,7 +352,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
               .then(() => {
                 return def.keyType.parse(key, {
                   ...params,
-                  path: [...params.path, index, 'key'],
+                  path: [...params.path, index, "key"],
                 });
               })
               .catch(HANDLE),
@@ -360,7 +360,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
               .then(() => {
                 const mapValue = def.valueType.parse(value, {
                   ...params,
-                  path: [...params.path, index, 'value'],
+                  path: [...params.path, index, "value"],
                 });
                 return [key, mapValue];
               })
@@ -372,7 +372,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
               }
             })
             .catch(HANDLE);
-        }),
+        })
       )
         .then(() => {
           if (!ERROR.isEmpty) {
@@ -394,7 +394,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.object,
             received: parsedType,
-          }),
+          })
         );
         THROW();
       }
@@ -405,7 +405,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
       const shapeKeys = Object.keys(shape);
       const dataKeys = Object.keys(data);
 
-      const extraKeys = dataKeys.filter(k => shapeKeys.indexOf(k) === -1);
+      const extraKeys = dataKeys.filter((k) => shapeKeys.indexOf(k) === -1);
 
       for (const key of shapeKeys) {
         const keyValidator = shapeKeys.includes(key)
@@ -419,7 +419,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
         }
 
         // first check is required to avoid non-enumerable keys
-        if (typeof data[key] === 'undefined' && !dataKeys.includes(key)) {
+        if (typeof data[key] === "undefined" && !dataKeys.includes(key)) {
           objectPromises[key] = new PseudoPromise()
             .then(() => {
               return keyValidator.parse(undefined, {
@@ -427,7 +427,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
                 path: [...params.path, key],
               });
             })
-            .then(output => {
+            .then((output) => {
               if (output === undefined) {
                 // schema is optional
                 // data is undefined
@@ -438,7 +438,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
                 return output;
               }
             })
-            .catch(err => {
+            .catch((err) => {
               if (err instanceof ZodError) {
                 const zerr: ZodError = err;
                 ERROR.addIssues(zerr.issues);
@@ -458,7 +458,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
               path: [...params.path, key],
             });
           })
-          .catch(err => {
+          .catch((err) => {
             if (err instanceof ZodError) {
               const zerr: ZodError = err;
               ERROR.addIssues(zerr.issues);
@@ -470,20 +470,20 @@ export const ZodParser = (schema: z.ZodType<any>) => (
       }
 
       if (def.catchall instanceof ZodNever) {
-        if (def.unknownKeys === 'passthrough') {
+        if (def.unknownKeys === "passthrough") {
           for (const key of extraKeys) {
             objectPromises[key] = PseudoPromise.resolve(data[key]);
           }
-        } else if (def.unknownKeys === 'strict') {
+        } else if (def.unknownKeys === "strict") {
           if (extraKeys.length > 0) {
             ERROR.addIssue(
               makeError(params, data, {
                 code: ZodIssueCode.unrecognized_keys,
                 keys: extraKeys,
-              }),
+              })
             );
           }
-        } else if (def.unknownKeys === 'strip') {
+        } else if (def.unknownKeys === "strip") {
           // do nothing
         } else {
           util.assertNever(def.unknownKeys);
@@ -499,7 +499,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
               });
               return parsedValue;
             })
-            .catch(err => {
+            .catch((err) => {
               if (err instanceof ZodError) {
                 ERROR.addIssues(err.issues);
               } else {
@@ -510,17 +510,17 @@ export const ZodParser = (schema: z.ZodType<any>) => (
       }
 
       PROMISE = PseudoPromise.object(objectPromises)
-        .then(resolvedObject => {
+        .then((resolvedObject) => {
           Object.assign(RESULT.output, resolvedObject);
           return RESULT.output;
         })
-        .then(finalObject => {
+        .then((finalObject) => {
           if (ERROR.issues.length > 0) {
             return INVALID;
           }
           return finalObject;
         })
-        .catch(err => {
+        .catch((err) => {
           if (err instanceof ZodError) {
             ERROR.addIssues(err.issues);
             return INVALID;
@@ -540,23 +540,23 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             .then(() => {
               return opt.parse(data, params);
             })
-            .then(optionData => {
+            .then((optionData) => {
               isValid = true;
               return optionData;
             })
-            .catch(err => {
+            .catch((err) => {
               if (err instanceof ZodError) {
                 unionErrors.push(err);
                 return INVALID;
               }
               throw err;
             });
-        }),
+        })
       )
-        .then(unionResults => {
+        .then((unionResults) => {
           if (!isValid) {
-            const nonTypeErrors = unionErrors.filter(err => {
-              return err.issues[0].code !== 'invalid_type';
+            const nonTypeErrors = unionErrors.filter((err) => {
+              return err.issues[0].code !== "invalid_type";
             });
             if (nonTypeErrors.length === 1) {
               ERROR.addIssues(nonTypeErrors[0].issues);
@@ -565,7 +565,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
                 makeError(params, data, {
                   code: ZodIssueCode.invalid_union,
                   unionErrors,
-                }),
+                })
               );
             }
             THROW();
@@ -607,7 +607,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
           ERROR.addIssue(
             makeError(params, data, {
               code: ZodIssueCode.invalid_intersection_types,
-            }),
+            })
           );
         }
       });
@@ -645,7 +645,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.array,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -656,8 +656,8 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.too_big,
             maximum: def.items.length,
             inclusive: true,
-            type: 'array',
-          }),
+            type: "array",
+          })
         );
       } else if (data.length < def.items.length) {
         ERROR.addIssue(
@@ -665,8 +665,8 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.too_small,
             minimum: def.items.length,
             inclusive: true,
-            type: 'array',
-          }),
+            type: "array",
+          })
         );
       }
 
@@ -683,24 +683,24 @@ export const ZodParser = (schema: z.ZodType<any>) => (
               });
               return tupleDatum;
             })
-            .catch(err => {
+            .catch((err) => {
               if (err instanceof ZodError) {
                 ERROR.addIssues(err.issues);
                 return;
               }
               throw err;
             })
-            .then(arg => {
+            .then((arg) => {
               return arg;
             });
-        }),
+        })
       )
-        .then(tupleData => {
+        .then((tupleData) => {
           if (!ERROR.isEmpty) THROW();
           return tupleData;
         })
 
-        .catch(err => {
+        .catch((err) => {
           throw err;
         });
 
@@ -715,7 +715,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
           makeError(params, data, {
             code: ZodIssueCode.invalid_literal_value,
             expected: def.value,
-          }),
+          })
         );
       }
       PROMISE = PseudoPromise.resolve(data);
@@ -726,7 +726,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
           makeError(params, data, {
             code: ZodIssueCode.invalid_enum_value,
             options: def.values,
-          }),
+          })
         );
       }
       PROMISE = PseudoPromise.resolve(data);
@@ -737,7 +737,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
           makeError(params, data, {
             code: ZodIssueCode.invalid_enum_value,
             options: util.objectValues(def.values),
-          }),
+          })
         );
       }
       PROMISE = PseudoPromise.resolve(data);
@@ -749,7 +749,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.function,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -765,34 +765,34 @@ export const ZodParser = (schema: z.ZodType<any>) => (
               async: isAsyncFunction,
             });
           })
-          .catch(err => {
+          .catch((err) => {
             if (!(err instanceof ZodError)) throw err;
             const argsError = new ZodError([]);
             argsError.addIssue(
               makeError(params, data, {
                 code: ZodIssueCode.invalid_arguments,
                 argumentsError: err,
-              }),
+              })
             );
             throw argsError;
           })
-          .then(args => {
+          .then((args) => {
             return data(...(args as any));
           })
-          .then(result => {
+          .then((result) => {
             return def.returns.parse(result, {
               ...params,
               async: isAsyncFunction,
             });
           })
-          .catch(err => {
+          .catch((err) => {
             if (err instanceof ZodError) {
               const returnsError = new ZodError([]);
               returnsError.addIssue(
                 makeError(params, data, {
                   code: ZodIssueCode.invalid_return_type,
                   returnTypeError: err,
-                }),
+                })
               );
               throw returnsError;
             }
@@ -815,7 +815,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.object,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -842,7 +842,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.date,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -851,7 +851,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
         ERROR.addIssue(
           makeError(params, data, {
             code: ZodIssueCode.invalid_date,
-          }),
+          })
         );
 
         THROW();
@@ -866,7 +866,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
             code: ZodIssueCode.invalid_type,
             expected: ZodParsedType.promise,
             received: parsedType,
-          }),
+          })
         );
 
         THROW();
@@ -878,7 +878,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
       PROMISE = PseudoPromise.resolve(
         promisified.then((resolvedData: any) => {
           return def.type.parse(resolvedData, params);
-        }),
+        })
       );
 
       break;
@@ -888,12 +888,12 @@ export const ZodParser = (schema: z.ZodType<any>) => (
           return def.input.parse(data, params);
         })
 
-        .then(inputParseResult => {
+        .then((inputParseResult) => {
           const transformed = def.transformer(inputParseResult);
           if (transformed instanceof Promise && params.async === false) {
             if (z.inputSchema(def.output)._def.t !== z.ZodTypes.promise) {
               throw new Error(
-                "You can't call .parse on a schema containing async transformations.",
+                "You can't call .parse on a schema containing async transformations."
               );
             }
           }
@@ -901,18 +901,18 @@ export const ZodParser = (schema: z.ZodType<any>) => (
           return transformed;
         })
 
-        .then(transformedResult => {
+        .then((transformedResult) => {
           return def.output.parse(transformedResult, params);
         });
 
       break;
     default:
-      PROMISE = PseudoPromise.resolve('adsf' as never);
+      PROMISE = PseudoPromise.resolve("adsf" as never);
       util.assertNever(def);
   }
 
   if ((PROMISE as any)._default === true) {
-    throw new Error('Result is not materialized.');
+    throw new Error("Result is not materialized.");
   }
 
   if (!ERROR.isEmpty) {
@@ -934,8 +934,8 @@ export const ZodParser = (schema: z.ZodType<any>) => (
       ERROR.addIssue(
         makeError(params, data, {
           code: ZodIssueCode.custom,
-          message: 'Invalid',
-        }),
+          message: "Invalid",
+        })
       );
     }
 
@@ -948,7 +948,7 @@ export const ZodParser = (schema: z.ZodType<any>) => (
 
       if (checkResult instanceof Promise)
         throw new Error(
-          "You can't use .parse on a schema containing async refinements. Use .parseAsync instead.",
+          "You can't use .parse on a schema containing async refinements. Use .parseAsync instead."
         );
     }
     if (!ERROR.isEmpty) {
@@ -966,8 +966,8 @@ export const ZodParser = (schema: z.ZodType<any>) => (
         ERROR.addIssue(
           makeError(params, data, {
             code: ZodIssueCode.custom,
-            message: 'Invalid',
-          }),
+            message: "Invalid",
+          })
         );
       }
 
@@ -988,9 +988,9 @@ export const ZodParser = (schema: z.ZodType<any>) => (
         }, Promise.resolve());
       } else {
         await Promise.all(
-          customChecks.map(async check => {
+          customChecks.map(async (check) => {
             await check.check(resolvedValue, checkCtx);
-          }),
+          })
         );
       }
 

--- a/src/switcher.ts
+++ b/src/switcher.ts
@@ -1,5 +1,5 @@
-import * as z from './index';
-import { util } from './helpers/util';
+import * as z from "./index";
+import { util } from "./helpers/util";
 
 export const visitor = (schema: z.ZodType<any, any>) => {
   const def = schema._def as z.ZodDef;

--- a/src/types/any.ts
+++ b/src/types/any.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -1,8 +1,8 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
-import { ZodIssueCode } from '../ZodError';
+import { ZodIssueCode } from "../ZodError";
 
 export interface ZodArrayDef<T extends z.ZodTypeAny = z.ZodTypeAny>
   extends z.ZodTypeDef {
@@ -12,9 +12,9 @@ export interface ZodArrayDef<T extends z.ZodTypeAny = z.ZodTypeAny>
 }
 
 export class ZodArray<T extends z.ZodTypeAny> extends z.ZodType<
-  T['_output'][],
+  T["_output"][],
   ZodArrayDef<T>,
-  T['_input'][]
+  T["_input"][]
 > {
   toJSON = () => {
     return {
@@ -33,22 +33,22 @@ export class ZodArray<T extends z.ZodTypeAny> extends z.ZodType<
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
 
   min = (minLength: number, message?: string | { message?: string }) =>
-    this.refinement(data => data.length >= minLength, {
+    this.refinement((data) => data.length >= minLength, {
       code: ZodIssueCode.too_small,
-      type: 'array',
+      type: "array",
       inclusive: true,
       minimum: minLength,
-      ...(typeof message === 'string' ? { message } : message),
+      ...(typeof message === "string" ? { message } : message),
     });
 
   max = (maxLength: number, message?: string | { message?: string }) =>
-    this.refinement(data => data.length <= maxLength, {
+    this.refinement((data) => data.length <= maxLength, {
       // check: data => data.length <= maxLength,
       code: ZodIssueCode.too_big,
-      type: 'array',
+      type: "array",
       inclusive: true,
       maximum: maxLength,
-      ...(typeof message === 'string' ? { message } : message),
+      ...(typeof message === "string" ? { message } : message),
     });
 
   length = (len: number, message?: string) =>
@@ -68,9 +68,9 @@ export class ZodArray<T extends z.ZodTypeAny> extends z.ZodType<
 }
 
 export class ZodNonEmptyArray<T extends z.ZodTypeAny> extends z.ZodType<
-  [T['_output'], ...T['_output'][]],
+  [T["_output"], ...T["_output"][]],
   ZodArrayDef<T>,
-  [T['_input'], ...T['_input'][]]
+  [T["_input"], ...T["_input"][]]
 > {
   toJSON = () => {
     return {
@@ -84,23 +84,23 @@ export class ZodNonEmptyArray<T extends z.ZodTypeAny> extends z.ZodType<
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
 
   min = (minLength: number, message?: string | { message?: string }) =>
-    this.refinement(data => data.length >= minLength, {
+    this.refinement((data) => data.length >= minLength, {
       // check: data => data.length >= minLength,
       code: ZodIssueCode.too_small,
       minimum: minLength,
-      type: 'array',
+      type: "array",
       inclusive: true,
-      ...(typeof message === 'string' ? { message } : message),
+      ...(typeof message === "string" ? { message } : message),
     });
 
   max = (maxLength: number, message?: string | { message?: string }) =>
-    this.refinement(data => data.length <= maxLength, {
+    this.refinement((data) => data.length <= maxLength, {
       // check:
       code: ZodIssueCode.too_big,
       maximum: maxLength,
-      type: 'array',
+      type: "array",
       inclusive: true,
-      ...(typeof message === 'string' ? { message } : message),
+      ...(typeof message === "string" ? { message } : message),
     });
 
   length = (len: number, message?: string) =>

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,5 +1,5 @@
-import { util } from '../helpers/util';
-import { ZodParser, ParseParams, MakeErrorData } from '../parser';
+import { util } from "../helpers/util";
+import { ZodParser, ParseParams, MakeErrorData } from "../parser";
 import {
   ZodIssueCode,
   ZodArray,
@@ -8,39 +8,39 @@ import {
   ZodOptional,
   ZodNullable,
   ZodCustomIssue,
-} from '../index';
+} from "../index";
 
-import { ZodOptionalType } from './optional';
-import { ZodNullableType } from './nullable';
+import { ZodOptionalType } from "./optional";
+import { ZodNullableType } from "./nullable";
 
 export enum ZodTypes {
-  string = 'string',
-  number = 'number',
-  bigint = 'bigint',
-  boolean = 'boolean',
-  date = 'date',
-  undefined = 'undefined',
-  null = 'null',
-  array = 'array',
-  object = 'object',
-  union = 'union',
-  intersection = 'intersection',
-  tuple = 'tuple',
-  record = 'record',
-  map = 'map',
-  function = 'function',
-  lazy = 'lazy',
-  literal = 'literal',
-  enum = 'enum',
-  nativeEnum = 'nativeEnum',
-  promise = 'promise',
-  any = 'any',
-  unknown = 'unknown',
-  never = 'never',
-  void = 'void',
-  transformer = 'transformer',
-  optional = 'optional',
-  nullable = 'nullable',
+  string = "string",
+  number = "number",
+  bigint = "bigint",
+  boolean = "boolean",
+  date = "date",
+  undefined = "undefined",
+  null = "null",
+  array = "array",
+  object = "object",
+  union = "union",
+  intersection = "intersection",
+  tuple = "tuple",
+  record = "record",
+  map = "map",
+  function = "function",
+  lazy = "lazy",
+  literal = "literal",
+  enum = "enum",
+  nativeEnum = "nativeEnum",
+  promise = "promise",
+  any = "any",
+  unknown = "unknown",
+  never = "never",
+  void = "void",
+  transformer = "transformer",
+  optional = "optional",
+  nullable = "nullable",
 }
 
 export type ZodTypeAny = ZodType<any, any, any>;
@@ -78,7 +78,7 @@ type InternalCheck<T> = {
 //   // params?: {[k:string]:any}
 // } & util.Omit<CustomError, 'code' | 'path'>;
 
-type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, 'code'>>;
+type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 // type Check<T> = {
 //   check: (arg: T) => any;
 //   refinementError: (arg: T) => CustomErrorParams;
@@ -90,10 +90,10 @@ export interface ZodTypeDef {
   accepts?: ZodType<any, any>;
 }
 
-export type TypeOf<T extends ZodType<any>> = T['_output'];
-export type input<T extends ZodType<any>> = T['_input'];
-export type output<T extends ZodType<any>> = T['_output'];
-export type infer<T extends ZodType<any>> = T['_output'];
+export type TypeOf<T extends ZodType<any>> = T["_output"];
+export type input<T extends ZodType<any>> = T["_input"];
+export type output<T extends ZodType<any>> = T["_output"];
+export type infer<T extends ZodType<any>> = T["_output"];
 
 export abstract class ZodType<
   Output,
@@ -118,10 +118,10 @@ export abstract class ZodType<
 
   safeParse: (
     x: unknown,
-    params?: ParseParams,
+    params?: ParseParams
   ) => { success: true; data: Output } | { success: false; error: ZodError } = (
     data,
-    params,
+    params
   ) => {
     try {
       const parsed = this.parse(data, params);
@@ -136,14 +136,14 @@ export abstract class ZodType<
 
   parseAsync: (x: unknown, params?: ParseParams) => Promise<Output> = async (
     value,
-    params,
+    params
   ) => {
     return await this.parse(value, { ...params, async: true });
   };
 
   safeParseAsync: (
     x: unknown,
-    params?: ParseParams,
+    params?: ParseParams
   ) => Promise<
     { success: true; data: Output } | { success: false; error: ZodError }
   > = async (data, params) => {
@@ -183,9 +183,9 @@ export abstract class ZodType<
     message:
       | string
       | CustomErrorParams
-      | ((arg: Output) => CustomErrorParams) = 'Invalid value.',
+      | ((arg: Output) => CustomErrorParams) = "Invalid value."
   ) => {
-    if (typeof message === 'string') {
+    if (typeof message === "string") {
       return this._refinement((val, ctx) => {
         const result = check(val);
         const setError = () =>
@@ -194,7 +194,7 @@ export abstract class ZodType<
             message,
           });
         if (result instanceof Promise) {
-          return result.then(data => {
+          return result.then((data) => {
             if (!data) setError();
           });
         }
@@ -204,7 +204,7 @@ export abstract class ZodType<
         }
       });
     }
-    if (typeof message === 'function') {
+    if (typeof message === "function") {
       return this._refinement((val, ctx) => {
         const result = check(val);
         const setError = () =>
@@ -213,7 +213,7 @@ export abstract class ZodType<
             ...message(val),
           });
         if (result instanceof Promise) {
-          return result.then(data => {
+          return result.then((data) => {
             if (!data) setError();
           });
         }
@@ -231,7 +231,7 @@ export abstract class ZodType<
           ...message,
         });
       if (result instanceof Promise) {
-        return result.then(data => {
+        return result.then((data) => {
           if (!data) setError();
         });
       }
@@ -247,22 +247,22 @@ export abstract class ZodType<
     check: (arg: Output) => any,
     refinementData:
       | MakeErrorData
-      | ((arg: Output, ctx: RefinementCtx) => MakeErrorData),
+      | ((arg: Output, ctx: RefinementCtx) => MakeErrorData)
   ) => {
     return this._refinement((val, ctx) => {
       if (!check(val)) {
         ctx.addIssue(
-          typeof refinementData === 'function'
+          typeof refinementData === "function"
             ? refinementData(val, ctx)
-            : refinementData,
+            : refinementData
         );
       }
     });
   };
 
-  _refinement: (
-    refinement: InternalCheck<Output>['check'],
-  ) => this = refinement => {
+  _refinement: (refinement: InternalCheck<Output>["check"]) => this = (
+    refinement
+  ) => {
     return new (this as any).constructor({
       ...this._def,
       checks: [...(this._def.checks || []), { check: refinement }],
@@ -289,13 +289,13 @@ export abstract class ZodType<
   transform<
     This extends this,
     U extends ZodType<any>,
-    Tx extends (arg: This['_output']) => U['_input'] | Promise<U['_input']>
+    Tx extends (arg: This["_output"]) => U["_input"] | Promise<U["_input"]>
   >(input: U, transformer: Tx): ZodTransformer<This, U>;
   transform<
     This extends this,
     Tx extends (
-      arg: This['_output'],
-    ) => This['_output'] | Promise<This['_output']>
+      arg: This["_output"]
+    ) => This["_output"] | Promise<This["_output"]>
   >(transformer: Tx): ZodTransformer<This, This>;
   transform(input: any, transformer?: any) {
     if (transformer) {
@@ -306,16 +306,16 @@ export abstract class ZodType<
 
   default<
     T extends Input = Input,
-    Opt extends ReturnType<this['optional']> = ReturnType<this['optional']>
+    Opt extends ReturnType<this["optional"]> = ReturnType<this["optional"]>
   >(def: T): ZodTransformer<Opt, this>;
   default<
     T extends (arg: this) => Input,
-    Opt extends ReturnType<this['optional']> = ReturnType<this['optional']>
+    Opt extends ReturnType<this["optional"]> = ReturnType<this["optional"]>
   >(def: T): ZodTransformer<Opt, this>;
   default(def: any) {
     return ZodTransformer.create(this.optional(), this, (x: any) => {
       return x === undefined
-        ? typeof def === 'function'
+        ? typeof def === "function"
           ? def(this)
           : def
         : x;

--- a/src/types/bigint.ts
+++ b/src/types/bigint.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';

--- a/src/types/boolean.ts
+++ b/src/types/boolean.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
@@ -12,12 +12,16 @@ type Values<T extends EnumValues> = {
   [k in T[number]]: k;
 };
 
-export interface ZodEnumDef<T extends EnumValues = EnumValues> extends z.ZodTypeDef {
+export interface ZodEnumDef<T extends EnumValues = EnumValues>
+  extends z.ZodTypeDef {
   t: z.ZodTypes.enum;
   values: T;
 }
 
-export class ZodEnum<T extends [string, ...string[]]> extends z.ZodType<T[number], ZodEnumDef<T>> {
+export class ZodEnum<T extends [string, ...string[]]> extends z.ZodType<
+  T[number],
+  ZodEnumDef<T>
+> {
   // opt optional: () => ZodUnion<[this, ZodUndefined]> = () => ZodUnion.create([this, ZodUndefined.create()]);
 
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
@@ -52,7 +56,9 @@ export class ZodEnum<T extends [string, ...string[]]> extends z.ZodType<T[number
     return enumValues as any;
   }
 
-  static create = <U extends string, T extends [U, ...U[]]>(values: T): ZodEnum<T> => {
+  static create = <U extends string, T extends [U, ...U[]]>(
+    values: T
+  ): ZodEnum<T> => {
     return new ZodEnum({
       t: z.ZodTypes.enum,
       values: values,

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -1,6 +1,6 @@
-import * as z from './base';
-import { ZodTuple } from './tuple';
-import { ZodUnknown } from './unknown';
+import * as z from "./base";
+import { ZodTuple } from "./tuple";
+import { ZodUnknown } from "./unknown";
 
 export interface ZodFunctionDef<
   Args extends ZodTuple<any> = ZodTuple<any>,
@@ -14,15 +14,15 @@ export interface ZodFunctionDef<
 export type OuterTypeOfFunction<
   Args extends ZodTuple<any>,
   Returns extends z.ZodTypeAny
-> = Args['_input'] extends Array<any>
-  ? (...args: Args['_input']) => Returns['_output']
+> = Args["_input"] extends Array<any>
+  ? (...args: Args["_input"]) => Returns["_output"]
   : never;
 
 export type InnerTypeOfFunction<
   Args extends ZodTuple<any>,
   Returns extends z.ZodTypeAny
-> = Args['_output'] extends Array<any>
-  ? (...args: Args['_output']) => Returns['_input']
+> = Args["_output"] extends Array<any>
+  ? (...args: Args["_output"]) => Returns["_input"]
   : never;
 
 // type as df = string extends unknown  ? true : false
@@ -37,7 +37,7 @@ export class ZodFunction<
   readonly _def!: ZodFunctionDef<Args, Returns>;
   //  readonly _type!: TypeOfFunction<Args, Returns>;
 
-  args = <Items extends Parameters<typeof ZodTuple['create']>[0]>(
+  args = <Items extends Parameters<typeof ZodTuple["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items>, Returns> => {
     return new ZodFunction({
@@ -47,7 +47,7 @@ export class ZodFunction<
   };
 
   returns = <NewReturnType extends z.ZodType<any, any>>(
-    returnType: NewReturnType,
+    returnType: NewReturnType
   ): ZodFunction<Args, NewReturnType> => {
     return new ZodFunction({
       ...this._def,
@@ -67,7 +67,7 @@ export class ZodFunction<
     U extends z.ZodTypeAny = ZodUnknown
   >(
     args?: T,
-    returns?: U,
+    returns?: U
   ): ZodFunction<T, U> => {
     return new ZodFunction({
       t: z.ZodTypes.function,

--- a/src/types/intersection.ts
+++ b/src/types/intersection.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
@@ -16,9 +16,9 @@ export class ZodIntersection<
   T extends z.ZodTypeAny,
   U extends z.ZodTypeAny
 > extends z.ZodType<
-  T['_output'] & U['_output'],
+  T["_output"] & U["_output"],
   ZodIntersectionDef<T, U>,
-  T['_input'] & U['_input']
+  T["_input"] & U["_input"]
 > {
   // opt optional: () => ZodUnion<[this, ZodUndefined]> = () => ZodUnion.create([this, ZodUndefined.create()]);
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
@@ -31,7 +31,7 @@ export class ZodIntersection<
 
   static create = <T extends z.ZodTypeAny, U extends z.ZodTypeAny>(
     left: T,
-    right: U,
+    right: U
   ): ZodIntersection<T, U> => {
     return new ZodIntersection({
       t: z.ZodTypes.intersection,

--- a/src/types/lazy.ts
+++ b/src/types/lazy.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';

--- a/src/types/literal.ts
+++ b/src/types/literal.ts
@@ -1,8 +1,8 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
-import { Primitive } from '../helpers/primitive';
+import { Primitive } from "../helpers/primitive";
 
 type LiteralValue = Primitive;
 

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 
 export interface ZodMapDef<
   Key extends z.ZodTypeAny = z.ZodTypeAny,
@@ -13,9 +13,9 @@ export class ZodMap<
   Key extends z.ZodTypeAny = z.ZodTypeAny,
   Value extends z.ZodTypeAny = z.ZodTypeAny
 > extends z.ZodType<
-  Map<Key['_output'], Value['_output']>,
+  Map<Key["_output"], Value["_output"]>,
   ZodMapDef<Key, Value>,
-  Map<Key['_input'], Value['_input']>
+  Map<Key["_input"], Value["_input"]>
 > {
   readonly _value!: Value;
 
@@ -30,7 +30,7 @@ export class ZodMap<
     Value extends z.ZodTypeAny = z.ZodTypeAny
   >(
     keyType: Key,
-    valueType: Value,
+    valueType: Value
   ): ZodMap<Key, Value> => {
     return new ZodMap({
       t: z.ZodTypes.map,

--- a/src/types/nativeEnum.ts
+++ b/src/types/nativeEnum.ts
@@ -1,13 +1,17 @@
-import * as z from './base';
+import * as z from "./base";
 
-export interface ZodNativeEnumDef<T extends EnumLike = EnumLike> extends z.ZodTypeDef {
+export interface ZodNativeEnumDef<T extends EnumLike = EnumLike>
+  extends z.ZodTypeDef {
   t: z.ZodTypes.nativeEnum;
   values: T;
 }
 
 type EnumLike = { [k: string]: string | number; [nu: number]: string };
 
-export class ZodNativeEnum<T extends EnumLike> extends z.ZodType<T[keyof T], ZodNativeEnumDef<T>> {
+export class ZodNativeEnum<T extends EnumLike> extends z.ZodType<
+  T[keyof T],
+  ZodNativeEnumDef<T>
+> {
   toJSON = () => this._def;
   static create = <T extends EnumLike>(values: T): ZodNativeEnum<T> => {
     return new ZodNativeEnum({

--- a/src/types/never.ts
+++ b/src/types/never.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 
 export interface ZodNeverDef extends z.ZodTypeDef {
   t: z.ZodTypes.never;

--- a/src/types/null.ts
+++ b/src/types/null.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodUnion } from './union';
 

--- a/src/types/nullable.ts
+++ b/src/types/nullable.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 
 export interface ZodNullableDef<T extends z.ZodTypeAny = z.ZodTypeAny>
   extends z.ZodTypeDef {
@@ -7,20 +7,18 @@ export interface ZodNullableDef<T extends z.ZodTypeAny = z.ZodTypeAny>
 }
 
 // This type allows for nullable flattening
-export type ZodNullableType<T extends z.ZodTypeAny> = T extends ZodNullable<
-  z.ZodTypeAny
->
-  ? T
-  : ZodNullable<T>;
+export type ZodNullableType<
+  T extends z.ZodTypeAny
+> = T extends ZodNullable<z.ZodTypeAny> ? T : ZodNullable<T>;
 
 export class ZodNullable<
   T extends z.ZodTypeAny
   //  Output extends T['_output'] | null = T['_output'] | null,
   //  Input extends T['_input'] | null = T['_input'] | null
 > extends z.ZodType<
-  T['_output'] | null,
+  T["_output"] | null,
   ZodNullableDef<T>,
-  T['_input'] | null
+  T["_input"] | null
 > {
   // An nullable nullable is the original nullable
   // nullable: () => ZodNullableType<this> = () => this as ZodNullableType<this>;

--- a/src/types/number.ts
+++ b/src/types/number.ts
@@ -1,9 +1,9 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
-import { ZodIssueCode } from '../ZodError';
-import { errorUtil } from '../helpers/errorUtil';
+import { ZodIssueCode } from "../ZodError";
+import { errorUtil } from "../helpers/errorUtil";
 
 export interface ZodNumberDef extends z.ZodTypeDef {
   t: z.ZodTypes.number;
@@ -22,63 +22,63 @@ export class ZodNumber extends z.ZodType<number, ZodNumberDef> {
   };
 
   min = (minimum: number, message?: errorUtil.ErrMessage) =>
-    this.refinement(data => data >= minimum, {
+    this.refinement((data) => data >= minimum, {
       code: ZodIssueCode.too_small,
       minimum,
-      type: 'number',
+      type: "number",
       inclusive: true,
       ...errorUtil.errToObj(message),
     });
 
   max = (maximum: number, message?: errorUtil.ErrMessage) =>
-    this.refinement(data => data <= maximum, {
+    this.refinement((data) => data <= maximum, {
       code: ZodIssueCode.too_big,
       maximum,
-      type: 'number',
+      type: "number",
       inclusive: true,
       ...errorUtil.errToObj(message),
     });
 
   int = (message?: errorUtil.ErrMessage) =>
-    this.refinement(data => Number.isInteger(data), {
+    this.refinement((data) => Number.isInteger(data), {
       code: ZodIssueCode.invalid_type,
-      expected: 'integer',
-      received: 'number',
+      expected: "integer",
+      received: "number",
       ...errorUtil.errToObj(message),
     });
 
   positive = (message?: errorUtil.ErrMessage) =>
-    this.refinement(data => data > 0, {
+    this.refinement((data) => data > 0, {
       code: ZodIssueCode.too_small,
       minimum: 0,
-      type: 'number',
+      type: "number",
       inclusive: false,
       ...errorUtil.errToObj(message),
     });
 
   negative = (message?: errorUtil.ErrMessage) =>
-    this.refinement(data => data < 0, {
+    this.refinement((data) => data < 0, {
       code: ZodIssueCode.too_big,
       maximum: 0,
-      type: 'number',
+      type: "number",
       inclusive: false,
       ...errorUtil.errToObj(message),
     });
 
   nonpositive = (message?: errorUtil.ErrMessage) =>
-    this.refinement(data => data <= 0, {
+    this.refinement((data) => data <= 0, {
       code: ZodIssueCode.too_big,
       maximum: 0,
-      type: 'number',
+      type: "number",
       inclusive: true,
       ...errorUtil.errToObj(message),
     });
 
   nonnegative = (message?: errorUtil.ErrMessage) =>
-    this.refinement(data => data >= 0, {
+    this.refinement((data) => data >= 0, {
       code: ZodIssueCode.too_small,
       minimum: 0,
-      type: 'number',
+      type: "number",
       inclusive: true,
       ...errorUtil.errToObj(message),
     });

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -1,27 +1,27 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
-import { objectUtil } from '../helpers/objectUtil';
-import { partialUtil } from '../helpers/partialUtil';
-import { isScalar } from '../isScalar';
-import { ZodNever } from '..';
-import { Scalars } from '../helpers/primitive';
+import { objectUtil } from "../helpers/objectUtil";
+import { partialUtil } from "../helpers/partialUtil";
+import { isScalar } from "../isScalar";
+import { ZodNever } from "..";
+import { Scalars } from "../helpers/primitive";
 
 const AugmentFactory = <Def extends ZodObjectDef>(def: Def) => <
   Augmentation extends z.ZodRawShape
 >(
-  augmentation: Augmentation,
+  augmentation: Augmentation
 ): ZodObject<
   {
     [k in Exclude<
-      keyof ReturnType<Def['shape']>,
+      keyof ReturnType<Def["shape"]>,
       keyof Augmentation
-    >]: ReturnType<Def['shape']>[k];
+    >]: ReturnType<Def["shape"]>[k];
   } &
     { [k in keyof Augmentation]: Augmentation[k] },
-  Def['unknownKeys'],
-  Def['catchall']
+  Def["unknownKeys"],
+  Def["catchall"]
 > => {
   return new ZodObject({
     ...def,
@@ -32,7 +32,7 @@ const AugmentFactory = <Def extends ZodObjectDef>(def: Def) => <
   }) as any;
 };
 
-type UnknownKeysParam = 'passthrough' | 'strict' | 'strip';
+type UnknownKeysParam = "passthrough" | "strict" | "strip";
 
 export interface ZodObjectDef<
   T extends z.ZodRawShape = z.ZodRawShape,
@@ -53,7 +53,7 @@ export type baseObjectOutputType<
 > = objectUtil.flatten<
   objectUtil.addQuestionMarks<
     {
-      [k in keyof Shape]: Shape[k]['_output'];
+      [k in keyof Shape]: Shape[k]["_output"];
     }
   > //{ [k: string]: Catchall['_output'] }
 >;
@@ -64,7 +64,7 @@ export type objectOutputType<
 > = z.ZodTypeAny extends Catchall
   ? baseObjectOutputType<Shape>
   : objectUtil.flatten<
-      baseObjectOutputType<Shape> & { [k: string]: Catchall['_output'] }
+      baseObjectOutputType<Shape> & { [k: string]: Catchall["_output"] }
     >;
 
 export type baseObjectInputType<
@@ -72,7 +72,7 @@ export type baseObjectInputType<
 > = objectUtil.flatten<
   objectUtil.addQuestionMarks<
     {
-      [k in keyof Shape]: Shape[k]['_input'];
+      [k in keyof Shape]: Shape[k]["_input"];
     }
   >
 >;
@@ -83,16 +83,16 @@ export type objectInputType<
 > = z.ZodTypeAny extends Catchall
   ? baseObjectInputType<Shape>
   : objectUtil.flatten<
-      baseObjectInputType<Shape> & { [k: string]: Catchall['_input'] }
+      baseObjectInputType<Shape> & { [k: string]: Catchall["_input"] }
     >;
 
 const objectDefToJson = (def: ZodObjectDef<any, any>) => ({
   t: def.t,
   shape: Object.assign(
     {},
-    ...Object.keys(def.shape()).map(k => ({
+    ...Object.keys(def.shape()).map((k) => ({
       [k]: def.shape()[k].toJSON(),
-    })),
+    }))
   ),
 });
 
@@ -139,7 +139,7 @@ export type AnyZodObject = ZodObject<any, any, any>;
 // >;
 export class ZodObject<
   T extends z.ZodRawShape,
-  UnknownKeys extends UnknownKeysParam = 'passthrough',
+  UnknownKeys extends UnknownKeysParam = "passthrough",
   Catchall extends z.ZodTypeAny = z.ZodTypeAny,
   // Params extends ZodObjectParams = { strict: true },
   // Type extends ZodObjectType<T, Params> = ZodObjectType<T, Params>
@@ -169,22 +169,22 @@ export class ZodObject<
 
   toJSON = () => objectDefToJson(this._def);
 
-  strict = (): ZodObject<T, 'strict', Catchall> =>
+  strict = (): ZodObject<T, "strict", Catchall> =>
     new ZodObject({
       ...this._def,
-      unknownKeys: 'strict',
+      unknownKeys: "strict",
     });
 
-  strip = (): ZodObject<T, 'strip', Catchall> =>
+  strip = (): ZodObject<T, "strip", Catchall> =>
     new ZodObject({
       ...this._def,
-      unknownKeys: 'strip',
+      unknownKeys: "strip",
     });
 
-  passthrough = (): ZodObject<T, 'passthrough', Catchall> =>
+  passthrough = (): ZodObject<T, "passthrough", Catchall> =>
     new ZodObject({
       ...this._def,
-      unknownKeys: 'passthrough',
+      unknownKeys: "passthrough",
     });
 
   nonstrict = this.passthrough;
@@ -198,7 +198,7 @@ export class ZodObject<
 
   setKey = <Key extends string, Schema extends z.ZodTypeAny>(
     key: Key,
-    schema: Schema,
+    schema: Schema
   ): ZodObject<T & { [k in Key]: Schema }, UnknownKeys, Catchall> => {
     return this.augment({ [key]: schema }) as any;
   };
@@ -209,16 +209,16 @@ export class ZodObject<
    * upgrade if you are experiencing issues.
    */
   merge: <Incoming extends AnyZodObject>(
-    other: Incoming,
+    other: Incoming
   ) => ZodObject<
-    T & Incoming['_shape'],
+    T & Incoming["_shape"],
     UnknownKeys,
     Catchall
     // objectUtil.MergeObjectParams<Params, MergeUnknownKeys>
   > = objectUtil.mergeObjects(this as any) as any;
 
   catchall = <Index extends z.ZodTypeAny>(
-    index: Index,
+    index: Index
   ): ZodObject<
     T,
     UnknownKeys,
@@ -233,14 +233,14 @@ export class ZodObject<
   };
 
   pick = <Mask extends { [k in keyof T]?: true }>(
-    mask: Mask,
+    mask: Mask
   ): ZodObject<
     objectUtil.NoNever<{ [k in keyof Mask]: k extends keyof T ? T[k] : never }>,
     UnknownKeys,
     Catchall
   > => {
     const shape: any = {};
-    Object.keys(mask).map(key => {
+    Object.keys(mask).map((key) => {
       shape[key] = this.shape[key];
     });
     return new ZodObject({
@@ -250,14 +250,14 @@ export class ZodObject<
   };
 
   omit = <Mask extends { [k in keyof T]?: true }>(
-    mask: Mask,
+    mask: Mask
   ): ZodObject<
     objectUtil.NoNever<{ [k in keyof T]: k extends keyof Mask ? never : T[k] }>,
     UnknownKeys,
     Catchall
   > => {
     const shape: any = {};
-    Object.keys(this.shape).map(key => {
+    Object.keys(this.shape).map((key) => {
       if (Object.keys(mask).indexOf(key) === -1) {
         shape[key] = this.shape[key];
       }
@@ -269,7 +269,7 @@ export class ZodObject<
   };
 
   partial = (): ZodObject<
-    { [k in keyof T]: ReturnType<T[k]['optional']> },
+    { [k in keyof T]: ReturnType<T[k]["optional"]> },
     UnknownKeys,
     Catchall
   > => {
@@ -315,7 +315,7 @@ export class ZodObject<
   primitives = (): ZodObject<
     objectUtil.NoNever<
       {
-        [k in keyof T]: [T[k]['_output']] extends [Scalars] ? T[k] : never;
+        [k in keyof T]: [T[k]["_output"]] extends [Scalars] ? T[k] : never;
       }
     >,
     UnknownKeys,
@@ -336,7 +336,7 @@ export class ZodObject<
   nonprimitives = (): ZodObject<
     objectUtil.NoNever<
       {
-        [k in keyof T]: [T[k]['_output']] extends [Scalars] ? never : T[k];
+        [k in keyof T]: [T[k]["_output"]] extends [Scalars] ? never : T[k];
       }
     >,
     UnknownKeys,
@@ -381,7 +381,7 @@ export class ZodObject<
     return new ZodObject({
       t: z.ZodTypes.object,
       shape: () => shape,
-      unknownKeys: 'strip',
+      unknownKeys: "strip",
       catchall: ZodNever.create(),
       //  params: {
       //    strict: true,
@@ -390,12 +390,12 @@ export class ZodObject<
   };
 
   static lazycreate = <T extends z.ZodRawShape>(
-    shape: () => T,
+    shape: () => T
   ): ZodObject<T> => {
     return new ZodObject({
       t: z.ZodTypes.object,
       shape,
-      unknownKeys: 'strip',
+      unknownKeys: "strip",
       catchall: ZodNever.create(),
     }) as any;
   };

--- a/src/types/optional.ts
+++ b/src/types/optional.ts
@@ -1,4 +1,4 @@
-import { ZodType, ZodTypeAny, ZodTypeDef, ZodTypes } from './base';
+import { ZodType, ZodTypeAny, ZodTypeDef, ZodTypes } from "./base";
 
 // import * as z from './base';
 // type asdf = ZodTypeAny
@@ -10,16 +10,14 @@ export interface ZodOptionalDef<T extends ZodTypeAny = ZodTypeAny>
 }
 
 // This type allows for optional flattening
-export type ZodOptionalType<T extends ZodTypeAny> = T extends ZodOptional<
-  ZodTypeAny
->
-  ? T
-  : ZodOptional<T>;
+export type ZodOptionalType<
+  T extends ZodTypeAny
+> = T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
 
 export class ZodOptional<T extends ZodTypeAny> extends ZodType<
-  T['_output'] | undefined,
+  T["_output"] | undefined,
   ZodOptionalDef<T>,
-  T['_input'] | undefined
+  T["_input"] | undefined
 > {
   // An optional optional is the original optional
   // optional: () => ZodOptionalType<this> = () => this as ZodOptionalType<this>;

--- a/src/types/promise.ts
+++ b/src/types/promise.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
@@ -10,9 +10,9 @@ export interface ZodPromiseDef<T extends z.ZodTypeAny = z.ZodTypeAny>
 }
 
 export class ZodPromise<T extends z.ZodTypeAny> extends z.ZodType<
-  Promise<T['_output']>,
+  Promise<T["_output"]>,
   ZodPromiseDef<T>,
-  Promise<T['_input']>
+  Promise<T["_input"]>
 > {
   toJSON = () => {
     return {

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
@@ -12,9 +12,9 @@ export interface ZodRecordDef<Value extends z.ZodTypeAny = z.ZodTypeAny>
 export class ZodRecord<
   Value extends z.ZodTypeAny = z.ZodTypeAny
 > extends z.ZodType<
-  Record<string, Value['_output']>, // { [k in keyof T]: T[k]['_type'] },
+  Record<string, Value["_output"]>, // { [k in keyof T]: T[k]['_type'] },
   ZodRecordDef<Value>,
-  Record<string, Value['_input']>
+  Record<string, Value["_input"]>
 > {
   readonly _value!: Value;
 
@@ -28,7 +28,7 @@ export class ZodRecord<
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
 
   static create = <Value extends z.ZodTypeAny = z.ZodTypeAny>(
-    valueType: Value,
+    valueType: Value
   ): ZodRecord<Value> => {
     return new ZodRecord({
       t: z.ZodTypes.record,

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -1,9 +1,9 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
-import { StringValidation, ZodIssueCode } from '../ZodError';
-import { errorUtil } from '../helpers/errorUtil';
+import { StringValidation, ZodIssueCode } from "../ZodError";
+import { errorUtil } from "../helpers/errorUtil";
 
 export interface ZodStringDef extends z.ZodTypeDef {
   t: z.ZodTypes.string;
@@ -22,19 +22,19 @@ export class ZodString extends z.ZodType<string, ZodStringDef> {
 
   toJSON = () => this._def;
   min = (minLength: number, message?: errorUtil.ErrMessage) =>
-    this.refinement(data => data.length >= minLength, {
+    this.refinement((data) => data.length >= minLength, {
       code: ZodIssueCode.too_small,
       minimum: minLength,
-      type: 'string',
+      type: "string",
       inclusive: true,
       ...errorUtil.errToObj(message),
     });
 
   max = (maxLength: number, message?: errorUtil.ErrMessage) =>
-    this.refinement(data => data.length <= maxLength, {
+    this.refinement((data) => data.length <= maxLength, {
       code: ZodIssueCode.too_big,
       maximum: maxLength,
-      type: 'string',
+      type: "string",
       inclusive: true,
       ...errorUtil.errToObj(message),
     });
@@ -46,9 +46,9 @@ export class ZodString extends z.ZodType<string, ZodStringDef> {
   protected _regex = (
     regex: RegExp,
     validation: StringValidation,
-    message?: errorUtil.ErrMessage,
+    message?: errorUtil.ErrMessage
   ) =>
-    this.refinement(data => regex.test(data), {
+    this.refinement((data) => regex.test(data), {
       validation,
       code: ZodIssueCode.invalid_string,
 
@@ -56,11 +56,11 @@ export class ZodString extends z.ZodType<string, ZodStringDef> {
     });
 
   email = (message?: errorUtil.ErrMessage) =>
-    this._regex(emailRegex, 'email', message);
+    this._regex(emailRegex, "email", message);
 
   url = (message?: errorUtil.ErrMessage) =>
     this.refinement(
-      data => {
+      (data) => {
         try {
           new URL(data);
           return true;
@@ -70,18 +70,18 @@ export class ZodString extends z.ZodType<string, ZodStringDef> {
       },
       {
         code: ZodIssueCode.invalid_string,
-        validation: 'url',
+        validation: "url",
         ...errorUtil.errToObj(message),
-      },
+      }
     );
 
   // url = (message?: errorUtil.ErrMessage) => this._regex(urlRegex, 'url', message);
 
   uuid = (message?: errorUtil.ErrMessage) =>
-    this._regex(uuidRegex, 'uuid', message);
+    this._regex(uuidRegex, "uuid", message);
 
   regex = (regexp: RegExp, message?: errorUtil.ErrMessage) =>
-    this._regex(regexp, 'regex', message);
+    this._regex(regexp, "regex", message);
 
   nonempty = (message?: errorUtil.ErrMessage) =>
     this.min(1, errorUtil.errToObj(message));

--- a/src/types/transformer.ts
+++ b/src/types/transformer.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';
@@ -10,13 +10,13 @@ export interface ZodTransformerDef<
   t: z.ZodTypes.transformer;
   input: T;
   output: U;
-  transformer: (arg: T['_output']) => U['_input'];
+  transformer: (arg: T["_output"]) => U["_input"];
 }
 
 export class ZodTransformer<
   T extends z.ZodTypeAny,
   U extends z.ZodTypeAny
-> extends z.ZodType<U['_output'], ZodTransformerDef<T, U>, T['_input']> {
+> extends z.ZodType<U["_output"], ZodTransformerDef<T, U>, T["_input"]> {
   // readonly _input!: T['_input'];
   // readonly _output!: U['_output'];
   // opt optional: () => ZodUnion<[this, ZodUndefined]> = () => ZodUnion.create([this, ZodUndefined.create()]);
@@ -61,7 +61,7 @@ export class ZodTransformer<
   static create = <I extends z.ZodTypeAny, O extends z.ZodTypeAny>(
     input: I,
     output: O,
-    transformer: (arg: I['_output']) => O['_input'] | Promise<O['_input']>,
+    transformer: (arg: I["_output"]) => O["_input"] | Promise<O["_input"]>
   ): ZodTransformer<I, O> => {
     return new ZodTransformer({
       t: z.ZodTypes.transformer,
@@ -72,13 +72,13 @@ export class ZodTransformer<
   };
 
   static fromSchema = <I extends z.ZodTypeAny>(
-    input: I,
+    input: I
   ): ZodTransformer<I, I> => {
     return new ZodTransformer({
       t: z.ZodTypes.transformer,
       input,
       output: input,
-      transformer: x => x,
+      transformer: (x) => x,
     });
   };
 }

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { objectUtil } from '../helpers/objectUtil';
 // import { ZodUnion } from './union';
 // import { ZodUndefined } from './undefined';
@@ -35,19 +35,19 @@ import * as z from './base';
 export type OutputTypeOfTuple<
   T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | []
 > = {
-  [k in keyof T]: T[k] extends z.ZodType<any, any> ? T[k]['_output'] : never;
+  [k in keyof T]: T[k] extends z.ZodType<any, any> ? T[k]["_output"] : never;
 };
 
 export type InputTypeOfTuple<
   T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | []
 > = {
-  [k in keyof T]: T[k] extends z.ZodType<any, any> ? T[k]['_input'] : never;
+  [k in keyof T]: T[k] extends z.ZodType<any, any> ? T[k]["_input"] : never;
 };
 
 export interface ZodTupleDef<
   T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | [] = [
     z.ZodTypeAny,
-    ...z.ZodTypeAny[],
+    ...z.ZodTypeAny[]
   ]
 > extends z.ZodTypeDef {
   t: z.ZodTypes.tuple;
@@ -57,12 +57,12 @@ export interface ZodTupleDef<
 export class ZodTuple<
   T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | [] = [
     z.ZodTypeAny,
-    ...z.ZodTypeAny[],
+    ...z.ZodTypeAny[]
   ]
 > extends z.ZodType<OutputTypeOfTuple<T>, ZodTupleDef<T>, InputTypeOfTuple<T>> {
   toJSON = () => ({
     t: this._def.t,
-    items: (this._def.items as any[]).map(item => item.toJSON()),
+    items: (this._def.items as any[]).map((item) => item.toJSON()),
   });
 
   get items() {
@@ -74,7 +74,7 @@ export class ZodTuple<
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
 
   static create = <T extends [z.ZodTypeAny, ...z.ZodTypeAny[]] | []>(
-    schemas: T,
+    schemas: T
   ): ZodTuple<T> => {
     return new ZodTuple({
       t: z.ZodTypes.tuple,

--- a/src/types/undefined.ts
+++ b/src/types/undefined.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUnion } from './union';
 // import { ZodNull } from './null';
 

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 
@@ -6,7 +6,7 @@ export interface ZodUnionDef<
   T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]] = [
     z.ZodTypeAny,
     z.ZodTypeAny,
-    ...z.ZodTypeAny[],
+    ...z.ZodTypeAny[]
   ]
 > extends z.ZodTypeDef {
   t: z.ZodTypes.union;
@@ -15,14 +15,14 @@ export interface ZodUnionDef<
 
 export class ZodUnion<
   T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]
-> extends z.ZodType<T[number]['_output'], ZodUnionDef<T>, T[number]['_input']> {
+> extends z.ZodType<T[number]["_output"], ZodUnionDef<T>, T[number]["_input"]> {
   // opt optional: () => ZodUnion<[this, ZodUndefined]> = () => ZodUnion.create([this, ZodUndefined.create()]);
 
   // null nullable: () => ZodUnion<[this, ZodNull]> = () => ZodUnion.create([this, ZodNull.create()]);
 
   toJSON = (): object => ({
     t: this._def.t,
-    options: this._def.options.map(x => x.toJSON()),
+    options: this._def.options.map((x) => x.toJSON()),
   });
 
   get options() {
@@ -34,7 +34,7 @@ export class ZodUnion<
   // };
 
   static create = <T extends [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]>(
-    types: T,
+    types: T
   ): ZodUnion<T> => {
     return new ZodUnion({
       t: z.ZodTypes.union,

--- a/src/types/unknown.ts
+++ b/src/types/unknown.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';

--- a/src/types/void.ts
+++ b/src/types/void.ts
@@ -1,4 +1,4 @@
-import * as z from './base';
+import * as z from "./base";
 // import { ZodUndefined } from './undefined';
 // import { ZodNull } from './null';
 // import { ZodUnion } from './union';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3371,10 +3371,10 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
Updates fixes format script to not fail when attempting to search for `src/**/*.js` files. Also, updates Prettier and runs `format` using the prettier defaults. The below table shows a comparison between the existing value for the Prettier options and the default value.

| Option          | Existing Value | Prettier Default Value |
| --------------- | -------------- | ---------------------- |
| `printWidth`    | `80`           | `80`                   |
| `trailingComma` | `"all"`        | `"es5"`                |
| `singleQuote`   | `true`         | `false`                |

Attempting to rip it off like a bandaid rather than let it roll in with each upcoming PR. If this is too much change, though, I can revert the changes to the files. Just let me know 👍 

Relates to #225.