### PR TITLE
Type refinements

### DIFF
--- a/deno/lib/__tests__/async-parsing.test.ts
+++ b/deno/lib/__tests__/async-parsing.test.ts
@@ -264,11 +264,10 @@ test("enum async parse", async () => {
 enum nativeEnumTest {
   asdf = "qwer",
 }
-// @ts-ignore
-const nativeEnumSchema = z.nativeEnum(nativeEnumTest);
+const nativeEnumSchema = z.nativeEnum<typeof nativeEnumTest>(nativeEnumTest);
 test("nativeEnum async parse", async () => {
   const goodData = nativeEnumTest.asdf;
-  const badData = "asdf";
+  const badData: keyof typeof nativeEnumTest = "asdf";
 
   const goodResult = await nativeEnumSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);

--- a/deno/lib/__tests__/bigint.test.ts
+++ b/deno/lib/__tests__/bigint.test.ts
@@ -6,11 +6,16 @@ import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
 
 test("type guard", () => {
-  const stringToNumber = z.string().transform((arg) => BigInt(Number.MAX_SAFE_INTEGER**(arg.length > 1 ? arg.length : 2)));
+  const stringToNumber = z
+    .string()
+    .transform<bigint>((arg) =>
+      BigInt(Number.MAX_SAFE_INTEGER ** (arg.length > 1 ? arg.length : 2))
+    );
 
   const s1 = z.object({
     stringToNumber
   });
+  
   type t1 = z.input<typeof s1>;
 
   const data = { stringToNumber: "asdf" };

--- a/deno/lib/__tests__/bigint.test.ts
+++ b/deno/lib/__tests__/bigint.test.ts
@@ -1,0 +1,30 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { util } from "../helpers/util.ts";
+import * as z from "../index.ts";
+
+test("type guard", () => {
+  const stringToNumber = z.string().transform((arg) => BigInt(Number.MAX_SAFE_INTEGER**(arg.length > 1 ? arg.length : 2)));
+
+  const s1 = z.object({
+    stringToNumber
+  });
+  type t1 = z.input<typeof s1>;
+
+  const data = { stringToNumber: "asdf" };
+  const parsed = s1.safeParse(data);
+  if (parsed.success) {
+    util.assertEqual<typeof data, t1>(true);
+  }
+});
+
+test("test this binding", () => {
+  const callback = (predicate: (val: string) => boolean) => {
+    return predicate("hello");
+  };
+
+  expect(callback((value) => z.string().safeParse(value).success)).toBe(true); // true
+  expect(callback((value) => z.string().safeParse(value).success)).toBe(true); // true
+});

--- a/deno/lib/__tests__/promise.test.ts
+++ b/deno/lib/__tests__/promise.test.ts
@@ -27,14 +27,14 @@ test("promise parsing success", async () => {
   expect(typeof result.age).toBe("number");
   expect(typeof result.name).toBe("string");
 });
-
+// this reduced testing time substantially (adding .then and .catch to this returned in fakePromise)
 test("promise parsing success 2", () => {
   const fakePromise = {
     then() {
-      return this;
+      return this.then;
     },
     catch() {
-      return this;
+      return this.catch;
     },
   };
   promSchema.parse(fakePromise);

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -48,16 +48,15 @@ export namespace util {
   export const objectKeys: {
     (...args: [o: Record<string, unknown>]): string[];
   } = Array.of<string>()
-      ? (obj: object | Record<string, unknown>) =>
+      ? (obj: Record<string, unknown>) =>
         Object.entries(obj)
-          .map(([x]) => x)
-          .map((val) => val)
-      : (object: Record<string, any>) => {
+          .map(([x, _vals]) => x)
+      : (object: Record<string, unknown>) => {
         const keys = Array.of<string>();
         for (const key in object) {
           if (
             Object.prototype.hasOwnProperty.call<
-              Record<string, any>,
+              Record<string, unknown>,
               [string],
               boolean
             >(object, key)

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -123,7 +123,7 @@ export const ZodParsedType = util.arrayToEnum([
 
 export type ZodParsedType = keyof typeof ZodParsedType;
 
-export const getParsedType = (data: any): ZodParsedType => {
+export const getParsedType = (data: unknown): ZodParsedType => {
   const t = typeof data;
 
   switch (t) {
@@ -134,7 +134,7 @@ export const getParsedType = (data: any): ZodParsedType => {
       return ZodParsedType.string;
 
     case "number":
-      return isNaN(data) ? ZodParsedType.nan : ZodParsedType.number;
+      return typeof data === "number" && isNaN(data) ? ZodParsedType.nan : ZodParsedType.number;
 
     case "boolean":
       return ZodParsedType.boolean;
@@ -153,10 +153,11 @@ export const getParsedType = (data: any): ZodParsedType => {
         return ZodParsedType.null;
       }
       if (
-        data.then &&
-        typeof data.then === "function" &&
-        data.catch &&
-        typeof data.catch === "function"
+        (data as ReturnType<typeof Promise["any"]>).then &&
+        typeof (data as ReturnType<typeof Promise["any"]>).then ===
+          "function" &&
+        (data as ReturnType<typeof Promise["any"]>).catch &&
+        typeof (data as ReturnType<typeof Promise["any"]>).catch === "function"
       ) {
         return ZodParsedType.promise;
       }

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -86,7 +86,7 @@ export namespace util {
     typeof Number.isInteger === "function"
       ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
       : (val) =>
-        /// ~~(val: number) === Math.floor(val: number); ~~(val: number) is more performant
+        /// ~~(val: number) === Math.floor(val: number); ~~(val: number) is more performant 
         typeof val === "number" && isFinite(val) && ~~(val) === val;
 
   export function joinValues<T extends any[]>(

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -19,7 +19,7 @@ export namespace util {
   export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
     items: U
   ): { [k in U[number]]: k } => {
-    const obj: any = {};
+    const obj: {[k in U[number]]: k;} = Object.prototype.constructor();
     for (const item of items) {
       obj[item] = item;
     }
@@ -43,11 +43,13 @@ export namespace util {
     });
   };
 
-  export const objectKeys: ObjectConstructor["keys"] =
-    typeof Object.keys === "function" // eslint-disable-line ban/ban
-      ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
-      : (object: any) => {
-          const keys = [];
+  export const objectKeys: {
+    (o: object): string[];
+    (o: {}): string[];
+}= Array.of<string>()
+      ? (obj: Record<string, any>) => Object.entries(obj).map(([x]) => x).map(val => val)
+      : (object: Record<string, any>) => {
+          const keys = Array.of<string>();
           for (const key in object) {
             if (Object.prototype.hasOwnProperty.call(object, key)) {
               keys.push(key);

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -1,12 +1,12 @@
 export namespace util {
   type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
     V
-  >() => V extends U ? 1 : 2
+    >() => V extends U ? 1 : 2
     ? true
     : false;
 
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
-  export function assertIs<T>(_arg: T): void {}
+  export function assertIs<T>(_arg: T): void { }
   export function assertNever(_x: never): never {
     throw new Error();
   }
@@ -19,44 +19,54 @@ export namespace util {
   export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
     items: U
   ): { [k in U[number]]: k } => {
-    const obj: {[k in U[number]]: k;} = Object.prototype.constructor();
+    const obj: { [k in U[number]]: k } = Object.prototype.constructor();
     for (const item of items) {
       obj[item] = item;
     }
-    return obj as any;
+    return obj as { [k in U[number]]: k };
   };
 
-  export const getValidEnumValues = (obj: any) => {
-    const validKeys = objectKeys(obj).filter(
-      (k: any) => typeof obj[obj[k]] !== "number"
+  export const getValidEnumValues = (
+    obj: Record<string, string | number>): (string | number)[] => {
+    const validKeys: string[] = objectKeys(obj).filter(
+      (k) => typeof obj[obj[k]] !== "number"
     );
-    const filtered: any = {};
+    const filtered: Record<string, string | number> = {}
     for (const k of validKeys) {
       filtered[k] = obj[k];
     }
     return objectValues(filtered);
   };
-
-  export const objectValues = (obj: any) => {
-    return objectKeys(obj).map(function (e) {
-      return obj[e];
+  
+  export const objectValues = (
+    (obj: Record<string, string | number>) => {
+      return objectKeys(obj).map<string | number>((e, i) => {
+        return ({ [i]: obj[e] }[i++]);
+      })
     });
-  };
 
   export const objectKeys: {
-    (o: object): string[];
-    (o: {}): string[];
-}= Array.of<string>()
-      ? (obj: Record<string, any>) => Object.entries(obj).map(([x]) => x).map(val => val)
+    (...args: [o: Record<string, unknown>]): string[];
+  } = Array.of<string>()
+      ? (obj: object | Record<string, unknown>) =>
+        Object.entries(obj)
+          .map(([x]) => x)
+          .map((val) => val)
       : (object: Record<string, any>) => {
-          const keys = Array.of<string>();
-          for (const key in object) {
-            if (Object.prototype.hasOwnProperty.call(object, key)) {
-              keys.push(key);
-            }
+        const keys = Array.of<string>();
+        for (const key in object) {
+          if (
+            Object.prototype.hasOwnProperty.call<
+              Record<string, any>,
+              [string],
+              boolean
+            >(object, key)
+          ) {
+            keys.push(key);
           }
-          return keys;
-        };
+        }
+        return keys;
+      };
 
   export const find = <T>(
     arr: T[],
@@ -76,7 +86,8 @@ export namespace util {
     typeof Number.isInteger === "function"
       ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
       : (val) =>
-          typeof val === "number" && isFinite(val) && Math.floor(val) === val;
+        /// ~~(val: number) === Math.floor(val: number); ~~(val: number) is more performant
+        typeof val === "number" && isFinite(val) && ~~(val) === val;
 
   export function joinValues<T extends any[]>(
     array: T,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3261,7 +3261,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       ctx.parsedType !== ZodParsedType.string &&
       ctx.parsedType !== ZodParsedType.number
     ) {
-      const expectedValues = util.objectValues(nativeEnumValues);
+      const expectedValues = util.objectValues(this._def.values);
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,
@@ -3271,12 +3271,14 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     }
 
     if (nativeEnumValues.indexOf(input.data) === -1) {
-      const expectedValues = util.objectValues(nativeEnumValues);
+      const expectedValues = util.objectValues(
+        Object.prototype.constructor({ ...nativeEnumValues })
+      );
 
       addIssueToContext(ctx, {
         received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
-        options: expectedValues,
+        options: expectedValues.map((val) => val),
       });
       return INVALID;
     }

--- a/src/__tests__/async-parsing.test.ts
+++ b/src/__tests__/async-parsing.test.ts
@@ -263,11 +263,10 @@ test("enum async parse", async () => {
 enum nativeEnumTest {
   asdf = "qwer",
 }
-// @ts-ignore
-const nativeEnumSchema = z.nativeEnum(nativeEnumTest);
+const nativeEnumSchema = z.nativeEnum<typeof nativeEnumTest>(nativeEnumTest);
 test("nativeEnum async parse", async () => {
   const goodData = nativeEnumTest.asdf;
-  const badData = "asdf";
+  const badData: keyof typeof nativeEnumTest = "asdf";
 
   const goodResult = await nativeEnumSchema.safeParseAsync(goodData);
   expect(goodResult.success).toBe(true);

--- a/src/__tests__/bigint.test.ts
+++ b/src/__tests__/bigint.test.ts
@@ -5,11 +5,16 @@ import { util } from "../helpers/util";
 import * as z from "../index";
 
 test("type guard", () => {
-  const stringToNumber = z.string().transform((arg) => BigInt(Number.MAX_SAFE_INTEGER**(arg.length > 1 ? arg.length : 2)));
+  const stringToNumber = z
+    .string()
+    .transform<bigint>((arg) =>
+      BigInt(Number.MAX_SAFE_INTEGER ** (arg.length > 1 ? arg.length : 2))
+    );
 
   const s1 = z.object({
     stringToNumber
   });
+  
   type t1 = z.input<typeof s1>;
 
   const data = { stringToNumber: "asdf" };

--- a/src/__tests__/bigint.test.ts
+++ b/src/__tests__/bigint.test.ts
@@ -1,0 +1,29 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import { util } from "../helpers/util";
+import * as z from "../index";
+
+test("type guard", () => {
+  const stringToNumber = z.string().transform((arg) => BigInt(Number.MAX_SAFE_INTEGER**(arg.length > 1 ? arg.length : 2)));
+
+  const s1 = z.object({
+    stringToNumber
+  });
+  type t1 = z.input<typeof s1>;
+
+  const data = { stringToNumber: "asdf" };
+  const parsed = s1.safeParse(data);
+  if (parsed.success) {
+    util.assertEqual<typeof data, t1>(true);
+  }
+});
+
+test("test this binding", () => {
+  const callback = (predicate: (val: string) => boolean) => {
+    return predicate("hello");
+  };
+
+  expect(callback((value) => z.string().safeParse(value).success)).toBe(true); // true
+  expect(callback((value) => z.string().safeParse(value).success)).toBe(true); // true
+});

--- a/src/__tests__/promise.test.ts
+++ b/src/__tests__/promise.test.ts
@@ -26,14 +26,14 @@ test("promise parsing success", async () => {
   expect(typeof result.age).toBe("number");
   expect(typeof result.name).toBe("string");
 });
-
+// this reduced testing time substantially (adding .then and .catch to this returned in fakePromise)
 test("promise parsing success 2", () => {
   const fakePromise = {
     then() {
-      return this;
+      return this.then;
     },
     catch() {
-      return this;
+      return this.catch;
     },
   };
   promSchema.parse(fakePromise);

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -48,16 +48,15 @@ export namespace util {
   export const objectKeys: {
     (...args: [o: Record<string, unknown>]): string[];
   } = Array.of<string>()
-      ? (obj: object | Record<string, unknown>) =>
+      ? (obj: Record<string, unknown>) =>
         Object.entries(obj)
-          .map(([x]) => x)
-          .map((val) => val)
-      : (object: Record<string, any>) => {
+          .map(([x, _vals]) => x)
+      : (object: Record<string, unknown>) => {
         const keys = Array.of<string>();
         for (const key in object) {
           if (
             Object.prototype.hasOwnProperty.call<
-              Record<string, any>,
+              Record<string, unknown>,
               [string],
               boolean
             >(object, key)

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -123,7 +123,7 @@ export const ZodParsedType = util.arrayToEnum([
 
 export type ZodParsedType = keyof typeof ZodParsedType;
 
-export const getParsedType = (data: any): ZodParsedType => {
+export const getParsedType = (data: unknown): ZodParsedType => {
   const t = typeof data;
 
   switch (t) {
@@ -134,7 +134,7 @@ export const getParsedType = (data: any): ZodParsedType => {
       return ZodParsedType.string;
 
     case "number":
-      return isNaN(data) ? ZodParsedType.nan : ZodParsedType.number;
+      return typeof data === "number" && isNaN(data) ? ZodParsedType.nan : ZodParsedType.number;
 
     case "boolean":
       return ZodParsedType.boolean;
@@ -153,10 +153,11 @@ export const getParsedType = (data: any): ZodParsedType => {
         return ZodParsedType.null;
       }
       if (
-        data.then &&
-        typeof data.then === "function" &&
-        data.catch &&
-        typeof data.catch === "function"
+        (data as ReturnType<typeof Promise["any"]>).then &&
+        typeof (data as ReturnType<typeof Promise["any"]>).then ===
+          "function" &&
+        (data as ReturnType<typeof Promise["any"]>).catch &&
+        typeof (data as ReturnType<typeof Promise["any"]>).catch === "function"
       ) {
         return ZodParsedType.promise;
       }

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -86,7 +86,7 @@ export namespace util {
     typeof Number.isInteger === "function"
       ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
       : (val) =>
-        /// ~~(val: number) === Math.floor(val: number); ~~(val: number) is more performant
+        /// ~~(val: number) === Math.floor(val: number); ~~(val: number) is more performant 
         typeof val === "number" && isFinite(val) && ~~(val) === val;
 
   export function joinValues<T extends any[]>(

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -19,7 +19,7 @@ export namespace util {
   export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
     items: U
   ): { [k in U[number]]: k } => {
-    const obj: any = {};
+    const obj: {[k in U[number]]: k;} = Object.prototype.constructor();
     for (const item of items) {
       obj[item] = item;
     }
@@ -43,11 +43,13 @@ export namespace util {
     });
   };
 
-  export const objectKeys: ObjectConstructor["keys"] =
-    typeof Object.keys === "function" // eslint-disable-line ban/ban
-      ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
-      : (object: any) => {
-          const keys = [];
+  export const objectKeys: {
+    (o: object): string[];
+    (o: {}): string[];
+}= Array.of<string>()
+      ? (obj: Record<string, any>) => Object.entries(obj).map(([x]) => x).map(val => val)
+      : (object: Record<string, any>) => {
+          const keys = Array.of<string>();
           for (const key in object) {
             if (Object.prototype.hasOwnProperty.call(object, key)) {
               keys.push(key);

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,12 +1,12 @@
 export namespace util {
   type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
     V
-  >() => V extends U ? 1 : 2
+    >() => V extends U ? 1 : 2
     ? true
     : false;
 
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
-  export function assertIs<T>(_arg: T): void {}
+  export function assertIs<T>(_arg: T): void { }
   export function assertNever(_x: never): never {
     throw new Error();
   }
@@ -19,44 +19,54 @@ export namespace util {
   export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
     items: U
   ): { [k in U[number]]: k } => {
-    const obj: {[k in U[number]]: k;} = Object.prototype.constructor();
+    const obj: { [k in U[number]]: k } = Object.prototype.constructor();
     for (const item of items) {
       obj[item] = item;
     }
-    return obj as any;
+    return obj as { [k in U[number]]: k };
   };
 
-  export const getValidEnumValues = (obj: any) => {
-    const validKeys = objectKeys(obj).filter(
-      (k: any) => typeof obj[obj[k]] !== "number"
+  export const getValidEnumValues = (
+    obj: Record<string, string | number>): (string | number)[] => {
+    const validKeys: string[] = objectKeys(obj).filter(
+      (k) => typeof obj[obj[k]] !== "number"
     );
-    const filtered: any = {};
+    const filtered: Record<string, string | number> = {}
     for (const k of validKeys) {
       filtered[k] = obj[k];
     }
     return objectValues(filtered);
   };
-
-  export const objectValues = (obj: any) => {
-    return objectKeys(obj).map(function (e) {
-      return obj[e];
+  
+  export const objectValues = (
+    (obj: Record<string, string | number>) => {
+      return objectKeys(obj).map<string | number>((e, i) => {
+        return ({ [i]: obj[e] }[i++]);
+      })
     });
-  };
 
   export const objectKeys: {
-    (o: object): string[];
-    (o: {}): string[];
-}= Array.of<string>()
-      ? (obj: Record<string, any>) => Object.entries(obj).map(([x]) => x).map(val => val)
+    (...args: [o: Record<string, unknown>]): string[];
+  } = Array.of<string>()
+      ? (obj: object | Record<string, unknown>) =>
+        Object.entries(obj)
+          .map(([x]) => x)
+          .map((val) => val)
       : (object: Record<string, any>) => {
-          const keys = Array.of<string>();
-          for (const key in object) {
-            if (Object.prototype.hasOwnProperty.call(object, key)) {
-              keys.push(key);
-            }
+        const keys = Array.of<string>();
+        for (const key in object) {
+          if (
+            Object.prototype.hasOwnProperty.call<
+              Record<string, any>,
+              [string],
+              boolean
+            >(object, key)
+          ) {
+            keys.push(key);
           }
-          return keys;
-        };
+        }
+        return keys;
+      };
 
   export const find = <T>(
     arr: T[],
@@ -76,7 +86,8 @@ export namespace util {
     typeof Number.isInteger === "function"
       ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
       : (val) =>
-          typeof val === "number" && isFinite(val) && Math.floor(val) === val;
+        /// ~~(val: number) === Math.floor(val: number); ~~(val: number) is more performant
+        typeof val === "number" && isFinite(val) && ~~(val) === val;
 
   export function joinValues<T extends any[]>(
     array: T,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3261,7 +3261,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       ctx.parsedType !== ZodParsedType.string &&
       ctx.parsedType !== ZodParsedType.number
     ) {
-      const expectedValues = util.objectValues(nativeEnumValues);
+      const expectedValues = util.objectValues(this._def.values);
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,
@@ -3271,12 +3271,14 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     }
 
     if (nativeEnumValues.indexOf(input.data) === -1) {
-      const expectedValues = util.objectValues(nativeEnumValues);
+      const expectedValues = util.objectValues(
+        Object.prototype.constructor({ ...nativeEnumValues })
+      );
 
       addIssueToContext(ctx, {
         received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
-        options: expectedValues,
+        options: expectedValues.map((val) => val),
       });
       return INVALID;
     }


### PR DESCRIPTION
### Type tightening of certain core definitions, namely in `src/helpers/utils.ts`  as follows:


##### arrayToEnum

 - Before

```ts
  export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
    items: U
  ): { [k in U[number]]: k } => {
    const obj: any = {};
    for (const item of items) {
      obj[item] = item;
    }
    return obj as any;
  };
```

- After

```ts
  export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
    items: U
  ): { [k in U[number]]: k } => {
    const obj: { [k in U[number]]: k } = Object.prototype.constructor();
    for (const item of items) {
      obj[item] = item;
    }
    return obj as { [k in U[number]]: k };
  };
```


##### getValidEnumValues

- Before

```ts
  export const getValidEnumValues = (obj: any) => {
    const validKeys = objectKeys(obj).filter(
      (k: any) => typeof obj[obj[k]] !== "number"
    );
    const filtered: any = {};
    for (const k of validKeys) {
      filtered[k] = obj[k];
    }
    return objectValues(filtered);
  };
```

- After

```ts
  export const getValidEnumValues = (
    obj: Record<string, string | number>): (string | number)[] => {
    const validKeys: string[] = objectKeys(obj).filter(
      (k) => typeof obj[obj[k]] !== "number"
    );
    const filtered: Record<string, string | number> = {}
    for (const k of validKeys) {
      filtered[k] = obj[k];
    }
    return objectValues(filtered);
  };
```


##### objectValues

- Before

```ts
  export const objectValues = (obj: any) => {
    return objectKeys(obj).map(function (e) {
      return obj[e];
    });
  };
```

- After

```ts
  export const objectValues = (
    (obj: Record<string, string | number>) => {
      return objectKeys(obj).map<string | number>((e, i) => {
        return ({ [i]: obj[e] }[i++]);
      })
    });
```

##### objectKeys

- Before

```ts
  export const objectKeys: ObjectConstructor["keys"] =
    typeof Object.keys === "function" // eslint-disable-line ban/ban
      ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
      : (object: any) => {
          const keys = [];
          for (const key in object) {
            if (Object.prototype.hasOwnProperty.call(object, key)) {
              keys.push(key);
            }
          }
          return keys;
        };
```

- After

```ts
  export const objectKeys: {
    (...args: [o: Record<string, unknown>]): string[];
  } = Array.of<string>()
      ? (obj: Record<string, unknown>) =>
        Object.entries(obj)
          .map(([x, _vals]) => x)
      : (object: Record<string, unknown>) => {
        const keys = Array.of<string>();
        for (const key in object) {
          if (
            Object.prototype.hasOwnProperty.call<
              Record<string, unknown>,
              [string],
              boolean
            >(object, key)
          ) {
            keys.push(key);
          }
        }
        return keys;
      };
```


##### isInteger (performance tweak)

- Before

```ts
  export const isInteger: NumberConstructor["isInteger"] =
    typeof Number.isInteger === "function"
      ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
      : (val) =>
          typeof val === "number" && isFinite(val) && Math.floor(val) === val;
```

- After

```ts
  export const isInteger: NumberConstructor["isInteger"] =
    typeof Number.isInteger === "function"
      ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
      : (val) =>
        /// ~~(val: number) === Math.floor(val: number); ~~(val: number) is more performant 
        typeof val === "number" && isFinite(val) && ~~(val) === val;
```