### PR TITLE
Optimize object strip case

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -604,7 +604,7 @@ dateSchema.safeParse(new Date("1/12/22")); // success: true
 dateSchema.safeParse("2022-01-12T00:00:00.000Z"); // success: true
 ```
 
-## Zod enums-
+## Zod enums
 
 ```ts
 const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1669,9 +1669,17 @@ export class ZodObject<
 
     const { shape, keys: shapeKeys } = this._getCached();
     const extraKeys: string[] = [];
-    for (const key in ctx.data) {
-      if (!shapeKeys.includes(key)) {
-        extraKeys.push(key);
+
+    if (
+      !(
+        this._def.catchall instanceof ZodNever &&
+        this._def.unknownKeys === "strip"
+      )
+    ) {
+      for (const key in ctx.data) {
+        if (!shapeKeys.includes(key)) {
+          extraKeys.push(key);
+        }
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1669,9 +1669,17 @@ export class ZodObject<
 
     const { shape, keys: shapeKeys } = this._getCached();
     const extraKeys: string[] = [];
-    for (const key in ctx.data) {
-      if (!shapeKeys.includes(key)) {
-        extraKeys.push(key);
+
+    if (
+      !(
+        this._def.catchall instanceof ZodNever &&
+        this._def.unknownKeys === "strip"
+      )
+    ) {
+      for (const key in ctx.data) {
+        if (!shapeKeys.includes(key)) {
+          extraKeys.push(key);
+        }
       }
     }
 


### PR DESCRIPTION
Refs #205

This skips the check for extra keys in the default case of `strip` being the object parsing strategy, because we don't use the extra keys.

This yields a pretty modest performance bump - about 5% in the realworld case in my testing.