### PR TITLE
fix: correct error when inner union used

### DIFF
--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -235,3 +235,60 @@ test("inferred type for unknown/any keys", () => {
   > = true;
   _f1;
 });
+
+test("inner union", () => {
+  const a = z.object({
+    letter: z.literal("a"),
+  });
+  const b = z.object({
+    letter: z.literal("b").or(z.literal("B")),
+  });
+  const union = z.union([a, b]);
+
+  const result = union.safeParse({
+    letter: "A",
+  });
+
+  if (result.success) {
+    fail("result should not be success");
+  }
+  expect(result.error).toMatchObject({
+    issues: [
+      {
+        code: "invalid_union",
+        unionErrors: [
+          {
+            issues: [
+              { code: "invalid_type", message: "Expected a, received A" },
+            ],
+          },
+          {
+            issues: [
+              {
+                code: "invalid_union",
+                unionErrors: [
+                  {
+                    issues: [
+                      {
+                        code: "invalid_type",
+                        message: "Expected b, received A",
+                      },
+                    ],
+                  },
+                  {
+                    issues: [
+                      {
+                        code: "invalid_type",
+                        message: "Expected B, received A",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1963,22 +1963,14 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
     const options = this._def.options;
     const noMatch = (allIssues: ZodIssue[][]) => {
       const unionErrors = allIssues.map((issues) => new ZodError(issues));
-      const nonTypeErrors = unionErrors.filter((err) => {
-        return err.issues[0].code !== "invalid_type";
-      });
-      if (nonTypeErrors.length === 1) {
-        // TODO encapsulate
-        nonTypeErrors[0].issues.forEach((issue) => ctx.issues.push(issue));
-      } else {
-        this._addIssue(
-          ctx,
-          {
-            code: ZodIssueCode.invalid_union,
-            unionErrors,
-          },
-          { data }
-        );
-      }
+      this._addIssue(
+        ctx,
+        {
+          code: ZodIssueCode.invalid_union,
+          unionErrors,
+        },
+        { data }
+      );
       return INVALID;
     };
 

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -234,3 +234,60 @@ test("inferred type for unknown/any keys", () => {
   > = true;
   _f1;
 });
+
+test("inner union", () => {
+  const a = z.object({
+    letter: z.literal("a"),
+  });
+  const b = z.object({
+    letter: z.literal("b").or(z.literal("B")),
+  });
+  const union = z.union([a, b]);
+
+  const result = union.safeParse({
+    letter: "A",
+  });
+
+  if (result.success) {
+    fail("result should not be success");
+  }
+  expect(result.error).toMatchObject({
+    issues: [
+      {
+        code: "invalid_union",
+        unionErrors: [
+          {
+            issues: [
+              { code: "invalid_type", message: "Expected a, received A" },
+            ],
+          },
+          {
+            issues: [
+              {
+                code: "invalid_union",
+                unionErrors: [
+                  {
+                    issues: [
+                      {
+                        code: "invalid_type",
+                        message: "Expected b, received A",
+                      },
+                    ],
+                  },
+                  {
+                    issues: [
+                      {
+                        code: "invalid_type",
+                        message: "Expected B, received A",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1963,22 +1963,14 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
     const options = this._def.options;
     const noMatch = (allIssues: ZodIssue[][]) => {
       const unionErrors = allIssues.map((issues) => new ZodError(issues));
-      const nonTypeErrors = unionErrors.filter((err) => {
-        return err.issues[0].code !== "invalid_type";
-      });
-      if (nonTypeErrors.length === 1) {
-        // TODO encapsulate
-        nonTypeErrors[0].issues.forEach((issue) => ctx.issues.push(issue));
-      } else {
-        this._addIssue(
-          ctx,
-          {
-            code: ZodIssueCode.invalid_union,
-            unionErrors,
-          },
-          { data }
-        );
-      }
+      this._addIssue(
+        ctx,
+        {
+          code: ZodIssueCode.invalid_union,
+          unionErrors,
+        },
+        { data }
+      );
       return INVALID;
     };
 


### PR DESCRIPTION
Fixes #603

Honestly, I didn't understand the reasons behind this condition (`if (nonTypeErrors.length === 1)`). I tried to search in git history, but looks like this block was written initially. Also, no tests were fail when I removed it.