### PR TITLE
Update types.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Some other great aspects:
 - Zero dependencies
 - Works in Node.js and browsers (including IE 11)
 - Tiny: 8kb minified + zipped
-- Immutable: methods (i.e. `.optional()` return a new instance
+- Immutable: methods (i.e. `.optional()`) return a new instance
 - Concise, chainable interface
 - Functional approach: [parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)
 - Works with plain JavaScript too! You don't need to use TypeScript.

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,9 +60,7 @@ export interface ZodTypeDef {
 const handleResult = <Input, Output>(
   ctx: ParseContext,
   result: SyncParseReturnType<Output>
-):
-  | { success: true; data: Output }
-  | { success: false; error: ZodError<Input> } => {
+): SafeParseReturnType<Input, Output> => {
   if (isValid(result)) {
     return { success: true, data: result.value };
   } else {
@@ -102,8 +100,8 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   return { errorMap: customMap };
 }
 
-export type SafeParseSuccess<Output> = { success: true; data: Output };
-export type SafeParseError<Input> = { success: false; error: ZodError<Input> };
+export type SafeParseSuccess<Output> = { success: true; data: Output; error: undefined };
+export type SafeParseError<Input> = { success: false; data: undefined; error: ZodError<Input> };
 
 export type SafeParseReturnType<Input, Output> =
   | SafeParseSuccess<Output>


### PR DESCRIPTION
- Removed some duplication:
```ts
{ success: true; data: Output } | { success: false; error: ZodError<Input> }
```
```ts
SafeParseReturnType<Input, Output>
```

- Added some better support for [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
```ts
export type SafeParseSuccess<Output> = { success: true; data: Output; error: undefined };
```
```ts
export type SafeParseError<Input> = { success: false; data: undefined; error: ZodError<Input> };
```