### PR TITLE
Fix getter for maxLength

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -509,7 +509,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   get maxLength() {
     let max: number | null = null;
     this._def.checks.map((ch) => {
-      if (ch.kind === "min") {
+      if (ch.kind === "max") {
         if (max === null || ch.value < max) {
           max = ch.value;
         }


### PR DESCRIPTION
Fix getter on ZodString for maxLength, changing the def.checks from kind min to max