### PR TITLE
Fix refine with type guard signature

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -604,7 +604,7 @@ dateSchema.safeParse(new Date("1/12/22")); // success: true
 dateSchema.safeParse("2022-01-12T00:00:00.000Z"); // success: true
 ```
 
-## Zod enums-
+## Zod enums
 
 ```ts
 const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -54,10 +54,14 @@ test("refinement type guard", () => {
   const validationSchema = z.object({
     a: z.string().refine((s): s is "a" => s === "a"),
   });
+  type Input = z.input<typeof validationSchema>;
   type Schema = z.infer<typeof validationSchema>;
 
+  util.assertEqual<"a", Input["a"]>(false);
+  util.assertEqual<string, Input["a"]>(true);
+
   util.assertEqual<"a", Schema["a"]>(true);
-  util.assertEqual<"string", Schema["a"]>(false);
+  util.assertEqual<string, Schema["a"]>(false);
 });
 
 test("refinement Promise", async () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -268,7 +268,7 @@ export abstract class ZodType<
   refine<RefinedOutput extends Output>(
     check: (arg: Output) => arg is RefinedOutput,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
-  ): ZodEffects<this, RefinedOutput, RefinedOutput>;
+  ): ZodEffects<this, RefinedOutput, Input>;
   refine(
     check: (arg: Output) => unknown | Promise<unknown>,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
@@ -315,7 +315,7 @@ export abstract class ZodType<
   refinement<RefinedOutput extends Output>(
     check: (arg: Output) => arg is RefinedOutput,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)
-  ): ZodEffects<this, RefinedOutput, RefinedOutput>;
+  ): ZodEffects<this, RefinedOutput, Input>;
   refinement(
     check: (arg: Output) => boolean,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -53,10 +53,14 @@ test("refinement type guard", () => {
   const validationSchema = z.object({
     a: z.string().refine((s): s is "a" => s === "a"),
   });
+  type Input = z.input<typeof validationSchema>;
   type Schema = z.infer<typeof validationSchema>;
 
+  util.assertEqual<"a", Input["a"]>(false);
+  util.assertEqual<string, Input["a"]>(true);
+
   util.assertEqual<"a", Schema["a"]>(true);
-  util.assertEqual<"string", Schema["a"]>(false);
+  util.assertEqual<string, Schema["a"]>(false);
 });
 
 test("refinement Promise", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -268,7 +268,7 @@ export abstract class ZodType<
   refine<RefinedOutput extends Output>(
     check: (arg: Output) => arg is RefinedOutput,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
-  ): ZodEffects<this, RefinedOutput, RefinedOutput>;
+  ): ZodEffects<this, RefinedOutput, Input>;
   refine(
     check: (arg: Output) => unknown | Promise<unknown>,
     message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
@@ -315,7 +315,7 @@ export abstract class ZodType<
   refinement<RefinedOutput extends Output>(
     check: (arg: Output) => arg is RefinedOutput,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)
-  ): ZodEffects<this, RefinedOutput, RefinedOutput>;
+  ): ZodEffects<this, RefinedOutput, Input>;
   refinement(
     check: (arg: Output) => boolean,
     refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)


### PR DESCRIPTION
When using `.refine` with a type guard, the current type definitions are changing the parser's `Input` type. This is inconsistent and causing issues in tRPC where Zod Input types are inferred for client procedure signatures.

This just updates the generic parameter and adds a (previously failing) test for the `Input` type.