### PR TITLE
Add option for superRefine to abort further validation

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -257,6 +257,7 @@ type stripPath<T extends object> = T extends any
 
 export type IssueData = stripPath<ZodIssueOptionalMessage> & {
   path?: (string | number)[];
+  fatal?: boolean;
 };
 export type MakeErrorData = IssueData;
 

--- a/deno/lib/__tests__/pickomit.test.ts
+++ b/deno/lib/__tests__/pickomit.test.ts
@@ -64,10 +64,8 @@ test("omit parse - fail", () => {
 test("nonstrict inference", () => {
   const laxfish = fish.nonstrict().pick({ name: true });
   type laxfish = z.infer<typeof laxfish>;
-  const f1: util.AssertEqual<
-    laxfish,
-    { [k: string]: any; name: string }
-  > = true;
+  const f1: util.AssertEqual<laxfish, { [k: string]: any; name: string }> =
+    true;
   f1;
 });
 

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -155,3 +155,30 @@ test("chained refinements", () => {
   expect(r2.success).toEqual(false);
   if (!r2.success) expect(r2.error.issues.length).toEqual(2);
 });
+
+test("fatal superRefine", () => {
+  const Strings = z
+    .string()
+    .superRefine((val, ctx) => {
+      if (val === "") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "foo",
+          fatal: true,
+        });
+      }
+    })
+    .superRefine((val, ctx) => {
+      if (val !== " ") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "bar",
+        });
+      }
+    });
+
+  const result = Strings.safeParse("");
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -113,9 +113,10 @@ export abstract class ZodType<
 
   abstract _parse(input: ParseInput): ParseReturnType<Output>;
 
-  _processInputParams(
-    input: ParseInput
-  ): { status: ParseStatus; ctx: ParseContext } {
+  _processInputParams(input: ParseInput): {
+    status: ParseStatus;
+    ctx: ParseContext;
+  } {
     return {
       status: new ParseStatus(),
       ctx: {
@@ -364,12 +365,14 @@ export interface ZodStringDef extends ZodTypeDef {
 }
 
 const cuidRegex = /^c[^\s-]{8,}$/i;
-const uuidRegex = /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
+const uuidRegex =
+  /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
 // eslint-disable-next-line
-const emailRegex = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+const emailRegex =
+  /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
 
 export class ZodString extends ZodType<string, ZodStringDef> {
   _parse(input: ParseInput): ParseReturnType<string> {
@@ -1234,8 +1237,7 @@ export type ZodNonEmptyArray<T extends ZodTypeAny> = ZodArray<T, "atleastone">;
 export namespace objectUtil {
   export type MergeShapes<U extends ZodRawShape, V extends ZodRawShape> = {
     [k in Exclude<keyof U, keyof V>]: U[k];
-  } &
-    V;
+  } & V;
 
   type optionalKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? k : never;
@@ -1245,8 +1247,7 @@ export namespace objectUtil {
 
   export type addQuestionMarks<T extends object> = {
     [k in optionalKeys<T>]?: T[k];
-  } &
-    { [k in requiredKeys<T>]: T[k] };
+  } & { [k in requiredKeys<T>]: T[k] };
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;
@@ -1255,11 +1256,9 @@ export namespace objectUtil {
     [k in keyof T]: [T[k]] extends [never] ? never : k;
   }[keyof T];
 
-  export type noNever<T extends ZodRawShape> = identity<
-    {
-      [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
-    }
-  >;
+  export type noNever<T extends ZodRawShape> = identity<{
+    [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
+  }>;
 
   export const mergeShapes = <U extends ZodRawShape, T extends ZodRawShape>(
     first: U,
@@ -1274,26 +1273,25 @@ export namespace objectUtil {
 
 export type extendShape<A, B> = {
   [k in Exclude<keyof A, keyof B>]: A[k];
-} &
-  { [k in keyof B]: B[k] };
+} & { [k in keyof B]: B[k] };
 
-const AugmentFactory = <Def extends ZodObjectDef>(def: Def) => <
-  Augmentation extends ZodRawShape
->(
-  augmentation: Augmentation
-): ZodObject<
-  extendShape<ReturnType<Def["shape"]>, Augmentation>,
-  Def["unknownKeys"],
-  Def["catchall"]
-> => {
-  return new ZodObject({
-    ...def,
-    shape: () => ({
-      ...def.shape(),
-      ...augmentation,
-    }),
-  }) as any;
-};
+const AugmentFactory =
+  <Def extends ZodObjectDef>(def: Def) =>
+  <Augmentation extends ZodRawShape>(
+    augmentation: Augmentation
+  ): ZodObject<
+    extendShape<ReturnType<Def["shape"]>, Augmentation>,
+    Def["unknownKeys"],
+    Def["catchall"]
+  > => {
+    return new ZodObject({
+      ...def,
+      shape: () => ({
+        ...def.shape(),
+        ...augmentation,
+      }),
+    }) as any;
+  };
 
 type UnknownKeysParam = "passthrough" | "strict" | "strip";
 
@@ -1311,15 +1309,12 @@ export interface ZodObjectDef<
   unknownKeys: UnknownKeys;
 }
 
-export type baseObjectOutputType<
-  Shape extends ZodRawShape
-> = objectUtil.flatten<
-  objectUtil.addQuestionMarks<
-    {
+export type baseObjectOutputType<Shape extends ZodRawShape> =
+  objectUtil.flatten<
+    objectUtil.addQuestionMarks<{
       [k in keyof Shape]: Shape[k]["_output"];
-    }
-  >
->;
+    }>
+  >;
 
 export type objectOutputType<
   Shape extends ZodRawShape,
@@ -1331,11 +1326,9 @@ export type objectOutputType<
     >;
 
 export type baseObjectInputType<Shape extends ZodRawShape> = objectUtil.flatten<
-  objectUtil.addQuestionMarks<
-    {
-      [k in keyof Shape]: Shape[k]["_input"];
-    }
-  >
+  objectUtil.addQuestionMarks<{
+    [k in keyof Shape]: Shape[k]["_input"];
+  }>
 >;
 
 export type objectInputType<
@@ -1634,11 +1627,9 @@ export class ZodObject<
   partial<Mask extends { [k in keyof T]?: true }>(
     mask: Mask
   ): ZodObject<
-    objectUtil.noNever<
-      {
-        [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k];
-      }
-    >,
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k];
+    }>,
     UnknownKeys,
     Catchall
   >;
@@ -1992,11 +1983,9 @@ export class ZodIntersection<
 ////////////////////////////////////////
 export type ZodTupleItems = [ZodTypeAny, ...ZodTypeAny[]];
 export type AssertArray<T extends any> = T extends any[] ? T : never;
-export type OutputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<
-  {
-    [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]["_output"] : never;
-  }
->;
+export type OutputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<{
+  [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]["_output"] : never;
+}>;
 export type OutputTypeOfTupleWithRest<
   T extends ZodTupleItems | [],
   Rest extends ZodTypeAny | null = null
@@ -2004,11 +1993,9 @@ export type OutputTypeOfTupleWithRest<
   ? [...OutputTypeOfTuple<T>, ...Rest["_output"][]]
   : OutputTypeOfTuple<T>;
 
-export type InputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<
-  {
-    [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]["_input"] : never;
-  }
->;
+export type InputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<{
+  [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]["_input"] : never;
+}>;
 export type InputTypeOfTupleWithRest<
   T extends ZodTupleItems | [],
   Rest extends ZodTypeAny | null = null
@@ -2070,7 +2057,7 @@ export class ZodTuple<
     const items = (ctx.data as any[])
       .map((item, itemIndex) => {
         const schema = this._def.items[itemIndex] || this._def.rest;
-        if (!schema) return (null as any) as SyncParseReturnType<any>;
+        if (!schema) return null as any as SyncParseReturnType<any>;
         return schema._parse({
           data: item,
           path: [...ctx.path, itemIndex],
@@ -2482,8 +2469,9 @@ export class ZodFunction<
             throw error;
           });
         const result = await fn(...(parsedArgs as any));
-        const parsedReturns = await (this._def
-          .returns as ZodPromise<ZodTypeAny>)._def.type
+        const parsedReturns = await (
+          this._def.returns as ZodPromise<ZodTypeAny>
+        )._def.type
           .parseAsync(result, params)
           .catch((e) => {
             error.addIssue(makeReturnsIssue(result, e));
@@ -2905,7 +2893,7 @@ export class ZodEffects<
       const checkCtx: RefinementCtx = {
         addIssue: (arg: IssueData) => {
           addIssueToContext(ctx, arg);
-          if (FATAL_CODES.includes(arg.code)) {
+          if (FATAL_CODES.includes(arg.code) || arg.fatal) {
             status.abort();
           } else {
             status.dirty();

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -257,6 +257,7 @@ type stripPath<T extends object> = T extends any
 
 export type IssueData = stripPath<ZodIssueOptionalMessage> & {
   path?: (string | number)[];
+  fatal?: boolean;
 };
 export type MakeErrorData = IssueData;
 

--- a/src/__tests__/pickomit.test.ts
+++ b/src/__tests__/pickomit.test.ts
@@ -63,10 +63,8 @@ test("omit parse - fail", () => {
 test("nonstrict inference", () => {
   const laxfish = fish.nonstrict().pick({ name: true });
   type laxfish = z.infer<typeof laxfish>;
-  const f1: util.AssertEqual<
-    laxfish,
-    { [k: string]: any; name: string }
-  > = true;
+  const f1: util.AssertEqual<laxfish, { [k: string]: any; name: string }> =
+    true;
   f1;
 });
 

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -154,3 +154,30 @@ test("chained refinements", () => {
   expect(r2.success).toEqual(false);
   if (!r2.success) expect(r2.error.issues.length).toEqual(2);
 });
+
+test("fatal superRefine", () => {
+  const Strings = z
+    .string()
+    .superRefine((val, ctx) => {
+      if (val === "") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "foo",
+          fatal: true,
+        });
+      }
+    })
+    .superRefine((val, ctx) => {
+      if (val !== " ") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "bar",
+        });
+      }
+    });
+
+  const result = Strings.safeParse("");
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,9 +113,10 @@ export abstract class ZodType<
 
   abstract _parse(input: ParseInput): ParseReturnType<Output>;
 
-  _processInputParams(
-    input: ParseInput
-  ): { status: ParseStatus; ctx: ParseContext } {
+  _processInputParams(input: ParseInput): {
+    status: ParseStatus;
+    ctx: ParseContext;
+  } {
     return {
       status: new ParseStatus(),
       ctx: {
@@ -364,12 +365,14 @@ export interface ZodStringDef extends ZodTypeDef {
 }
 
 const cuidRegex = /^c[^\s-]{8,}$/i;
-const uuidRegex = /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
+const uuidRegex =
+  /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
 // eslint-disable-next-line
-const emailRegex = /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+const emailRegex =
+  /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
 
 export class ZodString extends ZodType<string, ZodStringDef> {
   _parse(input: ParseInput): ParseReturnType<string> {
@@ -1234,8 +1237,7 @@ export type ZodNonEmptyArray<T extends ZodTypeAny> = ZodArray<T, "atleastone">;
 export namespace objectUtil {
   export type MergeShapes<U extends ZodRawShape, V extends ZodRawShape> = {
     [k in Exclude<keyof U, keyof V>]: U[k];
-  } &
-    V;
+  } & V;
 
   type optionalKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? k : never;
@@ -1245,8 +1247,7 @@ export namespace objectUtil {
 
   export type addQuestionMarks<T extends object> = {
     [k in optionalKeys<T>]?: T[k];
-  } &
-    { [k in requiredKeys<T>]: T[k] };
+  } & { [k in requiredKeys<T>]: T[k] };
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;
@@ -1255,11 +1256,9 @@ export namespace objectUtil {
     [k in keyof T]: [T[k]] extends [never] ? never : k;
   }[keyof T];
 
-  export type noNever<T extends ZodRawShape> = identity<
-    {
-      [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
-    }
-  >;
+  export type noNever<T extends ZodRawShape> = identity<{
+    [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
+  }>;
 
   export const mergeShapes = <U extends ZodRawShape, T extends ZodRawShape>(
     first: U,
@@ -1274,26 +1273,25 @@ export namespace objectUtil {
 
 export type extendShape<A, B> = {
   [k in Exclude<keyof A, keyof B>]: A[k];
-} &
-  { [k in keyof B]: B[k] };
+} & { [k in keyof B]: B[k] };
 
-const AugmentFactory = <Def extends ZodObjectDef>(def: Def) => <
-  Augmentation extends ZodRawShape
->(
-  augmentation: Augmentation
-): ZodObject<
-  extendShape<ReturnType<Def["shape"]>, Augmentation>,
-  Def["unknownKeys"],
-  Def["catchall"]
-> => {
-  return new ZodObject({
-    ...def,
-    shape: () => ({
-      ...def.shape(),
-      ...augmentation,
-    }),
-  }) as any;
-};
+const AugmentFactory =
+  <Def extends ZodObjectDef>(def: Def) =>
+  <Augmentation extends ZodRawShape>(
+    augmentation: Augmentation
+  ): ZodObject<
+    extendShape<ReturnType<Def["shape"]>, Augmentation>,
+    Def["unknownKeys"],
+    Def["catchall"]
+  > => {
+    return new ZodObject({
+      ...def,
+      shape: () => ({
+        ...def.shape(),
+        ...augmentation,
+      }),
+    }) as any;
+  };
 
 type UnknownKeysParam = "passthrough" | "strict" | "strip";
 
@@ -1311,15 +1309,12 @@ export interface ZodObjectDef<
   unknownKeys: UnknownKeys;
 }
 
-export type baseObjectOutputType<
-  Shape extends ZodRawShape
-> = objectUtil.flatten<
-  objectUtil.addQuestionMarks<
-    {
+export type baseObjectOutputType<Shape extends ZodRawShape> =
+  objectUtil.flatten<
+    objectUtil.addQuestionMarks<{
       [k in keyof Shape]: Shape[k]["_output"];
-    }
-  >
->;
+    }>
+  >;
 
 export type objectOutputType<
   Shape extends ZodRawShape,
@@ -1331,11 +1326,9 @@ export type objectOutputType<
     >;
 
 export type baseObjectInputType<Shape extends ZodRawShape> = objectUtil.flatten<
-  objectUtil.addQuestionMarks<
-    {
-      [k in keyof Shape]: Shape[k]["_input"];
-    }
-  >
+  objectUtil.addQuestionMarks<{
+    [k in keyof Shape]: Shape[k]["_input"];
+  }>
 >;
 
 export type objectInputType<
@@ -1634,11 +1627,9 @@ export class ZodObject<
   partial<Mask extends { [k in keyof T]?: true }>(
     mask: Mask
   ): ZodObject<
-    objectUtil.noNever<
-      {
-        [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k];
-      }
-    >,
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k];
+    }>,
     UnknownKeys,
     Catchall
   >;
@@ -1992,11 +1983,9 @@ export class ZodIntersection<
 ////////////////////////////////////////
 export type ZodTupleItems = [ZodTypeAny, ...ZodTypeAny[]];
 export type AssertArray<T extends any> = T extends any[] ? T : never;
-export type OutputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<
-  {
-    [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]["_output"] : never;
-  }
->;
+export type OutputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<{
+  [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]["_output"] : never;
+}>;
 export type OutputTypeOfTupleWithRest<
   T extends ZodTupleItems | [],
   Rest extends ZodTypeAny | null = null
@@ -2004,11 +1993,9 @@ export type OutputTypeOfTupleWithRest<
   ? [...OutputTypeOfTuple<T>, ...Rest["_output"][]]
   : OutputTypeOfTuple<T>;
 
-export type InputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<
-  {
-    [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]["_input"] : never;
-  }
->;
+export type InputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<{
+  [k in keyof T]: T[k] extends ZodType<any, any> ? T[k]["_input"] : never;
+}>;
 export type InputTypeOfTupleWithRest<
   T extends ZodTupleItems | [],
   Rest extends ZodTypeAny | null = null
@@ -2070,7 +2057,7 @@ export class ZodTuple<
     const items = (ctx.data as any[])
       .map((item, itemIndex) => {
         const schema = this._def.items[itemIndex] || this._def.rest;
-        if (!schema) return (null as any) as SyncParseReturnType<any>;
+        if (!schema) return null as any as SyncParseReturnType<any>;
         return schema._parse({
           data: item,
           path: [...ctx.path, itemIndex],
@@ -2482,8 +2469,9 @@ export class ZodFunction<
             throw error;
           });
         const result = await fn(...(parsedArgs as any));
-        const parsedReturns = await (this._def
-          .returns as ZodPromise<ZodTypeAny>)._def.type
+        const parsedReturns = await (
+          this._def.returns as ZodPromise<ZodTypeAny>
+        )._def.type
           .parseAsync(result, params)
           .catch((e) => {
             error.addIssue(makeReturnsIssue(result, e));
@@ -2905,7 +2893,7 @@ export class ZodEffects<
       const checkCtx: RefinementCtx = {
         addIssue: (arg: IssueData) => {
           addIssueToContext(ctx, arg);
-          if (FATAL_CODES.includes(arg.code)) {
+          if (FATAL_CODES.includes(arg.code) || arg.fatal) {
             status.abort();
           } else {
             status.dirty();


### PR DESCRIPTION
The recent introduction of failed validations not short circuiting the entire validation chain introduced an issue for one of my projects, where a later check relied on an earlier check in a deeper object to succeed.

This PR adds an option for `superRefine()` to set the abort status via the the `IssueData` by specifying the new optional `fatal` boolean property on it.
