### PR TITLE
fix typo

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -440,7 +440,7 @@ result.error.flatten((issue: ZodIssue) => ({
 You can infer the return type signature of `.format()` and `.flatten()` with the following utilities:
 
 ```ts
-type FormattedErros = z.inferFormattedErrors<typeof FormData>;
+type FormattedErrors = z.inferFormattedErrors<typeof FormData>;
 /*
   {  
     name?: {_errors?: string[]},


### PR DESCRIPTION
This is just to fix a small typo I encountered :)

`FormattedErros` 🡒 `FormattedErrors`