### PR TITLE
Forward path param for safeParseAsync method to _parse method

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -255,7 +255,7 @@ export abstract class ZodType<
       parsedType: getParsedType(data),
     };
 
-    const maybeAsyncResult = this._parse({ data, path: [], parent: ctx });
+    const maybeAsyncResult = this._parse({ data, path: ctx.path, parent: ctx });
     const result = await (isAsync(maybeAsyncResult)
       ? maybeAsyncResult
       : Promise.resolve(maybeAsyncResult));

--- a/src/types.ts
+++ b/src/types.ts
@@ -255,7 +255,7 @@ export abstract class ZodType<
       parsedType: getParsedType(data),
     };
 
-    const maybeAsyncResult = this._parse({ data, path: [], parent: ctx });
+    const maybeAsyncResult = this._parse({ data, path: ctx.path, parent: ctx });
     const result = await (isAsync(maybeAsyncResult)
       ? maybeAsyncResult
       : Promise.resolve(maybeAsyncResult));


### PR DESCRIPTION
**Problem**
The `path` option for `safeParseAsync` is not forwarded to the `_parse` method

**Solution**
Swap the empty array argument which is passed into the `safeParseAsync` method to the defined `path` in the current context

Fixes #1451