### PR TITLE
exporting ZodDiscriminatedUnionOption

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1912,7 +1912,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
 
-type ZodDiscriminatedUnionOption<
+export type ZodDiscriminatedUnionOption<
   Discriminator extends string,
   DiscriminatorValue extends Primitive
 > = ZodObject<

--- a/src/types.ts
+++ b/src/types.ts
@@ -1912,7 +1912,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
 
-type ZodDiscriminatedUnionOption<
+export type ZodDiscriminatedUnionOption<
   Discriminator extends string,
   DiscriminatorValue extends Primitive
 > = ZodObject<


### PR DESCRIPTION
I think that zod should export `ZodDiscriminatedUnionOption`. Please let me know if there is a good reason not to do this.