### PR TITLE
feat: Add lazy to root Zod class

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -368,6 +368,8 @@ export abstract class ZodType<
     this.and = this.and.bind(this);
     this.transform = this.transform.bind(this);
     this.default = this.default.bind(this);
+    this.brand = this.brand.bind(this);
+    this.lazy = this.lazy.bind(this);
     this.describe = this.describe.bind(this);
     this.isNullable = this.isNullable.bind(this);
     this.isOptional = this.isOptional.bind(this);
@@ -425,6 +427,10 @@ export abstract class ZodType<
       type: this,
       ...processCreateParams(undefined),
     });
+  }
+
+  lazy(): ZodLazy<this> {
+    return ZodLazy.create(() => this);
   }
 
   describe(description: string): this {

--- a/src/types.ts
+++ b/src/types.ts
@@ -368,6 +368,8 @@ export abstract class ZodType<
     this.and = this.and.bind(this);
     this.transform = this.transform.bind(this);
     this.default = this.default.bind(this);
+    this.brand = this.brand.bind(this);
+    this.lazy = this.lazy.bind(this);
     this.describe = this.describe.bind(this);
     this.isNullable = this.isNullable.bind(this);
     this.isOptional = this.isOptional.bind(this);
@@ -425,6 +427,10 @@ export abstract class ZodType<
       type: this,
       ...processCreateParams(undefined),
     });
+  }
+
+  lazy(): ZodLazy<this> {
+    return ZodLazy.create(() => this);
   }
 
   describe(description: string): this {


### PR DESCRIPTION
# Overview

Very tiny PR to add the `ZodLazy` type as a convenience method in the root `ZodType` class.

Also noticed the `brand` convenience method wasn't bound in the constructor, so I went ahead and fixed this too.