### PR TITLE
Moves eslint-plugin-unused-imports to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-unused-imports": "^1.1.0",
     "husky": "^4.3.4",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.3",
@@ -85,8 +86,5 @@
       "yarn fix:lint",
       "yarn fix:format"
     ]
-  },
-  "dependencies": {
-    "eslint-plugin-unused-imports": "^1.1.0"
   }
 }


### PR DESCRIPTION
It seems like perhaps this was just a mistake of omitting the -D because can't seem to find any reference to using the plugin in the main source.