### PR TITLE
Fix: dynamic zod.object() schema returned from function body with generic type, done right

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1663,14 +1663,15 @@ export namespace objectUtil {
     [k in keyof T]: undefined extends T[k] ? k : never;
   }[keyof T];
 
-  type requiredKeys<T extends object> = {
+  type filterRequiredOnly<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
-  }[keyof T];
+  };
 
-  export type addQuestionMarks<T extends object> = Partial<
-    Pick<T, optionalKeys<T>>
+  export type addQuestionMarks<T extends object> = Pick<
+    T,
+    keyof filterRequiredOnly<T>
   > &
-    Pick<T, requiredKeys<T>>;
+    Partial<Pick<T, optionalKeys<T>>>;
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1663,15 +1663,13 @@ export namespace objectUtil {
     [k in keyof T]: undefined extends T[k] ? k : never;
   }[keyof T];
 
-  type filterRequiredOnly<T extends object> = {
+  type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
-  };
+  }[keyof T];
 
-  export type addQuestionMarks<T extends object> = Pick<
-    T,
-    keyof filterRequiredOnly<T>
-  > &
-    Partial<Pick<T, optionalKeys<T>>>;
+  export type addQuestionMarks<T extends object> = Pick<T, requiredKeys<T>> &
+    Partial<Pick<T, optionalKeys<T>>> &
+    Omit<T, optionalKeys<T> | requiredKeys<T>>;
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1663,14 +1663,15 @@ export namespace objectUtil {
     [k in keyof T]: undefined extends T[k] ? k : never;
   }[keyof T];
 
-  type requiredKeys<T extends object> = {
+  type filterRequiredOnly<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
-  }[keyof T];
+  };
 
-  export type addQuestionMarks<T extends object> = Partial<
-    Pick<T, optionalKeys<T>>
+  export type addQuestionMarks<T extends object> = Pick<
+    T,
+    keyof filterRequiredOnly<T>
   > &
-    Pick<T, requiredKeys<T>>;
+    Partial<Pick<T, optionalKeys<T>>>;
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1663,15 +1663,13 @@ export namespace objectUtil {
     [k in keyof T]: undefined extends T[k] ? k : never;
   }[keyof T];
 
-  type filterRequiredOnly<T extends object> = {
+  type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
-  };
+  }[keyof T];
 
-  export type addQuestionMarks<T extends object> = Pick<
-    T,
-    keyof filterRequiredOnly<T>
-  > &
-    Partial<Pick<T, optionalKeys<T>>>;
+  export type addQuestionMarks<T extends object> = Pick<T, requiredKeys<T>> &
+    Partial<Pick<T, optionalKeys<T>>> &
+    Omit<T, optionalKeys<T> | requiredKeys<T>>;
 
   export type identity<T> = T;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;


### PR DESCRIPTION
I made a small, but very important fix of `objectUtil.addQuestionMarks` type. 
TBH i have no idea why it works, but from my logical point of view this looks right. 
It should close a bunch of issues, so i will not enumerate it here.
With this fix we are able to write something like this, that was not possible before:

```ts
import { z } from 'zod';

function anyZodRefinement<T>(t: T): z.ZodType<T> {
  return z.any().refine(() => t);
}

function dynamicZodObject<T>(t: T) {
  return z.object({
    arbitrary: anyZodRefinement(t),
  });
}

function doSomethingUseful<T>(t: T) {
  const schema = dynamicZodObject(t);
  const parsed = schema.parse({ arbitrary: t });
  // In the previous implementation this fiend have not been existed
  return parsed.arbitrary;
  // ^? returns type <T> here!!!
}

const result = doSomethingUseful('test' as const)
// ^? 'test' literal type!!!
```

And it will work as expected!

Please, don't ignore this PR, i have spent the whole sleepless night and day figuring out how to fix it 😄 