### PR TITLE
test(deno bundle): add syntax sanity check for deno bundle v1.7.1+

### DIFF
--- a/.github/workflows/fix.yaml
+++ b/.github/workflows/fix.yaml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: 14
       - run: yarn install
+      - run: yarn clean
       - run: yarn fix:lint
       - run: yarn build:deno
       - run: yarn fix:format

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,18 +30,23 @@ jobs:
     runs-on: Ubuntu-20.04
     strategy:
       matrix:
-        deno: [ '1.6' ]
+        deno: [ "v1.7.1", "v1.x" ]
     name: Test with Deno ${{ matrix.deno }}
     steps:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
         with:
           deno-version: ${{ matrix.deno }}
+      - run: deno --version
       - run: deno test
         working-directory: ./deno/lib
       - run: deno run ./index.ts
         working-directory: ./deno/lib
       - run: deno run ./mod.ts
+        working-directory: ./deno/lib
+      - run: |
+          deno bundle ./mod.ts ./bundle.js
+          deno run ./bundle.js
         working-directory: ./deno/lib
 
   lint:


### PR DESCRIPTION
The just-released [Deno 1.7.1](https://github.com/denoland/deno/releases/tag/v1.7.1) fixes the last issue (https://github.com/denoland/deno/issues/9097) that was causing invalid bundles to be generated for Zod. This PR adds a sanity check that the generated bundle is at least importable without an error, and updates the test matrix to run against Deno 1.7.1 and the latest stable Deno 1.x release (please feel free to change that if you'd prefer to only run one or the other), dropping the test for the broken-bundling Deno 1.6.

Also adds` yarn clean` to fix.yaml to remove stale files, and removes the previously accidentally-committed stale `bundle.js`.

I am optimistic that this will remain stable from now on, but if it does break don't hesitate to tag me. 🙃