### PR TITLE
fix #1046 `.required()` doesn't remove optional flag from the result of `.nullish()`.

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -779,7 +779,7 @@ nullableString.parse(null); // => null
 Or use the `.nullable()` method.
 
 ```ts
-const E = z.string().nullable(); // equivalent to D
+const E = z.string().nullable(); // equivalent to nullableString
 type E = z.infer<typeof E>; // string | null
 ```
 
@@ -1967,7 +1967,7 @@ petCat(fido); // works fine
 In some cases, its can be desirable to simulate _nominal typing_ inside TypeScript. For instance, you may wish to write a function that only accepts an input that has been validated by Zod. This can be achieved with _branded types_ (AKA _opaque types_).
 
 ```ts
-const Cat = z.object({ name: z.string }).brand<"Cat">();
+const Cat = z.object({ name: z.string() }).brand<"Cat">();
 type Cat = z.infer<typeof Cat>;
 
 const petCat = (cat: Cat) => {};
@@ -1983,7 +1983,7 @@ petCat({ name: "fido" });
 Under the hood, this works by attaching a "brand" to the inferred type using an intersection type. This way, plain/unbranded data structures are no longer assignable to the inferred type of the schema.
 
 ```ts
-const Cat = z.object({ name: z.string }).brand<"Cat">();
+const Cat = z.object({ name: z.string() }).brand<"Cat">();
 type Cat = z.infer<typeof Cat>;
 // {name: string} & {[symbol]: "Cat"}
 ```

--- a/deno/lib/__tests__/partials.test.ts
+++ b/deno/lib/__tests__/partials.test.ts
@@ -136,12 +136,38 @@ test("required", () => {
     name: z.string(),
     age: z.number().optional(),
     field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
   });
 
   const requiredObject = object.required();
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
   expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodNullable);
+});
+
+test("required inference", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required();
+
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age: number;
+    field: string;
+    nullableField: number | null;
+    nullishField: string | null;
+  };
+  util.assertEqual<expected, required>(true);
 });
 
 test("required with mask", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1601,6 +1601,8 @@ export type objectInputType<
 
 type deoptional<T extends ZodTypeAny> = T extends ZodOptional<infer U>
   ? deoptional<U>
+  : T extends ZodNullable<infer U>
+  ? ZodNullable<deoptional<U>>
   : T;
 
 export type SomeZodObject = ZodObject<

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -135,12 +135,38 @@ test("required", () => {
     name: z.string(),
     age: z.number().optional(),
     field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
   });
 
   const requiredObject = object.required();
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
   expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodNullable);
+});
+
+test("required inference", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required();
+
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age: number;
+    field: string;
+    nullableField: number | null;
+    nullishField: string | null;
+  };
+  util.assertEqual<expected, required>(true);
 });
 
 test("required with mask", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1601,6 +1601,8 @@ export type objectInputType<
 
 type deoptional<T extends ZodTypeAny> = T extends ZodOptional<infer U>
   ? deoptional<U>
+  : T extends ZodNullable<infer U>
+  ? ZodNullable<deoptional<U>>
   : T;
 
 export type SomeZodObject = ZodObject<


### PR DESCRIPTION
Hey :wave:

Love zod, we use it in production.. they used to call me the "zod guy" cause I'm the one who introduced it to the codebase. lol.

First time contributing here, sorry If I didn't do things properly.



fixes #1046.