### PR TITLE
feat(#1582): Allow for passing enums or ZodNativeEnums to ZodObject and fix ZodRecord

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1261,7 +1261,7 @@ type MyUnion =
   | { status: "failed"; error: Error };
 ```
 
-Such unions can be represented with the `z.discriminatedUnion` method. This enables faster evaluation, because Zod can check the _discriminator key_ (`status` in the example above) ot determine which schema should be used to parse the input. This makes parsing more efficient and lets Zod provide report friendlier errors.
+Such unions can be represented with the `z.discriminatedUnion` method. This enables faster evaluation, because Zod can check the _discriminator key_ (`status` in the example above) to determine which schema should be used to parse the input. This makes parsing more efficient and lets Zod report friendlier errors.
 
 With the basic union method the input is tested against each of the provided "options", and in the case of invalidity, issues for all the "options" are shown in the zod error. On the other hand, the discriminated union allows for selecting just one of the "options", testing against it, and showing only the issues related to this "option".
 


### PR DESCRIPTION
# Closes #1582 

This PR makes it possible to pass an `enum` or an instance of a `ZodNativeEnum` to a `ZodObject` as its shape. Output/Input types are inferred correctly, and conversion logic to real `ZodRawShape` is working as expected.

Additionally, this PR also fixes `ZodRecord`. When passed an instance of `ZodNativeEnum` to its `keySchema`, it no longer wraps the inferred type inside a `Partial`.

## Important note

This is an initial solution. There are many others, like add a `required()` method to `z.record()` to get rid of the `Partial`, or add a `.mapValues()` method to `ZodNativeEnum` to allow for mapping the enum values against a zod schema, among others.

Please feel free to provide any feedback.

## Example from issue

```ts
import { z } from "./src";

enum Status {
  NotStarted = "not-started",
  InProgress = "in-progress",
  CompletedSuccesfully = "completed-succesfully",
  CompletedWithFailures = "completed-with-failures",
  Failed = "failed",
}

/**
 * Let's call this mapping `Step 1`
 */
type StatusReports = {
  [k in Status]: number;
};

/**
 * And this intersection, `Step 2`
 */
type StatusReport = StatusReports & {
  total: number;
};

const sr: StatusReport = {
  total: 5,
  [Status.NotStarted]: 1,
  [Status.InProgress]: 1,
  [Status.CompletedSuccesfully]: 1,
  [Status.CompletedWithFailures]: 1,
  [Status.Failed]: 1,
};

/**
 * Step 1
 */
const StatusReports = z.record(z.nativeEnum(Status), z.number());
type StatusReports_ = z.infer<typeof StatusReports>;
//   ^?
```

<img width="408" alt="Screenshot 2022-12-10 at 3 09 38 AM" src="https://user-images.githubusercontent.com/98408205/206835000-7cb4e30b-b058-44b3-bc78-c0131b6b7b18.png">

```ts
/**
 * Step 2
 */
const StatusReport = z.object(Status).extend({ total: z.number() });
type StatusReport_ = z.infer<typeof StatusReport>;
//   ^?
```

<img width="462" alt="Screenshot 2022-12-10 at 3 13 21 AM" src="https://user-images.githubusercontent.com/98408205/206835100-21301bba-4dd0-406b-8906-70af7a3db7e4.png">

