### PR TITLE
Take `path` parameter into account within `.parseAsync()`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -255,7 +255,7 @@ export abstract class ZodType<
       parsedType: getParsedType(data),
     };
 
-    const maybeAsyncResult = this._parse({ data, path: [], parent: ctx });
+    const maybeAsyncResult = this._parse({ data, path: ctx.path, parent: ctx });
     const result = await (isAsync(maybeAsyncResult)
       ? maybeAsyncResult
       : Promise.resolve(maybeAsyncResult));


### PR DESCRIPTION
The `path` parameter is not taken into account when using `.parseAync()` method.
`parseAsync()` calls `safeParseAsync()` with the same params.
However, the line 258 is inconsistent with the similar line 227 of sync method.

```
// in safeParse():
const result = this._parseSync({ data, path: ctx.path, parent: ctx });
// in safeParseAsync()
const maybeAsyncResult = this._parse({ data, path: [], parent: ctx });
```

Therefore, `path` param is ineffective and this PR should fix it.