### PR TITLE
Fixed UUID regex

### DIFF
--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -68,6 +68,16 @@ test("url error overrides", () => {
 test("uuid", () => {
   const uuid = z.string().uuid("custom error");
   uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
+  const result = uuid.safeParse("9491d710-3185-4e06-bea0-6a2f275345e0X");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
+test("bad uuid", () => {
+  const uuid = z.string().uuid("custom error");
+  uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
   const result = uuid.safeParse("invalid uuid");
   expect(result.success).toEqual(false);
   if (!result.success) {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -405,7 +405,7 @@ export interface ZodStringDef extends ZodTypeDef {
 
 // eslint-disable-next-line
 const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
-const uuidRegex = /([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}/i;
+const uuidRegex = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$/;
 
 export class ZodString extends ZodType<string, ZodStringDef> {
   _parse(ctx: ParseContext): ParseReturnType<string> {
@@ -438,7 +438,11 @@ export class ZodString extends ZodType<string, ZodStringDef> {
       }
     }
 
+    console.log(`this._def.isUUID:`, this._def.isUUID);
+    console.log(`uuidRegex.test(ctx.data)`, uuidRegex.test(ctx.data));
+
     if (this._def.isUUID && !uuidRegex.test(ctx.data)) {
+      console.log(`parsing uuid`);
       ctx.addIssue({
         validation: "uuid",
         code: ZodIssueCode.invalid_string,

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -67,6 +67,16 @@ test("url error overrides", () => {
 test("uuid", () => {
   const uuid = z.string().uuid("custom error");
   uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
+  const result = uuid.safeParse("9491d710-3185-4e06-bea0-6a2f275345e0X");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
+test("bad uuid", () => {
+  const uuid = z.string().uuid("custom error");
+  uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
   const result = uuid.safeParse("invalid uuid");
   expect(result.success).toEqual(false);
   if (!result.success) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -405,7 +405,7 @@ export interface ZodStringDef extends ZodTypeDef {
 
 // eslint-disable-next-line
 const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
-const uuidRegex = /([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}){1}/i;
+const uuidRegex = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$/;
 
 export class ZodString extends ZodType<string, ZodStringDef> {
   _parse(ctx: ParseContext): ParseReturnType<string> {
@@ -438,7 +438,11 @@ export class ZodString extends ZodType<string, ZodStringDef> {
       }
     }
 
+    console.log(`this._def.isUUID:`, this._def.isUUID);
+    console.log(`uuidRegex.test(ctx.data)`, uuidRegex.test(ctx.data));
+
     if (this._def.isUUID && !uuidRegex.test(ctx.data)) {
+      console.log(`parsing uuid`);
       ctx.addIssue({
         validation: "uuid",
         code: ZodIssueCode.invalid_string,


### PR DESCRIPTION
Previously the regex was missing anchors (^ and $) so validation would pass as long as the argument contained a valid UUID as a substring. Closes #389.

