### PR TITLE
Update yup differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1490,20 +1490,16 @@ Doesn't support static type inference 😕 Immediate disqualification, sorry Joi
 
 [https://github.com/jquense/yup](https://github.com/jquense/yup)
 
-Yup is a full-featured library that was implemented first in vanilla JS, with TypeScript typings added later.
+Yup is a full-featured library that was implemented first in vanilla JS, and later rewritten in TypeScript.
 
 Differences
 
 - Supports for casting and transformation
 - All object fields are optional by default
-- Non-standard `.required()`¹
-- Missing object methods: (pick, omit, partial, deepPartial, merge, extend)
-- Missing nonempty arrays with proper typing (`[T, ...T[]]`)
+- Missing object methods: (partial, deepPartial)
 - Missing promise schemas
 - Missing function schemas
 - Missing union & intersection schemas
-
-¹ Yup has a strange interpretation of the `.required()` is odd and non-standard. Instead of meaning "not undefined", Yup uses it to mean "not empty". So `yup.string().required()` will not accept an empty string, and `yup.array(yup.string()).required()` will not accept an empty array. For Zod arrays there is a dedicated `.nonempty()` method to indicate this, or you can implement it with a custom validator.
 
 #### io-ts
 


### PR DESCRIPTION
👋  howdy, sorry for the drive-by edits. Updating the readme to match the current reality. I removed the note about `required()` since it was sort of misleading and i couldn't think of another way to explain the situation without adding a bunch of yup specific details you probably don't want in your readme. tl;dr;

`required()` is weird, and named poorly, it generally means "not null or undefined" except in the string case where it also means "not an empty string" (the empty array case has been finally changed to be normal and not mean "no empty arrays"). In terms of feature comparison tho, it's not the right method to call out. Yup has a "not undefined" method, it's called `defined()` which is the more apples to apples comparison to zod's `required()`. IDK if that's worth noting to your users happy to reword.