### PR TITLE
feat: Add extra coercions

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/__tests__/anyunknown.test.ts
+++ b/deno/lib/__tests__/anyunknown.test.ts
@@ -22,7 +22,7 @@ test("check unknown inference", () => {
 });
 
 test("check never inference", () => {
-  const t1 = z.never().nullish();
+  const t1 = z.never();
   expect(() => t1.parse(undefined)).toThrow();
   expect(() => t1.parse("asdf")).toThrow();
   expect(() => t1.parse(null)).toThrow();

--- a/deno/lib/__tests__/anyunknown.test.ts
+++ b/deno/lib/__tests__/anyunknown.test.ts
@@ -22,7 +22,7 @@ test("check unknown inference", () => {
 });
 
 test("check never inference", () => {
-  const t1 = z.never();
+  const t1 = z.never().nullish();
   expect(() => t1.parse(undefined)).toThrow();
   expect(() => t1.parse("asdf")).toThrow();
   expect(() => t1.parse(null)).toThrow();

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1838,6 +1838,7 @@ export interface ZodObjectDef<
   shape: () => T;
   catchall: Catchall;
   unknownKeys: UnknownKeys;
+  coerce: boolean;
 }
 
 export type baseObjectOutputType<Shape extends ZodRawShape> =
@@ -1929,6 +1930,10 @@ export class ZodObject<
   }
 
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
+    if (this._def.coerce && input.data instanceof Map) {
+      input.data = Object.fromEntries(input.data);
+    }
+
     const parsedType = this._getType(input);
     if (parsedType !== ZodParsedType.object) {
       const ctx = this._getOrReturnCtx(input);
@@ -2115,6 +2120,7 @@ export class ZodObject<
       shape: () =>
         objectUtil.mergeShapes(this._def.shape(), merging._def.shape()),
       typeName: ZodFirstPartyTypeKind.ZodObject,
+      coerce: merging._def.coerce,
     }) as any;
     return merged;
   }
@@ -2256,39 +2262,42 @@ export class ZodObject<
 
   static create = <T extends ZodRawShape>(
     shape: T,
-    params?: RawCreateParams
+    params?: RawCreateParams & { coerce?: boolean }
   ): ZodObject<T> => {
     return new ZodObject({
       shape: () => shape,
       unknownKeys: "strip",
       catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
+      coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     }) as any;
   };
 
   static strictCreate = <T extends ZodRawShape>(
     shape: T,
-    params?: RawCreateParams
+    params?: RawCreateParams & { coerce?: boolean }
   ): ZodObject<T, "strict"> => {
     return new ZodObject({
       shape: () => shape,
       unknownKeys: "strict",
       catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
+      coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     }) as any;
   };
 
   static lazycreate = <T extends ZodRawShape>(
     shape: () => T,
-    params?: RawCreateParams
+    params?: RawCreateParams & { coerce?: boolean }
   ): ZodObject<T> => {
     return new ZodObject({
       shape,
       unknownKeys: "strip",
       catchall: ZodNever.create(),
       typeName: ZodFirstPartyTypeKind.ZodObject,
+      coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     }) as any;
   };
@@ -4443,16 +4452,31 @@ export const coerce = {
     ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
   date: ((arg) =>
     ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
-  array: ((arg) =>
-    ZodArray.create({ ...arg, coerce: true })) as typeof ZodArray["create"],
-  set: ((arg) =>
-    ZodSet.create({ ...arg, coerce: true })) as typeof ZodSet["create"],
-  map: ((arg) =>
-    ZodMap.create({ ...arg, coerce: true })) as typeof ZodMap["create"],
-  object: ((arg) =>
-    ZodObject.create({ ...arg, coerce: true })) as typeof ZodObject["create"],
-  tuple: ((arg) =>
-    ZodTuple.create({ ...arg, coerce: true })) as typeof ZodTuple["create"],
+  array: ((element, arg) =>
+    ZodArray.create(element, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodArray["create"],
+  set: ((valueType, arg) =>
+    ZodSet.create(valueType, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodSet["create"],
+  map: ((keyType, valueType, arg) =>
+    ZodMap.create(keyType, valueType, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodMap["create"],
+  object: ((shape, arg) =>
+    ZodObject.create(shape, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodObject["create"],
+  tuple: ((schemas, arg) =>
+    ZodTuple.create(schemas, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodTuple["create"],
 };
 
 export {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3088,7 +3088,7 @@ export class ZodMap<
   >(
     keyType: Key,
     valueType: Value,
-    params?: RawCreateParams & { coerce: boolean }
+    params?: RawCreateParams & { coerce?: boolean }
   ): ZodMap<Key, Value> => {
     return new ZodMap({
       valueType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3107,6 +3107,7 @@ export interface ZodSetDef<Value extends ZodTypeAny = ZodTypeAny>
   typeName: ZodFirstPartyTypeKind.ZodSet;
   minSize: { value: number; message?: string } | null;
   maxSize: { value: number; message?: string } | null;
+  coerce: boolean;
 }
 
 export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
@@ -3115,6 +3116,10 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
   Set<Value["_input"]>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
+    if (this._def.coerce && Array.isArray(input.data)) {
+      input.data = new Set(input.data);
+    }
+
     const { status, ctx } = this._processInputParams(input);
     if (ctx.parsedType !== ZodParsedType.set) {
       addIssueToContext(ctx, {
@@ -3202,13 +3207,14 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
 
   static create = <Value extends ZodTypeAny = ZodTypeAny>(
     valueType: Value,
-    params?: RawCreateParams
+    params?: RawCreateParams & { coerce?: boolean }
   ): ZodSet<Value> => {
     return new ZodSet({
       valueType,
       minSize: null,
       maxSize: null,
       typeName: ZodFirstPartyTypeKind.ZodSet,
+      coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     });
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1608,6 +1608,7 @@ export interface ZodArrayDef<T extends ZodTypeAny = ZodTypeAny>
   exactLength: { value: number; message?: string } | null;
   minLength: { value: number; message?: string } | null;
   maxLength: { value: number; message?: string } | null;
+  coerce: boolean;
 }
 
 export type ArrayCardinality = "many" | "atleastone";
@@ -1629,6 +1630,10 @@ export class ZodArray<
     : T["_input"][]
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
+    if (this._def.coerce && input.data instanceof Set) {
+      input.data = Array.from(input.data);
+    }
+
     const { ctx, status } = this._processInputParams(input);
 
     const def = this._def;
@@ -1739,7 +1744,7 @@ export class ZodArray<
 
   static create = <T extends ZodTypeAny>(
     schema: T,
-    params?: RawCreateParams
+    params?: RawCreateParams & { coerce?: boolean }
   ): ZodArray<T> => {
     return new ZodArray({
       type: schema,
@@ -1747,6 +1752,7 @@ export class ZodArray<
       maxLength: null,
       exactLength: null,
       typeName: ZodFirstPartyTypeKind.ZodArray,
+      coerce: params?.coerce || false,
       ...processCreateParams(params),
     });
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -4452,6 +4452,31 @@ export const coerce = {
     ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
   date: ((arg) =>
     ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
+  array: ((element, arg) =>
+    ZodArray.create(element, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodArray["create"],
+  set: ((valueType, arg) =>
+    ZodSet.create(valueType, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodSet["create"],
+  map: ((keyType, valueType, arg) =>
+    ZodMap.create(keyType, valueType, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodMap["create"],
+  object: ((shape, arg) =>
+    ZodObject.create(shape, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodObject["create"],
+  tuple: ((schemas, arg) =>
+    ZodTuple.create(schemas, {
+      ...arg,
+      coerce: true,
+    })) as typeof ZodTuple["create"],
 };
 
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3006,6 +3006,7 @@ export interface ZodMapDef<
   valueType: Value;
   keyType: Key;
   typeName: ZodFirstPartyTypeKind.ZodMap;
+  coerce: boolean;
 }
 
 export class ZodMap<
@@ -3017,6 +3018,10 @@ export class ZodMap<
   Map<Key["_input"], Value["_input"]>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
+    if (this._def.coerce && this._getType(input) === "object") {
+      input.data = new Map(Object.entries(input.data as object));
+    }
+
     const { status, ctx } = this._processInputParams(input);
     if (ctx.parsedType !== ZodParsedType.map) {
       addIssueToContext(ctx, {
@@ -3083,12 +3088,13 @@ export class ZodMap<
   >(
     keyType: Key,
     valueType: Value,
-    params?: RawCreateParams
+    params?: RawCreateParams & { coerce?: boolean }
   ): ZodMap<Key, Value> => {
     return new ZodMap({
       valueType,
       keyType,
       typeName: ZodFirstPartyTypeKind.ZodMap,
+      coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     });
   };


### PR DESCRIPTION
This PR adds the following extra coercions:

1. `Set` -> `Array` in `ZodArray`
2. `Set` -> `Array` in `ZodTuple`
3. `Array` -> `Set` in `ZodSet`
4. `Object` -> `Map` in `ZodMap`
5. `Map` -> `Object` in `ZodObject`