### PR TITLE
Zod discriminated union discriminator value accepts zod enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -1104,9 +1104,9 @@ against it, and showing only the issues related to this "option".
 const item = z
   .discriminatedUnion("type", [
     z.object({ type: z.literal("a"), a: z.string() }),
-    z.object({ type: z.literal("b"), b: z.string() }),
+    z.object({ type: z.enum(["b", "c"]), b: z.string() }),
   ])
-  .parse({ type: "a", a: "abc" });
+  .parse({ type: "b", b: "abc" });
 ```
 
 ## Records

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1104,9 +1104,9 @@ against it, and showing only the issues related to this "option".
 const item = z
   .discriminatedUnion("type", [
     z.object({ type: z.literal("a"), a: z.string() }),
-    z.object({ type: z.literal("b"), b: z.string() }),
+    z.object({ type: z.enum(["b", "c"]), b: z.string() }),
   ])
-  .parse({ type: "a", a: "abc" });
+  .parse({ type: "b", b: "abc" });
 ```
 
 ## Records

--- a/deno/lib/__tests__/deepPartialify.test.ts
+++ b/deno/lib/__tests__/deepPartialify.test.ts
@@ -1,0 +1,60 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+const assertSerializeEqual = (x: any, y: any) => {
+    expect(JSON.stringify(x)).toStrictEqual(JSON.stringify(y))
+}
+
+test('Deep Partial on primitives', () => {
+    assertSerializeEqual(
+        z.deepPartialify(z.object({
+        s: z.string(),
+        n: z.number(),
+        i: z.bigint(),
+        b: z.boolean(),
+        z: z.null(),
+        u: z.undefined(),
+        })),
+        z.object({
+            s: z.string().optional(),
+            n: z.number().optional(),
+            i: z.bigint().optional(),
+            b: z.boolean().optional(),
+            z: z.null().optional(),
+            u: z.undefined().optional(),
+        })
+    )
+})
+
+test('Test Union', () => {
+    assertSerializeEqual(
+        z.deepPartialify(
+            z.union([
+                z.object({s: z.string()}),
+                z.object({n: z.number()}),
+            ])
+        ),
+        z.union([
+            z.object({s: z.string().optional()}),
+            z.object({n: z.number().optional()}),
+        ])
+    )
+})
+
+test('Test Discriminated Union', () => {
+    assertSerializeEqual(
+        z.deepPartialify(
+            z.discriminatedUnion('t', [
+                z.object({t: z.literal('s1'), s: z.string()}),
+                z.object({t: z.literal('n1'), n: z.number()}),
+            ])
+        ),
+        z.discriminatedUnion('t', [
+            z.object({t: z.literal('s1'), s: z.string().optional()}),
+            z.object({t: z.literal('n1'), n: z.number().optional()}),
+        ])
+    )
+})

--- a/deno/lib/__tests__/deepPartialify.test.ts
+++ b/deno/lib/__tests__/deepPartialify.test.ts
@@ -8,6 +8,7 @@ const assertSerializeEqual = (x: any, y: any) => {
     expect(JSON.stringify(x)).toStrictEqual(JSON.stringify(y))
 }
 
+// These tests are actually unreliable (will pass even with the `.optional()` removed)
 test('Deep Partial on primitives', () => {
     assertSerializeEqual(
         z.deepPartialify(z.object({

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1617,6 +1617,12 @@ export function deepPartialify<T extends ZodTypeAny>(
       ...schema._def,
       shape: () => newShape,
     }) as any;
+  } else if (schema instanceof ZodUnion) {
+    type Options = [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]];
+    const options = schema._def.options as Options;
+    return ZodUnion.create(
+      options.map((option) => deepPartialify(option)) as Options
+    ) as any;
   } else if (schema instanceof ZodArray) {
     return ZodArray.create(deepPartialify(schema.element)) as any;
   } else if (schema instanceof ZodOptional) {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1603,7 +1603,9 @@ export type SomeZodObject = ZodObject<
   any
 >;
 
-function deepPartialify(schema: ZodTypeAny): any {
+export function deepPartialify<T extends ZodTypeAny>(
+  schema: T
+): partialUtil.DeepPartial<T> {
   if (schema instanceof ZodObject) {
     const newShape: any = {};
 
@@ -1616,17 +1618,17 @@ function deepPartialify(schema: ZodTypeAny): any {
       shape: () => newShape,
     }) as any;
   } else if (schema instanceof ZodArray) {
-    return ZodArray.create(deepPartialify(schema.element));
+    return ZodArray.create(deepPartialify(schema.element)) as any;
   } else if (schema instanceof ZodOptional) {
-    return ZodOptional.create(deepPartialify(schema.unwrap()));
+    return ZodOptional.create(deepPartialify(schema.unwrap())) as any;
   } else if (schema instanceof ZodNullable) {
-    return ZodNullable.create(deepPartialify(schema.unwrap()));
+    return ZodNullable.create(deepPartialify(schema.unwrap())) as any;
   } else if (schema instanceof ZodTuple) {
     return ZodTuple.create(
       schema.items.map((item: any) => deepPartialify(item))
-    );
+    ) as any;
   } else {
-    return schema;
+    return schema as any;
   }
 }
 

--- a/src/__tests__/deepPartialify.test.ts
+++ b/src/__tests__/deepPartialify.test.ts
@@ -7,6 +7,7 @@ const assertSerializeEqual = (x: any, y: any) => {
     expect(JSON.stringify(x)).toStrictEqual(JSON.stringify(y))
 }
 
+// These tests are actually unreliable (will pass even with the `.optional()` removed)
 test('Deep Partial on primitives', () => {
     assertSerializeEqual(
         z.deepPartialify(z.object({

--- a/src/__tests__/deepPartialify.test.ts
+++ b/src/__tests__/deepPartialify.test.ts
@@ -1,0 +1,59 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+
+const assertSerializeEqual = (x: any, y: any) => {
+    expect(JSON.stringify(x)).toStrictEqual(JSON.stringify(y))
+}
+
+test('Deep Partial on primitives', () => {
+    assertSerializeEqual(
+        z.deepPartialify(z.object({
+        s: z.string(),
+        n: z.number(),
+        i: z.bigint(),
+        b: z.boolean(),
+        z: z.null(),
+        u: z.undefined(),
+        })),
+        z.object({
+            s: z.string().optional(),
+            n: z.number().optional(),
+            i: z.bigint().optional(),
+            b: z.boolean().optional(),
+            z: z.null().optional(),
+            u: z.undefined().optional(),
+        })
+    )
+})
+
+test('Test Union', () => {
+    assertSerializeEqual(
+        z.deepPartialify(
+            z.union([
+                z.object({s: z.string()}),
+                z.object({n: z.number()}),
+            ])
+        ),
+        z.union([
+            z.object({s: z.string().optional()}),
+            z.object({n: z.number().optional()}),
+        ])
+    )
+})
+
+test('Test Discriminated Union', () => {
+    assertSerializeEqual(
+        z.deepPartialify(
+            z.discriminatedUnion('t', [
+                z.object({t: z.literal('s1'), s: z.string()}),
+                z.object({t: z.literal('n1'), n: z.number()}),
+            ])
+        ),
+        z.discriminatedUnion('t', [
+            z.object({t: z.literal('s1'), s: z.string().optional()}),
+            z.object({t: z.literal('n1'), n: z.number().optional()}),
+        ])
+    )
+})

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -11,6 +11,15 @@ test("valid", () => {
       ])
       .parse({ type: "a", a: "abc" })
   ).toEqual({ type: "a", a: "abc" });
+
+  expect(
+    z
+      .discriminatedUnion("type", [
+        z.object({ type: z.literal("a"), a: z.string() }),
+        z.object({ type: z.enum(["b", "c"]), b: z.string() }),
+      ])
+      .parse({ type: "b", b: "abc" })
+  ).toEqual({ type: "b", b: "abc" });
 });
 
 test("valid - discriminator value of various primitive types", () => {
@@ -95,6 +104,23 @@ test("invalid discriminator value", () => {
       },
     ]);
   }
+
+  try {
+    z.discriminatedUnion("type", [
+      z.object({ type: z.literal("a"), a: z.string() }),
+      z.object({ type: z.enum(["b", "c"]), b: z.string() }),
+    ]).parse({ type: "x", a: "abc" });
+    throw new Error();
+  } catch (e: any) {
+    expect(JSON.parse(e.message)).toEqual([
+      {
+        code: z.ZodIssueCode.invalid_union_discriminator,
+        options: ["a", "b", "c"],
+        message: "Invalid discriminator value. Expected 'a' | 'b' | 'c'",
+        path: ["type"],
+      },
+    ]);
+  }
 });
 
 test("valid discriminator value, invalid data", () => {
@@ -111,6 +137,24 @@ test("valid discriminator value, invalid data", () => {
         expected: z.ZodParsedType.string,
         message: "Required",
         path: ["a"],
+        received: z.ZodParsedType.undefined,
+      },
+    ]);
+  }
+
+  try {
+    z.discriminatedUnion("type", [
+      z.object({ type: z.literal("a"), a: z.string() }),
+      z.object({ type: z.enum(["b", "c"]), b: z.string() }),
+    ]).parse({ type: "b", a: "abc" });
+    throw new Error();
+  } catch (e: any) {
+    expect(JSON.parse(e.message)).toEqual([
+      {
+        code: z.ZodIssueCode.invalid_type,
+        expected: z.ZodParsedType.string,
+        message: "Required",
+        path: ["b"],
         received: z.ZodParsedType.undefined,
       },
     ]);
@@ -136,6 +180,30 @@ test("wrong schema - duplicate discriminator values", () => {
     z.discriminatedUnion("type", [
       z.object({ type: z.literal("a"), a: z.string() }),
       z.object({ type: z.literal("a"), b: z.string() }),
+    ]);
+    throw new Error();
+  } catch (e: any) {
+    expect(e.message).toEqual(
+      "Some of the discriminator values are not unique"
+    );
+  }
+
+  try {
+    z.discriminatedUnion("type", [
+      z.object({ type: z.literal("a"), a: z.string() }),
+      z.object({ type: z.enum(["a", "b"]), b: z.string() }),
+    ]);
+    throw new Error();
+  } catch (e: any) {
+    expect(e.message).toEqual(
+      "Some of the discriminator values are not unique"
+    );
+  }
+
+  try {
+    z.discriminatedUnion("type", [
+      z.object({ type: z.enum(["a", "b"]), a: z.string() }),
+      z.object({ type: z.enum(["b", "c"]), b: z.string() }),
     ]);
     throw new Error();
   } catch (e: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1617,6 +1617,12 @@ export function deepPartialify<T extends ZodTypeAny>(
       ...schema._def,
       shape: () => newShape,
     }) as any;
+  } else if (schema instanceof ZodUnion) {
+    type Options = [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]];
+    const options = schema._def.options as Options;
+    return ZodUnion.create(
+      options.map((option) => deepPartialify(option)) as Options
+    ) as any;
   } else if (schema instanceof ZodArray) {
     return ZodArray.create(deepPartialify(schema.element)) as any;
   } else if (schema instanceof ZodOptional) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1603,7 +1603,9 @@ export type SomeZodObject = ZodObject<
   any
 >;
 
-function deepPartialify(schema: ZodTypeAny): any {
+export function deepPartialify<T extends ZodTypeAny>(
+  schema: T
+): partialUtil.DeepPartial<T> {
   if (schema instanceof ZodObject) {
     const newShape: any = {};
 
@@ -1616,17 +1618,17 @@ function deepPartialify(schema: ZodTypeAny): any {
       shape: () => newShape,
     }) as any;
   } else if (schema instanceof ZodArray) {
-    return ZodArray.create(deepPartialify(schema.element));
+    return ZodArray.create(deepPartialify(schema.element)) as any;
   } else if (schema instanceof ZodOptional) {
-    return ZodOptional.create(deepPartialify(schema.unwrap()));
+    return ZodOptional.create(deepPartialify(schema.unwrap())) as any;
   } else if (schema instanceof ZodNullable) {
-    return ZodNullable.create(deepPartialify(schema.unwrap()));
+    return ZodNullable.create(deepPartialify(schema.unwrap())) as any;
   } else if (schema instanceof ZodTuple) {
     return ZodTuple.create(
       schema.items.map((item: any) => deepPartialify(item))
-    );
+    ) as any;
   } else {
-    return schema;
+    return schema as any;
   }
 }
 


### PR DESCRIPTION
Zod discriminated union discriminator value accepts zod enum:

```ts
const item = z
  .discriminatedUnion("type", [
    z.object({ type: z.literal("a"), a: z.string() }),
    z.object({ type: z.enum(["b", "c"]), b: z.string() }),
  ])
  .parse({ type: "b", b: "abc" });
```

Updates test, README.md documentation, and some minor changes from lint / prettier.

Requested in https://github.com/colinhacks/zod/issues/1075 and https://github.com/colinhacks/zod/issues/1015.