### PR TITLE
Replace `ZodObject.keyof()` with comprehensive `z.keyof()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@
   - [.promise](#promise)
   - [.or](#or)
   - [.and](#and)
+- [Keyof](#zkeyof)
 - [Guides and concepts](#guides-and-concepts)
   - [Type inference](#type-inference)
   - [Writing generic functions](#writing-generic-functions)
@@ -795,15 +796,6 @@ Use `.shape` to access the schemas for a particular key.
 ```ts
 Dog.shape.name; // => string schema
 Dog.shape.age; // => number schema
-```
-
-### `.keyof`
-
-Use `.key` to create a `ZodEnum` schema from the keys of an object schema.
-
-```ts
-const keySchema = Dog.keyof();
-keySchema; // ZodEnum<["name", "age"]>
 ```
 
 ### `.extend`
@@ -1918,6 +1910,19 @@ type Cat = z.infer<typeof Cat>;
 ```
 
 Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
+
+## `z.keyof`
+
+Use `z.keyof()` to create a `ZodEnum` schema from the keys of any object-like schema, including intersections.  This method behaves similarly to TypeScript's `keyof` operator.
+
+```ts
+const schema = z.intersection(
+  z.object({ foo: z.string() }),
+  z.object({ bar: z.number() }),
+)
+const keySchema = z.keyof(schema);
+keySchema; // ZodEnum<["foo", "bar"]>
+```
 
 ## Guides and concepts
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -107,6 +107,7 @@
   - [.promise](#promise)
   - [.or](#or)
   - [.and](#and)
+- [Keyof](#zkeyof)
 - [Guides and concepts](#guides-and-concepts)
   - [Type inference](#type-inference)
   - [Writing generic functions](#writing-generic-functions)
@@ -795,15 +796,6 @@ Use `.shape` to access the schemas for a particular key.
 ```ts
 Dog.shape.name; // => string schema
 Dog.shape.age; // => number schema
-```
-
-### `.keyof`
-
-Use `.key` to create a `ZodEnum` schema from the keys of an object schema.
-
-```ts
-const keySchema = Dog.keyof();
-keySchema; // ZodEnum<["name", "age"]>
 ```
 
 ### `.extend`
@@ -1918,6 +1910,19 @@ type Cat = z.infer<typeof Cat>;
 ```
 
 Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
+
+## `z.keyof`
+
+Use `z.keyof()` to create a `ZodEnum` schema from the keys of any object-like schema, including intersections.  This method behaves similarly to TypeScript's `keyof` operator.
+
+```ts
+const schema = z.intersection(
+  z.object({ foo: z.string() }),
+  z.object({ bar: z.number() }),
+)
+const keySchema = z.keyof(schema);
+keySchema; // ZodEnum<["foo", "bar"]>
+```
 
 ## Guides and concepts
 

--- a/deno/lib/__tests__/keyof.test.ts
+++ b/deno/lib/__tests__/keyof.test.ts
@@ -84,6 +84,16 @@ test("keyof enum for lazy object schema", async () => {
   util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
 });
 
+test("keyof enum for object schema wrapped in effect", async () => {
+  const schema = z
+    .object({ a: z.string(), b: z.string().optional() })
+    .refine((o) => o.a === o.b);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
 test("keyof enum for optional object schema", async () => {
   const schema = z
     .object({ a: z.string(), b: z.string().optional() })

--- a/deno/lib/__tests__/keyof.test.ts
+++ b/deno/lib/__tests__/keyof.test.ts
@@ -1,0 +1,144 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { util } from "../helpers/util.ts";
+import * as z from "../index.ts";
+
+function expectEnumToHaveOptions(Enum: z.ZodEnum<any>, keys: string[]): void {
+  const values = Object.fromEntries(keys.map((k) => [k, k]));
+  expect(Enum.Values).toStrictEqual(values);
+  expect(Enum.enum).toStrictEqual(values);
+  expect(Enum._def.values).toStrictEqual(keys);
+}
+
+test("keyof enum for object", async () => {
+  const schema = z.object({ a: z.string(), b: z.string().optional() });
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for object intersection", async () => {
+  const schema = z.intersection(
+    z.object({ a: z.string(), b: z.string().optional() }),
+    z.object({ c: z.string(), d: z.string().optional() })
+  );
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b", "c", "d"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for overlapping object union", async () => {
+  const schema = z.union([
+    z.object({ a: z.string(), b: z.string().optional() }),
+    z.object({ a: z.string(), c: z.string() }),
+  ]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for non-overlapping object union", async () => {
+  const schema = z.union([
+    z.object({ a: z.string(), b: z.string().optional() }),
+    z.object({ c: z.string(), d: z.string() }),
+  ]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for discriminated union", async () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), a: z.string(), b: z.string().optional() }),
+    z.object({ type: z.literal("b"), a: z.string(), c: z.string() }),
+  ]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["type", "a"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for object schema with default value", async () => {
+  const schema = z
+    .object({ a: z.string(), b: z.string().optional() })
+    .default({ a: "" });
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for lazy object schema", async () => {
+  const schema = z.lazy(() =>
+    z.object({ a: z.string(), b: z.string().optional() })
+  );
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for optional object schema", async () => {
+  const schema = z
+    .object({ a: z.string(), b: z.string().optional() })
+    .optional();
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for nullable object schema", async () => {
+  const schema = z
+    .object({ a: z.string(), b: z.string().nullable() })
+    .optional();
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for primitive schema", async () => {
+  const schema = z.string();
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  // NOTE: We're choosing not to return `ZodEnum<["charAt", "length", ...]>` here.
+  util.assertEqual<Enum, never>(true);
+});
+
+test("keyof enum for array schema", async () => {
+  const schema = z.array(z.string());
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  // NOTE: We're choosing not to return `ZodEnum<["map", "length", ...]>` here.
+  util.assertEqual<Enum, never>(true);
+});
+
+test("keyof enum for union of object with array", async () => {
+  const schema = z.union([
+    z.object({
+      a: z.string(),
+    }),
+    z.array(z.string()),
+  ]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, never>(true);
+});
+
+test("keyof enum for union of primitive and array", async () => {
+  const schema = z.union([z.string(), z.array(z.string())]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, never>(true);
+});

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -233,7 +233,7 @@ test("inferred unioned object type with optional properties", async () => {
 });
 
 test("inferred enum type", async () => {
-  const Enum = z.object({ a: z.string(), b: z.string().optional() }).keyof();
+  const Enum = z.keyof(z.object({ a: z.string(), b: z.string().optional() }));
 
   expect(Enum.Values).toEqual({
     a: "a",

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -365,3 +365,19 @@ test("constructor key", () => {
   type Example = z.infer<typeof Example>;
   util.assertEqual<keyof Example, "prop" | "opt" | "arr">(true);
 });
+
+test("structural assignability", () => {
+  // See: https://github.com/colinhacks/zod/issues/1292
+
+  // The `{ foo: string }` intersection is necessary for this to fail for some reason.  The issue
+  // linked above explains.
+  type superset = { foo: string } & z.ZodObject<{
+    prop1: z.ZodString;
+    prop2: z.ZodNumber;
+  }>;
+
+  type subset = z.ZodObject<{ prop1: z.ZodString }>;
+
+  util.assertAssignable<superset, subset>(true);
+  util.assertAssignable<subset, superset>(false);
+});

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -232,22 +232,6 @@ test("inferred unioned object type with optional properties", async () => {
   >(true);
 });
 
-test("inferred enum type", async () => {
-  const Enum = z.keyof(z.object({ a: z.string(), b: z.string().optional() }));
-
-  expect(Enum.Values).toEqual({
-    a: "a",
-    b: "b",
-  });
-  expect(Enum.enum).toEqual({
-    a: "a",
-    b: "b",
-  });
-  expect(Enum._def.values).toEqual(["a", "b"]);
-  type Enum = z.infer<typeof Enum>;
-  util.assertEqual<Enum, "a" | "b">(true);
-});
-
 test("inferred partial object type with optional properties", async () => {
   const Partial = z
     .object({ a: z.string(), b: z.string().optional() })

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -5,7 +5,11 @@ export namespace util {
     ? true
     : false;
 
+  // Checks that `T` is assignable to `U`.
+  type AssertAssignable<T, U> = T extends U ? true : false;
+
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
+  export const assertAssignable = <A, B>(val: AssertAssignable<A, B>) => val;
   export function assertIs<T>(_arg: T): void {}
   export function assertNever(_x: never): never {
     throw new Error();

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -88,6 +88,15 @@ export namespace util {
       .map((val) => (typeof val === "string" ? `'${val}'` : val))
       .join(separator);
   }
+
+  export function intersect<T>(...arrays: T[][]): T[] {
+    const [first, ...rest] = arrays;
+    if (!first) {
+      return [];
+    }
+    const sets = rest.map((array) => new Set(array));
+    return first.filter((e) => sets.every((set) => set.has(e)));
+  }
 }
 
 export const ZodParsedType = util.arrayToEnum([

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3784,6 +3784,11 @@ function keyofTuple(schema: ZodTypeAny): string[] {
     return keyofTuple(schema.schema);
   } else if (schema instanceof ZodDefault) {
     return keyofTuple(schema._def.innerType);
+  } else if (schema instanceof ZodEffects) {
+    // NOTE: This is only correct for `ZodEffects` instances that *don't* change the output type
+    // (e.g., simple refinements).  Otherwise it's impossible for us to identify the output type of
+    // a transform (or type-guard refinement) at runtime.
+    return keyofTuple(schema.innerType());
   } else if (schema instanceof ZodIntersection) {
     return [...keyofTuple(schema._def.left), ...keyofTuple(schema._def.right)];
   } else if (schema instanceof ZodUnion) {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3800,7 +3800,7 @@ function keyofTuple(schema: ZodTypeAny): string[] {
 export function keyof<T>(schema: ZodType<T, any, any>): ZodEnum<
   // This condition avoids "possibly infinite" type instantiation.  Wrap in a tuple to avoid
   // distribution over unions.
-  [T] extends [Primitive | readonly any[]]
+  [T] extends [Primitive | Date | Function | readonly any[]]
     ? never
     : enumUtil.UnionToTupleString<keyof T>
 > {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1638,6 +1638,14 @@ function deepPartialify(schema: ZodTypeAny): any {
   }
 }
 
+export function keyof<T extends ZodRawShape>(
+  schema: ZodObject<T, any, any, any, any>
+): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
+  return createZodEnum(
+    util.objectKeys(schema.shape) as [string, ...string[]]
+  ) as any;
+}
+
 export class ZodObject<
   T extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = "strip",
@@ -1939,12 +1947,6 @@ export class ZodObject<
       ...this._def,
       shape: () => newShape,
     }) as any;
-  }
-
-  keyof(): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
-    return createZodEnum(
-      util.objectKeys(this.shape) as [string, ...string[]]
-    ) as any;
   }
 
   static create = <T extends ZodRawShape>(

--- a/src/__tests__/keyof.test.ts
+++ b/src/__tests__/keyof.test.ts
@@ -83,6 +83,16 @@ test("keyof enum for lazy object schema", async () => {
   util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
 });
 
+test("keyof enum for object schema wrapped in effect", async () => {
+  const schema = z
+    .object({ a: z.string(), b: z.string().optional() })
+    .refine((o) => o.a === o.b);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
 test("keyof enum for optional object schema", async () => {
   const schema = z
     .object({ a: z.string(), b: z.string().optional() })

--- a/src/__tests__/keyof.test.ts
+++ b/src/__tests__/keyof.test.ts
@@ -1,0 +1,143 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import { util } from "../helpers/util";
+import * as z from "../index";
+
+function expectEnumToHaveOptions(Enum: z.ZodEnum<any>, keys: string[]): void {
+  const values = Object.fromEntries(keys.map((k) => [k, k]));
+  expect(Enum.Values).toStrictEqual(values);
+  expect(Enum.enum).toStrictEqual(values);
+  expect(Enum._def.values).toStrictEqual(keys);
+}
+
+test("keyof enum for object", async () => {
+  const schema = z.object({ a: z.string(), b: z.string().optional() });
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for object intersection", async () => {
+  const schema = z.intersection(
+    z.object({ a: z.string(), b: z.string().optional() }),
+    z.object({ c: z.string(), d: z.string().optional() })
+  );
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b", "c", "d"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for overlapping object union", async () => {
+  const schema = z.union([
+    z.object({ a: z.string(), b: z.string().optional() }),
+    z.object({ a: z.string(), c: z.string() }),
+  ]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for non-overlapping object union", async () => {
+  const schema = z.union([
+    z.object({ a: z.string(), b: z.string().optional() }),
+    z.object({ c: z.string(), d: z.string() }),
+  ]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for discriminated union", async () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), a: z.string(), b: z.string().optional() }),
+    z.object({ type: z.literal("b"), a: z.string(), c: z.string() }),
+  ]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["type", "a"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for object schema with default value", async () => {
+  const schema = z
+    .object({ a: z.string(), b: z.string().optional() })
+    .default({ a: "" });
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for lazy object schema", async () => {
+  const schema = z.lazy(() =>
+    z.object({ a: z.string(), b: z.string().optional() })
+  );
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, ["a", "b"]);
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for optional object schema", async () => {
+  const schema = z
+    .object({ a: z.string(), b: z.string().optional() })
+    .optional();
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for nullable object schema", async () => {
+  const schema = z
+    .object({ a: z.string(), b: z.string().nullable() })
+    .optional();
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, keyof z.infer<typeof schema>>(true);
+});
+
+test("keyof enum for primitive schema", async () => {
+  const schema = z.string();
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  // NOTE: We're choosing not to return `ZodEnum<["charAt", "length", ...]>` here.
+  util.assertEqual<Enum, never>(true);
+});
+
+test("keyof enum for array schema", async () => {
+  const schema = z.array(z.string());
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  // NOTE: We're choosing not to return `ZodEnum<["map", "length", ...]>` here.
+  util.assertEqual<Enum, never>(true);
+});
+
+test("keyof enum for union of object with array", async () => {
+  const schema = z.union([
+    z.object({
+      a: z.string(),
+    }),
+    z.array(z.string()),
+  ]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, never>(true);
+});
+
+test("keyof enum for union of primitive and array", async () => {
+  const schema = z.union([z.string(), z.array(z.string())]);
+  const Enum = z.keyof(schema);
+  expectEnumToHaveOptions(Enum, []); // never.
+  type Enum = z.infer<typeof Enum>;
+  util.assertEqual<Enum, never>(true);
+});

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -232,7 +232,7 @@ test("inferred unioned object type with optional properties", async () => {
 });
 
 test("inferred enum type", async () => {
-  const Enum = z.object({ a: z.string(), b: z.string().optional() }).keyof();
+  const Enum = z.keyof(z.object({ a: z.string(), b: z.string().optional() }));
 
   expect(Enum.Values).toEqual({
     a: "a",

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -231,22 +231,6 @@ test("inferred unioned object type with optional properties", async () => {
   >(true);
 });
 
-test("inferred enum type", async () => {
-  const Enum = z.keyof(z.object({ a: z.string(), b: z.string().optional() }));
-
-  expect(Enum.Values).toEqual({
-    a: "a",
-    b: "b",
-  });
-  expect(Enum.enum).toEqual({
-    a: "a",
-    b: "b",
-  });
-  expect(Enum._def.values).toEqual(["a", "b"]);
-  type Enum = z.infer<typeof Enum>;
-  util.assertEqual<Enum, "a" | "b">(true);
-});
-
 test("inferred partial object type with optional properties", async () => {
   const Partial = z
     .object({ a: z.string(), b: z.string().optional() })

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -364,3 +364,19 @@ test("constructor key", () => {
   type Example = z.infer<typeof Example>;
   util.assertEqual<keyof Example, "prop" | "opt" | "arr">(true);
 });
+
+test("structural assignability", () => {
+  // See: https://github.com/colinhacks/zod/issues/1292
+
+  // The `{ foo: string }` intersection is necessary for this to fail for some reason.  The issue
+  // linked above explains.
+  type superset = { foo: string } & z.ZodObject<{
+    prop1: z.ZodString;
+    prop2: z.ZodNumber;
+  }>;
+
+  type subset = z.ZodObject<{ prop1: z.ZodString }>;
+
+  util.assertAssignable<superset, subset>(true);
+  util.assertAssignable<subset, superset>(false);
+});

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -5,7 +5,11 @@ export namespace util {
     ? true
     : false;
 
+  // Checks that `T` is assignable to `U`.
+  type AssertAssignable<T, U> = T extends U ? true : false;
+
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
+  export const assertAssignable = <A, B>(val: AssertAssignable<A, B>) => val;
   export function assertIs<T>(_arg: T): void {}
   export function assertNever(_x: never): never {
     throw new Error();

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -88,6 +88,15 @@ export namespace util {
       .map((val) => (typeof val === "string" ? `'${val}'` : val))
       .join(separator);
   }
+
+  export function intersect<T>(...arrays: T[][]): T[] {
+    const [first, ...rest] = arrays;
+    if (!first) {
+      return [];
+    }
+    const sets = rest.map((array) => new Set(array));
+    return first.filter((e) => sets.every((set) => set.has(e)));
+  }
 }
 
 export const ZodParsedType = util.arrayToEnum([

--- a/src/types.ts
+++ b/src/types.ts
@@ -3784,6 +3784,11 @@ function keyofTuple(schema: ZodTypeAny): string[] {
     return keyofTuple(schema.schema);
   } else if (schema instanceof ZodDefault) {
     return keyofTuple(schema._def.innerType);
+  } else if (schema instanceof ZodEffects) {
+    // NOTE: This is only correct for `ZodEffects` instances that *don't* change the output type
+    // (e.g., simple refinements).  Otherwise it's impossible for us to identify the output type of
+    // a transform (or type-guard refinement) at runtime.
+    return keyofTuple(schema.innerType());
   } else if (schema instanceof ZodIntersection) {
     return [...keyofTuple(schema._def.left), ...keyofTuple(schema._def.right)];
   } else if (schema instanceof ZodUnion) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3800,7 +3800,7 @@ function keyofTuple(schema: ZodTypeAny): string[] {
 export function keyof<T>(schema: ZodType<T, any, any>): ZodEnum<
   // This condition avoids "possibly infinite" type instantiation.  Wrap in a tuple to avoid
   // distribution over unions.
-  [T] extends [Primitive | readonly any[]]
+  [T] extends [Primitive | Date | Function | readonly any[]]
     ? never
     : enumUtil.UnionToTupleString<keyof T>
 > {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1638,6 +1638,14 @@ function deepPartialify(schema: ZodTypeAny): any {
   }
 }
 
+export function keyof<T extends ZodRawShape>(
+  schema: ZodObject<T, any, any, any, any>
+): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
+  return createZodEnum(
+    util.objectKeys(schema.shape) as [string, ...string[]]
+  ) as any;
+}
+
 export class ZodObject<
   T extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = "strip",
@@ -1939,12 +1947,6 @@ export class ZodObject<
       ...this._def,
       shape: () => newShape,
     }) as any;
-  }
-
-  keyof(): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
-    return createZodEnum(
-      util.objectKeys(this.shape) as [string, ...string[]]
-    ) as any;
   }
 
   static create = <T extends ZodRawShape>(


### PR DESCRIPTION
Expanded alternative to #1346.

This is a breaking change, which I introduced to revert the accidental breaking change described in #1292.

I have replaced the `ZodObject.keyof()` method with a `z.keyof()` helper function.  Unlike in #1346, this `z.keyof()` helper function works for any object-like schema, such as intersections of objects.  I think this is an improvement to `ZodObject.keyof()`, as it behaves more like TypeScript's `keyof` operator.

```ts
const schema = z.object({ a: z.string(), b: z.number() });
// BEFORE:
schema.keyof(); // ZodEnum<["a", "b"]>
// AFTER:
z.keyof(schema) // ZodEnum<["a", "b"]>
// ALSO WORKS AFTER:
const intersection = z.intersection(
  z.object({ a: z.string() }),
  z.object({ b: z.string() }),
)
z.keyof(intersection) // ZodEnum<["a", "b"]>
```
See the tests for all the supported cases.

I also added a test case for the problem described in #1292.  Removing `ZodObject.keyof()` is required to fix the assignability problem.

cc @ecyrbe.