### PR TITLE
feat: Add `extract`/`exclude` methods to `ZodEnum`

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1261,7 +1261,7 @@ type MyUnion =
   | { status: "failed"; error: Error };
 ```
 
-Such unions can be represented with the `z.discriminatedUnion` method. This enables faster evaluation, because Zod can check the _discriminator key_ (`status` in the example above) ot determine which schema should be used to parse the input. This makes parsing more efficient and lets Zod provide report friendlier errors.
+Such unions can be represented with the `z.discriminatedUnion` method. This enables faster evaluation, because Zod can check the _discriminator key_ (`status` in the example above) to determine which schema should be used to parse the input. This makes parsing more efficient and lets Zod report friendlier errors.
 
 With the basic union method the input is tested against each of the provided "options", and in the case of invalidity, issues for all the "options" are shown in the zod error. On the other hand, the discriminated union allows for selecting just one of the "options", testing against it, and showing only the issues related to this "option".
 

--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -41,3 +41,15 @@ test("error params", () => {
     expect(result.error.issues[0].message).toEqual("REQUIRED");
   }
 });
+
+test("extract/exclude", () => {
+  const FoodEnum = z.enum(["Pasta", "Pizza", "Tacos", "Burgers", "Salad"]);
+  const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
+  const UnhealthyEnum = FoodEnum.exclude(["Salad"]);
+
+  util.assertEqual<z.infer<typeof ItalianEnum>, "Pasta" | "Pizza">(true);
+  util.assertEqual<
+    z.infer<typeof UnhealthyEnum>,
+    "Pasta" | "Pizza" | "Tacos" | "Burgers"
+  >(true);
+});

--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -43,13 +43,18 @@ test("error params", () => {
 });
 
 test("extract/exclude", () => {
-  const FoodEnum = z.enum(["Pasta", "Pizza", "Tacos", "Burgers", "Salad"]);
+  const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
+  const FoodEnum = z.enum(foods);
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const UnhealthyEnum = FoodEnum.exclude(["Salad"]);
+  const EmptyFoodEnum = FoodEnum.exclude(foods);
 
   util.assertEqual<z.infer<typeof ItalianEnum>, "Pasta" | "Pizza">(true);
   util.assertEqual<
     z.infer<typeof UnhealthyEnum>,
     "Pasta" | "Pizza" | "Tacos" | "Burgers"
   >(true);
+  // @ts-expect-error TS2344
+  util.assertEqual<typeof EmptyFoodEnum, z.ZodEnum<[]>>(true);
+  util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3500,6 +3500,18 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
     return enumValues as any;
   }
 
+  extract<U extends T[number], _U extends readonly [U, ...U[]]>(values: _U) {
+    return ZodEnum.create(values);
+  }
+
+  exclude<U extends T[number]>(values: readonly [U, ...U[]]) {
+    return ZodEnum.create(
+      this.options.filter(
+        (opt) => !values.includes(opt as U)
+      ) as enumUtil.UnionToTupleString<Exclude<T[number], U>>
+    );
+  }
+
   static create = createZodEnum;
 }
 

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -40,3 +40,15 @@ test("error params", () => {
     expect(result.error.issues[0].message).toEqual("REQUIRED");
   }
 });
+
+test("extract/exclude", () => {
+  const FoodEnum = z.enum(["Pasta", "Pizza", "Tacos", "Burgers", "Salad"]);
+  const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
+  const UnhealthyEnum = FoodEnum.exclude(["Salad"]);
+
+  util.assertEqual<z.infer<typeof ItalianEnum>, "Pasta" | "Pizza">(true);
+  util.assertEqual<
+    z.infer<typeof UnhealthyEnum>,
+    "Pasta" | "Pizza" | "Tacos" | "Burgers"
+  >(true);
+});

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -42,13 +42,18 @@ test("error params", () => {
 });
 
 test("extract/exclude", () => {
-  const FoodEnum = z.enum(["Pasta", "Pizza", "Tacos", "Burgers", "Salad"]);
+  const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
+  const FoodEnum = z.enum(foods);
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const UnhealthyEnum = FoodEnum.exclude(["Salad"]);
+  const EmptyFoodEnum = FoodEnum.exclude(foods);
 
   util.assertEqual<z.infer<typeof ItalianEnum>, "Pasta" | "Pizza">(true);
   util.assertEqual<
     z.infer<typeof UnhealthyEnum>,
     "Pasta" | "Pizza" | "Tacos" | "Burgers"
   >(true);
+  // @ts-expect-error TS2344
+  util.assertEqual<typeof EmptyFoodEnum, z.ZodEnum<[]>>(true);
+  util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3500,6 +3500,18 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
     return enumValues as any;
   }
 
+  extract<U extends T[number], _U extends readonly [U, ...U[]]>(values: _U) {
+    return ZodEnum.create(values);
+  }
+
+  exclude<U extends T[number]>(values: readonly [U, ...U[]]) {
+    return ZodEnum.create(
+      this.options.filter(
+        (opt) => !values.includes(opt as U)
+      ) as enumUtil.UnionToTupleString<Exclude<T[number], U>>
+    );
+  }
+
   static create = createZodEnum;
 }
 


### PR DESCRIPTION
This PR adds two methods to `ZodEnum`:

1. `extract`
2. `exclude`

Both work exactly like the TS utility types of the same name.

You call `.extract()` with values that exist in the enum, and it returns a new one with these values only. The same thing for `.exclude()` but it returns a new enum _without_ the values you passed in.

## Example

<img width="457" alt="Screenshot 2022-12-08 at 5 52 30 AM" src="https://user-images.githubusercontent.com/98408205/206401796-31301c95-8e84-4c1a-9b02-8d7754d193ec.png">