### PR TITLE
Remove duplicated block on custom error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,15 +312,6 @@ tuna.value; // "tuna"
 
 ## Strings
 
-You can customize certain errors when creating a string schema.
-
-```ts
-const name = z.string({
-  required: "Name is required",
-  invalid: "Invalid name",
-});
-```
-
 Zod includes a handful of string-specific validations.
 
 ```ts


### PR DESCRIPTION
Almost the same block on custom error messages can be found in lines 336–345.

```js
const name = z.string({
  required_error: "Name is required",
  invalid_type_error: "Name must be a string",
});
```

Leaves the question whether the properties in that object can be both => 
`required`/`required_error` and `invalid`/`invalid_type_error`