### PR TITLE
Replace keyword boolean with date in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ z.date().safeParse(new Date()); // success: true
 z.date().safeParse("2022-01-12T00:00:00.000Z"); // success: false
 ```
 
-You can customize certain error messages when creating a boolean schema.
+You can customize certain error messages when creating a date schema.
 
 ```ts
 const myDateSchema = z.date({

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -558,7 +558,7 @@ z.date().safeParse(new Date()); // success: true
 z.date().safeParse("2022-01-12T00:00:00.000Z"); // success: false
 ```
 
-You can customize certain error messages when creating a boolean schema.
+You can customize certain error messages when creating a date schema.
 
 ```ts
 const myDateSchema = z.date({
@@ -1800,7 +1800,7 @@ z.optional(z.string());
 
 ### `.nullable`
 
-A convenience method that returns an nullable version of a schema.
+A convenience method that returns a nullable version of a schema.
 
 ```ts
 const nullableString = z.string().nullable(); // string | null


### PR DESCRIPTION
Just noticed with ac2fb4a in #1222 `boolean` has been pasted but not replaced with `date` in the docs.