### PR TITLE
fix: Fix `ZodCatch`

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/__tests__/catch.test.ts
+++ b/deno/lib/__tests__/catch.test.ts
@@ -48,7 +48,7 @@ test("catch with transform", () => {
   );
 
   type inp = z.input<typeof stringWithDefault>;
-  util.assertEqual<inp, string | undefined>(true);
+  util.assertEqual<inp, string>(true);
   type out = z.output<typeof stringWithDefault>;
   util.assertEqual<out, string>(true);
 });
@@ -66,7 +66,7 @@ test("catch on existing optional", () => {
   type inp = z.input<typeof stringWithDefault>;
   util.assertEqual<inp, string | undefined>(true);
   type out = z.output<typeof stringWithDefault>;
-  util.assertEqual<out, string>(true);
+  util.assertEqual<out, string | undefined>(true);
 });
 
 test("optional on catch", () => {
@@ -85,7 +85,7 @@ test("complex chain example", () => {
     .transform((val) => val + "!")
     .transform((val) => val.toUpperCase())
     .catch("qwer")
-    .removeDefault()
+    .removeCatch()
     .optional()
     .catch("asdfasdf");
 
@@ -94,8 +94,8 @@ test("complex chain example", () => {
   expect(complex.parse(true)).toBe("ASDF!");
 });
 
-test("removeDefault", () => {
-  const stringWithRemovedDefault = z.string().catch("asdf").removeDefault();
+test("removeCatch", () => {
+  const stringWithRemovedDefault = z.string().catch("asdf").removeCatch();
 
   type out = z.output<typeof stringWithRemovedDefault>;
   util.assertEqual<out, string>(true);
@@ -107,7 +107,7 @@ test("nested", () => {
     inner: "asdf",
   });
   type input = z.input<typeof outer>;
-  util.assertEqual<input, { inner?: string | undefined } | undefined>(true);
+  util.assertEqual<input, { inner: string }>(true);
   type out = z.output<typeof outer>;
   util.assertEqual<out, { inner: string }>(true);
   expect(outer.parse(undefined)).toEqual({ inner: "asdf" });
@@ -125,7 +125,7 @@ test("chained catch", () => {
 
 test("factory", () => {
   z.ZodCatch.create(z.string(), {
-    default: "asdf",
+    catch: "asdf",
   }).parse(undefined);
 });
 

--- a/src/__tests__/catch.test.ts
+++ b/src/__tests__/catch.test.ts
@@ -47,7 +47,7 @@ test("catch with transform", () => {
   );
 
   type inp = z.input<typeof stringWithDefault>;
-  util.assertEqual<inp, string | undefined>(true);
+  util.assertEqual<inp, string>(true);
   type out = z.output<typeof stringWithDefault>;
   util.assertEqual<out, string>(true);
 });
@@ -65,7 +65,7 @@ test("catch on existing optional", () => {
   type inp = z.input<typeof stringWithDefault>;
   util.assertEqual<inp, string | undefined>(true);
   type out = z.output<typeof stringWithDefault>;
-  util.assertEqual<out, string>(true);
+  util.assertEqual<out, string | undefined>(true);
 });
 
 test("optional on catch", () => {
@@ -84,7 +84,7 @@ test("complex chain example", () => {
     .transform((val) => val + "!")
     .transform((val) => val.toUpperCase())
     .catch("qwer")
-    .removeDefault()
+    .removeCatch()
     .optional()
     .catch("asdfasdf");
 
@@ -93,8 +93,8 @@ test("complex chain example", () => {
   expect(complex.parse(true)).toBe("ASDF!");
 });
 
-test("removeDefault", () => {
-  const stringWithRemovedDefault = z.string().catch("asdf").removeDefault();
+test("removeCatch", () => {
+  const stringWithRemovedDefault = z.string().catch("asdf").removeCatch();
 
   type out = z.output<typeof stringWithRemovedDefault>;
   util.assertEqual<out, string>(true);
@@ -106,7 +106,7 @@ test("nested", () => {
     inner: "asdf",
   });
   type input = z.input<typeof outer>;
-  util.assertEqual<input, { inner?: string | undefined } | undefined>(true);
+  util.assertEqual<input, { inner: string }>(true);
   type out = z.output<typeof outer>;
   util.assertEqual<out, { inner: string }>(true);
   expect(outer.parse(undefined)).toEqual({ inner: "asdf" });

--- a/src/__tests__/catch.test.ts
+++ b/src/__tests__/catch.test.ts
@@ -124,7 +124,7 @@ test("chained catch", () => {
 
 test("factory", () => {
   z.ZodCatch.create(z.string(), {
-    default: "asdf",
+    catch: "asdf",
   }).parse(undefined);
 });
 


### PR DESCRIPTION
This PR fixes `ZodCatch`.

It looks like `ZodCatch` was a product of a quick copy-paste from `ZodDefault`, which introduced some bugs to it.

1. The `output` of a `ZodCatch` was previously defined as `util.noUndefined<T["_output"]>` (from `ZodDefault`) when it should actually be `T["_output"] | <<catch value>>`.
2. The `input` of a `ZodCatch` was previously defined as `T["_input"] | undefined` (also from `ZodDefault`) when it should actually be the `T["_input"]` unchanged.
3. Renamed props and methods from `default` to `catch`.