### PR TITLE
Allow wrapped literal types in discriminatedUnion

### DIFF
--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -59,6 +59,27 @@ test("valid - discriminator value of various primitive types", () => {
   });
 });
 
+test("valid - literals with .default or .preprocess", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("foo").default("foo"),
+      a: z.string(),
+    }),
+    z.object({
+      type: z.literal("custom"),
+      method: z.string(),
+    }),
+    z.object({
+      type: z.preprocess((val) => String(val), z.literal("bar")),
+      c: z.string(),
+    }),
+  ]);
+  expect(schema.parse({ type: "foo", a: "foo" })).toEqual({
+    type: "foo",
+    a: "foo",
+  });
+});
+
 test("invalid - null", () => {
   try {
     z.discriminatedUnion("type", [
@@ -117,7 +138,6 @@ test("valid discriminator value, invalid data", () => {
     ]);
   }
 });
-
 test("wrong schema - missing discriminator", () => {
   try {
     z.discriminatedUnion("type", [

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -58,6 +58,27 @@ test("valid - discriminator value of various primitive types", () => {
   });
 });
 
+test("valid - literals with .default or .preprocess", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("foo").default("foo"),
+      a: z.string(),
+    }),
+    z.object({
+      type: z.literal("custom"),
+      method: z.string(),
+    }),
+    z.object({
+      type: z.preprocess((val) => String(val), z.literal("bar")),
+      c: z.string(),
+    }),
+  ]);
+  expect(schema.parse({ type: "foo", a: "foo" })).toEqual({
+    type: "foo",
+    a: "foo",
+  });
+});
+
 test("invalid - null", () => {
   try {
     z.discriminatedUnion("type", [
@@ -116,7 +137,6 @@ test("valid discriminator value, invalid data", () => {
     ]);
   }
 });
-
 test("wrong schema - missing discriminator", () => {
   try {
     z.discriminatedUnion("type", [


### PR DESCRIPTION
First of all thanks a lot for all your work in zod, it's a joy to use.

This PR fixes type checking when passing literal types with default values or preprocess transformations.

Before this change, the type checker was complaining that value does not exist, as described in https://github.com/colinhacks/zod/issues/1490.

Added a test case that had failing types but now works.

```js
test("valid - literals with .default or .preprocess", () => {
  const schema = z.discriminatedUnion("type", [
    z.object({
      type: z.literal("foo").default("foo"),
      a: z.string(),
    }),
    z.object({
      type: z.literal("custom"),
      method: z.string(),
    }),
    z.object({
      type: z.preprocess((val) => String(val), z.literal("bar")),
      c: z.string(),
    }),
  ]);
  expect(schema.parse({ type: "foo", a: "foo" })).toEqual({
    type: "foo",
    a: "foo",
  });
});
```

The fix consists in modifying the `ZodDiscriminatedUnionOption` to also allow `ZodDefault<ZodLiteral...>` and `ZodEffects<ZodLiteral...>`.

```ts
export type ZodDiscriminatedUnionOption<
  Discriminator extends string,
  DiscriminatorValue extends Primitive
> = ZodObject<
  {
    [key in Discriminator]:
      | ZodDefault<ZodLiteral<DiscriminatorValue>>
      | ZodEffects<ZodLiteral<DiscriminatorValue>, DiscriminatorValue, unknown>
      | ZodLiteral<DiscriminatorValue>;
  } & ZodRawShape,
  any,
  any
>;
```

Along with this change, I changed the logic to extract the discriminator value from the provided schemas. It now unwraps the inner literal type from `ZodDefault` or `ZodEffect`

```ts
try {
      types.forEach((type) => {
        const typeShape = type.shape[discriminator];
        if (typeShape instanceof ZodDefault) {
          const discriminatorValue = typeShape.removeDefault().value;
          options.set(discriminatorValue, type);
          return;
        }
        if (typeShape instanceof ZodEffects) {
          const discriminatorValue = typeShape.innerType().value;
          options.set(discriminatorValue, type);
          return;
        }
        if (typeShape instanceof ZodLiteral) {
          const discriminatorValue = typeShape.value;
          options.set(discriminatorValue, type);
          return;
        }
        throw new Error(`Wrong Zod Shape: ${typeShape}`);
      });
    } catch (e) {
      throw new Error(
        "The discriminator value could not be extracted from all the provided schemas"
      );
    }
```

Note: An even better solution I imagine is making sure that both `ZodDefault` and `ZodEffects` re-surface the inner type properties, such as `ZodLiteral`'s `value`. But I'd need more familiarity with the code base to propose that change.

Happy to hear your thoughts on the problem I identified, and whether this solution is appropriate. I can always iterate on both how I understood the issue and how to tackle it.

