### PR TITLE
Add Modular Forms to form integrations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 


### PR DESCRIPTION
Is it intended to add own projects to the ecosystem area? If no or the linking is not appropriate at this point, I understand if you close the PR.