### PR TITLE
Add `deepStrict` flag to `parse()` (#1370)

### DIFF
--- a/deno/lib/__tests__/parser.test.ts
+++ b/deno/lib/__tests__/parser.test.ts
@@ -46,3 +46,24 @@ test("invalid enum value", () => {
 test("parsing unknown", () => {
   z.string().parse("Red" as unknown);
 });
+
+test("parsing with deepStrict", () => {
+  const deepSchema = z.object({
+    nestedObject: z.object({
+      knownNestedKey: z.number(),
+    })
+  });
+
+  const deepObject = {
+    nestedObject: {
+      knownNestedKey: 1,
+      unknownNestedKey: 1,
+    }
+  }
+
+  deepSchema.parse(deepObject);
+
+  expect(() => deepSchema.parse(deepObject, {
+    deepStrict: true,
+  })).toThrow();
+});

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -36,6 +36,7 @@ export type ParseParams = {
   path: (string | number)[];
   errorMap: ZodErrorMap;
   async: boolean;
+  deepStrict: boolean,
 };
 
 export type ParsePathComponent = string | number;
@@ -53,12 +54,14 @@ export interface ParseContext {
   readonly parent: ParseContext | null;
   readonly data: any;
   readonly parsedType: ZodParsedType;
+  readonly deepStrict: boolean;
 }
 
 export type ParseInput = {
   data: any;
   path: (string | number)[];
   parent: ParseContext;
+  deepStrict: boolean;
 };
 
 export function addIssueToContext(

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -45,3 +45,24 @@ test("invalid enum value", () => {
 test("parsing unknown", () => {
   z.string().parse("Red" as unknown);
 });
+
+test("parsing with deepStrict", () => {
+  const deepSchema = z.object({
+    nestedObject: z.object({
+      knownNestedKey: z.number(),
+    })
+  });
+
+  const deepObject = {
+    nestedObject: {
+      knownNestedKey: 1,
+      unknownNestedKey: 1,
+    }
+  }
+
+  deepSchema.parse(deepObject);
+
+  expect(() => deepSchema.parse(deepObject, {
+    deepStrict: true,
+  })).toThrow();
+});

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -36,6 +36,7 @@ export type ParseParams = {
   path: (string | number)[];
   errorMap: ZodErrorMap;
   async: boolean;
+  deepStrict: boolean,
 };
 
 export type ParsePathComponent = string | number;
@@ -53,12 +54,14 @@ export interface ParseContext {
   readonly parent: ParseContext | null;
   readonly data: any;
   readonly parsedType: ZodParsedType;
+  readonly deepStrict: boolean;
 }
 
 export type ParseInput = {
   data: any;
   path: (string | number)[];
   parent: ParseContext;
+  deepStrict: boolean;
 };
 
 export function addIssueToContext(


### PR DESCRIPTION
Straightforward attempt to implement feature requested in #1370 
```javascript
schema.safeParse({
  deepStrict: true,
})
```