### PR TITLE
Fix typing typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,7 +953,7 @@ type StringNumberMap = z.infer<typeof stringNumberMap>;
 ## Sets
 
 ```ts
-const numberSet = z.set(z.string());
+const numberSet = z.set(z.number());
 type numberSet = z.infer<typeof numberSet>;
 // Set<number>
 ```


### PR DESCRIPTION
I believe the intention was to use `z.number()` instead of `z.string()`