### PR TITLE
Added Intersections to TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
 - [Records](#records)
 - [Maps](#maps)
 - [Sets](#sets)
+- [Intersections](#intersections)
 - [Recursive types](#recursive-types)
   - [JSON type](#json-type)
   - [Cyclical data](#cyclical-objects)

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -83,6 +83,7 @@
 - [Records](#records)
 - [Maps](#maps)
 - [Sets](#sets)
+- [Intersections](#intersections)
 - [Recursive types](#recursive-types)
   - [JSON type](#json-type)
   - [Cyclical data](#cyclical-objects)


### PR DESCRIPTION
This PR adds `Intersections` to TOC.

Was looking for how to do Intersections, couldn't find it in the TOC.
However a quick search via `CTRL+F` revealed that indeed there's a section for `Intersections`, it's just missing from the TOC.
