### PR TITLE
Fix z.void() to reject null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.0
+
+- `.void()` now only accepts undefined, not null.
+
 ### 3.5
 
 - Add discriminator to all first-party schema defs

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ z.date();
 // empty types
 z.undefined();
 z.null();
-z.void(); // accepts null or undefined
+z.void(); // accepts undefined
 
 // catch-all types
 // allows any value
@@ -1112,7 +1112,7 @@ myFunction.returnType();
 * `args: ZodTuple` The first argument is a tuple (created with `z.tuple([...])` and defines the schema of the arguments to your function. If the function doesn't accept arguments, you can pass an empty tuple (`z.tuple([])`).
 * `returnType: any Zod schema` The second argument is the function's return type. This can be any Zod schema. -->
 
-> You can use the special `z.void()` option if your function doesn't return anything. This will let Zod properly infer the type of void-returning functions. (Void-returning function can actually return either undefined or null.)
+> You can use the special `z.void()` option if your function doesn't return anything. This will let Zod properly infer the type of void-returning functions. (Void-returning functions actually return undefined.)
 
 <!--
 

--- a/deno/lib/__tests__/void.test.ts
+++ b/deno/lib/__tests__/void.test.ts
@@ -6,9 +6,9 @@ import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
 test("void", () => {
   const v = z.void();
-  v.parse(null);
   v.parse(undefined);
 
+  expect(() => v.parse(null)).toThrow();
   expect(() => v.parse("")).toThrow();
 
   type v = z.infer<typeof v>;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1013,10 +1013,7 @@ export class ZodVoid extends ZodType<void, ZodVoidDef> {
     data: any,
     parsedType: ZodParsedType
   ): ParseReturnType<void> {
-    if (
-      parsedType !== ZodParsedType.undefined &&
-      parsedType !== ZodParsedType.null
-    ) {
+    if (parsedType !== ZodParsedType.undefined) {
       ctx.addIssue(data, {
         code: ZodIssueCode.invalid_type,
         expected: ZodParsedType.void,

--- a/src/__tests__/void.test.ts
+++ b/src/__tests__/void.test.ts
@@ -5,9 +5,9 @@ import { util } from "../helpers/util";
 import * as z from "../index";
 test("void", () => {
   const v = z.void();
-  v.parse(null);
   v.parse(undefined);
 
+  expect(() => v.parse(null)).toThrow();
   expect(() => v.parse("")).toThrow();
 
   type v = z.infer<typeof v>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1013,10 +1013,7 @@ export class ZodVoid extends ZodType<void, ZodVoidDef> {
     data: any,
     parsedType: ZodParsedType
   ): ParseReturnType<void> {
-    if (
-      parsedType !== ZodParsedType.undefined &&
-      parsedType !== ZodParsedType.null
-    ) {
+    if (parsedType !== ZodParsedType.undefined) {
       ctx.addIssue(data, {
         code: ZodIssueCode.invalid_type,
         expected: ZodParsedType.void,


### PR DESCRIPTION
`z.void()` previously accepted `null` or `undefined`, but the TypeScript `void` type is only assignable from `undefined` (unless `strictNullChecks` is `false`, in which case every type is assignable from `null` regardless).

This unsoundness could be observed as follows:

```js
const x = z.string().or(z.void()).parse(null);
if (x !== undefined) {
  // TypeScript infers x is a string, but it’s actually null
  x.trim(); // oops
}
```