### PR TITLE
add `.utc()`/`.iso8601()` string formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,29 +492,11 @@ z.string().cuid();
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
-
-// date formats
-z.string().utc();
-z.string().utc({ ms: true }); // ms only
-z.string().utc({ ms: true, msLength: 3 }); // ms only, 3 digit precision
-z.string().utc({ ms: false }); // no ms only
-
-z.string().iso8601(); // allows offset
-z.string().iso8601({ ms: true }); // ms only
-z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
-z.string().iso8601({ ms: false }); // no ms only
-
-// trim whitespace
-z.string().trim();
-
-// deprecated, equivalent to .min(1)
-z.string().nonempty();
-
-// optional custom error message
-z.string().nonempty({ message: "Can't be empty" });
+z.string().trim(); // trim whitespace
+z.string().datetime(); // defaults to UTC, see below for options
 ```
 
-> Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions.
+> Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
 
 You can customize some common error messages when creating a string schema.
 
@@ -536,6 +518,40 @@ z.string().url({ message: "Invalid url" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
+z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
+```
+
+### Datetime validation
+
+The `z.string().datetime()` method defaults to UTC validation: no timezone offsets with arbitrary sub-second decimal precision.
+
+```ts
+const datetime = z.string().datetime();
+
+datetime.parse("2020-01-01T00:00:00Z"); // pass
+datetime.parse("2020-01-01T00:00:00.123Z"); // pass
+datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
+datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
+```
+
+Timezone offsets can be allowed by setting the `offset` option to `true`.
+
+```ts
+const datetime = z.string().datetime({ offset: true });
+
+datetime.parse("2020-01-01T00:00:00+02:00"); // pass
+datetime.parse("2020-01-01T00:00:00.123+02:00"); // pass (millis optional)
+datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
+```
+
+You can additionally constrain the allowable `precision`.
+
+```ts
+const datetime = z.string().datetime({ precision: 3 });
+
+datetime.parse("2020-01-01T00:00:00.123Z"); // pass
+datetime.parse("2020-01-01T00:00:00Z"); // fail
+datetime.parse("2020-01-01T00:00:00.123456Z"); // fail
 ```
 
 ## Numbers

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ z.string().utc({ ms: true }); // ms only
 z.string().utc({ ms: true, msLength: 3 }); // ms only, 3 digit precision
 z.string().utc({ ms: false }); // no ms only
 
-z.string().iso8601();
+z.string().iso8601(); // allows offset
 z.string().iso8601({ ms: true }); // ms only
 z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
 z.string().iso8601({ ms: false }); // no ms only

--- a/README.md
+++ b/README.md
@@ -495,14 +495,12 @@ z.string().endsWith(string);
 
 // date formats
 z.string().utc();
-z.string().utc({ ms: true }); // ms only, 3 digit precision
-z.string().utc({ ms: true, msLength: 0 }); // ms only, unspecified digit precision
-z.string().utc({ ms: true, msLength: 5 }); // ms only, 5 digit precision
+z.string().utc({ ms: true }); // ms only
+z.string().utc({ ms: true, msLength: 3 }); // ms only, 3 digit precision
 z.string().utc({ ms: false }); // no ms only
 
 z.string().iso8601();
-z.string().iso8601({ ms: true }); // ms only, 3 digit precision
-z.string().iso8601({ ms: true, msLength: 0 }); // ms only, unspecified digit precision
+z.string().iso8601({ ms: true }); // ms only
 z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
 z.string().iso8601({ ms: false }); // no ms only
 

--- a/README.md
+++ b/README.md
@@ -489,12 +489,17 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
-z.string().utc(); // Accepts both milliseconds and no milliseconds
-z.string().utc({ milliseconds: true }); // Accepts only milliseconds
-z.string().utc({ milliseconds: false }); // Accepts only no milliseconds
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
+
+// date formats
+z.string().utc();
+z.string().utc({ ms: true }); // milliseconds only
+z.string().utc({ ms: false }); // no milliseconds only
+z.string().iso8601();
+z.string().iso8601({ ms: true }); // milliseconds only
+z.string().iso8601({ ms: false }); // no milliseconds only
 
 // trim whitespace
 z.string().trim();

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ datetime.parse("2020-01-01T00:00:00.123+02:00"); // pass (millis optional)
 datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
 ```
 
-You can additionally constrain the allowable `precision`.
+You can additionally constrain the allowable `precision`. By default, arbitrary sub-second precision is supported (but optional).
 
 ```ts
 const datetime = z.string().datetime({ precision: 3 });

--- a/README.md
+++ b/README.md
@@ -495,11 +495,16 @@ z.string().endsWith(string);
 
 // date formats
 z.string().utc();
-z.string().utc({ ms: true }); // milliseconds only
-z.string().utc({ ms: false }); // no milliseconds only
+z.string().utc({ ms: true }); // ms only, 3 digit precision
+z.string().utc({ ms: true, msLength: 0 }); // ms only, unspecified digit precision
+z.string().utc({ ms: true, msLength: 5 }); // ms only, 5 digit precision
+z.string().utc({ ms: false }); // no ms only
+
 z.string().iso8601();
-z.string().iso8601({ ms: true }); // milliseconds only
-z.string().iso8601({ ms: false }); // no milliseconds only
+z.string().iso8601({ ms: true }); // ms only, 3 digit precision
+z.string().iso8601({ ms: true, msLength: 0 }); // ms only, unspecified digit precision
+z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
+z.string().iso8601({ ms: false }); // no ms only
 
 // trim whitespace
 z.string().trim();

--- a/README.md
+++ b/README.md
@@ -489,6 +489,9 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
+z.string().utc(); // Accepts both milliseconds and no milliseconds
+z.string().utc({ milliseconds: true }); // Accepts only milliseconds
+z.string().utc({ milliseconds: false }); // Accepts only no milliseconds
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
@@ -946,7 +949,6 @@ const deepPartialUser = user.deepPartial();
 ```
 
 > Important limitation: deep partials only work as expected in hierarchies of objects, arrays, and tuples.
-
 
 ### `.required`
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -492,29 +492,11 @@ z.string().cuid();
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
-
-// date formats
-z.string().utc();
-z.string().utc({ ms: true }); // ms only
-z.string().utc({ ms: true, msLength: 3 }); // ms only, 3 digit precision
-z.string().utc({ ms: false }); // no ms only
-
-z.string().iso8601(); // allows offset
-z.string().iso8601({ ms: true }); // ms only
-z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
-z.string().iso8601({ ms: false }); // no ms only
-
-// trim whitespace
-z.string().trim();
-
-// deprecated, equivalent to .min(1)
-z.string().nonempty();
-
-// optional custom error message
-z.string().nonempty({ message: "Can't be empty" });
+z.string().trim(); // trim whitespace
+z.string().datetime(); // defaults to UTC, see below for options
 ```
 
-> Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions.
+> Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
 
 You can customize some common error messages when creating a string schema.
 
@@ -536,6 +518,40 @@ z.string().url({ message: "Invalid url" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
+z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
+```
+
+### Datetime validation
+
+The `z.string().datetime()` method defaults to UTC validation: no timezone offsets with arbitrary sub-second decimal precision.
+
+```ts
+const datetime = z.string().datetime();
+
+datetime.parse("2020-01-01T00:00:00Z"); // pass
+datetime.parse("2020-01-01T00:00:00.123Z"); // pass
+datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
+datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
+```
+
+Timezone offsets can be allowed by setting the `offset` option to `true`.
+
+```ts
+const datetime = z.string().datetime({ offset: true });
+
+datetime.parse("2020-01-01T00:00:00+02:00"); // pass
+datetime.parse("2020-01-01T00:00:00.123+02:00"); // pass (millis optional)
+datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
+```
+
+You can additionally constrain the allowable `precision`.
+
+```ts
+const datetime = z.string().datetime({ precision: 3 });
+
+datetime.parse("2020-01-01T00:00:00.123Z"); // pass
+datetime.parse("2020-01-01T00:00:00Z"); // fail
+datetime.parse("2020-01-01T00:00:00.123456Z"); // fail
 ```
 
 ## Numbers

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -499,7 +499,7 @@ z.string().utc({ ms: true }); // ms only
 z.string().utc({ ms: true, msLength: 3 }); // ms only, 3 digit precision
 z.string().utc({ ms: false }); // no ms only
 
-z.string().iso8601();
+z.string().iso8601(); // allows offset
 z.string().iso8601({ ms: true }); // ms only
 z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
 z.string().iso8601({ ms: false }); // no ms only

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -495,14 +495,12 @@ z.string().endsWith(string);
 
 // date formats
 z.string().utc();
-z.string().utc({ ms: true }); // ms only, 3 digit precision
-z.string().utc({ ms: true, msLength: 0 }); // ms only, unspecified digit precision
-z.string().utc({ ms: true, msLength: 5 }); // ms only, 5 digit precision
+z.string().utc({ ms: true }); // ms only
+z.string().utc({ ms: true, msLength: 3 }); // ms only, 3 digit precision
 z.string().utc({ ms: false }); // no ms only
 
 z.string().iso8601();
-z.string().iso8601({ ms: true }); // ms only, 3 digit precision
-z.string().iso8601({ ms: true, msLength: 0 }); // ms only, unspecified digit precision
+z.string().iso8601({ ms: true }); // ms only
 z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
 z.string().iso8601({ ms: false }); // no ms only
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -489,12 +489,17 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
-z.string().utc(); // Accepts both milliseconds and no milliseconds
-z.string().utc({ milliseconds: true }); // Accepts only milliseconds
-z.string().utc({ milliseconds: false }); // Accepts only no milliseconds
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
+
+// date formats
+z.string().utc();
+z.string().utc({ ms: true }); // milliseconds only
+z.string().utc({ ms: false }); // no milliseconds only
+z.string().iso8601();
+z.string().iso8601({ ms: true }); // milliseconds only
+z.string().iso8601({ ms: false }); // no milliseconds only
 
 // trim whitespace
 z.string().trim();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -544,7 +544,7 @@ datetime.parse("2020-01-01T00:00:00.123+02:00"); // pass (millis optional)
 datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
 ```
 
-You can additionally constrain the allowable `precision`.
+You can additionally constrain the allowable `precision`. By default, arbitrary sub-second precision is supported (but optional).
 
 ```ts
 const datetime = z.string().datetime({ precision: 3 });

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -495,11 +495,16 @@ z.string().endsWith(string);
 
 // date formats
 z.string().utc();
-z.string().utc({ ms: true }); // milliseconds only
-z.string().utc({ ms: false }); // no milliseconds only
+z.string().utc({ ms: true }); // ms only, 3 digit precision
+z.string().utc({ ms: true, msLength: 0 }); // ms only, unspecified digit precision
+z.string().utc({ ms: true, msLength: 5 }); // ms only, 5 digit precision
+z.string().utc({ ms: false }); // no ms only
+
 z.string().iso8601();
-z.string().iso8601({ ms: true }); // milliseconds only
-z.string().iso8601({ ms: false }); // no milliseconds only
+z.string().iso8601({ ms: true }); // ms only, 3 digit precision
+z.string().iso8601({ ms: true, msLength: 0 }); // ms only, unspecified digit precision
+z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
+z.string().iso8601({ ms: false }); // no ms only
 
 // trim whitespace
 z.string().trim();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -489,6 +489,9 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
+z.string().utc(); // Accepts both milliseconds and no milliseconds
+z.string().utc({ milliseconds: true }); // Accepts only milliseconds
+z.string().utc({ milliseconds: false }); // Accepts only no milliseconds
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
@@ -946,7 +949,6 @@ const deepPartialUser = user.deepPartial();
 ```
 
 > Important limitation: deep partials only work as expected in hierarchies of objects, arrays, and tuples.
-
 
 ### `.required`
 

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -92,8 +92,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
-  | "utc"
-  | "iso8601"
+  | "datetime"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -93,6 +93,7 @@ export type StringValidation =
   | "regex"
   | "cuid"
   | "utc"
+  | "iso8601"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -92,6 +92,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "utc"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -172,33 +172,51 @@ test("checks getters", () => {
 test("date getters", () => {
   const utc = z.string().utc();
   const utcMs = z.string().utc({ ms: true });
+  const utcMsLen = z.string().utc({ ms: true, msLength: 3 });
   const utcNoMs = z.string().utc({ ms: false });
   const iso8601 = z.string().iso8601();
   const iso8601Ms = z.string().iso8601({ ms: true });
+  const iso8601MsLen = z.string().iso8601({ ms: true, msLength: 5 });
   const iso8601NoMs = z.string().iso8601({ ms: false });
 
   expect(utc.isUTC()).toEqual(true);
   expect(utcMs.isUTC()).toEqual(false);
+  expect(utcMsLen.isUTC()).toEqual(false);
   expect(utcNoMs.isUTC()).toEqual(false);
 
   expect(iso8601.isISO8601()).toEqual(true);
   expect(iso8601Ms.isISO8601()).toEqual(false);
+  expect(iso8601MsLen.isISO8601()).toEqual(false);
   expect(iso8601NoMs.isISO8601()).toEqual(false);
 
   expect(utc.isUTC({ ms: true })).toEqual(false);
   expect(utcMs.isUTC({ ms: true })).toEqual(true);
+  expect(utcMsLen.isUTC({ ms: true })).toEqual(false);
   expect(utcNoMs.isUTC({ ms: true })).toEqual(false);
 
   expect(iso8601.isISO8601({ ms: true })).toEqual(false);
   expect(iso8601Ms.isISO8601({ ms: true })).toEqual(true);
+  expect(iso8601MsLen.isISO8601({ ms: true })).toEqual(false);
   expect(iso8601NoMs.isISO8601({ ms: true })).toEqual(false);
+
+  expect(utc.isUTC({ ms: true, msLength: 3 })).toEqual(false);
+  expect(utcMs.isUTC({ ms: true, msLength: 3 })).toEqual(false);
+  expect(utcMsLen.isUTC({ ms: true, msLength: 3 })).toEqual(true);
+  expect(utcNoMs.isUTC({ ms: true, msLength: 3 })).toEqual(false);
+
+  expect(iso8601.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
+  expect(iso8601Ms.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
+  expect(iso8601MsLen.isISO8601({ ms: true, msLength: 5 })).toEqual(true);
+  expect(iso8601NoMs.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
 
   expect(utc.isUTC({ ms: false })).toEqual(false);
   expect(utcMs.isUTC({ ms: false })).toEqual(false);
+  expect(utcMsLen.isUTC({ ms: false })).toEqual(false);
   expect(utcNoMs.isUTC({ ms: false })).toEqual(true);
 
   expect(iso8601.isISO8601({ ms: false })).toEqual(false);
   expect(iso8601Ms.isISO8601({ ms: false })).toEqual(false);
+  expect(iso8601MsLen.isISO8601({ ms: false })).toEqual(false);
   expect(iso8601NoMs.isISO8601({ ms: false })).toEqual(true);
 });
 
@@ -223,6 +241,8 @@ test("trim", () => {
 test("utc", () => {
   const utc = z.string().utc();
   const utcMs = z.string().utc({ ms: true });
+  const utcMs1Len = z.string().utc({ ms: true, msLength: 1 });
+  const utcMsInf = z.string().utc({ ms: true, msLength: 0 });
   const utcNoMs = z.string().utc({ ms: false });
 
   utc.parse("1970-01-01T00:00:00.000Z");
@@ -231,6 +251,10 @@ test("utc", () => {
   utc.parse("2022-10-13T09:52:31Z");
   utcMs.parse("1970-01-01T00:00:00.000Z");
   utcMs.parse("2022-10-13T09:52:31.816Z");
+  utcMs1Len.parse("1970-01-01T00:00:00.0Z");
+  utcMs1Len.parse("2022-10-13T09:52:31.8Z");
+  utcMsInf.parse("2022-10-13T09:52:31.9999999Z");
+  utcMsInf.parse("2022-10-13T09:52:31.1Z");
   utcNoMs.parse("1970-01-01T00:00:00Z");
   utcNoMs.parse("2022-10-13T09:52:31Z");
 
@@ -241,6 +265,10 @@ test("utc", () => {
   expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
   expect(() => utcMs.parse("1970-01-01T00:00:00Z")).toThrow();
   expect(() => utcMs.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => utcMs1Len.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => utcMs1Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
+  expect(() => utcMsInf.parse("1970-01-01T00:00:00")).toThrow();
+  expect(() => utcMsInf.parse("2022-10-13T09:52:31:00")).toThrow();
   expect(() => utcNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => utcNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
 });
@@ -248,6 +276,8 @@ test("utc", () => {
 test("iso8601", () => {
   const iso8601 = z.string().iso8601();
   const iso8601Ms = z.string().iso8601({ ms: true });
+  const iso8601Ms5Len = z.string().iso8601({ ms: true, msLength: 5 });
+  const iso8601MsInf = z.string().iso8601({ ms: true, msLength: 0 });
   const iso8601NoMs = z.string().iso8601({ ms: false });
 
   iso8601.parse("1970-01-01T00:00:00.000Z");
@@ -258,6 +288,12 @@ test("iso8601", () => {
   iso8601Ms.parse("1970-01-01T00:00:00.000Z");
   iso8601Ms.parse("2022-10-13T09:52:31.816Z");
   iso8601Ms.parse("2020-10-14T17:42:29.999+00:00");
+  iso8601Ms5Len.parse("1970-01-01T00:00:00.00000Z");
+  iso8601Ms5Len.parse("2022-10-13T09:52:31.81600Z");
+  iso8601Ms5Len.parse("2020-10-14T17:42:29.99900+00:00");
+  iso8601MsInf.parse("1970-01-01T00:00:00.0Z");
+  iso8601MsInf.parse("2022-10-13T09:52:31.81Z");
+  iso8601MsInf.parse("2020-10-14T17:42:29.99900+00:00");
   iso8601NoMs.parse("1970-01-01T00:00:00Z");
   iso8601NoMs.parse("2022-10-13T09:52:31Z");
   iso8601NoMs.parse("2020-10-14T17:42:29+00:00");
@@ -269,6 +305,12 @@ test("iso8601", () => {
   expect(() => iso8601Ms.parse("1970-01-01T00:00:00Z")).toThrow();
   expect(() => iso8601Ms.parse("2022-10-13T09:52:31:00Z")).toThrow();
   expect(() => iso8601Ms.parse("2020-10-14T17:42:29+00:00")).toThrow();
+  expect(() => iso8601Ms5Len.parse("1970-01-01T00:00:00.0Z")).toThrow();
+  expect(() => iso8601Ms5Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
+  expect(() => iso8601Ms5Len.parse("2020-10-14T17:42:29.000+00:00")).toThrow();
+  expect(() => iso8601MsInf.parse("1970-01-01T00:00:00.Z")).toThrow();
+  expect(() => iso8601MsInf.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => iso8601MsInf.parse("2020-10-14T17:42:29+00:00")).toThrow();
   expect(() => iso8601NoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => iso8601NoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
   expect(() => iso8601NoMs.parse("2020-10-14T17:42:29.999+00:00")).toThrow();

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -169,68 +169,6 @@ test("checks getters", () => {
   expect(z.string().uuid().isUUID).toEqual(true);
 });
 
-test("date getters", () => {
-  const utc = z.string().utc();
-  const utcMs = z.string().utc({ ms: true });
-  const utcMsLen = z.string().utc({ ms: true, msLength: 3 });
-  const utcNoMs = z.string().utc({ ms: false });
-
-  const iso8601 = z.string().iso8601();
-  const iso8601Ms = z.string().iso8601({ ms: true });
-  const iso8601MsLen = z.string().iso8601({ ms: true, msLength: 5 });
-  const iso8601NoMs = z.string().iso8601({ ms: false });
-
-  expect(utc.isUTC()).toEqual(true);
-  expect(utcMs.isUTC()).toEqual(false);
-  expect(utcMsLen.isUTC()).toEqual(false);
-  expect(utcNoMs.isUTC()).toEqual(false);
-
-  expect(iso8601.isISO8601()).toEqual(true);
-  expect(iso8601Ms.isISO8601()).toEqual(false);
-  expect(iso8601MsLen.isISO8601()).toEqual(false);
-  expect(iso8601NoMs.isISO8601()).toEqual(false);
-
-  expect(utc.isUTC({ ms: true })).toEqual(false);
-  expect(utcMs.isUTC({ ms: true })).toEqual(true);
-  expect(utcMsLen.isUTC({ ms: true })).toEqual(false);
-  expect(utcNoMs.isUTC({ ms: true })).toEqual(false);
-
-  expect(iso8601.isISO8601({ ms: true })).toEqual(false);
-  expect(iso8601Ms.isISO8601({ ms: true })).toEqual(true);
-  expect(iso8601MsLen.isISO8601({ ms: true })).toEqual(false);
-  expect(iso8601NoMs.isISO8601({ ms: true })).toEqual(false);
-
-  expect(utc.isUTC({ ms: true, msLength: 3 })).toEqual(false);
-  expect(utcMs.isUTC({ ms: true, msLength: 3 })).toEqual(false);
-  expect(utcMsLen.isUTC({ ms: true, msLength: 3 })).toEqual(true);
-  expect(utcNoMs.isUTC({ ms: true, msLength: 3 })).toEqual(false);
-
-  expect(iso8601.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
-  expect(iso8601Ms.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
-  expect(iso8601MsLen.isISO8601({ ms: true, msLength: 5 })).toEqual(true);
-  expect(iso8601NoMs.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
-
-  expect(utc.isUTC({ ms: false })).toEqual(false);
-  expect(utcMs.isUTC({ ms: false })).toEqual(false);
-  expect(utcMsLen.isUTC({ ms: false })).toEqual(false);
-  expect(utcNoMs.isUTC({ ms: false })).toEqual(true);
-
-  expect(iso8601.isISO8601({ ms: false })).toEqual(false);
-  expect(iso8601Ms.isISO8601({ ms: false })).toEqual(false);
-  expect(iso8601MsLen.isISO8601({ ms: false })).toEqual(false);
-  expect(iso8601NoMs.isISO8601({ ms: false })).toEqual(true);
-
-  expect(utc.isUTC({ any: true })).toEqual(true);
-  expect(utcMs.isUTC({ any: true })).toEqual(true);
-  expect(utcMsLen.isUTC({ any: true })).toEqual(true);
-  expect(utcNoMs.isUTC({ any: true })).toEqual(true);
-
-  expect(iso8601.isISO8601({ any: true })).toEqual(true);
-  expect(iso8601Ms.isISO8601({ any: true })).toEqual(true);
-  expect(iso8601MsLen.isISO8601({ any: true })).toEqual(true);
-  expect(iso8601NoMs.isISO8601({ any: true })).toEqual(true);
-});
-
 test("min max getters", () => {
   expect(z.string().min(5).minLength).toEqual(5);
   expect(z.string().min(5).min(10).minLength).toEqual(10);
@@ -249,68 +187,79 @@ test("trim", () => {
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
 });
 
-test("utc", () => {
-  const utc = z.string().utc();
-  const utcMs = z.string().utc({ ms: true });
-  const utcMs1Len = z.string().utc({ ms: true, msLength: 1 });
-  const utcNoMs = z.string().utc({ ms: false });
+test("datetime", () => {
+  const a = z.string().datetime({});
+  expect(a.isDatetime()).toEqual(true);
 
-  utc.parse("1970-01-01T00:00:00.000Z");
-  utc.parse("2022-10-13T09:52:31.816Z");
-  utc.parse("1970-01-01T00:00:00Z");
-  utc.parse("2022-10-13T09:52:31Z");
-  utcMs.parse("1970-01-01T00:00:00.000Z");
-  utcMs.parse("2022-10-13T09:52:31.816Z");
-  utcMs1Len.parse("1970-01-01T00:00:00.0Z");
-  utcMs1Len.parse("2022-10-13T09:52:31.8Z");
-  utcNoMs.parse("1970-01-01T00:00:00Z");
-  utcNoMs.parse("2022-10-13T09:52:31Z");
+  const b = z.string().datetime({ offset: true });
+  expect(b.isDatetime()).toEqual(true);
 
-  expect(() => utc.parse("")).toThrow();
-  expect(() => utc.parse("foo")).toThrow();
-  expect(() => utc.parse("2020-10-14")).toThrow();
-  expect(() => utc.parse("T18:45:12.123")).toThrow();
-  expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
-  expect(() => utcMs.parse("1970-01-01T00:00:00Z")).toThrow();
-  expect(() => utcMs.parse("2022-10-13T09:52:31:00Z")).toThrow();
-  expect(() => utcMs1Len.parse("1970-01-01T00:00:00.000Z")).toThrow();
-  expect(() => utcMs1Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
-  expect(() => utcNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
-  expect(() => utcNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
+  const c = z.string().datetime({ precision: 3 });
+  expect(c.isDatetime()).toEqual(true);
+
+  const d = z.string().datetime({ offset: true, precision: 0 });
+  expect(d.isDatetime()).toEqual(true);
 });
 
-test("iso8601", () => {
-  const iso8601 = z.string().iso8601();
-  const iso8601Ms = z.string().iso8601({ ms: true });
-  const iso8601Ms5Len = z.string().iso8601({ ms: true, msLength: 5 });
-  const iso8601NoMs = z.string().iso8601({ ms: false });
+test("datetime parsing", () => {
+  const datetime = z.string().datetime();
+  datetime.parse("1970-01-01T00:00:00.000Z");
+  datetime.parse("2022-10-13T09:52:31.816Z");
+  datetime.parse("2022-10-13T09:52:31.8162314Z");
+  datetime.parse("1970-01-01T00:00:00Z");
+  datetime.parse("2022-10-13T09:52:31Z");
+  expect(() => datetime.parse("")).toThrow();
+  expect(() => datetime.parse("foo")).toThrow();
+  expect(() => datetime.parse("2020-10-14")).toThrow();
+  expect(() => datetime.parse("T18:45:12.123")).toThrow();
+  expect(() => datetime.parse("2020-10-14T17:42:29+00:00")).toThrow();
 
-  iso8601.parse("1970-01-01T00:00:00.000Z");
-  iso8601.parse("2022-10-13T09:52:31.816Z");
-  iso8601.parse("1970-01-01T00:00:00Z");
-  iso8601.parse("2022-10-13T09:52:31Z");
-  iso8601.parse("2020-10-14T17:42:29+00:00");
-  iso8601Ms.parse("1970-01-01T00:00:00.000Z");
-  iso8601Ms.parse("2022-10-13T09:52:31.816Z");
-  iso8601Ms.parse("2020-10-14T17:42:29.999+00:00");
-  iso8601Ms5Len.parse("1970-01-01T00:00:00.00000Z");
-  iso8601Ms5Len.parse("2022-10-13T09:52:31.81600Z");
-  iso8601Ms5Len.parse("2020-10-14T17:42:29.99900+00:00");
-  iso8601NoMs.parse("1970-01-01T00:00:00Z");
-  iso8601NoMs.parse("2022-10-13T09:52:31Z");
-  iso8601NoMs.parse("2020-10-14T17:42:29+00:00");
+  const datetimeNoMs = z.string().datetime({ precision: 0 });
+  datetimeNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeNoMs.parse("2022-10-13T09:52:31Z");
+  expect(() => datetimeNoMs.parse("tuna")).toThrow();
+  expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.Z")).toThrow();
+  expect(() => datetimeNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
 
-  expect(() => iso8601.parse("")).toThrow();
-  expect(() => iso8601.parse("foo")).toThrow();
-  expect(() => iso8601.parse("2020-10-14")).toThrow();
-  expect(() => iso8601.parse("T18:45:12.123")).toThrow();
-  expect(() => iso8601Ms.parse("1970-01-01T00:00:00Z")).toThrow();
-  expect(() => iso8601Ms.parse("2022-10-13T09:52:31:00Z")).toThrow();
-  expect(() => iso8601Ms.parse("2020-10-14T17:42:29+00:00")).toThrow();
-  expect(() => iso8601Ms5Len.parse("1970-01-01T00:00:00.0Z")).toThrow();
-  expect(() => iso8601Ms5Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
-  expect(() => iso8601Ms5Len.parse("2020-10-14T17:42:29.000+00:00")).toThrow();
-  expect(() => iso8601NoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
-  expect(() => iso8601NoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
-  expect(() => iso8601NoMs.parse("2020-10-14T17:42:29.999+00:00")).toThrow();
+  const datetime3Ms = z.string().datetime({ precision: 3 });
+  datetime3Ms.parse("1970-01-01T00:00:00.000Z");
+  datetime3Ms.parse("2022-10-13T09:52:31.123Z");
+  expect(() => datetime3Ms.parse("tuna")).toThrow();
+  expect(() => datetime3Ms.parse("1970-01-01T00:00:00.1Z")).toThrow();
+  expect(() => datetime3Ms.parse("1970-01-01T00:00:00.12Z")).toThrow();
+  expect(() => datetime3Ms.parse("2022-10-13T09:52:31Z")).toThrow();
+
+  const datetimeOffset = z.string().datetime({ offset: true });
+  datetimeOffset.parse("1970-01-01T00:00:00.000Z");
+  datetimeOffset.parse("2022-10-13T09:52:31.816234134Z");
+  datetimeOffset.parse("1970-01-01T00:00:00Z");
+  datetimeOffset.parse("2022-10-13T09:52:31.4Z");
+  datetimeOffset.parse("2020-10-14T17:42:29+00:00");
+  datetimeOffset.parse("2020-10-14T17:42:29+03:15");
+  expect(() => datetimeOffset.parse("tuna")).toThrow();
+  expect(() => datetimeOffset.parse("2022-10-13T09:52:31.Z")).toThrow();
+
+  const datetimeOffsetNoMs = z
+    .string()
+    .datetime({ offset: true, precision: 0 });
+  datetimeOffsetNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeOffsetNoMs.parse("2022-10-13T09:52:31Z");
+  datetimeOffsetNoMs.parse("2020-10-14T17:42:29+00:00");
+  expect(() => datetimeOffsetNoMs.parse("tuna")).toThrow();
+  expect(() => datetimeOffsetNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => datetimeOffsetNoMs.parse("1970-01-01T00:00:00.Z")).toThrow();
+  expect(() => datetimeOffsetNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
+  expect(() =>
+    datetimeOffsetNoMs.parse("2020-10-14T17:42:29.124+00:00")
+  ).toThrow();
+
+  const datetimeOffset4Ms = z.string().datetime({ offset: true, precision: 4 });
+  datetimeOffset4Ms.parse("1970-01-01T00:00:00.1234Z");
+  datetimeOffset4Ms.parse("2020-10-14T17:42:29.1234+00:00");
+  expect(() => datetimeOffset4Ms.parse("tuna")).toThrow();
+  expect(() => datetimeOffset4Ms.parse("1970-01-01T00:00:00.123Z")).toThrow();
+  expect(() =>
+    datetimeOffset4Ms.parse("2020-10-14T17:42:29.124+00:00")
+  ).toThrow();
 });

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -152,43 +152,64 @@ test("checks getters", () => {
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
-  expect(z.string().email().isUTC).toEqual(false);
-  expect(z.string().email().isISO8601).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
-  expect(z.string().url().isUTC).toEqual(false);
-  expect(z.string().url().isISO8601).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
-  expect(z.string().cuid().isUTC).toEqual(false);
-  expect(z.string().cuid().isISO8601).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
-  expect(z.string().uuid().isUTC).toEqual(false);
-  expect(z.string().uuid().isISO8601).toEqual(false);
 
   expect(z.string().utc().isEmail).toEqual(false);
   expect(z.string().utc().isURL).toEqual(false);
   expect(z.string().utc().isCUID).toEqual(false);
   expect(z.string().utc().isUUID).toEqual(false);
-  expect(z.string().utc().isUTC).toEqual(true);
-  expect(z.string().utc().isISO8601).toEqual(false);
 
   expect(z.string().iso8601().isEmail).toEqual(false);
   expect(z.string().iso8601().isURL).toEqual(false);
   expect(z.string().iso8601().isCUID).toEqual(false);
   expect(z.string().iso8601().isUUID).toEqual(false);
-  expect(z.string().iso8601().isUTC).toEqual(false);
-  expect(z.string().iso8601().isISO8601).toEqual(true);
+});
+
+test("date getters", () => {
+  const utc = z.string().utc();
+  const utcMs = z.string().utc({ ms: true });
+  const utcNoMs = z.string().utc({ ms: false });
+  const iso8601 = z.string().iso8601();
+  const iso8601Ms = z.string().iso8601({ ms: true });
+  const iso8601NoMs = z.string().iso8601({ ms: false });
+
+  expect(utc.isUTC()).toEqual(true);
+  expect(utcMs.isUTC()).toEqual(false);
+  expect(utcNoMs.isUTC()).toEqual(false);
+
+  expect(iso8601.isISO8601()).toEqual(true);
+  expect(iso8601Ms.isISO8601()).toEqual(false);
+  expect(iso8601NoMs.isISO8601()).toEqual(false);
+
+  expect(utc.isUTC({ ms: true })).toEqual(false);
+  expect(utcMs.isUTC({ ms: true })).toEqual(true);
+  expect(utcNoMs.isUTC({ ms: true })).toEqual(false);
+
+  expect(iso8601.isISO8601({ ms: true })).toEqual(false);
+  expect(iso8601Ms.isISO8601({ ms: true })).toEqual(true);
+  expect(iso8601NoMs.isISO8601({ ms: true })).toEqual(false);
+
+  expect(utc.isUTC({ ms: false })).toEqual(false);
+  expect(utcMs.isUTC({ ms: false })).toEqual(false);
+  expect(utcNoMs.isUTC({ ms: false })).toEqual(true);
+
+  expect(iso8601.isISO8601({ ms: false })).toEqual(false);
+  expect(iso8601Ms.isISO8601({ ms: false })).toEqual(false);
+  expect(iso8601NoMs.isISO8601({ ms: false })).toEqual(true);
 });
 
 test("min max getters", () => {

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -152,21 +152,31 @@ test("checks getters", () => {
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
+  expect(z.string().email().isUTC).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
+  expect(z.string().url().isUTC).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
+  expect(z.string().cuid().isUTC).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
+  expect(z.string().uuid().isUTC).toEqual(false);
+
+  expect(z.string().utc().isEmail).toEqual(false);
+  expect(z.string().utc().isURL).toEqual(false);
+  expect(z.string().utc().isCUID).toEqual(false);
+  expect(z.string().utc().isUUID).toEqual(false);
+  expect(z.string().utc().isUTC).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -185,4 +195,29 @@ test("trim", () => {
   // ordering of methods is respected
   expect(z.string().min(2).trim().parse(" 1 ")).toEqual("1");
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
+});
+
+test("utc", () => {
+  const utc = z.string().utc();
+  const utcMilliseconds = z.string().utc({ milliseconds: true });
+  const utcNoMilliseconds = z.string().utc({ milliseconds: false });
+
+  utc.parse("1970-01-01T00:00:00.000Z");
+  utc.parse("2022-10-13T09:52:31.816Z");
+  utc.parse("1970-01-01T00:00:00Z");
+  utc.parse("2022-10-13T09:52:31Z");
+  utcMilliseconds.parse("1970-01-01T00:00:00.000Z");
+  utcMilliseconds.parse("2022-10-13T09:52:31.816Z");
+  utcNoMilliseconds.parse("1970-01-01T00:00:00Z");
+  utcNoMilliseconds.parse("2022-10-13T09:52:31Z");
+
+  expect(() => utc.parse("")).toThrow();
+  expect(() => utc.parse("foo")).toThrow();
+  expect(() => utc.parse("2020-10-14")).toThrow();
+  expect(() => utc.parse("T18:45:12.123")).toThrow();
+  expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
+  expect(() => utcMilliseconds.parse("1970-01-01T00:00:00Z")).toThrow();
+  expect(() => utcMilliseconds.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => utcNoMilliseconds.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => utcNoMilliseconds.parse("2022-10-13T09:52:31.816Z")).toThrow();
 });

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -153,30 +153,42 @@ test("checks getters", () => {
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
   expect(z.string().email().isUTC).toEqual(false);
+  expect(z.string().email().isISO8601).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
   expect(z.string().url().isUTC).toEqual(false);
+  expect(z.string().url().isISO8601).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
   expect(z.string().cuid().isUTC).toEqual(false);
+  expect(z.string().cuid().isISO8601).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
   expect(z.string().uuid().isUTC).toEqual(false);
+  expect(z.string().uuid().isISO8601).toEqual(false);
 
   expect(z.string().utc().isEmail).toEqual(false);
   expect(z.string().utc().isURL).toEqual(false);
   expect(z.string().utc().isCUID).toEqual(false);
   expect(z.string().utc().isUUID).toEqual(false);
   expect(z.string().utc().isUTC).toEqual(true);
+  expect(z.string().utc().isISO8601).toEqual(false);
+
+  expect(z.string().iso8601().isEmail).toEqual(false);
+  expect(z.string().iso8601().isURL).toEqual(false);
+  expect(z.string().iso8601().isCUID).toEqual(false);
+  expect(z.string().iso8601().isUUID).toEqual(false);
+  expect(z.string().iso8601().isUTC).toEqual(false);
+  expect(z.string().iso8601().isISO8601).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -199,25 +211,54 @@ test("trim", () => {
 
 test("utc", () => {
   const utc = z.string().utc();
-  const utcMilliseconds = z.string().utc({ milliseconds: true });
-  const utcNoMilliseconds = z.string().utc({ milliseconds: false });
+  const utcMs = z.string().utc({ ms: true });
+  const utcNoMs = z.string().utc({ ms: false });
 
   utc.parse("1970-01-01T00:00:00.000Z");
   utc.parse("2022-10-13T09:52:31.816Z");
   utc.parse("1970-01-01T00:00:00Z");
   utc.parse("2022-10-13T09:52:31Z");
-  utcMilliseconds.parse("1970-01-01T00:00:00.000Z");
-  utcMilliseconds.parse("2022-10-13T09:52:31.816Z");
-  utcNoMilliseconds.parse("1970-01-01T00:00:00Z");
-  utcNoMilliseconds.parse("2022-10-13T09:52:31Z");
+  utcMs.parse("1970-01-01T00:00:00.000Z");
+  utcMs.parse("2022-10-13T09:52:31.816Z");
+  utcNoMs.parse("1970-01-01T00:00:00Z");
+  utcNoMs.parse("2022-10-13T09:52:31Z");
 
   expect(() => utc.parse("")).toThrow();
   expect(() => utc.parse("foo")).toThrow();
   expect(() => utc.parse("2020-10-14")).toThrow();
   expect(() => utc.parse("T18:45:12.123")).toThrow();
   expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
-  expect(() => utcMilliseconds.parse("1970-01-01T00:00:00Z")).toThrow();
-  expect(() => utcMilliseconds.parse("2022-10-13T09:52:31:00Z")).toThrow();
-  expect(() => utcNoMilliseconds.parse("1970-01-01T00:00:00.000Z")).toThrow();
-  expect(() => utcNoMilliseconds.parse("2022-10-13T09:52:31.816Z")).toThrow();
+  expect(() => utcMs.parse("1970-01-01T00:00:00Z")).toThrow();
+  expect(() => utcMs.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => utcNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => utcNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
+});
+
+test("iso8601", () => {
+  const iso8601 = z.string().iso8601();
+  const iso8601Ms = z.string().iso8601({ ms: true });
+  const iso8601NoMs = z.string().iso8601({ ms: false });
+
+  iso8601.parse("1970-01-01T00:00:00.000Z");
+  iso8601.parse("2022-10-13T09:52:31.816Z");
+  iso8601.parse("1970-01-01T00:00:00Z");
+  iso8601.parse("2022-10-13T09:52:31Z");
+  iso8601.parse("2020-10-14T17:42:29+00:00");
+  iso8601Ms.parse("1970-01-01T00:00:00.000Z");
+  iso8601Ms.parse("2022-10-13T09:52:31.816Z");
+  iso8601Ms.parse("2020-10-14T17:42:29.999+00:00");
+  iso8601NoMs.parse("1970-01-01T00:00:00Z");
+  iso8601NoMs.parse("2022-10-13T09:52:31Z");
+  iso8601NoMs.parse("2020-10-14T17:42:29+00:00");
+
+  expect(() => iso8601.parse("")).toThrow();
+  expect(() => iso8601.parse("foo")).toThrow();
+  expect(() => iso8601.parse("2020-10-14")).toThrow();
+  expect(() => iso8601.parse("T18:45:12.123")).toThrow();
+  expect(() => iso8601Ms.parse("1970-01-01T00:00:00Z")).toThrow();
+  expect(() => iso8601Ms.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => iso8601Ms.parse("2020-10-14T17:42:29+00:00")).toThrow();
+  expect(() => iso8601NoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => iso8601NoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
+  expect(() => iso8601NoMs.parse("2020-10-14T17:42:29.999+00:00")).toThrow();
 });

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -174,6 +174,7 @@ test("date getters", () => {
   const utcMs = z.string().utc({ ms: true });
   const utcMsLen = z.string().utc({ ms: true, msLength: 3 });
   const utcNoMs = z.string().utc({ ms: false });
+
   const iso8601 = z.string().iso8601();
   const iso8601Ms = z.string().iso8601({ ms: true });
   const iso8601MsLen = z.string().iso8601({ ms: true, msLength: 5 });
@@ -218,6 +219,16 @@ test("date getters", () => {
   expect(iso8601Ms.isISO8601({ ms: false })).toEqual(false);
   expect(iso8601MsLen.isISO8601({ ms: false })).toEqual(false);
   expect(iso8601NoMs.isISO8601({ ms: false })).toEqual(true);
+
+  expect(utc.isUTC({ any: true })).toEqual(true);
+  expect(utcMs.isUTC({ any: true })).toEqual(true);
+  expect(utcMsLen.isUTC({ any: true })).toEqual(true);
+  expect(utcNoMs.isUTC({ any: true })).toEqual(true);
+
+  expect(iso8601.isISO8601({ any: true })).toEqual(true);
+  expect(iso8601Ms.isISO8601({ any: true })).toEqual(true);
+  expect(iso8601MsLen.isISO8601({ any: true })).toEqual(true);
+  expect(iso8601NoMs.isISO8601({ any: true })).toEqual(true);
 });
 
 test("min max getters", () => {

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -242,7 +242,6 @@ test("utc", () => {
   const utc = z.string().utc();
   const utcMs = z.string().utc({ ms: true });
   const utcMs1Len = z.string().utc({ ms: true, msLength: 1 });
-  const utcMsInf = z.string().utc({ ms: true, msLength: 0 });
   const utcNoMs = z.string().utc({ ms: false });
 
   utc.parse("1970-01-01T00:00:00.000Z");
@@ -253,8 +252,6 @@ test("utc", () => {
   utcMs.parse("2022-10-13T09:52:31.816Z");
   utcMs1Len.parse("1970-01-01T00:00:00.0Z");
   utcMs1Len.parse("2022-10-13T09:52:31.8Z");
-  utcMsInf.parse("2022-10-13T09:52:31.9999999Z");
-  utcMsInf.parse("2022-10-13T09:52:31.1Z");
   utcNoMs.parse("1970-01-01T00:00:00Z");
   utcNoMs.parse("2022-10-13T09:52:31Z");
 
@@ -267,8 +264,6 @@ test("utc", () => {
   expect(() => utcMs.parse("2022-10-13T09:52:31:00Z")).toThrow();
   expect(() => utcMs1Len.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => utcMs1Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
-  expect(() => utcMsInf.parse("1970-01-01T00:00:00")).toThrow();
-  expect(() => utcMsInf.parse("2022-10-13T09:52:31:00")).toThrow();
   expect(() => utcNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => utcNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
 });
@@ -277,7 +272,6 @@ test("iso8601", () => {
   const iso8601 = z.string().iso8601();
   const iso8601Ms = z.string().iso8601({ ms: true });
   const iso8601Ms5Len = z.string().iso8601({ ms: true, msLength: 5 });
-  const iso8601MsInf = z.string().iso8601({ ms: true, msLength: 0 });
   const iso8601NoMs = z.string().iso8601({ ms: false });
 
   iso8601.parse("1970-01-01T00:00:00.000Z");
@@ -291,9 +285,6 @@ test("iso8601", () => {
   iso8601Ms5Len.parse("1970-01-01T00:00:00.00000Z");
   iso8601Ms5Len.parse("2022-10-13T09:52:31.81600Z");
   iso8601Ms5Len.parse("2020-10-14T17:42:29.99900+00:00");
-  iso8601MsInf.parse("1970-01-01T00:00:00.0Z");
-  iso8601MsInf.parse("2022-10-13T09:52:31.81Z");
-  iso8601MsInf.parse("2020-10-14T17:42:29.99900+00:00");
   iso8601NoMs.parse("1970-01-01T00:00:00Z");
   iso8601NoMs.parse("2022-10-13T09:52:31Z");
   iso8601NoMs.parse("2020-10-14T17:42:29+00:00");
@@ -308,9 +299,6 @@ test("iso8601", () => {
   expect(() => iso8601Ms5Len.parse("1970-01-01T00:00:00.0Z")).toThrow();
   expect(() => iso8601Ms5Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
   expect(() => iso8601Ms5Len.parse("2020-10-14T17:42:29.000+00:00")).toThrow();
-  expect(() => iso8601MsInf.parse("1970-01-01T00:00:00.Z")).toThrow();
-  expect(() => iso8601MsInf.parse("2022-10-13T09:52:31:00Z")).toThrow();
-  expect(() => iso8601MsInf.parse("2020-10-14T17:42:29+00:00")).toThrow();
   expect(() => iso8601NoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => iso8601NoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
   expect(() => iso8601NoMs.parse("2020-10-14T17:42:29.999+00:00")).toThrow();

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -167,16 +167,6 @@ test("checks getters", () => {
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
-
-  expect(z.string().utc().isEmail).toEqual(false);
-  expect(z.string().utc().isURL).toEqual(false);
-  expect(z.string().utc().isCUID).toEqual(false);
-  expect(z.string().utc().isUUID).toEqual(false);
-
-  expect(z.string().iso8601().isEmail).toEqual(false);
-  expect(z.string().iso8601().isURL).toEqual(false);
-  expect(z.string().iso8601().isCUID).toEqual(false);
-  expect(z.string().iso8601().isUUID).toEqual(false);
 });
 
 test("date getters", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -500,6 +500,13 @@ interface StringDateOptions {
   msLength?: number;
 }
 
+interface IsDateStringOptions extends StringDateOptions {
+  /**
+   * Match any configuration
+   */
+  any?: boolean;
+}
+
 // Adapted from https://stackoverflow.com/a/3143231
 const utcMsRegex = (msLength?: number): RegExp =>
   new RegExp(
@@ -819,20 +826,22 @@ export class ZodString extends ZodType<string, ZodStringDef> {
       checks: [...this._def.checks, { kind: "trim" }],
     });
 
-  isUTC(options?: { ms?: boolean; msLength?: number }) {
+  isUTC(options?: IsDateStringOptions) {
     return !!this._def.checks.find(
       (ch) =>
         ch.kind === "utc" &&
-        options?.ms === ch.options?.ms &&
-        options?.msLength === ch.options?.msLength
+        (options?.any ||
+          (options?.ms === ch.options?.ms &&
+            options?.msLength === ch.options?.msLength))
     );
   }
-  isISO8601(options?: { ms?: boolean; msLength?: number }) {
+  isISO8601(options?: IsDateStringOptions) {
     return !!this._def.checks.find(
       (ch) =>
         ch.kind === "iso8601" &&
-        options?.ms === ch.options?.ms &&
-        options?.msLength === ch.options?.msLength
+        (options?.any ||
+          (options?.ms === ch.options?.ms &&
+            options?.msLength === ch.options?.msLength))
     );
   }
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -463,12 +463,12 @@ type ZodStringCheck =
   | { kind: "trim"; message?: string }
   | {
       kind: "utc";
-      options?: DateStringOptions;
+      options?: StringDateOptions;
       message?: string;
     }
   | {
       kind: "iso8601";
-      options?: DateStringOptions;
+      options?: StringDateOptions;
       message?: string;
     };
 
@@ -487,7 +487,7 @@ const uuidRegex =
 const emailRegex =
   /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
 
-interface DateStringOptions {
+interface StringDateOptions {
   /**
    * `true` - only ms
    *
@@ -495,20 +495,20 @@ interface DateStringOptions {
    */
   ms?: boolean;
   /**
-   * ms digit precision. Defaults to `3`. Set to `0` for unspecified.
+   * ms digit precision
    */
   msLength?: number;
 }
 
 // Adapted from https://stackoverflow.com/a/3143231
-const utcMsRegex = (msLength = 3): RegExp =>
+const utcMsRegex = (msLength?: number): RegExp =>
   new RegExp(
     `\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d${
       msLength ? `{${msLength}}` : "+"
     }Z`
   );
 const utcNoMsRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\dZ/;
-const iso8601MsRegex = (msLength = 3): RegExp =>
+const iso8601MsRegex = (msLength?: number): RegExp =>
   new RegExp(
     `\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d${
       msLength ? `{${msLength}}` : "+"
@@ -747,14 +747,14 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
   }
-  utc(options?: DateStringOptions, message?: errorUtil.ErrMessage) {
+  utc(options?: StringDateOptions, message?: errorUtil.ErrMessage) {
     return this._addCheck({
       kind: "utc",
       options: options,
       ...errorUtil.errToObj(message),
     });
   }
-  iso8601(options?: DateStringOptions, message?: errorUtil.ErrMessage) {
+  iso8601(options?: StringDateOptions, message?: errorUtil.ErrMessage) {
     return this._addCheck({
       kind: "iso8601",
       options: options,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -783,6 +783,17 @@ export class ZodString extends ZodType<string, ZodStringDef> {
       checks: [...this._def.checks, { kind: "trim" }],
     });
 
+  isUTC(options?: { ms: boolean }) {
+    return !!this._def.checks.find(
+      (ch) => ch.kind === "utc" && options?.ms === ch.options?.ms
+    );
+  }
+  isISO8601(options?: { ms: boolean }) {
+    return !!this._def.checks.find(
+      (ch) => ch.kind === "iso8601" && options?.ms === ch.options?.ms
+    );
+  }
+
   get isEmail() {
     return !!this._def.checks.find((ch) => ch.kind === "email");
   }
@@ -794,12 +805,6 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
-  }
-  get isUTC() {
-    return !!this._def.checks.find((ch) => ch.kind === "utc");
-  }
-  get isISO8601() {
-    return !!this._def.checks.find((ch) => ch.kind === "iso8601");
   }
 
   get minLength() {

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -92,8 +92,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
-  | "utc"
-  | "iso8601"
+  | "datetime"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -93,6 +93,7 @@ export type StringValidation =
   | "regex"
   | "cuid"
   | "utc"
+  | "iso8601"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -92,6 +92,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "utc"
   | { startsWith: string }
   | { endsWith: string };
 

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -152,30 +152,42 @@ test("checks getters", () => {
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
   expect(z.string().email().isUTC).toEqual(false);
+  expect(z.string().email().isISO8601).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
   expect(z.string().url().isUTC).toEqual(false);
+  expect(z.string().url().isISO8601).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
   expect(z.string().cuid().isUTC).toEqual(false);
+  expect(z.string().cuid().isISO8601).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
   expect(z.string().uuid().isUTC).toEqual(false);
+  expect(z.string().uuid().isISO8601).toEqual(false);
 
   expect(z.string().utc().isEmail).toEqual(false);
   expect(z.string().utc().isURL).toEqual(false);
   expect(z.string().utc().isCUID).toEqual(false);
   expect(z.string().utc().isUUID).toEqual(false);
   expect(z.string().utc().isUTC).toEqual(true);
+  expect(z.string().utc().isISO8601).toEqual(false);
+
+  expect(z.string().iso8601().isEmail).toEqual(false);
+  expect(z.string().iso8601().isURL).toEqual(false);
+  expect(z.string().iso8601().isCUID).toEqual(false);
+  expect(z.string().iso8601().isUUID).toEqual(false);
+  expect(z.string().iso8601().isUTC).toEqual(false);
+  expect(z.string().iso8601().isISO8601).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -198,25 +210,54 @@ test("trim", () => {
 
 test("utc", () => {
   const utc = z.string().utc();
-  const utcMilliseconds = z.string().utc({ milliseconds: true });
-  const utcNoMilliseconds = z.string().utc({ milliseconds: false });
+  const utcMs = z.string().utc({ ms: true });
+  const utcNoMs = z.string().utc({ ms: false });
 
   utc.parse("1970-01-01T00:00:00.000Z");
   utc.parse("2022-10-13T09:52:31.816Z");
   utc.parse("1970-01-01T00:00:00Z");
   utc.parse("2022-10-13T09:52:31Z");
-  utcMilliseconds.parse("1970-01-01T00:00:00.000Z");
-  utcMilliseconds.parse("2022-10-13T09:52:31.816Z");
-  utcNoMilliseconds.parse("1970-01-01T00:00:00Z");
-  utcNoMilliseconds.parse("2022-10-13T09:52:31Z");
+  utcMs.parse("1970-01-01T00:00:00.000Z");
+  utcMs.parse("2022-10-13T09:52:31.816Z");
+  utcNoMs.parse("1970-01-01T00:00:00Z");
+  utcNoMs.parse("2022-10-13T09:52:31Z");
 
   expect(() => utc.parse("")).toThrow();
   expect(() => utc.parse("foo")).toThrow();
   expect(() => utc.parse("2020-10-14")).toThrow();
   expect(() => utc.parse("T18:45:12.123")).toThrow();
   expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
-  expect(() => utcMilliseconds.parse("1970-01-01T00:00:00Z")).toThrow();
-  expect(() => utcMilliseconds.parse("2022-10-13T09:52:31:00Z")).toThrow();
-  expect(() => utcNoMilliseconds.parse("1970-01-01T00:00:00.000Z")).toThrow();
-  expect(() => utcNoMilliseconds.parse("2022-10-13T09:52:31.816Z")).toThrow();
+  expect(() => utcMs.parse("1970-01-01T00:00:00Z")).toThrow();
+  expect(() => utcMs.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => utcNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => utcNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
+});
+
+test("iso8601", () => {
+  const iso8601 = z.string().iso8601();
+  const iso8601Ms = z.string().iso8601({ ms: true });
+  const iso8601NoMs = z.string().iso8601({ ms: false });
+
+  iso8601.parse("1970-01-01T00:00:00.000Z");
+  iso8601.parse("2022-10-13T09:52:31.816Z");
+  iso8601.parse("1970-01-01T00:00:00Z");
+  iso8601.parse("2022-10-13T09:52:31Z");
+  iso8601.parse("2020-10-14T17:42:29+00:00");
+  iso8601Ms.parse("1970-01-01T00:00:00.000Z");
+  iso8601Ms.parse("2022-10-13T09:52:31.816Z");
+  iso8601Ms.parse("2020-10-14T17:42:29.999+00:00");
+  iso8601NoMs.parse("1970-01-01T00:00:00Z");
+  iso8601NoMs.parse("2022-10-13T09:52:31Z");
+  iso8601NoMs.parse("2020-10-14T17:42:29+00:00");
+
+  expect(() => iso8601.parse("")).toThrow();
+  expect(() => iso8601.parse("foo")).toThrow();
+  expect(() => iso8601.parse("2020-10-14")).toThrow();
+  expect(() => iso8601.parse("T18:45:12.123")).toThrow();
+  expect(() => iso8601Ms.parse("1970-01-01T00:00:00Z")).toThrow();
+  expect(() => iso8601Ms.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => iso8601Ms.parse("2020-10-14T17:42:29+00:00")).toThrow();
+  expect(() => iso8601NoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => iso8601NoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
+  expect(() => iso8601NoMs.parse("2020-10-14T17:42:29.999+00:00")).toThrow();
 });

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -168,68 +168,6 @@ test("checks getters", () => {
   expect(z.string().uuid().isUUID).toEqual(true);
 });
 
-test("date getters", () => {
-  const utc = z.string().utc();
-  const utcMs = z.string().utc({ ms: true });
-  const utcMsLen = z.string().utc({ ms: true, msLength: 3 });
-  const utcNoMs = z.string().utc({ ms: false });
-
-  const iso8601 = z.string().iso8601();
-  const iso8601Ms = z.string().iso8601({ ms: true });
-  const iso8601MsLen = z.string().iso8601({ ms: true, msLength: 5 });
-  const iso8601NoMs = z.string().iso8601({ ms: false });
-
-  expect(utc.isUTC()).toEqual(true);
-  expect(utcMs.isUTC()).toEqual(false);
-  expect(utcMsLen.isUTC()).toEqual(false);
-  expect(utcNoMs.isUTC()).toEqual(false);
-
-  expect(iso8601.isISO8601()).toEqual(true);
-  expect(iso8601Ms.isISO8601()).toEqual(false);
-  expect(iso8601MsLen.isISO8601()).toEqual(false);
-  expect(iso8601NoMs.isISO8601()).toEqual(false);
-
-  expect(utc.isUTC({ ms: true })).toEqual(false);
-  expect(utcMs.isUTC({ ms: true })).toEqual(true);
-  expect(utcMsLen.isUTC({ ms: true })).toEqual(false);
-  expect(utcNoMs.isUTC({ ms: true })).toEqual(false);
-
-  expect(iso8601.isISO8601({ ms: true })).toEqual(false);
-  expect(iso8601Ms.isISO8601({ ms: true })).toEqual(true);
-  expect(iso8601MsLen.isISO8601({ ms: true })).toEqual(false);
-  expect(iso8601NoMs.isISO8601({ ms: true })).toEqual(false);
-
-  expect(utc.isUTC({ ms: true, msLength: 3 })).toEqual(false);
-  expect(utcMs.isUTC({ ms: true, msLength: 3 })).toEqual(false);
-  expect(utcMsLen.isUTC({ ms: true, msLength: 3 })).toEqual(true);
-  expect(utcNoMs.isUTC({ ms: true, msLength: 3 })).toEqual(false);
-
-  expect(iso8601.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
-  expect(iso8601Ms.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
-  expect(iso8601MsLen.isISO8601({ ms: true, msLength: 5 })).toEqual(true);
-  expect(iso8601NoMs.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
-
-  expect(utc.isUTC({ ms: false })).toEqual(false);
-  expect(utcMs.isUTC({ ms: false })).toEqual(false);
-  expect(utcMsLen.isUTC({ ms: false })).toEqual(false);
-  expect(utcNoMs.isUTC({ ms: false })).toEqual(true);
-
-  expect(iso8601.isISO8601({ ms: false })).toEqual(false);
-  expect(iso8601Ms.isISO8601({ ms: false })).toEqual(false);
-  expect(iso8601MsLen.isISO8601({ ms: false })).toEqual(false);
-  expect(iso8601NoMs.isISO8601({ ms: false })).toEqual(true);
-
-  expect(utc.isUTC({ any: true })).toEqual(true);
-  expect(utcMs.isUTC({ any: true })).toEqual(true);
-  expect(utcMsLen.isUTC({ any: true })).toEqual(true);
-  expect(utcNoMs.isUTC({ any: true })).toEqual(true);
-
-  expect(iso8601.isISO8601({ any: true })).toEqual(true);
-  expect(iso8601Ms.isISO8601({ any: true })).toEqual(true);
-  expect(iso8601MsLen.isISO8601({ any: true })).toEqual(true);
-  expect(iso8601NoMs.isISO8601({ any: true })).toEqual(true);
-});
-
 test("min max getters", () => {
   expect(z.string().min(5).minLength).toEqual(5);
   expect(z.string().min(5).min(10).minLength).toEqual(10);
@@ -248,68 +186,79 @@ test("trim", () => {
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
 });
 
-test("utc", () => {
-  const utc = z.string().utc();
-  const utcMs = z.string().utc({ ms: true });
-  const utcMs1Len = z.string().utc({ ms: true, msLength: 1 });
-  const utcNoMs = z.string().utc({ ms: false });
+test("datetime", () => {
+  const a = z.string().datetime({});
+  expect(a.isDatetime()).toEqual(true);
 
-  utc.parse("1970-01-01T00:00:00.000Z");
-  utc.parse("2022-10-13T09:52:31.816Z");
-  utc.parse("1970-01-01T00:00:00Z");
-  utc.parse("2022-10-13T09:52:31Z");
-  utcMs.parse("1970-01-01T00:00:00.000Z");
-  utcMs.parse("2022-10-13T09:52:31.816Z");
-  utcMs1Len.parse("1970-01-01T00:00:00.0Z");
-  utcMs1Len.parse("2022-10-13T09:52:31.8Z");
-  utcNoMs.parse("1970-01-01T00:00:00Z");
-  utcNoMs.parse("2022-10-13T09:52:31Z");
+  const b = z.string().datetime({ offset: true });
+  expect(b.isDatetime()).toEqual(true);
 
-  expect(() => utc.parse("")).toThrow();
-  expect(() => utc.parse("foo")).toThrow();
-  expect(() => utc.parse("2020-10-14")).toThrow();
-  expect(() => utc.parse("T18:45:12.123")).toThrow();
-  expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
-  expect(() => utcMs.parse("1970-01-01T00:00:00Z")).toThrow();
-  expect(() => utcMs.parse("2022-10-13T09:52:31:00Z")).toThrow();
-  expect(() => utcMs1Len.parse("1970-01-01T00:00:00.000Z")).toThrow();
-  expect(() => utcMs1Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
-  expect(() => utcNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
-  expect(() => utcNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
+  const c = z.string().datetime({ precision: 3 });
+  expect(c.isDatetime()).toEqual(true);
+
+  const d = z.string().datetime({ offset: true, precision: 0 });
+  expect(d.isDatetime()).toEqual(true);
 });
 
-test("iso8601", () => {
-  const iso8601 = z.string().iso8601();
-  const iso8601Ms = z.string().iso8601({ ms: true });
-  const iso8601Ms5Len = z.string().iso8601({ ms: true, msLength: 5 });
-  const iso8601NoMs = z.string().iso8601({ ms: false });
+test("datetime parsing", () => {
+  const datetime = z.string().datetime();
+  datetime.parse("1970-01-01T00:00:00.000Z");
+  datetime.parse("2022-10-13T09:52:31.816Z");
+  datetime.parse("2022-10-13T09:52:31.8162314Z");
+  datetime.parse("1970-01-01T00:00:00Z");
+  datetime.parse("2022-10-13T09:52:31Z");
+  expect(() => datetime.parse("")).toThrow();
+  expect(() => datetime.parse("foo")).toThrow();
+  expect(() => datetime.parse("2020-10-14")).toThrow();
+  expect(() => datetime.parse("T18:45:12.123")).toThrow();
+  expect(() => datetime.parse("2020-10-14T17:42:29+00:00")).toThrow();
 
-  iso8601.parse("1970-01-01T00:00:00.000Z");
-  iso8601.parse("2022-10-13T09:52:31.816Z");
-  iso8601.parse("1970-01-01T00:00:00Z");
-  iso8601.parse("2022-10-13T09:52:31Z");
-  iso8601.parse("2020-10-14T17:42:29+00:00");
-  iso8601Ms.parse("1970-01-01T00:00:00.000Z");
-  iso8601Ms.parse("2022-10-13T09:52:31.816Z");
-  iso8601Ms.parse("2020-10-14T17:42:29.999+00:00");
-  iso8601Ms5Len.parse("1970-01-01T00:00:00.00000Z");
-  iso8601Ms5Len.parse("2022-10-13T09:52:31.81600Z");
-  iso8601Ms5Len.parse("2020-10-14T17:42:29.99900+00:00");
-  iso8601NoMs.parse("1970-01-01T00:00:00Z");
-  iso8601NoMs.parse("2022-10-13T09:52:31Z");
-  iso8601NoMs.parse("2020-10-14T17:42:29+00:00");
+  const datetimeNoMs = z.string().datetime({ precision: 0 });
+  datetimeNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeNoMs.parse("2022-10-13T09:52:31Z");
+  expect(() => datetimeNoMs.parse("tuna")).toThrow();
+  expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.Z")).toThrow();
+  expect(() => datetimeNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
 
-  expect(() => iso8601.parse("")).toThrow();
-  expect(() => iso8601.parse("foo")).toThrow();
-  expect(() => iso8601.parse("2020-10-14")).toThrow();
-  expect(() => iso8601.parse("T18:45:12.123")).toThrow();
-  expect(() => iso8601Ms.parse("1970-01-01T00:00:00Z")).toThrow();
-  expect(() => iso8601Ms.parse("2022-10-13T09:52:31:00Z")).toThrow();
-  expect(() => iso8601Ms.parse("2020-10-14T17:42:29+00:00")).toThrow();
-  expect(() => iso8601Ms5Len.parse("1970-01-01T00:00:00.0Z")).toThrow();
-  expect(() => iso8601Ms5Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
-  expect(() => iso8601Ms5Len.parse("2020-10-14T17:42:29.000+00:00")).toThrow();
-  expect(() => iso8601NoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
-  expect(() => iso8601NoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
-  expect(() => iso8601NoMs.parse("2020-10-14T17:42:29.999+00:00")).toThrow();
+  const datetime3Ms = z.string().datetime({ precision: 3 });
+  datetime3Ms.parse("1970-01-01T00:00:00.000Z");
+  datetime3Ms.parse("2022-10-13T09:52:31.123Z");
+  expect(() => datetime3Ms.parse("tuna")).toThrow();
+  expect(() => datetime3Ms.parse("1970-01-01T00:00:00.1Z")).toThrow();
+  expect(() => datetime3Ms.parse("1970-01-01T00:00:00.12Z")).toThrow();
+  expect(() => datetime3Ms.parse("2022-10-13T09:52:31Z")).toThrow();
+
+  const datetimeOffset = z.string().datetime({ offset: true });
+  datetimeOffset.parse("1970-01-01T00:00:00.000Z");
+  datetimeOffset.parse("2022-10-13T09:52:31.816234134Z");
+  datetimeOffset.parse("1970-01-01T00:00:00Z");
+  datetimeOffset.parse("2022-10-13T09:52:31.4Z");
+  datetimeOffset.parse("2020-10-14T17:42:29+00:00");
+  datetimeOffset.parse("2020-10-14T17:42:29+03:15");
+  expect(() => datetimeOffset.parse("tuna")).toThrow();
+  expect(() => datetimeOffset.parse("2022-10-13T09:52:31.Z")).toThrow();
+
+  const datetimeOffsetNoMs = z
+    .string()
+    .datetime({ offset: true, precision: 0 });
+  datetimeOffsetNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeOffsetNoMs.parse("2022-10-13T09:52:31Z");
+  datetimeOffsetNoMs.parse("2020-10-14T17:42:29+00:00");
+  expect(() => datetimeOffsetNoMs.parse("tuna")).toThrow();
+  expect(() => datetimeOffsetNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => datetimeOffsetNoMs.parse("1970-01-01T00:00:00.Z")).toThrow();
+  expect(() => datetimeOffsetNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
+  expect(() =>
+    datetimeOffsetNoMs.parse("2020-10-14T17:42:29.124+00:00")
+  ).toThrow();
+
+  const datetimeOffset4Ms = z.string().datetime({ offset: true, precision: 4 });
+  datetimeOffset4Ms.parse("1970-01-01T00:00:00.1234Z");
+  datetimeOffset4Ms.parse("2020-10-14T17:42:29.1234+00:00");
+  expect(() => datetimeOffset4Ms.parse("tuna")).toThrow();
+  expect(() => datetimeOffset4Ms.parse("1970-01-01T00:00:00.123Z")).toThrow();
+  expect(() =>
+    datetimeOffset4Ms.parse("2020-10-14T17:42:29.124+00:00")
+  ).toThrow();
 });

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -151,43 +151,64 @@ test("checks getters", () => {
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
-  expect(z.string().email().isUTC).toEqual(false);
-  expect(z.string().email().isISO8601).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
-  expect(z.string().url().isUTC).toEqual(false);
-  expect(z.string().url().isISO8601).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
-  expect(z.string().cuid().isUTC).toEqual(false);
-  expect(z.string().cuid().isISO8601).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
-  expect(z.string().uuid().isUTC).toEqual(false);
-  expect(z.string().uuid().isISO8601).toEqual(false);
 
   expect(z.string().utc().isEmail).toEqual(false);
   expect(z.string().utc().isURL).toEqual(false);
   expect(z.string().utc().isCUID).toEqual(false);
   expect(z.string().utc().isUUID).toEqual(false);
-  expect(z.string().utc().isUTC).toEqual(true);
-  expect(z.string().utc().isISO8601).toEqual(false);
 
   expect(z.string().iso8601().isEmail).toEqual(false);
   expect(z.string().iso8601().isURL).toEqual(false);
   expect(z.string().iso8601().isCUID).toEqual(false);
   expect(z.string().iso8601().isUUID).toEqual(false);
-  expect(z.string().iso8601().isUTC).toEqual(false);
-  expect(z.string().iso8601().isISO8601).toEqual(true);
+});
+
+test("date getters", () => {
+  const utc = z.string().utc();
+  const utcMs = z.string().utc({ ms: true });
+  const utcNoMs = z.string().utc({ ms: false });
+  const iso8601 = z.string().iso8601();
+  const iso8601Ms = z.string().iso8601({ ms: true });
+  const iso8601NoMs = z.string().iso8601({ ms: false });
+
+  expect(utc.isUTC()).toEqual(true);
+  expect(utcMs.isUTC()).toEqual(false);
+  expect(utcNoMs.isUTC()).toEqual(false);
+
+  expect(iso8601.isISO8601()).toEqual(true);
+  expect(iso8601Ms.isISO8601()).toEqual(false);
+  expect(iso8601NoMs.isISO8601()).toEqual(false);
+
+  expect(utc.isUTC({ ms: true })).toEqual(false);
+  expect(utcMs.isUTC({ ms: true })).toEqual(true);
+  expect(utcNoMs.isUTC({ ms: true })).toEqual(false);
+
+  expect(iso8601.isISO8601({ ms: true })).toEqual(false);
+  expect(iso8601Ms.isISO8601({ ms: true })).toEqual(true);
+  expect(iso8601NoMs.isISO8601({ ms: true })).toEqual(false);
+
+  expect(utc.isUTC({ ms: false })).toEqual(false);
+  expect(utcMs.isUTC({ ms: false })).toEqual(false);
+  expect(utcNoMs.isUTC({ ms: false })).toEqual(true);
+
+  expect(iso8601.isISO8601({ ms: false })).toEqual(false);
+  expect(iso8601Ms.isISO8601({ ms: false })).toEqual(false);
+  expect(iso8601NoMs.isISO8601({ ms: false })).toEqual(true);
 });
 
 test("min max getters", () => {

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -151,21 +151,31 @@ test("checks getters", () => {
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
+  expect(z.string().email().isUTC).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
+  expect(z.string().url().isUTC).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isUUID).toEqual(false);
+  expect(z.string().cuid().isUTC).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
+  expect(z.string().uuid().isUTC).toEqual(false);
+
+  expect(z.string().utc().isEmail).toEqual(false);
+  expect(z.string().utc().isURL).toEqual(false);
+  expect(z.string().utc().isCUID).toEqual(false);
+  expect(z.string().utc().isUUID).toEqual(false);
+  expect(z.string().utc().isUTC).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -184,4 +194,29 @@ test("trim", () => {
   // ordering of methods is respected
   expect(z.string().min(2).trim().parse(" 1 ")).toEqual("1");
   expect(() => z.string().trim().min(2).parse(" 1 ")).toThrow();
+});
+
+test("utc", () => {
+  const utc = z.string().utc();
+  const utcMilliseconds = z.string().utc({ milliseconds: true });
+  const utcNoMilliseconds = z.string().utc({ milliseconds: false });
+
+  utc.parse("1970-01-01T00:00:00.000Z");
+  utc.parse("2022-10-13T09:52:31.816Z");
+  utc.parse("1970-01-01T00:00:00Z");
+  utc.parse("2022-10-13T09:52:31Z");
+  utcMilliseconds.parse("1970-01-01T00:00:00.000Z");
+  utcMilliseconds.parse("2022-10-13T09:52:31.816Z");
+  utcNoMilliseconds.parse("1970-01-01T00:00:00Z");
+  utcNoMilliseconds.parse("2022-10-13T09:52:31Z");
+
+  expect(() => utc.parse("")).toThrow();
+  expect(() => utc.parse("foo")).toThrow();
+  expect(() => utc.parse("2020-10-14")).toThrow();
+  expect(() => utc.parse("T18:45:12.123")).toThrow();
+  expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
+  expect(() => utcMilliseconds.parse("1970-01-01T00:00:00Z")).toThrow();
+  expect(() => utcMilliseconds.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => utcNoMilliseconds.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => utcNoMilliseconds.parse("2022-10-13T09:52:31.816Z")).toThrow();
 });

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -241,7 +241,6 @@ test("utc", () => {
   const utc = z.string().utc();
   const utcMs = z.string().utc({ ms: true });
   const utcMs1Len = z.string().utc({ ms: true, msLength: 1 });
-  const utcMsInf = z.string().utc({ ms: true, msLength: 0 });
   const utcNoMs = z.string().utc({ ms: false });
 
   utc.parse("1970-01-01T00:00:00.000Z");
@@ -252,8 +251,6 @@ test("utc", () => {
   utcMs.parse("2022-10-13T09:52:31.816Z");
   utcMs1Len.parse("1970-01-01T00:00:00.0Z");
   utcMs1Len.parse("2022-10-13T09:52:31.8Z");
-  utcMsInf.parse("2022-10-13T09:52:31.9999999Z");
-  utcMsInf.parse("2022-10-13T09:52:31.1Z");
   utcNoMs.parse("1970-01-01T00:00:00Z");
   utcNoMs.parse("2022-10-13T09:52:31Z");
 
@@ -266,8 +263,6 @@ test("utc", () => {
   expect(() => utcMs.parse("2022-10-13T09:52:31:00Z")).toThrow();
   expect(() => utcMs1Len.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => utcMs1Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
-  expect(() => utcMsInf.parse("1970-01-01T00:00:00")).toThrow();
-  expect(() => utcMsInf.parse("2022-10-13T09:52:31:00")).toThrow();
   expect(() => utcNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => utcNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
 });
@@ -276,7 +271,6 @@ test("iso8601", () => {
   const iso8601 = z.string().iso8601();
   const iso8601Ms = z.string().iso8601({ ms: true });
   const iso8601Ms5Len = z.string().iso8601({ ms: true, msLength: 5 });
-  const iso8601MsInf = z.string().iso8601({ ms: true, msLength: 0 });
   const iso8601NoMs = z.string().iso8601({ ms: false });
 
   iso8601.parse("1970-01-01T00:00:00.000Z");
@@ -290,9 +284,6 @@ test("iso8601", () => {
   iso8601Ms5Len.parse("1970-01-01T00:00:00.00000Z");
   iso8601Ms5Len.parse("2022-10-13T09:52:31.81600Z");
   iso8601Ms5Len.parse("2020-10-14T17:42:29.99900+00:00");
-  iso8601MsInf.parse("1970-01-01T00:00:00.0Z");
-  iso8601MsInf.parse("2022-10-13T09:52:31.81Z");
-  iso8601MsInf.parse("2020-10-14T17:42:29.99900+00:00");
   iso8601NoMs.parse("1970-01-01T00:00:00Z");
   iso8601NoMs.parse("2022-10-13T09:52:31Z");
   iso8601NoMs.parse("2020-10-14T17:42:29+00:00");
@@ -307,9 +298,6 @@ test("iso8601", () => {
   expect(() => iso8601Ms5Len.parse("1970-01-01T00:00:00.0Z")).toThrow();
   expect(() => iso8601Ms5Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
   expect(() => iso8601Ms5Len.parse("2020-10-14T17:42:29.000+00:00")).toThrow();
-  expect(() => iso8601MsInf.parse("1970-01-01T00:00:00.Z")).toThrow();
-  expect(() => iso8601MsInf.parse("2022-10-13T09:52:31:00Z")).toThrow();
-  expect(() => iso8601MsInf.parse("2020-10-14T17:42:29+00:00")).toThrow();
   expect(() => iso8601NoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => iso8601NoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
   expect(() => iso8601NoMs.parse("2020-10-14T17:42:29.999+00:00")).toThrow();

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -171,33 +171,51 @@ test("checks getters", () => {
 test("date getters", () => {
   const utc = z.string().utc();
   const utcMs = z.string().utc({ ms: true });
+  const utcMsLen = z.string().utc({ ms: true, msLength: 3 });
   const utcNoMs = z.string().utc({ ms: false });
   const iso8601 = z.string().iso8601();
   const iso8601Ms = z.string().iso8601({ ms: true });
+  const iso8601MsLen = z.string().iso8601({ ms: true, msLength: 5 });
   const iso8601NoMs = z.string().iso8601({ ms: false });
 
   expect(utc.isUTC()).toEqual(true);
   expect(utcMs.isUTC()).toEqual(false);
+  expect(utcMsLen.isUTC()).toEqual(false);
   expect(utcNoMs.isUTC()).toEqual(false);
 
   expect(iso8601.isISO8601()).toEqual(true);
   expect(iso8601Ms.isISO8601()).toEqual(false);
+  expect(iso8601MsLen.isISO8601()).toEqual(false);
   expect(iso8601NoMs.isISO8601()).toEqual(false);
 
   expect(utc.isUTC({ ms: true })).toEqual(false);
   expect(utcMs.isUTC({ ms: true })).toEqual(true);
+  expect(utcMsLen.isUTC({ ms: true })).toEqual(false);
   expect(utcNoMs.isUTC({ ms: true })).toEqual(false);
 
   expect(iso8601.isISO8601({ ms: true })).toEqual(false);
   expect(iso8601Ms.isISO8601({ ms: true })).toEqual(true);
+  expect(iso8601MsLen.isISO8601({ ms: true })).toEqual(false);
   expect(iso8601NoMs.isISO8601({ ms: true })).toEqual(false);
+
+  expect(utc.isUTC({ ms: true, msLength: 3 })).toEqual(false);
+  expect(utcMs.isUTC({ ms: true, msLength: 3 })).toEqual(false);
+  expect(utcMsLen.isUTC({ ms: true, msLength: 3 })).toEqual(true);
+  expect(utcNoMs.isUTC({ ms: true, msLength: 3 })).toEqual(false);
+
+  expect(iso8601.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
+  expect(iso8601Ms.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
+  expect(iso8601MsLen.isISO8601({ ms: true, msLength: 5 })).toEqual(true);
+  expect(iso8601NoMs.isISO8601({ ms: true, msLength: 5 })).toEqual(false);
 
   expect(utc.isUTC({ ms: false })).toEqual(false);
   expect(utcMs.isUTC({ ms: false })).toEqual(false);
+  expect(utcMsLen.isUTC({ ms: false })).toEqual(false);
   expect(utcNoMs.isUTC({ ms: false })).toEqual(true);
 
   expect(iso8601.isISO8601({ ms: false })).toEqual(false);
   expect(iso8601Ms.isISO8601({ ms: false })).toEqual(false);
+  expect(iso8601MsLen.isISO8601({ ms: false })).toEqual(false);
   expect(iso8601NoMs.isISO8601({ ms: false })).toEqual(true);
 });
 
@@ -222,6 +240,8 @@ test("trim", () => {
 test("utc", () => {
   const utc = z.string().utc();
   const utcMs = z.string().utc({ ms: true });
+  const utcMs1Len = z.string().utc({ ms: true, msLength: 1 });
+  const utcMsInf = z.string().utc({ ms: true, msLength: 0 });
   const utcNoMs = z.string().utc({ ms: false });
 
   utc.parse("1970-01-01T00:00:00.000Z");
@@ -230,6 +250,10 @@ test("utc", () => {
   utc.parse("2022-10-13T09:52:31Z");
   utcMs.parse("1970-01-01T00:00:00.000Z");
   utcMs.parse("2022-10-13T09:52:31.816Z");
+  utcMs1Len.parse("1970-01-01T00:00:00.0Z");
+  utcMs1Len.parse("2022-10-13T09:52:31.8Z");
+  utcMsInf.parse("2022-10-13T09:52:31.9999999Z");
+  utcMsInf.parse("2022-10-13T09:52:31.1Z");
   utcNoMs.parse("1970-01-01T00:00:00Z");
   utcNoMs.parse("2022-10-13T09:52:31Z");
 
@@ -240,6 +264,10 @@ test("utc", () => {
   expect(() => utc.parse("2020-10-14T17:42:29+00:00")).toThrow();
   expect(() => utcMs.parse("1970-01-01T00:00:00Z")).toThrow();
   expect(() => utcMs.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => utcMs1Len.parse("1970-01-01T00:00:00.000Z")).toThrow();
+  expect(() => utcMs1Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
+  expect(() => utcMsInf.parse("1970-01-01T00:00:00")).toThrow();
+  expect(() => utcMsInf.parse("2022-10-13T09:52:31:00")).toThrow();
   expect(() => utcNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => utcNoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
 });
@@ -247,6 +275,8 @@ test("utc", () => {
 test("iso8601", () => {
   const iso8601 = z.string().iso8601();
   const iso8601Ms = z.string().iso8601({ ms: true });
+  const iso8601Ms5Len = z.string().iso8601({ ms: true, msLength: 5 });
+  const iso8601MsInf = z.string().iso8601({ ms: true, msLength: 0 });
   const iso8601NoMs = z.string().iso8601({ ms: false });
 
   iso8601.parse("1970-01-01T00:00:00.000Z");
@@ -257,6 +287,12 @@ test("iso8601", () => {
   iso8601Ms.parse("1970-01-01T00:00:00.000Z");
   iso8601Ms.parse("2022-10-13T09:52:31.816Z");
   iso8601Ms.parse("2020-10-14T17:42:29.999+00:00");
+  iso8601Ms5Len.parse("1970-01-01T00:00:00.00000Z");
+  iso8601Ms5Len.parse("2022-10-13T09:52:31.81600Z");
+  iso8601Ms5Len.parse("2020-10-14T17:42:29.99900+00:00");
+  iso8601MsInf.parse("1970-01-01T00:00:00.0Z");
+  iso8601MsInf.parse("2022-10-13T09:52:31.81Z");
+  iso8601MsInf.parse("2020-10-14T17:42:29.99900+00:00");
   iso8601NoMs.parse("1970-01-01T00:00:00Z");
   iso8601NoMs.parse("2022-10-13T09:52:31Z");
   iso8601NoMs.parse("2020-10-14T17:42:29+00:00");
@@ -268,6 +304,12 @@ test("iso8601", () => {
   expect(() => iso8601Ms.parse("1970-01-01T00:00:00Z")).toThrow();
   expect(() => iso8601Ms.parse("2022-10-13T09:52:31:00Z")).toThrow();
   expect(() => iso8601Ms.parse("2020-10-14T17:42:29+00:00")).toThrow();
+  expect(() => iso8601Ms5Len.parse("1970-01-01T00:00:00.0Z")).toThrow();
+  expect(() => iso8601Ms5Len.parse("2022-10-13T09:52:31:00.00Z")).toThrow();
+  expect(() => iso8601Ms5Len.parse("2020-10-14T17:42:29.000+00:00")).toThrow();
+  expect(() => iso8601MsInf.parse("1970-01-01T00:00:00.Z")).toThrow();
+  expect(() => iso8601MsInf.parse("2022-10-13T09:52:31:00Z")).toThrow();
+  expect(() => iso8601MsInf.parse("2020-10-14T17:42:29+00:00")).toThrow();
   expect(() => iso8601NoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => iso8601NoMs.parse("2022-10-13T09:52:31.816Z")).toThrow();
   expect(() => iso8601NoMs.parse("2020-10-14T17:42:29.999+00:00")).toThrow();

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -173,6 +173,7 @@ test("date getters", () => {
   const utcMs = z.string().utc({ ms: true });
   const utcMsLen = z.string().utc({ ms: true, msLength: 3 });
   const utcNoMs = z.string().utc({ ms: false });
+
   const iso8601 = z.string().iso8601();
   const iso8601Ms = z.string().iso8601({ ms: true });
   const iso8601MsLen = z.string().iso8601({ ms: true, msLength: 5 });
@@ -217,6 +218,16 @@ test("date getters", () => {
   expect(iso8601Ms.isISO8601({ ms: false })).toEqual(false);
   expect(iso8601MsLen.isISO8601({ ms: false })).toEqual(false);
   expect(iso8601NoMs.isISO8601({ ms: false })).toEqual(true);
+
+  expect(utc.isUTC({ any: true })).toEqual(true);
+  expect(utcMs.isUTC({ any: true })).toEqual(true);
+  expect(utcMsLen.isUTC({ any: true })).toEqual(true);
+  expect(utcNoMs.isUTC({ any: true })).toEqual(true);
+
+  expect(iso8601.isISO8601({ any: true })).toEqual(true);
+  expect(iso8601Ms.isISO8601({ any: true })).toEqual(true);
+  expect(iso8601MsLen.isISO8601({ any: true })).toEqual(true);
+  expect(iso8601NoMs.isISO8601({ any: true })).toEqual(true);
 });
 
 test("min max getters", () => {

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -166,16 +166,6 @@ test("checks getters", () => {
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
-
-  expect(z.string().utc().isEmail).toEqual(false);
-  expect(z.string().utc().isURL).toEqual(false);
-  expect(z.string().utc().isCUID).toEqual(false);
-  expect(z.string().utc().isUUID).toEqual(false);
-
-  expect(z.string().iso8601().isEmail).toEqual(false);
-  expect(z.string().iso8601().isURL).toEqual(false);
-  expect(z.string().iso8601().isCUID).toEqual(false);
-  expect(z.string().iso8601().isUUID).toEqual(false);
 });
 
 test("date getters", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -500,6 +500,13 @@ interface StringDateOptions {
   msLength?: number;
 }
 
+interface IsDateStringOptions extends StringDateOptions {
+  /**
+   * Match any configuration
+   */
+  any?: boolean;
+}
+
 // Adapted from https://stackoverflow.com/a/3143231
 const utcMsRegex = (msLength?: number): RegExp =>
   new RegExp(
@@ -819,20 +826,22 @@ export class ZodString extends ZodType<string, ZodStringDef> {
       checks: [...this._def.checks, { kind: "trim" }],
     });
 
-  isUTC(options?: { ms?: boolean; msLength?: number }) {
+  isUTC(options?: IsDateStringOptions) {
     return !!this._def.checks.find(
       (ch) =>
         ch.kind === "utc" &&
-        options?.ms === ch.options?.ms &&
-        options?.msLength === ch.options?.msLength
+        (options?.any ||
+          (options?.ms === ch.options?.ms &&
+            options?.msLength === ch.options?.msLength))
     );
   }
-  isISO8601(options?: { ms?: boolean; msLength?: number }) {
+  isISO8601(options?: IsDateStringOptions) {
     return !!this._def.checks.find(
       (ch) =>
         ch.kind === "iso8601" &&
-        options?.ms === ch.options?.ms &&
-        options?.msLength === ch.options?.msLength
+        (options?.any ||
+          (options?.ms === ch.options?.ms &&
+            options?.msLength === ch.options?.msLength))
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -463,12 +463,12 @@ type ZodStringCheck =
   | { kind: "trim"; message?: string }
   | {
       kind: "utc";
-      options?: DateStringOptions;
+      options?: StringDateOptions;
       message?: string;
     }
   | {
       kind: "iso8601";
-      options?: DateStringOptions;
+      options?: StringDateOptions;
       message?: string;
     };
 
@@ -487,7 +487,7 @@ const uuidRegex =
 const emailRegex =
   /^(([^<>()[\]\.,;:\s@\"]+(\.[^<>()[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
 
-interface DateStringOptions {
+interface StringDateOptions {
   /**
    * `true` - only ms
    *
@@ -495,20 +495,20 @@ interface DateStringOptions {
    */
   ms?: boolean;
   /**
-   * ms digit precision. Defaults to `3`. Set to `0` for unspecified.
+   * ms digit precision
    */
   msLength?: number;
 }
 
 // Adapted from https://stackoverflow.com/a/3143231
-const utcMsRegex = (msLength = 3): RegExp =>
+const utcMsRegex = (msLength?: number): RegExp =>
   new RegExp(
     `\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d${
       msLength ? `{${msLength}}` : "+"
     }Z`
   );
 const utcNoMsRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\dZ/;
-const iso8601MsRegex = (msLength = 3): RegExp =>
+const iso8601MsRegex = (msLength?: number): RegExp =>
   new RegExp(
     `\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d${
       msLength ? `{${msLength}}` : "+"
@@ -747,14 +747,14 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
   }
-  utc(options?: DateStringOptions, message?: errorUtil.ErrMessage) {
+  utc(options?: StringDateOptions, message?: errorUtil.ErrMessage) {
     return this._addCheck({
       kind: "utc",
       options: options,
       ...errorUtil.errToObj(message),
     });
   }
-  iso8601(options?: DateStringOptions, message?: errorUtil.ErrMessage) {
+  iso8601(options?: StringDateOptions, message?: errorUtil.ErrMessage) {
     return this._addCheck({
       kind: "iso8601",
       options: options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -783,6 +783,17 @@ export class ZodString extends ZodType<string, ZodStringDef> {
       checks: [...this._def.checks, { kind: "trim" }],
     });
 
+  isUTC(options?: { ms: boolean }) {
+    return !!this._def.checks.find(
+      (ch) => ch.kind === "utc" && options?.ms === ch.options?.ms
+    );
+  }
+  isISO8601(options?: { ms: boolean }) {
+    return !!this._def.checks.find(
+      (ch) => ch.kind === "iso8601" && options?.ms === ch.options?.ms
+    );
+  }
+
   get isEmail() {
     return !!this._def.checks.find((ch) => ch.kind === "email");
   }
@@ -794,12 +805,6 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
-  }
-  get isUTC() {
-    return !!this._def.checks.find((ch) => ch.kind === "utc");
-  }
-  get isISO8601() {
-    return !!this._def.checks.find((ch) => ch.kind === "iso8601");
   }
 
   get minLength() {


### PR DESCRIPTION
Adds `.utc()` and `.iso8601()` from https://github.com/colinhacks/zod/issues/126.

Through this PR I learnt that dates can be very inconsistent but still valid 🤯 eg. you can give any number of ms which to me is a little silly. Imagine having `2022-07-08T00:00:00.000Z` alongside `2022-07-08T00:00:00.0000000000000000Z` in your system.

So I've tried to come up with a solution which is flexible but can be customised to be more strict if users wish.

`ms: true` and `ms: false` control whether users want to check for `ms` or not with the default being to accept both formats. I've also added the ability to specify the ms digit precision with `msLength` since technically any number of milliseconds is considered a "valid" timestamp 🙄 .

```ts
// date formats
z.string().utc();
z.string().utc({ ms: true }); // ms only
z.string().utc({ ms: true, msLength: 3 }); // ms only, 3 digit precision
z.string().utc({ ms: false }); // no ms only

z.string().iso8601(); // allows offset
z.string().iso8601({ ms: true }); // ms only
z.string().iso8601({ ms: true, msLength: 5 }); // ms only, 5 digit precision
z.string().iso8601({ ms: false }); // no ms only
```

Lastly I've added getters for both of these which take the same args so users can find ones which they have specifically created.

```ts
// date formats
z.string().utc().isUTC(); // true
z.string().utc({ ms: true }).isUTC({ ms: true }); // true
z.string().utc({ ms: true, msLength: 3 }.isUTC({ ms: true, msLength: 3 }) // true
z.string().utc({ ms: false}).isUTC({ ms: false }); // true
z.string().utc().isUTC({ any: true }); // matches all the above
```