### PR TITLE
add `.dateISOString()` format

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
+z.string().dateISOString(); // Date.prototype.toISOString() format
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
@@ -946,7 +947,6 @@ const deepPartialUser = user.deepPartial();
 ```
 
 > Important limitation: deep partials only work as expected in hierarchies of objects, arrays, and tuples.
-
 
 ### `.required`
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -489,6 +489,7 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
+z.string().dateISOString(); // Date.prototype.toISOString() format
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
@@ -946,7 +947,6 @@ const deepPartialUser = user.deepPartial();
 ```
 
 > Important limitation: deep partials only work as expected in hierarchies of objects, arrays, and tuples.
-
 
 ### `.required`
 

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -92,6 +92,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "dateISOString"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -152,21 +152,31 @@ test("checks getters", () => {
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
+  expect(z.string().email().isDateISOString).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
+  expect(z.string().url().isDateISOString).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
+  expect(z.string().cuid().isDateISOString).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
+  expect(z.string().uuid().isDateISOString).toEqual(false);
+
+  expect(z.string().dateISOString().isEmail).toEqual(false);
+  expect(z.string().dateISOString().isURL).toEqual(false);
+  expect(z.string().dateISOString().isCUID).toEqual(false);
+  expect(z.string().dateISOString().isUUID).toEqual(false);
+  expect(z.string().dateISOString().isDateISOString).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -185,4 +195,16 @@ test("trim", () => {
   // ordering of methods is respected
   expect(z.string().min(2).trim().parse(" 1 ")).toEqual("1");
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
+});
+
+test("dateISOString", () => {
+  const dateISOString = z.string().dateISOString();
+  dateISOString.parse("1970-01-01T00:00:00.000Z");
+  dateISOString.parse("2022-10-13T09:52:31.816Z");
+  expect(() => dateISOString.parse("")).toThrow();
+  expect(() => dateISOString.parse("foo")).toThrow();
+  expect(() => dateISOString.parse("2020-10-14")).toThrow();
+  expect(() => dateISOString.parse("T18:45:12.123")).toThrow();
+  expect(() => dateISOString.parse("2020-10-14T17:42:29Z")).toThrow();
+  expect(() => dateISOString.parse("2020-10-14T17:42:29+00:00")).toThrow();
 });

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -92,6 +92,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "dateISOString"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -151,21 +151,31 @@ test("checks getters", () => {
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
+  expect(z.string().email().isDateISOString).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
+  expect(z.string().url().isDateISOString).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
+  expect(z.string().cuid().isDateISOString).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
+  expect(z.string().uuid().isDateISOString).toEqual(false);
+
+  expect(z.string().dateISOString().isEmail).toEqual(false);
+  expect(z.string().dateISOString().isURL).toEqual(false);
+  expect(z.string().dateISOString().isCUID).toEqual(false);
+  expect(z.string().dateISOString().isUUID).toEqual(false);
+  expect(z.string().dateISOString().isDateISOString).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -184,4 +194,16 @@ test("trim", () => {
   // ordering of methods is respected
   expect(z.string().min(2).trim().parse(" 1 ")).toEqual("1");
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
+});
+
+test("dateISOString", () => {
+  const dateISOString = z.string().dateISOString();
+  dateISOString.parse("1970-01-01T00:00:00.000Z");
+  dateISOString.parse("2022-10-13T09:52:31.816Z");
+  expect(() => dateISOString.parse("")).toThrow();
+  expect(() => dateISOString.parse("foo")).toThrow();
+  expect(() => dateISOString.parse("2020-10-14")).toThrow();
+  expect(() => dateISOString.parse("T18:45:12.123")).toThrow();
+  expect(() => dateISOString.parse("2020-10-14T17:42:29Z")).toThrow();
+  expect(() => dateISOString.parse("2020-10-14T17:42:29+00:00")).toThrow();
 });


### PR DESCRIPTION
Adds a validator for what I think is a fairly common and universally accessible format in Javascript: [Date.prototype.toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).

I've gone down a fairly big rabbit hole of threads but I think this makes sense and is fairly clear. Since the RFC Colin https://github.com/colinhacks/zod/issues/126#issuecomment-708589382 here raised that `.utc()` should support milliseconds but not required could lead to some inconsistencies in codebases so I've decided to go a different route. I feel like I would likely want to choose milliseconds or no milliseconds for consistency. Hence I've decided to go with just this simple `.dateISOString()` which is also documented to be pointing to the `Date.prototype.toISOString()` function

Happy to be shot down here if we could get some progress.