### PR TITLE
Add Readonly to ZodUnionOptions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1774,9 +1774,9 @@ export type AnyZodObject = ZodObject<any, any, any>;
 //////////                    //////////
 ////////////////////////////////////////
 ////////////////////////////////////////
-type ZodUnionOptions = [ZodTypeAny, ...ZodTypeAny[]];
+type ZodUnionOptions = Readonly<[ZodTypeAny, ...ZodTypeAny[]]>;
 export interface ZodUnionDef<
-  T extends ZodUnionOptions = [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]
+  T extends ZodUnionOptions = Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>
 > extends ZodTypeDef {
   options: T;
   typeName: ZodFirstPartyTypeKind.ZodUnion;
@@ -1864,7 +1864,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
     return this._def.options;
   }
 
-  static create = <T extends [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>(
+  static create = <T extends Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>>(
     types: T,
     params?: RawCreateParams
   ): ZodUnion<T> => {


### PR DESCRIPTION
Addresses issues where `as const` needs to be used in definitions to allow further type inference.

Currently `as const` values are prevented from being used since the existing signature requires writeable arrays and tuples 

Using `as const` to declare actual readonly tuples instead of populating writeable arrays enables strong type inference and ensures arity is detectable for calls to union constructors (which need a tuple of at least 2 members).

Fixes https://github.com/colinhacks/zod/issues/831