### PR TITLE
Don't include received value in enum/literal error messages (fixes #461)

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -281,9 +281,7 @@ export const defaultErrorMap = (
     case ZodIssueCode.invalid_enum_value:
       message = `Invalid enum value. Expected ${issue.options
         .map((val) => (typeof val === "string" ? `'${val}'` : val))
-        .join(" | ")}, received ${
-        typeof _ctx.data === "string" ? `'${_ctx.data}'` : _ctx.data
-      }`;
+        .join(" | ")}`;
       break;
     case ZodIssueCode.invalid_arguments:
       message = `Invalid function arguments`;

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -398,6 +398,19 @@ test("strict error message", () => {
   }
 });
 
+test("enum default error message", () => {
+  try {
+    z.enum(["Tuna", "Trout"]).parse("Salmon");
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    expect(zerr.issues.length).toEqual(1);
+    expect(zerr.issues[0].message).toEqual(
+      "Invalid enum value. Expected 'Tuna' | 'Trout'"
+    );
+    expect(zerr.issues[0].message).not.toContain("Salmon");
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -411,6 +411,16 @@ test("enum default error message", () => {
   }
 });
 
+test("literal default error message", () => {
+  try {
+    z.literal("Tuna").parse("Trout");
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    expect(zerr.issues.length).toEqual(1);
+    expect(zerr.issues[0].message).toEqual("Expected string, received string");
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2659,8 +2659,8 @@ export class ZodLiteral<T extends any> extends ZodType<T, ZodLiteralDef<T>> {
     if (ctx.data !== this._def.value) {
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_type,
-        expected: this._def.value as any,
-        received: ctx.data,
+        expected: getParsedType(this._def.value),
+        received: ctx.parsedType,
       });
       return INVALID;
     }

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -281,9 +281,7 @@ export const defaultErrorMap = (
     case ZodIssueCode.invalid_enum_value:
       message = `Invalid enum value. Expected ${issue.options
         .map((val) => (typeof val === "string" ? `'${val}'` : val))
-        .join(" | ")}, received ${
-        typeof _ctx.data === "string" ? `'${_ctx.data}'` : _ctx.data
-      }`;
+        .join(" | ")}`;
       break;
     case ZodIssueCode.invalid_arguments:
       message = `Invalid function arguments`;

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -410,6 +410,16 @@ test("enum default error message", () => {
   }
 });
 
+test("literal default error message", () => {
+  try {
+    z.literal("Tuna").parse("Trout");
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    expect(zerr.issues.length).toEqual(1);
+    expect(zerr.issues[0].message).toEqual("Expected string, received string");
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -397,6 +397,19 @@ test("strict error message", () => {
   }
 });
 
+test("enum default error message", () => {
+  try {
+    z.enum(["Tuna", "Trout"]).parse("Salmon");
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    expect(zerr.issues.length).toEqual(1);
+    expect(zerr.issues[0].message).toEqual(
+      "Invalid enum value. Expected 'Tuna' | 'Trout'"
+    );
+    expect(zerr.issues[0].message).not.toContain("Salmon");
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -2659,8 +2659,8 @@ export class ZodLiteral<T extends any> extends ZodType<T, ZodLiteralDef<T>> {
     if (ctx.data !== this._def.value) {
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_type,
-        expected: this._def.value as any,
-        received: ctx.data,
+        expected: getParsedType(this._def.value),
+        received: ctx.parsedType,
       });
       return INVALID;
     }


### PR DESCRIPTION
See #461 

Also the error produced by `ZodLiteral` did not actually match the `ZodInvalidTypeIssue` interface or `ERROR_HANDLING.md` documentation (`expected` and `received` were not actually `ZodParsedType`s)