### PR TITLE
Restore existing type inference behaviour of z.ZodObject

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1363,13 +1363,18 @@ export namespace objectUtil {
     [k in Exclude<keyof U, keyof V>]: U[k];
   } & V;
 
-  export type requiredKeys<T extends object> = {
+  type optionalKeys<T extends object> = {
+    [k in keyof T]: undefined extends T[k] ? k : never;
+  }[keyof T];
+
+  type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
   }[keyof T];
 
-  export type addQuestionMarks<T extends object> = {
-    [k in keyof T]?: T[k];
-  } & { [k in requiredKeys<T>]: T[k] };
+  export type addQuestionMarks<T extends object> = Partial<
+    Pick<T, optionalKeys<T>>
+  > &
+    Pick<T, requiredKeys<T>>;
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;

--- a/src/__tests__/languageServerFeatures.test.ts
+++ b/src/__tests__/languageServerFeatures.test.ts
@@ -1,8 +1,9 @@
 // @ts-ignore TS6133
 import { expect, fit } from "@jest/globals";
-import { filePath } from "./languageServerFeatures.source";
-import { Project, Node, SyntaxKind } from "ts-morph";
 import path from "path";
+import { Node, Project, SyntaxKind } from "ts-morph";
+
+import { filePath } from "./languageServerFeatures.source";
 
 // The following tool is helpful for understanding the TypeScript AST associated with these tests:
 // https://ts-ast-viewer.com/ (just copy the contents of languageServerFeatures.source into the viewer)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1363,13 +1363,18 @@ export namespace objectUtil {
     [k in Exclude<keyof U, keyof V>]: U[k];
   } & V;
 
-  export type requiredKeys<T extends object> = {
+  type optionalKeys<T extends object> = {
+    [k in keyof T]: undefined extends T[k] ? k : never;
+  }[keyof T];
+
+  type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
   }[keyof T];
 
-  export type addQuestionMarks<T extends object> = {
-    [k in keyof T]?: T[k];
-  } & { [k in requiredKeys<T>]: T[k] };
+  export type addQuestionMarks<T extends object> = Partial<
+    Pick<T, optionalKeys<T>>
+  > &
+    Pick<T, requiredKeys<T>>;
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;


### PR DESCRIPTION
Fixes the issue documented here: https://github.com/colinhacks/zod/issues/1121

I'm pretty sure my PR introduced this issue: https://github.com/colinhacks/zod/pull/1117

In almost all cases `z.flatten<{ property: (T | undefined) & T }>` flattens to `{ property: T }`. However, this does not appear to be the case for some very specific types like this one:

```TypeScript
type Opaque<Type, Token = unknown> = Type & { tag: Token };

  enum FACE {
    QUEEN = "QUEEN",
    KING = "KING",
  }

  enum SUIT {
    HEARTS = "HEARTS",
    DIAMONDS = "DIAMONDS",
  }

  type FaceCard<Face extends FACE> = Opaque<`${Face}_${SUIT}`, "FaceCard">;

  type Hand = z.objectUtil.flatten<
    z.ZodObject<{
      card: z.ZodType<FaceCard<FACE.QUEEN>, z.ZodTypeDef, string>;
    }>["_output"]
  >;
  ```

In this case `Hand` is flattening to:
```TypeScript
type Hand = {
    card: (FaceCard<FACE.QUEEN> | undefined) & FaceCard<FACE.QUEEN>;
}
```


Fortunately, I now better understand the problem I was trying to fix in my PR, and it is actually possible to write `z.ZodObject` in a way that preserves both behaviours. 

It also has the benefit of being easier to understand:

```TypeScript
  type optionalKeys<T extends object> = {
    [k in keyof T]: undefined extends T[k] ? k : never;
  }[keyof T];

  type requiredKeys<T extends object> = {
    [k in keyof T]: undefined extends T[k] ? never : k;
  }[keyof T];

  export type addQuestionMarks<T extends object> = Partial<
    Pick<T, optionalKeys<T>>
  > &
    Pick<T, requiredKeys<T>>;
```

Unfortunately I couldn't see a way to write a test for this, as:

```TypeScript
type Hand = {
    card: (FaceCard<FACE.QUEEN> | undefined) & FaceCard<FACE.QUEEN>;
}
```

and 

```TypeScript
type Hand = {
    card: FaceCard<FACE.QUEEN>
}
```

are equal as far as `util.AssertEqual` is concerned.