### PR TITLE
Remove hanging string expressions

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -394,8 +394,6 @@ export abstract class ZodType<
   }
 
   optional(): ZodOptional<this> {
-    ("");
-    ("asdf");
     return ZodOptional.create(this) as any;
   }
   nullable(): ZodNullable<this> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -394,8 +394,6 @@ export abstract class ZodType<
   }
 
   optional(): ZodOptional<this> {
-    ("");
-    ("asdf");
     return ZodOptional.create(this) as any;
   }
   nullable(): ZodNullable<this> {


### PR DESCRIPTION
Apologies for not opening an issue first but this felt like low hanging fruit :)

It seems like there was some testing done on the repo's husky hooks (https://github.com/colinhacks/zod/commit/0dbd4ec8154d3390e23bdd2b1238fd20276893bf) and these no-op string expressions were accidentally pushed.