### PR TITLE
Fix isInvalid equality check

### DIFF
--- a/deno/lib/__tests__/parseUtil.test.ts
+++ b/deno/lib/__tests__/parseUtil.test.ts
@@ -1,0 +1,12 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { INVALID, isInvalid } from "../helpers/parseUtil.ts";
+
+test("parseUtil isInvalid should use structural typing", () => {
+  // Test for issue #556: https://github.com/colinhacks/zod/issues/556
+  const newInstance: INVALID = Object.freeze({ valid: false });
+  expect(isInvalid(newInstance)).toBe(true);
+  expect(isInvalid(INVALID)).toBe(true);
+});

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -198,7 +198,7 @@ export type ParseReturnType<T> =
   | ASYNC<SyncParseReturnType<T>>;
 
 export const isInvalid = (x: ParseReturnType<any>): x is INVALID =>
-  x === INVALID;
+  (x as any).valid === false;
 export const isOk = <T>(x: ParseReturnType<T>): x is OK<T> =>
   (x as any).valid === true;
 export const isAsync = <T>(

--- a/src/__tests__/parseUtil.test.ts
+++ b/src/__tests__/parseUtil.test.ts
@@ -1,0 +1,11 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import { INVALID, isInvalid } from "../helpers/parseUtil";
+
+test("parseUtil isInvalid should use structural typing", () => {
+  // Test for issue #556: https://github.com/colinhacks/zod/issues/556
+  const newInstance: INVALID = Object.freeze({ valid: false });
+  expect(isInvalid(newInstance)).toBe(true);
+  expect(isInvalid(INVALID)).toBe(true);
+});

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -198,7 +198,7 @@ export type ParseReturnType<T> =
   | ASYNC<SyncParseReturnType<T>>;
 
 export const isInvalid = (x: ParseReturnType<any>): x is INVALID =>
-  x === INVALID;
+  (x as any).valid === false;
 export const isOk = <T>(x: ParseReturnType<T>): x is OK<T> =>
   (x as any).valid === true;
 export const isAsync = <T>(


### PR DESCRIPTION
`===` comparisons only works when Zod is installed once in a monorepo setup with multiple packages using Zod.

This PR changes it to use structural type checking rather than referential equality checking.

The test reproduces the issue (i.e. fails before applying the change).

Closes #556