### PR TITLE
feat: support numberic string

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -93,6 +93,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "numeric"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -117,6 +117,16 @@ test("cuid", () => {
   }
 });
 
+test('numeric', () => {
+  const numericString = z.string().numeric();
+  numericString.parse("1234");
+  const result = numericString.safeParse("a1234");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("Invalid numeric");
+  }
+});
+
 test("regex", () => {
   z.string()
     .regex(/^moo+$/)

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -453,7 +453,8 @@ type ZodStringCheck =
   | { kind: "startsWith"; value: string; message?: string }
   | { kind: "endsWith"; value: string; message?: string }
   | { kind: "regex"; regex: RegExp; message?: string }
-  | { kind: "trim"; message?: string };
+  | { kind: "trim"; message?: string }
+  | { kind: "numeric"; message?: string };
 
 export interface ZodStringDef extends ZodTypeDef {
   checks: ZodStringCheck[];
@@ -469,6 +470,7 @@ const uuidRegex =
 // eslint-disable-next-line
 const emailRegex =
   /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+const numberRegex = /^[0-9]+$/;
 
 export class ZodString extends ZodType<string, ZodStringDef> {
   _parse(input: ParseInput): ParseReturnType<string> {
@@ -592,6 +594,16 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           });
           status.dirty();
         }
+      } else if (check.kind === "numeric") {
+        if (!numberRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "numeric",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else {
         util.assertNever(check);
       }
@@ -629,6 +641,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
+  }
+  numeric(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "numeric", ...errorUtil.errToObj(message) });
   }
   regex(regex: RegExp, message?: errorUtil.ErrMessage) {
     return this._addCheck({

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -93,6 +93,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "numeric"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -116,6 +116,16 @@ test("cuid", () => {
   }
 });
 
+test('numeric', () => {
+  const numericString = z.string().numeric();
+  numericString.parse("1234");
+  const result = numericString.safeParse("a1234");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("Invalid numeric");
+  }
+});
+
 test("regex", () => {
   z.string()
     .regex(/^moo+$/)

--- a/src/types.ts
+++ b/src/types.ts
@@ -453,7 +453,8 @@ type ZodStringCheck =
   | { kind: "startsWith"; value: string; message?: string }
   | { kind: "endsWith"; value: string; message?: string }
   | { kind: "regex"; regex: RegExp; message?: string }
-  | { kind: "trim"; message?: string };
+  | { kind: "trim"; message?: string }
+  | { kind: "numeric"; message?: string };
 
 export interface ZodStringDef extends ZodTypeDef {
   checks: ZodStringCheck[];
@@ -469,6 +470,7 @@ const uuidRegex =
 // eslint-disable-next-line
 const emailRegex =
   /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
+const numberRegex = /^[0-9]+$/;
 
 export class ZodString extends ZodType<string, ZodStringDef> {
   _parse(input: ParseInput): ParseReturnType<string> {
@@ -592,6 +594,16 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           });
           status.dirty();
         }
+      } else if (check.kind === "numeric") {
+        if (!numberRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "numeric",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else {
         util.assertNever(check);
       }
@@ -629,6 +641,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
+  }
+  numeric(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "numeric", ...errorUtil.errToObj(message) });
   }
   regex(regex: RegExp, message?: errorUtil.ErrMessage) {
     return this._addCheck({


### PR DESCRIPTION
I want to express number string。just use `z.string().numeric()` to replace `z.string().regex(/^[0-9]*$/)`

https://github.com/colinhacks/zod/issues/1240