### PR TITLE
[#1468] Fix zod.dev main page cross origin links.

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,17 @@
         auto2top: true,
         repo: "colinhacks/zod",
         routerMode: "history",
+        crossOriginLinks: [
+          "https://github.com/colinhacks/zod/actions?query=branch%3Amaster",
+          "https://opensource.org/licenses/MIT",
+          "https://www.npmjs.com/package/zod",
+          "https://discord.gg/KaSRdyX2vc",
+          "https://discord.gg/RcG33DQJdf",
+          "https://github.com/colinhacks/zod/issues/new",
+          "https://twitter.com/colinhacks",
+          "https://trpc.io/",
+          "https://zod.dev/",
+        ],
       };
     </script>
   </body>


### PR DESCRIPTION
Sets docsify [crossOriginLinks](https://docsify.js.org/#/configuration?id=crossoriginlinks) to fix #1468