### PR TITLE
ZodString.minLength defaults to null to be consistent with maxLength

### DIFF
--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -166,9 +166,11 @@ test("checks getters", () => {
 test("min max getters", () => {
   expect(z.string().min(5).minLength).toEqual(5);
   expect(z.string().min(5).min(10).minLength).toEqual(10);
+  expect(z.string().minLength).toEqual(-Infinity);
 
   expect(z.string().max(5).maxLength).toEqual(5);
   expect(z.string().max(5).max(1).maxLength).toEqual(1);
+  expect(z.string().maxLength).toEqual(Infinity);
 });
 
 test("trim", () => {

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -166,11 +166,11 @@ test("checks getters", () => {
 test("min max getters", () => {
   expect(z.string().min(5).minLength).toEqual(5);
   expect(z.string().min(5).min(10).minLength).toEqual(10);
-  expect(z.string().minLength).toEqual(-Infinity);
+  expect(z.string().minLength).toEqual(null);
 
   expect(z.string().max(5).maxLength).toEqual(5);
   expect(z.string().max(5).max(1).maxLength).toEqual(1);
-  expect(z.string().maxLength).toEqual(Infinity);
+  expect(z.string().maxLength).toEqual(null);
 });
 
 test("trim", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -662,26 +662,16 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
   }
   get minLength() {
-    let min: number | null = -Infinity;
-    this._def.checks.map((ch) => {
-      if (ch.kind === "min") {
-        if (min === null || ch.value > min) {
-          min = ch.value;
-        }
-      }
-    });
-    return min;
+    return this._def.checks.reduce(
+      (min, ch) => (ch.kind === "min" && ch.value > min ? ch.value : min),
+      -Infinity
+    );
   }
   get maxLength() {
-    let max: number | null = null;
-    this._def.checks.map((ch) => {
-      if (ch.kind === "max") {
-        if (max === null || ch.value < max) {
-          max = ch.value;
-        }
-      }
-    });
-    return max;
+    return this._def.checks.reduce(
+      (max, ch) => (ch.kind === "max" && ch.value < max ? ch.value : max),
+      Infinity
+    );
   }
 
   static create = (params?: RawCreateParams): ZodString => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -662,16 +662,22 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
   }
   get minLength() {
-    return this._def.checks.reduce(
-      (min, ch) => (ch.kind === "min" && ch.value > min ? ch.value : min),
-      -Infinity
-    );
+    let min: number | null = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "min") {
+        if (min === null || ch.value > min) min = ch.value;
+      }
+    }
+    return min;
   }
   get maxLength() {
-    return this._def.checks.reduce(
-      (max, ch) => (ch.kind === "max" && ch.value < max ? ch.value : max),
-      Infinity
-    );
+    let max: number | null = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "max") {
+        if (max === null || ch.value < max) max = ch.value;
+      }
+    }
+    return max;
   }
 
   static create = (params?: RawCreateParams): ZodString => {

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -165,11 +165,11 @@ test("checks getters", () => {
 test("min max getters", () => {
   expect(z.string().min(5).minLength).toEqual(5);
   expect(z.string().min(5).min(10).minLength).toEqual(10);
-  expect(z.string().minLength).toEqual(-Infinity);
+  expect(z.string().minLength).toEqual(null);
 
   expect(z.string().max(5).maxLength).toEqual(5);
   expect(z.string().max(5).max(1).maxLength).toEqual(1);
-  expect(z.string().maxLength).toEqual(Infinity);
+  expect(z.string().maxLength).toEqual(null);
 });
 
 test("trim", () => {

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -165,9 +165,11 @@ test("checks getters", () => {
 test("min max getters", () => {
   expect(z.string().min(5).minLength).toEqual(5);
   expect(z.string().min(5).min(10).minLength).toEqual(10);
+  expect(z.string().minLength).toEqual(-Infinity);
 
   expect(z.string().max(5).maxLength).toEqual(5);
   expect(z.string().max(5).max(1).maxLength).toEqual(1);
+  expect(z.string().maxLength).toEqual(Infinity);
 });
 
 test("trim", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -662,26 +662,16 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
   }
   get minLength() {
-    let min: number | null = -Infinity;
-    this._def.checks.map((ch) => {
-      if (ch.kind === "min") {
-        if (min === null || ch.value > min) {
-          min = ch.value;
-        }
-      }
-    });
-    return min;
+    return this._def.checks.reduce(
+      (min, ch) => (ch.kind === "min" && ch.value > min ? ch.value : min),
+      -Infinity
+    );
   }
   get maxLength() {
-    let max: number | null = null;
-    this._def.checks.map((ch) => {
-      if (ch.kind === "max") {
-        if (max === null || ch.value < max) {
-          max = ch.value;
-        }
-      }
-    });
-    return max;
+    return this._def.checks.reduce(
+      (max, ch) => (ch.kind === "max" && ch.value < max ? ch.value : max),
+      Infinity
+    );
   }
 
   static create = (params?: RawCreateParams): ZodString => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -662,16 +662,22 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
   }
   get minLength() {
-    return this._def.checks.reduce(
-      (min, ch) => (ch.kind === "min" && ch.value > min ? ch.value : min),
-      -Infinity
-    );
+    let min: number | null = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "min") {
+        if (min === null || ch.value > min) min = ch.value;
+      }
+    }
+    return min;
   }
   get maxLength() {
-    return this._def.checks.reduce(
-      (max, ch) => (ch.kind === "max" && ch.value < max ? ch.value : max),
-      Infinity
-    );
+    let max: number | null = null;
+    for (const ch of this._def.checks) {
+      if (ch.kind === "max") {
+        if (max === null || ch.value < max) max = ch.value;
+      }
+    }
+    return max;
   }
 
   static create = (params?: RawCreateParams): ZodString => {


### PR DESCRIPTION
This PR fixes #1246.

`minLength` and `maxLength` are inconsistent in `ZodString`, this PR makes the behaviour more consistent by returning `null` if no max is defined (not changed) and if no min is defined (instead of `-Infinity`).

This PR also improves the syntax by removing the incorrect usage of `Array.map` that had side effects & no return).

A couple tests are also added to make sure it works as intended.