### PR TITLE
Improve error message when err.path is empty

### DIFF
--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -144,10 +144,9 @@ export class ZodError extends Error {
       '',
     ];
     for (const err of this.errors) {
+      const pathString = err.path.join('.') || '[[root]]';
       errorMessage.push(
-        `  Issue #${this.errors.indexOf(err)}: ${err.code} at ${err.path.join(
-          '.',
-        )}`,
+        `  Issue #${this.errors.indexOf(err)}: ${err.code} at ${pathString}`,
       );
       errorMessage.push(`  ` + err.message);
       errorMessage.push('');


### PR DESCRIPTION
Currently, the ZodError message looks buggy when `err.path` is empty. There should be some kind of explicit indication of an error occurring at the root-level value, instead of just showing an empty string.

Before:
```
Issue #1: unrecognized_keys at
```

After:
```
Issue #1: unrecognized_keys at [[root]]
```