### PR TITLE
Fix README.md recommending deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ z.string().regex(regex);
 z.string().nonempty();
 ```
 
-> Use the `.nonempty` method if you want the empty string ( `""` ) to be considered invalid.
+> Use the `.min(1)` method if you want the empty string ( `""` ) to be considered invalid.
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions.
 

--- a/README.md
+++ b/README.md
@@ -317,8 +317,6 @@ z.string().regex(regex);
 z.string().nonempty();
 ```
 
-> Use the `.min(1)` method if you want the empty string ( `""` ) to be considered invalid.
-
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions.
 
 #### Custom error messages


### PR DESCRIPTION
Updated to be consistent with the comment above, which says that  `.nonempty` is deprecated .

Related issue: https://github.com/colinhacks/zod/issues/439