### PR TITLE
fix: multiple of decimals

### DIFF
--- a/deno/lib/__tests__/number.test.ts
+++ b/deno/lib/__tests__/number.test.ts
@@ -11,6 +11,7 @@ const lteFive = z.number().lte(5);
 const intNum = z.number().int();
 const multipleOfFive = z.number().multipleOf(5);
 const stepSixPointFour = z.number().step(6.4);
+const percentage = z.number().min(0).max(1).step(0.001);
 
 test("passing validations", () => {
   gtFive.parse(6);
@@ -20,6 +21,7 @@ test("passing validations", () => {
   intNum.parse(4);
   multipleOfFive.parse(15);
   stepSixPointFour.parse(12.8);
+  percentage.parse(0.5);
 });
 
 test("failing validations", () => {
@@ -30,6 +32,7 @@ test("failing validations", () => {
   expect(() => intNum.parse(3.14)).toThrow();
   expect(() => multipleOfFive.parse(14.9)).toThrow();
   expect(() => stepSixPointFour.parse(6.41)).toThrow();
+  expect(() => percentage.parse(0.00005)).toThrow();
 });
 
 test("parse NaN", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -679,7 +679,8 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
           status.dirty();
         }
       } else if (check.kind === "multipleOf") {
-        if (Math.round(ctx.data % check.value) !== 0) {
+        const division = ctx.data / check.value;
+        if (parseInt(division.toString(), 10) !== division) {
           addIssueToContext(ctx, {
             code: ZodIssueCode.not_multiple_of,
             multipleOf: check.value,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -679,7 +679,7 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
           status.dirty();
         }
       } else if (check.kind === "multipleOf") {
-        if (ctx.data % check.value !== 0) {
+        if (Math.round(ctx.data % check.value) !== 0) {
           addIssueToContext(ctx, {
             code: ZodIssueCode.not_multiple_of,
             multipleOf: check.value,

--- a/src/__tests__/number.test.ts
+++ b/src/__tests__/number.test.ts
@@ -10,6 +10,7 @@ const lteFive = z.number().lte(5);
 const intNum = z.number().int();
 const multipleOfFive = z.number().multipleOf(5);
 const stepSixPointFour = z.number().step(6.4);
+const percentage = z.number().min(0).max(1).step(0.001);
 
 test("passing validations", () => {
   gtFive.parse(6);
@@ -19,6 +20,7 @@ test("passing validations", () => {
   intNum.parse(4);
   multipleOfFive.parse(15);
   stepSixPointFour.parse(12.8);
+  percentage.parse(0.5);
 });
 
 test("failing validations", () => {
@@ -29,6 +31,7 @@ test("failing validations", () => {
   expect(() => intNum.parse(3.14)).toThrow();
   expect(() => multipleOfFive.parse(14.9)).toThrow();
   expect(() => stepSixPointFour.parse(6.41)).toThrow();
+  expect(() => percentage.parse(0.00005)).toThrow();
 });
 
 test("parse NaN", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -679,7 +679,8 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
           status.dirty();
         }
       } else if (check.kind === "multipleOf") {
-        if (Math.round(ctx.data % check.value) !== 0) {
+        const division = ctx.data / check.value;
+        if (parseInt(division.toString(), 10) !== division) {
           addIssueToContext(ctx, {
             code: ZodIssueCode.not_multiple_of,
             multipleOf: check.value,

--- a/src/types.ts
+++ b/src/types.ts
@@ -679,7 +679,7 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
           status.dirty();
         }
       } else if (check.kind === "multipleOf") {
-        if (ctx.data % check.value !== 0) {
+        if (Math.round(ctx.data % check.value) !== 0) {
           addIssueToContext(ctx, {
             code: ZodIssueCode.not_multiple_of,
             multipleOf: check.value,


### PR DESCRIPTION
Consider this:
```ts
const percentage = z.number().min(0).max(1).step(0.001);
```

Previously, `percentage.parse(0.5)` would fail because the Modulus operator would return non-zero
```
> 0.5 % 0.001
0.0009999999999999896
```

Instead, this PR adds the logic to check if the division is a whole number. Ideally, `Number.isInteger` would be used but it's banned via eslint rule 