### PR TITLE
Added native support for min and max date validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,14 +544,32 @@ const isActive = z.boolean({
 
 ## Dates
 
-z.date() accepts a date, not a date string
+Use z.date() to validate `Date` instances.
 
 ```ts
 z.date().safeParse(new Date()); // success: true
 z.date().safeParse("2022-01-12T00:00:00.000Z"); // success: false
 ```
 
-To allow for dates or date strings, you can use preprocess
+You can customize certain error messages when creating a boolean schema.
+
+```ts
+const myDateSchema = z.date({
+  required_error: "Please select a date and time",
+  invalid_type_error: "That's not a date!",
+});
+```
+
+Zod provides a handful of date-specific validations.
+
+```ts
+z.date().min(new Date("1900-01-01"), { message: "Too old" });
+z.date().max(new Date(), { message: "Too young!" });
+```
+
+**Supporting date strings**
+
+To write a schema that accepts either a `Date` or a date string, use (`z.preprocess`)[#preprocess].
 
 ```ts
 const dateSchema = z.preprocess((arg) => {

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -437,6 +437,20 @@ z.number().multipleOf(5); // x % 5 === 0
 z.number().max(5, { message: "this👏is👏too👏big" });
 ```
 
+## Dates
+
+```ts
+z.date().safeParse(new Date()); // success: true
+
+z.date({
+  required_error: "Please select a date and time",
+  invalid_type_error: "That's not a date!",
+});
+
+z.date().min(new Date("1900-01-01"), { message: "Too old" });
+z.date().max(new Date(), { message: "Too young!" });
+```
+
 ## Objects
 
 ```ts

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -544,14 +544,32 @@ const isActive = z.boolean({
 
 ## Dates
 
-z.date() accepts a date, not a date string
+Use z.date() to validate `Date` instances.
 
 ```ts
 z.date().safeParse(new Date()); // success: true
 z.date().safeParse("2022-01-12T00:00:00.000Z"); // success: false
 ```
 
-To allow for dates or date strings, you can use preprocess
+You can customize certain error messages when creating a boolean schema.
+
+```ts
+const myDateSchema = z.date({
+  required_error: "Please select a date and time",
+  invalid_type_error: "That's not a date!",
+});
+```
+
+Zod provides a handful of date-specific validations.
+
+```ts
+z.date().min(new Date("1900-01-01"), { message: "Too old" });
+z.date().max(new Date(), { message: "Too young!" });
+```
+
+**Supporting date strings**
+
+To write a schema that accepts either a `Date` or a date string, use (`z.preprocess`)[#preprocess].
 
 ```ts
 const dateSchema = z.preprocess((arg) => {

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -97,14 +97,14 @@ export interface ZodTooSmallIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_small;
   minimum: number;
   inclusive: boolean;
-  type: "array" | "string" | "number" | "set";
+  type: "array" | "string" | "number" | "set" | "date";
 }
 
 export interface ZodTooBigIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_big;
   maximum: number;
   inclusive: boolean;
-  type: "array" | "string" | "number" | "set";
+  type: "array" | "string" | "number" | "set" | "date";
 }
 
 export interface ZodInvalidIntersectionTypesIssue extends ZodIssueBase {
@@ -360,6 +360,10 @@ export const defaultErrorMap = (
         message = `Number must be greater than ${
           issue.inclusive ? `or equal to ` : ``
         }${issue.minimum}`;
+      else if (issue.type === "date")
+        message = `Date must be greater than or equal to ${new Date(
+          issue.minimum
+        )}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.too_big:
@@ -375,6 +379,10 @@ export const defaultErrorMap = (
         message = `Number must be less than ${
           issue.inclusive ? `or equal to ` : ``
         }${issue.maximum}`;
+      else if (issue.type === "date")
+        message = `Date must be smaller than or equal to ${new Date(
+          issue.maximum
+        )}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.custom:

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -361,9 +361,9 @@ export const defaultErrorMap = (
           issue.inclusive ? `or equal to ` : ``
         }${issue.minimum}`;
       else if (issue.type === "date")
-        message = `Date must be greater than or equal to ${new Date(
-          issue.minimum
-        )}`;
+        message = `Date must be greater than ${
+          issue.inclusive ? `or equal to ` : ``
+        }${new Date(issue.minimum)}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.too_big:
@@ -380,9 +380,9 @@ export const defaultErrorMap = (
           issue.inclusive ? `or equal to ` : ``
         }${issue.maximum}`;
       else if (issue.type === "date")
-        message = `Date must be smaller than or equal to ${new Date(
-          issue.maximum
-        )}`;
+        message = `Date must be smaller than ${
+          issue.inclusive ? `or equal to ` : ``
+        }${new Date(issue.maximum)}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.custom:

--- a/deno/lib/__tests__/date.test.ts
+++ b/deno/lib/__tests__/date.test.ts
@@ -1,0 +1,23 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+const benchmarkDate = new Date(2022, 10, 5);
+
+const minCheck = z.date().min(benchmarkDate);
+const maxCheck = z.date().max(benchmarkDate);
+
+test("passing validations", () => {
+  minCheck.parse(new Date(benchmarkDate));
+  minCheck.parse(new Date(benchmarkDate.getTime() + 1));
+
+  maxCheck.parse(new Date(benchmarkDate));
+  maxCheck.parse(new Date(benchmarkDate.getTime() - 1));
+});
+
+test("failing validations", () => {
+  expect(() => minCheck.parse(benchmarkDate.getTime() - 1)).toThrow();
+  expect(() => maxCheck.parse(benchmarkDate.getTime() + 1)).toThrow();
+});

--- a/deno/lib/__tests__/date.test.ts
+++ b/deno/lib/__tests__/date.test.ts
@@ -4,20 +4,32 @@ const test = Deno.test;
 
 import * as z from "../index.ts";
 
+const beforeBenchmarkDate = new Date(2022, 10, 4);
 const benchmarkDate = new Date(2022, 10, 5);
+const afterBenchmarkDate = new Date(2022, 10, 6);
 
 const minCheck = z.date().min(benchmarkDate);
 const maxCheck = z.date().max(benchmarkDate);
 
 test("passing validations", () => {
-  minCheck.parse(new Date(benchmarkDate));
-  minCheck.parse(new Date(benchmarkDate.getTime() + 1));
+  minCheck.parse(benchmarkDate);
+  minCheck.parse(afterBenchmarkDate);
 
-  maxCheck.parse(new Date(benchmarkDate));
-  maxCheck.parse(new Date(benchmarkDate.getTime() - 1));
+  maxCheck.parse(benchmarkDate);
+  maxCheck.parse(beforeBenchmarkDate);
 });
 
 test("failing validations", () => {
-  expect(() => minCheck.parse(benchmarkDate.getTime() - 1)).toThrow();
-  expect(() => maxCheck.parse(benchmarkDate.getTime() + 1)).toThrow();
+  expect(() => minCheck.parse(beforeBenchmarkDate)).toThrow();
+  expect(() => maxCheck.parse(afterBenchmarkDate)).toThrow();
+});
+
+test("min max getters", () => {
+  expect(minCheck.minDate).toEqual(benchmarkDate);
+  expect(minCheck.min(afterBenchmarkDate).minDate).toEqual(afterBenchmarkDate);
+
+  expect(maxCheck.maxDate).toEqual(benchmarkDate);
+  expect(maxCheck.max(beforeBenchmarkDate).maxDate).toEqual(
+    beforeBenchmarkDate
+  );
 });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1015,9 +1015,9 @@ export interface ZodDateDef extends ZodTypeDef {
 export class ZodDate extends ZodType<Date, ZodDateDef> {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const parsedType = this._getType(input);
-    const ctx: undefined | ParseContext = this._getOrReturnCtx(input);
 
     if (parsedType !== ZodParsedType.date) {
+      const ctx = this._getOrReturnCtx(input);
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_type,
         expected: ZodParsedType.date,
@@ -1027,6 +1027,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     }
 
     if (isNaN(input.data.getTime())) {
+      const ctx = this._getOrReturnCtx(input);
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_date,
       });
@@ -1034,10 +1035,12 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     }
 
     const status = new ParseStatus();
+    let ctx: undefined | ParseContext = undefined;
 
     for (const check of this._def.checks) {
       if (check.kind === "min") {
         if (input.data.getTime() < check.value) {
+          ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_small,
             message: check.message,
@@ -1049,6 +1052,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
         }
       } else if (check.kind === "max") {
         if (input.data.getTime() > check.value) {
+          ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_big,
             message: check.message,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1039,16 +1039,22 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
       if (check.kind === "min") {
         if (input.data.getTime() < check.value) {
           addIssueToContext(ctx, {
-            code: ZodIssueCode.invalid_date,
+            code: ZodIssueCode.too_small,
             message: check.message,
+            inclusive: true,
+            minimum: check.value,
+            type: "date",
           });
           status.dirty();
         }
       } else if (check.kind === "max") {
         if (input.data.getTime() > check.value) {
           addIssueToContext(ctx, {
-            code: ZodIssueCode.invalid_date,
+            code: ZodIssueCode.too_big,
             message: check.message,
+            inclusive: true,
+            maximum: check.value,
+            type: "date",
           });
           status.dirty();
         }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1096,6 +1096,28 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     });
   }
 
+  get minDate() {
+    let min: number | null = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "min") {
+        if (min === null || ch.value > min) min = ch.value;
+      }
+    }
+
+    return min != null ? new Date(min) : null;
+  }
+
+  get maxDate() {
+    let max: number | null = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "max") {
+        if (max === null || ch.value < max) max = ch.value;
+      }
+    }
+
+    return max != null ? new Date(max) : null;
+  }
+
   static create = (params?: RawCreateParams): ZodDate => {
     return new ZodDate({
       checks: [],

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -97,14 +97,14 @@ export interface ZodTooSmallIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_small;
   minimum: number;
   inclusive: boolean;
-  type: "array" | "string" | "number" | "set";
+  type: "array" | "string" | "number" | "set" | "date";
 }
 
 export interface ZodTooBigIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_big;
   maximum: number;
   inclusive: boolean;
-  type: "array" | "string" | "number" | "set";
+  type: "array" | "string" | "number" | "set" | "date";
 }
 
 export interface ZodInvalidIntersectionTypesIssue extends ZodIssueBase {
@@ -360,6 +360,10 @@ export const defaultErrorMap = (
         message = `Number must be greater than ${
           issue.inclusive ? `or equal to ` : ``
         }${issue.minimum}`;
+      else if (issue.type === "date")
+        message = `Date must be greater than or equal to ${new Date(
+          issue.minimum
+        )}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.too_big:
@@ -375,6 +379,10 @@ export const defaultErrorMap = (
         message = `Number must be less than ${
           issue.inclusive ? `or equal to ` : ``
         }${issue.maximum}`;
+      else if (issue.type === "date")
+        message = `Date must be smaller than or equal to ${new Date(
+          issue.maximum
+        )}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.custom:

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -361,9 +361,9 @@ export const defaultErrorMap = (
           issue.inclusive ? `or equal to ` : ``
         }${issue.minimum}`;
       else if (issue.type === "date")
-        message = `Date must be greater than or equal to ${new Date(
-          issue.minimum
-        )}`;
+        message = `Date must be greater than ${
+          issue.inclusive ? `or equal to ` : ``
+        }${new Date(issue.minimum)}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.too_big:
@@ -380,9 +380,9 @@ export const defaultErrorMap = (
           issue.inclusive ? `or equal to ` : ``
         }${issue.maximum}`;
       else if (issue.type === "date")
-        message = `Date must be smaller than or equal to ${new Date(
-          issue.maximum
-        )}`;
+        message = `Date must be smaller than ${
+          issue.inclusive ? `or equal to ` : ``
+        }${new Date(issue.maximum)}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.custom:

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -3,20 +3,32 @@ import { expect, test } from "@jest/globals";
 
 import * as z from "../index";
 
+const beforeBenchmarkDate = new Date(2022, 10, 4);
 const benchmarkDate = new Date(2022, 10, 5);
+const afterBenchmarkDate = new Date(2022, 10, 6);
 
 const minCheck = z.date().min(benchmarkDate);
 const maxCheck = z.date().max(benchmarkDate);
 
 test("passing validations", () => {
-  minCheck.parse(new Date(benchmarkDate));
-  minCheck.parse(new Date(benchmarkDate.getTime() + 1));
+  minCheck.parse(benchmarkDate);
+  minCheck.parse(afterBenchmarkDate);
 
-  maxCheck.parse(new Date(benchmarkDate));
-  maxCheck.parse(new Date(benchmarkDate.getTime() - 1));
+  maxCheck.parse(benchmarkDate);
+  maxCheck.parse(beforeBenchmarkDate);
 });
 
 test("failing validations", () => {
-  expect(() => minCheck.parse(benchmarkDate.getTime() - 1)).toThrow();
-  expect(() => maxCheck.parse(benchmarkDate.getTime() + 1)).toThrow();
+  expect(() => minCheck.parse(beforeBenchmarkDate)).toThrow();
+  expect(() => maxCheck.parse(afterBenchmarkDate)).toThrow();
+});
+
+test("min max getters", () => {
+  expect(minCheck.minDate).toEqual(benchmarkDate);
+  expect(minCheck.min(afterBenchmarkDate).minDate).toEqual(afterBenchmarkDate);
+
+  expect(maxCheck.maxDate).toEqual(benchmarkDate);
+  expect(maxCheck.max(beforeBenchmarkDate).maxDate).toEqual(
+    beforeBenchmarkDate
+  );
 });

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -1,0 +1,22 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+
+const benchmarkDate = new Date(2022, 10, 5);
+
+const minCheck = z.date().min(benchmarkDate);
+const maxCheck = z.date().max(benchmarkDate);
+
+test("passing validations", () => {
+  minCheck.parse(new Date(benchmarkDate));
+  minCheck.parse(new Date(benchmarkDate.getTime() + 1));
+
+  maxCheck.parse(new Date(benchmarkDate));
+  maxCheck.parse(new Date(benchmarkDate.getTime() - 1));
+});
+
+test("failing validations", () => {
+  expect(() => minCheck.parse(benchmarkDate.getTime() - 1)).toThrow();
+  expect(() => maxCheck.parse(benchmarkDate.getTime() + 1)).toThrow();
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1015,9 +1015,9 @@ export interface ZodDateDef extends ZodTypeDef {
 export class ZodDate extends ZodType<Date, ZodDateDef> {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const parsedType = this._getType(input);
-    const ctx: undefined | ParseContext = this._getOrReturnCtx(input);
 
     if (parsedType !== ZodParsedType.date) {
+      const ctx = this._getOrReturnCtx(input);
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_type,
         expected: ZodParsedType.date,
@@ -1027,6 +1027,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     }
 
     if (isNaN(input.data.getTime())) {
+      const ctx = this._getOrReturnCtx(input);
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_date,
       });
@@ -1034,10 +1035,12 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     }
 
     const status = new ParseStatus();
+    let ctx: undefined | ParseContext = undefined;
 
     for (const check of this._def.checks) {
       if (check.kind === "min") {
         if (input.data.getTime() < check.value) {
+          ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_small,
             message: check.message,
@@ -1049,6 +1052,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
         }
       } else if (check.kind === "max") {
         if (input.data.getTime() > check.value) {
+          ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_big,
             message: check.message,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1039,16 +1039,22 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
       if (check.kind === "min") {
         if (input.data.getTime() < check.value) {
           addIssueToContext(ctx, {
-            code: ZodIssueCode.invalid_date,
+            code: ZodIssueCode.too_small,
             message: check.message,
+            inclusive: true,
+            minimum: check.value,
+            type: "date",
           });
           status.dirty();
         }
       } else if (check.kind === "max") {
         if (input.data.getTime() > check.value) {
           addIssueToContext(ctx, {
-            code: ZodIssueCode.invalid_date,
+            code: ZodIssueCode.too_big,
             message: check.message,
+            inclusive: true,
+            maximum: check.value,
+            type: "date",
           });
           status.dirty();
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1096,6 +1096,28 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     });
   }
 
+  get minDate() {
+    let min: number | null = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "min") {
+        if (min === null || ch.value > min) min = ch.value;
+      }
+    }
+
+    return min != null ? new Date(min) : null;
+  }
+
+  get maxDate() {
+    let max: number | null = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "max") {
+        if (max === null || ch.value < max) max = ch.value;
+      }
+    }
+
+    return max != null ? new Date(max) : null;
+  }
+
   static create = (params?: RawCreateParams): ZodDate => {
     return new ZodDate({
       checks: [],


### PR DESCRIPTION
This PR fixes #1089.

`ZodDate` now can natively validate for `min` and `max` allowed dates.