### PR TITLE
Fix ZodDefault not being optional for infer

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3648,7 +3648,7 @@ export interface ZodDefaultDef<T extends ZodTypeAny = ZodTypeAny>
 }
 
 export class ZodDefault<T extends ZodTypeAny> extends ZodType<
-  util.noUndefined<T["_output"]>,
+  T["_output"] | undefined,
   ZodDefaultDef<T>,
   T["_input"] | undefined
 > {


### PR DESCRIPTION
This fixes ZodDefault not being optional for infer https://github.com/colinhacks/zod/issues/1257#issuecomment-1193396806