### PR TITLE
Stop inferring `unknown` fields as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### vNext
+
+- Object fields of type `unknown` are no longer inferred as optional.
 ### 3.2
 
 - Certain methods (`.or`, `.transform`) now return a new instance that wrap the current instance, instead of trying to avoid additional nesting. For example:

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -214,3 +214,10 @@ test("test inferred merged type", async () => {
   const f1: util.AssertEqual<asdf, { a: number }> = true;
   f1;
 });
+
+test("unknown field is not optional", () => {
+  const x = z.object({ a: z.unknown() });
+  type T = z.infer<typeof x>;
+  const f1: util.AssertEqual<T, { a: unknown }> = true;
+  f1;
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1217,7 +1217,11 @@ export namespace objectUtil {
     V;
 
   type optionalKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? k : never;
+    [k in keyof T]: unknown extends T[k]
+      ? never
+      : undefined extends T[k]
+      ? k
+      : never;
   }[keyof T];
 
   type requiredKeys<T extends object> = Exclude<keyof T, optionalKeys<T>>;

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -213,3 +213,10 @@ test("test inferred merged type", async () => {
   const f1: util.AssertEqual<asdf, { a: number }> = true;
   f1;
 });
+
+test("unknown field is not optional", () => {
+  const x = z.object({ a: z.unknown() });
+  type T = z.infer<typeof x>;
+  const f1: util.AssertEqual<T, { a: unknown }> = true;
+  f1;
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1217,7 +1217,11 @@ export namespace objectUtil {
     V;
 
   type optionalKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? k : never;
+    [k in keyof T]: unknown extends T[k]
+      ? never
+      : undefined extends T[k]
+      ? k
+      : never;
   }[keyof T];
 
   type requiredKeys<T extends object> = Exclude<keyof T, optionalKeys<T>>;


### PR DESCRIPTION
Addresses https://github.com/pkvince/medzy-monorepo/pull/295

This is a breaking change so let's wait until @colinhacks checks in