### PR TITLE
Add benchmarking for parser

### DIFF
--- a/deno/lib/benchmarks/index.ts
+++ b/deno/lib/benchmarks/index.ts
@@ -1,0 +1,6 @@
+import objectBenchmarks from "./object.ts";
+import stringBenchmarks from "./string.ts";
+
+for (const suite of [...stringBenchmarks.suites, ...objectBenchmarks.suites]) {
+  suite.run();
+}

--- a/deno/lib/benchmarks/object.ts
+++ b/deno/lib/benchmarks/object.ts
@@ -1,0 +1,68 @@
+import Benchmark from "benchmark";
+
+import { z } from "../index.ts";
+
+const emptySuite = new Benchmark.Suite("z.object: empty");
+const shortSuite = new Benchmark.Suite("z.object: short");
+const longSuite = new Benchmark.Suite("z.object: long");
+
+const empty = z.object({});
+const short = z.object({
+  string: z.string(),
+});
+const long = z.object({
+  string: z.string(),
+  number: z.number(),
+  boolean: z.boolean(),
+});
+
+emptySuite
+  .add("valid", () => {
+    empty.parse({});
+  })
+  .add("valid: extra keys", () => {
+    empty.parse({ string: "string" });
+  })
+  .add("invalid: null", () => {
+    try {
+      empty.parse(null);
+    } catch (err) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`empty: ${e.target}`);
+  })
+  .run({ async: true });
+
+shortSuite
+  .add("valid", () => {
+    short.parse({ string: "string" });
+  })
+  .add("valid: extra keys", () => {
+    short.parse({ string: "string", number: 42 });
+  })
+  .add("invalid: null", () => {
+    try {
+      short.parse(null);
+    } catch (err) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`short: ${e.target}`);
+  })
+  .run({ async: true });
+
+longSuite
+  .add("valid", () => {
+    long.parse({ string: "string", number: 42, boolean: true });
+  })
+  .add("valid: extra keys", () => {
+    long.parse({ string: "string", number: 42, boolean: true, list: [] });
+  })
+  .add("invalid: null", () => {
+    try {
+      long.parse(null);
+    } catch (err) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`long: ${e.target}`);
+  })
+  .run({ async: true });

--- a/deno/lib/benchmarks/object.ts
+++ b/deno/lib/benchmarks/object.ts
@@ -29,9 +29,8 @@ emptySuite
     } catch (err) {}
   })
   .on("cycle", (e: Benchmark.Event) => {
-    console.log(`empty: ${e.target}`);
-  })
-  .run({ async: true });
+    console.log(`${(emptySuite as any).name}: ${e.target}`);
+  });
 
 shortSuite
   .add("valid", () => {
@@ -46,9 +45,8 @@ shortSuite
     } catch (err) {}
   })
   .on("cycle", (e: Benchmark.Event) => {
-    console.log(`short: ${e.target}`);
-  })
-  .run({ async: true });
+    console.log(`${(shortSuite as any).name}: ${e.target}`);
+  });
 
 longSuite
   .add("valid", () => {
@@ -63,6 +61,9 @@ longSuite
     } catch (err) {}
   })
   .on("cycle", (e: Benchmark.Event) => {
-    console.log(`long: ${e.target}`);
-  })
-  .run({ async: true });
+    console.log(`${(longSuite as any).name}: ${e.target}`);
+  });
+
+export default {
+  suites: [emptySuite, shortSuite, longSuite],
+};

--- a/deno/lib/benchmarks/string.ts
+++ b/deno/lib/benchmarks/string.ts
@@ -14,16 +14,22 @@ const manual = (str: unknown) => {
 
   return str;
 };
+const stringSchema = z.string();
 
 suite
   .add("empty string", () => {
-    z.string().parse(empty);
+    stringSchema.parse(empty);
   })
   .add("short string", () => {
-    z.string().parse(short);
+    stringSchema.parse(short);
   })
   .add("long string", () => {
-    z.string().parse(long);
+    stringSchema.parse(long);
+  })
+  .add("invalid: null", () => {
+    try {
+      stringSchema.parse(null);
+    } catch (err) {}
   })
   .add("manual parser: long", () => {
     manual(long);

--- a/deno/lib/benchmarks/string.ts
+++ b/deno/lib/benchmarks/string.ts
@@ -2,7 +2,8 @@ import Benchmark from "benchmark";
 
 import { z } from "../index.ts";
 
-const suite = new Benchmark.Suite("z.string");
+const SUITE_NAME = "z.string";
+const suite = new Benchmark.Suite(SUITE_NAME);
 
 const empty = "";
 const short = "short";
@@ -35,6 +36,9 @@ suite
     manual(long);
   })
   .on("cycle", (e: Benchmark.Event) => {
-    console.log(String(e.target));
-  })
-  .run({ async: true });
+    console.log(`${SUITE_NAME}: ${e.target}`);
+  });
+
+export default {
+  suites: [suite],
+};

--- a/deno/lib/benchmarks/string.ts
+++ b/deno/lib/benchmarks/string.ts
@@ -1,0 +1,34 @@
+import Benchmark from "benchmark";
+
+import { z } from "../index.ts";
+
+const suite = new Benchmark.Suite("z.string");
+
+const empty = "";
+const short = "short";
+const long = "long".repeat(256);
+const manual = (str: unknown) => {
+  if (typeof str !== "string") {
+    throw new Error("Not a string");
+  }
+
+  return str;
+};
+
+suite
+  .add("empty string", () => {
+    z.string().parse(empty);
+  })
+  .add("short string", () => {
+    z.string().parse(short);
+  })
+  .add("long string", () => {
+    z.string().parse(long);
+  })
+  .add("manual parser: long", () => {
+    manual(long);
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(String(e.target));
+  })
+  .run({ async: true });

--- a/package.json
+++ b/package.json
@@ -59,10 +59,12 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.0",
+    "@types/benchmark": "^2.1.0",
     "@types/jest": "^26.0.17",
     "@types/node": "^14.14.10",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
+    "benchmark": "^2.1.4",
     "dependency-cruiser": "^9.19.0",
     "eslint": "^7.15.0",
     "eslint-config-prettier": "^7.1.0",
@@ -92,5 +94,6 @@
       "yarn fix:lint",
       "yarn fix:format"
     ]
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "badge": "make-coverage-badge --output-path ./coverage.svg",
     "prepublishOnly": "npm run test && npm run build && npm run build:deno",
     "play": "nodemon -e ts -w . -x ts-node src/playground.ts --project tsconfig.json --trace-warnings",
-    "depcruise": "depcruise -c .dependency-cruiser.js src"
+    "depcruise": "depcruise -c .dependency-cruiser.js src",
+    "benchmark": "ts-node src/benchmarks/index.ts"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.0",

--- a/src/benchmarks/index.ts
+++ b/src/benchmarks/index.ts
@@ -1,0 +1,6 @@
+import objectBenchmarks from "./object";
+import stringBenchmarks from "./string";
+
+for (const suite of [...stringBenchmarks.suites, ...objectBenchmarks.suites]) {
+  suite.run();
+}

--- a/src/benchmarks/object.ts
+++ b/src/benchmarks/object.ts
@@ -1,0 +1,68 @@
+import Benchmark from "benchmark";
+
+import { z } from "../index";
+
+const emptySuite = new Benchmark.Suite("z.object: empty");
+const shortSuite = new Benchmark.Suite("z.object: short");
+const longSuite = new Benchmark.Suite("z.object: long");
+
+const empty = z.object({});
+const short = z.object({
+  string: z.string(),
+});
+const long = z.object({
+  string: z.string(),
+  number: z.number(),
+  boolean: z.boolean(),
+});
+
+emptySuite
+  .add("valid", () => {
+    empty.parse({});
+  })
+  .add("valid: extra keys", () => {
+    empty.parse({ string: "string" });
+  })
+  .add("invalid: null", () => {
+    try {
+      empty.parse(null);
+    } catch (err) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`empty: ${e.target}`);
+  })
+  .run({ async: true });
+
+shortSuite
+  .add("valid", () => {
+    short.parse({ string: "string" });
+  })
+  .add("valid: extra keys", () => {
+    short.parse({ string: "string", number: 42 });
+  })
+  .add("invalid: null", () => {
+    try {
+      short.parse(null);
+    } catch (err) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`short: ${e.target}`);
+  })
+  .run({ async: true });
+
+longSuite
+  .add("valid", () => {
+    long.parse({ string: "string", number: 42, boolean: true });
+  })
+  .add("valid: extra keys", () => {
+    long.parse({ string: "string", number: 42, boolean: true, list: [] });
+  })
+  .add("invalid: null", () => {
+    try {
+      long.parse(null);
+    } catch (err) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`long: ${e.target}`);
+  })
+  .run({ async: true });

--- a/src/benchmarks/object.ts
+++ b/src/benchmarks/object.ts
@@ -29,9 +29,8 @@ emptySuite
     } catch (err) {}
   })
   .on("cycle", (e: Benchmark.Event) => {
-    console.log(`empty: ${e.target}`);
-  })
-  .run({ async: true });
+    console.log(`${(emptySuite as any).name}: ${e.target}`);
+  });
 
 shortSuite
   .add("valid", () => {
@@ -46,9 +45,8 @@ shortSuite
     } catch (err) {}
   })
   .on("cycle", (e: Benchmark.Event) => {
-    console.log(`short: ${e.target}`);
-  })
-  .run({ async: true });
+    console.log(`${(shortSuite as any).name}: ${e.target}`);
+  });
 
 longSuite
   .add("valid", () => {
@@ -63,6 +61,9 @@ longSuite
     } catch (err) {}
   })
   .on("cycle", (e: Benchmark.Event) => {
-    console.log(`long: ${e.target}`);
-  })
-  .run({ async: true });
+    console.log(`${(longSuite as any).name}: ${e.target}`);
+  });
+
+export default {
+  suites: [emptySuite, shortSuite, longSuite],
+};

--- a/src/benchmarks/string.ts
+++ b/src/benchmarks/string.ts
@@ -14,16 +14,22 @@ const manual = (str: unknown) => {
 
   return str;
 };
+const stringSchema = z.string();
 
 suite
   .add("empty string", () => {
-    z.string().parse(empty);
+    stringSchema.parse(empty);
   })
   .add("short string", () => {
-    z.string().parse(short);
+    stringSchema.parse(short);
   })
   .add("long string", () => {
-    z.string().parse(long);
+    stringSchema.parse(long);
+  })
+  .add("invalid: null", () => {
+    try {
+      stringSchema.parse(null);
+    } catch (err) {}
   })
   .add("manual parser: long", () => {
     manual(long);

--- a/src/benchmarks/string.ts
+++ b/src/benchmarks/string.ts
@@ -2,7 +2,8 @@ import Benchmark from "benchmark";
 
 import { z } from "../index";
 
-const suite = new Benchmark.Suite("z.string");
+const SUITE_NAME = "z.string";
+const suite = new Benchmark.Suite(SUITE_NAME);
 
 const empty = "";
 const short = "short";
@@ -35,6 +36,9 @@ suite
     manual(long);
   })
   .on("cycle", (e: Benchmark.Event) => {
-    console.log(String(e.target));
-  })
-  .run({ async: true });
+    console.log(`${SUITE_NAME}: ${e.target}`);
+  });
+
+export default {
+  suites: [suite],
+};

--- a/src/benchmarks/string.ts
+++ b/src/benchmarks/string.ts
@@ -1,0 +1,34 @@
+import Benchmark from "benchmark";
+
+import { z } from "../index";
+
+const suite = new Benchmark.Suite("z.string");
+
+const empty = "";
+const short = "short";
+const long = "long".repeat(256);
+const manual = (str: unknown) => {
+  if (typeof str !== "string") {
+    throw new Error("Not a string");
+  }
+
+  return str;
+};
+
+suite
+  .add("empty string", () => {
+    z.string().parse(empty);
+  })
+  .add("short string", () => {
+    z.string().parse(short);
+  })
+  .add("long string", () => {
+    z.string().parse(long);
+  })
+  .add("manual parser: long", () => {
+    manual(long);
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(String(e.target));
+  })
+  .run({ async: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -564,6 +564,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/benchmark@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/benchmark/-/benchmark-2.1.0.tgz#157e2ef22311d3140fb33e82a938a1beb26e78e0"
+  integrity sha512-wxT2/LZn4z0NvSfZirxmBx686CU7EXp299KHkIk79acXpQtgeYHrslFzDacPGXifC0Pe3CEaLup07bgY1PnuQw==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1070,6 +1075,14 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  integrity sha1-CfPeMckWQl1JjMLuVloOvzwqVik=
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
 
 binary-extensions@^2.0.0:
   version "2.0.0"
@@ -3601,6 +3614,11 @@ lodash@^4.17.13:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.4:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 log-symbols@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.0.0.tgz#69b3cc46d20f448eccdb75ea1fa733d9e821c920"
@@ -4205,6 +4223,11 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+platform@^1.3.3:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
As part of the work to help improve zod's performance, it seems to me like the first step is to add some benchmarking to track performance as we make changes. What's measured improves and all that.

Added a few really basic benchmarks and will want to expand this before landing it, but wanted to get some early feedback on this approach from @colinhacks and the rest of the community. It's also possible that we want these benchmarks to live "outside" of the code, so that it can import multiple versions to track changes, benchmark other similar libraries, incorporate other tools, etc.

TODO:

- [ ] Schemas
  - [x] String
  - [ ] Object
    - [x] Simple flat objects
    - [ ] Nested objects
    - [ ] Arrays of objects
  - [ ] etc..
- [ ] Documentation
- [ ] Add package.json script for running
- [ ] Collect results somewhere
- [ ] Add running infrastructure

===

## Current benchmarks:

```
z.string: empty string x 39,259 ops/sec ±3.98% (77 runs sampled)
z.string: short string x 40,917 ops/sec ±2.43% (77 runs sampled)
z.string: long string x 40,562 ops/sec ±2.54% (84 runs sampled)
z.string: invalid: null x 32,975 ops/sec ±3.76% (82 runs sampled)
z.string: manual parser: long x 770,761,225 ops/sec ±0.40% (95 runs sampled)

z.object: empty: valid x 25,292 ops/sec ±2.01% (77 runs sampled)
z.object: empty: valid: extra keys x 24,640 ops/sec ±2.69% (89 runs sampled)
z.object: empty: invalid: null x 35,210 ops/sec ±2.20% (86 runs sampled)
z.object: short: valid x 13,420 ops/sec ±3.00% (86 runs sampled)
z.object: short: valid: extra keys x 13,429 ops/sec ±2.00% (85 runs sampled)
z.object: short: invalid: null x 35,542 ops/sec ±3.11% (88 runs sampled)
z.object: long: valid x 7,155 ops/sec ±2.96% (81 runs sampled)
z.object: long: valid: extra keys x 7,292 ops/sec ±2.29% (87 runs sampled)
z.object: long: invalid: null x 35,468 ops/sec ±3.27% (84 runs sampled)
```