### PR TITLE
chore: Export a `SuperRefinement<T>` alias

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,10 @@ export type RefinementCtx = {
   path: (string | number)[];
   issueFound: boolean;
 };
+export type SuperRefinement<T> = (
+  val: T,
+  ctx: RefinementCtx
+) => void
 export type ZodRawShape = { [k: string]: ZodTypeAny };
 export type ZodTypeAny = ZodType<any, any, any>;
 export type TypeOf<T extends ZodType<any>> = T["_output"];


### PR DESCRIPTION
This is my attempt to add the type alias as described by Colin [here](https://github.com/colinhacks/zod/issues/540#issuecomment-883043680).

---

<details>
<summary>Examples of usage with the following schema</summary>

```ts
import {z} from 'zod';

// Current date state:
const currentMonth = new Date().getUTCMonth() + 1
const currentYear  = new Date().getUTCFullYear() - 2000


// Custom Validations:
// `.refine(inRange(x,y), err)` is like `z.number().min(x, err).max(y, err)`, but works after `transform()`
const inRange    = (x: number, y: number) => (n: number) => (n >= x && n <= y)
const r_isDigits = /^[0-9]+$/


// Custom Errors:
const errorRangeMonth = "Must be a number between 1 and 12"
const errorMinYear    = "Value should not be in the past"
const errorRangeCSC   = "Value should be 3 digits; 4 if American Express"
const errorDigits     = "Expected only numbers"


// Custom Types:
const zDigitString = z.string().regex(r_isDigits, errorDigits)
const zStringNumber = zDigitString.transform(s => parseInt(s))


// Actual schema
export const _zCreditCard = z.object({
  cc_number: zDigitString,
  cc_exp_month: zStringNumber.refine(inRange(1, 12), errorRangeMonth),
  cc_exp_year: zStringNumber.superRefine(min(currentYear, errorMinYear)),
  cc_csc: zDigitString.min(3, errorRangeCSC).max(4, errorRangeCSC),
})
```

</details>

With these two `superRefine()` methods:

```ts
// A `min()` implementation for zDigitString to use as if it were a `z.number().min(n, err)`
type zMin<T> = (min: T, message?: string) => z.SuperRefinement<T>
const min: zMin<number> = (min, message) => (val, ctx) => {
  if (val < min) {
    ctx.addIssue({
      code: z.ZodIssueCode.too_small,
      type: "number",
      minimum: min,
      inclusive: false,
      message,
    })
  }
}
```

```ts
// If not inlined into the schema definition, the type cannot be inferred implicitly.
// Explicitly infer and pass to `SuperRefinement<T>` for easier type definition:
type zOutput = z.infer<typeof _zCreditCard>
const isNotExpired: z.SuperRefinement<zOutput> = ({cc_exp_month: m, cc_exp_year: y}, ctx) => {
  if (y === currentYear && m <= currentMonth) {
    ctx.addIssue({
      code: z.ZodIssueCode.custom,
      path: ['cc_exp_month'],
      message: `Expiry date cannot be in the past`,
    })
  }
}

export const zCreditCard = _zCreditCard.superRefine(isNotExpired)
export type CreditCard = z.infer<typeof zCreditCard>
