### PR TITLE
docs: infer `Literal` from the schema in JSON type example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,9 +1185,9 @@ const Category: z.ZodType<Category> = BaseCategory.merge(
 If you want to validate any JSON value, you can use the snippet below.
 
 ```ts
-type Literal = boolean | null | number | string;
-type Json = Literal | { [key: string]: Json } | Json[];
 const literalSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+type Literal = z.infer<typeof literalSchema>;
+type Json = Literal | { [key: string]: Json } | Json[];
 const jsonSchema: z.ZodType<Json> = z.lazy(() =>
   z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)])
 );

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1012,9 +1012,9 @@ const Category: z.ZodSchema<Category> = BaseCategory.merge(
 如果你想验证任何 JSON 值，你可以使用下面的片段。
 
 ```ts
-type Literal = boolean | null | number | string;
-type Json = Literal | { [key: string]: Json } | Json[];
 const literalSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+type Literal = z.infer<typeof literalSchema>;
+type Json = Literal | { [key: string]: Json } | Json[];
 const jsonSchema: z.ZodSchema<Json> = z.lazy(() =>
   z.union([literalSchema, z.array(jsonSchema), z.record(jsonSchema)])
 );


### PR DESCRIPTION
I was using this great recommendation for JSON type and saw this small improvement to reduce duplication.