### PR TITLE
export interface ZodObjectParams

### DIFF
--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -41,7 +41,7 @@ const objectDefToJson = (def: ZodObjectDef<any, any>) => ({
   ),
 });
 
-interface ZodObjectParams {
+export interface ZodObjectParams {
   strict: boolean;
 }
 


### PR DESCRIPTION
I'm using Zod to enforce the shape of other Zod schemas (for consistent api endpoint definitions). 

When I try:
```typescript
export const obj = z.instanceof( z.ZodObject );
```
I get: `Exported variable 'obj' has or is using name 'ZodObjectParams' from external module "/.../node_modules/zod/lib/src/types/object" but cannot be named.` This fixes  that.