### PR TITLE
Add types to extract error results from schema

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -217,12 +217,24 @@ export class ZodError<T = any> extends Error {
     this.issues = [...this.issues, ...subs];
   };
 
-  flatten = <U = string>(
+  flatten(
+    mapper?: (issue: ZodIssue) => string
+  ): {
+    formErrors: string[];
+    fieldErrors: { [k: string]: string[] };
+  };
+  flatten<U>(
+    mapper?: (issue: ZodIssue) => U
+  ): {
+    formErrors: U[];
+    fieldErrors: { [k: string]: U[] };
+  };
+  flatten<U = string>(
     mapper: (issue: ZodIssue) => U = (issue: ZodIssue) => issue.message as any
   ): {
     formErrors: U[];
     fieldErrors: { [k: string]: U[] };
-  } => {
+  } {
     const fieldErrors: any = {};
     const formErrors: U[] = [];
     for (const sub of this.issues) {
@@ -234,7 +246,7 @@ export class ZodError<T = any> extends Error {
       }
     }
     return { formErrors, fieldErrors };
-  };
+  }
 
   get formErrors() {
     return this.flatten();

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -49,7 +49,23 @@ export type ZodTypeAny = ZodType<any, any, any>;
 export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
 export type input<T extends ZodType<any, any, any>> = T["_input"];
 export type output<T extends ZodType<any, any, any>> = T["_output"];
-export type { TypeOf as infer };
+export type TypeOfFlattenedError<
+  T extends ZodType<any, any, any>,
+  U = string
+> = {
+  formErrors: U[];
+  fieldErrors: {
+    [P in keyof TypeOf<T>]?: U[];
+  };
+};
+export type TypeOfFormErrors<
+  T extends ZodType<any, any, any>
+> = TypeOfFlattenedError<T>;
+export type {
+  TypeOf as infer,
+  TypeOfFlattenedError as inferFlattenedErrors,
+  TypeOfFormErrors as inferFormErrors,
+};
 
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -217,12 +217,24 @@ export class ZodError<T = any> extends Error {
     this.issues = [...this.issues, ...subs];
   };
 
-  flatten = <U = string>(
+  flatten(
+    mapper?: (issue: ZodIssue) => string
+  ): {
+    formErrors: string[];
+    fieldErrors: { [k: string]: string[] };
+  };
+  flatten<U>(
+    mapper?: (issue: ZodIssue) => U
+  ): {
+    formErrors: U[];
+    fieldErrors: { [k: string]: U[] };
+  };
+  flatten<U = string>(
     mapper: (issue: ZodIssue) => U = (issue: ZodIssue) => issue.message as any
   ): {
     formErrors: U[];
     fieldErrors: { [k: string]: U[] };
-  } => {
+  } {
     const fieldErrors: any = {};
     const formErrors: U[] = [];
     for (const sub of this.issues) {
@@ -234,7 +246,7 @@ export class ZodError<T = any> extends Error {
       }
     }
     return { formErrors, fieldErrors };
-  };
+  }
 
   get formErrors() {
     return this.flatten();

--- a/src/__tests__/all-errors.test.ts
+++ b/src/__tests__/all-errors.test.ts
@@ -1,7 +1,105 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
+import { util } from "../helpers/util";
 import * as z from "../index";
+
+const Test = z.object({
+  f1: z.number(),
+  f2: z.string().optional(),
+  f3: z.string().nullable(),
+  f4: z.array(z.object({ t: z.union([z.string(), z.boolean()]) })),
+});
+type TestFlattenedErrors = z.inferFlattenedErrors<
+  typeof Test,
+  { message: string; code: number }
+>;
+type TestFormErrors = z.inferFormErrors<typeof Test>;
+
+test("default flattened errors type inference", () => {
+  type TestTypeErrors = {
+    formErrors: string[];
+    fieldErrors: { [P in keyof z.TypeOf<typeof Test>]?: string[] | undefined };
+  };
+
+  const t1: util.AssertEqual<
+    z.TypeOfFlattenedError<typeof Test>,
+    TestTypeErrors
+  > = true;
+  const t2: util.AssertEqual<
+    z.TypeOfFlattenedError<typeof Test, { message: string }>,
+    TestTypeErrors
+  > = false;
+  [t1, t2];
+});
+
+test("custom flattened errors type inference", () => {
+  type ErrorType = { message: string; code: number };
+  type TestTypeErrors = {
+    formErrors: ErrorType[];
+    fieldErrors: {
+      [P in keyof z.TypeOf<typeof Test>]?: ErrorType[] | undefined;
+    };
+  };
+
+  const t1: util.AssertEqual<
+    z.TypeOfFlattenedError<typeof Test>,
+    TestTypeErrors
+  > = false;
+  const t2: util.AssertEqual<
+    z.TypeOfFlattenedError<typeof Test, { message: string; code: number }>,
+    TestTypeErrors
+  > = true;
+  const t3: util.AssertEqual<
+    z.TypeOfFlattenedError<typeof Test, { message: string }>,
+    TestTypeErrors
+  > = false;
+  [t1, t2, t3];
+});
+
+test("form errors type inference", () => {
+  type TestTypeErrors = {
+    formErrors: string[];
+    fieldErrors: { [P in keyof z.TypeOf<typeof Test>]?: string[] | undefined };
+  };
+
+  const t1: util.AssertEqual<
+    z.TypeOfFormErrors<typeof Test>,
+    TestTypeErrors
+  > = true;
+  [t1];
+});
+
+test(".flatten() type assertion", () => {
+  const parsed = Test.safeParse({}) as z.SafeParseError<void>;
+  const validFlattenedErrors: TestFlattenedErrors = parsed.error.flatten(
+    () => ({ message: "", code: 0 })
+  );
+  // @ts-expect-error should fail assertion between `TestFlattenedErrors` and unmapped `flatten()`.
+  const invalidFlattenedErrors: TestFlattenedErrors = parsed.error.flatten();
+  const validFormErrors: TestFormErrors = parsed.error.flatten();
+  // @ts-expect-error should fail assertion between `TestFormErrors` and mapped `flatten()`.
+  const invalidFormErrors: TestFormErrors = parsed.error.flatten(() => ({
+    message: "string",
+    code: 0,
+  }));
+
+  [
+    validFlattenedErrors,
+    invalidFlattenedErrors,
+    validFormErrors,
+    invalidFormErrors,
+  ];
+});
+
+test(".formErrors type assertion", () => {
+  const parsed = Test.safeParse({}) as z.SafeParseError<void>;
+  const validFormErrors: TestFormErrors = parsed.error.formErrors;
+  // @ts-expect-error should fail assertion between `TestFlattenedErrors` and `.formErrors`.
+  const invalidFlattenedErrors: TestFlattenedErrors = parsed.error.formErrors;
+
+  [validFormErrors, invalidFlattenedErrors];
+});
 
 test("all errors", () => {
   const propertySchema = z.string();

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,23 @@ export type ZodTypeAny = ZodType<any, any, any>;
 export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
 export type input<T extends ZodType<any, any, any>> = T["_input"];
 export type output<T extends ZodType<any, any, any>> = T["_output"];
-export type { TypeOf as infer };
+export type TypeOfFlattenedError<
+  T extends ZodType<any, any, any>,
+  U = string
+> = {
+  formErrors: U[];
+  fieldErrors: {
+    [P in keyof TypeOf<T>]?: U[];
+  };
+};
+export type TypeOfFormErrors<
+  T extends ZodType<any, any, any>
+> = TypeOfFlattenedError<T>;
+export type {
+  TypeOf as infer,
+  TypeOfFlattenedError as inferFlattenedErrors,
+  TypeOfFormErrors as inferFormErrors,
+};
 
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {


### PR DESCRIPTION
- Adds two types `z.inferFlattenedErrors` and alias type `z.inferFormErrors` to [infer error result types for `flatten()` from a schema](https://github.com/colinhacks/zod/pull/856/files#diff-ae3ae59764197d1e97d44cb8d123d849b078e60d66aa6d8332851e7b51fb24abR377).
- Adds additional overloading for `flatten` to [support type-safety with the new types](https://github.com/colinhacks/zod/pull/856/files#diff-ae3ae59764197d1e97d44cb8d123d849b078e60d66aa6d8332851e7b51fb24abR413-R417).

Fixes #855