### PR TITLE
Add ZodDiscriminatedUnion to ZodFirstPartySchemaTypes

### DIFF
--- a/deno/lib/__tests__/firstparty.test.ts
+++ b/deno/lib/__tests__/firstparty.test.ts
@@ -39,6 +39,8 @@ test("first party switch", () => {
       break;
     case z.ZodFirstPartyTypeKind.ZodUnion:
       break;
+    case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
+      break;
     case z.ZodFirstPartyTypeKind.ZodIntersection:
       break;
     case z.ZodFirstPartyTypeKind.ZodTuple:

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3551,6 +3551,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodArray<any, any>
   | ZodObject<any, any, any, any, any>
   | ZodUnion<any>
+  | ZodDiscriminatedUnion<any, any, any>
   | ZodIntersection<any, any>
   | ZodTuple<any, any>
   | ZodRecord<any, any>

--- a/src/__tests__/firstparty.test.ts
+++ b/src/__tests__/firstparty.test.ts
@@ -38,6 +38,8 @@ test("first party switch", () => {
       break;
     case z.ZodFirstPartyTypeKind.ZodUnion:
       break;
+    case z.ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
+      break;
     case z.ZodFirstPartyTypeKind.ZodIntersection:
       break;
     case z.ZodFirstPartyTypeKind.ZodTuple:

--- a/src/types.ts
+++ b/src/types.ts
@@ -3551,6 +3551,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodArray<any, any>
   | ZodObject<any, any, any, any, any>
   | ZodUnion<any>
+  | ZodDiscriminatedUnion<any, any, any>
   | ZodIntersection<any, any>
   | ZodTuple<any, any>
   | ZodRecord<any, any>


### PR DESCRIPTION
Is there a reason why `ZodDiscriminatedUnion`, which is a `ZodFirstPartyTypeKind`, isn't in the `ZodFirstPartySchemaTypes` union type? It seems like an oversight?