### PR TITLE
Add nullableInput

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -364,6 +364,7 @@ export abstract class ZodType<
     this.superRefine = this.superRefine.bind(this);
     this.optional = this.optional.bind(this);
     this.nullable = this.nullable.bind(this);
+    this.nullableInput = this.nullableInput.bind(this);
     this.nullish = this.nullish.bind(this);
     this.array = this.array.bind(this);
     this.promise = this.promise.bind(this);
@@ -381,6 +382,11 @@ export abstract class ZodType<
   }
   nullable(): ZodNullable<this> {
     return ZodNullable.create(this) as any;
+  }
+  nullableInput(
+    message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
+  ): ZodType<this["_output"], ZodNullableDef<this>, this["_input"] | null> {
+    return this.refine((v) => v !== null, message) as any;
   }
   nullish(): ZodNullable<ZodOptional<this>> {
     return this.optional().nullable();

--- a/src/types.ts
+++ b/src/types.ts
@@ -364,6 +364,7 @@ export abstract class ZodType<
     this.superRefine = this.superRefine.bind(this);
     this.optional = this.optional.bind(this);
     this.nullable = this.nullable.bind(this);
+    this.nullableInput = this.nullableInput.bind(this);
     this.nullish = this.nullish.bind(this);
     this.array = this.array.bind(this);
     this.promise = this.promise.bind(this);
@@ -381,6 +382,11 @@ export abstract class ZodType<
   }
   nullable(): ZodNullable<this> {
     return ZodNullable.create(this) as any;
+  }
+  nullableInput(
+    message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
+  ): ZodType<this["_output"], ZodNullableDef<this>, this["_input"] | null> {
+    return this.refine((v) => v !== null, message) as any;
   }
   nullish(): ZodNullable<ZodOptional<this>> {
     return this.optional().nullable();


### PR DESCRIPTION
Hello and thanks for this lib that has completely changed my way of doing client and server side validations.

One pattern that I'm missing is the ability to change the input type while keeping the output type strict. This PR includes my most needed one: Adding nullable type on the input.

## Why? 

I'm using schema["_input"] type to strongly type the initial values of my form, and some values are required but can't have a meaningful default (like choosing an entity from a list) and are set to null.

## Current solution

```ts
export const addNullInput = <A, B, C>(value: ZodType<A, B, C>) =>
  value
    .nullable()
    .refine((v) => v !== null, "Required")
    .transform((v) => v!);
```

The problem is it creates some runtime and type-checking overhead that could be simplified with a support from the lib. 

## Related

https://github.com/colinhacks/zod/issues/213