### PR TITLE
Introduce ZodTransformError type, to allow for transforms that fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1768,6 +1768,23 @@ const Strings = z.string().transform((val, ctx) => {
 });
 ```
 
+When attempting a transform that fails, and there is no value to return, the transform may throw an error of type `ZodTransformError`.
+The `ZodTransformError` constructor accepts an array of issues, all of which are treated as fatal. When a transform throws a `ZodTransformError`, no subsequent transforms or refinments are attempted..
+
+```ts
+const user = z.string().transform(async (id) => {
+  try {
+    const user = await getUserById(id);
+    return user;
+  } catch (e) {
+    throw new ZodTransformError({
+      code: "custom",
+      message: "User not found",
+    });
+  }
+});
+```
+
 #### Relationship to refinements
 
 Transforms and refinements can be interleaved. These will be executed in the order they are declared.

--- a/README.md
+++ b/README.md
@@ -1772,15 +1772,19 @@ When attempting a transform that fails, and there is no value to return, the tra
 The `ZodTransformError` constructor accepts an array of issues, all of which are treated as fatal. When a transform throws a `ZodTransformError`, no subsequent transforms or refinments are attempted..
 
 ```ts
+import { ZodTransformError } from "zod";
+
 const user = z.string().transform(async (id) => {
   try {
     const user = await getUserById(id);
     return user;
   } catch (e) {
-    throw new ZodTransformError({
-      code: "custom",
-      message: "User not found",
-    });
+    throw new ZodTransformError([
+      {
+        code: "custom",
+        message: "User not found",
+      },
+    ]);
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -1769,7 +1769,7 @@ const Strings = z.string().transform((val, ctx) => {
 ```
 
 When attempting a transform that fails, and there is no value to return, the transform may throw an error of type `ZodTransformError`.
-The `ZodTransformError` constructor accepts an array of issues, all of which are treated as fatal. When a transform throws a `ZodTransformError`, no subsequent transforms or refinments are attempted..
+The `ZodTransformError` constructor accepts an array of issues, all of which are treated as fatal. When a transform throws a `ZodTransformError`, no subsequent transforms or refinments are attempted.
 
 ```ts
 import { ZodTransformError } from "zod";

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -604,7 +604,7 @@ dateSchema.safeParse(new Date("1/12/22")); // success: true
 dateSchema.safeParse("2022-01-12T00:00:00.000Z"); // success: true
 ```
 
-## Zod enums-
+## Zod enums
 
 ```ts
 const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1768,6 +1768,23 @@ const Strings = z.string().transform((val, ctx) => {
 });
 ```
 
+When attempting a transform that fails, and there is no value to return, the transform may throw an error of type `ZodTransformError`.
+The `ZodTransformError` constructor accepts an array of issues, all of which are treated as fatal. When a transform throws a `ZodTransformError`, no subsequent transforms or refinments are attempted..
+
+```ts
+const user = z.string().transform(async (id) => {
+  try {
+    const user = await getUserById(id);
+    return user;
+  } catch (e) {
+    throw new ZodTransformError({
+      code: "custom",
+      message: "User not found",
+    });
+  }
+});
+```
+
 #### Relationship to refinements
 
 Transforms and refinements can be interleaved. These will be executed in the order they are declared.

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1772,15 +1772,19 @@ When attempting a transform that fails, and there is no value to return, the tra
 The `ZodTransformError` constructor accepts an array of issues, all of which are treated as fatal. When a transform throws a `ZodTransformError`, no subsequent transforms or refinments are attempted..
 
 ```ts
+import { ZodTransformError } from "zod";
+
 const user = z.string().transform(async (id) => {
   try {
     const user = await getUserById(id);
     return user;
   } catch (e) {
-    throw new ZodTransformError({
-      code: "custom",
-      message: "User not found",
-    });
+    throw new ZodTransformError([
+      {
+        code: "custom",
+        message: "User not found",
+      },
+    ]);
   }
 });
 ```

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1769,7 +1769,7 @@ const Strings = z.string().transform((val, ctx) => {
 ```
 
 When attempting a transform that fails, and there is no value to return, the transform may throw an error of type `ZodTransformError`.
-The `ZodTransformError` constructor accepts an array of issues, all of which are treated as fatal. When a transform throws a `ZodTransformError`, no subsequent transforms or refinments are attempted..
+The `ZodTransformError` constructor accepts an array of issues, all of which are treated as fatal. When a transform throws a `ZodTransformError`, no subsequent transforms or refinments are attempted.
 
 ```ts
 import { ZodTransformError } from "zod";

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -292,8 +292,11 @@ type stripPath<T extends object> = T extends any
   ? util.OmitKeys<T, "path">
   : never;
 
-export type IssueData = stripPath<ZodIssueOptionalMessage> & {
+export type FatalIssueData = stripPath<ZodIssueOptionalMessage> & {
   path?: (string | number)[];
+};
+
+export type IssueData = FatalIssueData & {
   fatal?: boolean;
 };
 export type MakeErrorData = IssueData;

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -4,12 +4,83 @@ const test = Deno.test;
 
 import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
+import { ZodTransformError } from "../index.ts";
 
 const stringToNumber = z.string().transform((arg) => parseFloat(arg));
 // const numberToString = z
 //   .transformer(z.number())
 //   .transform((n) => String(n));
 const asyncNumberToString = z.number().transform(async (n) => String(n));
+
+test("transform throwing ZodTransformError, with safeParse", () => {
+  const strs = ["foo", "bar"];
+
+  const result = z
+    .string()
+    .transform((data) => {
+      const i = strs.indexOf(data);
+      if (i === -1) {
+        throw new ZodTransformError([
+          {
+            code: "custom",
+            message: `${data} is not one of our allowed strings`,
+          },
+        ]);
+      }
+      return data.length;
+    })
+    .transform((data) => data > 0)
+    .safeParse("asdf");
+
+  expect(result).toMatchObject({
+    success: false,
+    error: expect.objectContaining({
+      issues: [
+        {
+          code: "custom",
+          message: "asdf is not one of our allowed strings",
+          fatal: true,
+          path: [],
+        },
+      ],
+    }),
+  });
+});
+
+test("transform throwing ZodTransformError, with safeParseAsync", async () => {
+  const strs = ["foo", "bar"];
+
+  const result = await z
+    .string()
+    .transform(async (data) => {
+      const i = strs.indexOf(data);
+      if (i === -1) {
+        throw new ZodTransformError([
+          {
+            code: "custom",
+            message: `${data} is not one of our allowed strings`,
+          },
+        ]);
+      }
+      return data.length;
+    })
+    .transform((data) => data > 0)
+    .safeParseAsync("asdf");
+
+  expect(result).toMatchObject({
+    success: false,
+    error: expect.objectContaining({
+      issues: [
+        {
+          code: "custom",
+          message: "asdf is not one of our allowed strings",
+          fatal: true,
+          path: [],
+        },
+      ],
+    }),
+  });
+});
 
 test("transform ctx.addIssue with parse", () => {
   const strs = ["foo", "bar"];

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3538,6 +3538,7 @@ export class ZodEffects<
               });
               return base.value;
             }
+            /* istanbul ignore next */
             throw err;
           }
         };
@@ -3560,7 +3561,8 @@ export class ZodEffects<
             // if (base.status === "dirty") {
             //   return { status: "dirty", value: base.value };
             // }
-            return Promise.resolve(effect.transform(base.value, checkCtx))
+            return Promise.resolve()
+              .then(() => effect.transform(base.value, checkCtx))
               .catch((err) => {
                 if (err instanceof ZodTransformError) {
                   err.issues.forEach((issue) => {
@@ -3568,6 +3570,7 @@ export class ZodEffects<
                   });
                   return base.value;
                 }
+                /* istanbul ignore next */
                 throw err;
               })
               .then((result) => ({ status: status.value, value: result }));

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -292,8 +292,11 @@ type stripPath<T extends object> = T extends any
   ? util.OmitKeys<T, "path">
   : never;
 
-export type IssueData = stripPath<ZodIssueOptionalMessage> & {
+export type FatalIssueData = stripPath<ZodIssueOptionalMessage> & {
   path?: (string | number)[];
+};
+
+export type IssueData = FatalIssueData & {
   fatal?: boolean;
 };
 export type MakeErrorData = IssueData;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { defaultErrorMap, getErrorMap } from "./errors";
+import { FatalIssueData } from "./external";
 import { enumUtil } from "./helpers/enumUtil";
 import { errorUtil } from "./helpers/errorUtil";
 import {
@@ -3408,6 +3409,20 @@ export interface ZodEffectsDef<T extends ZodTypeAny = ZodTypeAny>
   effect: Effect<any>;
 }
 
+export class ZodTransformError extends Error {
+  issues: Array<IssueData> = [];
+  constructor(issues: Array<FatalIssueData>) {
+    super("ZodTransformError");
+    this.name = "ZodTransformError";
+    this.issues = issues.map((issue) => {
+      return {
+        ...issue,
+        fatal: true,
+      };
+    });
+  }
+}
+
 export class ZodEffects<
   T extends ZodTypeAny,
   Output = T["_output"],
@@ -3513,7 +3528,22 @@ export class ZodEffects<
         // }
         if (!isValid(base)) return base;
 
-        const result = effect.transform(base.value, checkCtx);
+        const execTransform = () => {
+          try {
+            return effect.transform(base.value, checkCtx);
+          } catch (err) {
+            if (err instanceof ZodTransformError) {
+              err.issues.forEach((issue) => {
+                checkCtx.addIssue(issue);
+              });
+              return base.value;
+            }
+            throw err;
+          }
+        };
+
+        const result = execTransform();
+
         if (result instanceof Promise) {
           throw new Error(
             `Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`
@@ -3530,9 +3560,17 @@ export class ZodEffects<
             // if (base.status === "dirty") {
             //   return { status: "dirty", value: base.value };
             // }
-            return Promise.resolve(effect.transform(base.value, checkCtx)).then(
-              (result) => ({ status: status.value, value: result })
-            );
+            return Promise.resolve(effect.transform(base.value, checkCtx))
+              .catch((err) => {
+                if (err instanceof ZodTransformError) {
+                  err.issues.forEach((issue) => {
+                    checkCtx.addIssue(issue);
+                  });
+                  return base.value;
+                }
+                throw err;
+              })
+              .then((result) => ({ status: status.value, value: result }));
           });
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3538,6 +3538,7 @@ export class ZodEffects<
               });
               return base.value;
             }
+            /* istanbul ignore next */
             throw err;
           }
         };
@@ -3560,7 +3561,8 @@ export class ZodEffects<
             // if (base.status === "dirty") {
             //   return { status: "dirty", value: base.value };
             // }
-            return Promise.resolve(effect.transform(base.value, checkCtx))
+            return Promise.resolve()
+              .then(() => effect.transform(base.value, checkCtx))
               .catch((err) => {
                 if (err instanceof ZodTransformError) {
                   err.issues.forEach((issue) => {
@@ -3568,6 +3570,7 @@ export class ZodEffects<
                   });
                   return base.value;
                 }
+                /* istanbul ignore next */
                 throw err;
               })
               .then((result) => ({ status: status.value, value: result }));


### PR DESCRIPTION
This PR introduces a new Error type, `ZodTransformError`, which accepts an array of issues in it's constructor.

Closes https://github.com/colinhacks/zod/issues/1390

When thrown inside a transform, this error class will be caught by Zod, and the issues it contains treated a fatal and added to the parse result.

The rational for this PR is to allow for transforms that may fail, such as the following example.

```ts
import { ZodTransformError } from "zod";

const user = z.string().transform(async (id) => {
  try {
    const user = await getUserById(id);
    return user;
  } catch (e) {
    throw new ZodTransformError([{
      code: "custom",
      message: "User not found",
    }]);
  }
});
```
