### PR TITLE
Only call .catch() method when parsing fails

### DIFF
--- a/deno/lib/__tests__/catch.test.ts
+++ b/deno/lib/__tests__/catch.test.ts
@@ -9,6 +9,12 @@ test("basic catch", () => {
   expect(z.string().catch("default").parse(undefined)).toBe("default");
 });
 
+test("catch fn does not run when parsing succeeds", () => {
+  const cb = jest.fn().mockReturnValue("x") as () => string;
+  expect(z.string().catch(cb).parse("test")).toBe("test");
+  expect(cb).not.toBeCalled();
+});
+
 test("basic catch async", async () => {
   const result = await z.string().catch("default").parseAsync(1243);
   expect(result).toBe("default");

--- a/deno/lib/__tests__/catch.test.ts
+++ b/deno/lib/__tests__/catch.test.ts
@@ -10,9 +10,13 @@ test("basic catch", () => {
 });
 
 test("catch fn does not run when parsing succeeds", () => {
-  const cb = jest.fn().mockReturnValue("x") as () => string;
+  let isCalled = false;
+  const cb = () => {
+    isCalled = true;
+    return "asdf";
+  };
   expect(z.string().catch(cb).parse("test")).toBe("test");
-  expect(cb).not.toBeCalled();
+  expect(isCalled).toEqual(false);
 });
 
 test("basic catch async", async () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4076,17 +4076,17 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
 
     if (isAsync(result)) {
       return result.then((result) => {
-        const defaultValue = this._def.defaultValue();
         return {
           status: "valid",
-          value: result.status === "valid" ? result.value : defaultValue,
+          value:
+            result.status === "valid" ? result.value : this._def.defaultValue(),
         };
       });
     } else {
-      const defaultValue = this._def.defaultValue();
       return {
         status: "valid",
-        value: result.status === "valid" ? result.value : defaultValue,
+        value:
+          result.status === "valid" ? result.value : this._def.defaultValue(),
       };
     }
   }

--- a/src/__tests__/catch.test.ts
+++ b/src/__tests__/catch.test.ts
@@ -1,5 +1,5 @@
 // @ts-ignore TS6133
-import { expect, jest, test } from "@jest/globals";
+import { expect, test } from "@jest/globals";
 
 import { z } from "..";
 import { util } from "../helpers/util";
@@ -9,9 +9,13 @@ test("basic catch", () => {
 });
 
 test("catch fn does not run when parsing succeeds", () => {
-  const cb = jest.fn().mockReturnValue("x") as () => string;
+  let isCalled = false;
+  const cb = () => {
+    isCalled = true;
+    return "asdf";
+  };
   expect(z.string().catch(cb).parse("test")).toBe("test");
-  expect(cb).not.toBeCalled();
+  expect(isCalled).toEqual(false);
 });
 
 test("basic catch async", async () => {

--- a/src/__tests__/catch.test.ts
+++ b/src/__tests__/catch.test.ts
@@ -1,11 +1,17 @@
 // @ts-ignore TS6133
-import { expect, test } from "@jest/globals";
+import { expect, jest, test } from "@jest/globals";
 
 import { z } from "..";
 import { util } from "../helpers/util";
 
 test("basic catch", () => {
   expect(z.string().catch("default").parse(undefined)).toBe("default");
+});
+
+test("catch fn does not run when parsing succeeds", () => {
+  const cb = jest.fn().mockReturnValue("x") as () => string;
+  expect(z.string().catch(cb).parse("test")).toBe("test");
+  expect(cb).not.toBeCalled();
 });
 
 test("basic catch async", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4076,17 +4076,17 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
 
     if (isAsync(result)) {
       return result.then((result) => {
-        const defaultValue = this._def.defaultValue();
         return {
           status: "valid",
-          value: result.status === "valid" ? result.value : defaultValue,
+          value:
+            result.status === "valid" ? result.value : this._def.defaultValue(),
         };
       });
     } else {
-      const defaultValue = this._def.defaultValue();
       return {
         status: "valid",
-        value: result.status === "valid" ? result.value : defaultValue,
+        value:
+          result.status === "valid" ? result.value : this._def.defaultValue(),
       };
     }
   }


### PR DESCRIPTION
- Fixes #1673