### PR TITLE
feat: Add `unwrapDeep` to `ZodOptional` and `ZodNullable`

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/__tests__/nullable.test.ts
+++ b/deno/lib/__tests__/nullable.test.ts
@@ -3,6 +3,7 @@ import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
 import * as z from "../index.ts";
+import { util } from "../index.ts";
 
 function checkErrors(a: z.ZodTypeAny, bad: any) {
   let expected;
@@ -40,4 +41,10 @@ test("Should have error messages appropriate for the underlying type", () => {
 test("unwrap", () => {
   const unwrapped = z.string().nullable().unwrap();
   expect(unwrapped).toBeInstanceOf(z.ZodString);
+});
+
+test("unwrapDeep", () => {
+  const unwrapped = z.string().nullable().nullable().nullable().unwrapDeep();
+  expect(unwrapped).toBeInstanceOf(z.ZodString);
+  util.assertEqual<z.infer<typeof unwrapped>, string>(true);
 });

--- a/deno/lib/__tests__/optional.test.ts
+++ b/deno/lib/__tests__/optional.test.ts
@@ -3,6 +3,7 @@ import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
 import * as z from "../index.ts";
+import { util } from "../index.ts";
 
 function checkErrors(a: z.ZodTypeAny, bad: any) {
   let expected;
@@ -40,4 +41,10 @@ test("Should have error messages appropriate for the underlying type", () => {
 test("unwrap", () => {
   const unwrapped = z.string().optional().unwrap();
   expect(unwrapped).toBeInstanceOf(z.ZodString);
+});
+
+test("unwrapDeep", () => {
+  const unwrapped = z.string().optional().optional().optional().unwrapDeep();
+  expect(unwrapped).toBeInstanceOf(z.ZodString);
+  util.assertEqual<z.infer<typeof unwrapped>, string>(true);
 });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3919,6 +3919,12 @@ export interface ZodOptionalDef<T extends ZodTypeAny = ZodTypeAny>
 
 export type ZodOptionalType<T extends ZodTypeAny> = ZodOptional<T>;
 
+export type UnwrapZodOptionalDeep<T extends ZodTypeAny> = T extends ZodOptional<
+  infer U
+>
+  ? UnwrapZodOptionalDeep<U>
+  : T;
+
 export class ZodOptional<T extends ZodTypeAny> extends ZodType<
   T["_output"] | undefined,
   ZodOptionalDef<T>,
@@ -3934,6 +3940,13 @@ export class ZodOptional<T extends ZodTypeAny> extends ZodType<
 
   unwrap() {
     return this._def.innerType;
+  }
+
+  unwrapDeep(): UnwrapZodOptionalDeep<T> {
+    const { innerType } = this._def;
+    return innerType instanceof ZodOptional
+      ? innerType.unwrapDeep()
+      : innerType;
   }
 
   static create = <T extends ZodTypeAny>(
@@ -3963,6 +3976,12 @@ export interface ZodNullableDef<T extends ZodTypeAny = ZodTypeAny>
 
 export type ZodNullableType<T extends ZodTypeAny> = ZodNullable<T>;
 
+export type UnwrapZodNullableDeep<T extends ZodTypeAny> = T extends ZodNullable<
+  infer U
+>
+  ? UnwrapZodNullableDeep<U>
+  : T;
+
 export class ZodNullable<T extends ZodTypeAny> extends ZodType<
   T["_output"] | null,
   ZodNullableDef<T>,
@@ -3978,6 +3997,13 @@ export class ZodNullable<T extends ZodTypeAny> extends ZodType<
 
   unwrap() {
     return this._def.innerType;
+  }
+
+  unwrapDeep(): UnwrapZodNullableDeep<T> {
+    const { innerType } = this._def;
+    return innerType instanceof ZodNullable
+      ? innerType.unwrapDeep()
+      : innerType;
   }
 
   static create = <T extends ZodTypeAny>(

--- a/src/__tests__/nullable.test.ts
+++ b/src/__tests__/nullable.test.ts
@@ -2,6 +2,7 @@
 import { expect, test } from "@jest/globals";
 
 import * as z from "../index";
+import { util } from "../index";
 
 function checkErrors(a: z.ZodTypeAny, bad: any) {
   let expected;
@@ -39,4 +40,10 @@ test("Should have error messages appropriate for the underlying type", () => {
 test("unwrap", () => {
   const unwrapped = z.string().nullable().unwrap();
   expect(unwrapped).toBeInstanceOf(z.ZodString);
+});
+
+test("unwrapDeep", () => {
+  const unwrapped = z.string().nullable().nullable().nullable().unwrapDeep();
+  expect(unwrapped).toBeInstanceOf(z.ZodString);
+  util.assertEqual<z.infer<typeof unwrapped>, string>(true);
 });

--- a/src/__tests__/optional.test.ts
+++ b/src/__tests__/optional.test.ts
@@ -2,6 +2,7 @@
 import { expect, test } from "@jest/globals";
 
 import * as z from "../index";
+import { util } from "../index";
 
 function checkErrors(a: z.ZodTypeAny, bad: any) {
   let expected;
@@ -39,4 +40,10 @@ test("Should have error messages appropriate for the underlying type", () => {
 test("unwrap", () => {
   const unwrapped = z.string().optional().unwrap();
   expect(unwrapped).toBeInstanceOf(z.ZodString);
+});
+
+test("unwrapDeep", () => {
+  const unwrapped = z.string().optional().optional().optional().unwrapDeep();
+  expect(unwrapped).toBeInstanceOf(z.ZodString);
+  util.assertEqual<z.infer<typeof unwrapped>, string>(true);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3919,6 +3919,12 @@ export interface ZodOptionalDef<T extends ZodTypeAny = ZodTypeAny>
 
 export type ZodOptionalType<T extends ZodTypeAny> = ZodOptional<T>;
 
+export type UnwrapZodOptionalDeep<T extends ZodTypeAny> = T extends ZodOptional<
+  infer U
+>
+  ? UnwrapZodOptionalDeep<U>
+  : T;
+
 export class ZodOptional<T extends ZodTypeAny> extends ZodType<
   T["_output"] | undefined,
   ZodOptionalDef<T>,
@@ -3934,6 +3940,13 @@ export class ZodOptional<T extends ZodTypeAny> extends ZodType<
 
   unwrap() {
     return this._def.innerType;
+  }
+
+  unwrapDeep(): UnwrapZodOptionalDeep<T> {
+    const { innerType } = this._def;
+    return innerType instanceof ZodOptional
+      ? innerType.unwrapDeep()
+      : innerType;
   }
 
   static create = <T extends ZodTypeAny>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -3976,6 +3976,12 @@ export interface ZodNullableDef<T extends ZodTypeAny = ZodTypeAny>
 
 export type ZodNullableType<T extends ZodTypeAny> = ZodNullable<T>;
 
+export type UnwrapZodNullableDeep<T extends ZodTypeAny> = T extends ZodNullable<
+  infer U
+>
+  ? UnwrapZodNullableDeep<U>
+  : T;
+
 export class ZodNullable<T extends ZodTypeAny> extends ZodType<
   T["_output"] | null,
   ZodNullableDef<T>,
@@ -3991,6 +3997,13 @@ export class ZodNullable<T extends ZodTypeAny> extends ZodType<
 
   unwrap() {
     return this._def.innerType;
+  }
+
+  unwrapDeep(): UnwrapZodNullableDeep<T> {
+    const { innerType } = this._def;
+    return innerType instanceof ZodNullable
+      ? innerType.unwrapDeep()
+      : innerType;
   }
 
   static create = <T extends ZodTypeAny>(


### PR DESCRIPTION
This PR adds the `unwrapDeep` method to both `ZodOptional`s and `ZodNullable`s, which recursively unwraps the schema in case of multiple calls to `.optional()` or `.nullable()`.

I understand that this will have more impact on the library itself than on the end users, for example, we can now use these methods:

1. on the `deepPartial` method of `ZodObject`; or
2. to possibly create a `deepPartial` on `ZodTuple`s in the future; or
3. to improve `ZodUnion` by unwrapping the unnecessarily chained optionals/nullables prior to parsing.

Anyway, it doesn't hurt to expose these methods too.