### PR TITLE
Introduce data hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
   - [.superRefine](#superRefine)
   - [.transform](#transform)
   - [.default](#default)
+  - [.hydrate](#hydrate)
   - [.optional](#optional)
   - [.nullable](#nullable)
   - [.nullish](#nullish)
@@ -1813,6 +1814,42 @@ const numberWithRandomDefault = z.number().default(Math.random);
 numberWithRandomDefault.parse(undefined); // => 0.4413456736055323
 numberWithRandomDefault.parse(undefined); // => 0.1871840107401901
 numberWithRandomDefault.parse(undefined); // => 0.7223408162401552
+```
+
+### `.hydrate`
+
+You can use `.hydrate` method to implement the concept of "data hydration" in Zod. This method is similar to `.default` but it comes into play when passed data does not match the declared schema rather than just being `undefined`.
+
+```ts
+const schema = z.string().hydrate("asd");
+
+schema.parse({})); // => "asd"
+schema.parse(123)); // => "asd"
+schema.parse("aaa")); // => "aaa"
+```
+
+```ts
+const schema = z.strictObject({
+  s: z.string().hydrate(""),
+  n1: z.number().hydrate(1),
+  n2: z.number().hydrate((e) => (e === "asd" ? 2 : 3)),
+});
+
+schema.parse({}); // => { s: "", n1: 1, n2: 3 }
+schema.parse({ s: 123, n2: "asd" }); // => { s: "", n1: 1, n2: 2 }
+```
+
+If you need you can pass a function into `.hydrate` that will be executed every time a hydration value needs to be generated:
+
+```ts
+let n = 0;
+const getOrder = () => ++n;
+
+const schema = z.number().hydrate(getOrder);
+
+schema.parse([123, 'a']); // => 1
+schema.parse({}); // => 2
+schema.parse('0'); // => 3
 ```
 
 ### `.optional`

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -99,6 +99,7 @@
   - [.superRefine](#superRefine)
   - [.transform](#transform)
   - [.default](#default)
+  - [.hydrate](#hydrate)
   - [.optional](#optional)
   - [.nullable](#nullable)
   - [.nullish](#nullish)
@@ -1813,6 +1814,42 @@ const numberWithRandomDefault = z.number().default(Math.random);
 numberWithRandomDefault.parse(undefined); // => 0.4413456736055323
 numberWithRandomDefault.parse(undefined); // => 0.1871840107401901
 numberWithRandomDefault.parse(undefined); // => 0.7223408162401552
+```
+
+### `.hydrate`
+
+You can use `.hydrate` method to implement the concept of "data hydration" in Zod. This method is similar to `.default` but it comes into play when passed data does not match the declared schema rather than just being `undefined`.
+
+```ts
+const schema = z.string().hydrate("asd");
+
+schema.parse({})); // => "asd"
+schema.parse(123)); // => "asd"
+schema.parse("aaa")); // => "aaa"
+```
+
+```ts
+const schema = z.strictObject({
+  s: z.string().hydrate(""),
+  n1: z.number().hydrate(1),
+  n2: z.number().hydrate((e) => (e === "asd" ? 2 : 3)),
+});
+
+schema.parse({}); // => { s: "", n1: 1, n2: 3 }
+schema.parse({ s: 123, n2: "asd" }); // => { s: "", n1: 1, n2: 2 }
+```
+
+If you need you can pass a function into `.hydrate` that will be executed every time a hydration value needs to be generated:
+
+```ts
+let n = 0;
+const getOrder = () => ++n;
+
+const schema = z.number().hydrate(getOrder);
+
+schema.parse([123, 'a']); // => 1
+schema.parse({}); // => 2
+schema.parse('0'); // => 3
 ```
 
 ### `.optional`

--- a/deno/lib/__tests__/anyunknown.test.ts
+++ b/deno/lib/__tests__/anyunknown.test.ts
@@ -27,3 +27,10 @@ test("check never inference", () => {
   expect(() => t1.parse("asdf")).toThrow();
   expect(() => t1.parse(null)).toThrow();
 });
+
+test("pass data hydration", () => {
+  expect(z.any().hydrate(2).parse({})).toEqual({});
+  expect(z.any().hydrate(123).parse(null)).toEqual(null);
+  expect(z.unknown().hydrate("2").parse([2, 123])).toEqual([2, 123]);
+  expect(z.unknown().hydrate("asd").parse("undefined")).toEqual("undefined");
+});

--- a/deno/lib/__tests__/array.test.ts
+++ b/deno/lib/__tests__/array.test.ts
@@ -64,3 +64,18 @@ test("continue parsing despite array size error", () => {
     expect(result.error.issues.length).toEqual(2);
   }
 });
+
+test("pass data hydration", () => {
+  expect(() => z.string().hydrate("whatever").array().parse(null)).toThrow();
+  expect(z.string().hydrate("abc").array().parse([null])).toEqual(["abc"]);
+  expect(z.string().hydrate("123").array().hydrate([]).parse(123)).toEqual([]);
+  expect(z.string().hydrate("str").array().hydrate([]).parse([true])).toEqual([
+    "str",
+  ]);
+  expect(
+    z.string().hydrate("123").array().hydrate([]).parse(["string"])
+  ).toEqual(["string"]);
+  expect(
+    z.array(z.string().hydrate("123")).min(2).hydrate([]).parse(["string"])
+  ).toEqual([]);
+});

--- a/deno/lib/__tests__/date.test.ts
+++ b/deno/lib/__tests__/date.test.ts
@@ -33,3 +33,10 @@ test("min max getters", () => {
     beforeBenchmarkDate
   );
 });
+
+test("pass data hydration", () => {
+  expect(z.date().hydrate(new Date(123)).parse({})).toEqual(new Date(123));
+  expect(z.date().hydrate(new Date(123456)).parse(123)).toEqual(
+    new Date(123456)
+  );
+});

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -196,3 +196,15 @@ test("async - invalid", async () => {
     ]);
   }
 });
+
+test("pass data hydration", () => {
+  expect(
+    z
+      .discriminatedUnion("asd", [
+        z.object({ asd: z.literal("2"), a: z.number() }),
+        z.object({ asd: z.literal("3"), b: z.string() }),
+      ])
+      .hydrate({ asd: "3", b: "2" })
+      .parse([null])
+  ).toEqual({ asd: "3", b: "2" });
+});

--- a/deno/lib/__tests__/function.test.ts
+++ b/deno/lib/__tests__/function.test.ts
@@ -240,3 +240,20 @@ test("fallback to OuterTypeOfFunction", () => {
     (arg: string, ...args_1: unknown[]) => number
   >(true);
 });
+
+test("pass data hydration", () => {
+  expect(
+    z
+      .function()
+      .hydrate(() => () => {})
+      .parse([null])
+      .toString()
+  ).toEqual(String(() => {}));
+  expect(
+    z
+      .function(z.tuple([z.string()]), z.string())
+      .hydrate(() => () => "2")
+      .parse([null])
+      .toString()
+  ).toEqual(String(() => "2"));
+});

--- a/deno/lib/__tests__/intersection.test.ts
+++ b/deno/lib/__tests__/intersection.test.ts
@@ -119,3 +119,12 @@ test("invalid array merge", async () => {
     );
   }
 });
+
+test("pass data hydration", () => {
+  expect(
+    z
+      .intersection(z.object({ a: z.number() }), z.object({ b: z.string() }))
+      .hydrate({ a: 2, b: "3" })
+      .parse(123)
+  ).toEqual({ a: 2, b: "3" });
+});

--- a/deno/lib/__tests__/map.test.ts
+++ b/deno/lib/__tests__/map.test.ts
@@ -109,3 +109,21 @@ test("dirty", async () => {
     expect(result.error.issues[1].message).toEqual("Keys must be uppercase");
   }
 });
+
+test("pass data hydration", () => {
+  expect(z.map(z.string(), z.number()).hydrate().parse([null])).toEqual(
+    new Map()
+  );
+  expect(
+    z
+      .map(z.string(), z.number())
+      .hydrate(new Map([["a", 2]]))
+      .parse([null])
+  ).toEqual(new Map([["a", 2]]));
+  expect(
+    z
+      .map(z.string().array(), z.number())
+      .hydrate(new Map([[["a"], 2]]))
+      .parse([null])
+  ).toEqual(new Map([[["a"], 2]]));
+});

--- a/deno/lib/__tests__/number.test.ts
+++ b/deno/lib/__tests__/number.test.ts
@@ -55,3 +55,9 @@ test("min max getters", () => {
   expect(z.number().max(5).maxValue).toEqual(5);
   expect(z.number().max(5).max(1).maxValue).toEqual(1);
 });
+
+test("pass data hydration", () => {
+  expect(z.number().hydrate().parse({})).toEqual(0);
+  expect(z.number().hydrate(123).parse(null)).toEqual(123);
+  expect(z.number().max(22).hydrate(-2).parse(30)).toEqual(-2);
+});

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -388,3 +388,10 @@ test("unknownkeys merging", () => {
   util.assertEqual<mergedSchema["_def"]["catchall"], z.ZodString>(true);
   expect(mergedSchema._def.catchall instanceof z.ZodString).toEqual(true);
 });
+
+test("pass data hydration", () => {
+  expect(z.object({}).hydrate("abc").parse([null])).toEqual("abc");
+  expect(
+    z.object({ a: z.string() }).hydrate({ a: "2" }).parse({ b: 3 })
+  ).toEqual({ a: "2" });
+});

--- a/deno/lib/__tests__/record.test.ts
+++ b/deno/lib/__tests__/record.test.ts
@@ -134,3 +134,10 @@ test("key and value getters", () => {
   rec.valueSchema.parse(1234);
   rec.element.parse(1234);
 });
+
+test("pass data hydration", () => {
+  expect(z.record(z.string()).hydrate({ a: "2" }).parse([null])).toEqual({
+    a: "2",
+  });
+  expect(z.record(z.string()).hydrate({}).parse([null])).toEqual({});
+});

--- a/deno/lib/__tests__/set.test.ts
+++ b/deno/lib/__tests__/set.test.ts
@@ -141,3 +141,14 @@ test("throws when the given set has multiple invalid entries", () => {
     expect(result.error.issues[1].path).toEqual([1]);
   }
 });
+
+test("pass data hydration", () => {
+  expect(z.set(z.string()).hydrate().parse([null])).toEqual(new Set());
+  expect(z.set(z.string()).hydrate().parse(null)).toEqual(new Set());
+  expect(
+    z
+      .set(z.string())
+      .hydrate(new Set(["asd"]))
+      .parse(null)
+  ).toEqual(new Set(["asd"]));
+});

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -186,3 +186,22 @@ test("trim", () => {
   expect(z.string().min(2).trim().parse(" 1 ")).toEqual("1");
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
 });
+
+test("pass data hydration", () => {
+  expect(z.string().hydrate().parse({})).toEqual("");
+  expect(z.string().hydrate("123").parse(null)).toEqual("123");
+  expect(
+    z
+      .string()
+      .hydrate(() => "123")
+      .parse(null)
+  ).toEqual("123");
+  {
+    const schema = z.string().hydrate((e) => (e === 7 ? "1" : "2"));
+    expect(schema.parse(7)).toEqual("1");
+    expect(schema.parse(77)).toEqual("2");
+  }
+  expect(z.string().max(2).hydrate("default").parse("too_long")).toEqual(
+    "default"
+  );
+});

--- a/deno/lib/__tests__/tuple.test.ts
+++ b/deno/lib/__tests__/tuple.test.ts
@@ -95,3 +95,9 @@ test("tuple with rest schema", () => {
 //     .safeParse(['asdf']);
 //   expect(result).toEqual(['asdf']);
 // });
+
+test("pass data hydration", () => {
+  expect(
+    z.tuple([z.string(), z.number()]).hydrate(["abc", 2]).parse([null])
+  ).toEqual(["abc", 2]);
+});

--- a/deno/lib/__tests__/unions.test.ts
+++ b/deno/lib/__tests__/unions.test.ts
@@ -62,3 +62,9 @@ test("readonly union", async () => {
   union.parse("asdf");
   union.parse(12);
 });
+
+test("pass data hydration", () => {
+  expect(
+    z.union([z.string(), z.number()]).hydrate("abc").parse([null])
+  ).toEqual("abc");
+});

--- a/deno/lib/__tests__/void.test.ts
+++ b/deno/lib/__tests__/void.test.ts
@@ -14,3 +14,7 @@ test("void", () => {
   type v = z.infer<typeof v>;
   util.assertEqual<v, void>(true);
 });
+
+test("pass data hydration", () => {
+  expect(z.void().hydrate().parse({})).toEqual(undefined);
+});

--- a/src/__tests__/anyunknown.test.ts
+++ b/src/__tests__/anyunknown.test.ts
@@ -26,3 +26,10 @@ test("check never inference", () => {
   expect(() => t1.parse("asdf")).toThrow();
   expect(() => t1.parse(null)).toThrow();
 });
+
+test("pass data hydration", () => {
+  expect(z.any().hydrate(2).parse({})).toEqual({});
+  expect(z.any().hydrate(123).parse(null)).toEqual(null);
+  expect(z.unknown().hydrate("2").parse([2, 123])).toEqual([2, 123]);
+  expect(z.unknown().hydrate("asd").parse("undefined")).toEqual("undefined");
+});

--- a/src/__tests__/array.test.ts
+++ b/src/__tests__/array.test.ts
@@ -63,3 +63,18 @@ test("continue parsing despite array size error", () => {
     expect(result.error.issues.length).toEqual(2);
   }
 });
+
+test("pass data hydration", () => {
+  expect(() => z.string().hydrate("whatever").array().parse(null)).toThrow();
+  expect(z.string().hydrate("abc").array().parse([null])).toEqual(["abc"]);
+  expect(z.string().hydrate("123").array().hydrate([]).parse(123)).toEqual([]);
+  expect(z.string().hydrate("str").array().hydrate([]).parse([true])).toEqual([
+    "str",
+  ]);
+  expect(
+    z.string().hydrate("123").array().hydrate([]).parse(["string"])
+  ).toEqual(["string"]);
+  expect(
+    z.array(z.string().hydrate("123")).min(2).hydrate([]).parse(["string"])
+  ).toEqual([]);
+});

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -32,3 +32,10 @@ test("min max getters", () => {
     beforeBenchmarkDate
   );
 });
+
+test("pass data hydration", () => {
+  expect(z.date().hydrate(new Date(123)).parse({})).toEqual(new Date(123));
+  expect(z.date().hydrate(new Date(123456)).parse(123)).toEqual(
+    new Date(123456)
+  );
+});

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -195,3 +195,15 @@ test("async - invalid", async () => {
     ]);
   }
 });
+
+test("pass data hydration", () => {
+  expect(
+    z
+      .discriminatedUnion("asd", [
+        z.object({ asd: z.literal("2"), a: z.number() }),
+        z.object({ asd: z.literal("3"), b: z.string() }),
+      ])
+      .hydrate({ asd: "3", b: "2" })
+      .parse([null])
+  ).toEqual({ asd: "3", b: "2" });
+});

--- a/src/__tests__/function.test.ts
+++ b/src/__tests__/function.test.ts
@@ -239,3 +239,20 @@ test("fallback to OuterTypeOfFunction", () => {
     (arg: string, ...args_1: unknown[]) => number
   >(true);
 });
+
+test("pass data hydration", () => {
+  expect(
+    z
+      .function()
+      .hydrate(() => () => {})
+      .parse([null])
+      .toString()
+  ).toEqual(String(() => {}));
+  expect(
+    z
+      .function(z.tuple([z.string()]), z.string())
+      .hydrate(() => () => "2")
+      .parse([null])
+      .toString()
+  ).toEqual(String(() => "2"));
+});

--- a/src/__tests__/intersection.test.ts
+++ b/src/__tests__/intersection.test.ts
@@ -118,3 +118,12 @@ test("invalid array merge", async () => {
     );
   }
 });
+
+test("pass data hydration", () => {
+  expect(
+    z
+      .intersection(z.object({ a: z.number() }), z.object({ b: z.string() }))
+      .hydrate({ a: 2, b: "3" })
+      .parse(123)
+  ).toEqual({ a: 2, b: "3" });
+});

--- a/src/__tests__/map.test.ts
+++ b/src/__tests__/map.test.ts
@@ -108,3 +108,21 @@ test("dirty", async () => {
     expect(result.error.issues[1].message).toEqual("Keys must be uppercase");
   }
 });
+
+test("pass data hydration", () => {
+  expect(z.map(z.string(), z.number()).hydrate().parse([null])).toEqual(
+    new Map()
+  );
+  expect(
+    z
+      .map(z.string(), z.number())
+      .hydrate(new Map([["a", 2]]))
+      .parse([null])
+  ).toEqual(new Map([["a", 2]]));
+  expect(
+    z
+      .map(z.string().array(), z.number())
+      .hydrate(new Map([[["a"], 2]]))
+      .parse([null])
+  ).toEqual(new Map([[["a"], 2]]));
+});

--- a/src/__tests__/number.test.ts
+++ b/src/__tests__/number.test.ts
@@ -54,3 +54,9 @@ test("min max getters", () => {
   expect(z.number().max(5).maxValue).toEqual(5);
   expect(z.number().max(5).max(1).maxValue).toEqual(1);
 });
+
+test("pass data hydration", () => {
+  expect(z.number().hydrate().parse({})).toEqual(0);
+  expect(z.number().hydrate(123).parse(null)).toEqual(123);
+  expect(z.number().max(22).hydrate(-2).parse(30)).toEqual(-2);
+});

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -387,3 +387,10 @@ test("unknownkeys merging", () => {
   util.assertEqual<mergedSchema["_def"]["catchall"], z.ZodString>(true);
   expect(mergedSchema._def.catchall instanceof z.ZodString).toEqual(true);
 });
+
+test("pass data hydration", () => {
+  expect(z.object({}).hydrate("abc").parse([null])).toEqual("abc");
+  expect(
+    z.object({ a: z.string() }).hydrate({ a: "2" }).parse({ b: 3 })
+  ).toEqual({ a: "2" });
+});

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -133,3 +133,10 @@ test("key and value getters", () => {
   rec.valueSchema.parse(1234);
   rec.element.parse(1234);
 });
+
+test("pass data hydration", () => {
+  expect(z.record(z.string()).hydrate({ a: "2" }).parse([null])).toEqual({
+    a: "2",
+  });
+  expect(z.record(z.string()).hydrate({}).parse([null])).toEqual({});
+});

--- a/src/__tests__/set.test.ts
+++ b/src/__tests__/set.test.ts
@@ -140,3 +140,14 @@ test("throws when the given set has multiple invalid entries", () => {
     expect(result.error.issues[1].path).toEqual([1]);
   }
 });
+
+test("pass data hydration", () => {
+  expect(z.set(z.string()).hydrate().parse([null])).toEqual(new Set());
+  expect(z.set(z.string()).hydrate().parse(null)).toEqual(new Set());
+  expect(
+    z
+      .set(z.string())
+      .hydrate(new Set(["asd"]))
+      .parse(null)
+  ).toEqual(new Set(["asd"]));
+});

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -185,3 +185,22 @@ test("trim", () => {
   expect(z.string().min(2).trim().parse(" 1 ")).toEqual("1");
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
 });
+
+test("pass data hydration", () => {
+  expect(z.string().hydrate().parse({})).toEqual("");
+  expect(z.string().hydrate("123").parse(null)).toEqual("123");
+  expect(
+    z
+      .string()
+      .hydrate(() => "123")
+      .parse(null)
+  ).toEqual("123");
+  {
+    const schema = z.string().hydrate((e) => (e === 7 ? "1" : "2"));
+    expect(schema.parse(7)).toEqual("1");
+    expect(schema.parse(77)).toEqual("2");
+  }
+  expect(z.string().max(2).hydrate("default").parse("too_long")).toEqual(
+    "default"
+  );
+});

--- a/src/__tests__/tuple.test.ts
+++ b/src/__tests__/tuple.test.ts
@@ -94,3 +94,9 @@ test("tuple with rest schema", () => {
 //     .safeParse(['asdf']);
 //   expect(result).toEqual(['asdf']);
 // });
+
+test("pass data hydration", () => {
+  expect(
+    z.tuple([z.string(), z.number()]).hydrate(["abc", 2]).parse([null])
+  ).toEqual(["abc", 2]);
+});

--- a/src/__tests__/unions.test.ts
+++ b/src/__tests__/unions.test.ts
@@ -61,3 +61,9 @@ test("readonly union", async () => {
   union.parse("asdf");
   union.parse(12);
 });
+
+test("pass data hydration", () => {
+  expect(
+    z.union([z.string(), z.number()]).hydrate("abc").parse([null])
+  ).toEqual("abc");
+});

--- a/src/__tests__/void.test.ts
+++ b/src/__tests__/void.test.ts
@@ -13,3 +13,7 @@ test("void", () => {
   type v = z.infer<typeof v>;
   util.assertEqual<v, void>(true);
 });
+
+test("pass data hydration", () => {
+  expect(z.void().hydrate().parse({})).toEqual(undefined);
+});


### PR DESCRIPTION
Implement data hydration.

For example, when you need to validate any input data and get `string[]` on output, without hydration you can only get validation error or set default value (if parse `undefined`), but with hydration if data validation fails it fallbacks on what you pass to `.hydrate` method.

```ts
const schema = z.string().hydrate(/* '' by default */).array().hydrate([]);

schema.parse(undefined); // => []
schema.parse({ a: 123 }); // => []
schema.parse([]); // => []
schema.parse(['asd']); // => ['asd']
schema.parse([1]); // => ['']
schema.parse([1, 'a', 2]); // => ['', 'a', '']
```

So on output you always have `string[]`.