### PR TITLE
Discriminated union example fails to parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,7 +1292,7 @@ const myUnion = z.discriminatedUnion("status", [
   z.object({ status: z.literal("failed"), error: z.instanceof(Error) }),
 ]);
 
-myUnion.parse({ type: "success", data: "yippie ki yay" });
+myUnion.parse({ status: "success", data: "yippie ki yay" });
 ```
 
 ## Records


### PR DESCRIPTION
https://zod.dev/?id=discriminated-unions

``` typescript
…
myUnion.parse({ type: "success", data: "yippie ki yay" });
```
→ :x:
``` json
{
	"ZodError": [{
		"code": "invalid_union_discriminator",
		"options": [
			"success",
			"failed"
		],
		"path": [
			"status"
		],
		"message": "Invalid discriminator value. Expected 'success' | 'failed'"
	}]
}
```
… because the key we want is `status`, not `type`.

Fix:
``` typescript
myUnion.parse({ status: "success", data: "yippie ki yay" });
```
→ :white_check_mark: