### PR TITLE
fix implement return type

### DIFF
--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -57,7 +57,7 @@ export class ZodFunction<
     });
   };
 
-  implement = <F extends InnerTypeOfFunction<Args, Returns>>(func: F): F => {
+  implement = <F extends InnerTypeOfFunction<Args, Returns>>(func: F): InnerTypeOfFunction<Args, Returns> => {
     const validatedFunc = this.parse(func);
     return validatedFunc as any;
   };


### PR DESCRIPTION
function.implement should return a function which has the same type declaration with the function shema. but T extends ... is a weaker definition.

for example

```typescript
const MyFnSchema = z.function().args(z.number()).returns(args.number());

const myFn = MyFnSchema.implement(a => a*2 as any)
// Oops, it works, but myFn is with type (a: number) => any, not (a:number) => number
```