### PR TITLE
Add pattern matching to unions

### DIFF
--- a/deno/lib/__tests__/pattern-matching.test.ts
+++ b/deno/lib/__tests__/pattern-matching.test.ts
@@ -1,0 +1,27 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+it('pattern matches', () => {
+  const teacherOrStudent = z
+    .object({ name: z.string(), role: z.literal('teacher') })
+    .or(z.object({ name: z.string(), role: z.literal('student') }))
+
+  const isTeacherOrStudent = teacherOrStudent.match(
+    teacher => teacher.role === 'teacher',
+    student => student.role === 'student'
+  )
+  expect(isTeacherOrStudent({ name: 'abcd', role: 'teacher' })).toStrictEqual({ key: 0, value: true })
+  expect(isTeacherOrStudent({ name: 'efgh', role: 'student' })).toStrictEqual({ key: 1, value: true })
+
+  const teacherOrStudentOrProgrammer = teacherOrStudent.or(z.object({ name: z.string(), role: z.literal('programmer') }))
+  const worksInClassrooms = teacherOrStudentOrProgrammer.match(
+    {key: 'teacherOrStudent', check: () => true}, // teacher or student (the first union does not get unwrapped)
+    {key: 'programmer', check: () => false}, // programmer
+  )
+  expect(worksInClassrooms({ name: 'abcd', role: 'teacher' })).toStrictEqual({ key: 'teacherOrStudent', value: true })
+  expect(worksInClassrooms({ name: 'efgh', role: 'student' })).toStrictEqual({ key: 'teacherOrStudent', value: true })
+  expect(worksInClassrooms({ name: 'ijkl', role: 'programmer' })).toStrictEqual({ key: 'programmer', value: false })
+})

--- a/src/__tests__/pattern-matching.test.ts
+++ b/src/__tests__/pattern-matching.test.ts
@@ -1,0 +1,26 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+
+it('pattern matches', () => {
+  const teacherOrStudent = z
+    .object({ name: z.string(), role: z.literal('teacher') })
+    .or(z.object({ name: z.string(), role: z.literal('student') }))
+
+  const isTeacherOrStudent = teacherOrStudent.match(
+    teacher => teacher.role === 'teacher',
+    student => student.role === 'student'
+  )
+  expect(isTeacherOrStudent({ name: 'abcd', role: 'teacher' })).toStrictEqual({ key: 0, value: true })
+  expect(isTeacherOrStudent({ name: 'efgh', role: 'student' })).toStrictEqual({ key: 1, value: true })
+
+  const teacherOrStudentOrProgrammer = teacherOrStudent.or(z.object({ name: z.string(), role: z.literal('programmer') }))
+  const worksInClassrooms = teacherOrStudentOrProgrammer.match(
+    {key: 'teacherOrStudent', check: () => true}, // teacher or student (the first union does not get unwrapped)
+    {key: 'programmer', check: () => false}, // programmer
+  )
+  expect(worksInClassrooms({ name: 'abcd', role: 'teacher' })).toStrictEqual({ key: 'teacherOrStudent', value: true })
+  expect(worksInClassrooms({ name: 'efgh', role: 'student' })).toStrictEqual({ key: 'teacherOrStudent', value: true })
+  expect(worksInClassrooms({ name: 'ijkl', role: 'programmer' })).toStrictEqual({ key: 'programmer', value: false })
+})


### PR DESCRIPTION
# Pattern matching in Unions

## Overview

This PR adds a pattern matching function to `ZodUnions`, similar to [`Runtypes`](https://github.com/pelotom/runtypes#pattern-matching)

The code is a bit complex so I can go through it in detail.

The `match` function receives a rest parameter of the same length as the tuple that defined the union type. Let's say you have the following `ZodUnion`:

```ts
z.union(z.string(), z.number(), z.bigint(), z.literal('a'))
```

then, the `match` function will receive four arguments, ordered.

For each argument, you have two options: 

1. Pass only a function that receives the `output` of the schema in that position and can return whatever you'd like.
2. Or you can pass an object with a `key` and a `check` function. You can use `key` to name your case. The `check` key should receive the same function as described in item 1.

So, for example:

```ts
// For this union:
const myUnion = z.union(z.string(), z.number(), z.bigint(), z.literal('a'))

const isGreaterThanTwo = myUnion.match(
  (str) => str.length > 2,
  (num) => num > 2,
  { key: "my bigint", check: (bi) => false },
  { key: "my literal", check: () => false },
)
```

This will return another function that you can use to see if an input matches one of the patterns. In this example, the function returned would have the following signature:

```
(x: unknown /* the input */ ) => {
  key: 0, value: boolean
} | {
  key: 1, value: boolean,
} | {
  key: "my bigint", value: boolean
} | {
  key: "my literal", value: boolean
}
```

Here you can notice that unnamed cases receive the array index as `key`, while named cases get identified back.

All return types and case names get inferred correctly, and you can mix and match return types freely.

```ts
const anotherExample = myUnion.match(
  (str) => str.length > 2,
  (num) => `${num}`,
  { key: "my bigint", check: (bi) => { an: "object" } },
  { key: "my literal", check: () => [0, 1] },
)

// which returns: 

(x: unknown) => {
    key: "0";
    value: boolean;
} | {
    key: "1";
    value: string;
} | {
    key: "my bigint";
    value: {
        an: string;
    };
} | {
    key: "my literal";
    value: number[];
}
```

Last but not least, the return type is a discriminated union with `key` as the discriminator, so you can make use of this to know at which case your function matched.

---

### Next steps

_(doesn't have to be in this PR)_

- [ ] Add catchall support