### PR TITLE
Removed _coverpage.md

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,5 +1,0 @@
-# Welcome to Zod
-
-this is a coverpage
-
-<a href="/#/README">Go to docs</a><a href="/#/README">Screencasts</a><a href="/#/README">Screencasts</a><a href="/#/screencasts">Screencasts</a><a href="/#/README">Screencasts</a>

--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,2 +1,0 @@
-* [Docs]("#/README")
-* [Screencasts]("#/screencasts")


### PR DESCRIPTION
Removed Doc against issue [#1008](https://github.com/colinhacks/zod/issues/1008)

**ISSUE**: Unnecessary Documentation in zod/docs. All links inside the documentation ( [_coverpage.md](https://github.com/colinhacks/zod/blob/master/docs/_coverpage.md)) have expired or lead to 404 not found page leaving it useless and occupy free space.

**PROPOSED**: Removal of _coverpage.md documentation from the repository.