### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1778,7 +1778,7 @@ type RefineParams = {
 };
 ```
 
-For advanced cases, the second argument can also be a function that returns `RefineParams`/
+For advanced cases, the second argument can also be a function that returns `RefineParams`.
 
 ```ts
 const longString = z.string().refine(

--- a/README.md
+++ b/README.md
@@ -1973,7 +1973,7 @@ The `.transform` method can simultaneously validate and transform the value. Thi
 As with `.superRefine`, the transform function receives a `ctx` object with a `addIssue` method that can be used to register validation issues.
 
 ```ts
-const Strings = z.string().transform((val, ctx) => {
+const numberInString = z.string().transform((val, ctx) => {
   const parsed = parseInt(val);
   if (isNaN(parsed)) {
     ctx.addIssue({

--- a/README.md
+++ b/README.md
@@ -1968,7 +1968,7 @@ emailToDomain.parse("colinhacks@example.com"); // => example.com
 
 #### Validating during transform
 
-The `.transform` method can simultaneously validate and transform the value. This is often simpler and less duplicative than chaining `refine` and `validate`.
+The `.transform` method can simultaneously validate and transform the value. This is often simpler and less duplicative than chaining `transform` and `refine`.
 
 As with `.superRefine`, the transform function receives a `ctx` object with a `addIssue` method that can be used to register validation issues.
 

--- a/README.md
+++ b/README.md
@@ -1690,7 +1690,7 @@ stringSchema.parse(12); // throws error
 If you use asynchronous [refinements](#refine) or [transforms](#transform) (more on those later), you'll need to use `.parseAsync`
 
 ```ts
-const stringSchema = z.string().refine(async (val) => val.length < 8);
+const stringSchema = z.string().refine(async (val) => val.length <= 8);
 
 await stringSchema.parseAsync("hello"); // => returns "hello"
 await stringSchema.parseAsync("hello world"); // => throws error

--- a/README.md
+++ b/README.md
@@ -1691,10 +1691,10 @@ If you use asynchronous [refinements](#refine) or [transforms](#transform) (more
 
 ```ts
 const stringSchema1 = z.string().refine(async (val) => val.length < 20);
-const value1 = await stringSchema.parseAsync("hello"); // => hello
+const value1 = await stringSchema1.parseAsync("hello"); // => hello
 
 const stringSchema2 = z.string().refine(async (val) => val.length > 20);
-const value2 = await stringSchema.parseAsync("hello"); // => throws
+const value2 = await stringSchema2.parseAsync("hello"); // => throws
 ```
 
 ### `.safeParse`

--- a/README.md
+++ b/README.md
@@ -1680,7 +1680,7 @@ Given any Zod schema, you can call its `.parse` method to check `data` is valid.
 const stringSchema = z.string();
 
 stringSchema.parse("fish"); // => returns "fish"
-stringSchema.parse(12); // throws Error('Non-string type: number');
+stringSchema.parse(12); // throws error
 ```
 
 ### `.parseAsync`
@@ -1692,8 +1692,8 @@ If you use asynchronous [refinements](#refine) or [transforms](#transform) (more
 ```ts
 const stringSchema = z.string().refine(async (val) => val.length < 8);
 
-await stringSchema.parseAsync("hello"); // => hello
-await stringSchema.parseAsync("hello world"); // => throws
+await stringSchema.parseAsync("hello"); // => returns "hello"
+await stringSchema.parseAsync("hello world"); // => throws error
 ```
 
 ### `.safeParse`

--- a/README.md
+++ b/README.md
@@ -1690,11 +1690,10 @@ stringSchema.parse(12); // throws Error('Non-string type: number');
 If you use asynchronous [refinements](#refine) or [transforms](#transform) (more on those later), you'll need to use `.parseAsync`
 
 ```ts
-const stringSchema1 = z.string().refine(async (val) => val.length < 20);
-const value1 = await stringSchema1.parseAsync("hello"); // => hello
+const stringSchema = z.string().refine(async (val) => val.length < 8);
 
-const stringSchema2 = z.string().refine(async (val) => val.length > 20);
-const value2 = await stringSchema2.parseAsync("hello"); // => throws
+await stringSchema.parseAsync("hello"); // => hello
+await stringSchema.parseAsync("hello world"); // => throws
 ```
 
 ### `.safeParse`


### PR DESCRIPTION
The original snippet created `stringSchema1` and `stringSchema2` variables but forgot to use the correct names after that.

This PR first fixes the names and realized that the example can be fixed by only using one `stringSchema` variable.