### PR TITLE
[#1287] add params to transform and refine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1658,7 +1658,7 @@ ZodError {
 
 #### Dynamic refine
 
-To make refine having a dynamic behavior depending on runtime parameters, the refine function can optionaly take a params additional argument that represent the .parse method second optional argument. Here is an exemple:
+To make refine having a dynamic behavior depending on runtime parameters, the refine function can optionaly take a params additional argument that represent the .parse method argument "params". Here is an exemple:
 
 ```ts
 const objectWithRef = z.object({
@@ -1669,10 +1669,10 @@ const objectWithRef = z.object({
 
 const idList = ["a", "b"];
 
-const obj1 = objectWithRef.parse({ ref: "a" }, { idList });
+const obj1 = objectWithRef.parse({ ref: "a" }, { params: { idList } });
 // => {ref: 'a'}
 
-const obj2 = objectWithRef.parse({ ref: "c" }, { idList });
+const obj2 = objectWithRef.parse({ ref: "c" }, { params: { idList } });
 // => throws
 ```
 
@@ -1749,10 +1749,10 @@ const objectWithRef = z.object({
 
 const idList = ["a", "b"];
 
-const obj1 = objectWithRef.parse({ ref: "a" }, { idList });
+const obj1 = objectWithRef.parse({ ref: "a" }, { params: { idList } });
 // => {ref: 'a'}
 
-const obj2 = objectWithRef.parse({ ref: "c" }, { idList });
+const obj2 = objectWithRef.parse({ ref: "c" }, { params: { idList } });
 // => throws
 ```
 
@@ -1848,10 +1848,10 @@ const objectWithRef = z
 
 const elements = { a: "a data", b: "b data" };
 
-const obj1 = objectWithRef.parse({ ref: "a" }, { elements });
+const obj1 = objectWithRef.parse({ ref: "a" }, { params: { elements } });
 // => 'a data'
 
-const obj2 = objectWithRef.parse({ ref: "c" }, { elements });
+const obj2 = objectWithRef.parse({ ref: "c" }, { params: { elements } });
 // => throws
 ```
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1658,7 +1658,7 @@ ZodError {
 
 #### Dynamic refine
 
-To make refine having a dynamic behavior depending on runtime parameters, the refine function can optionaly take a params additional argument that represent the .parse method second optional argument. Here is an exemple:
+To make refine having a dynamic behavior depending on runtime parameters, the refine function can optionaly take a params additional argument that represent the .parse method argument "params". Here is an exemple:
 
 ```ts
 const objectWithRef = z.object({
@@ -1669,10 +1669,10 @@ const objectWithRef = z.object({
 
 const idList = ["a", "b"];
 
-const obj1 = objectWithRef.parse({ ref: "a" }, { idList });
+const obj1 = objectWithRef.parse({ ref: "a" }, { params: { idList } });
 // => {ref: 'a'}
 
-const obj2 = objectWithRef.parse({ ref: "c" }, { idList });
+const obj2 = objectWithRef.parse({ ref: "c" }, { params: { idList } });
 // => throws
 ```
 
@@ -1749,10 +1749,10 @@ const objectWithRef = z.object({
 
 const idList = ["a", "b"];
 
-const obj1 = objectWithRef.parse({ ref: "a" }, { idList });
+const obj1 = objectWithRef.parse({ ref: "a" }, { params: { idList } });
 // => {ref: 'a'}
 
-const obj2 = objectWithRef.parse({ ref: "c" }, { idList });
+const obj2 = objectWithRef.parse({ ref: "c" }, { params: { idList } });
 // => throws
 ```
 
@@ -1848,10 +1848,10 @@ const objectWithRef = z
 
 const elements = { a: "a data", b: "b data" };
 
-const obj1 = objectWithRef.parse({ ref: "a" }, { elements });
+const obj1 = objectWithRef.parse({ ref: "a" }, { params: { elements } });
 // => 'a data'
 
-const obj2 = objectWithRef.parse({ ref: "c" }, { elements });
+const obj2 = objectWithRef.parse({ ref: "c" }, { params: { elements } });
 // => throws
 ```
 

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -215,3 +215,26 @@ test("fatal superRefine", () => {
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 });
+
+test("use param in superRefine", () => {
+  const objWithReference = z.object({
+    refId: z.string().superRefine((val, ctx) => {
+      if (!(ctx.params as string[]).includes(val)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `No matching Id`,
+        });
+      }
+    }),
+  });
+
+  const result = objWithReference.safeParse(
+    { refId: "c" },
+    { params: ["a", "b"] }
+  );
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+
+  objWithReference.parse({ refId: "b" }, { params: ["a", "b"] });
+});

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -231,33 +231,33 @@ test("async short circuit on dirty", async () => {
 });
 
 test("transform with params", () => {
-  const objWithReference = z.object({
-    refId: z.string().transform((val, ctx) => {
-      const elem = (ctx.params as Record<string, string>)[val];
+  const objWithReference = z.array(
+    z.object({
+      refId: z.string().transform((val, ctx) => {
+        const elem = (ctx.params as Record<string, string>)[val];
 
-      if (!elem) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `No matching Id`,
-        });
-      }
+        if (!elem) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `No matching Id`,
+          });
+        }
 
-      return elem;
-    }),
-  });
-
-  const result = objWithReference.safeParse(
-    { refId: "c" },
-    { params: { a: "a data", b: "b data" } }
+        return elem;
+      }),
+    })
   );
+
+  const result = objWithReference.safeParse([{ refId: "c" }], {
+    params: { a: "a data", b: "b data" },
+  });
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 
-  const result2 = objWithReference.parse(
-    { refId: "b" },
-    { params: { a: "a data", b: "b data" } }
-  );
+  const result2 = objWithReference.parse([{ refId: "b" }], {
+    params: { a: "a data", b: "b data" },
+  });
 
-  expect(result2.refId).toEqual("b data");
+  expect(result2[0].refId).toEqual("b data");
 });

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -229,3 +229,35 @@ test("async short circuit on dirty", async () => {
     expect(result2.error.issues[0].code).toEqual(z.ZodIssueCode.invalid_type);
   }
 });
+
+test("transform with params", () => {
+  const objWithReference = z.object({
+    refId: z.string().transform((val, ctx) => {
+      const elem = (ctx.params as Record<string, string>)[val];
+
+      if (!elem) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `No matching Id`,
+        });
+      }
+
+      return elem;
+    }),
+  });
+
+  const result = objWithReference.safeParse(
+    { refId: "c" },
+    { params: { a: "a data", b: "b data" } }
+  );
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+
+  const result2 = objWithReference.parse(
+    { refId: "b" },
+    { params: { a: "a data", b: "b data" } }
+  );
+
+  expect(result2.refId).toEqual("b data");
+});

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -35,7 +35,7 @@ export type ParseParams = {
   path: (string | number)[];
   errorMap: ZodErrorMap;
   async: boolean;
-  params: unknown;
+  params?: any;
 };
 
 export type ParsePathComponent = string | number;
@@ -54,14 +54,14 @@ export interface ParseContext {
   readonly data: any;
   readonly parsedType: ZodParsedType;
 
-  readonly params?: unknown;
+  readonly params?: any;
 }
 
 export type ParseInput = {
   data: any;
   path: (string | number)[];
   parent: ParseContext;
-  params?: unknown;
+  params?: any;
 };
 
 export function addIssueToContext(

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -35,6 +35,7 @@ export type ParseParams = {
   path: (string | number)[];
   errorMap: ZodErrorMap;
   async: boolean;
+  params: unknown;
 };
 
 export type ParsePathComponent = string | number;
@@ -52,12 +53,15 @@ export interface ParseContext {
   readonly parent: ParseContext | null;
   readonly data: any;
   readonly parsedType: ZodParsedType;
+
+  readonly params?: unknown;
 }
 
 export type ParseInput = {
   data: any;
   path: (string | number)[];
   parent: ParseContext;
+  params?: unknown;
 };
 
 export function addIssueToContext(

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -53,47 +53,6 @@ export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
 export type input<T extends ZodType<any, any, any>> = T["_input"];
 export type output<T extends ZodType<any, any, any>> = T["_output"];
 export type { TypeOf as infer };
-export { ZodEffects as ZodTransformer };
-export { ZodType as Schema, ZodType as ZodSchema };
-export {
-  anyType as any,
-  arrayType as array,
-  bigIntType as bigint,
-  booleanType as boolean,
-  dateType as date,
-  discriminatedUnionType as discriminatedUnion,
-  effectsType as effect,
-  enumType as enum,
-  functionType as function,
-  instanceOfType as instanceof,
-  intersectionType as intersection,
-  lazyType as lazy,
-  literalType as literal,
-  mapType as map,
-  nanType as nan,
-  nativeEnumType as nativeEnum,
-  neverType as never,
-  nullType as null,
-  nullableType as nullable,
-  numberType as number,
-  objectType as object,
-  oboolean,
-  onumber,
-  optionalType as optional,
-  ostring,
-  preprocessType as preprocess,
-  promiseType as promise,
-  recordType as record,
-  setType as set,
-  strictObjectType as strictObject,
-  stringType as string,
-  effectsType as transformer,
-  tupleType as tuple,
-  undefinedType as undefined,
-  unionType as union,
-  unknownType as unknown,
-  voidType as void,
-};
 
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
@@ -3626,6 +3585,8 @@ export class ZodEffects<
   };
 }
 
+export { ZodEffects as ZodTransformer };
+
 ///////////////////////////////////////////
 ///////////////////////////////////////////
 //////////                       //////////
@@ -3814,6 +3775,8 @@ export const custom = <T>(
   return ZodAny.create();
 };
 
+export { ZodType as Schema, ZodType as ZodSchema };
+
 export const late = {
   object: ZodObject.lazycreate,
 };
@@ -3926,3 +3889,43 @@ const preprocessType = ZodEffects.createWithPreprocess;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
+
+export {
+  anyType as any,
+  arrayType as array,
+  bigIntType as bigint,
+  booleanType as boolean,
+  dateType as date,
+  discriminatedUnionType as discriminatedUnion,
+  effectsType as effect,
+  enumType as enum,
+  functionType as function,
+  instanceOfType as instanceof,
+  intersectionType as intersection,
+  lazyType as lazy,
+  literalType as literal,
+  mapType as map,
+  nanType as nan,
+  nativeEnumType as nativeEnum,
+  neverType as never,
+  nullType as null,
+  nullableType as nullable,
+  numberType as number,
+  objectType as object,
+  oboolean,
+  onumber,
+  optionalType as optional,
+  ostring,
+  preprocessType as preprocess,
+  promiseType as promise,
+  recordType as record,
+  setType as set,
+  strictObjectType as strictObject,
+  stringType as string,
+  effectsType as transformer,
+  tupleType as tuple,
+  undefinedType as undefined,
+  unionType as union,
+  unknownType as unknown,
+  voidType as void,
+};

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -45,7 +45,7 @@ import {
 export type RefinementCtx = {
   addIssue: (arg: IssueData) => void;
   path: (string | number)[];
-  params?: unknown;
+  params?: any;
 };
 export type ZodRawShape = { [k: string]: ZodTypeAny };
 export type ZodTypeAny = ZodType<any, any, any>;
@@ -53,6 +53,47 @@ export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
 export type input<T extends ZodType<any, any, any>> = T["_input"];
 export type output<T extends ZodType<any, any, any>> = T["_output"];
 export type { TypeOf as infer };
+export { ZodEffects as ZodTransformer };
+export { ZodType as Schema, ZodType as ZodSchema };
+export {
+  anyType as any,
+  arrayType as array,
+  bigIntType as bigint,
+  booleanType as boolean,
+  dateType as date,
+  discriminatedUnionType as discriminatedUnion,
+  effectsType as effect,
+  enumType as enum,
+  functionType as function,
+  instanceOfType as instanceof,
+  intersectionType as intersection,
+  lazyType as lazy,
+  literalType as literal,
+  mapType as map,
+  nanType as nan,
+  nativeEnumType as nativeEnum,
+  neverType as never,
+  nullType as null,
+  nullableType as nullable,
+  numberType as number,
+  objectType as object,
+  oboolean,
+  onumber,
+  optionalType as optional,
+  ostring,
+  preprocessType as preprocess,
+  promiseType as promise,
+  recordType as record,
+  setType as set,
+  strictObjectType as strictObject,
+  stringType as string,
+  effectsType as transformer,
+  tupleType as tuple,
+  undefinedType as undefined,
+  unionType as union,
+  unknownType as unknown,
+  voidType as void,
+};
 
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
@@ -63,7 +104,7 @@ export interface ZodTypeDef {
 class ParseInputLazyPath implements ParseInput {
   parent: ParseContext;
   data: any;
-  params?: unknown;
+  params?: any;
   _path: ParsePath;
   _key: string | number | (string | number)[];
   constructor(
@@ -286,15 +327,15 @@ export abstract class ZodType<
   spa = this.safeParseAsync;
 
   refine<RefinedOutput extends Output>(
-    check: (arg: Output, params?: unknown) => arg is RefinedOutput,
+    check: (arg: Output, params?: any) => arg is RefinedOutput,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
   ): ZodEffects<this, RefinedOutput, RefinedOutput>;
   refine(
-    check: (arg: Output, params?: unknown) => unknown | Promise<unknown>,
+    check: (arg: Output, params?: any) => unknown | Promise<unknown>,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
   ): ZodEffects<this, Output, Input>;
   refine(
-    check: (arg: Output, params?: unknown) => unknown,
+    check: (arg: Output, params?: any) => unknown,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
   ): ZodEffects<this, Output, Input> {
     const getIssueProperties: any = (val: Output) => {
@@ -333,15 +374,15 @@ export abstract class ZodType<
   }
 
   refinement<RefinedOutput extends Output>(
-    check: (arg: Output, params?: unknown) => arg is RefinedOutput,
+    check: (arg: Output, params?: any) => arg is RefinedOutput,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)
   ): ZodEffects<this, RefinedOutput, RefinedOutput>;
   refinement(
-    check: (arg: Output, params?: unknown) => boolean,
+    check: (arg: Output, params?: any) => boolean,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)
   ): ZodEffects<this, Output, Input>;
   refinement(
-    check: (arg: Output, params?: unknown) => unknown,
+    check: (arg: Output, params?: any) => unknown,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)
   ): ZodEffects<this, Output, Input> {
     return this._refinement((val, ctx) => {
@@ -3569,8 +3610,6 @@ export class ZodEffects<
   };
 }
 
-export { ZodEffects as ZodTransformer };
-
 ///////////////////////////////////////////
 ///////////////////////////////////////////
 //////////                       //////////
@@ -3759,8 +3798,6 @@ export const custom = <T>(
   return ZodAny.create();
 };
 
-export { ZodType as Schema, ZodType as ZodSchema };
-
 export const late = {
   object: ZodObject.lazycreate,
 };
@@ -3873,43 +3910,3 @@ const preprocessType = ZodEffects.createWithPreprocess;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
-
-export {
-  anyType as any,
-  arrayType as array,
-  bigIntType as bigint,
-  booleanType as boolean,
-  dateType as date,
-  discriminatedUnionType as discriminatedUnion,
-  effectsType as effect,
-  enumType as enum,
-  functionType as function,
-  instanceOfType as instanceof,
-  intersectionType as intersection,
-  lazyType as lazy,
-  literalType as literal,
-  mapType as map,
-  nanType as nan,
-  nativeEnumType as nativeEnum,
-  neverType as never,
-  nullType as null,
-  nullableType as nullable,
-  numberType as number,
-  objectType as object,
-  oboolean,
-  onumber,
-  optionalType as optional,
-  ostring,
-  preprocessType as preprocess,
-  promiseType as promise,
-  recordType as record,
-  setType as set,
-  strictObjectType as strictObject,
-  stringType as string,
-  effectsType as transformer,
-  tupleType as tuple,
-  undefinedType as undefined,
-  unionType as union,
-  unknownType as unknown,
-  voidType as void,
-};

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2113,6 +2113,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
               data: ctx.data,
               path: ctx.path,
               parent: childCtx,
+              params: ctx.params,
             }),
             ctx: childCtx,
           };
@@ -2135,6 +2136,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
           data: ctx.data,
           path: ctx.path,
           parent: childCtx,
+          params: ctx.params,
         });
 
         if (result.status === "valid") {
@@ -2247,12 +2249,14 @@ export class ZodDiscriminatedUnion<
         data: ctx.data,
         path: ctx.path,
         parent: ctx,
+        params: ctx.params,
       });
     } else {
       return option._parseSync({
         data: ctx.data,
         path: ctx.path,
         parent: ctx,
+        params: ctx.params,
       });
     }
   }
@@ -2433,11 +2437,13 @@ export class ZodIntersection<
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         }),
         this._def.right._parseAsync({
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         }),
       ]).then(([left, right]: any) => handleParsed(left, right));
     } else {
@@ -2446,11 +2452,13 @@ export class ZodIntersection<
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         }),
         this._def.right._parseSync({
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         })
       );
     }
@@ -3467,6 +3475,7 @@ export class ZodEffects<
             data: processed,
             path: ctx.path,
             parent: ctx,
+            params: ctx.params,
           });
         });
       } else {
@@ -3474,6 +3483,7 @@ export class ZodEffects<
           data: processed,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         });
       }
     }
@@ -3516,6 +3526,7 @@ export class ZodEffects<
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         });
         if (inner.status === "aborted") return INVALID;
         if (inner.status === "dirty") status.dirty();
@@ -3525,7 +3536,12 @@ export class ZodEffects<
         return { status: status.value, value: inner.value };
       } else {
         return this._def.schema
-          ._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx })
+          ._parseAsync({
+            data: ctx.data,
+            path: ctx.path,
+            parent: ctx,
+            params: ctx.params,
+          })
           .then((inner) => {
             if (inner.status === "aborted") return INVALID;
             if (inner.status === "dirty") status.dirty();

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -214,3 +214,26 @@ test("fatal superRefine", () => {
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 });
+
+test("use param in superRefine", () => {
+  const objWithReference = z.object({
+    refId: z.string().superRefine((val, ctx) => {
+      if (!(ctx.params as string[]).includes(val)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `No matching Id`,
+        });
+      }
+    }),
+  });
+
+  const result = objWithReference.safeParse(
+    { refId: "c" },
+    { params: ["a", "b"] }
+  );
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+
+  objWithReference.parse({ refId: "b" }, { params: ["a", "b"] });
+});

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -216,24 +216,28 @@ test("fatal superRefine", () => {
 });
 
 test("use param in superRefine", () => {
-  const objWithReference = z.object({
-    refId: z.string().superRefine((val, ctx) => {
-      if (!(ctx.params as string[]).includes(val)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `No matching Id`,
-        });
-      }
-    }),
-  });
+  const objWithReference = z.union([
+    z.array(
+      z.object({
+        refId: z.string().superRefine((val, ctx) => {
+          if (!(ctx.params as string[]).includes(val)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `No matching Id`,
+            });
+          }
+        }),
+      })
+    ),
+    z.string(),
+  ]);
 
-  const result = objWithReference.safeParse(
-    { refId: "c" },
-    { params: ["a", "b"] }
-  );
+  const result = objWithReference.safeParse([{ refId: "c" }], {
+    params: ["a", "b"],
+  });
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 
-  objWithReference.parse({ refId: "b" }, { params: ["a", "b"] });
+  objWithReference.parse([{ refId: "b" }], { params: ["a", "b"] });
 });

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -230,33 +230,33 @@ test("async short circuit on dirty", async () => {
 });
 
 test("transform with params", () => {
-  const objWithReference = z.object({
-    refId: z.string().transform((val, ctx) => {
-      const elem = (ctx.params as Record<string, string>)[val];
+  const objWithReference = z.array(
+    z.object({
+      refId: z.string().transform((val, ctx) => {
+        const elem = (ctx.params as Record<string, string>)[val];
 
-      if (!elem) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `No matching Id`,
-        });
-      }
+        if (!elem) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `No matching Id`,
+          });
+        }
 
-      return elem;
-    }),
-  });
-
-  const result = objWithReference.safeParse(
-    { refId: "c" },
-    { params: { a: "a data", b: "b data" } }
+        return elem;
+      }),
+    })
   );
+
+  const result = objWithReference.safeParse([{ refId: "c" }], {
+    params: { a: "a data", b: "b data" },
+  });
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 
-  const result2 = objWithReference.parse(
-    { refId: "b" },
-    { params: { a: "a data", b: "b data" } }
-  );
+  const result2 = objWithReference.parse([{ refId: "b" }], {
+    params: { a: "a data", b: "b data" },
+  });
 
-  expect(result2.refId).toEqual("b data");
+  expect(result2[0].refId).toEqual("b data");
 });

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -228,3 +228,35 @@ test("async short circuit on dirty", async () => {
     expect(result2.error.issues[0].code).toEqual(z.ZodIssueCode.invalid_type);
   }
 });
+
+test("transform with params", () => {
+  const objWithReference = z.object({
+    refId: z.string().transform((val, ctx) => {
+      const elem = (ctx.params as Record<string, string>)[val];
+
+      if (!elem) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `No matching Id`,
+        });
+      }
+
+      return elem;
+    }),
+  });
+
+  const result = objWithReference.safeParse(
+    { refId: "c" },
+    { params: { a: "a data", b: "b data" } }
+  );
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+
+  const result2 = objWithReference.parse(
+    { refId: "b" },
+    { params: { a: "a data", b: "b data" } }
+  );
+
+  expect(result2.refId).toEqual("b data");
+});

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -35,7 +35,7 @@ export type ParseParams = {
   path: (string | number)[];
   errorMap: ZodErrorMap;
   async: boolean;
-  params: unknown;
+  params?: any;
 };
 
 export type ParsePathComponent = string | number;
@@ -54,14 +54,14 @@ export interface ParseContext {
   readonly data: any;
   readonly parsedType: ZodParsedType;
 
-  readonly params?: unknown;
+  readonly params?: any;
 }
 
 export type ParseInput = {
   data: any;
   path: (string | number)[];
   parent: ParseContext;
-  params?: unknown;
+  params?: any;
 };
 
 export function addIssueToContext(

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -35,6 +35,7 @@ export type ParseParams = {
   path: (string | number)[];
   errorMap: ZodErrorMap;
   async: boolean;
+  params: unknown;
 };
 
 export type ParsePathComponent = string | number;
@@ -52,12 +53,15 @@ export interface ParseContext {
   readonly parent: ParseContext | null;
   readonly data: any;
   readonly parsedType: ZodParsedType;
+
+  readonly params?: unknown;
 }
 
 export type ParseInput = {
   data: any;
   path: (string | number)[];
   parent: ParseContext;
+  params?: unknown;
 };
 
 export function addIssueToContext(

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,47 +53,6 @@ export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
 export type input<T extends ZodType<any, any, any>> = T["_input"];
 export type output<T extends ZodType<any, any, any>> = T["_output"];
 export type { TypeOf as infer };
-export { ZodEffects as ZodTransformer };
-export { ZodType as Schema, ZodType as ZodSchema };
-export {
-  anyType as any,
-  arrayType as array,
-  bigIntType as bigint,
-  booleanType as boolean,
-  dateType as date,
-  discriminatedUnionType as discriminatedUnion,
-  effectsType as effect,
-  enumType as enum,
-  functionType as function,
-  instanceOfType as instanceof,
-  intersectionType as intersection,
-  lazyType as lazy,
-  literalType as literal,
-  mapType as map,
-  nanType as nan,
-  nativeEnumType as nativeEnum,
-  neverType as never,
-  nullType as null,
-  nullableType as nullable,
-  numberType as number,
-  objectType as object,
-  oboolean,
-  onumber,
-  optionalType as optional,
-  ostring,
-  preprocessType as preprocess,
-  promiseType as promise,
-  recordType as record,
-  setType as set,
-  strictObjectType as strictObject,
-  stringType as string,
-  effectsType as transformer,
-  tupleType as tuple,
-  undefinedType as undefined,
-  unionType as union,
-  unknownType as unknown,
-  voidType as void,
-};
 
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
@@ -3626,6 +3585,8 @@ export class ZodEffects<
   };
 }
 
+export { ZodEffects as ZodTransformer };
+
 ///////////////////////////////////////////
 ///////////////////////////////////////////
 //////////                       //////////
@@ -3814,6 +3775,8 @@ export const custom = <T>(
   return ZodAny.create();
 };
 
+export { ZodType as Schema, ZodType as ZodSchema };
+
 export const late = {
   object: ZodObject.lazycreate,
 };
@@ -3926,3 +3889,43 @@ const preprocessType = ZodEffects.createWithPreprocess;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
+
+export {
+  anyType as any,
+  arrayType as array,
+  bigIntType as bigint,
+  booleanType as boolean,
+  dateType as date,
+  discriminatedUnionType as discriminatedUnion,
+  effectsType as effect,
+  enumType as enum,
+  functionType as function,
+  instanceOfType as instanceof,
+  intersectionType as intersection,
+  lazyType as lazy,
+  literalType as literal,
+  mapType as map,
+  nanType as nan,
+  nativeEnumType as nativeEnum,
+  neverType as never,
+  nullType as null,
+  nullableType as nullable,
+  numberType as number,
+  objectType as object,
+  oboolean,
+  onumber,
+  optionalType as optional,
+  ostring,
+  preprocessType as preprocess,
+  promiseType as promise,
+  recordType as record,
+  setType as set,
+  strictObjectType as strictObject,
+  stringType as string,
+  effectsType as transformer,
+  tupleType as tuple,
+  undefinedType as undefined,
+  unionType as union,
+  unknownType as unknown,
+  voidType as void,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ import {
 export type RefinementCtx = {
   addIssue: (arg: IssueData) => void;
   path: (string | number)[];
-  params?: unknown;
+  params?: any;
 };
 export type ZodRawShape = { [k: string]: ZodTypeAny };
 export type ZodTypeAny = ZodType<any, any, any>;
@@ -53,6 +53,47 @@ export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
 export type input<T extends ZodType<any, any, any>> = T["_input"];
 export type output<T extends ZodType<any, any, any>> = T["_output"];
 export type { TypeOf as infer };
+export { ZodEffects as ZodTransformer };
+export { ZodType as Schema, ZodType as ZodSchema };
+export {
+  anyType as any,
+  arrayType as array,
+  bigIntType as bigint,
+  booleanType as boolean,
+  dateType as date,
+  discriminatedUnionType as discriminatedUnion,
+  effectsType as effect,
+  enumType as enum,
+  functionType as function,
+  instanceOfType as instanceof,
+  intersectionType as intersection,
+  lazyType as lazy,
+  literalType as literal,
+  mapType as map,
+  nanType as nan,
+  nativeEnumType as nativeEnum,
+  neverType as never,
+  nullType as null,
+  nullableType as nullable,
+  numberType as number,
+  objectType as object,
+  oboolean,
+  onumber,
+  optionalType as optional,
+  ostring,
+  preprocessType as preprocess,
+  promiseType as promise,
+  recordType as record,
+  setType as set,
+  strictObjectType as strictObject,
+  stringType as string,
+  effectsType as transformer,
+  tupleType as tuple,
+  undefinedType as undefined,
+  unionType as union,
+  unknownType as unknown,
+  voidType as void,
+};
 
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
@@ -63,7 +104,7 @@ export interface ZodTypeDef {
 class ParseInputLazyPath implements ParseInput {
   parent: ParseContext;
   data: any;
-  params?: unknown;
+  params?: any;
   _path: ParsePath;
   _key: string | number | (string | number)[];
   constructor(
@@ -286,15 +327,15 @@ export abstract class ZodType<
   spa = this.safeParseAsync;
 
   refine<RefinedOutput extends Output>(
-    check: (arg: Output, params?: unknown) => arg is RefinedOutput,
+    check: (arg: Output, params?: any) => arg is RefinedOutput,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
   ): ZodEffects<this, RefinedOutput, RefinedOutput>;
   refine(
-    check: (arg: Output, params?: unknown) => unknown | Promise<unknown>,
+    check: (arg: Output, params?: any) => unknown | Promise<unknown>,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
   ): ZodEffects<this, Output, Input>;
   refine(
-    check: (arg: Output, params?: unknown) => unknown,
+    check: (arg: Output, params?: any) => unknown,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
   ): ZodEffects<this, Output, Input> {
     const getIssueProperties: any = (val: Output) => {
@@ -333,15 +374,15 @@ export abstract class ZodType<
   }
 
   refinement<RefinedOutput extends Output>(
-    check: (arg: Output, params?: unknown) => arg is RefinedOutput,
+    check: (arg: Output, params?: any) => arg is RefinedOutput,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)
   ): ZodEffects<this, RefinedOutput, RefinedOutput>;
   refinement(
-    check: (arg: Output, params?: unknown) => boolean,
+    check: (arg: Output, params?: any) => boolean,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)
   ): ZodEffects<this, Output, Input>;
   refinement(
-    check: (arg: Output, params?: unknown) => unknown,
+    check: (arg: Output, params?: any) => unknown,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)
   ): ZodEffects<this, Output, Input> {
     return this._refinement((val, ctx) => {
@@ -3569,8 +3610,6 @@ export class ZodEffects<
   };
 }
 
-export { ZodEffects as ZodTransformer };
-
 ///////////////////////////////////////////
 ///////////////////////////////////////////
 //////////                       //////////
@@ -3759,8 +3798,6 @@ export const custom = <T>(
   return ZodAny.create();
 };
 
-export { ZodType as Schema, ZodType as ZodSchema };
-
 export const late = {
   object: ZodObject.lazycreate,
 };
@@ -3873,43 +3910,3 @@ const preprocessType = ZodEffects.createWithPreprocess;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
-
-export {
-  anyType as any,
-  arrayType as array,
-  bigIntType as bigint,
-  booleanType as boolean,
-  dateType as date,
-  discriminatedUnionType as discriminatedUnion,
-  effectsType as effect,
-  enumType as enum,
-  functionType as function,
-  instanceOfType as instanceof,
-  intersectionType as intersection,
-  lazyType as lazy,
-  literalType as literal,
-  mapType as map,
-  nanType as nan,
-  nativeEnumType as nativeEnum,
-  neverType as never,
-  nullType as null,
-  nullableType as nullable,
-  numberType as number,
-  objectType as object,
-  oboolean,
-  onumber,
-  optionalType as optional,
-  ostring,
-  preprocessType as preprocess,
-  promiseType as promise,
-  recordType as record,
-  setType as set,
-  strictObjectType as strictObject,
-  stringType as string,
-  effectsType as transformer,
-  tupleType as tuple,
-  undefinedType as undefined,
-  unionType as union,
-  unknownType as unknown,
-  voidType as void,
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -2113,6 +2113,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
               data: ctx.data,
               path: ctx.path,
               parent: childCtx,
+              params: ctx.params,
             }),
             ctx: childCtx,
           };
@@ -2135,6 +2136,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
           data: ctx.data,
           path: ctx.path,
           parent: childCtx,
+          params: ctx.params,
         });
 
         if (result.status === "valid") {
@@ -2247,12 +2249,14 @@ export class ZodDiscriminatedUnion<
         data: ctx.data,
         path: ctx.path,
         parent: ctx,
+        params: ctx.params,
       });
     } else {
       return option._parseSync({
         data: ctx.data,
         path: ctx.path,
         parent: ctx,
+        params: ctx.params,
       });
     }
   }
@@ -2433,11 +2437,13 @@ export class ZodIntersection<
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         }),
         this._def.right._parseAsync({
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         }),
       ]).then(([left, right]: any) => handleParsed(left, right));
     } else {
@@ -2446,11 +2452,13 @@ export class ZodIntersection<
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         }),
         this._def.right._parseSync({
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         })
       );
     }
@@ -3467,6 +3475,7 @@ export class ZodEffects<
             data: processed,
             path: ctx.path,
             parent: ctx,
+            params: ctx.params,
           });
         });
       } else {
@@ -3474,6 +3483,7 @@ export class ZodEffects<
           data: processed,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         });
       }
     }
@@ -3516,6 +3526,7 @@ export class ZodEffects<
           data: ctx.data,
           path: ctx.path,
           parent: ctx,
+          params: ctx.params,
         });
         if (inner.status === "aborted") return INVALID;
         if (inner.status === "dirty") status.dirty();
@@ -3525,7 +3536,12 @@ export class ZodEffects<
         return { status: status.value, value: inner.value };
       } else {
         return this._def.schema
-          ._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx })
+          ._parseAsync({
+            data: ctx.data,
+            path: ctx.path,
+            parent: ctx,
+            params: ctx.params,
+          })
           .then((inner) => {
             if (inner.status === "aborted") return INVALID;
             if (inner.status === "dirty") status.dirty();


### PR DESCRIPTION
This PR solve the issue #1287 by adding the ability to add a params object as optional argument to parse functions, this params argument will be available in transform and refine callbacks to perform more customizable data checks and transformation.

I will extend this PR with a few doc when I'll get some time.