### PR TITLE
Precache, avoid cache-checking boolean values, and avoid unnecessary spreads

### DIFF
--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -50,7 +50,7 @@ export const getParsedType = (
 
   switch (t) {
     case "undefined":
-      return cacheAndReturn(data, ZodParsedType.undefined, cache);
+      return ZodParsedType.undefined;
 
     case "string":
       return cacheAndReturn(data, ZodParsedType.string, cache);
@@ -63,7 +63,7 @@ export const getParsedType = (
       );
 
     case "boolean":
-      return cacheAndReturn(data, ZodParsedType.boolean, cache);
+      return ZodParsedType.boolean;
 
     case "function":
       return cacheAndReturn(data, ZodParsedType.function, cache);
@@ -76,7 +76,7 @@ export const getParsedType = (
         return cacheAndReturn(data, ZodParsedType.array, cache);
       }
       if (data === null) {
-        return cacheAndReturn(data, ZodParsedType.null, cache);
+        return ZodParsedType.null;
       }
       if (
         data.then &&

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -151,7 +151,10 @@ export abstract class ZodType<
     return {
       status: new ParseStatus(),
       ctx: {
-        ...input.parent,
+        issues: input.parent.issues,
+        contextualErrorMap: input.parent.contextualErrorMap,
+        async: input.parent.async,
+        typeCache: input.parent.typeCache,
         data: input.data,
         parsedType: getParsedType(input.data, input.parent.typeCache),
         schemaErrorMap: this._def.errorMap,
@@ -220,7 +223,15 @@ export abstract class ZodType<
       contextualErrorMap: params?.errorMap,
       schemaErrorMap: this._def.errorMap,
       async: true,
-      typeCache: typeof Map !== "undefined" ? new Map() : undefined,
+      typeCache:
+        typeof Map !== "undefined"
+          ? new Map([
+              [true, ZodParsedType.boolean],
+              [false, ZodParsedType.boolean],
+              [null, ZodParsedType.null],
+              [undefined, ZodParsedType.undefined],
+            ])
+          : undefined,
       parent: null,
       data,
       parsedType: getParsedType(data),

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -50,7 +50,7 @@ export const getParsedType = (
 
   switch (t) {
     case "undefined":
-      return cacheAndReturn(data, ZodParsedType.undefined, cache);
+      return ZodParsedType.undefined;
 
     case "string":
       return cacheAndReturn(data, ZodParsedType.string, cache);
@@ -63,7 +63,7 @@ export const getParsedType = (
       );
 
     case "boolean":
-      return cacheAndReturn(data, ZodParsedType.boolean, cache);
+      return ZodParsedType.boolean;
 
     case "function":
       return cacheAndReturn(data, ZodParsedType.function, cache);
@@ -76,7 +76,7 @@ export const getParsedType = (
         return cacheAndReturn(data, ZodParsedType.array, cache);
       }
       if (data === null) {
-        return cacheAndReturn(data, ZodParsedType.null, cache);
+        return ZodParsedType.null;
       }
       if (
         data.then &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,7 +151,10 @@ export abstract class ZodType<
     return {
       status: new ParseStatus(),
       ctx: {
-        ...input.parent,
+        issues: input.parent.issues,
+        contextualErrorMap: input.parent.contextualErrorMap,
+        async: input.parent.async,
+        typeCache: input.parent.typeCache,
         data: input.data,
         parsedType: getParsedType(input.data, input.parent.typeCache),
         schemaErrorMap: this._def.errorMap,
@@ -220,7 +223,15 @@ export abstract class ZodType<
       contextualErrorMap: params?.errorMap,
       schemaErrorMap: this._def.errorMap,
       async: true,
-      typeCache: typeof Map !== "undefined" ? new Map() : undefined,
+      typeCache:
+        typeof Map !== "undefined"
+          ? new Map([
+              [true, ZodParsedType.boolean],
+              [false, ZodParsedType.boolean],
+              [null, ZodParsedType.null],
+              [undefined, ZodParsedType.undefined],
+            ])
+          : undefined,
       parent: null,
       data,
       parsedType: getParsedType(data),


### PR DESCRIPTION
Combination of two things that I could find that caused significant performance bumps for my benchmark:

- This optimizes the cache for literals. true, false, null, and undefined are always going to be equal to each other: we might as well fill the cache with them and when they're returned, avoid the `cacheAndReturn` logic.
- In hot code, using `...` is causing performance drag because, in the current setup, zod's distributed files are using TypeScript helpers. This I'll file another PR for: my suspicion is that a very large portion of zod's performance problems are caused by that.