### PR TITLE
feat: Add abort early (fatal) option to refine (#1603)

### DIFF
--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -217,3 +217,25 @@ test("fatal superRefine", () => {
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 });
+
+test("fatal refine", () => {
+  const Strings = z
+    .string()
+    .refine((val) => val === "", {
+      message: "foo",
+      fatal: true,
+    })
+    .superRefine((val, ctx) => {
+      if (val !== " ") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "bar",
+        });
+      }
+    });
+
+  const result = Strings.safeParse("");
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+});

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -239,3 +239,25 @@ test("fatal refine", () => {
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 });
+
+test("chained refinements with type narrowing", () => {
+  const isNotNull = <T>(val: T | null): val is T => val !== null;
+  const schema = z
+    .object({ test: z.literal(true) })
+    .nullable()
+    .refine(isNotNull, {
+      message: "foo",
+      fatal: true,
+    })
+    .superRefine((val, ctx) => {
+      // Would throw exception here without fatal on the previous refine
+      if (val.test) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "bar" });
+      }
+    });
+
+  const result = schema.safeParse(null);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -52,7 +52,9 @@ export type input<T extends ZodType<any, any, any>> = T["_input"];
 export type output<T extends ZodType<any, any, any>> = T["_output"];
 export type { TypeOf as infer };
 
-export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
+export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">> & {
+  fatal?: boolean;
+};
 export interface ZodTypeDef {
   errorMap?: ZodErrorMap;
   description?: string;

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -216,3 +216,25 @@ test("fatal superRefine", () => {
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 });
+
+test("fatal refine", () => {
+  const Strings = z
+    .string()
+    .refine((val) => val === "", {
+      message: "foo",
+      fatal: true,
+    })
+    .superRefine((val, ctx) => {
+      if (val !== " ") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "bar",
+        });
+      }
+    });
+
+  const result = Strings.safeParse("");
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(1);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,9 @@ export type input<T extends ZodType<any, any, any>> = T["_input"];
 export type output<T extends ZodType<any, any, any>> = T["_output"];
 export type { TypeOf as infer };
 
-export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
+export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">> & {
+  fatal?: boolean;
+};
 export interface ZodTypeDef {
   errorMap?: ZodErrorMap;
   description?: string;


### PR DESCRIPTION
Closes #1603

`CustomErrorParams` is not used anywhere else besides `refine`, so it should be fine to add the `fatal` field directly there. The object gets then passed to `ctx.addIssue`.