### PR TITLE
Remove datetime from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,6 @@ z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().trim(); // trim whitespace
-z.string().datetime(); // defaults to UTC, see below for options
 ```
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
@@ -526,40 +525,6 @@ z.string().url({ message: "Invalid url" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
-z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
-```
-
-### Datetime validation
-
-The `z.string().datetime()` method defaults to UTC validation: no timezone offsets with arbitrary sub-second decimal precision.
-
-```ts
-const datetime = z.string().datetime();
-
-datetime.parse("2020-01-01T00:00:00Z"); // pass
-datetime.parse("2020-01-01T00:00:00.123Z"); // pass
-datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
-datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
-```
-
-Timezone offsets can be allowed by setting the `offset` option to `true`.
-
-```ts
-const datetime = z.string().datetime({ offset: true });
-
-datetime.parse("2020-01-01T00:00:00+02:00"); // pass
-datetime.parse("2020-01-01T00:00:00.123+02:00"); // pass (millis optional)
-datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
-```
-
-You can additionally constrain the allowable `precision`. By default, arbitrary sub-second precision is supported (but optional).
-
-```ts
-const datetime = z.string().datetime({ precision: 3 });
-
-datetime.parse("2020-01-01T00:00:00.123Z"); // pass
-datetime.parse("2020-01-01T00:00:00Z"); // fail
-datetime.parse("2020-01-01T00:00:00.123456Z"); // fail
 ```
 
 ## Numbers

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -501,7 +501,6 @@ z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().trim(); // trim whitespace
-z.string().datetime(); // defaults to UTC, see below for options
 ```
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
@@ -526,40 +525,6 @@ z.string().url({ message: "Invalid url" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
-z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
-```
-
-### Datetime validation
-
-The `z.string().datetime()` method defaults to UTC validation: no timezone offsets with arbitrary sub-second decimal precision.
-
-```ts
-const datetime = z.string().datetime();
-
-datetime.parse("2020-01-01T00:00:00Z"); // pass
-datetime.parse("2020-01-01T00:00:00.123Z"); // pass
-datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
-datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
-```
-
-Timezone offsets can be allowed by setting the `offset` option to `true`.
-
-```ts
-const datetime = z.string().datetime({ offset: true });
-
-datetime.parse("2020-01-01T00:00:00+02:00"); // pass
-datetime.parse("2020-01-01T00:00:00.123+02:00"); // pass (millis optional)
-datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
-```
-
-You can additionally constrain the allowable `precision`. By default, arbitrary sub-second precision is supported (but optional).
-
-```ts
-const datetime = z.string().datetime({ precision: 3 });
-
-datetime.parse("2020-01-01T00:00:00.123Z"); // pass
-datetime.parse("2020-01-01T00:00:00Z"); // fail
-datetime.parse("2020-01-01T00:00:00.123456Z"); // fail
 ```
 
 ## Numbers


### PR DESCRIPTION
It isn't implemented (#126)

There is recent activity in #126; let me know if this is the wrong approach. I think the changes contemplated recently in #126 will add `.utc` and would require removing `.datetime` anyways.