### PR TITLE
Improve accuracy of the `isAsync` type guard

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -175,4 +175,4 @@ export const isValid = <T>(x: ParseReturnType<T>): x is OK<T> | DIRTY<T> =>
 export const isAsync = <T>(
   x: ParseReturnType<T>
 ): x is AsyncParseReturnType<T> =>
-  typeof Promise !== undefined && x instanceof Promise;
+  typeof Promise !== "undefined" && x instanceof Promise;

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -175,4 +175,4 @@ export const isValid = <T>(x: ParseReturnType<T>): x is OK<T> | DIRTY<T> =>
 export const isAsync = <T>(
   x: ParseReturnType<T>
 ): x is AsyncParseReturnType<T> =>
-  typeof Promise !== undefined && x instanceof Promise;
+  typeof Promise !== "undefined" && x instanceof Promise;


### PR DESCRIPTION
This PR updates the `isAsync` type guard to check the `typeof Promise` result against a string literal instead of the `undefined` data type. This change should improve the accuracy and reliability of the function when determining if a value is a Promise.