### PR TITLE
feat: default `unknownKeys` strategy can be overridden by parse param

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,17 +728,22 @@ const deepPartialUser = user.deepPartial();
 
 #### Unrecognized keys
 
-By default Zod objects schemas strip out unrecognized keys during parsing.
+By default Zod objects schemas strip out unrecognized keys during parsing. If necessary, there are other strategies that you can use during the parsing: (`passthrough`, `strict`, `strip`) and you can select it by the second argument in the parse method. It has an effect on all nested objects except those that have explicitly defined `unknownKeys` strategy.
 
 ```ts
 const person = z.object({
   name: z.string(),
 });
 
-person.parse({
-  name: "bob dylan",
-  extraKey: 61,
-});
+person.parse(
+  {
+    name: "bob dylan",
+    extraKey: 61,
+  },
+//  {
+//    unknownKeys: 'strip' // default strategy
+//  }
+);
 // => { name: "bob dylan" }
 // extraKey has been stripped
 ```

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -92,6 +92,14 @@ test("passthrough unknown", () => {
   expect(val).toEqual(data);
 });
 
+test("passthrough thanks to parse param", () => {
+  const val = z
+    .object({ points: z.number() })
+    .parse(data, { unknownKeys: "passthrough" });
+
+  expect(val).toEqual(data);
+});
+
 test("strip unknown", () => {
   const val = z.object({ points: z.number() }).strip().parse(data);
 
@@ -100,6 +108,23 @@ test("strip unknown", () => {
 
 test("strict", () => {
   const val = z.object({ points: z.number() }).strict().safeParse(data);
+
+  expect(val.success).toEqual(false);
+});
+
+test("strict thanks to parse param", () => {
+  const val = z
+    .object({ points: z.number() })
+    .safeParse(data, { unknownKeys: "strict" });
+
+  expect(val.success).toEqual(false);
+});
+
+test("strict though parse param uses passthrough", () => {
+  const val = z
+    .object({ points: z.number() })
+    .strict()
+    .safeParse(data, { unknownKeys: "passthrough" });
 
   expect(val.success).toEqual(false);
 });

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -135,8 +135,10 @@ export type ParseParams = {
   path: (string | number)[];
   errorMap: ZodErrorMap;
   async: boolean;
+  unknownKeys: DefaultUnknownKeys;
 };
 
+type DefaultUnknownKeys = "passthrough" | "strict" | "strip";
 export type ParsePathComponent = string | number;
 export type ParsePath = ParsePathComponent[];
 export const EMPTY_PATH: ParsePath = [];
@@ -151,6 +153,7 @@ export interface ParseContext {
   readonly typeCache: Map<any, ZodParsedType>;
   readonly data: any;
   readonly parsedType: ZodParsedType;
+  readonly unknownKeys: DefaultUnknownKeys;
 }
 
 export type ParseInput = {

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -91,6 +91,14 @@ test("passthrough unknown", () => {
   expect(val).toEqual(data);
 });
 
+test("passthrough thanks to parse param", () => {
+  const val = z
+    .object({ points: z.number() })
+    .parse(data, { unknownKeys: "passthrough" });
+
+  expect(val).toEqual(data);
+});
+
 test("strip unknown", () => {
   const val = z.object({ points: z.number() }).strip().parse(data);
 
@@ -99,6 +107,23 @@ test("strip unknown", () => {
 
 test("strict", () => {
   const val = z.object({ points: z.number() }).strict().safeParse(data);
+
+  expect(val.success).toEqual(false);
+});
+
+test("strict thanks to parse param", () => {
+  const val = z
+    .object({ points: z.number() })
+    .safeParse(data, { unknownKeys: "strict" });
+
+  expect(val.success).toEqual(false);
+});
+
+test("strict though parse param uses passthrough", () => {
+  const val = z
+    .object({ points: z.number() })
+    .strict()
+    .safeParse(data, { unknownKeys: "passthrough" });
 
   expect(val.success).toEqual(false);
 });

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -135,8 +135,10 @@ export type ParseParams = {
   path: (string | number)[];
   errorMap: ZodErrorMap;
   async: boolean;
+  unknownKeys: DefaultUnknownKeys;
 };
 
+type DefaultUnknownKeys = "passthrough" | "strict" | "strip";
 export type ParsePathComponent = string | number;
 export type ParsePath = ParsePathComponent[];
 export const EMPTY_PATH: ParsePath = [];
@@ -151,6 +153,7 @@ export interface ParseContext {
   readonly typeCache: Map<any, ZodParsedType>;
   readonly data: any;
   readonly parsedType: ZodParsedType;
+  readonly unknownKeys: DefaultUnknownKeys;
 }
 
 export type ParseInput = {


### PR DESCRIPTION
Hi,

It'd be nice to have an option for forcing the default `unknownKeys` strategy on all objects that have not explicitly defined their own unknownKeys behavior. In real life, I sometimes need to have just one schema for one complex object, but once with `strict` strategy (mostly in endpoint input validations to avoid mistakes) and once with `passthrough` (for response validation from 3rd party APIs). With the current Zod version, I don't see any simple solution for my use case without big code duplication. So I'd like to know your opinion on my PR that perfectly solves my problem.

Huge thanks for your awesome library.