### PR TITLE
Update readme keyof typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,7 +799,7 @@ Dog.shape.age; // => number schema
 
 ### `.keyof`
 
-Use `.key` to create a `ZodEnum` schema from the keys of an object schema.
+Use `.keyof` to create a `ZodEnum` schema from the keys of an object schema.
 
 ```ts
 const keySchema = Dog.keyof();


### PR DESCRIPTION
Update: Use `.keyof` to create a `ZodEnum` schema from the keys of an object schema.

closes https://github.com/colinhacks/zod/issues/1326