### PR TITLE
make addQuestionMarks a homomorphic mapped type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1153,16 +1153,14 @@ export namespace objectUtil {
   } &
     V;
 
-  type optionalKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? k : never;
-  }[keyof T];
-
-  type requiredKeys<T extends object> = Exclude<keyof T, optionalKeys<T>>;
+  type CanBeUndefined<K extends keyof T, T> = undefined extends T[K] ? K : never;
+  type CanNotBeUndefined<K extends keyof T, T> = undefined extends T[K] ? never : K;
 
   export type addQuestionMarks<T extends object> = {
-    [k in optionalKeys<T>]?: T[k];
-  } &
-    { [k in requiredKeys<T>]: T[k] };
+    [K in keyof T as CanBeUndefined<K, T>]?: T[K]
+  } & {
+    [K in keyof T as CanNotBeUndefined<K, T>]: T[K]
+  }
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;


### PR DESCRIPTION
This means that docstrings on the schema definition will transfer to the z.Infer generated type.

Fixes #423 

I can't think of a way to embed this into a test though. If anyone has any idea how to do so I'm all ears.