### PR TITLE
improve typing of `isOptional` and `isNullable`

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -370,10 +370,10 @@ export abstract class ZodType<
     });
   }
 
-  isOptional(): boolean {
+  isOptional(): this is ZodOptional<this> {
     return this.safeParse(undefined).success;
   }
-  isNullable(): boolean {
+  isNullable(): this is ZodNullable<this> {
     return this.safeParse(null).success;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -370,10 +370,10 @@ export abstract class ZodType<
     });
   }
 
-  isOptional(): boolean {
+  isOptional(): this is ZodOptional<this> {
     return this.safeParse(undefined).success;
   }
-  isNullable(): boolean {
+  isNullable(): this is ZodNullable<this> {
     return this.safeParse(null).success;
   }
 }


### PR DESCRIPTION
Today I encountered following situation:

I have a function that returns a schema depending on an input of that function. It either returns a `ZodObject` of a `ZodOptional` wrapping a `ZodObject`. Later in the code I need to `pick` only a certain subtree of that schema. The `pick` function does not exist on `ZodOptional` so i fist have to `unwrap` it.

Here is a simplified version of that example:

```ts
const getZod = (input: number) => {
	const zod = z.object({ })
	if (input < 0.5) {
		return zod
	} else {
		return zod.optional()
	}
}

const zod = getZod(Math.random())

if (zod.isOptional()) {
	zod.unwrap().pick({ })
} else {
	zod.pick({ })
}
```

With the current implementation I get two TypeScript errors:

```ts
if (zod.isOptional()) {
	zod.unwrap().pick({}) // Property 'unwrap' does not exist on type 'ZodObject<...>'.ts(2339)
} else {
	zod.pick({}) // Property 'pick' does not exist on type 'ZodOptional<...>'.ts(2339)
}
```

By only changing the return type of the `isOptional` from `boolean` to `this is ZodOptional<this>` we can tell TypeScript that if `isOptional` return `true` then the object is of type `ZodOptional`.
And both errors are gone.

I haven't used `isNullable` in a real-world example yet, but we can improve the type-definition also on that function.