### PR TITLE
Fix react-native/metro bundler warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "module": "./lib/index.mjs",
   "exports": {
     "require": "./lib/index.js",
-    "import": "./lib/index.mjs"
+    "import": "./lib/index.mjs",
+    "./package.json": "./package.json"
   },
   "files": [
     "/lib"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "types": "./lib/index.d.ts",
   "module": "./lib/index.mjs",
   "exports": {
-    "require": "./lib/index.js",
-    "import": "./lib/index.mjs",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    ".": {
+      "require": "./lib/index.js",
+      "import": "./lib/index.mjs",
+    }
   },
   "files": [
     "/lib"

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "types": "./lib/index.d.ts",
   "module": "./lib/index.mjs",
   "exports": {
-    "./package.json": "./package.json",
     ".": {
       "require": "./lib/index.js",
       "import": "./lib/index.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "/lib"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "./package.json": "./package.json",
     ".": {
       "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
+      "import": "./lib/index.mjs"
     }
   },
   "files": [


### PR DESCRIPTION
When using Zod in a react-native app, we see the following warning when running the bundler:
```
warn Package zod has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in <path>/node_modules/zod/package.json
```

The problem is described in https://github.com/react-native-community/cli/issues/1168 and that is where it should be properly fixed. In the meantime (that issue has been open for some time), the warning can be fixed in affected packages by adding an export for `package.json`.