### PR TITLE
Fix for TypeScript 4.4

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -153,10 +153,10 @@ export abstract class ZodType<
   spa = this.safeParseAsync;
 
   /** The .is method has been removed in Zod 3. For details see https://github.com/colinhacks/zod/tree/v3. */
-  is: never;
+  is!: never;
 
   /** The .check method has been removed in Zod 3. For details see https://github.com/colinhacks/zod/tree/v3. */
-  check: never;
+  check!: never;
 
   refine: <Func extends (arg: Output) => any, This extends this = this>(
     check: Func,

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,10 +153,10 @@ export abstract class ZodType<
   spa = this.safeParseAsync;
 
   /** The .is method has been removed in Zod 3. For details see https://github.com/colinhacks/zod/tree/v3. */
-  is: never;
+  is!: never;
 
   /** The .check method has been removed in Zod 3. For details see https://github.com/colinhacks/zod/tree/v3. */
-  check: never;
+  check!: never;
 
   refine: <Func extends (arg: Output) => any, This extends this = this>(
     check: Func,


### PR DESCRIPTION
Before:
```
$ deno cache https://deno.land/x/zod@v3.8.0/mod.ts
Check https://deno.land/x/zod@v3.8.0/mod.ts
error: TS2564 [ERROR]: Property 'is' has no initializer and is not definitely assigned in the constructor.
  is: never;
  ~~
    at https://deno.land/x/zod@v3.8.0/types.ts:156:3

TS2564 [ERROR]: Property 'check' has no initializer and is not definitely assigned in the constructor.
  check: never;
  ~~~~~
    at https://deno.land/x/zod@v3.8.0/types.ts:159:3

Found 2 errors.
```

Why is https://deno.land/x/zod 2 patch releases behind npm?