### PR TITLE
Removed screencasts.md

### DIFF
--- a/docs/screencasts.md
+++ b/docs/screencasts.md
@@ -1,7 +1,0 @@
-# Screencasts!
-
-asdlfijasdf
-asdf
-asdfadfas
-
-asdfasdf


### PR DESCRIPTION
Removed Doc against issue #1010

**ISSUE**: Unnecessary Documentation in zod/docs. Documentation ( [screencasts.md](https://github.com/colinhacks/zod/blob/master/docs/screencasts.md)) contains random strings making no sense of its purpose.

**PROPOSED**: Removal of screencasts.md documentation from the repository.