### PR TITLE
Removed BRAND from ZodBrand Input definition

### DIFF
--- a/deno/lib/__tests__/branded.test.ts
+++ b/deno/lib/__tests__/branded.test.ts
@@ -47,6 +47,17 @@ test("branded types", () => {
     true
   );
 
+  // keeping brands out of input types
+  const age = z.number().brand<"age">();
+
+  type Age = z.infer<typeof age>;
+  type AgeInput = z.input<typeof age>;
+
+  util.assertEqual<AgeInput, Age>(false);
+
+  util.assertEqual<number, AgeInput>(true);
+  util.assertEqual<number & z.BRAND<"age">, Age>(true);
+
   // @ts-expect-error
   doStuff({ name: "hello there!" });
 });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3795,11 +3795,7 @@ export type BRAND<T extends string | number | symbol> = {
 export class ZodBranded<
   T extends ZodTypeAny,
   B extends string | number | symbol
-> extends ZodType<
-  T["_output"] & BRAND<B>,
-  ZodBrandedDef<T>,
-  T["_input"] & BRAND<B>
-> {
+> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, T["_input"]> {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;

--- a/src/__tests__/branded.test.ts
+++ b/src/__tests__/branded.test.ts
@@ -46,6 +46,17 @@ test("branded types", () => {
     true
   );
 
+  // keeping brands out of input types
+  const age = z.number().brand<"age">();
+
+  type Age = z.infer<typeof age>;
+  type AgeInput = z.input<typeof age>;
+
+  util.assertEqual<AgeInput, Age>(false);
+
+  util.assertEqual<number, AgeInput>(true);
+  util.assertEqual<number & z.BRAND<"age">, Age>(true);
+
   // @ts-expect-error
   doStuff({ name: "hello there!" });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3795,11 +3795,7 @@ export type BRAND<T extends string | number | symbol> = {
 export class ZodBranded<
   T extends ZodTypeAny,
   B extends string | number | symbol
-> extends ZodType<
-  T["_output"] & BRAND<B>,
-  ZodBrandedDef<T>,
-  T["_input"] & BRAND<B>
-> {
+> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, T["_input"]> {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;


### PR DESCRIPTION
A type's brand should only be accessible in its output aka `z.infer` or `z.output` but it's also carried over to its input. This makes it difficult to create a typesafe parse function as the code doesn't compile

For example:
```ts
const Age = z.number().min(18).brand<"Age">()

type AgeInput = z.input<typeof Age>
```
an input for `Age.parse(x)` aka `AgeInput` should just be `number` but it's `number & BRAND<"Age">` which doesn't make sense

[Working typescript playground example](https://www.typescriptlang.org/play?ssl=3&ssc=46&pln=3&pc=1#code/JYWwDg9gTgLgBAbzgLzgXzgMyhEcDkyEAJvgFBkDGEAdgM7wCCA5gKZwC8KAdDQK4gARqygAKAJTcQwGqICMADkmCoAQxrEAPACIWrbQD4JFTHxqUYwWnBx8YI0TLB2AXHH5CR4xGThwwqlB0rI40zjDiZGgmZhZWNP6BwaKqbG7I3E52mjAAnmCsEJhwegbeCFFAA)