### PR TITLE
feat(#1690): Add `ZodRequired`

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -16,6 +16,7 @@ export type typeToFlattenedError<T, U = string> = {
 };
 
 export const ZodIssueCode = util.arrayToEnum([
+  "required",
   "invalid_type",
   "invalid_literal",
   "custom",
@@ -40,6 +41,10 @@ export type ZodIssueBase = {
   path: (string | number)[];
   message?: string;
 };
+
+export interface ZodRequiredIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.required;
+}
 
 export interface ZodInvalidTypeIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_type;
@@ -139,6 +144,7 @@ export interface ZodCustomIssue extends ZodIssueBase {
 export type DenormalizedError = { [k: string]: DenormalizedError | string[] };
 
 export type ZodIssueOptionalMessage =
+  | ZodRequiredIssue
   | ZodInvalidTypeIssue
   | ZodInvalidLiteralIssue
   | ZodUnrecognizedKeysIssue

--- a/deno/lib/__tests__/partials.test.ts
+++ b/deno/lib/__tests__/partials.test.ts
@@ -141,11 +141,11 @@ test("required", () => {
   });
 
   const requiredObject = object.required();
-  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
-  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
-  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
-  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
-  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodRequired);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodRequired);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodRequired);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodRequired);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodRequired);
 });
 
 test("required inference", () => {
@@ -180,7 +180,7 @@ test("required with mask", () => {
 
   const requiredObject = object.required({ age: true });
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
-  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodRequired);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
   expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
 });

--- a/deno/lib/__tests__/required.test.ts
+++ b/deno/lib/__tests__/required.test.ts
@@ -1,0 +1,54 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { util } from "../helpers/util.ts";
+import * as z from "../index.ts";
+
+const requiredUndefined = z.required(z.undefined());
+const requiredVoid = z.required(z.void());
+const requiredOptional = z.required(z.string().optional());
+const requiredOptionalOptional = z.required(z.string().optional().optional());
+const requiredNullable = z.required(z.string().nullable());
+const requiredNullish = z.required(z.string().nullish());
+const requiredStringWithDefault = z.required(z.string().default("asdf"));
+const requiredStringWithCatch = z.required(z.string().catch("asdf"));
+
+test("inference", () => {
+  // Input
+  util.assertEqual<z.input<typeof requiredUndefined>, never>(true);
+  util.assertEqual<z.input<typeof requiredVoid>, void>(true);
+  util.assertEqual<z.input<typeof requiredOptional>, string>(true);
+  util.assertEqual<z.input<typeof requiredOptionalOptional>, string>(true);
+  util.assertEqual<z.input<typeof requiredNullable>, string | null>(true);
+  util.assertEqual<z.input<typeof requiredNullish>, string | null>(true);
+  util.assertEqual<z.input<typeof requiredStringWithDefault>, string>(true);
+  util.assertEqual<z.input<typeof requiredStringWithCatch>, string>(true);
+  // Output
+  util.assertEqual<z.output<typeof requiredUndefined>, never>(true);
+  util.assertEqual<z.output<typeof requiredVoid>, void>(true);
+  util.assertEqual<z.output<typeof requiredOptional>, string>(true);
+  util.assertEqual<z.output<typeof requiredOptionalOptional>, string>(true);
+  util.assertEqual<z.output<typeof requiredNullable>, string | null>(true);
+  util.assertEqual<z.output<typeof requiredNullish>, string | null>(true);
+  util.assertEqual<z.output<typeof requiredStringWithDefault>, string>(true);
+  util.assertEqual<z.output<typeof requiredStringWithCatch>, string>(true);
+});
+
+test("fails", () => {
+  expect(() => requiredUndefined.parse(undefined)).toThrow();
+  expect(() => requiredVoid.parse(undefined)).toThrow();
+  expect(() => requiredOptional.parse(undefined)).toThrow();
+  expect(() => requiredOptionalOptional.parse(undefined)).toThrow();
+  expect(() => requiredNullable.parse(undefined)).toThrow();
+  expect(() => requiredNullish.parse(undefined)).toThrow();
+  expect(() => requiredStringWithDefault.parse(undefined)).toThrow();
+  expect(() => requiredStringWithCatch.parse(undefined)).toThrow();
+});
+
+test("passes", () => {
+  const optionalRequired = z.optional(z.required(z.string()));
+  const requiredWithDefault = z.required(z.string()).default("asdf");
+  optionalRequired.parse(undefined);
+  requiredWithDefault.parse(undefined);
+});

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -4,6 +4,9 @@ import { ZodErrorMap, ZodIssueCode } from "../ZodError.ts";
 const errorMap: ZodErrorMap = (issue, _ctx) => {
   let message: string;
   switch (issue.code) {
+    case ZodIssueCode.required:
+      message = "Required";
+      break;
     case ZodIssueCode.invalid_type:
       if (issue.received === ZodParsedType.undefined) {
         message = "Required";

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2206,13 +2206,13 @@ export class ZodObject<
 
   required(
     this: this
-  ): ZodObject<{ [k in keyof T]: deoptional<T[k]> }, UnknownKeys, Catchall>;
+  ): ZodObject<{ [k in keyof T]: ZodRequired<T[k]> }, UnknownKeys, Catchall>;
   required<Mask extends { [k in keyof T]?: true }>(
     this: this,
     mask: Mask
   ): ZodObject<
     objectUtil.noNever<{
-      [k in keyof T]: k extends keyof Mask ? deoptional<T[k]> : T[k];
+      [k in keyof T]: k extends keyof Mask ? ZodRequired<T[k]> : T[k];
     }>,
     UnknownKeys,
     Catchall

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4451,7 +4451,7 @@ const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
 const pipelineType = ZodPipeline.create;
-const requiredTyoe = ZodRequired.create;
+const requiredType = ZodRequired.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -4499,7 +4499,7 @@ export {
   preprocessType as preprocess,
   promiseType as promise,
   recordType as record,
-  requiredTyoe as required,
+  requiredType as required,
   setType as set,
   strictObjectType as strictObject,
   stringType as string,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -118,8 +118,9 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   }
   if (errorMap) return { errorMap: errorMap, description };
   const customMap: ZodErrorMap = (iss, ctx) => {
-    if (iss.code !== "invalid_type") return { message: ctx.defaultError };
-    if (typeof ctx.data === "undefined") {
+    if (iss.code !== "invalid_type" && iss.code !== "required")
+      return { message: ctx.defaultError };
+    if (iss.code === "required" || typeof ctx.data === "undefined") {
       return { message: required_error ?? ctx.defaultError };
     }
     return { message: invalid_type_error ?? ctx.defaultError };

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -399,6 +399,13 @@ export abstract class ZodType<
   nullish(): ZodNullable<ZodOptional<this>> {
     return this.optional().nullable();
   }
+
+  required(this: AnyZodObject): any;
+  required(this: ZodTypeAny): ZodRequired<this>;
+  required() {
+    return ZodRequired.create(this);
+  }
+
   array(): ZodArray<this> {
     return ZodArray.create(this);
   }
@@ -2197,12 +2204,11 @@ export class ZodObject<
     }) as any;
   }
 
-  required(): ZodObject<
-    { [k in keyof T]: deoptional<T[k]> },
-    UnknownKeys,
-    Catchall
-  >;
+  required(
+    this: AnyZodObject
+  ): ZodObject<{ [k in keyof T]: deoptional<T[k]> }, UnknownKeys, Catchall>;
   required<Mask extends { [k in keyof T]?: true }>(
+    this: AnyZodObject,
     mask: Mask
   ): ZodObject<
     objectUtil.noNever<{
@@ -2211,7 +2217,8 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  required(mask?: any) {
+  required(this: ZodTypeAny): ZodRequired<this>;
+  required(this: AnyZodObject, mask?: any) {
     const newShape: any = {};
     if (mask) {
       util.objectKeys(this.shape).map((key) => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2217,7 +2217,7 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  required(this: never): ZodRequired<this>;
+  required(this: never): never;
   required(mask?: any) {
     const newShape: any = {};
     if (mask) {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -401,7 +401,7 @@ export abstract class ZodType<
   }
 
   required(this: AnyZodObject): any;
-  required(this: ZodTypeAny): ZodRequired<this>;
+  required(this: this): ZodRequired<this>;
   required() {
     return ZodRequired.create(this);
   }
@@ -2205,10 +2205,10 @@ export class ZodObject<
   }
 
   required(
-    this: AnyZodObject
+    this: this
   ): ZodObject<{ [k in keyof T]: deoptional<T[k]> }, UnknownKeys, Catchall>;
   required<Mask extends { [k in keyof T]?: true }>(
-    this: AnyZodObject,
+    this: this,
     mask: Mask
   ): ZodObject<
     objectUtil.noNever<{
@@ -2217,8 +2217,8 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  required(this: ZodTypeAny): ZodRequired<this>;
-  required(this: AnyZodObject, mask?: any) {
+  required(this: never): ZodRequired<this>;
+  required(mask?: any) {
     const newShape: any = {};
     if (mask) {
       util.objectKeys(this.shape).map((key) => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2218,23 +2218,12 @@ export class ZodObject<
         if (util.objectKeys(mask).indexOf(key) === -1) {
           newShape[key] = this.shape[key];
         } else {
-          const fieldSchema = this.shape[key];
-          let newField = fieldSchema;
-          while (newField instanceof ZodOptional) {
-            newField = (newField as ZodOptional<any>)._def.innerType;
-          }
-          newShape[key] = newField;
+          newShape[key] = ZodRequired.create(this.shape[key]);
         }
       });
     } else {
       for (const key in this.shape) {
-        const fieldSchema = this.shape[key];
-        let newField = fieldSchema;
-        while (newField instanceof ZodOptional) {
-          newField = (newField as ZodOptional<any>)._def.innerType;
-        }
-
-        newShape[key] = newField;
+        newShape[key] = ZodRequired.create(this.shape[key]);
       }
     }
     return new ZodObject({

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3995,6 +3995,52 @@ export class ZodNullable<T extends ZodTypeAny> extends ZodType<
 ////////////////////////////////////////////
 ////////////////////////////////////////////
 //////////                        //////////
+//////////       ZodRequired      //////////
+//////////                        //////////
+////////////////////////////////////////////
+////////////////////////////////////////////
+export interface ZodRequiredDef<T extends ZodTypeAny = ZodTypeAny>
+  extends ZodTypeDef {
+  innerType: T;
+  typeName: ZodFirstPartyTypeKind.ZodRequired;
+}
+
+export type ZodRequiredType<T extends ZodTypeAny> = ZodRequired<T>;
+
+export class ZodRequired<T extends ZodTypeAny> extends ZodType<
+  util.noUndefined<T["_output"]>,
+  ZodRequiredDef<T>,
+  util.noUndefined<T["_input"]>
+> {
+  _parse(input: ParseInput): ParseReturnType<this["_output"]> {
+    const parsedType = this._getType(input);
+    if (parsedType === ZodParsedType.undefined) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, { code: ZodIssueCode.required });
+      return INVALID;
+    }
+    return this._def.innerType._parse(input);
+  }
+
+  unwrap() {
+    return this._def.innerType;
+  }
+
+  static create = <T extends ZodTypeAny>(
+    type: T,
+    params?: RawCreateParams
+  ): ZodRequired<T> => {
+    return new ZodRequired({
+      innerType: type,
+      typeName: ZodFirstPartyTypeKind.ZodRequired,
+      ...processCreateParams(params),
+    });
+  };
+}
+
+////////////////////////////////////////////
+////////////////////////////////////////////
+//////////                        //////////
 //////////       ZodDefault       //////////
 //////////                        //////////
 ////////////////////////////////////////////
@@ -4320,6 +4366,7 @@ export enum ZodFirstPartyTypeKind {
   ZodPromise = "ZodPromise",
   ZodBranded = "ZodBranded",
   ZodPipeline = "ZodPipeline",
+  ZodRequired = "ZodRequired",
 }
 export type ZodFirstPartySchemaTypes =
   | ZodString
@@ -4404,6 +4451,7 @@ const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
 const pipelineType = ZodPipeline.create;
+const requiredTyoe = ZodRequired.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -4451,6 +4499,7 @@ export {
   preprocessType as preprocess,
   promiseType as promise,
   recordType as record,
+  requiredTyoe as required,
   setType as set,
   strictObjectType as strictObject,
   stringType as string,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1873,12 +1873,6 @@ export type objectInputType<
       baseObjectInputType<Shape> & { [k: string]: Catchall["_input"] }
     >;
 
-export type deoptional<T extends ZodTypeAny> = T extends ZodOptional<infer U>
-  ? deoptional<U>
-  : T extends ZodNullable<infer U>
-  ? ZodNullable<deoptional<U>>
-  : T;
-
 export type SomeZodObject = ZodObject<
   ZodRawShape,
   UnknownKeysParam,

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -16,6 +16,7 @@ export type typeToFlattenedError<T, U = string> = {
 };
 
 export const ZodIssueCode = util.arrayToEnum([
+  "required",
   "invalid_type",
   "invalid_literal",
   "custom",
@@ -40,6 +41,10 @@ export type ZodIssueBase = {
   path: (string | number)[];
   message?: string;
 };
+
+export interface ZodRequiredIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.required;
+}
 
 export interface ZodInvalidTypeIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_type;
@@ -139,6 +144,7 @@ export interface ZodCustomIssue extends ZodIssueBase {
 export type DenormalizedError = { [k: string]: DenormalizedError | string[] };
 
 export type ZodIssueOptionalMessage =
+  | ZodRequiredIssue
   | ZodInvalidTypeIssue
   | ZodInvalidLiteralIssue
   | ZodUnrecognizedKeysIssue

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -140,11 +140,11 @@ test("required", () => {
   });
 
   const requiredObject = object.required();
-  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
-  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
-  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
-  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
-  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodRequired);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodRequired);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodRequired);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodRequired);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodRequired);
 });
 
 test("required inference", () => {
@@ -179,7 +179,7 @@ test("required with mask", () => {
 
   const requiredObject = object.required({ age: true });
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
-  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodRequired);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
   expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
 });

--- a/src/__tests__/required.test.ts
+++ b/src/__tests__/required.test.ts
@@ -4,14 +4,29 @@ import { expect, test } from "@jest/globals";
 import { util } from "../helpers/util";
 import * as z from "../index";
 
-const requiredUndefined = z.required(z.undefined());
-const requiredVoid = z.required(z.void());
-const requiredOptional = z.required(z.string().optional());
-const requiredOptionalOptional = z.required(z.string().optional().optional());
-const requiredNullable = z.required(z.string().nullable());
-const requiredNullish = z.required(z.string().nullish());
-const requiredStringWithDefault = z.required(z.string().default("asdf"));
-const requiredStringWithCatch = z.required(z.string().catch("asdf"));
+const requiredUndefined = z.undefined().required();
+const requiredVoid = z.void().required();
+const requiredOptional = z.string().optional().required();
+const requiredOptionalOptional = z.string().optional().optional().required();
+const requiredNullable = z.string().nullable().required();
+const requiredNullish = z.string().nullish().required();
+const requiredStringWithDefault = z.string().default("asdf").required();
+const requiredStringWithCatch = z.string().catch("asdf").required();
+
+const requiredObj = z
+  .object({
+    a: z.string().optional(),
+    b: z.number().nullable(),
+    c: z.bigint().nullish(),
+  })
+  .required();
+const requiredObjWithMask = z
+  .object({
+    a: z.string().optional(),
+    b: z.number().nullable(),
+    c: z.bigint().nullish(),
+  })
+  .required({ a: true, b: true });
 
 test("inference", () => {
   // Input
@@ -32,6 +47,15 @@ test("inference", () => {
   util.assertEqual<z.output<typeof requiredNullish>, string | null>(true);
   util.assertEqual<z.output<typeof requiredStringWithDefault>, string>(true);
   util.assertEqual<z.output<typeof requiredStringWithCatch>, string>(true);
+  // Obj
+  util.assertEqual<
+    z.infer<typeof requiredObj>,
+    { a: string; b: number | null; c: bigint | null }
+  >(true);
+  util.assertEqual<
+    z.infer<typeof requiredObjWithMask>,
+    { a: string; b: number | null; c?: bigint | null | undefined }
+  >(true);
 });
 
 test("fails", () => {
@@ -43,6 +67,20 @@ test("fails", () => {
   expect(() => requiredNullish.parse(undefined)).toThrow();
   expect(() => requiredStringWithDefault.parse(undefined)).toThrow();
   expect(() => requiredStringWithCatch.parse(undefined)).toThrow();
+  expect(() =>
+    requiredObj.parse({
+      a: undefined,
+      b: null,
+      c: undefined,
+    })
+  ).toThrow();
+  expect(() =>
+    requiredObjWithMask.parse({
+      a: undefined,
+      b: null,
+      c: undefined,
+    })
+  ).toThrow();
 });
 
 test("passes", () => {
@@ -50,4 +88,9 @@ test("passes", () => {
   const requiredWithDefault = z.required(z.string()).default("asdf");
   optionalRequired.parse(undefined);
   requiredWithDefault.parse(undefined);
+  requiredObjWithMask.parse({
+    a: "asdf",
+    b: null,
+    c: undefined,
+  });
 });

--- a/src/__tests__/required.test.ts
+++ b/src/__tests__/required.test.ts
@@ -1,0 +1,53 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import { util } from "../helpers/util";
+import * as z from "../index";
+
+const requiredUndefined = z.required(z.undefined());
+const requiredVoid = z.required(z.void());
+const requiredOptional = z.required(z.string().optional());
+const requiredOptionalOptional = z.required(z.string().optional().optional());
+const requiredNullable = z.required(z.string().nullable());
+const requiredNullish = z.required(z.string().nullish());
+const requiredStringWithDefault = z.required(z.string().default("asdf"));
+const requiredStringWithCatch = z.required(z.string().catch("asdf"));
+
+test("inference", () => {
+  // Input
+  util.assertEqual<z.input<typeof requiredUndefined>, never>(true);
+  util.assertEqual<z.input<typeof requiredVoid>, void>(true);
+  util.assertEqual<z.input<typeof requiredOptional>, string>(true);
+  util.assertEqual<z.input<typeof requiredOptionalOptional>, string>(true);
+  util.assertEqual<z.input<typeof requiredNullable>, string | null>(true);
+  util.assertEqual<z.input<typeof requiredNullish>, string | null>(true);
+  util.assertEqual<z.input<typeof requiredStringWithDefault>, string>(true);
+  util.assertEqual<z.input<typeof requiredStringWithCatch>, string>(true);
+  // Output
+  util.assertEqual<z.output<typeof requiredUndefined>, never>(true);
+  util.assertEqual<z.output<typeof requiredVoid>, void>(true);
+  util.assertEqual<z.output<typeof requiredOptional>, string>(true);
+  util.assertEqual<z.output<typeof requiredOptionalOptional>, string>(true);
+  util.assertEqual<z.output<typeof requiredNullable>, string | null>(true);
+  util.assertEqual<z.output<typeof requiredNullish>, string | null>(true);
+  util.assertEqual<z.output<typeof requiredStringWithDefault>, string>(true);
+  util.assertEqual<z.output<typeof requiredStringWithCatch>, string>(true);
+});
+
+test("fails", () => {
+  expect(() => requiredUndefined.parse(undefined)).toThrow();
+  expect(() => requiredVoid.parse(undefined)).toThrow();
+  expect(() => requiredOptional.parse(undefined)).toThrow();
+  expect(() => requiredOptionalOptional.parse(undefined)).toThrow();
+  expect(() => requiredNullable.parse(undefined)).toThrow();
+  expect(() => requiredNullish.parse(undefined)).toThrow();
+  expect(() => requiredStringWithDefault.parse(undefined)).toThrow();
+  expect(() => requiredStringWithCatch.parse(undefined)).toThrow();
+});
+
+test("passes", () => {
+  const optionalRequired = z.optional(z.required(z.string()));
+  const requiredWithDefault = z.required(z.string()).default("asdf");
+  optionalRequired.parse(undefined);
+  requiredWithDefault.parse(undefined);
+});

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -4,6 +4,9 @@ import { ZodErrorMap, ZodIssueCode } from "../ZodError";
 const errorMap: ZodErrorMap = (issue, _ctx) => {
   let message: string;
   switch (issue.code) {
+    case ZodIssueCode.required:
+      message = "Required";
+      break;
     case ZodIssueCode.invalid_type:
       if (issue.received === ZodParsedType.undefined) {
         message = "Required";

--- a/src/types.ts
+++ b/src/types.ts
@@ -2206,13 +2206,13 @@ export class ZodObject<
 
   required(
     this: this
-  ): ZodObject<{ [k in keyof T]: deoptional<T[k]> }, UnknownKeys, Catchall>;
+  ): ZodObject<{ [k in keyof T]: ZodRequired<T[k]> }, UnknownKeys, Catchall>;
   required<Mask extends { [k in keyof T]?: true }>(
     this: this,
     mask: Mask
   ): ZodObject<
     objectUtil.noNever<{
-      [k in keyof T]: k extends keyof Mask ? deoptional<T[k]> : T[k];
+      [k in keyof T]: k extends keyof Mask ? ZodRequired<T[k]> : T[k];
     }>,
     UnknownKeys,
     Catchall

--- a/src/types.ts
+++ b/src/types.ts
@@ -4451,7 +4451,7 @@ const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
 const pipelineType = ZodPipeline.create;
-const requiredTyoe = ZodRequired.create;
+const requiredType = ZodRequired.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -4499,7 +4499,7 @@ export {
   preprocessType as preprocess,
   promiseType as promise,
   recordType as record,
-  requiredTyoe as required,
+  requiredType as required,
   setType as set,
   strictObjectType as strictObject,
   stringType as string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,8 +118,9 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   }
   if (errorMap) return { errorMap: errorMap, description };
   const customMap: ZodErrorMap = (iss, ctx) => {
-    if (iss.code !== "invalid_type") return { message: ctx.defaultError };
-    if (typeof ctx.data === "undefined") {
+    if (iss.code !== "invalid_type" && iss.code !== "required")
+      return { message: ctx.defaultError };
+    if (iss.code === "required" || typeof ctx.data === "undefined") {
       return { message: required_error ?? ctx.defaultError };
     }
     return { message: invalid_type_error ?? ctx.defaultError };

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,6 +399,13 @@ export abstract class ZodType<
   nullish(): ZodNullable<ZodOptional<this>> {
     return this.optional().nullable();
   }
+
+  required(this: AnyZodObject): any;
+  required(this: ZodTypeAny): ZodRequired<this>;
+  required() {
+    return ZodRequired.create(this);
+  }
+
   array(): ZodArray<this> {
     return ZodArray.create(this);
   }
@@ -2197,12 +2204,11 @@ export class ZodObject<
     }) as any;
   }
 
-  required(): ZodObject<
-    { [k in keyof T]: deoptional<T[k]> },
-    UnknownKeys,
-    Catchall
-  >;
+  required(
+    this: AnyZodObject
+  ): ZodObject<{ [k in keyof T]: deoptional<T[k]> }, UnknownKeys, Catchall>;
   required<Mask extends { [k in keyof T]?: true }>(
+    this: AnyZodObject,
     mask: Mask
   ): ZodObject<
     objectUtil.noNever<{
@@ -2211,7 +2217,8 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  required(mask?: any) {
+  required(this: ZodTypeAny): ZodRequired<this>;
+  required(this: AnyZodObject, mask?: any) {
     const newShape: any = {};
     if (mask) {
       util.objectKeys(this.shape).map((key) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2217,7 +2217,7 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  required(this: never): ZodRequired<this>;
+  required(this: never): never;
   required(mask?: any) {
     const newShape: any = {};
     if (mask) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -401,7 +401,7 @@ export abstract class ZodType<
   }
 
   required(this: AnyZodObject): any;
-  required(this: ZodTypeAny): ZodRequired<this>;
+  required(this: this): ZodRequired<this>;
   required() {
     return ZodRequired.create(this);
   }
@@ -2205,10 +2205,10 @@ export class ZodObject<
   }
 
   required(
-    this: AnyZodObject
+    this: this
   ): ZodObject<{ [k in keyof T]: deoptional<T[k]> }, UnknownKeys, Catchall>;
   required<Mask extends { [k in keyof T]?: true }>(
-    this: AnyZodObject,
+    this: this,
     mask: Mask
   ): ZodObject<
     objectUtil.noNever<{
@@ -2217,8 +2217,8 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  required(this: ZodTypeAny): ZodRequired<this>;
-  required(this: AnyZodObject, mask?: any) {
+  required(this: never): ZodRequired<this>;
+  required(mask?: any) {
     const newShape: any = {};
     if (mask) {
       util.objectKeys(this.shape).map((key) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2218,23 +2218,12 @@ export class ZodObject<
         if (util.objectKeys(mask).indexOf(key) === -1) {
           newShape[key] = this.shape[key];
         } else {
-          const fieldSchema = this.shape[key];
-          let newField = fieldSchema;
-          while (newField instanceof ZodOptional) {
-            newField = (newField as ZodOptional<any>)._def.innerType;
-          }
-          newShape[key] = newField;
+          newShape[key] = ZodRequired.create(this.shape[key]);
         }
       });
     } else {
       for (const key in this.shape) {
-        const fieldSchema = this.shape[key];
-        let newField = fieldSchema;
-        while (newField instanceof ZodOptional) {
-          newField = (newField as ZodOptional<any>)._def.innerType;
-        }
-
-        newShape[key] = newField;
+        newShape[key] = ZodRequired.create(this.shape[key]);
       }
     }
     return new ZodObject({

--- a/src/types.ts
+++ b/src/types.ts
@@ -3995,6 +3995,52 @@ export class ZodNullable<T extends ZodTypeAny> extends ZodType<
 ////////////////////////////////////////////
 ////////////////////////////////////////////
 //////////                        //////////
+//////////       ZodRequired      //////////
+//////////                        //////////
+////////////////////////////////////////////
+////////////////////////////////////////////
+export interface ZodRequiredDef<T extends ZodTypeAny = ZodTypeAny>
+  extends ZodTypeDef {
+  innerType: T;
+  typeName: ZodFirstPartyTypeKind.ZodRequired;
+}
+
+export type ZodRequiredType<T extends ZodTypeAny> = ZodRequired<T>;
+
+export class ZodRequired<T extends ZodTypeAny> extends ZodType<
+  util.noUndefined<T["_output"]>,
+  ZodRequiredDef<T>,
+  util.noUndefined<T["_input"]>
+> {
+  _parse(input: ParseInput): ParseReturnType<this["_output"]> {
+    const parsedType = this._getType(input);
+    if (parsedType === ZodParsedType.undefined) {
+      const ctx = this._getOrReturnCtx(input);
+      addIssueToContext(ctx, { code: ZodIssueCode.required });
+      return INVALID;
+    }
+    return this._def.innerType._parse(input);
+  }
+
+  unwrap() {
+    return this._def.innerType;
+  }
+
+  static create = <T extends ZodTypeAny>(
+    type: T,
+    params?: RawCreateParams
+  ): ZodRequired<T> => {
+    return new ZodRequired({
+      innerType: type,
+      typeName: ZodFirstPartyTypeKind.ZodRequired,
+      ...processCreateParams(params),
+    });
+  };
+}
+
+////////////////////////////////////////////
+////////////////////////////////////////////
+//////////                        //////////
 //////////       ZodDefault       //////////
 //////////                        //////////
 ////////////////////////////////////////////
@@ -4320,6 +4366,7 @@ export enum ZodFirstPartyTypeKind {
   ZodPromise = "ZodPromise",
   ZodBranded = "ZodBranded",
   ZodPipeline = "ZodPipeline",
+  ZodRequired = "ZodRequired",
 }
 export type ZodFirstPartySchemaTypes =
   | ZodString
@@ -4404,6 +4451,7 @@ const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
 const pipelineType = ZodPipeline.create;
+const requiredTyoe = ZodRequired.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -4451,6 +4499,7 @@ export {
   preprocessType as preprocess,
   promiseType as promise,
   recordType as record,
+  requiredTyoe as required,
   setType as set,
   strictObjectType as strictObject,
   stringType as string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1873,12 +1873,6 @@ export type objectInputType<
       baseObjectInputType<Shape> & { [k: string]: Catchall["_input"] }
     >;
 
-export type deoptional<T extends ZodTypeAny> = T extends ZodOptional<infer U>
-  ? deoptional<U>
-  : T extends ZodNullable<infer U>
-  ? ZodNullable<deoptional<U>>
-  : T;
-
 export type SomeZodObject = ZodObject<
   ZodRawShape,
   UnknownKeysParam,


### PR DESCRIPTION
## Closes #1690 

This PR adds the `ZodRequired` type, which removes any `undefined` from both the schema's output _and_ input.

> ~Note: I couldn't add `.required()` to the root `ZodType` class because it conflicts with the `.required()` method of `ZodObject`. Suggestions are welcome. I feel like it should live in the root `ZodType` class...~