### PR TITLE
Issue 1677 Fixing ZodString::isDatetime.

### DIFF
--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -192,16 +192,19 @@ test("trim", () => {
 
 test("datetime", () => {
   const a = z.string().datetime({});
-  expect(a.isDatetime()).toEqual(true);
+  expect(a.isDatetime).toEqual(true);
 
   const b = z.string().datetime({ offset: true });
-  expect(b.isDatetime()).toEqual(true);
+  expect(b.isDatetime).toEqual(true);
 
   const c = z.string().datetime({ precision: 3 });
-  expect(c.isDatetime()).toEqual(true);
+  expect(c.isDatetime).toEqual(true);
 
   const d = z.string().datetime({ offset: true, precision: 0 });
-  expect(d.isDatetime()).toEqual(true);
+  expect(d.isDatetime).toEqual(true);
+
+  const { isDatetime } = z.string().datetime();
+  expect(isDatetime).toEqual(true);
 });
 
 test("datetime parsing", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -847,7 +847,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
       checks: [...this._def.checks, { kind: "trim" }],
     });
 
-  isDatetime() {
+  get isDatetime() {
     return !!this._def.checks.find((ch) => ch.kind === "datetime");
   }
 

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -191,16 +191,19 @@ test("trim", () => {
 
 test("datetime", () => {
   const a = z.string().datetime({});
-  expect(a.isDatetime()).toEqual(true);
+  expect(a.isDatetime).toEqual(true);
 
   const b = z.string().datetime({ offset: true });
-  expect(b.isDatetime()).toEqual(true);
+  expect(b.isDatetime).toEqual(true);
 
   const c = z.string().datetime({ precision: 3 });
-  expect(c.isDatetime()).toEqual(true);
+  expect(c.isDatetime).toEqual(true);
 
   const d = z.string().datetime({ offset: true, precision: 0 });
-  expect(d.isDatetime()).toEqual(true);
+  expect(d.isDatetime).toEqual(true);
+
+  const { isDatetime } = z.string().datetime();
+  expect(isDatetime).toEqual(true);
 });
 
 test("datetime parsing", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -847,7 +847,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
       checks: [...this._def.checks, { kind: "trim" }],
     });
 
-  isDatetime() {
+  get isDatetime() {
     return !!this._def.checks.find((ch) => ch.kind === "datetime");
   }
 


### PR DESCRIPTION
Closes #1677

Making `isDatetime` consistent with other getters of `ZodString`, fixing its binding.