### PR TITLE
Deprecate `.nonstrict()`

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1522,6 +1522,10 @@ export class ZodObject<
       unknownKeys: "passthrough",
     }) as any;
 
+  /**
+   * @deprecated In most cases, this is no longer needed - unknown properties are now silently stripped.
+   * If you want to pass through unknown properies, use `.passthrough()` instead.
+   */
   nonstrict = this.passthrough;
 
   augment = AugmentFactory<ZodObjectDef<T, UnknownKeys, Catchall>>(this._def);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1522,6 +1522,10 @@ export class ZodObject<
       unknownKeys: "passthrough",
     }) as any;
 
+  /**
+   * @deprecated In most cases, this is no longer needed - unknown properties are now silently stripped.
+   * If you want to pass through unknown properies, use `.passthrough()` instead.
+   */
   nonstrict = this.passthrough;
 
   augment = AugmentFactory<ZodObjectDef<T, UnknownKeys, Catchall>>(this._def);


### PR DESCRIPTION
In my team's codebase, we have used `.nonstrict()` in many, many places because it was necessary with zod 1. Easy example: validating `process.env`, which always has extra properties that we don't care about.  Now that we've updated to zod 3, our code is still working, but it's unnecessary and slightly less safe than the default behaviour of `.strip()`. It'd be good if our IDE/linter could help us find these cases _and_ make sure that people who haven't carefully read zod changelogs don't add any new usages of `.nonstrict()`.