### PR TITLE
Faster extra keys detection

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1558,8 +1558,12 @@ export class ZodObject<
     const { status, ctx } = this._processInputParams(input);
 
     const { shape, keys: shapeKeys } = this._getCached();
-    const dataKeys = util.objectKeys(ctx.data);
-    const extraKeys = dataKeys.filter((k) => !shapeKeys.includes(k));
+    const extraKeys: string[] = [];
+    for (const key in ctx.data) {
+      if (!shapeKeys.includes(key)) {
+        extraKeys.push(key);
+      }
+    }
 
     const pairs: {
       key: ParseReturnType<any>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1558,8 +1558,12 @@ export class ZodObject<
     const { status, ctx } = this._processInputParams(input);
 
     const { shape, keys: shapeKeys } = this._getCached();
-    const dataKeys = util.objectKeys(ctx.data);
-    const extraKeys = dataKeys.filter((k) => !shapeKeys.includes(k));
+    const extraKeys: string[] = [];
+    for (const key in ctx.data) {
+      if (!shapeKeys.includes(key)) {
+        extraKeys.push(key);
+      }
+    }
 
     const pairs: {
       key: ParseReturnType<any>;


### PR DESCRIPTION
This increases object parsing performance by about 8-10% by skipping a call to Object.keys and instead using `in`. I know it's odd, but this seemingly insignificant few lines of code really seems to be a hotspot.

Benchmark results: https://observablehq.com/d/8978a77c49a9c6ef - there's a lot of test jitter in mainly unrelated benchmarks - no reason to think this'll change string parsing performance.