### PR TITLE
fix: [#1693] Tuple with empty items

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/__tests__/array.test.ts
+++ b/deno/lib/__tests__/array.test.ts
@@ -64,3 +64,9 @@ test("continue parsing despite array size error", () => {
     expect(result.error.issues.length).toEqual(2);
   }
 });
+
+test("parse should fail given sparse array", () => {
+  const schema = z.array(z.string()).nonempty().min(1).max(3);
+
+  expect(() => schema.parse(new Array(3))).toThrow();
+});

--- a/deno/lib/__tests__/tuple.test.ts
+++ b/deno/lib/__tests__/tuple.test.ts
@@ -89,11 +89,8 @@ test("tuple with rest schema", () => {
   util.assertEqual<t1, [string, number, ...boolean[]]>(true);
 });
 
-test("tuple with empty items", () => {
-  const inputTuple: any[] = [];
-  inputTuple[2] = ["blue"]; // create an array of length 3 with two first items being empty - typeof undefined
-
-  expect(() => testTuple.parse(inputTuple)).toThrow();
+test("parse should fail given sparse array as tuple", () => {
+  expect(() => testTuple.parse(new Array(3))).toThrow();
 });
 
 // test('tuple with optional elements', () => {

--- a/deno/lib/__tests__/tuple.test.ts
+++ b/deno/lib/__tests__/tuple.test.ts
@@ -89,6 +89,13 @@ test("tuple with rest schema", () => {
   util.assertEqual<t1, [string, number, ...boolean[]]>(true);
 });
 
+test("tuple with empty items", () => {
+  const inputTuple: any[] = [];
+  inputTuple[2] = ["blue"]; // create an array of length 3 with two first items being empty - typeof undefined
+
+  expect(() => testTuple.parse(inputTuple)).toThrow();
+});
+
 // test('tuple with optional elements', () => {
 //   const result = z
 //     .tuple([z.string(), z.number().optional()])

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2827,7 +2827,7 @@ export class ZodTuple<
       status.dirty();
     }
 
-    const items = (ctx.data as any[])
+    const items = ([...ctx.data] as any[])
       .map((item, itemIndex) => {
         const schema = this._def.items[itemIndex] || this._def.rest;
         if (!schema) return null as any as SyncParseReturnType<any>;

--- a/src/__tests__/array.test.ts
+++ b/src/__tests__/array.test.ts
@@ -63,3 +63,9 @@ test("continue parsing despite array size error", () => {
     expect(result.error.issues.length).toEqual(2);
   }
 });
+
+test("parse should fail given sparse array", () => {
+  const schema = z.array(z.string()).nonempty().min(1).max(3);
+
+  expect(() => schema.parse(new Array(3))).toThrow();
+});

--- a/src/__tests__/tuple.test.ts
+++ b/src/__tests__/tuple.test.ts
@@ -88,6 +88,13 @@ test("tuple with rest schema", () => {
   util.assertEqual<t1, [string, number, ...boolean[]]>(true);
 });
 
+test("tuple with empty items", () => {
+  const inputTuple: any[] = [];
+  inputTuple[2] = ["blue"]; // create an array of length 3 with two first items being empty - typeof undefined
+
+  expect(() => testTuple.parse(inputTuple)).toThrow();
+});
+
 // test('tuple with optional elements', () => {
 //   const result = z
 //     .tuple([z.string(), z.number().optional()])

--- a/src/__tests__/tuple.test.ts
+++ b/src/__tests__/tuple.test.ts
@@ -88,11 +88,8 @@ test("tuple with rest schema", () => {
   util.assertEqual<t1, [string, number, ...boolean[]]>(true);
 });
 
-test("tuple with empty items", () => {
-  const inputTuple: any[] = [];
-  inputTuple[2] = ["blue"]; // create an array of length 3 with two first items being empty - typeof undefined
-
-  expect(() => testTuple.parse(inputTuple)).toThrow();
+test("parse should fail given sparse array as tuple", () => {
+  expect(() => testTuple.parse(new Array(3))).toThrow();
 });
 
 // test('tuple with optional elements', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1689,7 +1689,7 @@ export class ZodArray<
 
     if (ctx.common.async) {
       return Promise.all(
-        (ctx.data as any[]).map((item, i) => {
+        ([...ctx.data] as any[]).map((item, i) => {
           return def.type._parseAsync(
             new ParseInputLazyPath(ctx, item, ctx.path, i)
           );
@@ -1699,7 +1699,7 @@ export class ZodArray<
       });
     }
 
-    const result = (ctx.data as any[]).map((item, i) => {
+    const result = ([...ctx.data] as any[]).map((item, i) => {
       return def.type._parseSync(
         new ParseInputLazyPath(ctx, item, ctx.path, i)
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -2827,7 +2827,7 @@ export class ZodTuple<
       status.dirty();
     }
 
-    const items = (ctx.data as any[])
+    const items = ([...ctx.data] as any[])
       .map((item, itemIndex) => {
         const schema = this._def.items[itemIndex] || this._def.rest;
         if (!schema) return null as any as SyncParseReturnType<any>;


### PR DESCRIPTION
`map()` as referenced in [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) is is invoked only for array indexes which have assigned values. It is not invoked for empty slots in sparse arrays. 


In some cases, these slots behave as `undefined` (that would be caught by existing implementation) but in others (e.g. array iteration methods), empty slots are skipped. More info [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#array_methods_and_empty_slots).


Destructing will result in usage of property enumeration instead of iterator which should fix this issue.  

Screenshot for reference.
<img width="351" alt="Screenshot 2022-12-17 at 00 19 40" src="https://user-images.githubusercontent.com/21112021/208204131-59684de9-d423-4c13-aee5-3da6c05c37d8.png">

Fixes both: `ZodTuple` and `ZodArray`. 
Reported in #1693 