### PR TITLE
Added expected and received properties to enum and native enum

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -68,6 +68,8 @@ export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
+  expected: ZodParsedType;
+  received: any;
   code: typeof ZodIssueCode.invalid_enum_value;
   options: (string | number)[];
 }
@@ -316,22 +318,23 @@ export const defaultErrorMap = (
       )}`;
       break;
     case ZodIssueCode.unrecognized_keys:
-      message = `Unrecognized key(s) in object: ${issue.keys
-        .map((k) => `'${k}'`)
-        .join(", ")}`;
+      message = `Unrecognized key(s) in object: ${util.joinValues(
+        issue.keys,
+        ", "
+      )}`;
       break;
     case ZodIssueCode.invalid_union:
       message = `Invalid input`;
       break;
     case ZodIssueCode.invalid_union_discriminator:
-      message = `Invalid discriminator value. Expected ${issue.options
-        .map((val) => (typeof val === "string" ? `'${val}'` : val))
-        .join(" | ")}`;
+      message = `Invalid discriminator value. Expected ${util.joinValues(
+        issue.options
+      )}`;
       break;
     case ZodIssueCode.invalid_enum_value:
-      message = `Invalid enum value. Expected ${issue.options
-        .map((val) => (typeof val === "string" ? `'${val}'` : val))
-        .join(" | ")}`;
+      message = `Invalid enum value. Expected ${util.joinValues(
+        issue.options
+      )} received '${issue.received}'`;
       break;
     case ZodIssueCode.invalid_arguments:
       message = `Invalid function arguments`;

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -68,8 +68,7 @@ export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
-  expected: ZodParsedType;
-  received: any;
+  received: string;
   code: typeof ZodIssueCode.invalid_enum_value;
   options: (string | number)[];
 }
@@ -334,7 +333,7 @@ export const defaultErrorMap = (
     case ZodIssueCode.invalid_enum_value:
       message = `Invalid enum value. Expected ${util.joinValues(
         issue.options
-      )} received '${issue.received}'`;
+      )}, received '${issue.received}'`;
       break;
     case ZodIssueCode.invalid_arguments:
       message = `Invalid function arguments`;

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -410,14 +410,26 @@ test("strict error message", () => {
   }
 });
 
-test("enum default error message", () => {
+test("enum error message, invalid enum elementstring", () => {
   try {
     z.enum(["Tuna", "Trout"]).parse("Salmon");
   } catch (err) {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
     expect(zerr.issues[0].message).toEqual(
-      "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
+      "Invalid enum value. Expected 'Tuna' | 'Trout', received 'Salmon'"
+    );
+  }
+});
+
+test("enum error message, invalid type", () => {
+  try {
+    z.enum(["Tuna", "Trout"]).parse(12);
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    expect(zerr.issues.length).toEqual(1);
+    expect(zerr.issues[0].message).toEqual(
+      "Expected 'Tuna' | 'Trout', received number"
     );
   }
 });
@@ -433,7 +445,7 @@ test("nativeEnum default error message", () => {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
     expect(zerr.issues[0].message).toEqual(
-      "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
+      "Invalid enum value. Expected 'Tuna' | 'Trout', received 'Salmon'"
     );
   }
 });

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -417,9 +417,24 @@ test("enum default error message", () => {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
     expect(zerr.issues[0].message).toEqual(
-      "Invalid enum value. Expected 'Tuna' | 'Trout'"
+      "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
     );
-    expect(zerr.issues[0].message).not.toContain("Salmon");
+  }
+});
+
+test("nativeEnum default error message", () => {
+  enum Fish {
+    Tuna = "Tuna",
+    Trout = "Trout",
+  }
+  try {
+    z.nativeEnum(Fish).parse("Salmon");
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    expect(zerr.issues.length).toEqual(1);
+    expect(zerr.issues[0].message).toEqual(
+      "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
+    );
   }
 });
 

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -73,4 +73,13 @@ export namespace util {
       ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
       : (val) =>
           typeof val === "number" && isFinite(val) && Math.floor(val) === val;
+
+  export function joinValues<T extends any[]>(
+    array: T,
+    separator = " | "
+  ): string {
+    return array
+      .map((val) => (typeof val === "string" ? `'${val}'` : val))
+      .join(separator);
+  }
 }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3021,12 +3021,22 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
   ZodEnumDef<T>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
+    if (typeof input.data !== "string") {
+      const ctx = this._getOrReturnCtx(input);
+      const expectedValues = this._def.values;
+      addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues) as "string",
+        received: ctx.parsedType,
+        code: ZodIssueCode.invalid_type,
+      });
+      return INVALID;
+    }
+
     if (this._def.values.indexOf(input.data) === -1) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
 
       addIssueToContext(ctx, {
-        expected: util.joinValues(expectedValues) as "string",
         received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
         options: expectedValues,
@@ -3088,19 +3098,32 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
 > {
   _parse(input: ParseInput): ParseReturnType<T[keyof T]> {
     const nativeEnumValues = util.getValidEnumValues(this._def.values);
+
+    const ctx = this._getOrReturnCtx(input);
+    if (
+      ctx.parsedType !== ZodParsedType.string &&
+      ctx.parsedType !== ZodParsedType.number
+    ) {
+      const expectedValues = util.objectValues(nativeEnumValues);
+      addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues) as "string",
+        received: ctx.parsedType,
+        code: ZodIssueCode.invalid_type,
+      });
+      return INVALID;
+    }
+
     if (nativeEnumValues.indexOf(input.data) === -1) {
-      const ctx = this._getOrReturnCtx(input);
       const expectedValues = util.objectValues(nativeEnumValues);
 
       addIssueToContext(ctx, {
-        expected: util.joinValues(expectedValues) as "string",
         received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
         options: expectedValues,
       });
       return INVALID;
     }
-    return OK(input.data);
+    return OK(input.data as any);
   }
 
   get enum() {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3023,9 +3023,13 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     if (this._def.values.indexOf(input.data) === -1) {
       const ctx = this._getOrReturnCtx(input);
+      const expectedValues = this._def.values;
+
       addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues) as "string",
+        received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
-        options: this._def.values,
+        options: expectedValues,
       });
       return INVALID;
     }
@@ -3086,9 +3090,13 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     const nativeEnumValues = util.getValidEnumValues(this._def.values);
     if (nativeEnumValues.indexOf(input.data) === -1) {
       const ctx = this._getOrReturnCtx(input);
+      const expectedValues = util.objectValues(nativeEnumValues);
+
       addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues) as "string",
+        received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
-        options: util.objectValues(nativeEnumValues),
+        options: expectedValues,
       });
       return INVALID;
     }

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -68,6 +68,8 @@ export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
+  expected: ZodParsedType;
+  received: any;
   code: typeof ZodIssueCode.invalid_enum_value;
   options: (string | number)[];
 }
@@ -316,22 +318,23 @@ export const defaultErrorMap = (
       )}`;
       break;
     case ZodIssueCode.unrecognized_keys:
-      message = `Unrecognized key(s) in object: ${issue.keys
-        .map((k) => `'${k}'`)
-        .join(", ")}`;
+      message = `Unrecognized key(s) in object: ${util.joinValues(
+        issue.keys,
+        ", "
+      )}`;
       break;
     case ZodIssueCode.invalid_union:
       message = `Invalid input`;
       break;
     case ZodIssueCode.invalid_union_discriminator:
-      message = `Invalid discriminator value. Expected ${issue.options
-        .map((val) => (typeof val === "string" ? `'${val}'` : val))
-        .join(" | ")}`;
+      message = `Invalid discriminator value. Expected ${util.joinValues(
+        issue.options
+      )}`;
       break;
     case ZodIssueCode.invalid_enum_value:
-      message = `Invalid enum value. Expected ${issue.options
-        .map((val) => (typeof val === "string" ? `'${val}'` : val))
-        .join(" | ")}`;
+      message = `Invalid enum value. Expected ${util.joinValues(
+        issue.options
+      )} received '${issue.received}'`;
       break;
     case ZodIssueCode.invalid_arguments:
       message = `Invalid function arguments`;

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -68,8 +68,7 @@ export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
-  expected: ZodParsedType;
-  received: any;
+  received: string;
   code: typeof ZodIssueCode.invalid_enum_value;
   options: (string | number)[];
 }
@@ -334,7 +333,7 @@ export const defaultErrorMap = (
     case ZodIssueCode.invalid_enum_value:
       message = `Invalid enum value. Expected ${util.joinValues(
         issue.options
-      )} received '${issue.received}'`;
+      )}, received '${issue.received}'`;
       break;
     case ZodIssueCode.invalid_arguments:
       message = `Invalid function arguments`;

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -409,14 +409,26 @@ test("strict error message", () => {
   }
 });
 
-test("enum default error message", () => {
+test("enum error message, invalid enum elementstring", () => {
   try {
     z.enum(["Tuna", "Trout"]).parse("Salmon");
   } catch (err) {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
     expect(zerr.issues[0].message).toEqual(
-      "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
+      "Invalid enum value. Expected 'Tuna' | 'Trout', received 'Salmon'"
+    );
+  }
+});
+
+test("enum error message, invalid type", () => {
+  try {
+    z.enum(["Tuna", "Trout"]).parse(12);
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    expect(zerr.issues.length).toEqual(1);
+    expect(zerr.issues[0].message).toEqual(
+      "Expected 'Tuna' | 'Trout', received number"
     );
   }
 });
@@ -432,7 +444,7 @@ test("nativeEnum default error message", () => {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
     expect(zerr.issues[0].message).toEqual(
-      "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
+      "Invalid enum value. Expected 'Tuna' | 'Trout', received 'Salmon'"
     );
   }
 });

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -416,9 +416,24 @@ test("enum default error message", () => {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
     expect(zerr.issues[0].message).toEqual(
-      "Invalid enum value. Expected 'Tuna' | 'Trout'"
+      "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
     );
-    expect(zerr.issues[0].message).not.toContain("Salmon");
+  }
+});
+
+test("nativeEnum default error message", () => {
+  enum Fish {
+    Tuna = "Tuna",
+    Trout = "Trout",
+  }
+  try {
+    z.nativeEnum(Fish).parse("Salmon");
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    expect(zerr.issues.length).toEqual(1);
+    expect(zerr.issues[0].message).toEqual(
+      "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
+    );
   }
 });
 

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -73,4 +73,13 @@ export namespace util {
       ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
       : (val) =>
           typeof val === "number" && isFinite(val) && Math.floor(val) === val;
+
+  export function joinValues<T extends any[]>(
+    array: T,
+    separator = " | "
+  ): string {
+    return array
+      .map((val) => (typeof val === "string" ? `'${val}'` : val))
+      .join(separator);
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3021,12 +3021,22 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
   ZodEnumDef<T>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
+    if (typeof input.data !== "string") {
+      const ctx = this._getOrReturnCtx(input);
+      const expectedValues = this._def.values;
+      addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues) as "string",
+        received: ctx.parsedType,
+        code: ZodIssueCode.invalid_type,
+      });
+      return INVALID;
+    }
+
     if (this._def.values.indexOf(input.data) === -1) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
 
       addIssueToContext(ctx, {
-        expected: util.joinValues(expectedValues) as "string",
         received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
         options: expectedValues,
@@ -3088,19 +3098,32 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
 > {
   _parse(input: ParseInput): ParseReturnType<T[keyof T]> {
     const nativeEnumValues = util.getValidEnumValues(this._def.values);
+
+    const ctx = this._getOrReturnCtx(input);
+    if (
+      ctx.parsedType !== ZodParsedType.string &&
+      ctx.parsedType !== ZodParsedType.number
+    ) {
+      const expectedValues = util.objectValues(nativeEnumValues);
+      addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues) as "string",
+        received: ctx.parsedType,
+        code: ZodIssueCode.invalid_type,
+      });
+      return INVALID;
+    }
+
     if (nativeEnumValues.indexOf(input.data) === -1) {
-      const ctx = this._getOrReturnCtx(input);
       const expectedValues = util.objectValues(nativeEnumValues);
 
       addIssueToContext(ctx, {
-        expected: util.joinValues(expectedValues) as "string",
         received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
         options: expectedValues,
       });
       return INVALID;
     }
-    return OK(input.data);
+    return OK(input.data as any);
   }
 
   get enum() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3023,9 +3023,13 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     if (this._def.values.indexOf(input.data) === -1) {
       const ctx = this._getOrReturnCtx(input);
+      const expectedValues = this._def.values;
+
       addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues) as "string",
+        received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
-        options: this._def.values,
+        options: expectedValues,
       });
       return INVALID;
     }
@@ -3086,9 +3090,13 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     const nativeEnumValues = util.getValidEnumValues(this._def.values);
     if (nativeEnumValues.indexOf(input.data) === -1) {
       const ctx = this._getOrReturnCtx(input);
+      const expectedValues = util.objectValues(nativeEnumValues);
+
       addIssueToContext(ctx, {
+        expected: util.joinValues(expectedValues) as "string",
+        received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
-        options: util.objectValues(nativeEnumValues),
+        options: expectedValues,
       });
       return INVALID;
     }


### PR DESCRIPTION
Fixes #1042

Small note, I typed the `received` property in `ZodInvalidEnumValueIssue` as `any` since we are returning what was inputed originally, instead of it's `ParsedType`. I think this is right but will wait for confirmation :)

Also added an small util to reduce the code duplication around quoting and joining arrays of strings.

TL;DR;

Given
```ts
enum Fish {
  Tuna = "Tuna",
  Trout = "Trout"
}

z.nativeEnum(Fish).parse("Salmon");
```

```diff
- "Invalid enum value. Expected 'Tuna' | 'Trout'"
+ "Invalid enum value. Expected 'Tuna' | 'Trout' received 'Salmon'"
```