### PR TITLE
Fix issue #1611

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -106,6 +106,7 @@ export interface ZodTooSmallIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_small;
   minimum: number;
   inclusive: boolean;
+  exact: boolean;
   type: "array" | "string" | "number" | "set" | "date";
 }
 
@@ -113,6 +114,7 @@ export interface ZodTooBigIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_big;
   maximum: number;
   inclusive: boolean;
+  exact: boolean;
   type: "array" | "string" | "number" | "set" | "date";
 }
 

--- a/deno/lib/__tests__/validations.test.ts
+++ b/deno/lib/__tests__/validations.test.ts
@@ -42,6 +42,24 @@ test("array length", async () => {
   }
 });
 
+test("string length", async () => {
+  try {
+    await z.string().length(4).parseAsync("asd");
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "String must contain exactly 4 character(s)"
+    );
+  }
+
+  try {
+    await z.string().length(4).parseAsync("asdaa");
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "String must contain exactly 4 character(s)"
+    );
+  }
+});
+
 test("string min", async () => {
   try {
     await z.string().min(4).parseAsync("asd");

--- a/deno/lib/__tests__/validations.test.ts
+++ b/deno/lib/__tests__/validations.test.ts
@@ -24,6 +24,24 @@ test("array max", async () => {
   }
 });
 
+test("array length", async () => {
+  try {
+    await z.array(z.string()).length(2).parseAsync(["asdf", "asdf", "asdf"]);
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "Array must contain exactly 2 element(s)"
+    );
+  }
+
+  try {
+    await z.array(z.string()).length(2).parseAsync(["asdf"]);
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "Array must contain exactly 2 element(s)"
+    );
+  }
+});
+
 test("string min", async () => {
   try {
     await z.string().min(4).parseAsync("asd");

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -63,39 +63,55 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.too_small:
       if (issue.type === "array")
         message = `Array must contain ${
-          issue.inclusive ? `at least` : `more than`
+          issue.exact ? "exactly" : issue.inclusive ? `at least` : `more than`
         } ${issue.minimum} element(s)`;
       else if (issue.type === "string")
         message = `String must contain ${
-          issue.inclusive ? `at least` : `over`
+          issue.exact ? "exactly" : issue.inclusive ? `at least` : `over`
         } ${issue.minimum} character(s)`;
       else if (issue.type === "number")
-        message = `Number must be greater than ${
-          issue.inclusive ? `or equal to ` : ``
+        message = `Number must be ${
+          issue.exact
+            ? `exactly equal to `
+            : issue.inclusive
+            ? `greater than or equal to `
+            : `greater than `
         }${issue.minimum}`;
       else if (issue.type === "date")
-        message = `Date must be greater than ${
-          issue.inclusive ? `or equal to ` : ``
+        message = `Date must be ${
+          issue.exact
+            ? `exactly equal to `
+            : issue.inclusive
+            ? `greater than or equal to `
+            : `greater than `
         }${new Date(issue.minimum)}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.too_big:
       if (issue.type === "array")
         message = `Array must contain ${
-          issue.inclusive ? `at most` : `less than`
+          issue.exact ? `exactly` : issue.inclusive ? `at most` : `less than`
         } ${issue.maximum} element(s)`;
       else if (issue.type === "string")
         message = `String must contain ${
-          issue.inclusive ? `at most` : `under`
+          issue.exact ? `exactly` : issue.inclusive ? `at most` : `under`
         } ${issue.maximum} character(s)`;
       else if (issue.type === "number")
-        message = `Number must be less than ${
-          issue.inclusive ? `or equal to ` : ``
-        }${issue.maximum}`;
+        message = `Number must be ${
+          issue.exact
+            ? `exactly`
+            : issue.inclusive
+            ? `less than or equal to`
+            : `less than`
+        } ${issue.maximum}`;
       else if (issue.type === "date")
-        message = `Date must be smaller than ${
-          issue.inclusive ? `or equal to ` : ``
-        }${new Date(issue.maximum)}`;
+        message = `Date must be ${
+          issue.exact
+            ? `exactly`
+            : issue.inclusive
+            ? `smaller than or equal to`
+            : `smaller than`
+        } ${new Date(issue.maximum)}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.custom:

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1623,7 +1623,10 @@ export class ZodArray<
   }
 
   length(len: number, message?: errorUtil.ErrMessage): this {
-    return this.min(len, message).max(len, message) as any;
+    const defaultMessage = `Array must contain exactly ${len} element(s)`;
+    const actualMessage = message ?? defaultMessage;
+
+    return this.min(len, actualMessage).max(len, actualMessage) as any;
   }
 
   nonempty(message?: errorUtil.ErrMessage): ZodArray<T, "atleastone"> {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -781,7 +781,10 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
 
   length(len: number, message?: errorUtil.ErrMessage) {
-    return this.min(len, message).max(len, message);
+    const defaultMessage = `String must contain exactly ${len} character(s)`;
+    const actualMessage = message ?? defaultMessage;
+
+    return this.min(len, actualMessage).max(len, actualMessage);
   }
 
   /**

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -106,6 +106,7 @@ export interface ZodTooSmallIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_small;
   minimum: number;
   inclusive: boolean;
+  exact: boolean;
   type: "array" | "string" | "number" | "set" | "date";
 }
 
@@ -113,6 +114,7 @@ export interface ZodTooBigIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_big;
   maximum: number;
   inclusive: boolean;
+  exact: boolean;
   type: "array" | "string" | "number" | "set" | "date";
 }
 

--- a/src/__tests__/validations.test.ts
+++ b/src/__tests__/validations.test.ts
@@ -41,6 +41,24 @@ test("array length", async () => {
   }
 });
 
+test("string length", async () => {
+  try {
+    await z.string().length(4).parseAsync("asd");
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "String must contain exactly 4 character(s)"
+    );
+  }
+
+  try {
+    await z.string().length(4).parseAsync("asdaa");
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "String must contain exactly 4 character(s)"
+    );
+  }
+});
+
 test("string min", async () => {
   try {
     await z.string().min(4).parseAsync("asd");

--- a/src/__tests__/validations.test.ts
+++ b/src/__tests__/validations.test.ts
@@ -23,6 +23,24 @@ test("array max", async () => {
   }
 });
 
+test("array length", async () => {
+  try {
+    await z.array(z.string()).length(2).parseAsync(["asdf", "asdf", "asdf"]);
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "Array must contain exactly 2 element(s)"
+    );
+  }
+
+  try {
+    await z.array(z.string()).length(2).parseAsync(["asdf"]);
+  } catch (err) {
+    expect((err as z.ZodError).issues[0].message).toEqual(
+      "Array must contain exactly 2 element(s)"
+    );
+  }
+});
+
 test("string min", async () => {
   try {
     await z.string().min(4).parseAsync("asd");

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -63,39 +63,55 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.too_small:
       if (issue.type === "array")
         message = `Array must contain ${
-          issue.inclusive ? `at least` : `more than`
+          issue.exact ? "exactly" : issue.inclusive ? `at least` : `more than`
         } ${issue.minimum} element(s)`;
       else if (issue.type === "string")
         message = `String must contain ${
-          issue.inclusive ? `at least` : `over`
+          issue.exact ? "exactly" : issue.inclusive ? `at least` : `over`
         } ${issue.minimum} character(s)`;
       else if (issue.type === "number")
-        message = `Number must be greater than ${
-          issue.inclusive ? `or equal to ` : ``
+        message = `Number must be ${
+          issue.exact
+            ? `exactly equal to `
+            : issue.inclusive
+            ? `greater than or equal to `
+            : `greater than `
         }${issue.minimum}`;
       else if (issue.type === "date")
-        message = `Date must be greater than ${
-          issue.inclusive ? `or equal to ` : ``
+        message = `Date must be ${
+          issue.exact
+            ? `exactly equal to `
+            : issue.inclusive
+            ? `greater than or equal to `
+            : `greater than `
         }${new Date(issue.minimum)}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.too_big:
       if (issue.type === "array")
         message = `Array must contain ${
-          issue.inclusive ? `at most` : `less than`
+          issue.exact ? `exactly` : issue.inclusive ? `at most` : `less than`
         } ${issue.maximum} element(s)`;
       else if (issue.type === "string")
         message = `String must contain ${
-          issue.inclusive ? `at most` : `under`
+          issue.exact ? `exactly` : issue.inclusive ? `at most` : `under`
         } ${issue.maximum} character(s)`;
       else if (issue.type === "number")
-        message = `Number must be less than ${
-          issue.inclusive ? `or equal to ` : ``
-        }${issue.maximum}`;
+        message = `Number must be ${
+          issue.exact
+            ? `exactly`
+            : issue.inclusive
+            ? `less than or equal to`
+            : `less than`
+        } ${issue.maximum}`;
       else if (issue.type === "date")
-        message = `Date must be smaller than ${
-          issue.inclusive ? `or equal to ` : ``
-        }${new Date(issue.maximum)}`;
+        message = `Date must be ${
+          issue.exact
+            ? `exactly`
+            : issue.inclusive
+            ? `smaller than or equal to`
+            : `smaller than`
+        } ${new Date(issue.maximum)}`;
       else message = "Invalid input";
       break;
     case ZodIssueCode.custom:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1623,7 +1623,10 @@ export class ZodArray<
   }
 
   length(len: number, message?: errorUtil.ErrMessage): this {
-    return this.min(len, message).max(len, message) as any;
+    const defaultMessage = `Array must contain exactly ${len} element(s)`;
+    const actualMessage = message ?? defaultMessage;
+
+    return this.min(len, actualMessage).max(len, actualMessage) as any;
   }
 
   nonempty(message?: errorUtil.ErrMessage): ZodArray<T, "atleastone"> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -781,7 +781,10 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
 
   length(len: number, message?: errorUtil.ErrMessage) {
-    return this.min(len, message).max(len, message);
+    const defaultMessage = `String must contain exactly ${len} character(s)`;
+    const actualMessage = message ?? defaultMessage;
+
+    return this.min(len, actualMessage).max(len, actualMessage);
   }
 
   /**


### PR DESCRIPTION
closes #1611 

I quickly drafted a working solution so we could iterate and discuss its design.

I also added the same proposed behavior to strings as well, since both strings and arrays share the `.length` function.

Looking further into the codebase, I think it would be ideal to create a new check (something like "exact_legth") and a ZodIssueCode so we can share the same locale behavior between Arrays and Strings.

Whats your take? How should I integrate those changes into Zod's current codebase?