### PR TITLE
Improve JSDoc deprecation warning for nonempty

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -634,8 +634,8 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
 
   /**
-   * Deprecated.
-   * Use z.string().min(1) instead.
+   * @deprecated Use z.string().min(1) instead.
+   * @see {@link ZodString.min}
    */
   nonempty = (message?: errorUtil.ErrMessage) =>
     this.min(1, errorUtil.errToObj(message));

--- a/src/types.ts
+++ b/src/types.ts
@@ -634,8 +634,8 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
 
   /**
-   * Deprecated.
-   * Use z.string().min(1) instead.
+   * @deprecated Use z.string().min(1) instead.
+   * @see {@link ZodString.min}
    */
   nonempty = (message?: errorUtil.ErrMessage) =>
     this.min(1, errorUtil.errToObj(message));


### PR DESCRIPTION
Pretty self-explanatory I guess. By using the `@deprecated` tag in JSDoc your IDE will automatically mark the method as deprecated when you use it in your code.