### PR TITLE
feat: allow specifying a message for unrecognized_keys error at strict call

### DIFF
--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -368,6 +368,16 @@ test("invalid and required and errorMap", () => {
   }).toThrow();
 });
 
+test("strict error message", () => {
+  const errorMsg = "Invalid object";
+  const obj = z.object({ x: z.string() }).strict(errorMsg);
+  const result = obj.safeParse({ x: "a", y: "b" });
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(errorMsg);
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1711,10 +1711,23 @@ export class ZodObject<
     return this._def.shape();
   }
 
-  strict(): ZodObject<T, "strict", Catchall> {
+  strict(message?: errorUtil.ErrMessage): ZodObject<T, "strict", Catchall> {
     return new ZodObject({
       ...this._def,
       unknownKeys: "strict",
+      ...(message !== undefined
+        ? {
+            errorMap: (issue, _ctx) => {
+              if (issue.code === "unrecognized_keys")
+                return { message: message.toString() };
+              return {
+                message:
+                  this._def.errorMap?.(issue, _ctx).message.toString() ??
+                  _ctx.defaultError,
+              };
+            },
+          }
+        : {}),
     }) as any;
   }
 

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -367,6 +367,16 @@ test("invalid and required and errorMap", () => {
   }).toThrow();
 });
 
+test("strict error message", () => {
+  const errorMsg = "Invalid object";
+  const obj = z.object({ x: z.string() }).strict(errorMsg);
+  const result = obj.safeParse({ x: "a", y: "b" });
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(errorMsg);
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1711,10 +1711,23 @@ export class ZodObject<
     return this._def.shape();
   }
 
-  strict(): ZodObject<T, "strict", Catchall> {
+  strict(message?: errorUtil.ErrMessage): ZodObject<T, "strict", Catchall> {
     return new ZodObject({
       ...this._def,
       unknownKeys: "strict",
+      ...(message !== undefined
+        ? {
+            errorMap: (issue, _ctx) => {
+              if (issue.code === "unrecognized_keys")
+                return { message: message.toString() };
+              return {
+                message:
+                  this._def.errorMap?.(issue, _ctx).message.toString() ??
+                  _ctx.defaultError,
+              };
+            },
+          }
+        : {}),
     }) as any;
   }
 


### PR DESCRIPTION
Allows to specify a custom error message for `unrecognized_keys` at the `strict()` call, to allow reusing schemas that doesn't handle that error in their own `errorMap`