### PR TITLE
Fix small typo in ERROR_HANDLING.md

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -200,7 +200,7 @@ This message is then passed as `ctx.defaultError` into `overrideErrorMap`. This 
 
 ```ts
 const myErrorMap: z.ZodErrorMap = /* ... */;
-z.setErrorMap(errorMap);
+z.setErrorMap(myErrorMap);
 ```
 
 ### Schema-bound error map

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 


### PR DESCRIPTION
- `errorMap` → `myErrorMap`