### PR TITLE
feat: [#1075] Allows more discriminatedUnion values, use DiscriminatedValue as union element

### DIFF
--- a/README.md
+++ b/README.md
@@ -1216,6 +1216,16 @@ const myUnion = z.discriminatedUnion("status", [
 myUnion.parse({ type: "success", data: "yippie ki yay" });
 ```
 
+Discriminated unions can also be nested for flexibility:
+
+```ts
+const A = z.object({ type: z.literal("a"), a: z.literal(1) });
+const B = z.object({ type: z.literal("b"), b: z.literal(2) });
+const C = z.object({ type: z.literal("c"), c: z.literal(3) });
+const AorB = z.discriminatedUnion("type", [A, B]);
+const schema = z.discriminatedUnion("type", [AorB, C]);
+```
+
 ## Records
 
 Record schemas are used to validate types such as `{ [k: string]: number }`.
@@ -1739,7 +1749,6 @@ z.string()
 ```
 
 <!-- Note that the `path` is set to `["confirm"]` , so you can easily display this error underneath the "Confirm password" textbox.
-
 
 ```ts
 const allForms = z.object({ passwordForm }).parse({

--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,56 @@ const AorB = z.discriminatedUnion("type", [A, B]);
 const schema = z.discriminatedUnion("type", [AorB, C]);
 ```
 
+Additionally, "disjointed" discriminated unions can be created, where the child discriminated unions use a different discriminator than the parent:
+
+```ts
+  const subtype = z.discriminatedUnion("subtype", [
+    z.object({
+      type: z.literal("baz"),
+      subtype: z.literal("able"),
+    }),
+    z.object({
+      type: z.literal("bauble"),
+      subtype: z.literal("beehive"),
+      undertype: z.literal("alpha"),
+    }),
+    z.object({
+      type: z.literal("baz"),
+      subtype: z.literal("baker"),
+    }),
+  ]);
+
+  const schema = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("foo"),
+    }),
+    z.object({
+      type: z.literal("bar"),
+    }),
+    subtype,
+  ]);
+
+/**
+type schema = {
+    type: "baz";
+    subtype: "able";
+} | {
+    type: "bauble";
+    subtype: "beehive";
+    undertype: "alpha";
+} | {
+    type: "baz";
+    subtype: "baker";
+} | {
+    type: "foo";
+} | {
+    type: "bar";
+}
+*/
+```
+
+> ⚠️ You cannot create disjointed discriminated unions where a child member does not have the discriminator of a parent. If you find yourself in this scenario, a normal [union](#unions) might be better suited for your use case.
+
 ## Records
 
 Record schemas are used to validate types such as `{ [k: string]: number }`.

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1216,6 +1216,16 @@ const myUnion = z.discriminatedUnion("status", [
 myUnion.parse({ type: "success", data: "yippie ki yay" });
 ```
 
+Discriminated unions can also be nested for flexibility:
+
+```ts
+const A = z.object({ type: z.literal("a"), a: z.literal(1) });
+const B = z.object({ type: z.literal("b"), b: z.literal(2) });
+const C = z.object({ type: z.literal("c"), c: z.literal(3) });
+const AorB = z.discriminatedUnion("type", [A, B]);
+const schema = z.discriminatedUnion("type", [AorB, C]);
+```
+
 ## Records
 
 Record schemas are used to validate types such as `{ [k: string]: number }`.
@@ -1739,7 +1749,6 @@ z.string()
 ```
 
 <!-- Note that the `path` is set to `["confirm"]` , so you can easily display this error underneath the "Confirm password" textbox.
-
 
 ```ts
 const allForms = z.object({ passwordForm }).parse({

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1305,6 +1305,56 @@ const AorB = z.discriminatedUnion("type", [A, B]);
 const schema = z.discriminatedUnion("type", [AorB, C]);
 ```
 
+Additionally, "disjointed" discriminated unions can be created, where the child discriminated unions use a different discriminator than the parent:
+
+```ts
+  const subtype = z.discriminatedUnion("subtype", [
+    z.object({
+      type: z.literal("baz"),
+      subtype: z.literal("able"),
+    }),
+    z.object({
+      type: z.literal("bauble"),
+      subtype: z.literal("beehive"),
+      undertype: z.literal("alpha"),
+    }),
+    z.object({
+      type: z.literal("baz"),
+      subtype: z.literal("baker"),
+    }),
+  ]);
+
+  const schema = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("foo"),
+    }),
+    z.object({
+      type: z.literal("bar"),
+    }),
+    subtype,
+  ]);
+
+/**
+type schema = {
+    type: "baz";
+    subtype: "able";
+} | {
+    type: "bauble";
+    subtype: "beehive";
+    undertype: "alpha";
+} | {
+    type: "baz";
+    subtype: "baker";
+} | {
+    type: "foo";
+} | {
+    type: "bar";
+}
+*/
+```
+
+> ⚠️ You cannot create disjointed discriminated unions where a child member does not have the discriminator of a parent. If you find yourself in this scenario, a normal [union](#unions) might be better suited for your use case.
+
 ## Records
 
 Record schemas are used to validate types such as `{ [k: string]: number }`.

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -230,6 +230,19 @@ test("valid expected types from inference with another DiscriminatedUnion elemen
   >(true);
 });
 
+test("DU flattens children DiscriminatedUnion elements with same discriminator key", () => {
+  const A = z.object({ type: z.literal("a"), a: z.literal(1) });
+  const B = z.object({ type: z.literal("b"), b: z.literal(2) });
+  const C = z.object({ type: z.literal("c").optional(), c: z.literal(true) });
+  const D = z.object({ type: z.literal("d"), d: z.literal("d") });
+
+  const AorB = z.discriminatedUnion("type", [A, B]);
+  const child = z.discriminatedUnion("type", [AorB, C]);
+  const parent = z.discriminatedUnion("type", [child, D]);
+
+  expect(parent.options.length).toEqual(4);
+});
+
 test("valid - nested disjointed DiscriminatedUnions", () => {
   const subtype = z.discriminatedUnion("subtype", [
     z.object({

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -1,7 +1,9 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
+import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
+import { ZodDiscriminatedUnion } from "../index.ts";
 
 test("valid", () => {
   expect(
@@ -60,6 +62,53 @@ test("valid - discriminator value of various primitive types", () => {
     type: undefined,
     val: 9,
   });
+});
+
+test("valid - various zod validator discriminators", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.undefined(), val: z.literal(1) }),
+    z.object({ type: z.null(), val: z.literal(2) }),
+    z.object({ type: z.enum(["a", "b", "c"]), val: z.literal(3) }),
+  ]);
+
+  expect(schema.parse({ type: undefined, val: 1 })).toEqual({
+    type: undefined,
+    val: 1,
+  });
+  expect(schema.parse({ type: null, val: 2 })).toEqual({
+    type: null,
+    val: 2,
+  });
+  expect(schema.parse({ type: "c", val: 3 })).toEqual({
+    type: "c",
+    val: 3,
+  });
+});
+
+test("valid - wrapped optional discriminator value ", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("1").optional(), val: z.literal(1) }),
+    z.object({ type: z.literal(1), val: z.literal(2) }),
+  ]);
+
+  expect(schema.parse({ type: "1", val: 1 })).toEqual({ type: "1", val: 1 });
+  expect(schema.parse({ type: undefined, val: 1 })).toEqual({
+    type: undefined,
+    val: 1,
+  });
+  expect(schema.parse({ type: 1, val: 2 })).toEqual({ type: 1, val: 2 });
+});
+
+test("invalid - collision with multiple undefined discriminators", () => {
+  try {
+    z.discriminatedUnion("type", [
+      z.object({ type: z.literal("1").optional(), val: z.literal(1) }),
+      z.object({ type: z.literal(undefined), val: z.literal(2) }),
+    ]);
+    throw new Error();
+  } catch (e: any) {
+    expect(e.message.includes("has duplicate value")).toEqual(true);
+  }
 });
 
 test("invalid - null", () => {
@@ -145,6 +194,241 @@ test("wrong schema - duplicate discriminator values", () => {
   }
 });
 
+test("valid - `DiscriminatedUnion` as a union option", () => {
+  const A = z.object({ type: z.literal("a"), a: z.literal(1) });
+  const B = z.object({ type: z.literal("b"), b: z.literal(2) });
+  const C = z.object({ type: z.literal("c").optional(), c: z.literal(true) });
+  const AorB = z.discriminatedUnion("type", [A, B]);
+  const schema = z.discriminatedUnion("type", [AorB, C]);
+
+  expect(schema.parse({ type: "a", a: 1 })).toEqual({ type: "a", a: 1 });
+  expect(schema.parse({ type: "b", b: 2 })).toEqual({ type: "b", b: 2 });
+  expect(schema.parse({ type: undefined, c: true })).toEqual({
+    type: undefined,
+    c: true,
+  });
+
+  expect(schema.parse({ type: "c", c: true })).toEqual({
+    type: "c",
+    c: true,
+  });
+});
+
+test("valid expected types from inference with another DiscriminatedUnion element", () => {
+  const A = z.object({ type: z.literal("a"), a: z.literal(1) });
+  const B = z.object({ type: z.literal("b"), b: z.literal(2) });
+  const C = z.object({ type: z.literal("c").optional(), c: z.literal(true) });
+  const AorB = z.discriminatedUnion("type", [A, B]);
+  const schema = z.discriminatedUnion("type", [AorB, C]);
+  type schemaType = z.infer<typeof schema>;
+
+  util.assertEqual<
+    schemaType,
+    | { type: "a"; a: 1 }
+    | { type: "b"; b: 2 }
+    | { type?: "c" | undefined; c: true }
+  >(true);
+});
+
+test("valid - nested disjointed DiscriminatedUnions", () => {
+  const subtype = z.discriminatedUnion("subtype", [
+    z.object({
+      type: z.literal("baz"),
+      subtype: z.literal("able"),
+    }),
+    z.object({
+      type: z.literal("bauble"),
+      subtype: z.literal("beehive"),
+      undertype: z.literal("alpha"),
+    }),
+    z.object({
+      type: z.literal("baz"),
+      subtype: z.literal("baker"),
+    }),
+  ]);
+
+  const schema = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("foo"),
+    }),
+    z.object({
+      type: z.literal("bar"),
+    }),
+    subtype,
+  ]);
+
+  const testMaps = [
+    { type: "baz", subtype: "able" },
+    { type: "baz", subtype: "baker" },
+    { type: "bauble", subtype: "beehive", undertype: "alpha" },
+    { type: "foo" },
+    { type: "bar" },
+  ];
+
+  testMaps.map((el) => expect(schema.parse(el)).toEqual(el));
+});
+
+test("valid expected types from inference with disjointed nested DiscriminatedUnions", () => {
+  const underDU = z.discriminatedUnion("undertype", [
+    z.object({
+      undertype: z.literal("a"),
+      subtype: z.literal(1),
+      wowee: z.literal(true),
+    }),
+    z.object({
+      undertype: z.literal("b"),
+      subtype: z.literal(1),
+      wowee: z.literal(false),
+    }),
+    z.object({
+      undertype: z.literal("c"),
+      subtype: z.literal(2),
+      extra: z.literal("yes"),
+    }),
+  ]);
+
+  const subDU = z.discriminatedUnion("subtype", [
+    underDU,
+    z.object({
+      subtype: z.literal(9),
+      additional: z.literal("true"),
+    }),
+  ]);
+
+  type schemaType = z.infer<typeof subDU>;
+
+  util.assertEqual<
+    schemaType,
+    | { undertype: "a"; subtype: 1; wowee: true }
+    | { undertype: "b"; subtype: 1; wowee: false }
+    | { undertype: "c"; subtype: 2; extra: "yes" }
+    | { subtype: 9; additional: "true" }
+  >(true);
+});
+
+test("invalid - duplicate values for nested disjointed DUs", () => {
+  const underDU = z.discriminatedUnion("undertype", [
+    z.object({
+      undertype: z.literal("a"),
+      subtype: z.literal(9),
+      wowee: z.literal(true),
+    }),
+    z.object({
+      undertype: z.literal("b"),
+      subtype: z.literal(1),
+      wowee: z.literal(false),
+    }),
+    z.object({
+      undertype: z.literal("c"),
+      subtype: z.literal(2),
+      extra: z.literal("yes"),
+    }),
+  ]);
+  try {
+    z.discriminatedUnion("subtype", [
+      underDU,
+      z.object({
+        subtype: z.literal(9),
+        additional: z.literal("true"),
+      }),
+    ]);
+    throw new Error();
+  } catch (e: any) {
+    expect(e.message.includes("has duplicate value `9`")).toEqual(true);
+  }
+});
+
+test("invalid - nested DUs with missing parent discriminator keys", () => {
+  const underDU = z.discriminatedUnion("undertype", [
+    z.object({
+      undertype: z.literal("a"),
+      subtype: z.literal(1),
+      wowee: z.literal(true),
+    }),
+    z.object({
+      undertype: z.literal("b"),
+      subtype: z.literal(1),
+      wowee: z.literal(false),
+      additional: z.literal("true"),
+    }),
+    z.object({
+      undertype: z.literal("c"),
+      subtype: z.literal(2),
+      extra: z.literal("yes"),
+    }),
+  ]);
+
+  const subDU = z.discriminatedUnion("subtype", [
+    underDU,
+    z.object({
+      subtype: z.literal(9),
+      additional: z.literal("false"),
+    }),
+  ]);
+
+  try {
+    z.discriminatedUnion("additional", [
+      subDU,
+      z.object({
+        subtype: z.literal(9),
+        additional: z.literal("true"),
+      }),
+    ]);
+    throw new Error();
+  } catch (e: any) {
+    expect(
+      e.message.includes("value for key `additional` could not be extracted")
+    ).toEqual(true);
+  }
+});
+
+test("multiple nested DiscriminatedUnion elements", () => {
+  const NESTING_DEPTH = 20;
+  const elementArray = Array(NESTING_DEPTH)
+    .fill(0)
+    .map((_el, i) =>
+      z.object({ type: z.literal(i), [`${i}`]: z.literal(true) })
+    );
+
+  const firstSchema = z.discriminatedUnion("type", [
+    elementArray[0],
+    elementArray[1],
+  ]);
+
+  const schema = elementArray
+    .slice(2)
+    .reduce<ZodDiscriminatedUnion<"type", any>>(
+      (prev, curr) => z.discriminatedUnion("type", [prev, curr]),
+      firstSchema
+    );
+
+  Array(NESTING_DEPTH)
+    .fill(0)
+    .map((_el, i) => ({ type: i, [`${i}`]: true }))
+    .map((el) => {
+      expect(schema.parse(el)).toEqual(el);
+    });
+});
+
+test("discriminator not available for nested DiscriminatedUnion", () => {
+  try {
+    const A = z.object({ type: z.literal("a"), a: z.literal(1) });
+    const B = z.object({ type: z.literal("b"), b: z.literal(2) });
+    const AorB = z.discriminatedUnion("type", [A, B]);
+
+    const C = z.object({ foo: z.literal("c"), a: z.literal(3) });
+    const D = z.object({ foo: z.literal("d"), b: z.literal(4) });
+    const CorD = z.discriminatedUnion("foo", [C, D]);
+
+    z.discriminatedUnion("type", [AorB, CorD as any]);
+    throw new Error();
+  } catch (e: any) {
+    expect(
+      e.message.includes("value for key `type` could not be extracted")
+    ).toEqual(true);
+  }
+});
+
 test("async - valid", async () => {
   expect(
     await z
@@ -216,3 +500,5 @@ test("valid - literals with .default or .preprocess", () => {
     a: "foo",
   });
 });
+
+test("nested DUs with disjointed base discriminators", () => {});

--- a/deno/lib/benchmarks/discriminatedUnion.ts
+++ b/deno/lib/benchmarks/discriminatedUnion.ts
@@ -4,6 +4,7 @@ import { z } from "../index.ts";
 
 const doubleSuite = new Benchmark.Suite("z.discriminatedUnion: double");
 const manySuite = new Benchmark.Suite("z.discriminatedUnion: many");
+const nestedSuite = new Benchmark.Suite("z.discriminatedUnion: nested");
 
 const aSchema = z.object({
   type: z.literal("a"),
@@ -32,6 +33,7 @@ const dSchema = z.object({
 
 const double = z.discriminatedUnion("type", [aSchema, bSchema]);
 const many = z.discriminatedUnion("type", [aSchema, bSchema, cSchema, dSchema]);
+const nested = z.discriminatedUnion("type", [double, cSchema, dSchema]);
 
 doubleSuite
   .add("valid: a", () => {
@@ -75,6 +77,30 @@ manySuite
     console.log(`${(manySuite as any).name}: ${e.target}`);
   });
 
+nestedSuite
+  .add("valid: a", () => {
+    nested.parse(objA);
+  })
+  .add("valid: b", () => {
+    nested.parse(objB);
+  })
+  .add("valid: c", () => {
+    nested.parse(objC);
+  })
+  .add("invalid: null", () => {
+    try {
+      nested.parse(null);
+    } catch (err) {}
+  })
+  .add("invalid: wrong shape", () => {
+    try {
+      nested.parse(objC);
+    } catch (err) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`${(nestedSuite as any).name}: ${e.target}`);
+  });
+
 export default {
-  suites: [doubleSuite, manySuite],
+  suites: [doubleSuite, manySuite, nestedSuite],
 };

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2332,9 +2332,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
 
-const getDiscriminator = <T extends ZodTypeAny>(
-  type: T
-): Primitive[] | null => {
+const getDiscriminator = <T extends ZodTypeAny>(type: T): Primitive[] => {
   if (type instanceof ZodLazy) {
     return getDiscriminator(type.schema);
   } else if (type instanceof ZodEffects) {
@@ -2346,33 +2344,42 @@ const getDiscriminator = <T extends ZodTypeAny>(
   } else if (type instanceof ZodNativeEnum) {
     // eslint-disable-next-line ban/ban
     return Object.keys(type.enum as any);
+  } else if (type instanceof ZodDiscriminatedUnion) {
+    return getDiscriminator(type._def.innerType);
   } else if (type instanceof ZodDefault) {
     return getDiscriminator(type._def.innerType);
+  } else if (type instanceof ZodOptional) {
+    return [undefined, ...getDiscriminator(type.unwrap())];
   } else if (type instanceof ZodUndefined) {
     return [undefined];
   } else if (type instanceof ZodNull) {
     return [null];
   } else {
-    return null;
+    return [];
   }
 };
 
-export type ZodDiscriminatedUnionOption<Discriminator extends string> =
+export type ZodDiscriminatedUnionObject<Discriminator extends string> =
   ZodObject<{ [key in Discriminator]: ZodTypeAny } & ZodRawShape, any, any>;
+
+export type ZodDiscriminatedUnionOption<Discriminator extends string> =
+  | ZodDiscriminatedUnionObject<Discriminator>
+  | ZodDiscriminatedUnion<string, Array<ZodDiscriminatedUnionOption<string>>>;
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<any>[]
+  Options extends ZodDiscriminatedUnionOption<string>[]
 > extends ZodTypeDef {
   discriminator: Discriminator;
+  parentDiscriminators: Set<string>;
   options: Options;
-  optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<any>>;
+  optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<Discriminator>>;
   typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion;
 }
 
 export class ZodDiscriminatedUnion<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<Discriminator>[]
+  Options extends Array<ZodDiscriminatedUnionOption<string>>
 > extends ZodType<
   output<Options[number]>,
   ZodDiscriminatedUnionDef<Discriminator, Options>,
@@ -2422,12 +2429,48 @@ export class ZodDiscriminatedUnion<
     return this._def.discriminator;
   }
 
+  get parentDiscriminators() {
+    return Array.from(this._def.parentDiscriminators);
+  }
+
   get options() {
     return this._def.options;
   }
 
   get optionsMap() {
     return this._def.optionsMap;
+  }
+
+  _addParentDiscriminator(discriminator: string) {
+    const valueSet = new Set<Primitive>();
+    for (const type of this._def.options) {
+      if (type instanceof ZodObject) {
+        const discriminatorValues = getDiscriminator(type.shape[discriminator]);
+        if (!discriminatorValues.length) {
+          throw new Error(
+            `A discriminator value for key \`${discriminator}\` ` +
+              `could not be extracted from all schema options`
+          );
+        }
+        discriminatorValues.map((el) => valueSet.add(el));
+      } else if (type instanceof ZodDiscriminatedUnion) {
+        const values = type._addParentDiscriminator(discriminator);
+        if (values.length < 1) {
+          throw new Error(
+            `No value for key \`${discriminator}\` was found for DiscriminatedUnion with discriminator \`${type.discriminator}\``
+          );
+        }
+        values.map((el) => valueSet.add(el));
+      }
+    }
+    this._def.parentDiscriminators.add(discriminator);
+    const valueArray = Array.from(valueSet);
+    if (!valueArray.length) {
+      throw new Error(
+        `at least one value must be present for \`${discriminator}\` in DiscriminatedUnion for all children DUs`
+      );
+    }
+    return valueArray;
   }
 
   /**
@@ -2438,11 +2481,12 @@ export class ZodDiscriminatedUnion<
    * @param types an array of object schemas
    * @param params
    */
+
   static create<
     Discriminator extends string,
     Types extends [
       ZodDiscriminatedUnionOption<Discriminator>,
-      ...ZodDiscriminatedUnionOption<Discriminator>[]
+      ...Array<ZodDiscriminatedUnionOption<Discriminator>>
     ]
   >(
     discriminator: Discriminator,
@@ -2452,35 +2496,45 @@ export class ZodDiscriminatedUnion<
     // Get all the valid discriminator values
     const optionsMap: Map<Primitive, Types[number]> = new Map();
 
-    // try {
-    for (const type of options) {
-      const discriminatorValues = getDiscriminator(type.shape[discriminator]);
-      if (!discriminatorValues) {
-        throw new Error(
-          `A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`
-        );
-      }
-      for (const value of discriminatorValues) {
+    const addUniqueDiscriminatorValues = (
+      values: Array<Primitive>,
+      type: Types[number]
+    ) => {
+      for (const value of values) {
         if (optionsMap.has(value)) {
           throw new Error(
-            `Discriminator property ${String(
-              discriminator
-            )} has duplicate value ${String(value)}`
+            `Discriminator property \`${discriminator}\` has duplicate value \`${String(
+              value
+            )}\``
           );
         }
+
         optionsMap.set(value, type);
+      }
+    };
+
+    for (const type of options) {
+      if (type instanceof ZodDiscriminatedUnion) {
+        const values = type._addParentDiscriminator(discriminator);
+        addUniqueDiscriminatorValues(values, type);
+      } else {
+        const discriminatorValues = getDiscriminator(type.shape[discriminator]);
+        if (!discriminatorValues.length) {
+          throw new Error(
+            `A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`
+          );
+        }
+
+        addUniqueDiscriminatorValues(discriminatorValues, type);
       }
     }
 
-    return new ZodDiscriminatedUnion<
-      Discriminator,
-      // DiscriminatorValue,
-      Types
-    >({
+    return new ZodDiscriminatedUnion<Discriminator, Types>({
       typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion,
       discriminator,
       options,
       optionsMap,
+      parentDiscriminators: new Set(),
       ...processCreateParams(params),
     });
   }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2480,7 +2480,6 @@ export interface ZodDiscriminatedUnionDef<
   >
 > extends ZodTypeDef {
   discriminator: Discriminator;
-  parentDiscriminators: Set<string>;
   options: Options;
   optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<Discriminator>>;
   typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion;
@@ -2538,10 +2537,6 @@ export class ZodDiscriminatedUnion<
     return this._def.discriminator;
   }
 
-  get parentDiscriminators() {
-    return Array.from(this._def.parentDiscriminators);
-  }
-
   get options() {
     return this._def.options;
   }
@@ -2550,7 +2545,7 @@ export class ZodDiscriminatedUnion<
     return this._def.optionsMap;
   }
 
-  _addParentDiscriminator(discriminator: string) {
+  _enforceParentDiscriminator(discriminator: string) {
     const valueSet = new Set<Primitive>();
     for (const type of this._def.options) {
       if (type instanceof ZodObject) {
@@ -2563,7 +2558,7 @@ export class ZodDiscriminatedUnion<
         }
         discriminatorValues.map((el) => valueSet.add(el));
       } else if (type instanceof ZodDiscriminatedUnion) {
-        const values = type._addParentDiscriminator(discriminator);
+        const values = type._enforceParentDiscriminator(discriminator);
         if (values.length < 1) {
           throw new Error(
             `No value for key \`${discriminator}\` was found for DiscriminatedUnion with discriminator \`${type.discriminator}\``
@@ -2572,7 +2567,6 @@ export class ZodDiscriminatedUnion<
         values.map((el) => valueSet.add(el));
       }
     }
-    this._def.parentDiscriminators.add(discriminator);
     const valueArray = Array.from(valueSet);
     if (!valueArray.length) {
       throw new Error(
@@ -2624,7 +2618,7 @@ export class ZodDiscriminatedUnion<
 
     for (const type of options) {
       if (type instanceof ZodDiscriminatedUnion) {
-        const values = type._addParentDiscriminator(discriminator);
+        const values = type._enforceParentDiscriminator(discriminator);
         addUniqueDiscriminatorValues(values, type);
       } else {
         const discriminatorValues = getDiscriminator(type.shape[discriminator]);
@@ -2643,7 +2637,6 @@ export class ZodDiscriminatedUnion<
       discriminator,
       options,
       optionsMap,
-      parentDiscriminators: new Set(),
       ...processCreateParams(params),
     });
   }

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -229,6 +229,19 @@ test("valid expected types from inference with another DiscriminatedUnion elemen
   >(true);
 });
 
+test("DU flattens children DiscriminatedUnion elements with same discriminator key", () => {
+  const A = z.object({ type: z.literal("a"), a: z.literal(1) });
+  const B = z.object({ type: z.literal("b"), b: z.literal(2) });
+  const C = z.object({ type: z.literal("c").optional(), c: z.literal(true) });
+  const D = z.object({ type: z.literal("d"), d: z.literal("d") });
+
+  const AorB = z.discriminatedUnion("type", [A, B]);
+  const child = z.discriminatedUnion("type", [AorB, C]);
+  const parent = z.discriminatedUnion("type", [child, D]);
+
+  expect(parent.options.length).toEqual(4);
+});
+
 test("valid - nested disjointed DiscriminatedUnions", () => {
   const subtype = z.discriminatedUnion("subtype", [
     z.object({

--- a/src/benchmarks/discriminatedUnion.ts
+++ b/src/benchmarks/discriminatedUnion.ts
@@ -4,6 +4,7 @@ import { z } from "../index";
 
 const doubleSuite = new Benchmark.Suite("z.discriminatedUnion: double");
 const manySuite = new Benchmark.Suite("z.discriminatedUnion: many");
+const nestedSuite = new Benchmark.Suite("z.discriminatedUnion: nested");
 
 const aSchema = z.object({
   type: z.literal("a"),
@@ -32,6 +33,7 @@ const dSchema = z.object({
 
 const double = z.discriminatedUnion("type", [aSchema, bSchema]);
 const many = z.discriminatedUnion("type", [aSchema, bSchema, cSchema, dSchema]);
+const nested = z.discriminatedUnion("type", [double, cSchema, dSchema]);
 
 doubleSuite
   .add("valid: a", () => {
@@ -75,6 +77,30 @@ manySuite
     console.log(`${(manySuite as any).name}: ${e.target}`);
   });
 
+nestedSuite
+  .add("valid: a", () => {
+    nested.parse(objA);
+  })
+  .add("valid: b", () => {
+    nested.parse(objB);
+  })
+  .add("valid: c", () => {
+    nested.parse(objC);
+  })
+  .add("invalid: null", () => {
+    try {
+      nested.parse(null);
+    } catch (err) {}
+  })
+  .add("invalid: wrong shape", () => {
+    try {
+      nested.parse(objC);
+    } catch (err) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`${(nestedSuite as any).name}: ${e.target}`);
+  });
+
 export default {
-  suites: [doubleSuite, manySuite],
+  suites: [doubleSuite, manySuite, nestedSuite],
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2332,9 +2332,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
 /////////////////////////////////////////////////////
 /////////////////////////////////////////////////////
 
-const getDiscriminator = <T extends ZodTypeAny>(
-  type: T
-): Primitive[] | null => {
+const getDiscriminator = <T extends ZodTypeAny>(type: T): Primitive[] => {
   if (type instanceof ZodLazy) {
     return getDiscriminator(type.schema);
   } else if (type instanceof ZodEffects) {
@@ -2346,33 +2344,42 @@ const getDiscriminator = <T extends ZodTypeAny>(
   } else if (type instanceof ZodNativeEnum) {
     // eslint-disable-next-line ban/ban
     return Object.keys(type.enum as any);
+  } else if (type instanceof ZodDiscriminatedUnion) {
+    return getDiscriminator(type._def.innerType);
   } else if (type instanceof ZodDefault) {
     return getDiscriminator(type._def.innerType);
+  } else if (type instanceof ZodOptional) {
+    return [undefined, ...getDiscriminator(type.unwrap())];
   } else if (type instanceof ZodUndefined) {
     return [undefined];
   } else if (type instanceof ZodNull) {
     return [null];
   } else {
-    return null;
+    return [];
   }
 };
 
-export type ZodDiscriminatedUnionOption<Discriminator extends string> =
+export type ZodDiscriminatedUnionObject<Discriminator extends string> =
   ZodObject<{ [key in Discriminator]: ZodTypeAny } & ZodRawShape, any, any>;
+
+export type ZodDiscriminatedUnionOption<Discriminator extends string> =
+  | ZodDiscriminatedUnionObject<Discriminator>
+  | ZodDiscriminatedUnion<string, Array<ZodDiscriminatedUnionOption<string>>>;
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<any>[]
+  Options extends ZodDiscriminatedUnionOption<string>[]
 > extends ZodTypeDef {
   discriminator: Discriminator;
+  parentDiscriminators: Set<string>;
   options: Options;
-  optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<any>>;
+  optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<Discriminator>>;
   typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion;
 }
 
 export class ZodDiscriminatedUnion<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<Discriminator>[]
+  Options extends Array<ZodDiscriminatedUnionOption<string>>
 > extends ZodType<
   output<Options[number]>,
   ZodDiscriminatedUnionDef<Discriminator, Options>,
@@ -2422,12 +2429,48 @@ export class ZodDiscriminatedUnion<
     return this._def.discriminator;
   }
 
+  get parentDiscriminators() {
+    return Array.from(this._def.parentDiscriminators);
+  }
+
   get options() {
     return this._def.options;
   }
 
   get optionsMap() {
     return this._def.optionsMap;
+  }
+
+  _addParentDiscriminator(discriminator: string) {
+    const valueSet = new Set<Primitive>();
+    for (const type of this._def.options) {
+      if (type instanceof ZodObject) {
+        const discriminatorValues = getDiscriminator(type.shape[discriminator]);
+        if (!discriminatorValues.length) {
+          throw new Error(
+            `A discriminator value for key \`${discriminator}\` ` +
+              `could not be extracted from all schema options`
+          );
+        }
+        discriminatorValues.map((el) => valueSet.add(el));
+      } else if (type instanceof ZodDiscriminatedUnion) {
+        const values = type._addParentDiscriminator(discriminator);
+        if (values.length < 1) {
+          throw new Error(
+            `No value for key \`${discriminator}\` was found for DiscriminatedUnion with discriminator \`${type.discriminator}\``
+          );
+        }
+        values.map((el) => valueSet.add(el));
+      }
+    }
+    this._def.parentDiscriminators.add(discriminator);
+    const valueArray = Array.from(valueSet);
+    if (!valueArray.length) {
+      throw new Error(
+        `at least one value must be present for \`${discriminator}\` in DiscriminatedUnion for all children DUs`
+      );
+    }
+    return valueArray;
   }
 
   /**
@@ -2438,11 +2481,12 @@ export class ZodDiscriminatedUnion<
    * @param types an array of object schemas
    * @param params
    */
+
   static create<
     Discriminator extends string,
     Types extends [
       ZodDiscriminatedUnionOption<Discriminator>,
-      ...ZodDiscriminatedUnionOption<Discriminator>[]
+      ...Array<ZodDiscriminatedUnionOption<Discriminator>>
     ]
   >(
     discriminator: Discriminator,
@@ -2452,35 +2496,45 @@ export class ZodDiscriminatedUnion<
     // Get all the valid discriminator values
     const optionsMap: Map<Primitive, Types[number]> = new Map();
 
-    // try {
-    for (const type of options) {
-      const discriminatorValues = getDiscriminator(type.shape[discriminator]);
-      if (!discriminatorValues) {
-        throw new Error(
-          `A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`
-        );
-      }
-      for (const value of discriminatorValues) {
+    const addUniqueDiscriminatorValues = (
+      values: Array<Primitive>,
+      type: Types[number]
+    ) => {
+      for (const value of values) {
         if (optionsMap.has(value)) {
           throw new Error(
-            `Discriminator property ${String(
-              discriminator
-            )} has duplicate value ${String(value)}`
+            `Discriminator property \`${discriminator}\` has duplicate value \`${String(
+              value
+            )}\``
           );
         }
+
         optionsMap.set(value, type);
+      }
+    };
+
+    for (const type of options) {
+      if (type instanceof ZodDiscriminatedUnion) {
+        const values = type._addParentDiscriminator(discriminator);
+        addUniqueDiscriminatorValues(values, type);
+      } else {
+        const discriminatorValues = getDiscriminator(type.shape[discriminator]);
+        if (!discriminatorValues.length) {
+          throw new Error(
+            `A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`
+          );
+        }
+
+        addUniqueDiscriminatorValues(discriminatorValues, type);
       }
     }
 
-    return new ZodDiscriminatedUnion<
-      Discriminator,
-      // DiscriminatorValue,
-      Types
-    >({
+    return new ZodDiscriminatedUnion<Discriminator, Types>({
       typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion,
       discriminator,
       options,
       optionsMap,
+      parentDiscriminators: new Set(),
       ...processCreateParams(params),
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2480,7 +2480,6 @@ export interface ZodDiscriminatedUnionDef<
   >
 > extends ZodTypeDef {
   discriminator: Discriminator;
-  parentDiscriminators: Set<string>;
   options: Options;
   optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<Discriminator>>;
   typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion;
@@ -2538,10 +2537,6 @@ export class ZodDiscriminatedUnion<
     return this._def.discriminator;
   }
 
-  get parentDiscriminators() {
-    return Array.from(this._def.parentDiscriminators);
-  }
-
   get options() {
     return this._def.options;
   }
@@ -2550,7 +2545,7 @@ export class ZodDiscriminatedUnion<
     return this._def.optionsMap;
   }
 
-  _addParentDiscriminator(discriminator: string) {
+  _enforceParentDiscriminator(discriminator: string) {
     const valueSet = new Set<Primitive>();
     for (const type of this._def.options) {
       if (type instanceof ZodObject) {
@@ -2563,7 +2558,7 @@ export class ZodDiscriminatedUnion<
         }
         discriminatorValues.map((el) => valueSet.add(el));
       } else if (type instanceof ZodDiscriminatedUnion) {
-        const values = type._addParentDiscriminator(discriminator);
+        const values = type._enforceParentDiscriminator(discriminator);
         if (values.length < 1) {
           throw new Error(
             `No value for key \`${discriminator}\` was found for DiscriminatedUnion with discriminator \`${type.discriminator}\``
@@ -2572,7 +2567,6 @@ export class ZodDiscriminatedUnion<
         values.map((el) => valueSet.add(el));
       }
     }
-    this._def.parentDiscriminators.add(discriminator);
     const valueArray = Array.from(valueSet);
     if (!valueArray.length) {
       throw new Error(
@@ -2624,7 +2618,7 @@ export class ZodDiscriminatedUnion<
 
     for (const type of options) {
       if (type instanceof ZodDiscriminatedUnion) {
-        const values = type._addParentDiscriminator(discriminator);
+        const values = type._enforceParentDiscriminator(discriminator);
         addUniqueDiscriminatorValues(values, type);
       } else {
         const discriminatorValues = getDiscriminator(type.shape[discriminator]);
@@ -2643,7 +2637,6 @@ export class ZodDiscriminatedUnion<
       discriminator,
       options,
       optionsMap,
-      parentDiscriminators: new Set(),
       ...processCreateParams(params),
     });
   }


### PR DESCRIPTION
Partially closes https://github.com/colinhacks/zod/issues/1075 , fully closes #1884  with the following:

## feature: more valid discriminator values

The following are now well-supported discriminator values (enum/undefined could have been already)
- `z.undefined()`
- `z.null()`
- `z.enum()`
- `z.discriminatedUnion()`

This does **not** address functionality like the below, where a full primitive validator (like `z.string()`) is used as discriminator. This requires more changes and I'd like to address it separately.
```typescript
  const ResultSchema = z.discriminatedUnion("error", [
    z.object({ error: z.string().min(1) }), // error here
    z.object({ error: z.undefined(), value: z.string().min(1) }),
  ]);
```

## feature: use `ZodDiscriminatedUnion` as a union element

Allows adding a `ZodDiscriminatedUnion` as an element in the discriminated union, such that this is possible: 

```typescript
  const A = z.object({ type: z.literal("a") });
  const B = z.object({ type: z.literal("b") });
  const C = z.object({ type: z.literal("c").optional(), c: z.literal(true) });
  const AorB = z.discriminatedUnion("type", [A, B]);
  // using another discriminated union with the same discriminator as a union member
  const AorBorC = z.discriminatedUnion("type", [AorB, C]);
  type full = z.infer<typeof AorBorC>;
  /**
   * 
type full = {
    type: "a";
} | {
    type: "b";
} | {
    type?: "c" | undefined;
    c: true;
}
   */
```


Benchmarks for the new functionality (compared to two and four union elements, where `nested` is one of the options of `DiscriminatedUnion` itself):
```shell
$ yarn benchmark                                                                                                                                                                                           
yarn run v1.22.19
$ tsx src/benchmarks/index.ts
z.discriminatedUnion: double: valid: a x 994,112 ops/sec ±0.91% (85 runs sampled)
z.discriminatedUnion: double: valid: b x 964,468 ops/sec ±0.98% (85 runs sampled)
z.discriminatedUnion: double: invalid: null x 31,516 ops/sec ±1.10% (80 runs sampled)
z.discriminatedUnion: double: invalid: wrong shape x 34,323 ops/sec ±1.37% (81 runs sampled)
z.discriminatedUnion: many: valid: a x 948,977 ops/sec ±0.89% (87 runs sampled)
z.discriminatedUnion: many: valid: c x 944,571 ops/sec ±0.85% (85 runs sampled)
z.discriminatedUnion: many: invalid: null x 29,904 ops/sec ±1.24% (87 runs sampled)
z.discriminatedUnion: many: invalid: wrong shape x 32,622 ops/sec ±1.16% (88 runs sampled)
z.discriminatedUnion: nested: valid: a x 961,652 ops/sec ±0.82% (85 runs sampled)
z.discriminatedUnion: nested: valid: b x 963,830 ops/sec ±0.96% (86 runs sampled)
z.discriminatedUnion: nested: valid: c x 956,284 ops/sec ±0.88% (84 runs sampled)
z.discriminatedUnion: nested: invalid: null x 29,937 ops/sec ±1.19% (87 runs sampled)
z.discriminatedUnion: nested: invalid: wrong shape x 964,482 ops/sec ±0.91% (86 runs sampled)
✨  Done in 71.60s.
```
## feature: disjointed discriminators for nested DUs

Now the following is possible: 
```ts
  const subtype = z.discriminatedUnion("subtype", [
    z.object({
      type: z.literal("baz"),
      subtype: z.literal("able"),
    }),
    z.object({
      type: z.literal("bauble"),
      subtype: z.literal("beehive"),
      undertype: z.literal("alpha"),
    }),
    z.object({
      type: z.literal("baz"),
      subtype: z.literal("baker"),
    }),
  ]);

  const schema = z.discriminatedUnion("type", [
    z.object({
      type: z.literal("foo"),
    }),
    z.object({
      type: z.literal("bar"),
    }),
    subtype,
  ]);

/**
type schema = {
    type: "baz";
    subtype: "able";
} | {
    type: "bauble";
    subtype: "beehive";
    undertype: "alpha";
} | {
    type: "baz";
    subtype: "baker";
} | {
    type: "foo";
} | {
    type: "bar";
}
*/
```

Care was taken to ensure that there aren't any edge cases where nested DUs can be created without overlapping, resolvable discriminators at every level.

## Follow-ups
- Use the following zod validators as `DiscriminatedUnion` elements:
  - `z.intersection()`
  - `z.string()`
  - `z.boolean()`
  - others depending on implementation 