### PR TITLE
Support array type during intersection

### DIFF
--- a/src/__tests__/intersection.test.ts
+++ b/src/__tests__/intersection.test.ts
@@ -42,3 +42,29 @@ test("deep intersection", () => {
   const cat = Cat.parse({ properties: { is_animal: true, jumped: true } });
   expect(cat.properties).toEqual({ is_animal: true, jumped: true });
 });
+
+test("deep intersection of arrays", () => {
+  const Author = z.object({
+    posts: z.array(
+      z.object({
+        post_id: z.number(),
+      })
+    ),
+  });
+  const Registry = z
+    .object({
+      posts: z.array(
+        z.object({
+          title: z.string(),
+        })
+      ),
+    })
+    .and(Author);
+
+  const posts = [
+    { post_id: 1, title: 'Novels' },
+    { post_id: 2, title: 'Fairy tales' },
+  ];
+  const cat = Registry.parse({ posts });
+  expect(cat.posts).toEqual(posts);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -2067,6 +2067,25 @@ function mergeValues(
     }
 
     return { valid: true, data: newObj };
+  } else if (aType === ZodParsedType.array && bType === ZodParsedType.array) {
+    if (a.length !== b.length) {
+      return { valid: false };
+    }
+
+    const newArray = [];
+    for (let index = 0; index < a.length; index++) {
+      const itemA = a[index];
+      const itemB = b[index];
+      const sharedValue = mergeValues(itemA, itemB);
+
+      if (!sharedValue.valid) {
+        return { valid: false };
+      }
+
+      newArray.push(sharedValue.data);
+    }
+
+    return { valid: true, data: newArray };
   } else {
     return { valid: false };
   }


### PR DESCRIPTION
The change is motivated by https://github.com/colinhacks/zod/issues/636.
It should be possible to intersect schemas that consist of common fields, even
in the common fields are defined via `z.array`. Prior to the current change it
was only possible to intersect primitives/objects.