### PR TITLE
Add parent ctx to refinement

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ import {
 export type RefinementCtx = {
   addIssue: (arg: IssueData) => void;
   path: (string | number)[];
+  parent: ParseContext;
 };
 export type ZodRawShape = { [k: string]: ZodTypeAny };
 export type ZodTypeAny = ZodType<any, any, any>;
@@ -3267,6 +3268,9 @@ export class ZodEffects<
         get path() {
           return ctx.path;
         },
+        get parent() {
+          return ctx
+        }
       };
 
       checkCtx.addIssue = checkCtx.addIssue.bind(checkCtx);


### PR DESCRIPTION
make refine more powerful by offering parent (data) ctx to validation function