### PR TITLE
Chain schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1822,14 +1822,16 @@ const updateUserDTOSchema = z.object({
   active: z.boolean(),
 });
 
-const userSchema = z
-  .object({
-    id: z.string().trim().uuid(),
-    name: z.string().trim().min(1),
-    email: z.string().trim().email(),
-    active: z.boolean(),
-  })
-  .refine((val) => allowedDomains.includes(emailDomain(val.email)));
+const userSchema = z.object({
+  id: z.string().trim().uuid(),
+  name: z.string().trim().min(1),
+  email: z
+    .string()
+    .trim()
+    .email()
+    .refine((val) => allowedDomains.includes(emailDomain(val))),
+  active: z.boolean(),
+});
 
 const createUserSchema = createUserDTOSchema.chain(userSchema);
 const updateUserSchema = updateUserDTOSchema.chain(userSchema);

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
   - [.refine](#refine)
   - [.superRefine](#superRefine)
   - [.transform](#transform)
+  - [.chain](#chain)
   - [.default](#default)
   - [.optional](#optional)
   - [.nullable](#nullable)
@@ -1793,6 +1794,8 @@ const IdToUser = z
   });
 ```
 
+> ⚠️ If your schema contains asynchronous transforms, you must use .parseAsync() or .safeParseAsync() to parse data. Otherwise Zod will throw an error.
+
 ### `.chain`
 
 You can chain schemas, passing the output of one as the input to another.
@@ -1831,8 +1834,6 @@ const userSchema = z
 const createUserSchema = createUserDTOSchema.chain(userSchema);
 const updateUserSchema = updateUserDTOSchema.chain(userSchema);
 ```
-
-> ⚠️ If your schema contains asynchronous transforms, you must use .parseAsync() or .safeParseAsync() to parse data. Otherwise Zod will throw an error.
 
 ### `.default`
 

--- a/README.md
+++ b/README.md
@@ -1799,7 +1799,7 @@ const IdToUser = z
 ### `.chain`
 
 You can chain schemas, passing the output of one as the input to another.
-The output of the first schema is typechecked to ensure compatibility with the input of the second schema.
+The output of the first schema is type-checked to ensure compatibility with the input of the second schema.
 
 ```ts
 const createUserDTOSchema = z

--- a/README.md
+++ b/README.md
@@ -1793,6 +1793,45 @@ const IdToUser = z
   });
 ```
 
+### `.chain`
+
+You can chain schemas, passing the output of one as the input to another.
+The output of the first schema is typechecked to ensure compatibility with the input of the second schema.
+
+```ts
+const createUserDTOSchema = z
+  .object({
+    name: z.string(),
+    email: z.string(),
+    active: z.boolean(),
+  })
+  .transform((input) => {
+    return {
+      id: uuid(),
+      ...input,
+    };
+  });
+
+const updateUserDTOSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  active: z.boolean(),
+});
+
+const userSchema = z
+  .object({
+    id: z.string().trim().uuid(),
+    name: z.string().trim().min(1),
+    email: z.string().trim().email(),
+    active: z.boolean(),
+  })
+  .refine((val) => allowedDomains.includes(emailDomain(val.email)));
+
+const createUserSchema = createUserDTOSchema.chain(userSchema);
+const updateUserSchema = updateUserDTOSchema.chain(userSchema);
+```
+
 > ⚠️ If your schema contains asynchronous transforms, you must use .parseAsync() or .safeParseAsync() to parse data. Otherwise Zod will throw an error.
 
 ### `.default`

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -604,7 +604,7 @@ dateSchema.safeParse(new Date("1/12/22")); // success: true
 dateSchema.safeParse("2022-01-12T00:00:00.000Z"); // success: true
 ```
 
-## Zod enums-
+## Zod enums
 
 ```ts
 const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1822,14 +1822,16 @@ const updateUserDTOSchema = z.object({
   active: z.boolean(),
 });
 
-const userSchema = z
-  .object({
-    id: z.string().trim().uuid(),
-    name: z.string().trim().min(1),
-    email: z.string().trim().email(),
-    active: z.boolean(),
-  })
-  .refine((val) => allowedDomains.includes(emailDomain(val.email)));
+const userSchema = z.object({
+  id: z.string().trim().uuid(),
+  name: z.string().trim().min(1),
+  email: z
+    .string()
+    .trim()
+    .email()
+    .refine((val) => allowedDomains.includes(emailDomain(val))),
+  active: z.boolean(),
+});
 
 const createUserSchema = createUserDTOSchema.chain(userSchema);
 const updateUserSchema = updateUserDTOSchema.chain(userSchema);

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -98,6 +98,7 @@
   - [.refine](#refine)
   - [.superRefine](#superRefine)
   - [.transform](#transform)
+  - [.chain](#chain)
   - [.default](#default)
   - [.optional](#optional)
   - [.nullable](#nullable)
@@ -1793,6 +1794,8 @@ const IdToUser = z
   });
 ```
 
+> ⚠️ If your schema contains asynchronous transforms, you must use .parseAsync() or .safeParseAsync() to parse data. Otherwise Zod will throw an error.
+
 ### `.chain`
 
 You can chain schemas, passing the output of one as the input to another.
@@ -1831,8 +1834,6 @@ const userSchema = z
 const createUserSchema = createUserDTOSchema.chain(userSchema);
 const updateUserSchema = updateUserDTOSchema.chain(userSchema);
 ```
-
-> ⚠️ If your schema contains asynchronous transforms, you must use .parseAsync() or .safeParseAsync() to parse data. Otherwise Zod will throw an error.
 
 ### `.default`
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1799,7 +1799,7 @@ const IdToUser = z
 ### `.chain`
 
 You can chain schemas, passing the output of one as the input to another.
-The output of the first schema is typechecked to ensure compatibility with the input of the second schema.
+The output of the first schema is type-checked to ensure compatibility with the input of the second schema.
 
 ```ts
 const createUserDTOSchema = z

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1795,11 +1795,41 @@ const IdToUser = z
 
 ### `.chain`
 
-You can chain schemas, passing the output of one as the input to another. This allows reuseable schemas to be sequenced.
-Typechecking ensures that the output of the first schema is compatible with the input of the second.
+You can chain schemas, passing the output of one as the input to another.
+The output of the first schema is typechecked to ensure compatibility with the input of the second schema.
 
 ```ts
-const schema = z.string().chain((s) => z.number().min(s.length));
+const createUserDTOSchema = z
+  .object({
+    name: z.string(),
+    email: z.string(),
+    active: z.boolean(),
+  })
+  .transform((input) => {
+    return {
+      id: uuid(),
+      ...input,
+    };
+  });
+
+const updateUserDTOSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  active: z.boolean(),
+});
+
+const userSchema = z
+  .object({
+    id: z.string().trim().uuid(),
+    name: z.string().trim().min(1),
+    email: z.string().trim().email(),
+    active: z.boolean(),
+  })
+  .refine((val) => allowedDomains.includes(emailDomain(val.email)));
+
+const createUserSchema = createUserDTOSchema.chain(userSchema);
+const updateUserSchema = updateUserDTOSchema.chain(userSchema);
 ```
 
 > ⚠️ If your schema contains asynchronous transforms, you must use .parseAsync() or .safeParseAsync() to parse data. Otherwise Zod will throw an error.

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1793,6 +1793,15 @@ const IdToUser = z
   });
 ```
 
+### `.chain`
+
+You can chain schemas, passing the output of one as the input to another. This allows reuseable schemas to be sequenced.
+Typechecking ensures that the output of the first schema is compatible with the input of the second.
+
+```ts
+const schema = z.string().chain((s) => z.number().min(s.length));
+```
+
 > ⚠️ If your schema contains asynchronous transforms, you must use .parseAsync() or .safeParseAsync() to parse data. Otherwise Zod will throw an error.
 
 ### `.default`

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -83,7 +83,7 @@ test.each([
       }),
     },
   },
-])('Schema chaining "$input"', ({ input, output }) => {
+])('Schema chaining "$input"', async ({ input, output }) => {
   const from = z
     .string()
     .transform((val) => parseInt(val, 10))
@@ -137,6 +137,8 @@ test.each([
   util.assertEqual<ChainInput, FromInput>(true);
   util.assertEqual<ChainOutput, ToOutput>(true);
 
-  const res = chain.safeParse(input);
-  expect(res).toEqual(output);
+  const resSync = chain.safeParse(input);
+  expect(resSync).toEqual(output);
+  const resAsync = await chain.safeParseAsync(input);
+  expect(resAsync).toEqual(output);
 });

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -148,6 +148,7 @@ test.each([
   util.assertAssignable<ToInput, FromOutput>(true);
   util.assertAssignable<FromOutput, ToInput>(false);
 
+  // Test chain factory
   const chain = z.chain(fromSchema, toSchema);
 
   type ChainInput = z.input<typeof chain>;
@@ -160,6 +161,21 @@ test.each([
   expect(resSync).toEqual(output);
   const resAsync = await chain.safeParseAsync(input);
   expect(resAsync).toEqual(output);
+
+  // Test chain method.
+  // const methChain = fromSchema.chain(toSchema);
+  // toSchema.chain(fromSchema); // TODO Should not compile, remore
+
+  // type MethChainInput = z.input<typeof methChain>;
+  // type MethChainOutput = z.output<typeof methChain>;
+
+  // util.assertEqual<MethChainInput, FromInput>(true);
+  // util.assertEqual<MethChainOutput, ToOutput>(true);
+
+  // const methResSync = methChain.safeParse(input);
+  // expect(methResSync).toEqual(output);
+  // const methResAsync = await methChain.safeParseAsync(input);
+  // expect(methResAsync).toEqual(output);
 });
 
 const numProm = Promise.resolve(12);
@@ -426,6 +442,7 @@ test.each([
   util.assertAssignable<ToInput, FromOutput>(true);
   util.assertAssignable<FromOutput, ToInput>(false);
 
+  // Test chain factory
   const chain = z.chain(fromSchema, toSchema);
 
   type ChainInput = z.input<typeof chain>;
@@ -438,4 +455,18 @@ test.each([
   expect(resSync).toEqual(output);
   const resAsync = await chain.safeParseAsync(input);
   expect(resAsync).toEqual(output);
+
+  // Test chain method
+  // const methChain = fromSchema.chain(toSchema);
+
+  // type MethChainInput = z.input<typeof methChain>;
+  // type MethChainOutput = z.output<typeof methChain>;
+
+  // util.assertEqual<MethChainInput, FromInput>(true);
+  // util.assertEqual<MethChainOutput, ToOutput>(true);
+
+  // const methResSync = methChain.safeParse(input);
+  // expect(methResSync).toEqual(output);
+  // const methResAsync = await methChain.safeParseAsync(input);
+  // expect(methResAsync).toEqual(output);
 });

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -11,6 +11,11 @@ test("schema chaining", () => {
 
   const chain = from.chain(to);
 
+  type FromOutput = z.output<typeof from>;
+  type ToInput = z.input<typeof to>;
+
+  util.assertEqual<FromOutput, ToInput>(true);
+
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;
 

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -102,7 +102,7 @@ test.each([
     },
   },
 ])('Schema chaining "$input"', async ({ input, output }) => {
-  const from = z
+  const fromSchema = z
     .string()
     .transform((val) => parseInt(val, 10))
     .optional()
@@ -122,7 +122,7 @@ test.each([
         });
       }
     });
-  const to = z
+  const toSchema = z
     .number()
     .min(1)
     .max(10)
@@ -139,15 +139,15 @@ test.each([
     })
     .refine((val) => val !== 6, { message: "It really can not be 6" });
 
-  type FromInput = z.input<typeof from>;
-  type FromOutput = z.output<typeof from>;
+  type FromInput = z.input<typeof fromSchema>;
+  type FromOutput = z.output<typeof fromSchema>;
 
-  type ToInput = z.input<typeof to>;
-  type ToOutput = z.output<typeof to>;
+  type ToInput = z.input<typeof toSchema>;
+  type ToOutput = z.output<typeof toSchema>;
 
   util.assertAssignable<ToInput, FromOutput>(true);
 
-  const chain = z.chain(from, to);
+  const chain = z.chain(fromSchema, toSchema);
 
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -1,0 +1,19 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { util } from "../helpers/util.ts";
+import * as z from "../index.ts";
+
+test("schema chaining", () => {
+  const from = z.string().transform((val) => parseInt(val, 10));
+  const to = z.number().min(1).max(10);
+
+  const chain = from.chain(to);
+
+  type ChainInput = z.input<typeof chain>;
+  type ChainOutput = z.output<typeof chain>;
+
+  util.assertEqual<ChainInput, string>(true);
+  util.assertEqual<ChainOutput, number>(true);
+});

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -101,7 +101,7 @@ test.each([
       }),
     },
   },
-])('Scalar schema chaining "$input"', async ({ input, output }) => {
+])("Scalar schema chaining - $input", async ({ input, output }) => {
   const fromSchema = z
     .string()
     .transform((val) => parseInt(val, 10))
@@ -188,7 +188,7 @@ test.each([
         sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
         intersection: { p2: 0 },
         enum: "one",
-        passthrough: { points: 1234, score: 999 },
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
         numProm,
         lenfun: 42,
       },
@@ -360,7 +360,9 @@ test.each([
       z.object({ p3: z.number().optional() })
     ),
     enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
-    passthrough: z.object({ points: z.number(), score: z.number() }),
+    passthrough: z
+      .object({ points: z.number(), score: z.number() })
+      .passthrough(),
     numProm: z.promise(z.number()),
     lenfun: z.function(
       z.tuple([z.string(), z.number().optional()]),

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -148,6 +148,10 @@ test.each([
   util.assertAssignable<ToInput, FromOutput>(true);
   util.assertAssignable<FromOutput, ToInput>(false);
 
+  // Check invalid chains are not possible
+  // @ts-expect-error
+  z.chain(toSchema, fromSchema), toSchema.chain(fromSchema);
+
   // Test chain factory
   const chain = z.chain(fromSchema, toSchema);
 
@@ -440,6 +444,10 @@ test.each([
 
   util.assertAssignable<ToInput, FromOutput>(true);
   util.assertAssignable<FromOutput, ToInput>(false);
+
+  // Check invalid chains are not possible
+  // @ts-expect-error
+  z.chain(toSchema, fromSchema), toSchema.chain(fromSchema);
 
   // Test chain factory
   const chain = z.chain(fromSchema, toSchema);

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -56,12 +56,12 @@ test.each([
           {
             code: "custom",
             message: "Cannot be 5",
-            path: [],
+            path: ["new_path"],
           },
           {
             code: "custom",
             message: "It really can not be 5",
-            path: [],
+            path: ["newer_path"],
           },
         ],
       }),
@@ -83,7 +83,7 @@ test.each([
       }),
     },
   },
-])("Schema chaining", ({ input, output }) => {
+])('Schema chaining "$input"', ({ input, output }) => {
   const from = z
     .string()
     .transform((val) => parseInt(val, 10))
@@ -93,6 +93,7 @@ test.each([
         ctx.addIssue({
           code: "custom",
           message: "Cannot be 5",
+          path: ["new_path"],
         });
       }
       if (val === 6) {
@@ -109,7 +110,15 @@ test.each([
     .max(10)
     .nullable()
     .optional()
-    .refine((val) => val !== 5, { message: "It really can not be 5" })
+    .superRefine((val, ctx) => {
+      if (val === 5) {
+        ctx.addIssue({
+          code: "custom",
+          message: "It really can not be 5",
+          path: ["newer_path"],
+        });
+      }
+    })
     .refine((val) => val !== 6, { message: "It really can not be 6" });
 
   type FromInput = z.input<typeof from>;

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -5,12 +5,118 @@ const test = Deno.test;
 import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
 
-test("schema chaining", () => {
-  const from = z.string().transform((val) => parseInt(val, 10));
-  const to = z.number().min(1).max(10).nullable();
+test.each([
+  {
+    input: "1",
+    output: {
+      success: true,
+      data: 1,
+    },
+  },
+  {
+    input: "",
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "invalid_type",
+            expected: "number",
+            received: "nan",
+            path: [],
+            message: "Expected number, received nan",
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: null,
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "invalid_type",
+            expected: "string",
+            received: "null",
+            path: [],
+            message: "Expected string, received null",
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: "5",
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Cannot be 5",
+            path: [],
+          },
+          {
+            code: "custom",
+            message: "It really can not be 5",
+            path: [],
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: "6",
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Cannot be 6",
+            fatal: true,
+            path: [],
+          },
+        ],
+      }),
+    },
+  },
+])("Schema chaining", ({ input, output }) => {
+  const from = z
+    .string()
+    .transform((val) => parseInt(val, 10))
+    .optional()
+    .superRefine((val, ctx) => {
+      if (val === 5) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Cannot be 5",
+        });
+      }
+      if (val === 6) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Cannot be 6",
+          fatal: true,
+        });
+      }
+    });
+  const to = z
+    .number()
+    .min(1)
+    .max(10)
+    .nullable()
+    .optional()
+    .refine((val) => val !== 5, { message: "It really can not be 5" })
+    .refine((val) => val !== 6, { message: "It really can not be 6" });
 
+  type FromInput = z.input<typeof from>;
   type FromOutput = z.output<typeof from>;
+
   type ToInput = z.input<typeof to>;
+  type ToOutput = z.output<typeof to>;
 
   util.assertAssignable<ToInput, FromOutput>(true);
 
@@ -19,6 +125,9 @@ test("schema chaining", () => {
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;
 
-  util.assertEqual<ChainInput, string>(true);
-  util.assertEqual<ChainOutput, number | null>(true);
+  util.assertEqual<ChainInput, FromInput>(true);
+  util.assertEqual<ChainOutput, ToOutput>(true);
+
+  const res = chain.safeParse(input);
+  expect(res).toEqual(output);
 });

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -6,22 +6,19 @@ import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
 
 test("schema chaining", () => {
-  const from = z
-    .string()
-    .transform((val) => parseInt(val, 10))
-    .nullable();
+  const from = z.string().transform((val) => parseInt(val, 10));
   const to = z.number().min(1).max(10).nullable();
-
-  const chain = z.chain(from, to);
 
   type FromOutput = z.output<typeof from>;
   type ToInput = z.input<typeof to>;
 
-  util.assertEqual<FromOutput, ToInput>(true);
+  util.assertAssignable<ToInput, FromOutput>(true);
+
+  const chain = z.chain(from, to);
 
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;
 
-  util.assertEqual<ChainInput, string | null>(true);
+  util.assertEqual<ChainInput, string>(true);
   util.assertEqual<ChainOutput, number | null>(true);
 });

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -5,203 +5,192 @@ const test = Deno.test;
 import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
 
-test.each([
-  {
-    input: "1",
-    output: {
-      success: true,
-      data: 1,
+describe("Schema chaining", () => {
+  test.each([
+    {
+      input: "1",
+      output: {
+        success: true,
+        data: 1,
+      },
     },
-  },
-  {
-    input: "",
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "invalid_type",
-            expected: "number",
-            received: "nan",
-            path: [],
-            message: "Expected number, received nan",
-          },
-        ],
-      }),
+    {
+      input: "",
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "invalid_type",
+              expected: "number",
+              received: "nan",
+              path: [],
+              message: "Expected number, received nan",
+            },
+          ],
+        }),
+      },
     },
-  },
-  {
-    input: null,
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "invalid_type",
-            expected: "string",
-            received: "null",
-            path: [],
-            message: "Expected string, received null",
-          },
-        ],
-      }),
+    {
+      input: null,
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "invalid_type",
+              expected: "string",
+              received: "null",
+              path: [],
+              message: "Expected string, received null",
+            },
+          ],
+        }),
+      },
     },
-  },
-  {
-    input: "5",
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
+    {
+      input: "5",
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Cannot be 5",
+              path: ["new_path"],
+            },
+            {
+              code: "custom",
+              message: "It really can not be 5",
+              path: ["newer_path"],
+            },
+          ],
+        }),
+      },
+    },
+    {
+      input: "6",
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Cannot be 6",
+              fatal: true,
+              path: [],
+            },
+          ],
+        }),
+      },
+    },
+    {
+      input: "11",
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "too_big",
+              maximum: 10,
+              type: "number",
+              inclusive: true,
+              message: "Number must be less than or equal to 10",
+              path: [],
+            },
+          ],
+        }),
+      },
+    },
+  ])("Scalar schema chaining - $input", async ({ input, output }) => {
+    const fromSchema = z
+      .string()
+      .transform((val) => parseInt(val, 10))
+      .optional()
+      .superRefine((val, ctx) => {
+        if (val === 5) {
+          ctx.addIssue({
             code: "custom",
             message: "Cannot be 5",
             path: ["new_path"],
-          },
-          {
-            code: "custom",
-            message: "It really can not be 5",
-            path: ["newer_path"],
-          },
-        ],
-      }),
-    },
-  },
-  {
-    input: "6",
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
+          });
+        }
+        if (val === 6) {
+          ctx.addIssue({
             code: "custom",
             message: "Cannot be 6",
             fatal: true,
-            path: [],
-          },
-        ],
-      }),
-    },
-  },
-  {
-    input: "11",
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "too_big",
-            maximum: 10,
-            type: "number",
-            inclusive: true,
-            message: "Number must be less than or equal to 10",
-            path: [],
-          },
-        ],
-      }),
-    },
-  },
-])("Scalar schema chaining - $input", async ({ input, output }) => {
-  const fromSchema = z
-    .string()
-    .transform((val) => parseInt(val, 10))
-    .optional()
-    .superRefine((val, ctx) => {
-      if (val === 5) {
-        ctx.addIssue({
-          code: "custom",
-          message: "Cannot be 5",
-          path: ["new_path"],
-        });
-      }
-      if (val === 6) {
-        ctx.addIssue({
-          code: "custom",
-          message: "Cannot be 6",
-          fatal: true,
-        });
-      }
-    });
-  const toSchema = z
-    .number()
-    .min(1)
-    .max(10)
-    .nullable()
-    .optional()
-    .superRefine((val, ctx) => {
-      if (val === 5) {
-        ctx.addIssue({
-          code: "custom",
-          message: "It really can not be 5",
-          path: ["newer_path"],
-        });
-      }
-    })
-    .refine((val) => val !== 6, { message: "It really can not be 6" });
+          });
+        }
+      });
+    const toSchema = z
+      .number()
+      .min(1)
+      .max(10)
+      .nullable()
+      .optional()
+      .superRefine((val, ctx) => {
+        if (val === 5) {
+          ctx.addIssue({
+            code: "custom",
+            message: "It really can not be 5",
+            path: ["newer_path"],
+          });
+        }
+      })
+      .refine((val) => val !== 6, { message: "It really can not be 6" });
 
-  type FromInput = z.input<typeof fromSchema>;
-  type FromOutput = z.output<typeof fromSchema>;
+    type FromInput = z.input<typeof fromSchema>;
+    type FromOutput = z.output<typeof fromSchema>;
 
-  type ToInput = z.input<typeof toSchema>;
-  type ToOutput = z.output<typeof toSchema>;
+    type ToInput = z.input<typeof toSchema>;
+    type ToOutput = z.output<typeof toSchema>;
 
-  util.assertAssignable<ToInput, FromOutput>(true);
-  util.assertAssignable<FromOutput, ToInput>(false);
+    util.assertAssignable<ToInput, FromOutput>(true);
+    util.assertAssignable<FromOutput, ToInput>(false);
 
-  // Check invalid chains are not possible
-  // @ts-expect-error
-  z.chain(toSchema, fromSchema), toSchema.chain(fromSchema);
+    // Check invalid chains are not possible
+    // @ts-expect-error
+    z.chain(toSchema, fromSchema);
+    // @ts-expect-error
+    toSchema.chain(fromSchema);
 
-  // Test chain factory
-  const chain = z.chain(fromSchema, toSchema);
+    // Test chain factory
+    const factoryChain = z.chain(fromSchema, toSchema);
 
-  type ChainInput = z.input<typeof chain>;
-  type ChainOutput = z.output<typeof chain>;
+    type FactoryChainInput = z.input<typeof factoryChain>;
+    type FactoryChainOutput = z.output<typeof factoryChain>;
 
-  util.assertEqual<ChainInput, FromInput>(true);
-  util.assertEqual<ChainOutput, ToOutput>(true);
+    util.assertEqual<FactoryChainInput, FromInput>(true);
+    util.assertEqual<FactoryChainOutput, ToOutput>(true);
 
-  const resSync = chain.safeParse(input);
-  expect(resSync).toEqual(output);
-  const resAsync = await chain.safeParseAsync(input);
-  expect(resAsync).toEqual(output);
+    const factoryResSync = factoryChain.safeParse(input);
+    expect(factoryResSync).toEqual(output);
+    const factoryResAsync = await factoryChain.safeParseAsync(input);
+    expect(factoryResAsync).toEqual(output);
 
-  // Test chain method.
-  const methChain = fromSchema.chain(toSchema);
+    // Test chain method.
+    const builtChain = fromSchema.chain(toSchema);
 
-  type MethChainInput = z.input<typeof methChain>;
-  type MethChainOutput = z.output<typeof methChain>;
+    type BuiltChainInput = z.input<typeof builtChain>;
+    type BuiltChainOutput = z.output<typeof builtChain>;
 
-  util.assertEqual<MethChainInput, FromInput>(true);
-  util.assertEqual<MethChainOutput, ToOutput>(true);
+    util.assertEqual<BuiltChainInput, FromInput>(true);
+    util.assertEqual<BuiltChainOutput, ToOutput>(true);
 
-  const methResSync = methChain.safeParse(input);
-  expect(methResSync).toEqual(output);
-  const methResAsync = await methChain.safeParseAsync(input);
-  expect(methResAsync).toEqual(output);
-});
+    const builtResSync = builtChain.safeParse(input);
+    expect(builtResSync).toEqual(output);
+    const builtResAsync = await builtChain.safeParseAsync(input);
+    expect(builtResAsync).toEqual(output);
+  });
 
-const numProm = Promise.resolve(12);
+  const numProm = Promise.resolve(12);
 
-test.each([
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
-    },
-    output: {
-      success: true,
-      data: {
+  test.each([
+    {
+      input: {
         tuple: ["abcd", 1234, true, null, undefined, "1234"],
-        merged: { k1: "abdc" },
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
         union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
         array: [12, 15, 16],
         sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
@@ -209,271 +198,288 @@ test.each([
         enum: "one",
         passthrough: { points: 1234, score: 999, name: "General Zod" },
         numProm,
-        lenfun: 42,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: true,
+        data: {
+          tuple: ["abcd", 1234, true, null, undefined, "1234"],
+          merged: { k1: "abdc" },
+          union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+          array: [12, 15, 16],
+          sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
+          intersection: { p2: 0 },
+          enum: "one",
+          passthrough: { points: 1234, score: 999, name: "General Zod" },
+          numProm,
+          lenfun: 42,
+        },
       },
     },
-  },
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    {
+      input: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
+        numProm,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Array must be at least 8 items long",
+              path: ["sumMinLength", "values"],
+            },
+          ],
+        }),
+      },
     },
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "custom",
-            message: "Array must be at least 8 items long",
-            path: ["sumMinLength", "values"],
-          },
-        ],
+    {
+      input: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12, 15, 16, 98, 24] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
+        numProm,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Array must be at least 6 items long",
+              path: ["sumMinLength", "values"],
+            },
+            {
+              code: "custom",
+              message: "Array must be at least 8 items long",
+              path: ["sumMinLength", "values"],
+            },
+          ],
+        }),
+      },
+    },
+    {
+      input: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12, 15, 16] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
+        numProm,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Array must be at least 6 items long",
+              path: ["sumMinLength", "values"],
+            },
+            {
+              code: "custom",
+              message: "Array really must be at least 4 items long",
+              path: ["sumMinLength", "values"],
+              fatal: true,
+            },
+            {
+              code: "custom",
+              message: "Array must be at least 8 items long",
+              path: ["sumMinLength", "values"],
+            },
+          ],
+        }),
+      },
+    },
+    {
+      input: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
+        numProm,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Array really must be at least 2 items long",
+              path: ["sumMinLength", "values"],
+              fatal: true,
+            },
+            {
+              code: "custom",
+              message: "Array must be at least 6 items long",
+              path: ["sumMinLength", "values"],
+            },
+          ],
+        }),
+      },
+    },
+  ])("Object schema chaining - $#", async ({ input, output }) => {
+    const fromSchema = z.object({
+      tuple: z.tuple([
+        z.string().nullable(),
+        z.number().optional(),
+        z.boolean().nullable().optional(),
+        z.null(),
+        z.undefined(),
+        z.literal("1234"),
+      ]),
+      merged: z
+        .object({
+          k1: z.string(),
+        })
+        .merge(z.object({ k2: z.string(), k3: z.number() })),
+      union: z.array(z.union([z.literal("ABCD"), z.literal(42)])).nonempty(),
+      array: z.array(z.number()),
+      sumMinLength: z.object({
+        values: z.array(z.number()).superRefine((arg, ctx) => {
+          if (arg.length < 2) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Array really must be at least 2 items long",
+              fatal: true,
+            });
+          }
+          if (arg.length < 6) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Array must be at least 6 items long",
+            });
+          }
+        }),
       }),
-    },
-  },
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12, 15, 16, 98, 24] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
-    },
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "custom",
-            message: "Array must be at least 6 items long",
-            path: ["sumMinLength", "values"],
-          },
-          {
-            code: "custom",
-            message: "Array must be at least 8 items long",
-            path: ["sumMinLength", "values"],
-          },
-        ],
+      intersection: z.intersection(
+        z.object({ p1: z.string().optional() }),
+        z.object({ p2: z.number() }),
+        z.object({ p3: z.number().optional() })
+      ),
+      enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
+      passthrough: z
+        .object({ points: z.number(), score: z.number() })
+        .passthrough(),
+      numProm: z.promise(z.number()),
+      lenfun: z.function(
+        z.tuple([z.string(), z.number().optional()]),
+        z.number()
+      ),
+    });
+
+    const toSchema = z.object({
+      tuple: z.tuple([
+        z.string().nullable().optional(),
+        z.number().nullable().optional(),
+        z.boolean().nullable().optional(),
+        z.null().optional(),
+        z.undefined().optional(),
+        z.literal("1234").nullable().optional(),
+      ]),
+      merged: z
+        .object({
+          k1: z.string().optional(),
+        })
+        .merge(z.object({ k1: z.string().nullable() })),
+      union: z
+        .array(z.union([z.literal("ABCD"), z.literal(42), z.literal("42")]))
+        .nonempty(),
+      array: z.array(z.number()),
+      sumMinLength: z.object({
+        values: z.array(z.number()).superRefine((arg, ctx) => {
+          if (arg.length < 4) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Array really must be at least 4 items long",
+              fatal: true,
+            });
+          }
+          if (arg.length < 8) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Array must be at least 8 items long",
+            });
+          }
+        }),
       }),
-    },
-  },
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12, 15, 16] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
-    },
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "custom",
-            message: "Array must be at least 6 items long",
-            path: ["sumMinLength", "values"],
-          },
-          {
-            code: "custom",
-            message: "Array really must be at least 4 items long",
-            path: ["sumMinLength", "values"],
-            fatal: true,
-          },
-          {
-            code: "custom",
-            message: "Array must be at least 8 items long",
-            path: ["sumMinLength", "values"],
-          },
-        ],
-      }),
-    },
-  },
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
-    },
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "custom",
-            message: "Array really must be at least 2 items long",
-            path: ["sumMinLength", "values"],
-            fatal: true,
-          },
-          {
-            code: "custom",
-            message: "Array must be at least 6 items long",
-            path: ["sumMinLength", "values"],
-          },
-        ],
-      }),
-    },
-  },
-])("Object schema chaining - $#", async ({ input, output }) => {
-  const fromSchema = z.object({
-    tuple: z.tuple([
-      z.string().nullable(),
-      z.number().optional(),
-      z.boolean().nullable().optional(),
-      z.null(),
-      z.undefined(),
-      z.literal("1234"),
-    ]),
-    merged: z
-      .object({
-        k1: z.string(),
-      })
-      .merge(z.object({ k2: z.string(), k3: z.number() })),
-    union: z.array(z.union([z.literal("ABCD"), z.literal(42)])).nonempty(),
-    array: z.array(z.number()),
-    sumMinLength: z.object({
-      values: z.array(z.number()).superRefine((arg, ctx) => {
-        if (arg.length < 2) {
-          ctx.addIssue({
-            code: "custom",
-            message: "Array really must be at least 2 items long",
-            fatal: true,
-          });
-        }
-        if (arg.length < 6) {
-          ctx.addIssue({
-            code: "custom",
-            message: "Array must be at least 6 items long",
-          });
-        }
-      }),
-    }),
-    intersection: z.intersection(
-      z.object({ p1: z.string().optional() }),
-      z.object({ p2: z.number() }),
-      z.object({ p3: z.number().optional() })
-    ),
-    enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
-    passthrough: z
-      .object({ points: z.number(), score: z.number() })
-      .passthrough(),
-    numProm: z.promise(z.number()),
-    lenfun: z.function(
-      z.tuple([z.string(), z.number().optional()]),
-      z.number()
-    ),
+      intersection: z.intersection(
+        z.object({ p1: z.string().optional() }),
+        z.object({ p2: z.number().optional() })
+      ),
+      enum: z.enum(["zero", "one"]),
+      passthrough: z.object({ points: z.number() }).passthrough(),
+      numProm: z.promise(z.number()),
+      lenfun: z
+        .function(z.tuple([z.string(), z.number().optional()]), z.number())
+        .transform((fn) => fn("Hello", 37)),
+    });
+
+    type FromInput = z.input<typeof fromSchema>;
+    type FromOutput = z.output<typeof fromSchema>;
+
+    type ToInput = z.input<typeof toSchema>;
+    type ToOutput = z.output<typeof toSchema>;
+
+    util.assertAssignable<ToInput, FromOutput>(true);
+    util.assertAssignable<FromOutput, ToInput>(false);
+
+    // Check invalid chains are not possible
+    // @ts-expect-error
+    z.chain(toSchema, fromSchema);
+    // @ts-expect-error
+    toSchema.chain(fromSchema);
+
+    // Test chain factory
+    const factoryChain = z.chain(fromSchema, toSchema);
+
+    type FactoryChainInput = z.input<typeof factoryChain>;
+    type FactoryChainOutput = z.output<typeof factoryChain>;
+
+    util.assertEqual<FactoryChainInput, FromInput>(true);
+    util.assertEqual<FactoryChainOutput, ToOutput>(true);
+
+    const factoryResSync = factoryChain.safeParse(input);
+    expect(factoryResSync).toEqual(output);
+    const factoryResAsync = await factoryChain.safeParseAsync(input);
+    expect(factoryResAsync).toEqual(output);
+
+    // Test chain method
+    const builtChain = fromSchema.chain(toSchema);
+
+    type BuiltChainInput = z.input<typeof builtChain>;
+    type BuiltChainOutput = z.output<typeof builtChain>;
+
+    util.assertEqual<BuiltChainInput, FromInput>(true);
+    util.assertEqual<BuiltChainOutput, ToOutput>(true);
+
+    const builtResSync = builtChain.safeParse(input);
+    expect(builtResSync).toEqual(output);
+    const builtResAsync = await builtChain.safeParseAsync(input);
+    expect(builtResAsync).toEqual(output);
   });
-
-  const toSchema = z.object({
-    tuple: z.tuple([
-      z.string().nullable().optional(),
-      z.number().nullable().optional(),
-      z.boolean().nullable().optional(),
-      z.null().optional(),
-      z.undefined().optional(),
-      z.literal("1234").nullable().optional(),
-    ]),
-    merged: z
-      .object({
-        k1: z.string().optional(),
-      })
-      .merge(z.object({ k1: z.string().nullable() })),
-    union: z
-      .array(z.union([z.literal("ABCD"), z.literal(42), z.literal("42")]))
-      .nonempty(),
-    array: z.array(z.number()),
-    sumMinLength: z.object({
-      values: z.array(z.number()).superRefine((arg, ctx) => {
-        if (arg.length < 4) {
-          ctx.addIssue({
-            code: "custom",
-            message: "Array really must be at least 4 items long",
-            fatal: true,
-          });
-        }
-        if (arg.length < 8) {
-          ctx.addIssue({
-            code: "custom",
-            message: "Array must be at least 8 items long",
-          });
-        }
-      }),
-    }),
-    intersection: z.intersection(
-      z.object({ p1: z.string().optional() }),
-      z.object({ p2: z.number().optional() })
-    ),
-    enum: z.enum(["zero", "one"]),
-    passthrough: z.object({ points: z.number() }).passthrough(),
-    numProm: z.promise(z.number()),
-    lenfun: z
-      .function(z.tuple([z.string(), z.number().optional()]), z.number())
-      .transform((fn) => fn("Hello", 37)),
-  });
-
-  type FromInput = z.input<typeof fromSchema>;
-  type FromOutput = z.output<typeof fromSchema>;
-
-  type ToInput = z.input<typeof toSchema>;
-  type ToOutput = z.output<typeof toSchema>;
-
-  util.assertAssignable<ToInput, FromOutput>(true);
-  util.assertAssignable<FromOutput, ToInput>(false);
-
-  // Check invalid chains are not possible
-  // @ts-expect-error
-  z.chain(toSchema, fromSchema), toSchema.chain(fromSchema);
-
-  // Test chain factory
-  const chain = z.chain(fromSchema, toSchema);
-
-  type ChainInput = z.input<typeof chain>;
-  type ChainOutput = z.output<typeof chain>;
-
-  util.assertEqual<ChainInput, FromInput>(true);
-  util.assertEqual<ChainOutput, ToOutput>(true);
-
-  const resSync = chain.safeParse(input);
-  expect(resSync).toEqual(output);
-  const resAsync = await chain.safeParseAsync(input);
-  expect(resAsync).toEqual(output);
-
-  // Test chain method
-  const methChain = fromSchema.chain(toSchema);
-
-  type MethChainInput = z.input<typeof methChain>;
-  type MethChainOutput = z.output<typeof methChain>;
-
-  util.assertEqual<MethChainInput, FromInput>(true);
-  util.assertEqual<MethChainOutput, ToOutput>(true);
-
-  const methResSync = methChain.safeParse(input);
-  expect(methResSync).toEqual(output);
-  const methResAsync = await methChain.safeParseAsync(input);
-  expect(methResAsync).toEqual(output);
 });

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -101,7 +101,7 @@ test.each([
       }),
     },
   },
-])('Schema chaining "$input"', async ({ input, output }) => {
+])('Scalar schema chaining "$input"', async ({ input, output }) => {
   const fromSchema = z
     .string()
     .transform((val) => parseInt(val, 10))
@@ -146,6 +146,283 @@ test.each([
   type ToOutput = z.output<typeof toSchema>;
 
   util.assertAssignable<ToInput, FromOutput>(true);
+  util.assertAssignable<FromOutput, ToInput>(false);
+
+  const chain = z.chain(fromSchema, toSchema);
+
+  type ChainInput = z.input<typeof chain>;
+  type ChainOutput = z.output<typeof chain>;
+
+  util.assertEqual<ChainInput, FromInput>(true);
+  util.assertEqual<ChainOutput, ToOutput>(true);
+
+  const resSync = chain.safeParse(input);
+  expect(resSync).toEqual(output);
+  const resAsync = await chain.safeParseAsync(input);
+  expect(resAsync).toEqual(output);
+});
+
+const numProm = Promise.resolve(12);
+
+test.each([
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: true,
+      data: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc" },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999 },
+        numProm,
+        lenfun: 42,
+      },
+    },
+  },
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Array must be at least 8 items long",
+            path: ["sumMinLength", "values"],
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12, 15, 16, 98, 24] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Array must be at least 6 items long",
+            path: ["sumMinLength", "values"],
+          },
+          {
+            code: "custom",
+            message: "Array must be at least 8 items long",
+            path: ["sumMinLength", "values"],
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12, 15, 16] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Array must be at least 6 items long",
+            path: ["sumMinLength", "values"],
+          },
+          {
+            code: "custom",
+            message: "Array really must be at least 4 items long",
+            path: ["sumMinLength", "values"],
+            fatal: true,
+          },
+          {
+            code: "custom",
+            message: "Array must be at least 8 items long",
+            path: ["sumMinLength", "values"],
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Array really must be at least 2 items long",
+            path: ["sumMinLength", "values"],
+            fatal: true,
+          },
+          {
+            code: "custom",
+            message: "Array must be at least 6 items long",
+            path: ["sumMinLength", "values"],
+          },
+        ],
+      }),
+    },
+  },
+])("Object schema chaining - $#", async ({ input, output }) => {
+  const fromSchema = z.object({
+    tuple: z.tuple([
+      z.string().nullable(),
+      z.number().optional(),
+      z.boolean().nullable().optional(),
+      z.null(),
+      z.undefined(),
+      z.literal("1234"),
+    ]),
+    merged: z
+      .object({
+        k1: z.string(),
+      })
+      .merge(z.object({ k2: z.string(), k3: z.number() })),
+    union: z.array(z.union([z.literal("ABCD"), z.literal(42)])).nonempty(),
+    array: z.array(z.number()),
+    sumMinLength: z.object({
+      values: z.array(z.number()).superRefine((arg, ctx) => {
+        if (arg.length < 2) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Array really must be at least 2 items long",
+            fatal: true,
+          });
+        }
+        if (arg.length < 6) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Array must be at least 6 items long",
+          });
+        }
+      }),
+    }),
+    intersection: z.intersection(
+      z.object({ p1: z.string().optional() }),
+      z.object({ p2: z.number() }),
+      z.object({ p3: z.number().optional() })
+    ),
+    enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
+    passthrough: z.object({ points: z.number(), score: z.number() }),
+    numProm: z.promise(z.number()),
+    lenfun: z.function(
+      z.tuple([z.string(), z.number().optional()]),
+      z.number()
+    ),
+  });
+
+  const toSchema = z.object({
+    tuple: z.tuple([
+      z.string().nullable().optional(),
+      z.number().nullable().optional(),
+      z.boolean().nullable().optional(),
+      z.null().optional(),
+      z.undefined().optional(),
+      z.literal("1234").nullable().optional(),
+    ]),
+    merged: z
+      .object({
+        k1: z.string().optional(),
+      })
+      .merge(z.object({ k1: z.string().nullable() })),
+    union: z
+      .array(z.union([z.literal("ABCD"), z.literal(42), z.literal("42")]))
+      .nonempty(),
+    array: z.array(z.number()),
+    sumMinLength: z.object({
+      values: z.array(z.number()).superRefine((arg, ctx) => {
+        if (arg.length < 4) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Array really must be at least 4 items long",
+            fatal: true,
+          });
+        }
+        if (arg.length < 8) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Array must be at least 8 items long",
+          });
+        }
+      }),
+    }),
+    intersection: z.intersection(
+      z.object({ p1: z.string().optional() }),
+      z.object({ p2: z.number().optional() })
+    ),
+    enum: z.enum(["zero", "one"]),
+    passthrough: z.object({ points: z.number() }).passthrough(),
+    numProm: z.promise(z.number()),
+    lenfun: z
+      .function(z.tuple([z.string(), z.number().optional()]), z.number())
+      .transform((fn) => fn("Hello", 37)),
+  });
+
+  type FromInput = z.input<typeof fromSchema>;
+  type FromOutput = z.output<typeof fromSchema>;
+
+  type ToInput = z.input<typeof toSchema>;
+  type ToOutput = z.output<typeof toSchema>;
+
+  util.assertAssignable<ToInput, FromOutput>(true);
+  util.assertAssignable<FromOutput, ToInput>(false);
 
   const chain = z.chain(fromSchema, toSchema);
 

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -6,10 +6,13 @@ import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
 
 test("schema chaining", () => {
-  const from = z.string().transform((val) => parseInt(val, 10));
-  const to = z.number().min(1).max(10);
+  const from = z
+    .string()
+    .transform((val) => parseInt(val, 10))
+    .nullable();
+  const to = z.number().min(1).max(10).nullable();
 
-  const chain = from.chain(to);
+  const chain = z.chain(from, to);
 
   type FromOutput = z.output<typeof from>;
   type ToInput = z.input<typeof to>;
@@ -19,6 +22,6 @@ test("schema chaining", () => {
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;
 
-  util.assertEqual<ChainInput, string>(true);
-  util.assertEqual<ChainOutput, number>(true);
+  util.assertEqual<ChainInput, string | null>(true);
+  util.assertEqual<ChainOutput, number | null>(true);
 });

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -83,6 +83,24 @@ test.each([
       }),
     },
   },
+  {
+    input: "11",
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "too_big",
+            maximum: 10,
+            type: "number",
+            inclusive: true,
+            message: "Number must be less than or equal to 10",
+            path: [],
+          },
+        ],
+      }),
+    },
+  },
 ])('Schema chaining "$input"', async ({ input, output }) => {
   const from = z
     .string()

--- a/deno/lib/__tests__/chain.test.ts
+++ b/deno/lib/__tests__/chain.test.ts
@@ -163,19 +163,18 @@ test.each([
   expect(resAsync).toEqual(output);
 
   // Test chain method.
-  // const methChain = fromSchema.chain(toSchema);
-  // toSchema.chain(fromSchema); // TODO Should not compile, remore
+  const methChain = fromSchema.chain(toSchema);
 
-  // type MethChainInput = z.input<typeof methChain>;
-  // type MethChainOutput = z.output<typeof methChain>;
+  type MethChainInput = z.input<typeof methChain>;
+  type MethChainOutput = z.output<typeof methChain>;
 
-  // util.assertEqual<MethChainInput, FromInput>(true);
-  // util.assertEqual<MethChainOutput, ToOutput>(true);
+  util.assertEqual<MethChainInput, FromInput>(true);
+  util.assertEqual<MethChainOutput, ToOutput>(true);
 
-  // const methResSync = methChain.safeParse(input);
-  // expect(methResSync).toEqual(output);
-  // const methResAsync = await methChain.safeParseAsync(input);
-  // expect(methResAsync).toEqual(output);
+  const methResSync = methChain.safeParse(input);
+  expect(methResSync).toEqual(output);
+  const methResAsync = await methChain.safeParseAsync(input);
+  expect(methResAsync).toEqual(output);
 });
 
 const numProm = Promise.resolve(12);
@@ -457,16 +456,16 @@ test.each([
   expect(resAsync).toEqual(output);
 
   // Test chain method
-  // const methChain = fromSchema.chain(toSchema);
+  const methChain = fromSchema.chain(toSchema);
 
-  // type MethChainInput = z.input<typeof methChain>;
-  // type MethChainOutput = z.output<typeof methChain>;
+  type MethChainInput = z.input<typeof methChain>;
+  type MethChainOutput = z.output<typeof methChain>;
 
-  // util.assertEqual<MethChainInput, FromInput>(true);
-  // util.assertEqual<MethChainOutput, ToOutput>(true);
+  util.assertEqual<MethChainInput, FromInput>(true);
+  util.assertEqual<MethChainOutput, ToOutput>(true);
 
-  // const methResSync = methChain.safeParse(input);
-  // expect(methResSync).toEqual(output);
-  // const methResAsync = await methChain.safeParseAsync(input);
-  // expect(methResAsync).toEqual(output);
+  const methResSync = methChain.safeParse(input);
+  expect(methResSync).toEqual(output);
+  const methResAsync = await methChain.safeParseAsync(input);
+  expect(methResAsync).toEqual(output);
 });

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -83,8 +83,11 @@ export type ObjectPair = {
   key: SyncParseReturnType<any>;
   value: SyncParseReturnType<any>;
 };
+
+type ParseStatusValue = "aborted" | "dirty" | "valid";
+
 export class ParseStatus {
-  value: "aborted" | "dirty" | "valid" = "valid";
+  value: ParseStatusValue = "valid";
   dirty() {
     if (this.value === "valid") this.value = "dirty";
   }
@@ -176,3 +179,16 @@ export const isAsync = <T>(
   x: ParseReturnType<T>
 ): x is AsyncParseReturnType<T> =>
   typeof Promise !== undefined && x instanceof Promise;
+
+export const overrideReturnType = <T>(
+  rt: SyncParseReturnType<T>,
+  status: ParseStatusValue
+) => {
+  if (rt.status === "aborted" || status === "aborted") {
+    return INVALID;
+  }
+  if (rt.status === "dirty" || status === "dirty") {
+    return DIRTY(rt.value);
+  }
+  return rt;
+};

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -163,6 +163,19 @@ export const DIRTY = <T>(value: T): DIRTY<T> => ({ status: "dirty", value });
 export type OK<T> = { status: "valid"; value: T };
 export const OK = <T>(value: T): OK<T> => ({ status: "valid", value });
 
+export const overrideReturnType = <T>(
+  rt: SyncParseReturnType<T>,
+  status: ParseStatusValue
+) => {
+  if (rt.status === "aborted" || status === "aborted") {
+    return INVALID;
+  }
+  if (rt.status === "dirty" || status === "dirty") {
+    return DIRTY(rt.value);
+  }
+  return rt;
+};
+
 export type SyncParseReturnType<T = any> = OK<T> | DIRTY<T> | INVALID;
 export type AsyncParseReturnType<T> = Promise<SyncParseReturnType<T>>;
 export type ParseReturnType<T> =
@@ -179,16 +192,3 @@ export const isAsync = <T>(
   x: ParseReturnType<T>
 ): x is AsyncParseReturnType<T> =>
   typeof Promise !== undefined && x instanceof Promise;
-
-export const overrideReturnType = <T>(
-  rt: SyncParseReturnType<T>,
-  status: ParseStatusValue
-) => {
-  if (rt.status === "aborted" || status === "aborted") {
-    return INVALID;
-  }
-  if (rt.status === "dirty" || status === "dirty") {
-    return DIRTY(rt.value);
-  }
-  return rt;
-};

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -6,6 +6,11 @@ export namespace util {
     : false;
 
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
+
+  type AssertAssignable<L, R> = R extends L ? true : false;
+
+  export const assertAssignable = <A, B>(val: AssertAssignable<A, B>) => val;
+
   export function assertIs<T>(_arg: T): void {}
   export function assertNever(_x: never): never {
     throw new Error();

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -7,9 +7,9 @@ export namespace util {
 
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
 
-  type AssertAssignable<L, R> = R extends L ? true : false;
+  type AssertAssignable<L, R> = [R] extends [L] ? true : false;
 
-  export const assertAssignable = <A, B>(val: AssertAssignable<A, B>) => val;
+  export const assertAssignable = <L, R>(val: AssertAssignable<L, R>) => val;
 
   export function assertIs<T>(_arg: T): void {}
   export function assertNever(_x: never): never {

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -9,6 +9,7 @@ export namespace util {
 
   type AssertAssignable<L, R> = [R] extends [L] ? true : false;
 
+  // Assert that a value of type `R` is assignable to a variable of type `L`
   export const assertAssignable = <L, R>(val: AssertAssignable<L, R>) => val;
 
   export function assertIs<T>(_arg: T): void {}

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -407,15 +407,17 @@ export abstract class ZodType<
     }) as any;
   }
 
-  chain<
-    ToDef extends ZodTypeDef,
-    To extends ZodType<To["_output"], ToDef, Output>
-  >(to: To): ZodChain<Def, Output, this, ToDef, To> {
-    return new ZodChain<Def, Output, this, ToDef, To>({
-      from: this,
-      to: to,
-    });
-  }
+  // chain<
+  //   FromOut extends ToIn & Output,
+  //   ToIn,
+  //   ToDef extends ZodTypeDef,
+  //   To extends ZodType<To["_output"], ToDef, ToIn>
+  // >(to: To): ZodChain<Def, FromOut, this, ToIn, ToDef, To> {
+  //   return new ZodChain<Def, FromOut, this, ToIn, ToDef, To>({
+  //     from: this,
+  //     to: to,
+  //   });
+  // }
 
   default(def: util.noUndefined<Input>): ZodDefault<this>;
   default(def: () => util.noUndefined<Input>): ZodDefault<this>;
@@ -3594,16 +3596,12 @@ export interface ZodChainDef<From extends ZodTypeAny, To extends ZodTypeAny>
 }
 
 export class ZodChain<
-  FromDef extends ZodTypeDef,
   FromOut extends To["_input"],
+  FromDef extends ZodTypeDef,
   From extends ZodType<FromOut, FromDef, From["_input"]>,
   ToDef extends ZodTypeDef,
   To extends ZodType<To["_output"], ToDef, To["_input"]>
 > extends ZodType<To["_output"], ZodChainDef<From, To>, From["_input"]> {
-  innerType() {
-    return this;
-  }
-
   _parse(input: ParseInput): ParseReturnType<To["_output"]> {
     const { status, ctx } = this._processInputParams(input);
 
@@ -3641,6 +3639,23 @@ export class ZodChain<
       });
     }
   }
+
+  static create = <
+    FromOut extends To["_input"],
+    FromDef extends ZodTypeDef,
+    From extends ZodType<FromOut, FromDef, From["_input"]>,
+    ToDef extends ZodTypeDef,
+    To extends ZodType<To["_output"], ToDef, To["_input"]>
+  >(
+    from: From,
+    to: To
+  ) => {
+    return new ZodChain({
+      from,
+      to,
+      // ...processCreateParams(params),
+    });
+  };
 }
 
 ///////////////////////////////////////////
@@ -3988,6 +4003,7 @@ const enumType = ZodEnum.create;
 const nativeEnumType = ZodNativeEnum.create;
 const promiseType = ZodPromise.create;
 const effectsType = ZodEffects.create;
+const chainType = ZodChain.create;
 const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
@@ -4000,6 +4016,7 @@ export {
   arrayType as array,
   bigIntType as bigint,
   booleanType as boolean,
+  chainType as chain,
   dateType as date,
   discriminatedUnionType as discriminatedUnion,
   effectsType as effect,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3661,24 +3661,20 @@ export class ZodChain<
     }
   }
 
-  static create = <
+  static create<
     From extends ZodType<From["_output"], any, From["_input"]>,
     To extends ZodType<
       To["_output"],
       any,
       From["_output"] extends To["_input"] ? To["_input"] : never
     >
-  >(
-    from: From,
-    to: To,
-    params?: RawCreateParams
-  ) => {
+  >(from: From, to: To, params?: RawCreateParams) {
     return new ZodChain({
       from,
       to,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////////

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -410,8 +410,8 @@ export abstract class ZodType<
   chain<
     ToDef extends ZodTypeDef,
     To extends ZodType<To["_output"], ToDef, Output>
-  >(to: To): ZodChain<Def, Output, this, Output, ToDef, To> {
-    return new ZodChain<Def, Output, this, Output, ToDef, To>({
+  >(to: To): ZodChain<Def, Output, this, ToDef, To> {
+    return new ZodChain<Def, Output, this, ToDef, To>({
       from: this,
       to: to,
     });
@@ -3595,11 +3595,10 @@ export interface ZodChainDef<From extends ZodTypeAny, To extends ZodTypeAny>
 
 export class ZodChain<
   FromDef extends ZodTypeDef,
-  FromOut extends ToIn,
+  FromOut extends To["_input"],
   From extends ZodType<FromOut, FromDef, From["_input"]>,
-  ToIn,
   ToDef extends ZodTypeDef,
-  To extends ZodType<To["_output"], ToDef, ToIn>
+  To extends ZodType<To["_output"], ToDef, To["_input"]>
 > extends ZodType<To["_output"], ZodChainDef<From, To>, From["_input"]> {
   innerType() {
     return this;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -408,10 +408,14 @@ export abstract class ZodType<
     }) as any;
   }
 
-  chain<To extends ZodType<To["_output"], any, Output>>(
-    to: To
-  ): ZodChain<Output, this, To> {
-    return new ZodChain<Output, this, To>({
+  chain<
+    To extends ZodType<
+      To["_output"],
+      any,
+      this["_output"] extends To["_input"] ? To["_input"] : never
+    >
+  >(to: To): ZodChain<this, To> {
+    return new ZodChain<this, To>({
       from: this,
       to,
     });
@@ -3596,23 +3600,25 @@ export { ZodEffects as ZodTransformer };
 //////////////////////////////////////////
 
 export interface ZodChainDef<
-  FromOut extends To["_input"],
-  From extends ZodType<FromOut, any, From["_input"]>,
-  To extends ZodType<To["_output"], any, To["_input"]>
+  From extends ZodType<From["_output"], any, From["_input"]>,
+  To extends ZodType<
+    To["_output"],
+    any,
+    From["_output"] extends To["_input"] ? To["_input"] : never
+  >
 > extends ZodTypeDef {
   from: From;
   to: To;
 }
 
 export class ZodChain<
-  FromOut extends To["_input"],
-  From extends ZodType<FromOut, any, From["_input"]>,
-  To extends ZodType<To["_output"], any, To["_input"]>
-> extends ZodType<
-  To["_output"],
-  ZodChainDef<FromOut, From, To>,
-  From["_input"]
-> {
+  From extends ZodType<From["_output"], any, From["_input"]>,
+  To extends ZodType<
+    To["_output"],
+    any,
+    From["_output"] extends To["_input"] ? To["_input"] : never
+  >
+> extends ZodType<To["_output"], ZodChainDef<From, To>, From["_input"]> {
   _parse(input: ParseInput): ParseReturnType<To["_output"]> {
     const { ctx } = this._processInputParams(input);
 
@@ -3656,11 +3662,12 @@ export class ZodChain<
   }
 
   static create = <
-    FromOut extends To["_input"],
-    FromDef extends ZodTypeDef,
-    From extends ZodType<FromOut, FromDef, From["_input"]>,
-    ToDef extends ZodTypeDef,
-    To extends ZodType<To["_output"], ToDef, To["_input"]>
+    From extends ZodType<From["_output"], any, From["_input"]>,
+    To extends ZodType<
+      To["_output"],
+      any,
+      From["_output"] extends To["_input"] ? To["_input"] : never
+    >
   >(
     from: From,
     to: To,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -407,18 +407,6 @@ export abstract class ZodType<
     }) as any;
   }
 
-  // chain<
-  //   FromOut extends ToIn & Output,
-  //   ToIn,
-  //   ToDef extends ZodTypeDef,
-  //   To extends ZodType<To["_output"], ToDef, ToIn>
-  // >(to: To): ZodChain<Def, FromOut, this, ToIn, ToDef, To> {
-  //   return new ZodChain<Def, FromOut, this, ToIn, ToDef, To>({
-  //     from: this,
-  //     to: to,
-  //   });
-  // }
-
   default(def: util.noUndefined<Input>): ZodDefault<this>;
   default(def: () => util.noUndefined<Input>): ZodDefault<this>;
   default(def: any) {
@@ -3589,8 +3577,13 @@ export { ZodEffects as ZodTransformer };
 //////////////////////////////////////////
 //////////////////////////////////////////
 
-export interface ZodChainDef<From extends ZodTypeAny, To extends ZodTypeAny>
-  extends ZodTypeDef {
+export interface ZodChainDef<
+  FromOut extends To["_input"],
+  FromDef extends ZodTypeDef,
+  From extends ZodType<FromOut, FromDef, From["_input"]>,
+  ToDef extends ZodTypeDef,
+  To extends ZodType<To["_output"], ToDef, To["_input"]>
+> extends ZodTypeDef {
   from: From;
   to: To;
 }
@@ -3601,7 +3594,11 @@ export class ZodChain<
   From extends ZodType<FromOut, FromDef, From["_input"]>,
   ToDef extends ZodTypeDef,
   To extends ZodType<To["_output"], ToDef, To["_input"]>
-> extends ZodType<To["_output"], ZodChainDef<From, To>, From["_input"]> {
+> extends ZodType<
+  To["_output"],
+  ZodChainDef<FromOut, FromDef, From, ToDef, To>,
+  From["_input"]
+> {
   _parse(input: ParseInput): ParseReturnType<To["_output"]> {
     const { status, ctx } = this._processInputParams(input);
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -408,6 +408,15 @@ export abstract class ZodType<
     }) as any;
   }
 
+  chain<To extends ZodType<To["_output"], any, Output>>(
+    to: To
+  ): ZodChain<Output, this, To> {
+    return new ZodChain<Output, this, To>({
+      from: this,
+      to,
+    });
+  }
+
   default(def: util.noUndefined<Input>): ZodDefault<this>;
   default(def: () => util.noUndefined<Input>): ZodDefault<this>;
   default(def: any) {
@@ -3588,10 +3597,8 @@ export { ZodEffects as ZodTransformer };
 
 export interface ZodChainDef<
   FromOut extends To["_input"],
-  FromDef extends ZodTypeDef,
-  From extends ZodType<FromOut, FromDef, From["_input"]>,
-  ToDef extends ZodTypeDef,
-  To extends ZodType<To["_output"], ToDef, To["_input"]>
+  From extends ZodType<FromOut, any, From["_input"]>,
+  To extends ZodType<To["_output"], any, To["_input"]>
 > extends ZodTypeDef {
   from: From;
   to: To;
@@ -3599,13 +3606,11 @@ export interface ZodChainDef<
 
 export class ZodChain<
   FromOut extends To["_input"],
-  FromDef extends ZodTypeDef,
-  From extends ZodType<FromOut, FromDef, From["_input"]>,
-  ToDef extends ZodTypeDef,
-  To extends ZodType<To["_output"], ToDef, To["_input"]>
+  From extends ZodType<FromOut, any, From["_input"]>,
+  To extends ZodType<To["_output"], any, To["_input"]>
 > extends ZodType<
   To["_output"],
-  ZodChainDef<FromOut, FromDef, From, ToDef, To>,
+  ZodChainDef<FromOut, From, To>,
   From["_input"]
 > {
   _parse(input: ParseInput): ParseReturnType<To["_output"]> {

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -4,203 +4,192 @@ import { expect, test } from "@jest/globals";
 import { util } from "../helpers/util";
 import * as z from "../index";
 
-test.each([
-  {
-    input: "1",
-    output: {
-      success: true,
-      data: 1,
+describe("Schema chaining", () => {
+  test.each([
+    {
+      input: "1",
+      output: {
+        success: true,
+        data: 1,
+      },
     },
-  },
-  {
-    input: "",
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "invalid_type",
-            expected: "number",
-            received: "nan",
-            path: [],
-            message: "Expected number, received nan",
-          },
-        ],
-      }),
+    {
+      input: "",
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "invalid_type",
+              expected: "number",
+              received: "nan",
+              path: [],
+              message: "Expected number, received nan",
+            },
+          ],
+        }),
+      },
     },
-  },
-  {
-    input: null,
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "invalid_type",
-            expected: "string",
-            received: "null",
-            path: [],
-            message: "Expected string, received null",
-          },
-        ],
-      }),
+    {
+      input: null,
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "invalid_type",
+              expected: "string",
+              received: "null",
+              path: [],
+              message: "Expected string, received null",
+            },
+          ],
+        }),
+      },
     },
-  },
-  {
-    input: "5",
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
+    {
+      input: "5",
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Cannot be 5",
+              path: ["new_path"],
+            },
+            {
+              code: "custom",
+              message: "It really can not be 5",
+              path: ["newer_path"],
+            },
+          ],
+        }),
+      },
+    },
+    {
+      input: "6",
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Cannot be 6",
+              fatal: true,
+              path: [],
+            },
+          ],
+        }),
+      },
+    },
+    {
+      input: "11",
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "too_big",
+              maximum: 10,
+              type: "number",
+              inclusive: true,
+              message: "Number must be less than or equal to 10",
+              path: [],
+            },
+          ],
+        }),
+      },
+    },
+  ])("Scalar schema chaining - $input", async ({ input, output }) => {
+    const fromSchema = z
+      .string()
+      .transform((val) => parseInt(val, 10))
+      .optional()
+      .superRefine((val, ctx) => {
+        if (val === 5) {
+          ctx.addIssue({
             code: "custom",
             message: "Cannot be 5",
             path: ["new_path"],
-          },
-          {
-            code: "custom",
-            message: "It really can not be 5",
-            path: ["newer_path"],
-          },
-        ],
-      }),
-    },
-  },
-  {
-    input: "6",
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
+          });
+        }
+        if (val === 6) {
+          ctx.addIssue({
             code: "custom",
             message: "Cannot be 6",
             fatal: true,
-            path: [],
-          },
-        ],
-      }),
-    },
-  },
-  {
-    input: "11",
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "too_big",
-            maximum: 10,
-            type: "number",
-            inclusive: true,
-            message: "Number must be less than or equal to 10",
-            path: [],
-          },
-        ],
-      }),
-    },
-  },
-])("Scalar schema chaining - $input", async ({ input, output }) => {
-  const fromSchema = z
-    .string()
-    .transform((val) => parseInt(val, 10))
-    .optional()
-    .superRefine((val, ctx) => {
-      if (val === 5) {
-        ctx.addIssue({
-          code: "custom",
-          message: "Cannot be 5",
-          path: ["new_path"],
-        });
-      }
-      if (val === 6) {
-        ctx.addIssue({
-          code: "custom",
-          message: "Cannot be 6",
-          fatal: true,
-        });
-      }
-    });
-  const toSchema = z
-    .number()
-    .min(1)
-    .max(10)
-    .nullable()
-    .optional()
-    .superRefine((val, ctx) => {
-      if (val === 5) {
-        ctx.addIssue({
-          code: "custom",
-          message: "It really can not be 5",
-          path: ["newer_path"],
-        });
-      }
-    })
-    .refine((val) => val !== 6, { message: "It really can not be 6" });
+          });
+        }
+      });
+    const toSchema = z
+      .number()
+      .min(1)
+      .max(10)
+      .nullable()
+      .optional()
+      .superRefine((val, ctx) => {
+        if (val === 5) {
+          ctx.addIssue({
+            code: "custom",
+            message: "It really can not be 5",
+            path: ["newer_path"],
+          });
+        }
+      })
+      .refine((val) => val !== 6, { message: "It really can not be 6" });
 
-  type FromInput = z.input<typeof fromSchema>;
-  type FromOutput = z.output<typeof fromSchema>;
+    type FromInput = z.input<typeof fromSchema>;
+    type FromOutput = z.output<typeof fromSchema>;
 
-  type ToInput = z.input<typeof toSchema>;
-  type ToOutput = z.output<typeof toSchema>;
+    type ToInput = z.input<typeof toSchema>;
+    type ToOutput = z.output<typeof toSchema>;
 
-  util.assertAssignable<ToInput, FromOutput>(true);
-  util.assertAssignable<FromOutput, ToInput>(false);
+    util.assertAssignable<ToInput, FromOutput>(true);
+    util.assertAssignable<FromOutput, ToInput>(false);
 
-  // Check invalid chains are not possible
-  // @ts-expect-error
-  z.chain(toSchema, fromSchema), toSchema.chain(fromSchema);
+    // Check invalid chains are not possible
+    // @ts-expect-error
+    z.chain(toSchema, fromSchema);
+    // @ts-expect-error
+    toSchema.chain(fromSchema);
 
-  // Test chain factory
-  const chain = z.chain(fromSchema, toSchema);
+    // Test chain factory
+    const factoryChain = z.chain(fromSchema, toSchema);
 
-  type ChainInput = z.input<typeof chain>;
-  type ChainOutput = z.output<typeof chain>;
+    type FactoryChainInput = z.input<typeof factoryChain>;
+    type FactoryChainOutput = z.output<typeof factoryChain>;
 
-  util.assertEqual<ChainInput, FromInput>(true);
-  util.assertEqual<ChainOutput, ToOutput>(true);
+    util.assertEqual<FactoryChainInput, FromInput>(true);
+    util.assertEqual<FactoryChainOutput, ToOutput>(true);
 
-  const resSync = chain.safeParse(input);
-  expect(resSync).toEqual(output);
-  const resAsync = await chain.safeParseAsync(input);
-  expect(resAsync).toEqual(output);
+    const factoryResSync = factoryChain.safeParse(input);
+    expect(factoryResSync).toEqual(output);
+    const factoryResAsync = await factoryChain.safeParseAsync(input);
+    expect(factoryResAsync).toEqual(output);
 
-  // Test chain method.
-  const methChain = fromSchema.chain(toSchema);
+    // Test chain method.
+    const builtChain = fromSchema.chain(toSchema);
 
-  type MethChainInput = z.input<typeof methChain>;
-  type MethChainOutput = z.output<typeof methChain>;
+    type BuiltChainInput = z.input<typeof builtChain>;
+    type BuiltChainOutput = z.output<typeof builtChain>;
 
-  util.assertEqual<MethChainInput, FromInput>(true);
-  util.assertEqual<MethChainOutput, ToOutput>(true);
+    util.assertEqual<BuiltChainInput, FromInput>(true);
+    util.assertEqual<BuiltChainOutput, ToOutput>(true);
 
-  const methResSync = methChain.safeParse(input);
-  expect(methResSync).toEqual(output);
-  const methResAsync = await methChain.safeParseAsync(input);
-  expect(methResAsync).toEqual(output);
-});
+    const builtResSync = builtChain.safeParse(input);
+    expect(builtResSync).toEqual(output);
+    const builtResAsync = await builtChain.safeParseAsync(input);
+    expect(builtResAsync).toEqual(output);
+  });
 
-const numProm = Promise.resolve(12);
+  const numProm = Promise.resolve(12);
 
-test.each([
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
-    },
-    output: {
-      success: true,
-      data: {
+  test.each([
+    {
+      input: {
         tuple: ["abcd", 1234, true, null, undefined, "1234"],
-        merged: { k1: "abdc" },
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
         union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
         array: [12, 15, 16],
         sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
@@ -208,271 +197,288 @@ test.each([
         enum: "one",
         passthrough: { points: 1234, score: 999, name: "General Zod" },
         numProm,
-        lenfun: 42,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: true,
+        data: {
+          tuple: ["abcd", 1234, true, null, undefined, "1234"],
+          merged: { k1: "abdc" },
+          union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+          array: [12, 15, 16],
+          sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
+          intersection: { p2: 0 },
+          enum: "one",
+          passthrough: { points: 1234, score: 999, name: "General Zod" },
+          numProm,
+          lenfun: 42,
+        },
       },
     },
-  },
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    {
+      input: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
+        numProm,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Array must be at least 8 items long",
+              path: ["sumMinLength", "values"],
+            },
+          ],
+        }),
+      },
     },
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "custom",
-            message: "Array must be at least 8 items long",
-            path: ["sumMinLength", "values"],
-          },
-        ],
+    {
+      input: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12, 15, 16, 98, 24] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
+        numProm,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Array must be at least 6 items long",
+              path: ["sumMinLength", "values"],
+            },
+            {
+              code: "custom",
+              message: "Array must be at least 8 items long",
+              path: ["sumMinLength", "values"],
+            },
+          ],
+        }),
+      },
+    },
+    {
+      input: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12, 15, 16] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
+        numProm,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Array must be at least 6 items long",
+              path: ["sumMinLength", "values"],
+            },
+            {
+              code: "custom",
+              message: "Array really must be at least 4 items long",
+              path: ["sumMinLength", "values"],
+              fatal: true,
+            },
+            {
+              code: "custom",
+              message: "Array must be at least 8 items long",
+              path: ["sumMinLength", "values"],
+            },
+          ],
+        }),
+      },
+    },
+    {
+      input: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc", k2: "1234", k3: 12 },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
+        numProm,
+        lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+      },
+      output: {
+        success: false,
+        error: expect.objectContaining({
+          issues: [
+            {
+              code: "custom",
+              message: "Array really must be at least 2 items long",
+              path: ["sumMinLength", "values"],
+              fatal: true,
+            },
+            {
+              code: "custom",
+              message: "Array must be at least 6 items long",
+              path: ["sumMinLength", "values"],
+            },
+          ],
+        }),
+      },
+    },
+  ])("Object schema chaining - $#", async ({ input, output }) => {
+    const fromSchema = z.object({
+      tuple: z.tuple([
+        z.string().nullable(),
+        z.number().optional(),
+        z.boolean().nullable().optional(),
+        z.null(),
+        z.undefined(),
+        z.literal("1234"),
+      ]),
+      merged: z
+        .object({
+          k1: z.string(),
+        })
+        .merge(z.object({ k2: z.string(), k3: z.number() })),
+      union: z.array(z.union([z.literal("ABCD"), z.literal(42)])).nonempty(),
+      array: z.array(z.number()),
+      sumMinLength: z.object({
+        values: z.array(z.number()).superRefine((arg, ctx) => {
+          if (arg.length < 2) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Array really must be at least 2 items long",
+              fatal: true,
+            });
+          }
+          if (arg.length < 6) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Array must be at least 6 items long",
+            });
+          }
+        }),
       }),
-    },
-  },
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12, 15, 16, 98, 24] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
-    },
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "custom",
-            message: "Array must be at least 6 items long",
-            path: ["sumMinLength", "values"],
-          },
-          {
-            code: "custom",
-            message: "Array must be at least 8 items long",
-            path: ["sumMinLength", "values"],
-          },
-        ],
+      intersection: z.intersection(
+        z.object({ p1: z.string().optional() }),
+        z.object({ p2: z.number() }),
+        z.object({ p3: z.number().optional() })
+      ),
+      enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
+      passthrough: z
+        .object({ points: z.number(), score: z.number() })
+        .passthrough(),
+      numProm: z.promise(z.number()),
+      lenfun: z.function(
+        z.tuple([z.string(), z.number().optional()]),
+        z.number()
+      ),
+    });
+
+    const toSchema = z.object({
+      tuple: z.tuple([
+        z.string().nullable().optional(),
+        z.number().nullable().optional(),
+        z.boolean().nullable().optional(),
+        z.null().optional(),
+        z.undefined().optional(),
+        z.literal("1234").nullable().optional(),
+      ]),
+      merged: z
+        .object({
+          k1: z.string().optional(),
+        })
+        .merge(z.object({ k1: z.string().nullable() })),
+      union: z
+        .array(z.union([z.literal("ABCD"), z.literal(42), z.literal("42")]))
+        .nonempty(),
+      array: z.array(z.number()),
+      sumMinLength: z.object({
+        values: z.array(z.number()).superRefine((arg, ctx) => {
+          if (arg.length < 4) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Array really must be at least 4 items long",
+              fatal: true,
+            });
+          }
+          if (arg.length < 8) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Array must be at least 8 items long",
+            });
+          }
+        }),
       }),
-    },
-  },
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12, 15, 16] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
-    },
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "custom",
-            message: "Array must be at least 6 items long",
-            path: ["sumMinLength", "values"],
-          },
-          {
-            code: "custom",
-            message: "Array really must be at least 4 items long",
-            path: ["sumMinLength", "values"],
-            fatal: true,
-          },
-          {
-            code: "custom",
-            message: "Array must be at least 8 items long",
-            path: ["sumMinLength", "values"],
-          },
-        ],
-      }),
-    },
-  },
-  {
-    input: {
-      tuple: ["abcd", 1234, true, null, undefined, "1234"],
-      merged: { k1: "abdc", k2: "1234", k3: 12 },
-      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
-      array: [12, 15, 16],
-      sumMinLength: { values: [12] },
-      intersection: { p2: 0 },
-      enum: "one",
-      passthrough: { points: 1234, score: 999, name: "General Zod" },
-      numProm,
-      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
-    },
-    output: {
-      success: false,
-      error: expect.objectContaining({
-        issues: [
-          {
-            code: "custom",
-            message: "Array really must be at least 2 items long",
-            path: ["sumMinLength", "values"],
-            fatal: true,
-          },
-          {
-            code: "custom",
-            message: "Array must be at least 6 items long",
-            path: ["sumMinLength", "values"],
-          },
-        ],
-      }),
-    },
-  },
-])("Object schema chaining - $#", async ({ input, output }) => {
-  const fromSchema = z.object({
-    tuple: z.tuple([
-      z.string().nullable(),
-      z.number().optional(),
-      z.boolean().nullable().optional(),
-      z.null(),
-      z.undefined(),
-      z.literal("1234"),
-    ]),
-    merged: z
-      .object({
-        k1: z.string(),
-      })
-      .merge(z.object({ k2: z.string(), k3: z.number() })),
-    union: z.array(z.union([z.literal("ABCD"), z.literal(42)])).nonempty(),
-    array: z.array(z.number()),
-    sumMinLength: z.object({
-      values: z.array(z.number()).superRefine((arg, ctx) => {
-        if (arg.length < 2) {
-          ctx.addIssue({
-            code: "custom",
-            message: "Array really must be at least 2 items long",
-            fatal: true,
-          });
-        }
-        if (arg.length < 6) {
-          ctx.addIssue({
-            code: "custom",
-            message: "Array must be at least 6 items long",
-          });
-        }
-      }),
-    }),
-    intersection: z.intersection(
-      z.object({ p1: z.string().optional() }),
-      z.object({ p2: z.number() }),
-      z.object({ p3: z.number().optional() })
-    ),
-    enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
-    passthrough: z
-      .object({ points: z.number(), score: z.number() })
-      .passthrough(),
-    numProm: z.promise(z.number()),
-    lenfun: z.function(
-      z.tuple([z.string(), z.number().optional()]),
-      z.number()
-    ),
+      intersection: z.intersection(
+        z.object({ p1: z.string().optional() }),
+        z.object({ p2: z.number().optional() })
+      ),
+      enum: z.enum(["zero", "one"]),
+      passthrough: z.object({ points: z.number() }).passthrough(),
+      numProm: z.promise(z.number()),
+      lenfun: z
+        .function(z.tuple([z.string(), z.number().optional()]), z.number())
+        .transform((fn) => fn("Hello", 37)),
+    });
+
+    type FromInput = z.input<typeof fromSchema>;
+    type FromOutput = z.output<typeof fromSchema>;
+
+    type ToInput = z.input<typeof toSchema>;
+    type ToOutput = z.output<typeof toSchema>;
+
+    util.assertAssignable<ToInput, FromOutput>(true);
+    util.assertAssignable<FromOutput, ToInput>(false);
+
+    // Check invalid chains are not possible
+    // @ts-expect-error
+    z.chain(toSchema, fromSchema);
+    // @ts-expect-error
+    toSchema.chain(fromSchema);
+
+    // Test chain factory
+    const factoryChain = z.chain(fromSchema, toSchema);
+
+    type FactoryChainInput = z.input<typeof factoryChain>;
+    type FactoryChainOutput = z.output<typeof factoryChain>;
+
+    util.assertEqual<FactoryChainInput, FromInput>(true);
+    util.assertEqual<FactoryChainOutput, ToOutput>(true);
+
+    const factoryResSync = factoryChain.safeParse(input);
+    expect(factoryResSync).toEqual(output);
+    const factoryResAsync = await factoryChain.safeParseAsync(input);
+    expect(factoryResAsync).toEqual(output);
+
+    // Test chain method
+    const builtChain = fromSchema.chain(toSchema);
+
+    type BuiltChainInput = z.input<typeof builtChain>;
+    type BuiltChainOutput = z.output<typeof builtChain>;
+
+    util.assertEqual<BuiltChainInput, FromInput>(true);
+    util.assertEqual<BuiltChainOutput, ToOutput>(true);
+
+    const builtResSync = builtChain.safeParse(input);
+    expect(builtResSync).toEqual(output);
+    const builtResAsync = await builtChain.safeParseAsync(input);
+    expect(builtResAsync).toEqual(output);
   });
-
-  const toSchema = z.object({
-    tuple: z.tuple([
-      z.string().nullable().optional(),
-      z.number().nullable().optional(),
-      z.boolean().nullable().optional(),
-      z.null().optional(),
-      z.undefined().optional(),
-      z.literal("1234").nullable().optional(),
-    ]),
-    merged: z
-      .object({
-        k1: z.string().optional(),
-      })
-      .merge(z.object({ k1: z.string().nullable() })),
-    union: z
-      .array(z.union([z.literal("ABCD"), z.literal(42), z.literal("42")]))
-      .nonempty(),
-    array: z.array(z.number()),
-    sumMinLength: z.object({
-      values: z.array(z.number()).superRefine((arg, ctx) => {
-        if (arg.length < 4) {
-          ctx.addIssue({
-            code: "custom",
-            message: "Array really must be at least 4 items long",
-            fatal: true,
-          });
-        }
-        if (arg.length < 8) {
-          ctx.addIssue({
-            code: "custom",
-            message: "Array must be at least 8 items long",
-          });
-        }
-      }),
-    }),
-    intersection: z.intersection(
-      z.object({ p1: z.string().optional() }),
-      z.object({ p2: z.number().optional() })
-    ),
-    enum: z.enum(["zero", "one"]),
-    passthrough: z.object({ points: z.number() }).passthrough(),
-    numProm: z.promise(z.number()),
-    lenfun: z
-      .function(z.tuple([z.string(), z.number().optional()]), z.number())
-      .transform((fn) => fn("Hello", 37)),
-  });
-
-  type FromInput = z.input<typeof fromSchema>;
-  type FromOutput = z.output<typeof fromSchema>;
-
-  type ToInput = z.input<typeof toSchema>;
-  type ToOutput = z.output<typeof toSchema>;
-
-  util.assertAssignable<ToInput, FromOutput>(true);
-  util.assertAssignable<FromOutput, ToInput>(false);
-
-  // Check invalid chains are not possible
-  // @ts-expect-error
-  z.chain(toSchema, fromSchema), toSchema.chain(fromSchema);
-
-  // Test chain factory
-  const chain = z.chain(fromSchema, toSchema);
-
-  type ChainInput = z.input<typeof chain>;
-  type ChainOutput = z.output<typeof chain>;
-
-  util.assertEqual<ChainInput, FromInput>(true);
-  util.assertEqual<ChainOutput, ToOutput>(true);
-
-  const resSync = chain.safeParse(input);
-  expect(resSync).toEqual(output);
-  const resAsync = await chain.safeParseAsync(input);
-  expect(resAsync).toEqual(output);
-
-  // Test chain method
-  const methChain = fromSchema.chain(toSchema);
-
-  type MethChainInput = z.input<typeof methChain>;
-  type MethChainOutput = z.output<typeof methChain>;
-
-  util.assertEqual<MethChainInput, FromInput>(true);
-  util.assertEqual<MethChainOutput, ToOutput>(true);
-
-  const methResSync = methChain.safeParse(input);
-  expect(methResSync).toEqual(output);
-  const methResAsync = await methChain.safeParseAsync(input);
-  expect(methResAsync).toEqual(output);
 });

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -4,12 +4,118 @@ import { expect, test } from "@jest/globals";
 import { util } from "../helpers/util";
 import * as z from "../index";
 
-test("schema chaining", () => {
-  const from = z.string().transform((val) => parseInt(val, 10));
-  const to = z.number().min(1).max(10).nullable();
+test.each([
+  {
+    input: "1",
+    output: {
+      success: true,
+      data: 1,
+    },
+  },
+  {
+    input: "",
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "invalid_type",
+            expected: "number",
+            received: "nan",
+            path: [],
+            message: "Expected number, received nan",
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: null,
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "invalid_type",
+            expected: "string",
+            received: "null",
+            path: [],
+            message: "Expected string, received null",
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: "5",
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Cannot be 5",
+            path: [],
+          },
+          {
+            code: "custom",
+            message: "It really can not be 5",
+            path: [],
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: "6",
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Cannot be 6",
+            fatal: true,
+            path: [],
+          },
+        ],
+      }),
+    },
+  },
+])("Schema chaining", ({ input, output }) => {
+  const from = z
+    .string()
+    .transform((val) => parseInt(val, 10))
+    .optional()
+    .superRefine((val, ctx) => {
+      if (val === 5) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Cannot be 5",
+        });
+      }
+      if (val === 6) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Cannot be 6",
+          fatal: true,
+        });
+      }
+    });
+  const to = z
+    .number()
+    .min(1)
+    .max(10)
+    .nullable()
+    .optional()
+    .refine((val) => val !== 5, { message: "It really can not be 5" })
+    .refine((val) => val !== 6, { message: "It really can not be 6" });
 
+  type FromInput = z.input<typeof from>;
   type FromOutput = z.output<typeof from>;
+
   type ToInput = z.input<typeof to>;
+  type ToOutput = z.output<typeof to>;
 
   util.assertAssignable<ToInput, FromOutput>(true);
 
@@ -18,6 +124,9 @@ test("schema chaining", () => {
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;
 
-  util.assertEqual<ChainInput, string>(true);
-  util.assertEqual<ChainOutput, number | null>(true);
+  util.assertEqual<ChainInput, FromInput>(true);
+  util.assertEqual<ChainOutput, ToOutput>(true);
+
+  const res = chain.safeParse(input);
+  expect(res).toEqual(output);
 });

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -147,6 +147,10 @@ test.each([
   util.assertAssignable<ToInput, FromOutput>(true);
   util.assertAssignable<FromOutput, ToInput>(false);
 
+  // Check invalid chains are not possible
+  // @ts-expect-error
+  z.chain(toSchema, fromSchema), toSchema.chain(fromSchema);
+
   // Test chain factory
   const chain = z.chain(fromSchema, toSchema);
 
@@ -439,6 +443,10 @@ test.each([
 
   util.assertAssignable<ToInput, FromOutput>(true);
   util.assertAssignable<FromOutput, ToInput>(false);
+
+  // Check invalid chains are not possible
+  // @ts-expect-error
+  z.chain(toSchema, fromSchema), toSchema.chain(fromSchema);
 
   // Test chain factory
   const chain = z.chain(fromSchema, toSchema);

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -82,6 +82,24 @@ test.each([
       }),
     },
   },
+  {
+    input: "11",
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "too_big",
+            maximum: 10,
+            type: "number",
+            inclusive: true,
+            message: "Number must be less than or equal to 10",
+            path: [],
+          },
+        ],
+      }),
+    },
+  },
 ])('Schema chaining "$input"', async ({ input, output }) => {
   const from = z
     .string()

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -162,19 +162,18 @@ test.each([
   expect(resAsync).toEqual(output);
 
   // Test chain method.
-  // const methChain = fromSchema.chain(toSchema);
-  // toSchema.chain(fromSchema); // TODO Should not compile, remore
+  const methChain = fromSchema.chain(toSchema);
 
-  // type MethChainInput = z.input<typeof methChain>;
-  // type MethChainOutput = z.output<typeof methChain>;
+  type MethChainInput = z.input<typeof methChain>;
+  type MethChainOutput = z.output<typeof methChain>;
 
-  // util.assertEqual<MethChainInput, FromInput>(true);
-  // util.assertEqual<MethChainOutput, ToOutput>(true);
+  util.assertEqual<MethChainInput, FromInput>(true);
+  util.assertEqual<MethChainOutput, ToOutput>(true);
 
-  // const methResSync = methChain.safeParse(input);
-  // expect(methResSync).toEqual(output);
-  // const methResAsync = await methChain.safeParseAsync(input);
-  // expect(methResAsync).toEqual(output);
+  const methResSync = methChain.safeParse(input);
+  expect(methResSync).toEqual(output);
+  const methResAsync = await methChain.safeParseAsync(input);
+  expect(methResAsync).toEqual(output);
 });
 
 const numProm = Promise.resolve(12);
@@ -456,16 +455,16 @@ test.each([
   expect(resAsync).toEqual(output);
 
   // Test chain method
-  // const methChain = fromSchema.chain(toSchema);
+  const methChain = fromSchema.chain(toSchema);
 
-  // type MethChainInput = z.input<typeof methChain>;
-  // type MethChainOutput = z.output<typeof methChain>;
+  type MethChainInput = z.input<typeof methChain>;
+  type MethChainOutput = z.output<typeof methChain>;
 
-  // util.assertEqual<MethChainInput, FromInput>(true);
-  // util.assertEqual<MethChainOutput, ToOutput>(true);
+  util.assertEqual<MethChainInput, FromInput>(true);
+  util.assertEqual<MethChainOutput, ToOutput>(true);
 
-  // const methResSync = methChain.safeParse(input);
-  // expect(methResSync).toEqual(output);
-  // const methResAsync = await methChain.safeParseAsync(input);
-  // expect(methResAsync).toEqual(output);
+  const methResSync = methChain.safeParse(input);
+  expect(methResSync).toEqual(output);
+  const methResAsync = await methChain.safeParseAsync(input);
+  expect(methResAsync).toEqual(output);
 });

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -5,22 +5,19 @@ import { util } from "../helpers/util";
 import * as z from "../index";
 
 test("schema chaining", () => {
-  const from = z
-    .string()
-    .transform((val) => parseInt(val, 10))
-    .nullable();
+  const from = z.string().transform((val) => parseInt(val, 10));
   const to = z.number().min(1).max(10).nullable();
-
-  const chain = z.chain(from, to);
 
   type FromOutput = z.output<typeof from>;
   type ToInput = z.input<typeof to>;
 
-  util.assertEqual<FromOutput, ToInput>(true);
+  util.assertAssignable<ToInput, FromOutput>(true);
+
+  const chain = z.chain(from, to);
 
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;
 
-  util.assertEqual<ChainInput, string | null>(true);
+  util.assertEqual<ChainInput, string>(true);
   util.assertEqual<ChainOutput, number | null>(true);
 });

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -5,10 +5,13 @@ import { util } from "../helpers/util";
 import * as z from "../index";
 
 test("schema chaining", () => {
-  const from = z.string().transform((val) => parseInt(val, 10));
-  const to = z.number().min(1).max(10);
+  const from = z
+    .string()
+    .transform((val) => parseInt(val, 10))
+    .nullable();
+  const to = z.number().min(1).max(10).nullable();
 
-  const chain = from.chain(to);
+  const chain = z.chain(from, to);
 
   type FromOutput = z.output<typeof from>;
   type ToInput = z.input<typeof to>;
@@ -18,6 +21,6 @@ test("schema chaining", () => {
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;
 
-  util.assertEqual<ChainInput, string>(true);
-  util.assertEqual<ChainOutput, number>(true);
+  util.assertEqual<ChainInput, string | null>(true);
+  util.assertEqual<ChainOutput, number | null>(true);
 });

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -1,0 +1,18 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import { util } from "../helpers/util";
+import * as z from "../index";
+
+test("schema chaining", () => {
+  const from = z.string().transform((val) => parseInt(val, 10));
+  const to = z.number().min(1).max(10);
+
+  const chain = from.chain(to);
+
+  type ChainInput = z.input<typeof chain>;
+  type ChainOutput = z.output<typeof chain>;
+
+  util.assertEqual<ChainInput, string>(true);
+  util.assertEqual<ChainOutput, number>(true);
+});

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -55,12 +55,12 @@ test.each([
           {
             code: "custom",
             message: "Cannot be 5",
-            path: [],
+            path: ["new_path"],
           },
           {
             code: "custom",
             message: "It really can not be 5",
-            path: [],
+            path: ["newer_path"],
           },
         ],
       }),
@@ -82,7 +82,7 @@ test.each([
       }),
     },
   },
-])("Schema chaining", ({ input, output }) => {
+])('Schema chaining "$input"', ({ input, output }) => {
   const from = z
     .string()
     .transform((val) => parseInt(val, 10))
@@ -92,6 +92,7 @@ test.each([
         ctx.addIssue({
           code: "custom",
           message: "Cannot be 5",
+          path: ["new_path"],
         });
       }
       if (val === 6) {
@@ -108,7 +109,15 @@ test.each([
     .max(10)
     .nullable()
     .optional()
-    .refine((val) => val !== 5, { message: "It really can not be 5" })
+    .superRefine((val, ctx) => {
+      if (val === 5) {
+        ctx.addIssue({
+          code: "custom",
+          message: "It really can not be 5",
+          path: ["newer_path"],
+        });
+      }
+    })
     .refine((val) => val !== 6, { message: "It really can not be 6" });
 
   type FromInput = z.input<typeof from>;

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -10,6 +10,11 @@ test("schema chaining", () => {
 
   const chain = from.chain(to);
 
+  type FromOutput = z.output<typeof from>;
+  type ToInput = z.input<typeof to>;
+
+  util.assertEqual<FromOutput, ToInput>(true);
+
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;
 

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -101,7 +101,7 @@ test.each([
     },
   },
 ])('Schema chaining "$input"', async ({ input, output }) => {
-  const from = z
+  const fromSchema = z
     .string()
     .transform((val) => parseInt(val, 10))
     .optional()
@@ -121,7 +121,7 @@ test.each([
         });
       }
     });
-  const to = z
+  const toSchema = z
     .number()
     .min(1)
     .max(10)
@@ -138,15 +138,15 @@ test.each([
     })
     .refine((val) => val !== 6, { message: "It really can not be 6" });
 
-  type FromInput = z.input<typeof from>;
-  type FromOutput = z.output<typeof from>;
+  type FromInput = z.input<typeof fromSchema>;
+  type FromOutput = z.output<typeof fromSchema>;
 
-  type ToInput = z.input<typeof to>;
-  type ToOutput = z.output<typeof to>;
+  type ToInput = z.input<typeof toSchema>;
+  type ToOutput = z.output<typeof toSchema>;
 
   util.assertAssignable<ToInput, FromOutput>(true);
 
-  const chain = z.chain(from, to);
+  const chain = z.chain(fromSchema, toSchema);
 
   type ChainInput = z.input<typeof chain>;
   type ChainOutput = z.output<typeof chain>;

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -147,6 +147,7 @@ test.each([
   util.assertAssignable<ToInput, FromOutput>(true);
   util.assertAssignable<FromOutput, ToInput>(false);
 
+  // Test chain factory
   const chain = z.chain(fromSchema, toSchema);
 
   type ChainInput = z.input<typeof chain>;
@@ -159,6 +160,21 @@ test.each([
   expect(resSync).toEqual(output);
   const resAsync = await chain.safeParseAsync(input);
   expect(resAsync).toEqual(output);
+
+  // Test chain method.
+  // const methChain = fromSchema.chain(toSchema);
+  // toSchema.chain(fromSchema); // TODO Should not compile, remore
+
+  // type MethChainInput = z.input<typeof methChain>;
+  // type MethChainOutput = z.output<typeof methChain>;
+
+  // util.assertEqual<MethChainInput, FromInput>(true);
+  // util.assertEqual<MethChainOutput, ToOutput>(true);
+
+  // const methResSync = methChain.safeParse(input);
+  // expect(methResSync).toEqual(output);
+  // const methResAsync = await methChain.safeParseAsync(input);
+  // expect(methResAsync).toEqual(output);
 });
 
 const numProm = Promise.resolve(12);
@@ -425,6 +441,7 @@ test.each([
   util.assertAssignable<ToInput, FromOutput>(true);
   util.assertAssignable<FromOutput, ToInput>(false);
 
+  // Test chain factory
   const chain = z.chain(fromSchema, toSchema);
 
   type ChainInput = z.input<typeof chain>;
@@ -437,4 +454,18 @@ test.each([
   expect(resSync).toEqual(output);
   const resAsync = await chain.safeParseAsync(input);
   expect(resAsync).toEqual(output);
+
+  // Test chain method
+  // const methChain = fromSchema.chain(toSchema);
+
+  // type MethChainInput = z.input<typeof methChain>;
+  // type MethChainOutput = z.output<typeof methChain>;
+
+  // util.assertEqual<MethChainInput, FromInput>(true);
+  // util.assertEqual<MethChainOutput, ToOutput>(true);
+
+  // const methResSync = methChain.safeParse(input);
+  // expect(methResSync).toEqual(output);
+  // const methResAsync = await methChain.safeParseAsync(input);
+  // expect(methResAsync).toEqual(output);
 });

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -82,7 +82,7 @@ test.each([
       }),
     },
   },
-])('Schema chaining "$input"', ({ input, output }) => {
+])('Schema chaining "$input"', async ({ input, output }) => {
   const from = z
     .string()
     .transform((val) => parseInt(val, 10))
@@ -136,6 +136,8 @@ test.each([
   util.assertEqual<ChainInput, FromInput>(true);
   util.assertEqual<ChainOutput, ToOutput>(true);
 
-  const res = chain.safeParse(input);
-  expect(res).toEqual(output);
+  const resSync = chain.safeParse(input);
+  expect(resSync).toEqual(output);
+  const resAsync = await chain.safeParseAsync(input);
+  expect(resAsync).toEqual(output);
 });

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -100,7 +100,7 @@ test.each([
       }),
     },
   },
-])('Scalar schema chaining "$input"', async ({ input, output }) => {
+])("Scalar schema chaining - $input", async ({ input, output }) => {
   const fromSchema = z
     .string()
     .transform((val) => parseInt(val, 10))
@@ -187,7 +187,7 @@ test.each([
         sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
         intersection: { p2: 0 },
         enum: "one",
-        passthrough: { points: 1234, score: 999 },
+        passthrough: { points: 1234, score: 999, name: "General Zod" },
         numProm,
         lenfun: 42,
       },
@@ -359,7 +359,9 @@ test.each([
       z.object({ p3: z.number().optional() })
     ),
     enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
-    passthrough: z.object({ points: z.number(), score: z.number() }),
+    passthrough: z
+      .object({ points: z.number(), score: z.number() })
+      .passthrough(),
     numProm: z.promise(z.number()),
     lenfun: z.function(
       z.tuple([z.string(), z.number().optional()]),

--- a/src/__tests__/chain.test.ts
+++ b/src/__tests__/chain.test.ts
@@ -100,7 +100,7 @@ test.each([
       }),
     },
   },
-])('Schema chaining "$input"', async ({ input, output }) => {
+])('Scalar schema chaining "$input"', async ({ input, output }) => {
   const fromSchema = z
     .string()
     .transform((val) => parseInt(val, 10))
@@ -145,6 +145,283 @@ test.each([
   type ToOutput = z.output<typeof toSchema>;
 
   util.assertAssignable<ToInput, FromOutput>(true);
+  util.assertAssignable<FromOutput, ToInput>(false);
+
+  const chain = z.chain(fromSchema, toSchema);
+
+  type ChainInput = z.input<typeof chain>;
+  type ChainOutput = z.output<typeof chain>;
+
+  util.assertEqual<ChainInput, FromInput>(true);
+  util.assertEqual<ChainOutput, ToOutput>(true);
+
+  const resSync = chain.safeParse(input);
+  expect(resSync).toEqual(output);
+  const resAsync = await chain.safeParseAsync(input);
+  expect(resAsync).toEqual(output);
+});
+
+const numProm = Promise.resolve(12);
+
+test.each([
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: true,
+      data: {
+        tuple: ["abcd", 1234, true, null, undefined, "1234"],
+        merged: { k1: "abdc" },
+        union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+        array: [12, 15, 16],
+        sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89, 65] },
+        intersection: { p2: 0 },
+        enum: "one",
+        passthrough: { points: 1234, score: 999 },
+        numProm,
+        lenfun: 42,
+      },
+    },
+  },
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12, 15, 16, 98, 24, 63, 89] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Array must be at least 8 items long",
+            path: ["sumMinLength", "values"],
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12, 15, 16, 98, 24] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Array must be at least 6 items long",
+            path: ["sumMinLength", "values"],
+          },
+          {
+            code: "custom",
+            message: "Array must be at least 8 items long",
+            path: ["sumMinLength", "values"],
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12, 15, 16] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Array must be at least 6 items long",
+            path: ["sumMinLength", "values"],
+          },
+          {
+            code: "custom",
+            message: "Array really must be at least 4 items long",
+            path: ["sumMinLength", "values"],
+            fatal: true,
+          },
+          {
+            code: "custom",
+            message: "Array must be at least 8 items long",
+            path: ["sumMinLength", "values"],
+          },
+        ],
+      }),
+    },
+  },
+  {
+    input: {
+      tuple: ["abcd", 1234, true, null, undefined, "1234"],
+      merged: { k1: "abdc", k2: "1234", k3: 12 },
+      union: ["ABCD", 42, "ABCD", 42, "ABCD", 42],
+      array: [12, 15, 16],
+      sumMinLength: { values: [12] },
+      intersection: { p2: 0 },
+      enum: "one",
+      passthrough: { points: 1234, score: 999, name: "General Zod" },
+      numProm,
+      lenfun: (x: string, y?: number) => x.length + (y ?? 0),
+    },
+    output: {
+      success: false,
+      error: expect.objectContaining({
+        issues: [
+          {
+            code: "custom",
+            message: "Array really must be at least 2 items long",
+            path: ["sumMinLength", "values"],
+            fatal: true,
+          },
+          {
+            code: "custom",
+            message: "Array must be at least 6 items long",
+            path: ["sumMinLength", "values"],
+          },
+        ],
+      }),
+    },
+  },
+])("Object schema chaining - $#", async ({ input, output }) => {
+  const fromSchema = z.object({
+    tuple: z.tuple([
+      z.string().nullable(),
+      z.number().optional(),
+      z.boolean().nullable().optional(),
+      z.null(),
+      z.undefined(),
+      z.literal("1234"),
+    ]),
+    merged: z
+      .object({
+        k1: z.string(),
+      })
+      .merge(z.object({ k2: z.string(), k3: z.number() })),
+    union: z.array(z.union([z.literal("ABCD"), z.literal(42)])).nonempty(),
+    array: z.array(z.number()),
+    sumMinLength: z.object({
+      values: z.array(z.number()).superRefine((arg, ctx) => {
+        if (arg.length < 2) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Array really must be at least 2 items long",
+            fatal: true,
+          });
+        }
+        if (arg.length < 6) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Array must be at least 6 items long",
+          });
+        }
+      }),
+    }),
+    intersection: z.intersection(
+      z.object({ p1: z.string().optional() }),
+      z.object({ p2: z.number() }),
+      z.object({ p3: z.number().optional() })
+    ),
+    enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
+    passthrough: z.object({ points: z.number(), score: z.number() }),
+    numProm: z.promise(z.number()),
+    lenfun: z.function(
+      z.tuple([z.string(), z.number().optional()]),
+      z.number()
+    ),
+  });
+
+  const toSchema = z.object({
+    tuple: z.tuple([
+      z.string().nullable().optional(),
+      z.number().nullable().optional(),
+      z.boolean().nullable().optional(),
+      z.null().optional(),
+      z.undefined().optional(),
+      z.literal("1234").nullable().optional(),
+    ]),
+    merged: z
+      .object({
+        k1: z.string().optional(),
+      })
+      .merge(z.object({ k1: z.string().nullable() })),
+    union: z
+      .array(z.union([z.literal("ABCD"), z.literal(42), z.literal("42")]))
+      .nonempty(),
+    array: z.array(z.number()),
+    sumMinLength: z.object({
+      values: z.array(z.number()).superRefine((arg, ctx) => {
+        if (arg.length < 4) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Array really must be at least 4 items long",
+            fatal: true,
+          });
+        }
+        if (arg.length < 8) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Array must be at least 8 items long",
+          });
+        }
+      }),
+    }),
+    intersection: z.intersection(
+      z.object({ p1: z.string().optional() }),
+      z.object({ p2: z.number().optional() })
+    ),
+    enum: z.enum(["zero", "one"]),
+    passthrough: z.object({ points: z.number() }).passthrough(),
+    numProm: z.promise(z.number()),
+    lenfun: z
+      .function(z.tuple([z.string(), z.number().optional()]), z.number())
+      .transform((fn) => fn("Hello", 37)),
+  });
+
+  type FromInput = z.input<typeof fromSchema>;
+  type FromOutput = z.output<typeof fromSchema>;
+
+  type ToInput = z.input<typeof toSchema>;
+  type ToOutput = z.output<typeof toSchema>;
+
+  util.assertAssignable<ToInput, FromOutput>(true);
+  util.assertAssignable<FromOutput, ToInput>(false);
 
   const chain = z.chain(fromSchema, toSchema);
 

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -83,8 +83,11 @@ export type ObjectPair = {
   key: SyncParseReturnType<any>;
   value: SyncParseReturnType<any>;
 };
+
+type ParseStatusValue = "aborted" | "dirty" | "valid";
+
 export class ParseStatus {
-  value: "aborted" | "dirty" | "valid" = "valid";
+  value: ParseStatusValue = "valid";
   dirty() {
     if (this.value === "valid") this.value = "dirty";
   }
@@ -176,3 +179,16 @@ export const isAsync = <T>(
   x: ParseReturnType<T>
 ): x is AsyncParseReturnType<T> =>
   typeof Promise !== undefined && x instanceof Promise;
+
+export const overrideReturnType = <T>(
+  rt: SyncParseReturnType<T>,
+  status: ParseStatusValue
+) => {
+  if (rt.status === "aborted" || status === "aborted") {
+    return INVALID;
+  }
+  if (rt.status === "dirty" || status === "dirty") {
+    return DIRTY(rt.value);
+  }
+  return rt;
+};

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -163,6 +163,19 @@ export const DIRTY = <T>(value: T): DIRTY<T> => ({ status: "dirty", value });
 export type OK<T> = { status: "valid"; value: T };
 export const OK = <T>(value: T): OK<T> => ({ status: "valid", value });
 
+export const overrideReturnType = <T>(
+  rt: SyncParseReturnType<T>,
+  status: ParseStatusValue
+) => {
+  if (rt.status === "aborted" || status === "aborted") {
+    return INVALID;
+  }
+  if (rt.status === "dirty" || status === "dirty") {
+    return DIRTY(rt.value);
+  }
+  return rt;
+};
+
 export type SyncParseReturnType<T = any> = OK<T> | DIRTY<T> | INVALID;
 export type AsyncParseReturnType<T> = Promise<SyncParseReturnType<T>>;
 export type ParseReturnType<T> =
@@ -179,16 +192,3 @@ export const isAsync = <T>(
   x: ParseReturnType<T>
 ): x is AsyncParseReturnType<T> =>
   typeof Promise !== undefined && x instanceof Promise;
-
-export const overrideReturnType = <T>(
-  rt: SyncParseReturnType<T>,
-  status: ParseStatusValue
-) => {
-  if (rt.status === "aborted" || status === "aborted") {
-    return INVALID;
-  }
-  if (rt.status === "dirty" || status === "dirty") {
-    return DIRTY(rt.value);
-  }
-  return rt;
-};

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -6,6 +6,11 @@ export namespace util {
     : false;
 
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
+
+  type AssertAssignable<L, R> = R extends L ? true : false;
+
+  export const assertAssignable = <A, B>(val: AssertAssignable<A, B>) => val;
+
   export function assertIs<T>(_arg: T): void {}
   export function assertNever(_x: never): never {
     throw new Error();

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -7,9 +7,9 @@ export namespace util {
 
   export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
 
-  type AssertAssignable<L, R> = R extends L ? true : false;
+  type AssertAssignable<L, R> = [R] extends [L] ? true : false;
 
-  export const assertAssignable = <A, B>(val: AssertAssignable<A, B>) => val;
+  export const assertAssignable = <L, R>(val: AssertAssignable<L, R>) => val;
 
   export function assertIs<T>(_arg: T): void {}
   export function assertNever(_x: never): never {

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -9,6 +9,7 @@ export namespace util {
 
   type AssertAssignable<L, R> = [R] extends [L] ? true : false;
 
+  // Assert that a value of type `R` is assignable to a variable of type `L`
   export const assertAssignable = <L, R>(val: AssertAssignable<L, R>) => val;
 
   export function assertIs<T>(_arg: T): void {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -407,15 +407,17 @@ export abstract class ZodType<
     }) as any;
   }
 
-  chain<
-    ToDef extends ZodTypeDef,
-    To extends ZodType<To["_output"], ToDef, Output>
-  >(to: To): ZodChain<Def, Output, this, ToDef, To> {
-    return new ZodChain<Def, Output, this, ToDef, To>({
-      from: this,
-      to: to,
-    });
-  }
+  // chain<
+  //   FromOut extends ToIn & Output,
+  //   ToIn,
+  //   ToDef extends ZodTypeDef,
+  //   To extends ZodType<To["_output"], ToDef, ToIn>
+  // >(to: To): ZodChain<Def, FromOut, this, ToIn, ToDef, To> {
+  //   return new ZodChain<Def, FromOut, this, ToIn, ToDef, To>({
+  //     from: this,
+  //     to: to,
+  //   });
+  // }
 
   default(def: util.noUndefined<Input>): ZodDefault<this>;
   default(def: () => util.noUndefined<Input>): ZodDefault<this>;
@@ -3594,16 +3596,12 @@ export interface ZodChainDef<From extends ZodTypeAny, To extends ZodTypeAny>
 }
 
 export class ZodChain<
-  FromDef extends ZodTypeDef,
   FromOut extends To["_input"],
+  FromDef extends ZodTypeDef,
   From extends ZodType<FromOut, FromDef, From["_input"]>,
   ToDef extends ZodTypeDef,
   To extends ZodType<To["_output"], ToDef, To["_input"]>
 > extends ZodType<To["_output"], ZodChainDef<From, To>, From["_input"]> {
-  innerType() {
-    return this;
-  }
-
   _parse(input: ParseInput): ParseReturnType<To["_output"]> {
     const { status, ctx } = this._processInputParams(input);
 
@@ -3641,6 +3639,23 @@ export class ZodChain<
       });
     }
   }
+
+  static create = <
+    FromOut extends To["_input"],
+    FromDef extends ZodTypeDef,
+    From extends ZodType<FromOut, FromDef, From["_input"]>,
+    ToDef extends ZodTypeDef,
+    To extends ZodType<To["_output"], ToDef, To["_input"]>
+  >(
+    from: From,
+    to: To
+  ) => {
+    return new ZodChain({
+      from,
+      to,
+      // ...processCreateParams(params),
+    });
+  };
 }
 
 ///////////////////////////////////////////
@@ -3988,6 +4003,7 @@ const enumType = ZodEnum.create;
 const nativeEnumType = ZodNativeEnum.create;
 const promiseType = ZodPromise.create;
 const effectsType = ZodEffects.create;
+const chainType = ZodChain.create;
 const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
@@ -4000,6 +4016,7 @@ export {
   arrayType as array,
   bigIntType as bigint,
   booleanType as boolean,
+  chainType as chain,
   dateType as date,
   discriminatedUnionType as discriminatedUnion,
   effectsType as effect,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3661,24 +3661,20 @@ export class ZodChain<
     }
   }
 
-  static create = <
+  static create<
     From extends ZodType<From["_output"], any, From["_input"]>,
     To extends ZodType<
       To["_output"],
       any,
       From["_output"] extends To["_input"] ? To["_input"] : never
     >
-  >(
-    from: From,
-    to: To,
-    params?: RawCreateParams
-  ) => {
+  >(from: From, to: To, params?: RawCreateParams) {
     return new ZodChain({
       from,
       to,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////////

--- a/src/types.ts
+++ b/src/types.ts
@@ -410,8 +410,8 @@ export abstract class ZodType<
   chain<
     ToDef extends ZodTypeDef,
     To extends ZodType<To["_output"], ToDef, Output>
-  >(to: To): ZodChain<Def, Output, this, Output, ToDef, To> {
-    return new ZodChain<Def, Output, this, Output, ToDef, To>({
+  >(to: To): ZodChain<Def, Output, this, ToDef, To> {
+    return new ZodChain<Def, Output, this, ToDef, To>({
       from: this,
       to: to,
     });
@@ -3595,11 +3595,10 @@ export interface ZodChainDef<From extends ZodTypeAny, To extends ZodTypeAny>
 
 export class ZodChain<
   FromDef extends ZodTypeDef,
-  FromOut extends ToIn,
+  FromOut extends To["_input"],
   From extends ZodType<FromOut, FromDef, From["_input"]>,
-  ToIn,
   ToDef extends ZodTypeDef,
-  To extends ZodType<To["_output"], ToDef, ToIn>
+  To extends ZodType<To["_output"], ToDef, To["_input"]>
 > extends ZodType<To["_output"], ZodChainDef<From, To>, From["_input"]> {
   innerType() {
     return this;

--- a/src/types.ts
+++ b/src/types.ts
@@ -408,10 +408,14 @@ export abstract class ZodType<
     }) as any;
   }
 
-  chain<To extends ZodType<To["_output"], any, Output>>(
-    to: To
-  ): ZodChain<Output, this, To> {
-    return new ZodChain<Output, this, To>({
+  chain<
+    To extends ZodType<
+      To["_output"],
+      any,
+      this["_output"] extends To["_input"] ? To["_input"] : never
+    >
+  >(to: To): ZodChain<this, To> {
+    return new ZodChain<this, To>({
       from: this,
       to,
     });
@@ -3596,23 +3600,25 @@ export { ZodEffects as ZodTransformer };
 //////////////////////////////////////////
 
 export interface ZodChainDef<
-  FromOut extends To["_input"],
-  From extends ZodType<FromOut, any, From["_input"]>,
-  To extends ZodType<To["_output"], any, To["_input"]>
+  From extends ZodType<From["_output"], any, From["_input"]>,
+  To extends ZodType<
+    To["_output"],
+    any,
+    From["_output"] extends To["_input"] ? To["_input"] : never
+  >
 > extends ZodTypeDef {
   from: From;
   to: To;
 }
 
 export class ZodChain<
-  FromOut extends To["_input"],
-  From extends ZodType<FromOut, any, From["_input"]>,
-  To extends ZodType<To["_output"], any, To["_input"]>
-> extends ZodType<
-  To["_output"],
-  ZodChainDef<FromOut, From, To>,
-  From["_input"]
-> {
+  From extends ZodType<From["_output"], any, From["_input"]>,
+  To extends ZodType<
+    To["_output"],
+    any,
+    From["_output"] extends To["_input"] ? To["_input"] : never
+  >
+> extends ZodType<To["_output"], ZodChainDef<From, To>, From["_input"]> {
   _parse(input: ParseInput): ParseReturnType<To["_output"]> {
     const { ctx } = this._processInputParams(input);
 
@@ -3656,11 +3662,12 @@ export class ZodChain<
   }
 
   static create = <
-    FromOut extends To["_input"],
-    FromDef extends ZodTypeDef,
-    From extends ZodType<FromOut, FromDef, From["_input"]>,
-    ToDef extends ZodTypeDef,
-    To extends ZodType<To["_output"], ToDef, To["_input"]>
+    From extends ZodType<From["_output"], any, From["_input"]>,
+    To extends ZodType<
+      To["_output"],
+      any,
+      From["_output"] extends To["_input"] ? To["_input"] : never
+    >
   >(
     from: From,
     to: To,

--- a/src/types.ts
+++ b/src/types.ts
@@ -407,18 +407,6 @@ export abstract class ZodType<
     }) as any;
   }
 
-  // chain<
-  //   FromOut extends ToIn & Output,
-  //   ToIn,
-  //   ToDef extends ZodTypeDef,
-  //   To extends ZodType<To["_output"], ToDef, ToIn>
-  // >(to: To): ZodChain<Def, FromOut, this, ToIn, ToDef, To> {
-  //   return new ZodChain<Def, FromOut, this, ToIn, ToDef, To>({
-  //     from: this,
-  //     to: to,
-  //   });
-  // }
-
   default(def: util.noUndefined<Input>): ZodDefault<this>;
   default(def: () => util.noUndefined<Input>): ZodDefault<this>;
   default(def: any) {
@@ -3589,8 +3577,13 @@ export { ZodEffects as ZodTransformer };
 //////////////////////////////////////////
 //////////////////////////////////////////
 
-export interface ZodChainDef<From extends ZodTypeAny, To extends ZodTypeAny>
-  extends ZodTypeDef {
+export interface ZodChainDef<
+  FromOut extends To["_input"],
+  FromDef extends ZodTypeDef,
+  From extends ZodType<FromOut, FromDef, From["_input"]>,
+  ToDef extends ZodTypeDef,
+  To extends ZodType<To["_output"], ToDef, To["_input"]>
+> extends ZodTypeDef {
   from: From;
   to: To;
 }
@@ -3601,7 +3594,11 @@ export class ZodChain<
   From extends ZodType<FromOut, FromDef, From["_input"]>,
   ToDef extends ZodTypeDef,
   To extends ZodType<To["_output"], ToDef, To["_input"]>
-> extends ZodType<To["_output"], ZodChainDef<From, To>, From["_input"]> {
+> extends ZodType<
+  To["_output"],
+  ZodChainDef<FromOut, FromDef, From, ToDef, To>,
+  From["_input"]
+> {
   _parse(input: ParseInput): ParseReturnType<To["_output"]> {
     const { status, ctx } = this._processInputParams(input);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -408,6 +408,15 @@ export abstract class ZodType<
     }) as any;
   }
 
+  chain<To extends ZodType<To["_output"], any, Output>>(
+    to: To
+  ): ZodChain<Output, this, To> {
+    return new ZodChain<Output, this, To>({
+      from: this,
+      to,
+    });
+  }
+
   default(def: util.noUndefined<Input>): ZodDefault<this>;
   default(def: () => util.noUndefined<Input>): ZodDefault<this>;
   default(def: any) {
@@ -3588,10 +3597,8 @@ export { ZodEffects as ZodTransformer };
 
 export interface ZodChainDef<
   FromOut extends To["_input"],
-  FromDef extends ZodTypeDef,
-  From extends ZodType<FromOut, FromDef, From["_input"]>,
-  ToDef extends ZodTypeDef,
-  To extends ZodType<To["_output"], ToDef, To["_input"]>
+  From extends ZodType<FromOut, any, From["_input"]>,
+  To extends ZodType<To["_output"], any, To["_input"]>
 > extends ZodTypeDef {
   from: From;
   to: To;
@@ -3599,13 +3606,11 @@ export interface ZodChainDef<
 
 export class ZodChain<
   FromOut extends To["_input"],
-  FromDef extends ZodTypeDef,
-  From extends ZodType<FromOut, FromDef, From["_input"]>,
-  ToDef extends ZodTypeDef,
-  To extends ZodType<To["_output"], ToDef, To["_input"]>
+  From extends ZodType<FromOut, any, From["_input"]>,
+  To extends ZodType<To["_output"], any, To["_input"]>
 > extends ZodType<
   To["_output"],
-  ZodChainDef<FromOut, FromDef, From, ToDef, To>,
+  ZodChainDef<FromOut, From, To>,
   From["_input"]
 > {
   _parse(input: ParseInput): ParseReturnType<To["_output"]> {


### PR DESCRIPTION
Allow schemas to be chained, passing the output of one as the input to another.
The output of the first schema is type-checked to ensure compatibility with the input of the second schema.

```ts
const createUserDTOSchema = z
  .object({
    name: z.string(),
    email: z.string(),
    active: z.boolean(),
  })
  .transform((input) => {
    return {
      id: uuid(),
      ...input,
    };
  });

const updateUserDTOSchema = z.object({
  id: z.string(),
  name: z.string(),
  email: z.string(),
  active: z.boolean(),
});

const userSchema = z.object({
  id: z.string().trim().uuid(),
  name: z.string().trim().min(1),
  email: z
    .string()
    .trim()
    .email()
    .refine((val) => allowedDomains.includes(emailDomain(val))),
  active: z.boolean(),
});

const createUserSchema = createUserDTOSchema.chain(userSchema);
const updateUserSchema = updateUserDTOSchema.chain(userSchema);
```