### PR TITLE
docs: remove dead link from TOC of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@
 - [Nullables](#nullables)
 - [Objects](#objects)
   - [.shape](#shape)
-  - [.enum](#enum)
   - [.extend](#extend)
   - [.merge](#merge)
   - [.pick/.omit](#pickomit)


### PR DESCRIPTION
There is a link to `.enum()` under "Objects" which does not exist (anymore?).