### PR TITLE
Adds remix-domains to the README under Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`prisma-zod-generator`](https://github.com/omar-dulaimi/prisma-zod-generator): Emit Zod schemas from your Prisma schema.
 - [`prisma-trpc-generator`](https://github.com/omar-dulaimi/prisma-trpc-generator): Emit fully implemented tRPC routers and their validation schemas using Zod.
 - [`nestjs-graphql-zod`](https://github.com/incetarik/nestjs-graphql-zod): Generates NestJS GraphQL model classes from Zod schemas dynamically and provides GraphQL method decorators working with Zod schemas.
+- [`remix-domains`](https://github.com/SeasonedSoftware/remix-domains/): Improves end-to-end type safety in [Remix](https://remix.run/) by leveraging Zod to parse the framework's inputs such as FormData, URLSearchParams, etc.
 
 #### Form integrations
 


### PR DESCRIPTION
We'd like to add remix-domains in the README (under ecosystem) as our library is only possible due to the existence of Zod <3 and we believe it improves a lot the DX of Remix.

LMK if this PR is welcome or should I make any changes to it.