### PR TITLE
Add `.utc()` string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
+z.string().utc(); // Date.prototype.toISOString() format
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -489,6 +489,7 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
+z.string().utc(); // Date.prototype.toISOString() format
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -92,6 +92,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "utc"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -152,21 +152,31 @@ test("checks getters", () => {
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
+  expect(z.string().email().isUTC).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
+  expect(z.string().url().isUTC).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
+  expect(z.string().cuid().isUTC).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
+  expect(z.string().uuid().isUTC).toEqual(false);
+
+  expect(z.string().utc().isEmail).toEqual(false);
+  expect(z.string().utc().isURL).toEqual(false);
+  expect(z.string().utc().isCUID).toEqual(false);
+  expect(z.string().utc().isUUID).toEqual(false);
+  expect(z.string().utc().isUTC).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -185,4 +195,16 @@ test("trim", () => {
   // ordering of methods is respected
   expect(z.string().min(2).trim().parse(" 1 ")).toEqual("1");
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
+});
+
+test("utc", () => {
+  const utc = z.string().utc();
+  utc.parse("1970-01-01T00:00:00.000Z");
+  utc.parse("2022-10-13T09:52:31.816Z");
+  expect(() => utc.parse("")).toThrow();
+  expect(() => utc.parse("foo")).toThrow();
+  expect(() => utc.parse("2020-10-14")).toThrow();
+  expect(() => utc.parse("T18:45:12.123")).toThrow();
+  expect(() => utc.parse("2020-10-14T17:42:29Z")).toThrow();
+  expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
 });

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -92,6 +92,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "utc"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -151,21 +151,31 @@ test("checks getters", () => {
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
+  expect(z.string().email().isUTC).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
+  expect(z.string().url().isUTC).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
+  expect(z.string().cuid().isUTC).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
+  expect(z.string().uuid().isUTC).toEqual(false);
+
+  expect(z.string().utc().isEmail).toEqual(false);
+  expect(z.string().utc().isURL).toEqual(false);
+  expect(z.string().utc().isCUID).toEqual(false);
+  expect(z.string().utc().isUUID).toEqual(false);
+  expect(z.string().utc().isUTC).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -184,4 +194,16 @@ test("trim", () => {
   // ordering of methods is respected
   expect(z.string().min(2).trim().parse(" 1 ")).toEqual("1");
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
+});
+
+test("utc", () => {
+  const utc = z.string().utc();
+  utc.parse("1970-01-01T00:00:00.000Z");
+  utc.parse("2022-10-13T09:52:31.816Z");
+  expect(() => utc.parse("")).toThrow();
+  expect(() => utc.parse("foo")).toThrow();
+  expect(() => utc.parse("2020-10-14")).toThrow();
+  expect(() => utc.parse("T18:45:12.123")).toThrow();
+  expect(() => utc.parse("2020-10-14T17:42:29Z")).toThrow();
+  expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
 });


### PR DESCRIPTION
Adds `.utc()` from: https://github.com/colinhacks/zod/issues/126#issuecomment-708589382.

I think milliseconds being required makes sense but I'm happy to be corrected. I'm also happy to rename this matcher to be more specific to being a matcher for the [`.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) format which I think is fairly used and easy to access in Javascript.

`.dateIsoString()` could also work.