### PR TITLE
docs: likely a minor typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Some other great aspects:
 - Zero dependencies
 - Works in Node.js and all modern browsers
 - Tiny: 8kb minified + zipped
-- Immutable: methods (i.e. `.optional()`) return a new instance
+- Immutable: methods (e.g. `.optional()`) return a new instance
 - Concise, chainable interface
 - Functional approach: [parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/)
 - Works with plain JavaScript too! You don't need to use TypeScript.


### PR DESCRIPTION
_i.e._ means _that is_,
whereas
_e.g._ means _for example_

I'm assuming `.optional()` is just an example here