### PR TITLE
Fix "Symbol is undefined" error

### DIFF
--- a/deno/lib/PseudoPromise.ts
+++ b/deno/lib/PseudoPromise.ts
@@ -7,7 +7,8 @@ type Catcher = (error: Error, ctx: { async: boolean }) => any;
 type CatcherItem = { type: "catcher"; catcher: Catcher };
 type Items = (FuncItem | CatcherItem)[];
 
-export const NOSET = Symbol("no_set");
+export const NOSET =
+  typeof Symbol === "function" ? Symbol("no_set") : { no_set: true };
 export class PseudoPromise<PayloadType = undefined> {
   readonly _return: PayloadType | undefined;
   items: Items;

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -1,4 +1,7 @@
-export const INVALID = Symbol("invalid_data");
+export const INVALID =
+  typeof Symbol === "function"
+    ? Symbol("invalid_data")
+    : { invalid_data: true };
 export type INVALID = typeof INVALID;
 export namespace util {
   export type AssertEqual<T, Expected> = [T] extends [Expected]

--- a/src/PseudoPromise.ts
+++ b/src/PseudoPromise.ts
@@ -7,7 +7,8 @@ type Catcher = (error: Error, ctx: { async: boolean }) => any;
 type CatcherItem = { type: "catcher"; catcher: Catcher };
 type Items = (FuncItem | CatcherItem)[];
 
-export const NOSET = Symbol("no_set");
+export const NOSET =
+  typeof Symbol === "function" ? Symbol("no_set") : { no_set: true };
 export class PseudoPromise<PayloadType = undefined> {
   readonly _return: PayloadType | undefined;
   items: Items;

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,4 +1,7 @@
-export const INVALID = Symbol("invalid_data");
+export const INVALID =
+  typeof Symbol === "function"
+    ? Symbol("invalid_data")
+    : { invalid_data: true };
 export type INVALID = typeof INVALID;
 export namespace util {
   export type AssertEqual<T, Expected> = [T] extends [Expected]


### PR DESCRIPTION
We faced with issue, that in old browsers Symbol is not supported.
As I see, in the code, Symbol is used as unique value (not as unique key in an object).
So I added the check if Symbol exists and use an Object if not.