### PR TITLE
Replace `ZodObject.keyof()` with `z.keyof()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@
   - [.promise](#promise)
   - [.or](#or)
   - [.and](#and)
+- [Keyof](#zkeyof)
 - [Guides and concepts](#guides-and-concepts)
   - [Type inference](#type-inference)
   - [Writing generic functions](#writing-generic-functions)
@@ -795,15 +796,6 @@ Use `.shape` to access the schemas for a particular key.
 ```ts
 Dog.shape.name; // => string schema
 Dog.shape.age; // => number schema
-```
-
-### `.keyof`
-
-Use `.key` to create a `ZodEnum` schema from the keys of an object schema.
-
-```ts
-const keySchema = Dog.keyof();
-keySchema; // ZodEnum<["name", "age"]>
 ```
 
 ### `.extend`
@@ -1918,6 +1910,16 @@ type Cat = z.infer<typeof Cat>;
 ```
 
 Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
+
+## `z.keyof`
+
+Use `z.keyof()` to create a `ZodEnum` schema from the keys of an object schema.
+
+```ts
+const objectSchema = z.object({ foo: z.string(), bar: z.number() });
+const keySchema = z.keyof(objectSchema);
+keySchema; // ZodEnum<["foo", "bar"]>
+```
 
 ## Guides and concepts
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -107,6 +107,7 @@
   - [.promise](#promise)
   - [.or](#or)
   - [.and](#and)
+- [Keyof](#zkeyof)
 - [Guides and concepts](#guides-and-concepts)
   - [Type inference](#type-inference)
   - [Writing generic functions](#writing-generic-functions)
@@ -795,15 +796,6 @@ Use `.shape` to access the schemas for a particular key.
 ```ts
 Dog.shape.name; // => string schema
 Dog.shape.age; // => number schema
-```
-
-### `.keyof`
-
-Use `.key` to create a `ZodEnum` schema from the keys of an object schema.
-
-```ts
-const keySchema = Dog.keyof();
-keySchema; // ZodEnum<["name", "age"]>
 ```
 
 ### `.extend`
@@ -1918,6 +1910,16 @@ type Cat = z.infer<typeof Cat>;
 ```
 
 Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
+
+## `z.keyof`
+
+Use `z.keyof()` to create a `ZodEnum` schema from the keys of an object schema.
+
+```ts
+const objectSchema = z.object({ foo: z.string(), bar: z.number() });
+const keySchema = z.keyof(objectSchema);
+keySchema; // ZodEnum<["foo", "bar"]>
+```
 
 ## Guides and concepts
 

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -233,7 +233,7 @@ test("inferred unioned object type with optional properties", async () => {
 });
 
 test("inferred enum type", async () => {
-  const Enum = z.object({ a: z.string(), b: z.string().optional() }).keyof();
+  const Enum = z.keyof(z.object({ a: z.string(), b: z.string().optional() }));
 
   expect(Enum.Values).toEqual({
     a: "a",

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -365,3 +365,19 @@ test("constructor key", () => {
   type Example = z.infer<typeof Example>;
   util.assertEqual<keyof Example, "prop" | "opt" | "arr">(true);
 });
+
+test("structural assignability", () => {
+  // See: https://github.com/colinhacks/zod/issues/1292
+
+  // The `{ foo: string }` intersection is necessary for this to fail for some reason.  The issue
+  // linked above explains.
+  type superset = { foo: string } & z.ZodObject<{
+    prop1: z.ZodString;
+    prop2: z.ZodNumber;
+  }>;
+
+  type subset = z.ZodObject<{ prop1: z.ZodString }>;
+
+  util.assertAssignable<superset, subset>(true);
+  util.assertAssignable<subset, superset>(false);
+});

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -5,7 +5,11 @@ export namespace util {
     ? true
     : false;
 
+  // Checks that `T` is assignable to `U`.
+  type AssertAssignable<T, U> = T extends U ? true : false;
+
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
+  export const assertAssignable = <A, B>(val: AssertAssignable<A, B>) => val;
   export function assertIs<T>(_arg: T): void {}
   export function assertNever(_x: never): never {
     throw new Error();

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1638,6 +1638,14 @@ function deepPartialify(schema: ZodTypeAny): any {
   }
 }
 
+export function keyof<T extends ZodRawShape>(
+  schema: ZodObject<T, any, any, any, any>
+): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
+  return createZodEnum(
+    util.objectKeys(schema.shape) as [string, ...string[]]
+  ) as any;
+}
+
 export class ZodObject<
   T extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = "strip",
@@ -1939,12 +1947,6 @@ export class ZodObject<
       ...this._def,
       shape: () => newShape,
     }) as any;
-  }
-
-  keyof(): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
-    return createZodEnum(
-      util.objectKeys(this.shape) as [string, ...string[]]
-    ) as any;
   }
 
   static create = <T extends ZodRawShape>(

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -232,7 +232,7 @@ test("inferred unioned object type with optional properties", async () => {
 });
 
 test("inferred enum type", async () => {
-  const Enum = z.object({ a: z.string(), b: z.string().optional() }).keyof();
+  const Enum = z.keyof(z.object({ a: z.string(), b: z.string().optional() }));
 
   expect(Enum.Values).toEqual({
     a: "a",

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -364,3 +364,19 @@ test("constructor key", () => {
   type Example = z.infer<typeof Example>;
   util.assertEqual<keyof Example, "prop" | "opt" | "arr">(true);
 });
+
+test("structural assignability", () => {
+  // See: https://github.com/colinhacks/zod/issues/1292
+
+  // The `{ foo: string }` intersection is necessary for this to fail for some reason.  The issue
+  // linked above explains.
+  type superset = { foo: string } & z.ZodObject<{
+    prop1: z.ZodString;
+    prop2: z.ZodNumber;
+  }>;
+
+  type subset = z.ZodObject<{ prop1: z.ZodString }>;
+
+  util.assertAssignable<superset, subset>(true);
+  util.assertAssignable<subset, superset>(false);
+});

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -5,7 +5,11 @@ export namespace util {
     ? true
     : false;
 
+  // Checks that `T` is assignable to `U`.
+  type AssertAssignable<T, U> = T extends U ? true : false;
+
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
+  export const assertAssignable = <A, B>(val: AssertAssignable<A, B>) => val;
   export function assertIs<T>(_arg: T): void {}
   export function assertNever(_x: never): never {
     throw new Error();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1638,6 +1638,14 @@ function deepPartialify(schema: ZodTypeAny): any {
   }
 }
 
+export function keyof<T extends ZodRawShape>(
+  schema: ZodObject<T, any, any, any, any>
+): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
+  return createZodEnum(
+    util.objectKeys(schema.shape) as [string, ...string[]]
+  ) as any;
+}
+
 export class ZodObject<
   T extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = "strip",
@@ -1939,12 +1947,6 @@ export class ZodObject<
       ...this._def,
       shape: () => newShape,
     }) as any;
-  }
-
-  keyof(): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
-    return createZodEnum(
-      util.objectKeys(this.shape) as [string, ...string[]]
-    ) as any;
   }
 
   static create = <T extends ZodRawShape>(


### PR DESCRIPTION
Minimal alternative to #1347.

This is a breaking change, which I introduced to revert the accidental breaking change described in #1292.

I have replaced the `ZodObject.keyof()` method with a `z.keyof()` helper function.  They work similarly:

```ts
const schema = z.object({ a: z.string(), b: z.number() });
// BEFORE:
schema.keyof(); // ZodEnum<["a", "b"]>
// AFTER:
z.keyof(schema) // ZodEnum<["a", "b"]>
```

I also added a test case for the problem described in #1292.  Removing `ZodObject.keyof()` is required to fix the assignability problem.

I will also propose an alternative PR that expands `z.keyof()` to work with other schemas, not just `ZodObject` (#1347)

cc @ecyrbe.