### PR TITLE
Removed _navbar.md

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,2 +1,0 @@
-* [Docs]("#/README")
-* [Screencasts]("#/screencasts")


### PR DESCRIPTION
Removed Doc against issue #1009

**ISSUE**: Unnecessary Documentation in zod/docs. All links inside the documentation ( [_navbar.md](https://github.com/colinhacks/zod/blob/master/docs/_navbar.md)) have expired or lead to 404 not found page leaving it useless and occupy free space.

**PROPOSED**: Removal of _navbar.md documentation from the repository.