### PR TITLE
Faster paths for nested parsers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -81,12 +81,12 @@ class ParseInputLazyPath implements ParseInput {
   parent: ParseContext;
   data: any;
   _path: ParsePath;
-  _key: string | number;
+  _key: string | number | (string | number)[];
   constructor(
     parent: ParseContext,
     value: any,
     path: ParsePath,
-    key: string | number
+    key: string | number | (string | number)[]
   ) {
     this.parent = parent;
     this.data = value;
@@ -94,7 +94,7 @@ class ParseInputLazyPath implements ParseInput {
     this._key = key;
   }
   get path() {
-    return [...this._path, this._key];
+    return this._path.concat(this._key);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ import {
   ParseParams,
   ParseReturnType,
   ParseStatus,
+  ParsePath,
   SyncParseReturnType,
   ZodParsedType,
 } from "./helpers/parseUtil";
@@ -74,6 +75,27 @@ export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
   errorMap?: ZodErrorMap;
   description?: string;
+}
+
+class ParseInputLazyPath implements ParseInput {
+  parent: ParseContext;
+  data: any;
+  _path: ParsePath;
+  _key: string | number;
+  constructor(
+    parent: ParseContext,
+    value: any,
+    path: ParsePath,
+    key: string | number
+  ) {
+    this.parent = parent;
+    this.data = value;
+    this._path = path;
+    this._key = key;
+  }
+  get path() {
+    return [...this._path, this._key];
+  }
 }
 
 const handleResult = <Input, Output>(
@@ -1289,11 +1311,9 @@ export class ZodArray<
     if (ctx.common.async) {
       return Promise.all(
         (ctx.data as any[]).map((item, i) => {
-          return def.type._parseAsync({
-            parent: ctx,
-            path: [...ctx.path, i],
-            data: item,
-          });
+          return def.type._parseAsync(
+            new ParseInputLazyPath(ctx, item, ctx.path, i)
+          );
         })
       ).then((result) => {
         return ParseStatus.mergeArray(status, result);
@@ -1301,11 +1321,9 @@ export class ZodArray<
     }
 
     const result = (ctx.data as any[]).map((item, i) => {
-      return def.type._parseSync({
-        parent: ctx,
-        path: [...ctx.path, i],
-        data: item,
-      });
+      return def.type._parseSync(
+        new ParseInputLazyPath(ctx, item, ctx.path, i)
+      );
     });
 
     return ParseStatus.mergeArray(status, result);
@@ -1505,6 +1523,7 @@ function deepPartialify(schema: ZodTypeAny): any {
     return schema;
   }
 }
+
 export class ZodObject<
   T extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = "strip",
@@ -1552,11 +1571,9 @@ export class ZodObject<
       const value = ctx.data[key];
       pairs.push({
         key: { status: "valid", value: key },
-        value: keyValidator._parse({
-          parent: ctx,
-          data: value,
-          path: [...ctx.path, key],
-        }),
+        value: keyValidator._parse(
+          new ParseInputLazyPath(ctx, value, ctx.path, key)
+        ),
         alwaysSet: key in ctx.data,
       });
     }
@@ -1592,7 +1609,7 @@ export class ZodObject<
         pairs.push({
           key: { status: "valid", value: key },
           value: catchall._parse(
-            { parent: ctx, path: [...ctx.path, key], data: value } //, ctx.child(key), value, getParsedType(value)
+            new ParseInputLazyPath(ctx, value, ctx.path, key) //, ctx.child(key), value, getParsedType(value)
           ),
           alwaysSet: key in ctx.data,
         });
@@ -2368,11 +2385,9 @@ export class ZodTuple<
       .map((item, itemIndex) => {
         const schema = this._def.items[itemIndex] || this._def.rest;
         if (!schema) return null as any as SyncParseReturnType<any>;
-        return schema._parse({
-          data: item,
-          path: [...ctx.path, itemIndex],
-          parent: ctx,
-        });
+        return schema._parse(
+          new ParseInputLazyPath(ctx, item, ctx.path, itemIndex)
+        );
       })
       .filter((x) => !!x); // filter nulls
 
@@ -2468,16 +2483,10 @@ export class ZodRecord<
 
     for (const key in ctx.data) {
       pairs.push({
-        key: keyType._parse({
-          data: key,
-          path: [...ctx.path, key],
-          parent: ctx,
-        }),
-        value: valueType._parse({
-          data: ctx.data[key],
-          path: [...ctx.path, key],
-          parent: ctx,
-        }),
+        key: keyType._parse(new ParseInputLazyPath(ctx, key, ctx.path, key)),
+        value: valueType._parse(
+          new ParseInputLazyPath(ctx, ctx.data[key], ctx.path, key)
+        ),
       });
     }
 
@@ -2698,7 +2707,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
     }
 
     const elements = [...(ctx.data as Set<unknown>).values()].map((item, i) =>
-      valueType._parse({ data: item, path: [...ctx.path, i], parent: ctx })
+      valueType._parse(new ParseInputLazyPath(ctx, item, ctx.path, i))
     );
 
     if (ctx.common.async) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2570,16 +2570,12 @@ export class ZodMap<
     const pairs = [...(ctx.data as Map<unknown, unknown>).entries()].map(
       ([key, value], index) => {
         return {
-          key: keyType._parse({
-            data: key,
-            path: [...ctx.path, index, "key"],
-            parent: ctx,
-          }),
-          value: valueType._parse({
-            data: value,
-            path: [...ctx.path, index, "value"],
-            parent: ctx,
-          }),
+          key: keyType._parse(
+            new ParseInputLazyPath(ctx, key, ctx.path, [index, "key"])
+          ),
+          value: valueType._parse(
+            new ParseInputLazyPath(ctx, value, ctx.path, [index, "value"])
+          ),
         };
       }
     );


### PR DESCRIPTION
Okay! Got another. Paths, specifically the pattern `[...ctx.path, key]` is a performance hotspot. This PR replaces that pattern with an object, `ParseInputLazyPath`, which is `ParseInput`, but instead of concatenating the path immediately, only creates the new array if it's needed (if there is an error). This yields a 20-30% performance boost on inputs like the realworld benchmark and the object benchmarks, and I can't easily profile it, but should reduce memory overhead a bit too.

- Refs #205

---

Before

```
% y benchmark
yarn run v1.22.4
$ ts-node src/benchmarks/index.ts
realworld: valid x 3,819 ops/sec ±0.97% (92 runs sampled)
z.enum: valid x 12,049,817 ops/sec ±0.72% (87 runs sampled)
z.enum: invalid x 65,717 ops/sec ±4.31% (88 runs sampled)
z.undefined: valid x 10,393,122 ops/sec ±0.98% (88 runs sampled)
z.undefined: invalid x 65,767 ops/sec ±3.98% (89 runs sampled)
z.literal: valid x 22,997,780 ops/sec ±0.59% (93 runs sampled)
z.literal: invalid x 69,284 ops/sec ±0.93% (89 runs sampled)
z.number: valid x 9,296,436 ops/sec ±1.02% (89 runs sampled)
z.number: invalid type x 66,951 ops/sec ±4.44% (88 runs sampled)
z.number: invalid number x 69,723 ops/sec ±1.09% (89 runs sampled)
z.string: empty string x 9,793,495 ops/sec ±0.82% (89 runs sampled)
z.string: short string x 9,464,260 ops/sec ±0.98% (88 runs sampled)
z.string: long string x 9,578,131 ops/sec ±0.99% (86 runs sampled)
z.string: optional string x 7,780,586 ops/sec ±1.08% (83 runs sampled)
z.string: nullable string x 6,718,051 ops/sec ±0.83% (88 runs sampled)
z.string: nullable (null) string x 9,268,075 ops/sec ±0.71% (88 runs sampled)
z.string: invalid: null x 65,552 ops/sec ±4.41% (88 runs sampled)
z.string: manual parser: long x 917,656,518 ops/sec ±1.39% (90 runs sampled)
z.object: empty: valid x 4,709,549 ops/sec ±1.17% (83 runs sampled)
z.object: empty: valid: extra keys x 4,065,901 ops/sec ±0.76% (90 runs sampled)
z.object: empty: invalid: null x 67,518 ops/sec ±0.84% (91 runs sampled)
z.object: short: valid x 2,259,276 ops/sec ±0.87% (88 runs sampled)
z.object: short: valid: extra keys x 2,019,209 ops/sec ±1.03% (86 runs sampled)
z.object: short: invalid: null x 62,770 ops/sec ±4.48% (86 runs sampled)
z.object: long: valid x 1,185,061 ops/sec ±1.02% (89 runs sampled)
z.object: long: valid: extra keys x 1,149,035 ops/sec ±1.12% (90 runs sampled)
z.object: long: invalid: null x 66,780 ops/sec ±0.78% (91 runs sampled)
z.union: double: valid: a x 1,765,709 ops/sec ±0.95% (88 runs sampled)
z.union: double: valid: b x 216,561 ops/sec ±7.73% (88 runs sampled)
z.union: double: invalid: null x 24,409 ops/sec ±1.17% (91 runs sampled)
z.union: double: invalid: wrong shape x 22,772 ops/sec ±4.70% (87 runs sampled)
z.union: many: valid: a x 1,792,144 ops/sec ±1.06% (86 runs sampled)
z.union: many: valid: c x 123,370 ops/sec ±6.10% (84 runs sampled)
z.union: many: invalid: null x 14,940 ops/sec ±4.33% (87 runs sampled)
z.union: many: invalid: wrong shape x 14,601 ops/sec ±1.10% (90 runs sampled)
z.discriminatedUnion: double: valid: a x 1,794,083 ops/sec ±0.97% (88 runs sampled)
z.discriminatedUnion: double: valid: b x 1,901,624 ops/sec ±0.94% (85 runs sampled)
z.discriminatedUnion: double: invalid: null x 62,635 ops/sec ±4.22% (83 runs sampled)
z.discriminatedUnion: double: invalid: wrong shape x 79,999 ops/sec ±0.99% (95 runs sampled)
z.discriminatedUnion: many: valid: a x 1,942,452 ops/sec ±1.02% (88 runs sampled)
z.discriminatedUnion: many: valid: c x 1,962,238 ops/sec ±0.96% (92 runs sampled)
z.discriminatedUnion: many: invalid: null x 84,518 ops/sec ±0.56% (92 runs sampled)
z.discriminatedUnion: many: invalid: wrong shape x 77,013 ops/sec ±0.82% (93 runs sampled)
✨  Done in 237.98s.
```


After

```
% y benchmark
yarn run v1.22.4
$ ts-node src/benchmarks/index.ts
realworld: valid x 4,934 ops/sec ±1.18% (88 runs sampled)
z.enum: valid x 12,020,432 ops/sec ±0.97% (89 runs sampled)
z.enum: invalid x 66,359 ops/sec ±4.15% (89 runs sampled)
z.undefined: valid x 10,118,294 ops/sec ±1.00% (88 runs sampled)
z.undefined: invalid x 64,990 ops/sec ±4.09% (88 runs sampled)
z.literal: valid x 22,881,671 ops/sec ±0.71% (95 runs sampled)
z.literal: invalid x 64,326 ops/sec ±1.02% (89 runs sampled)
z.number: valid x 7,213,872 ops/sec ±1.12% (87 runs sampled)
z.number: invalid type x 62,500 ops/sec ±4.11% (81 runs sampled)
z.number: invalid number x 66,110 ops/sec ±0.97% (91 runs sampled)
z.string: empty string x 7,727,690 ops/sec ±0.98% (89 runs sampled)
z.string: short string x 7,533,898 ops/sec ±1.01% (87 runs sampled)
z.string: long string x 7,424,665 ops/sec ±1.11% (90 runs sampled)
z.string: optional string x 6,298,061 ops/sec ±1.06% (88 runs sampled)
z.string: nullable string x 5,351,823 ops/sec ±1.27% (86 runs sampled)
z.string: nullable (null) string x 9,295,395 ops/sec ±1.00% (90 runs sampled)
z.string: invalid: null x 64,821 ops/sec ±4.40% (87 runs sampled)
z.string: manual parser: long x 898,213,431 ops/sec ±1.36% (87 runs sampled)
z.object: empty: valid x 4,163,427 ops/sec ±2.03% (89 runs sampled)
z.object: empty: valid: extra keys x 3,750,210 ops/sec ±1.11% (89 runs sampled)
z.object: empty: invalid: null x 67,258 ops/sec ±0.92% (91 runs sampled)
z.object: short: valid x 2,395,853 ops/sec ±1.11% (88 runs sampled)
z.object: short: valid: extra keys x 2,118,128 ops/sec ±0.99% (87 runs sampled)
z.object: short: invalid: null x 63,278 ops/sec ±4.17% (86 runs sampled)
z.object: long: valid x 1,436,958 ops/sec ±1.09% (89 runs sampled)
z.object: long: valid: extra keys x 1,330,563 ops/sec ±1.34% (90 runs sampled)
z.object: long: invalid: null x 65,808 ops/sec ±1.07% (89 runs sampled)
z.union: double: valid: a x 1,858,340 ops/sec ±0.98% (87 runs sampled)
z.union: double: valid: b x 214,908 ops/sec ±6.27% (91 runs sampled)
z.union: double: invalid: null x 23,372 ops/sec ±4.25% (87 runs sampled)
z.union: double: invalid: wrong shape x 23,212 ops/sec ±1.26% (90 runs sampled)
z.union: many: valid: a x 1,755,110 ops/sec ±1.17% (87 runs sampled)
z.union: many: valid: c x 117,378 ops/sec ±8.97% (86 runs sampled)
z.union: many: invalid: null x 15,048 ops/sec ±0.91% (91 runs sampled)
z.union: many: invalid: wrong shape x 14,277 ops/sec ±4.43% (88 runs sampled)
z.discriminatedUnion: double: valid: a x 1,952,220 ops/sec ±1.06% (88 runs sampled)
z.discriminatedUnion: double: valid: b x 1,975,703 ops/sec ±1.10% (89 runs sampled)
z.discriminatedUnion: double: invalid: null x 65,141 ops/sec ±0.94% (94 runs sampled)
z.discriminatedUnion: double: invalid: wrong shape x 78,921 ops/sec ±1.12% (90 runs sampled)
z.discriminatedUnion: many: valid: a x 1,931,200 ops/sec ±0.99% (86 runs sampled)
z.discriminatedUnion: many: valid: c x 1,922,676 ops/sec ±0.89% (86 runs sampled)
z.discriminatedUnion: many: invalid: null x 82,803 ops/sec ±1.04% (92 runs sampled)
z.discriminatedUnion: many: invalid: wrong shape x 76,801 ops/sec ±0.71% (90 runs sampled)
✨  Done in 238.26s.
```