### PR TITLE
Add branded types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1880,7 +1880,7 @@ const fido: Dog = { name: "fido" };
 petCat(fido); // works fine
 ```
 
-In some cases, its can be desirable to simulate _nominal typing_ inside TypeScript. For instance, you may wish to write a function that only accepts an input that has been validated by Zod. This can be achieved with a _branded type_. These are also known as _opaque types_.
+In some cases, its can be desirable to simulate _nominal typing_ inside TypeScript. For instance, you may wish to write a function that only accepts an input that has been validated by Zod. This can be achieved with _branded types_ (AKA _opaque types_).
 
 ```ts
 const Cat = z.object({ name: z.string }).brand<"Cat">();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1880,7 +1880,7 @@ const fido: Dog = { name: "fido" };
 petCat(fido); // works fine
 ```
 
-In some cases, its can be desirable to simulate _nominal typing_ inside TypeScript. For instance, you may wish to write a function that only accepts an input that has been validated by Zod. This can be achieved with a _branded type_. These are also known as _opaque types_.
+In some cases, its can be desirable to simulate _nominal typing_ inside TypeScript. For instance, you may wish to write a function that only accepts an input that has been validated by Zod. This can be achieved with _branded types_ (AKA _opaque types_).
 
 ```ts
 const Cat = z.object({ name: z.string }).brand<"Cat">();

--- a/deno/lib/__tests__/branded.test.ts
+++ b/deno/lib/__tests__/branded.test.ts
@@ -10,17 +10,48 @@ test("branded types", () => {
     .object({
       name: z.string(),
     })
-    .brand<"mySchema">();
+    .brand<"superschema">();
 
+  // simple branding
   type MySchema = z.infer<typeof mySchema>;
-
-  const doStuff = (arg: MySchema) => arg;
-  doStuff(mySchema.parse({ name: "hello there" }));
   const f1: util.AssertEqual<
     MySchema,
-    { name: string } & { [z.BRAND]: "mySchema" }
+    { name: string } & { [z.BRAND]: { superschema: true } }
   > = true;
   f1;
+  const doStuff = (arg: MySchema) => arg;
+  doStuff(mySchema.parse({ name: "hello there" }));
+
+  // inheritance
+  const extendedSchema = mySchema.brand<"subschema">();
+  type ExtendedSchema = z.infer<typeof extendedSchema>;
+  const f2: util.AssertEqual<
+    ExtendedSchema,
+    { name: string } & { [z.BRAND]: { superschema: true; subschema: true } }
+  > = true;
+  f2;
+  doStuff(extendedSchema.parse({ name: "hello again" }));
+
+  // number branding
+  const numberSchema = z.number().brand<42>();
+  type NumberSchema = z.infer<typeof numberSchema>;
+  const f3: util.AssertEqual<
+    NumberSchema,
+    number & { [z.BRAND]: { 42: true } }
+  > = true;
+  f3;
+
+  // symbol branding
+  const MyBrand: unique symbol = Symbol("hello");
+  type MyBrand = typeof MyBrand;
+  const symbolBrand = z.number().brand<"sup">().brand<typeof MyBrand>();
+  type SymbolBrand = z.infer<typeof symbolBrand>;
+  // number & { [z.BRAND]: { [MyBrand]: true } }
+  const f4: util.AssertEqual<
+    SymbolBrand,
+    number & { [z.BRAND]: { 42: true; [MyBrand]: true } }
+  > = true;
+  f4;
 
   // @ts-expect-error
   doStuff({ name: "hello there!" });

--- a/deno/lib/__tests__/branded.test.ts
+++ b/deno/lib/__tests__/branded.test.ts
@@ -1,0 +1,27 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { util } from "../helpers/util.ts";
+import * as z from "../index.ts";
+
+test("branded types", () => {
+  const mySchema = z
+    .object({
+      name: z.string(),
+    })
+    .brand<"mySchema">();
+
+  type MySchema = z.infer<typeof mySchema>;
+
+  const doStuff = (arg: MySchema) => arg;
+  doStuff(mySchema.parse({ name: "hello there" }));
+  const f1: util.AssertEqual<
+    MySchema,
+    { name: string } & { [z.BRAND]: "mySchema" }
+  > = true;
+  f1;
+
+  // @ts-expect-error
+  doStuff({ name: "hello there!" });
+});

--- a/deno/lib/__tests__/branded.test.ts
+++ b/deno/lib/__tests__/branded.test.ts
@@ -46,10 +46,10 @@ test("branded types", () => {
   type MyBrand = typeof MyBrand;
   const symbolBrand = z.number().brand<"sup">().brand<typeof MyBrand>();
   type SymbolBrand = z.infer<typeof symbolBrand>;
-  // number & { [z.BRAND]: { [MyBrand]: true } }
+  // number & { [z.BRAND]: { sup: true, [MyBrand]: true } }
   const f4: util.AssertEqual<
     SymbolBrand,
-    number & { [z.BRAND]: { 42: true; [MyBrand]: true } }
+    number & { [z.BRAND]: { sup: true; [MyBrand]: true } }
   > = true;
   f4;
 

--- a/deno/lib/__tests__/firstparty.test.ts
+++ b/deno/lib/__tests__/firstparty.test.ts
@@ -71,6 +71,8 @@ test("first party switch", () => {
       break;
     case z.ZodFirstPartyTypeKind.ZodPromise:
       break;
+    case z.ZodFirstPartyTypeKind.ZodBranded:
+      break;
     default:
       util.assertNever(def);
   }

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -66,7 +66,7 @@ export namespace util {
   };
 
   export type identity<T> = T;
-  export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;
+  export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;
   export type noUndefined<T> = T extends undefined ? never : T;
 
   export const isInteger: NumberConstructor["isInteger"] =

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3760,6 +3760,10 @@ export class ZodBranded<
       parent: ctx,
     });
   }
+
+  unwrap() {
+    return this._def.type;
+  }
 }
 
 export const custom = <T>(

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -420,7 +420,7 @@ export abstract class ZodType<
     }) as any;
   }
 
-  brand<B extends string>(): ZodBranded<this, B> {
+  brand<B extends string | number | symbol>(): ZodBranded<this, B> {
     return new ZodBranded({
       typeName: ZodFirstPartyTypeKind.ZodBranded,
       type: this,
@@ -3739,8 +3739,14 @@ export interface ZodBrandedDef<T extends ZodTypeAny> extends ZodTypeDef {
 }
 
 export const BRAND: unique symbol = Symbol("zod_brand");
-type Brand<T> = { [BRAND]: T };
-export class ZodBranded<T extends ZodTypeAny, B extends string> extends ZodType<
+type Brand<T extends string | number | symbol> = {
+  [BRAND]: { [k in T]: true };
+};
+
+export class ZodBranded<
+  T extends ZodTypeAny,
+  B extends string | number | symbol
+> extends ZodType<
   T["_output"] & Brand<B>,
   ZodBrandedDef<T>,
   T["_input"] & Brand<B>
@@ -3748,13 +3754,11 @@ export class ZodBranded<T extends ZodTypeAny, B extends string> extends ZodType<
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;
-    const result = this._def.type._parse({
+    return this._def.type._parse({
       data,
       path: ctx.path,
       parent: ctx,
     });
-    // (result as any)[ZODBRAND] = this._def.brand;
-    return result;
   }
 }
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3887,7 +3887,6 @@ const effectsType = ZodEffects.create;
 const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
-// const brandedType = ZodBranded.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -3897,7 +3896,6 @@ export {
   arrayType as array,
   bigIntType as bigint,
   booleanType as boolean,
-  // brandedType as branded,
   dateType as date,
   discriminatedUnionType as discriminatedUnion,
   effectsType as effect,

--- a/src/__tests__/branded.test.ts
+++ b/src/__tests__/branded.test.ts
@@ -9,17 +9,48 @@ test("branded types", () => {
     .object({
       name: z.string(),
     })
-    .brand<"mySchema">();
+    .brand<"superschema">();
 
+  // simple branding
   type MySchema = z.infer<typeof mySchema>;
-
-  const doStuff = (arg: MySchema) => arg;
-  doStuff(mySchema.parse({ name: "hello there" }));
   const f1: util.AssertEqual<
     MySchema,
-    { name: string } & { [z.BRAND]: "mySchema" }
+    { name: string } & { [z.BRAND]: { superschema: true } }
   > = true;
   f1;
+  const doStuff = (arg: MySchema) => arg;
+  doStuff(mySchema.parse({ name: "hello there" }));
+
+  // inheritance
+  const extendedSchema = mySchema.brand<"subschema">();
+  type ExtendedSchema = z.infer<typeof extendedSchema>;
+  const f2: util.AssertEqual<
+    ExtendedSchema,
+    { name: string } & { [z.BRAND]: { superschema: true; subschema: true } }
+  > = true;
+  f2;
+  doStuff(extendedSchema.parse({ name: "hello again" }));
+
+  // number branding
+  const numberSchema = z.number().brand<42>();
+  type NumberSchema = z.infer<typeof numberSchema>;
+  const f3: util.AssertEqual<
+    NumberSchema,
+    number & { [z.BRAND]: { 42: true } }
+  > = true;
+  f3;
+
+  // symbol branding
+  const MyBrand: unique symbol = Symbol("hello");
+  type MyBrand = typeof MyBrand;
+  const symbolBrand = z.number().brand<"sup">().brand<typeof MyBrand>();
+  type SymbolBrand = z.infer<typeof symbolBrand>;
+  // number & { [z.BRAND]: { [MyBrand]: true } }
+  const f4: util.AssertEqual<
+    SymbolBrand,
+    number & { [z.BRAND]: { 42: true; [MyBrand]: true } }
+  > = true;
+  f4;
 
   // @ts-expect-error
   doStuff({ name: "hello there!" });

--- a/src/__tests__/branded.test.ts
+++ b/src/__tests__/branded.test.ts
@@ -45,10 +45,10 @@ test("branded types", () => {
   type MyBrand = typeof MyBrand;
   const symbolBrand = z.number().brand<"sup">().brand<typeof MyBrand>();
   type SymbolBrand = z.infer<typeof symbolBrand>;
-  // number & { [z.BRAND]: { [MyBrand]: true } }
+  // number & { [z.BRAND]: { sup: true, [MyBrand]: true } }
   const f4: util.AssertEqual<
     SymbolBrand,
-    number & { [z.BRAND]: { 42: true; [MyBrand]: true } }
+    number & { [z.BRAND]: { sup: true; [MyBrand]: true } }
   > = true;
   f4;
 

--- a/src/__tests__/branded.test.ts
+++ b/src/__tests__/branded.test.ts
@@ -1,0 +1,26 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import { util } from "../helpers/util";
+import * as z from "../index";
+
+test("branded types", () => {
+  const mySchema = z
+    .object({
+      name: z.string(),
+    })
+    .brand<"mySchema">();
+
+  type MySchema = z.infer<typeof mySchema>;
+
+  const doStuff = (arg: MySchema) => arg;
+  doStuff(mySchema.parse({ name: "hello there" }));
+  const f1: util.AssertEqual<
+    MySchema,
+    { name: string } & { [z.BRAND]: "mySchema" }
+  > = true;
+  f1;
+
+  // @ts-expect-error
+  doStuff({ name: "hello there!" });
+});

--- a/src/__tests__/firstparty.test.ts
+++ b/src/__tests__/firstparty.test.ts
@@ -70,6 +70,8 @@ test("first party switch", () => {
       break;
     case z.ZodFirstPartyTypeKind.ZodPromise:
       break;
+    case z.ZodFirstPartyTypeKind.ZodBranded:
+      break;
     default:
       util.assertNever(def);
   }

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -66,7 +66,7 @@ export namespace util {
   };
 
   export type identity<T> = T;
-  export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;
+  export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;
   export type noUndefined<T> = T extends undefined ? never : T;
 
   export const isInteger: NumberConstructor["isInteger"] =

--- a/src/types.ts
+++ b/src/types.ts
@@ -3760,6 +3760,10 @@ export class ZodBranded<
       parent: ctx,
     });
   }
+
+  unwrap() {
+    return this._def.type;
+  }
 }
 
 export const custom = <T>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -420,7 +420,7 @@ export abstract class ZodType<
     }) as any;
   }
 
-  brand<B extends string>(): ZodBranded<this, B> {
+  brand<B extends string | number | symbol>(): ZodBranded<this, B> {
     return new ZodBranded({
       typeName: ZodFirstPartyTypeKind.ZodBranded,
       type: this,
@@ -3739,8 +3739,14 @@ export interface ZodBrandedDef<T extends ZodTypeAny> extends ZodTypeDef {
 }
 
 export const BRAND: unique symbol = Symbol("zod_brand");
-type Brand<T> = { [BRAND]: T };
-export class ZodBranded<T extends ZodTypeAny, B extends string> extends ZodType<
+type Brand<T extends string | number | symbol> = {
+  [BRAND]: { [k in T]: true };
+};
+
+export class ZodBranded<
+  T extends ZodTypeAny,
+  B extends string | number | symbol
+> extends ZodType<
   T["_output"] & Brand<B>,
   ZodBrandedDef<T>,
   T["_input"] & Brand<B>
@@ -3748,13 +3754,11 @@ export class ZodBranded<T extends ZodTypeAny, B extends string> extends ZodType<
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;
-    const result = this._def.type._parse({
+    return this._def.type._parse({
       data,
       path: ctx.path,
       parent: ctx,
     });
-    // (result as any)[ZODBRAND] = this._def.brand;
-    return result;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3887,7 +3887,6 @@ const effectsType = ZodEffects.create;
 const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
-// const brandedType = ZodBranded.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -3897,7 +3896,6 @@ export {
   arrayType as array,
   bigIntType as bigint,
   booleanType as boolean,
-  // brandedType as branded,
   dateType as date,
   discriminatedUnionType as discriminatedUnion,
   effectsType as effect,


### PR DESCRIPTION
```ts
const mySchema = z
  .object({
    name: z.string(),
  })
  .brand<"mySchema">();
type MySchema = z.infer<typeof mySchema>;

const doStuff = (arg: MySchema) => {}

// works
doStuff(mySchema.parse({ name: "hello there" }));
// fails
doStuff({ name: "hello there!" });
```