### PR TITLE
feat: allow ctx.addIssue from transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 src/playground.ts
 deno/lib/playground.ts
 .eslintcache
+workspace.code-workspace

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -12,32 +12,32 @@ const stringToNumber = z.string().transform((arg) => parseFloat(arg));
 const asyncNumberToString = z.number().transform(async (n) => String(n));
 
 test("transform ctx.addIssue", () => {
-  const strs = [
-    'foo',
-    'bar'
-  ]
+  const strs = ["foo", "bar"];
 
   expect(() => {
-    z
-    .string()
-    .transform((data, ctx) => {
-      const i = strs.indexOf(data)
-      if (i === -1) {
-        ctx.addIssue({
-          code: 'custom',
-          message: `${data} is not one of our allowed strings`,
-        })
-      }
-      return data.length
-    })
-    .parse("asdf");
+    z.string()
+      .transform((data, ctx) => {
+        const i = strs.indexOf(data);
+        if (i === -1) {
+          ctx.addIssue({
+            code: "custom",
+            message: `${data} is not one of our allowed strings`,
+          });
+        }
+        return data.length;
+      })
+      .parse("asdf");
   }).toThrow(
     JSON.stringify(
-      [{
-        code: 'custom',
-        message: 'asdf is not one of our allowed strings',
-        path: [],
-      }], null, 2
+      [
+        {
+          code: "custom",
+          message: "asdf is not one of our allowed strings",
+          path: [],
+        },
+      ],
+      null,
+      2
     )
   );
 });

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -11,6 +11,29 @@ const stringToNumber = z.string().transform((arg) => parseFloat(arg));
 //   .transform((n) => String(n));
 const asyncNumberToString = z.number().transform(async (n) => String(n));
 
+test("transform ctx.addIssue", () => {
+  const strs = [
+    'foo',
+    'bar'
+  ]
+
+  expect(() => {
+    z
+    .string()
+    .transform((data, ctx) => {
+      const i = strs.indexOf(data)
+      if (i === -1) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `${data} is not one of our allowed strings`,
+        })
+      }
+      return data.length
+    })
+    .parse("asdf");
+  }).toThrow();
+});
+
 test("basic transformations", () => {
   const r1 = z
     .string()

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -31,7 +31,15 @@ test("transform ctx.addIssue", () => {
       return data.length
     })
     .parse("asdf");
-  }).toThrow();
+  }).toThrow(
+    JSON.stringify(
+      [{
+        code: 'custom',
+        message: 'asdf is not one of our allowed strings',
+        path: [],
+      }], null, 2
+    )
+  );
 });
 
 test("basic transformations", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -422,7 +422,7 @@ export abstract class ZodType<
   }
 
   transform<NewOut>(
-    transform: (arg: Output) => NewOut | Promise<NewOut>
+    transform: (arg: Output, ctx: RefinementCtx) => NewOut | Promise<NewOut>
   ): ZodEffects<this, NewOut> {
     return new ZodEffects({
       schema: this,
@@ -3219,7 +3219,7 @@ export type RefinementEffect<T> = {
 };
 export type TransformEffect<T> = {
   type: "transform";
-  transform: (arg: T) => any;
+  transform: (arg: T, ctx: RefinementCtx) => any;
 };
 export type PreprocessEffect<T> = {
   type: "preprocess";
@@ -3271,23 +3271,22 @@ export class ZodEffects<
       }
     }
 
+    const checkCtx: RefinementCtx = {
+      addIssue: (arg: IssueData) => {
+        addIssueToContext(ctx, arg);
+        if (arg.fatal) {
+          status.abort();
+        } else {
+          status.dirty();
+        }
+      },
+      get path() {
+        return ctx.path;
+      },
+    };
+
+    checkCtx.addIssue = checkCtx.addIssue.bind(checkCtx);
     if (effect.type === "refinement") {
-      const checkCtx: RefinementCtx = {
-        addIssue: (arg: IssueData) => {
-          addIssueToContext(ctx, arg);
-          if (arg.fatal) {
-            status.abort();
-          } else {
-            status.dirty();
-          }
-        },
-        get path() {
-          return ctx.path;
-        },
-      };
-
-      checkCtx.addIssue = checkCtx.addIssue.bind(checkCtx);
-
       const executeRefinement = (
         acc: unknown
         // effect: RefinementEffect<any>
@@ -3343,13 +3342,14 @@ export class ZodEffects<
         // }
         if (!isValid(base)) return base;
 
-        const result = effect.transform(base.value);
+        const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
           throw new Error(
             `Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`
           );
         }
-        return OK(result);
+
+        return { status: status.value, value: result };
       } else {
         return this._def.schema
           ._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx })
@@ -3359,7 +3359,9 @@ export class ZodEffects<
             // if (base.status === "dirty") {
             //   return { status: "dirty", value: base.value };
             // }
-            return Promise.resolve(effect.transform(base.value)).then(OK);
+            return Promise.resolve(effect.transform(base.value, checkCtx)).then(
+              OK
+            );
           });
       }
     }

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -30,7 +30,7 @@ test("transform ctx.addIssue", () => {
       return data.length
     })
     .parse("asdf");
-  }).toThrow();
+  }).toThrow('asdf is not one of our allowed strings');
 });
 
 test("basic transformations", () => {

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -10,6 +10,29 @@ const stringToNumber = z.string().transform((arg) => parseFloat(arg));
 //   .transform((n) => String(n));
 const asyncNumberToString = z.number().transform(async (n) => String(n));
 
+test("transform ctx.addIssue", () => {
+  const strs = [
+    'foo',
+    'bar'
+  ]
+
+  expect(() => {
+    z
+    .string()
+    .transform((data, ctx) => {
+      const i = strs.indexOf(data)
+      if (i === -1) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `${data} is not one of our allowed strings`,
+        })
+      }
+      return data.length
+    })
+    .parse("asdf");
+  }).toThrow();
+});
+
 test("basic transformations", () => {
   const r1 = z
     .string()

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -11,26 +11,34 @@ const stringToNumber = z.string().transform((arg) => parseFloat(arg));
 const asyncNumberToString = z.number().transform(async (n) => String(n));
 
 test("transform ctx.addIssue", () => {
-  const strs = [
-    'foo',
-    'bar'
-  ]
+  const strs = ["foo", "bar"];
 
   expect(() => {
-    z
-    .string()
-    .transform((data, ctx) => {
-      const i = strs.indexOf(data)
-      if (i === -1) {
-        ctx.addIssue({
-          code: 'custom',
-          message: `${data} is not one of our allowed strings`,
-        })
-      }
-      return data.length
-    })
-    .parse("asdf");
-  }).toThrow('asdf is not one of our allowed strings');
+    z.string()
+      .transform((data, ctx) => {
+        const i = strs.indexOf(data);
+        if (i === -1) {
+          ctx.addIssue({
+            code: "custom",
+            message: `${data} is not one of our allowed strings`,
+          });
+        }
+        return data.length;
+      })
+      .parse("asdf");
+  }).toThrow(
+    JSON.stringify(
+      [
+        {
+          code: "custom",
+          message: "asdf is not one of our allowed strings",
+          path: [],
+        },
+      ],
+      null,
+      2
+    )
+  );
 });
 
 test("basic transformations", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -422,7 +422,7 @@ export abstract class ZodType<
   }
 
   transform<NewOut>(
-    transform: (arg: Output) => NewOut | Promise<NewOut>
+    transform: (arg: Output, ctx: RefinementCtx) => NewOut | Promise<NewOut>
   ): ZodEffects<this, NewOut> {
     return new ZodEffects({
       schema: this,
@@ -3219,7 +3219,7 @@ export type RefinementEffect<T> = {
 };
 export type TransformEffect<T> = {
   type: "transform";
-  transform: (arg: T) => any;
+  transform: (arg: T, ctx: RefinementCtx) => any;
 };
 export type PreprocessEffect<T> = {
   type: "preprocess";
@@ -3271,23 +3271,22 @@ export class ZodEffects<
       }
     }
 
+    const checkCtx: RefinementCtx = {
+      addIssue: (arg: IssueData) => {
+        addIssueToContext(ctx, arg);
+        if (arg.fatal) {
+          status.abort();
+        } else {
+          status.dirty();
+        }
+      },
+      get path() {
+        return ctx.path;
+      },
+    };
+
+    checkCtx.addIssue = checkCtx.addIssue.bind(checkCtx);
     if (effect.type === "refinement") {
-      const checkCtx: RefinementCtx = {
-        addIssue: (arg: IssueData) => {
-          addIssueToContext(ctx, arg);
-          if (arg.fatal) {
-            status.abort();
-          } else {
-            status.dirty();
-          }
-        },
-        get path() {
-          return ctx.path;
-        },
-      };
-
-      checkCtx.addIssue = checkCtx.addIssue.bind(checkCtx);
-
       const executeRefinement = (
         acc: unknown
         // effect: RefinementEffect<any>
@@ -3343,13 +3342,14 @@ export class ZodEffects<
         // }
         if (!isValid(base)) return base;
 
-        const result = effect.transform(base.value);
+        const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
           throw new Error(
             `Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`
           );
         }
-        return OK(result);
+
+        return { status: status.value, value: result };
       } else {
         return this._def.schema
           ._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx })
@@ -3359,7 +3359,9 @@ export class ZodEffects<
             // if (base.status === "dirty") {
             //   return { status: "dirty", value: base.value };
             // }
-            return Promise.resolve(effect.transform(base.value)).then(OK);
+            return Promise.resolve(effect.transform(base.value, checkCtx)).then(
+              OK
+            );
           });
       }
     }


### PR DESCRIPTION
Closes out part of #696 . Except only on transforms!

```
z
    .string()
    .transform((data, ctx) => {
      const i = strs.indexOf(data)
      if (i === -1) {
        ctx.addIssue({
          code: 'custom',
          message: `${data} is not one of our allowed strings`,
        })
      }
      return data.length
    })
    .parse("asdf");
```
Will throw. `ctx` works just like in superRefine()