### PR TITLE
Add formik-validator-zod to README ecosystem links

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zod-formik-adapter`](https://github.com/robertLichtnow/zod-formik-adapter): A community-maintained Formik adapter for Zod.
 - [`react-zorm`](https://github.com/esamattis/react-zorm): Standalone `<form>` generation and validation for React using Zod.
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
+- [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 
 #### Zod to X
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -358,6 +358,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zod-formik-adapter`](https://github.com/robertLichtnow/zod-formik-adapter): A community-maintained Formik adapter for Zod.
 - [`react-zorm`](https://github.com/esamattis/react-zorm): Standalone `<form>` generation and validation for React using Zod.
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
+- [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 
 #### Zod to X
 


### PR DESCRIPTION
`formik-validator-zod` is a utility library that makes it much easier to use Zod in order to validate Formik form inputs.

It serves a similar purpose to `zod-formik-adapter` but has the added benefit of supporting a greater number of Zod features such as `z.enum`. [Ref](https://github.com/robertLichtnow/zod-formik-adapter/issues/2)