### PR TITLE
add `ZodNumber.isFinite`, make `ZodNumber.isInt` true if `.multipleOf(int)`.

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/__tests__/number.test.ts
+++ b/deno/lib/__tests__/number.test.ts
@@ -6,10 +6,17 @@ import * as z from "../index.ts";
 
 const gtFive = z.number().gt(5);
 const gteFive = z.number().gte(5);
+const minFive = z.number().min(5);
 const ltFive = z.number().lt(5);
 const lteFive = z.number().lte(5);
+const maxFive = z.number().max(5);
 const intNum = z.number().int();
+const positive = z.number().positive();
+const negative = z.number().negative();
+const nonpositive = z.number().nonpositive();
+const nonnegative = z.number().nonnegative();
 const multipleOfFive = z.number().multipleOf(5);
+const multipleOfNegativeFive = z.number().multipleOf(-5);
 const finite = z.number().finite();
 const stepPointOne = z.number().step(0.1);
 const stepPointZeroZeroZeroOne = z.number().step(0.0001);
@@ -24,11 +31,32 @@ test("passing validations", () => {
   z.number().parse(Infinity);
   z.number().parse(-Infinity);
   gtFive.parse(6);
+  gtFive.parse(Infinity);
   gteFive.parse(5);
+  gteFive.parse(Infinity);
+  minFive.parse(5);
+  minFive.parse(Infinity);
   ltFive.parse(4);
+  ltFive.parse(-Infinity);
   lteFive.parse(5);
+  lteFive.parse(-Infinity);
+  maxFive.parse(5);
+  maxFive.parse(-Infinity);
   intNum.parse(4);
+  positive.parse(1);
+  positive.parse(Infinity);
+  negative.parse(-1);
+  negative.parse(-Infinity);
+  nonpositive.parse(0);
+  nonpositive.parse(-1);
+  nonpositive.parse(-Infinity);
+  nonnegative.parse(0);
+  nonnegative.parse(1);
+  nonnegative.parse(Infinity);
   multipleOfFive.parse(15);
+  multipleOfFive.parse(-15);
+  multipleOfNegativeFive.parse(-15);
+  multipleOfNegativeFive.parse(15);
   finite.parse(123);
   stepPointOne.parse(6);
   stepPointOne.parse(6.1);
@@ -40,10 +68,21 @@ test("passing validations", () => {
 test("failing validations", () => {
   expect(() => ltFive.parse(5)).toThrow();
   expect(() => lteFive.parse(6)).toThrow();
+  expect(() => maxFive.parse(6)).toThrow();
   expect(() => gtFive.parse(5)).toThrow();
   expect(() => gteFive.parse(4)).toThrow();
+  expect(() => minFive.parse(4)).toThrow();
   expect(() => intNum.parse(3.14)).toThrow();
-  expect(() => multipleOfFive.parse(14.9)).toThrow();
+  expect(() => positive.parse(0)).toThrow();
+  expect(() => positive.parse(-1)).toThrow();
+  expect(() => negative.parse(0)).toThrow();
+  expect(() => negative.parse(1)).toThrow();
+  expect(() => nonpositive.parse(1)).toThrow();
+  expect(() => nonnegative.parse(-1)).toThrow();
+  expect(() => multipleOfFive.parse(7.5)).toThrow();
+  expect(() => multipleOfFive.parse(-7.5)).toThrow();
+  expect(() => multipleOfNegativeFive.parse(-7.5)).toThrow();
+  expect(() => multipleOfNegativeFive.parse(7.5)).toThrow();
   expect(() => finite.parse(Infinity)).toThrow();
   expect(() => finite.parse(-Infinity)).toThrow();
 
@@ -57,12 +96,73 @@ test("parse NaN", () => {
 });
 
 test("min max getters", () => {
-  expect(z.number().int().isInt).toEqual(true);
+  expect(z.number().minValue).toBeNull;
+  expect(ltFive.minValue).toBeNull;
+  expect(lteFive.minValue).toBeNull;
+  expect(maxFive.minValue).toBeNull;
+  expect(negative.minValue).toBeNull;
+  expect(nonpositive.minValue).toBeNull;
+  expect(intNum.minValue).toBeNull;
+  expect(multipleOfFive.minValue).toBeNull;
+  expect(finite.minValue).toBeNull;
+  expect(gtFive.minValue).toEqual(5);
+  expect(gteFive.minValue).toEqual(5);
+  expect(minFive.minValue).toEqual(5);
+  expect(minFive.min(10).minValue).toEqual(10);
+  expect(positive.minValue).toEqual(0);
+  expect(nonnegative.minValue).toEqual(0);
+
+  expect(z.number().maxValue).toBeNull;
+  expect(gtFive.maxValue).toBeNull;
+  expect(gteFive.maxValue).toBeNull;
+  expect(minFive.maxValue).toBeNull;
+  expect(positive.maxValue).toBeNull;
+  expect(nonnegative.maxValue).toBeNull;
+  expect(intNum.minValue).toBeNull;
+  expect(multipleOfFive.minValue).toBeNull;
+  expect(finite.minValue).toBeNull;
+  expect(ltFive.maxValue).toEqual(5);
+  expect(lteFive.maxValue).toEqual(5);
+  expect(maxFive.maxValue).toEqual(5);
+  expect(maxFive.max(1).maxValue).toEqual(1);
+  expect(negative.maxValue).toEqual(0);
+  expect(nonpositive.maxValue).toEqual(0);
+});
+
+test("int getter", () => {
   expect(z.number().isInt).toEqual(false);
+  expect(z.number().multipleOf(1.5).isInt).toEqual(false);
+  expect(gtFive.isInt).toEqual(false);
+  expect(gteFive.isInt).toEqual(false);
+  expect(minFive.isInt).toEqual(false);
+  expect(positive.isInt).toEqual(false);
+  expect(nonnegative.isInt).toEqual(false);
+  expect(finite.isInt).toEqual(false);
+  expect(ltFive.isInt).toEqual(false);
+  expect(lteFive.isInt).toEqual(false);
+  expect(maxFive.isInt).toEqual(false);
+  expect(negative.isInt).toEqual(false);
+  expect(nonpositive.isInt).toEqual(false);
 
-  expect(z.number().min(5).minValue).toEqual(5);
-  expect(z.number().min(5).min(10).minValue).toEqual(10);
+  expect(intNum.isInt).toEqual(true);
+  expect(multipleOfFive.isInt).toEqual(true);
+});
 
-  expect(z.number().max(5).maxValue).toEqual(5);
-  expect(z.number().max(5).max(1).maxValue).toEqual(1);
+test("finite getter", () => {
+  expect(z.number().isFinite).toEqual(false);
+  expect(gtFive.isFinite).toEqual(false);
+  expect(gteFive.isFinite).toEqual(false);
+  expect(minFive.isFinite).toEqual(false);
+  expect(positive.isFinite).toEqual(false);
+  expect(nonnegative.isFinite).toEqual(false);
+  expect(ltFive.isFinite).toEqual(false);
+  expect(lteFive.isFinite).toEqual(false);
+  expect(maxFive.isFinite).toEqual(false);
+  expect(negative.isFinite).toEqual(false);
+  expect(nonpositive.isFinite).toEqual(false);
+
+  expect(finite.isFinite).toEqual(true);
+  expect(intNum.isFinite).toEqual(true);
+  expect(multipleOfFive.isFinite).toEqual(true);
+  expect(z.number().min(5).max(10).isFinite).toEqual(true);
 });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1150,7 +1150,30 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
   }
 
   get isInt() {
-    return !!this._def.checks.find((ch) => ch.kind === "int");
+    return !!this._def.checks.find(
+      (ch) =>
+        ch.kind === "int" ||
+        (ch.kind === "multipleOf" && util.isInteger(ch.value))
+    );
+  }
+
+  get isFinite() {
+    let max: number | null = null,
+      min: number | null = null;
+    for (const ch of this._def.checks) {
+      if (
+        ch.kind === "finite" ||
+        ch.kind === "int" ||
+        ch.kind === "multipleOf"
+      ) {
+        return true;
+      } else if (ch.kind === "min") {
+        if (min === null || ch.value > min) min = ch.value;
+      } else if (ch.kind === "max") {
+        if (max === null || ch.value < max) max = ch.value;
+      }
+    }
+    return Number.isFinite(min) && Number.isFinite(max);
   }
 }
 

--- a/src/__tests__/number.test.ts
+++ b/src/__tests__/number.test.ts
@@ -5,10 +5,17 @@ import * as z from "../index";
 
 const gtFive = z.number().gt(5);
 const gteFive = z.number().gte(5);
+const minFive = z.number().min(5);
 const ltFive = z.number().lt(5);
 const lteFive = z.number().lte(5);
+const maxFive = z.number().max(5);
 const intNum = z.number().int();
+const positive = z.number().positive();
+const negative = z.number().negative();
+const nonpositive = z.number().nonpositive();
+const nonnegative = z.number().nonnegative();
 const multipleOfFive = z.number().multipleOf(5);
+const multipleOfNegativeFive = z.number().multipleOf(-5);
 const finite = z.number().finite();
 const stepPointOne = z.number().step(0.1);
 const stepPointZeroZeroZeroOne = z.number().step(0.0001);
@@ -23,11 +30,32 @@ test("passing validations", () => {
   z.number().parse(Infinity);
   z.number().parse(-Infinity);
   gtFive.parse(6);
+  gtFive.parse(Infinity);
   gteFive.parse(5);
+  gteFive.parse(Infinity);
+  minFive.parse(5);
+  minFive.parse(Infinity);
   ltFive.parse(4);
+  ltFive.parse(-Infinity);
   lteFive.parse(5);
+  lteFive.parse(-Infinity);
+  maxFive.parse(5);
+  maxFive.parse(-Infinity);
   intNum.parse(4);
+  positive.parse(1);
+  positive.parse(Infinity);
+  negative.parse(-1);
+  negative.parse(-Infinity);
+  nonpositive.parse(0);
+  nonpositive.parse(-1);
+  nonpositive.parse(-Infinity);
+  nonnegative.parse(0);
+  nonnegative.parse(1);
+  nonnegative.parse(Infinity);
   multipleOfFive.parse(15);
+  multipleOfFive.parse(-15);
+  multipleOfNegativeFive.parse(-15);
+  multipleOfNegativeFive.parse(15);
   finite.parse(123);
   stepPointOne.parse(6);
   stepPointOne.parse(6.1);
@@ -39,10 +67,21 @@ test("passing validations", () => {
 test("failing validations", () => {
   expect(() => ltFive.parse(5)).toThrow();
   expect(() => lteFive.parse(6)).toThrow();
+  expect(() => maxFive.parse(6)).toThrow();
   expect(() => gtFive.parse(5)).toThrow();
   expect(() => gteFive.parse(4)).toThrow();
+  expect(() => minFive.parse(4)).toThrow();
   expect(() => intNum.parse(3.14)).toThrow();
-  expect(() => multipleOfFive.parse(14.9)).toThrow();
+  expect(() => positive.parse(0)).toThrow();
+  expect(() => positive.parse(-1)).toThrow();
+  expect(() => negative.parse(0)).toThrow();
+  expect(() => negative.parse(1)).toThrow();
+  expect(() => nonpositive.parse(1)).toThrow();
+  expect(() => nonnegative.parse(-1)).toThrow();
+  expect(() => multipleOfFive.parse(7.5)).toThrow();
+  expect(() => multipleOfFive.parse(-7.5)).toThrow();
+  expect(() => multipleOfNegativeFive.parse(-7.5)).toThrow();
+  expect(() => multipleOfNegativeFive.parse(7.5)).toThrow();
   expect(() => finite.parse(Infinity)).toThrow();
   expect(() => finite.parse(-Infinity)).toThrow();
 
@@ -56,12 +95,73 @@ test("parse NaN", () => {
 });
 
 test("min max getters", () => {
-  expect(z.number().int().isInt).toEqual(true);
+  expect(z.number().minValue).toBeNull;
+  expect(ltFive.minValue).toBeNull;
+  expect(lteFive.minValue).toBeNull;
+  expect(maxFive.minValue).toBeNull;
+  expect(negative.minValue).toBeNull;
+  expect(nonpositive.minValue).toBeNull;
+  expect(intNum.minValue).toBeNull;
+  expect(multipleOfFive.minValue).toBeNull;
+  expect(finite.minValue).toBeNull;
+  expect(gtFive.minValue).toEqual(5);
+  expect(gteFive.minValue).toEqual(5);
+  expect(minFive.minValue).toEqual(5);
+  expect(minFive.min(10).minValue).toEqual(10);
+  expect(positive.minValue).toEqual(0);
+  expect(nonnegative.minValue).toEqual(0);
+
+  expect(z.number().maxValue).toBeNull;
+  expect(gtFive.maxValue).toBeNull;
+  expect(gteFive.maxValue).toBeNull;
+  expect(minFive.maxValue).toBeNull;
+  expect(positive.maxValue).toBeNull;
+  expect(nonnegative.maxValue).toBeNull;
+  expect(intNum.minValue).toBeNull;
+  expect(multipleOfFive.minValue).toBeNull;
+  expect(finite.minValue).toBeNull;
+  expect(ltFive.maxValue).toEqual(5);
+  expect(lteFive.maxValue).toEqual(5);
+  expect(maxFive.maxValue).toEqual(5);
+  expect(maxFive.max(1).maxValue).toEqual(1);
+  expect(negative.maxValue).toEqual(0);
+  expect(nonpositive.maxValue).toEqual(0);
+});
+
+test("int getter", () => {
   expect(z.number().isInt).toEqual(false);
+  expect(z.number().multipleOf(1.5).isInt).toEqual(false);
+  expect(gtFive.isInt).toEqual(false);
+  expect(gteFive.isInt).toEqual(false);
+  expect(minFive.isInt).toEqual(false);
+  expect(positive.isInt).toEqual(false);
+  expect(nonnegative.isInt).toEqual(false);
+  expect(finite.isInt).toEqual(false);
+  expect(ltFive.isInt).toEqual(false);
+  expect(lteFive.isInt).toEqual(false);
+  expect(maxFive.isInt).toEqual(false);
+  expect(negative.isInt).toEqual(false);
+  expect(nonpositive.isInt).toEqual(false);
 
-  expect(z.number().min(5).minValue).toEqual(5);
-  expect(z.number().min(5).min(10).minValue).toEqual(10);
+  expect(intNum.isInt).toEqual(true);
+  expect(multipleOfFive.isInt).toEqual(true);
+});
 
-  expect(z.number().max(5).maxValue).toEqual(5);
-  expect(z.number().max(5).max(1).maxValue).toEqual(1);
+test("finite getter", () => {
+  expect(z.number().isFinite).toEqual(false);
+  expect(gtFive.isFinite).toEqual(false);
+  expect(gteFive.isFinite).toEqual(false);
+  expect(minFive.isFinite).toEqual(false);
+  expect(positive.isFinite).toEqual(false);
+  expect(nonnegative.isFinite).toEqual(false);
+  expect(ltFive.isFinite).toEqual(false);
+  expect(lteFive.isFinite).toEqual(false);
+  expect(maxFive.isFinite).toEqual(false);
+  expect(negative.isFinite).toEqual(false);
+  expect(nonpositive.isFinite).toEqual(false);
+
+  expect(finite.isFinite).toEqual(true);
+  expect(intNum.isFinite).toEqual(true);
+  expect(multipleOfFive.isFinite).toEqual(true);
+  expect(z.number().min(5).max(10).isFinite).toEqual(true);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1150,7 +1150,30 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
   }
 
   get isInt() {
-    return !!this._def.checks.find((ch) => ch.kind === "int");
+    return !!this._def.checks.find(
+      (ch) =>
+        ch.kind === "int" ||
+        (ch.kind === "multipleOf" && util.isInteger(ch.value))
+    );
+  }
+
+  get isFinite() {
+    let max: number | null = null,
+      min: number | null = null;
+    for (const ch of this._def.checks) {
+      if (
+        ch.kind === "finite" ||
+        ch.kind === "int" ||
+        ch.kind === "multipleOf"
+      ) {
+        return true;
+      } else if (ch.kind === "min") {
+        if (min === null || ch.value > min) min = ch.value;
+      } else if (ch.kind === "max") {
+        if (max === null || ch.value < max) max = ch.value;
+      }
+    }
+    return Number.isFinite(min) && Number.isFinite(max);
   }
 }
 


### PR DESCRIPTION
Hey 👋 

- Forgot to add `.isFinite` @ #1546.

- A multiple of an integer is an integer, so let's make `.isInt` truthy in that case. This might allow people to ditch `.int()` if all they need is `.multipleOf(int)` but had something that uses `isInt`.