### PR TITLE
Docs improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1362,6 +1362,7 @@ const Strings = z.array(z.string()).superRefine((val, ctx) => {
       inclusive: true,
       message: "Too many items 😡",
     });
+    return false;
   }
 
   if (val.length !== new Set(val).size) {
@@ -1369,9 +1370,14 @@ const Strings = z.array(z.string()).superRefine((val, ctx) => {
       code: z.ZodIssueCode.custom,
       message: `No duplicated allowed.`,
     });
+    return false;
   }
+  
+  return true;
 });
 ```
+
+> ⚠️ Like `.refine`, `.superRefine` should not throw. Instead it should return a falsy value to signal failure.
 
 You can add as many issues as you like. If `ctx.addIssue` is NOT called during the execution of the function, validation passes.
 


### PR DESCRIPTION
When updating to version 3.3.4 typechecking failed for us since the signature of the superRefine function changed from returning `void` to returning `boolean | Promise<boolean>`.

This updates the code example to match the types + adds a note explaining the return type (like `.refine()`).

I'm not entirely sure if this was intentional given the documentation states that:

> If `ctx.addIssue` is NOT called during the execution of the function, validation passes.