### PR TITLE
fix: add type-predicate function through the `is`-method.

### DIFF
--- a/deno/lib/__tests__/is.test.ts
+++ b/deno/lib/__tests__/is.test.ts
@@ -1,0 +1,23 @@
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { z } from "../index.ts";
+
+test("test is ", () => {
+  const schema = z.object({ key1: z.string(), key2: z.number() });
+  type ExpectedType = { key1: string; key2: number };
+
+  const value = { key1: "a", key2: 5 } as unknown;
+
+  expect.assertions(1);
+  if (schema.is(value)) {
+    const typeCheckedValue: ExpectedType = value;
+    expect(typeCheckedValue).toBe(value);
+  } else {
+    //@ts-expect-error
+    const typeCheckedValue: ExpectedType = value;
+    // So that the "unused" error goes away
+    expect(typeCheckedValue).toBe(value);
+    expect(false).toBe(true);
+  }
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -211,6 +211,10 @@ export abstract class ZodType<
     throw result.error;
   }
 
+  is(data: unknown): data is Output {
+    return this.safeParse(data).success;
+  }
+
   safeParse(
     data: unknown,
     params?: Partial<ParseParams>
@@ -356,6 +360,7 @@ export abstract class ZodType<
     this._def = def;
     this.parse = this.parse.bind(this);
     this.safeParse = this.safeParse.bind(this);
+    this.is = this.is.bind(this);
     this.parseAsync = this.parseAsync.bind(this);
     this.safeParseAsync = this.safeParseAsync.bind(this);
     this.spa = this.spa.bind(this);

--- a/src/__tests__/is.test.ts
+++ b/src/__tests__/is.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@jest/globals";
+
+import { z } from "..";
+
+test("test is ", () => {
+  const schema = z.object({ key1: z.string(), key2: z.number() });
+  type ExpectedType = { key1: string; key2: number };
+
+  const value = { key1: "a", key2: 5 } as unknown;
+
+  expect.assertions(1);
+  if (schema.is(value)) {
+    const typeCheckedValue: ExpectedType = value;
+    expect(typeCheckedValue).toBe(value);
+  } else {
+    //@ts-expect-error
+    const typeCheckedValue: ExpectedType = value;
+    // So that the "unused" error goes away
+    expect(typeCheckedValue).toBe(value);
+    expect(false).toBe(true);
+  }
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,10 @@ export abstract class ZodType<
     throw result.error;
   }
 
+  is(data: unknown): data is Output {
+    return this.safeParse(data).success;
+  }
+
   safeParse(
     data: unknown,
     params?: Partial<ParseParams>
@@ -356,6 +360,7 @@ export abstract class ZodType<
     this._def = def;
     this.parse = this.parse.bind(this);
     this.safeParse = this.safeParse.bind(this);
+    this.is = this.is.bind(this);
     this.parseAsync = this.parseAsync.bind(this);
     this.safeParseAsync = this.safeParseAsync.bind(this);
     this.spa = this.spa.bind(this);


### PR DESCRIPTION
Is it possible for is to add an `is`-method, which basically is the type: `is(data: unknown): data is Output`?

This feature is called [type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) 