### PR TITLE
Add realworld benchmark

### DIFF
--- a/deno/lib/benchmarks/index.ts
+++ b/deno/lib/benchmarks/index.ts
@@ -1,9 +1,11 @@
 import discriminatedUnionBenchmarks from "./discriminatedUnion.ts";
 import objectBenchmarks from "./object.ts";
+import realworld from "./realworld.ts";
 import stringBenchmarks from "./string.ts";
 import unionBenchmarks from "./union.ts";
 
 for (const suite of [
+  ...realworld.suites,
   ...stringBenchmarks.suites,
   ...objectBenchmarks.suites,
   ...unionBenchmarks.suites,

--- a/deno/lib/benchmarks/realworld.ts
+++ b/deno/lib/benchmarks/realworld.ts
@@ -1,0 +1,63 @@
+import Benchmark from "benchmark";
+
+import { z } from "../index.ts";
+
+const shortSuite = new Benchmark.Suite("realworld");
+
+const People = z.array(
+  z.object({
+    type: z.literal("person"),
+    hair: z.enum(["blue", "brown"]),
+    active: z.boolean(),
+    name: z.string(),
+    age: z.number().int(),
+    hobbies: z.array(z.string()),
+    address: z.object({
+      street: z.string(),
+      zip: z.string(),
+      country: z.string(),
+    }),
+  })
+);
+
+let i = 0;
+
+function num() {
+  return ++i;
+}
+
+function str() {
+  return (++i % 100).toString(16);
+}
+
+function array<T>(fn: () => T): T[] {
+  return Array.from({ length: ++i % 10 }, () => fn());
+}
+
+const people = Array.from({ length: 100 }, () => {
+  return {
+    type: "person",
+    hair: i % 2 ? "blue" : "brown",
+    active: !!(i % 2),
+    name: str(),
+    age: num(),
+    hobbies: array(str),
+    address: {
+      street: str(),
+      zip: str(),
+      country: str(),
+    },
+  };
+});
+
+shortSuite
+  .add("valid", () => {
+    People.parse(people);
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`${(shortSuite as any).name}: ${e.target}`);
+  });
+
+export default {
+  suites: [shortSuite],
+};

--- a/src/benchmarks/index.ts
+++ b/src/benchmarks/index.ts
@@ -1,9 +1,11 @@
 import discriminatedUnionBenchmarks from "./discriminatedUnion";
 import objectBenchmarks from "./object";
+import realworld from "./realworld";
 import stringBenchmarks from "./string";
 import unionBenchmarks from "./union";
 
 for (const suite of [
+  ...realworld.suites,
   ...stringBenchmarks.suites,
   ...objectBenchmarks.suites,
   ...unionBenchmarks.suites,

--- a/src/benchmarks/realworld.ts
+++ b/src/benchmarks/realworld.ts
@@ -1,0 +1,63 @@
+import Benchmark from "benchmark";
+
+import { z } from "../index";
+
+const shortSuite = new Benchmark.Suite("realworld");
+
+const People = z.array(
+  z.object({
+    type: z.literal("person"),
+    hair: z.enum(["blue", "brown"]),
+    active: z.boolean(),
+    name: z.string(),
+    age: z.number().int(),
+    hobbies: z.array(z.string()),
+    address: z.object({
+      street: z.string(),
+      zip: z.string(),
+      country: z.string(),
+    }),
+  })
+);
+
+let i = 0;
+
+function num() {
+  return ++i;
+}
+
+function str() {
+  return (++i % 100).toString(16);
+}
+
+function array<T>(fn: () => T): T[] {
+  return Array.from({ length: ++i % 10 }, () => fn());
+}
+
+const people = Array.from({ length: 100 }, () => {
+  return {
+    type: "person",
+    hair: i % 2 ? "blue" : "brown",
+    active: !!(i % 2),
+    name: str(),
+    age: num(),
+    hobbies: array(str),
+    address: {
+      street: str(),
+      zip: str(),
+      country: str(),
+    },
+  };
+});
+
+shortSuite
+  .add("valid", () => {
+    People.parse(people);
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`${(shortSuite as any).name}: ${e.target}`);
+  });
+
+export default {
+  suites: [shortSuite],
+};


### PR DESCRIPTION
This PR exists to complement / gut-check the work in #1023 - the `typeCache` would make the realworld benchmark faster if it was a net win, because it would replace some `typeof` checks with a map lookup. This benchmark confirms that removing typeCache is about 10% faster in my testing, even if there are repeated values in the dataset.