### PR TITLE
Return invalid_union on dirty results

### DIFF
--- a/deno/lib/__tests__/unions.test.ts
+++ b/deno/lib/__tests__/unions.test.ts
@@ -102,6 +102,74 @@ test("return all dirty results over aborted", () => {
   }
 });
 
+test("don't continue parsing on aborted result", () => {
+  const result = z
+    .union([z.number(), z.boolean()])
+    .refine(() => false)
+    .safeParse("a");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues).toEqual([
+      {
+        code: "invalid_union",
+        message: "Invalid input",
+        path: [],
+        unionErrors: [
+          new ZodError([
+            {
+              code: "invalid_type",
+              expected: "number",
+              received: "string",
+              path: [],
+              message: "Expected number, received string",
+            },
+          ]),
+          new ZodError([
+            {
+              code: "invalid_type",
+              expected: "boolean",
+              received: "string",
+              path: [],
+              message: "Expected boolean, received string",
+            },
+          ]),
+        ],
+      },
+    ]);
+  }
+});
+
+test("continue parsing on dirty result", () => {
+  const result = z
+    .union([z.number(), z.string().refine(() => false)])
+    .refine(() => false)
+    .safeParse("a");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues).toEqual([
+      {
+        code: "invalid_union",
+        message: "Invalid input",
+        path: [],
+        unionErrors: [
+          new ZodError([
+            {
+              code: "custom",
+              message: "Invalid input",
+              path: [],
+            },
+          ]),
+        ],
+      },
+      {
+        code: "custom",
+        message: "Invalid input",
+        path: [],
+      },
+    ]);
+  }
+});
+
 test("options getter", async () => {
   const union = z.union([z.string(), z.number()]);
   union.options[0].parse("asdf");

--- a/deno/lib/__tests__/unions.test.ts
+++ b/deno/lib/__tests__/unions.test.ts
@@ -2,6 +2,7 @@ import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
 import * as z from "../index.ts";
+import { ZodError } from "../ZodError.ts";
 
 test("function parsing", () => {
   const schema = z.union([
@@ -32,17 +33,70 @@ test("return valid over invalid", () => {
   });
 });
 
-test("return dirty result over aborted", () => {
+test("return all results when there are no dirty", () => {
+  const result = z.union([z.number(), z.boolean()]).safeParse("a");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues).toEqual([
+      {
+        code: "invalid_union",
+        message: "Invalid input",
+        path: [],
+        unionErrors: [
+          new ZodError([
+            {
+              code: "invalid_type",
+              expected: "number",
+              received: "string",
+              path: [],
+              message: "Expected number, received string",
+            },
+          ]),
+          new ZodError([
+            {
+              code: "invalid_type",
+              expected: "boolean",
+              received: "string",
+              path: [],
+              message: "Expected boolean, received string",
+            },
+          ]),
+        ],
+      },
+    ]);
+  }
+});
+
+test("return all dirty results over aborted", () => {
   const result = z
-    .union([z.number(), z.string().refine(() => false)])
+    .union([z.number(), z.string().refine(() => false), z.string().max(0)])
     .safeParse("a");
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues).toEqual([
       {
-        code: "custom",
+        code: "invalid_union",
         message: "Invalid input",
         path: [],
+        unionErrors: [
+          new ZodError([
+            {
+              code: "custom",
+              message: "Invalid input",
+              path: [],
+            },
+          ]),
+          new ZodError([
+            {
+              code: "too_big",
+              maximum: 0,
+              type: "string",
+              inclusive: true,
+              message: "String must contain at most 0 character(s)",
+              path: [],
+            },
+          ]),
+        ],
       },
     ]);
   }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1830,23 +1830,18 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
         }
       }
 
-      for (const result of results) {
-        if (result.result.status === "dirty") {
-          // add issues from dirty option
-
-          ctx.issues.push(...result.ctx.issues);
-          return result.result;
-        }
-      }
-
-      // return invalid
-      const unionErrors = results.map(
-        (result) => new ZodError(result.ctx.issues)
+      const isAnyDirty = results.some(
+        (result) => result.result.status === "dirty"
       );
+
+      const unionErrors = results
+        .filter((result) => !isAnyDirty || result.result.status === "dirty")
+        .map((result) => new ZodError(result.ctx.issues));
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_union,
         unionErrors,
       });
+
       return INVALID;
     }
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2,6 +2,7 @@ import { errorUtil } from "./helpers/errorUtil.ts";
 import {
   addIssueToContext,
   AsyncParseReturnType,
+  DIRTY,
   getParsedType,
   INVALID,
   isAborted,
@@ -1842,6 +1843,9 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
         unionErrors,
       });
 
+      if (isAnyDirty) {
+        return DIRTY(ctx.data);
+      }
       return INVALID;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1830,23 +1830,18 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
         }
       }
 
-      for (const result of results) {
-        if (result.result.status === "dirty") {
-          // add issues from dirty option
-
-          ctx.issues.push(...result.ctx.issues);
-          return result.result;
-        }
-      }
-
-      // return invalid
-      const unionErrors = results.map(
-        (result) => new ZodError(result.ctx.issues)
+      const isAnyDirty = results.some(
+        (result) => result.result.status === "dirty"
       );
+
+      const unionErrors = results
+        .filter((result) => !isAnyDirty || result.result.status === "dirty")
+        .map((result) => new ZodError(result.ctx.issues));
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_union,
         unionErrors,
       });
+
       return INVALID;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { errorUtil } from "./helpers/errorUtil";
 import {
   addIssueToContext,
   AsyncParseReturnType,
+  DIRTY,
   getParsedType,
   INVALID,
   isAborted,
@@ -1842,6 +1843,9 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
         unionErrors,
       });
 
+      if (isAnyDirty) {
+        return DIRTY(ctx.data);
+      }
       return INVALID;
     }
 


### PR DESCRIPTION
When one or more of the results in the union is dirty the union would
previously just return that result. However this can make the error
message strange and inconvenient to override in some cases, drops the
rest of the dirty results if there are multiple, and hides the fact that
it's a union.

Therefore, it's changed to return an invalid_union issue with all the
dirty results. When there are some dirty results, the aborted results
are not included, since they are not relevant. When there are no dirty
results, all the results are included as before.

An example of an error message that's strange and inconvenient to
override is if you have a union of two strict objects, e.g.:

```ts
z.union([
    z.object({ a: z.number() }).strict(),
    z.object({ b: z.number() }).strict()
])
```

If the input is `{ a: 1, b: 1 }`, it would previously return the result
from the first object, which would be code unrecognized_keys with keys
`b`. If you wanted to override the error message, you would have to do
that in the first object, it wouldn't suffice to override the message in
union.

With this patch, the result would be code invalid_union with the two
unrecognized_keys in the unionErrors array. Since the error is now
always invalid_union it suffices to override the error message in union
for both this case when both keys are provided, and for the case when
none of the union schemas match.

Fixes #866

The PR also includes one more commit:

> Mark union as dirty when the results are dirty
> 
> When one or more of the results of the schemas in the union are dirty, I
> think it makes sense to mark the union itself as dirty too.