### PR TITLE
Support type inference for `ZodString` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ z.string().cuid();
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
+z.string().includes(string);
 z.string().trim(); // trim whitespace
 z.string().datetime(); // defaults to UTC, see below for options
 ```
@@ -562,6 +563,7 @@ z.string().url({ message: "Invalid url" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
+z.string().includes("token=", { message: "query parameter 'token' must be provided!" });
 z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
 ```
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 
@@ -535,6 +536,7 @@ z.string().cuid();
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
+z.string().includes(string);
 z.string().trim(); // trim whitespace
 z.string().datetime(); // defaults to UTC, see below for options
 ```
@@ -561,6 +563,7 @@ z.string().url({ message: "Invalid url" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
+z.string().includes("token=", { message: "query parameter 'token' must be provided!" });
 z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
 ```
 

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -10,6 +10,7 @@ const justFive = z.string().length(5);
 const nonempty = z.string().nonempty("nonempty");
 const startsWith = z.string().startsWith("startsWith");
 const endsWith = z.string().endsWith("endsWith");
+const includes = z.string().includes("includes");
 
 test("passing validations", () => {
   minFive.parse("12345");
@@ -20,6 +21,7 @@ test("passing validations", () => {
   justFive.parse("12345");
   startsWith.parse("startsWithX");
   endsWith.parse("XendsWith");
+  includes.parse("aincludesb");
 });
 
 test("failing validations", () => {

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -9,6 +9,7 @@ const justFive = z.string().length(5);
 const nonempty = z.string().nonempty("nonempty");
 const startsWith = z.string().startsWith("startsWith");
 const endsWith = z.string().endsWith("endsWith");
+const includes = z.string().includes("includes");
 
 test("passing validations", () => {
   minFive.parse("12345");
@@ -19,6 +20,7 @@ test("passing validations", () => {
   justFive.parse("12345");
   startsWith.parse("startsWithX");
   endsWith.parse("XendsWith");
+  includes.parse("aincludesb");
 });
 
 test("failing validations", () => {


### PR DESCRIPTION
We could use Typescript template literal to narrow the type provided by `z.infer<T>`. This is especially useful when working with discriminated unions where part of the discriminator is dynamic. For example, the type should be ``​`Hello${string}world!` | undefined`` instead of `string | undefined`: 

```ts
 const zstr = z.string()
  .startsWith("Hello")
  .endsWith("world!")
  .optional();

type ZStr = z.infer<typeof zstr>; // `Hello${string}world!` | undefined

// Scenario 1: Works fine
const data: ZStr = "Hello world!"; 
zstr.parse(data);

// Scenario 2:
const data: ZStr = "I don't follow rules!"; // ts(2322): Type '"I don't follow rules!"' is not assignable to type '`Hello${string}world!`
zstr.parse(data); // Error
 ```

Here is an example of discriminated unions: 
```ts
const ZCat = z.object({
    discrimiator: z.string().startsWith("cat"),
    claws: z.array(z.string().uuid()),
})
const ZBird = z.object({
    discrimiator: z.string().startsWith("bird"),
    wings: z.array(z.string().uuid()),
});

const ZAnimal = z.union([ZCat, ZBird]);
type Animal = z.infer<typeof ZAnimal>;
const catWithWings: Animal = {
    discrimiator: "cat/abyssinian",
    // Oh no! Typescript think our cat have wings is valid!
    wings: [faker.datatype.uuid()]
};

// Zod will catch the error
ZAnimal.parse(catWithWings) 
```

Here's an example after these changes:
```ts
// ... zod definitions above
type Animal = z.infer<typeof ZAnimal>;
const catWithWings: Animal = {
    discrimiator: "cat/abyssinian",
    // ts(2232): Type '{ discrimiator: "cat/abyssinian"; wings: string[]; }' is not assignable to type
    // '{ discrimiator: `cat${string}`; claws: string[]; } | { discrimiator: `bird${string}`; wings: string[]; }'.
    wings: [faker.datatype.uuid()],
};
```

While we are at it, I think it is beneficial to implement a method that checks for a substring. I will call it `includes` for now for its similarity with Javascript standard library. 