### PR TITLE
Find discriminator inside ZodIntersection 

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -328,6 +328,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zod-xlsx`](https://github.com/sidwebworks/zod-xlsx): A xlsx based resource validator using Zod schemas.
 - [`remix-domains`](https://github.com/SeasonedSoftware/remix-domains/): Improves end-to-end type safety in [Remix](https://remix.run/) by leveraging Zod to parse the framework's inputs such as FormData, URLSearchParams, etc.
 - [`@zodios/core`](https://github.com/ecyrbe/zodios): A typescript API client with runtime and compile time validation backed by axios and zod.
+- [`@runtyping/zod`](https://github.com/johngeorgewright/runtyping/tree/master/packages/zod): Generate zod from static types & JSON schema.
 
 #### Form integrations
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2224,6 +2224,7 @@ export class ZodDiscriminatedUnion<
       ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>,
       ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>,
       ...ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>[]
+      // TODO do I need to add a Intersection Type here ?
     ]
   >(
     discriminator: Discriminator,
@@ -2235,8 +2236,30 @@ export class ZodDiscriminatedUnion<
 
     try {
       types.forEach((type) => {
-        const discriminatorValue = type.shape[discriminator].value;
-        options.set(discriminatorValue, type);
+        if (type instanceof ZodIntersection) {
+          // @ts-ignore
+          if (
+            type._def.left instanceof ZodObject &&
+            !(type._def.right instanceof ZodObject)
+          ) {
+            // @ts-ignore
+            const discriminatorValue =
+              type._def.left.shape[discriminator].value;
+            options.set(discriminatorValue, type);
+            // @ts-ignore
+          } else if (
+            !(type._def.left instanceof ZodObject) &&
+            type._def.right instanceof ZodObject
+          ) {
+            // @ts-ignore
+            const discriminatorValue =
+              type._def.right.shape[discriminator].value;
+            options.set(discriminatorValue, type);
+          }
+        } else {
+          const discriminatorValue = type.shape[discriminator].value;
+          options.set(discriminatorValue, type);
+        }
       });
     } catch (e) {
       throw new Error(

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2129,7 +2129,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
 
-export type ZodDiscriminatedUnionOption<
+export type ZodDiscriminatedUnionOptionBase<
   Discriminator extends string,
   DiscriminatorValue extends Primitive
 > = ZodObject<
@@ -2137,6 +2137,21 @@ export type ZodDiscriminatedUnionOption<
   any,
   any
 >;
+
+// the left or right side should also allow for a union/discriminatedUnion as long as they are ZodObject, right ?
+export type ZodDiscriminatedUnionOption<
+  Discriminator extends string,
+  DiscriminatorValue extends Primitive
+> =
+  | ZodDiscriminatedUnionOptionBase<Discriminator, DiscriminatorValue>
+  | ZodIntersection<
+      ZodDiscriminatedUnionOptionBase<Discriminator, DiscriminatorValue>,
+      AnyZodObject
+    >
+  | ZodIntersection<
+      AnyZodObject,
+      ZodDiscriminatedUnionOptionBase<Discriminator, DiscriminatorValue>
+    >;
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
@@ -2224,7 +2239,6 @@ export class ZodDiscriminatedUnion<
       ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>,
       ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>,
       ...ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>[]
-      // TODO do I need to add a Intersection Type here ?
     ]
   >(
     discriminator: Discriminator,
@@ -2237,21 +2251,17 @@ export class ZodDiscriminatedUnion<
     try {
       types.forEach((type) => {
         if (type instanceof ZodIntersection) {
-          // @ts-ignore
           if (
             type._def.left instanceof ZodObject &&
             !(type._def.right instanceof ZodObject)
           ) {
-            // @ts-ignore
             const discriminatorValue =
               type._def.left.shape[discriminator].value;
             options.set(discriminatorValue, type);
-            // @ts-ignore
           } else if (
             !(type._def.left instanceof ZodObject) &&
             type._def.right instanceof ZodObject
           ) {
-            // @ts-ignore
             const discriminatorValue =
               type._def.right.shape[discriminator].value;
             options.set(discriminatorValue, type);

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -58,6 +58,55 @@ test("valid - discriminator value of various primitive types", () => {
   });
 });
 
+test("valid - discriminator value when at least one discriminated schema is ZodIntersection", () => {
+  const union = z.discriminatedUnion("hasPropA", [
+    z.object({ hasPropA: z.literal(null) }),
+    z.object({ hasPropA: z.literal(true), propA: z.string().min(1) }),
+  ]);
+
+  const schema = z.discriminatedUnion("type", [
+    // @ts-ignore
+    z.object({ type: z.literal("intersection") }).and(union),
+    z.object({ type: z.literal("other"), propB: z.string().min(2) }),
+    z.object({ type: z.literal("more"), propC: z.number() }),
+  ]);
+
+  expect(schema.parse({ type: "intersection", hasPropA: null }));
+  expect(
+    schema.parse({ type: "intersection", hasPropA: true, propA: "test" })
+  );
+  expect(schema.parse({ type: "other", propB: "st" }));
+  expect(schema.parse({ type: "more", propC: 1 }));
+});
+
+test("valid discriminator value, invalid data when at least discriminated schema is ZodIntersection", () => {
+  const union = z.discriminatedUnion("hasPropA", [
+    z.object({ hasPropA: z.literal(null) }),
+    z.object({ hasPropA: z.literal(true), propA: z.string().min(1) }),
+  ]);
+
+  const schema = z.discriminatedUnion("type", [
+    // @ts-ignore
+    z.object({ type: z.literal("intersection") }).and(union),
+    z.object({ type: z.literal("other"), propB: z.string().min(2) }),
+    z.object({ type: z.literal("more"), propC: z.number() }),
+  ]);
+
+  try {
+    schema.parse({ type: "intersection" });
+    throw new Error();
+  } catch (e: any) {
+    expect(JSON.parse(e.message)).toEqual([
+      {
+        code: z.ZodIssueCode.invalid_union_discriminator,
+        message: "Invalid discriminator value. Expected  | true",
+        path: ["hasPropA"],
+        options: [null, true]
+      },
+    ]);
+  }
+});
+
 test("invalid - null", () => {
   try {
     z.discriminatedUnion("type", [

--- a/src/types.ts
+++ b/src/types.ts
@@ -2224,6 +2224,7 @@ export class ZodDiscriminatedUnion<
       ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>,
       ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>,
       ...ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>[]
+      // TODO do I need to add a Intersection Type here ?
     ]
   >(
     discriminator: Discriminator,
@@ -2235,8 +2236,30 @@ export class ZodDiscriminatedUnion<
 
     try {
       types.forEach((type) => {
-        const discriminatorValue = type.shape[discriminator].value;
-        options.set(discriminatorValue, type);
+        if (type instanceof ZodIntersection) {
+          // @ts-ignore
+          if (
+            type._def.left instanceof ZodObject &&
+            !(type._def.right instanceof ZodObject)
+          ) {
+            // @ts-ignore
+            const discriminatorValue =
+              type._def.left.shape[discriminator].value;
+            options.set(discriminatorValue, type);
+            // @ts-ignore
+          } else if (
+            !(type._def.left instanceof ZodObject) &&
+            type._def.right instanceof ZodObject
+          ) {
+            // @ts-ignore
+            const discriminatorValue =
+              type._def.right.shape[discriminator].value;
+            options.set(discriminatorValue, type);
+          }
+        } else {
+          const discriminatorValue = type.shape[discriminator].value;
+          options.set(discriminatorValue, type);
+        }
       });
     } catch (e) {
       throw new Error(

--- a/src/types.ts
+++ b/src/types.ts
@@ -2129,7 +2129,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
 
-export type ZodDiscriminatedUnionOption<
+export type ZodDiscriminatedUnionOptionBase<
   Discriminator extends string,
   DiscriminatorValue extends Primitive
 > = ZodObject<
@@ -2137,6 +2137,21 @@ export type ZodDiscriminatedUnionOption<
   any,
   any
 >;
+
+// the left or right side should also allow for a union/discriminatedUnion as long as they are ZodObject, right ?
+export type ZodDiscriminatedUnionOption<
+  Discriminator extends string,
+  DiscriminatorValue extends Primitive
+> =
+  | ZodDiscriminatedUnionOptionBase<Discriminator, DiscriminatorValue>
+  | ZodIntersection<
+      ZodDiscriminatedUnionOptionBase<Discriminator, DiscriminatorValue>,
+      AnyZodObject
+    >
+  | ZodIntersection<
+      AnyZodObject,
+      ZodDiscriminatedUnionOptionBase<Discriminator, DiscriminatorValue>
+    >;
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
@@ -2224,7 +2239,6 @@ export class ZodDiscriminatedUnion<
       ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>,
       ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>,
       ...ZodDiscriminatedUnionOption<Discriminator, DiscriminatorValue>[]
-      // TODO do I need to add a Intersection Type here ?
     ]
   >(
     discriminator: Discriminator,
@@ -2237,21 +2251,17 @@ export class ZodDiscriminatedUnion<
     try {
       types.forEach((type) => {
         if (type instanceof ZodIntersection) {
-          // @ts-ignore
           if (
             type._def.left instanceof ZodObject &&
             !(type._def.right instanceof ZodObject)
           ) {
-            // @ts-ignore
             const discriminatorValue =
               type._def.left.shape[discriminator].value;
             options.set(discriminatorValue, type);
-            // @ts-ignore
           } else if (
             !(type._def.left instanceof ZodObject) &&
             type._def.right instanceof ZodObject
           ) {
-            // @ts-ignore
             const discriminatorValue =
               type._def.right.shape[discriminator].value;
             options.set(discriminatorValue, type);


### PR DESCRIPTION
### Beforehand

This is not done! This is a WIP!

Hopefully it is okay to start a Draft Pull Request because this shouldn't be merged in it's current state 

### Why

For my Application I need a `discriminatedUnion` and one of the Schemas is not a `ZodObject` but a `ZodIntersection`. I tried a few different ways to to get around using a `ZodIntersection` but I couldn't. Sadly, a simple `ZodUnion` doesn't work for me since I use `react-hook-form` and without the `ZodDiscriminatedUnion` the resolver doesn't properly find the "path" and doesn't show the correct Error Messages.

Before I started looking into the `zod` Source Code, I started a [Discussion](https://github.com/colinhacks/zod/discussions/1274) and asked a question in [Discord](https://discord.com/channels/893487829802418277/893488038477434881/1004278879608913931).

Without any solution I delved into the Source Code and might've come up with a Solution.

### Solution

Inside the `create` Method when we iterate over the `types` I do the following ...

```typescript
types.forEach((type) => {
  // if type is an instanceof ZodIntersection, 
  // we check if only the left OR right side is of type ZodObject and extract the discriminatorValue from there
  // this could be improved and allow left and right to be ZodObject BUT we'd need to make sure only one has the discriminator
  if (type instanceof ZodIntersection) {
    if (type._def.left instanceof ZodObject && !(type._def.right instanceof ZodObject)) {
      const discriminatorValue = type._def.left.shape[discriminator].value;
      options.set(discriminatorValue, type);
    } else if (!(type._def.left instanceof ZodObject) && type._def.right instanceof ZodObject) {
      const discriminatorValue = type._def.right.shape[discriminator].value;
      options.set(discriminatorValue, type);
    }
  } else {
    const discriminatorValue = type.shape[discriminator].value;
    options.set(discriminatorValue, type);
  }
});
```

I added a test and tested it inside my Application and can't see any Issues but maybe you have some concerns or there are Sideeffects that I can't see right now.

If this is something that desired, I'd be willing to add more tests and try to improve the typing since right now it still expects `type` to be a `ZodObject`.