### PR TITLE
Revert "Make unknown input type for preprocess"

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3591,7 +3591,7 @@ export class ZodEffects<
     preprocess: (arg: unknown) => unknown,
     schema: I,
     params?: RawCreateParams
-  ): ZodEffects<I, I["_output"], unknown> => {
+  ): ZodEffects<I, I["_output"]> => {
     return new ZodEffects({
       schema,
       effect: { type: "preprocess", transform: preprocess },

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -201,7 +201,7 @@ test("preprocess", () => {
 
   const value = schema.parse("asdf");
   expect(value).toEqual(["asdf"]);
-  util.assertEqual<typeof schema["_input"], unknown>(true);
+  util.assertEqual<typeof schema["_input"], string[]>(true);
 });
 
 test("async preprocess", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3591,7 +3591,7 @@ export class ZodEffects<
     preprocess: (arg: unknown) => unknown,
     schema: I,
     params?: RawCreateParams
-  ): ZodEffects<I, I["_output"], unknown> => {
+  ): ZodEffects<I, I["_output"]> => {
     return new ZodEffects({
       schema,
       effect: { type: "preprocess", transform: preprocess },


### PR DESCRIPTION
This reverts commit 2893e1659875944198aff28a3ba404858f834ed8.
Make the input type generic again. The original change breaks existing
behaviour, its motivation is vague.

This PR aims to fix a couple of issues raised since 3.19.1 was released: https://github.com/colinhacks/zod/issues/1473 and https://github.com/colinhacks/zod/issues/1458.