### PR TITLE
feat(#1508): Add mergeDeep to ZodObject

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -389,3 +389,73 @@ test("unknownkeys merging", () => {
   util.assertEqual<mergedSchema["_def"]["catchall"], z.ZodString>(true);
   expect(mergedSchema._def.catchall instanceof z.ZodString).toEqual(true);
 });
+
+const A = z.object({
+  a: z.string(),
+  b: z.object({
+    c: z.string(),
+    d: z.string(),
+    e: z.object({
+      f: z.string(),
+      g: z.string(),
+      h: z.string(),
+    }),
+  }),
+});
+
+const B = z.object({
+  b: z.object({
+    i: z.string(),
+    j: z.string(),
+    e: z.object({
+      k: z.string(),
+      l: z.string(),
+      // Overwrite from string to bigint
+      h: z.bigint(),
+    }),
+  }),
+});
+
+const mergedDeep = A.mergeDeep(B);
+type mergedDeep = z.infer<typeof mergedDeep>;
+
+test("mergeDeep inference", () => {
+  util.assertEqual<
+    mergedDeep,
+    {
+      a: string;
+      b: {
+        c: string;
+        d: string;
+        e: {
+          // From A
+          f: string;
+          g: string;
+          // From B
+          k: string;
+          l: string;
+          h: bigint;
+        };
+        // From B
+        i: string;
+        j: string;
+      };
+    }
+  >(true);
+});
+
+test("mergeDeep shape", () => {
+  expect(mergedDeep.shape.a).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b).toBeInstanceOf(z.ZodObject);
+  expect(mergedDeep.shape.b.shape.c).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b.shape.d).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b.shape.e).toBeInstanceOf(z.ZodObject);
+  expect(mergedDeep.shape.b.shape.e.shape.f).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b.shape.e.shape.g).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b.shape.e.shape.k).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b.shape.e.shape.l).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b.shape.e.shape.h).toBeInstanceOf(z.ZodBigInt);
+  expect(mergedDeep.shape.b.shape.i).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b.shape.j).toBeInstanceOf(z.ZodString);
+  expect(mergedDeep.shape.b.shape.e.shape.h).toBeInstanceOf(z.ZodBigInt);
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1906,6 +1906,31 @@ function deepPartialify(schema: ZodTypeAny): any {
   }
 }
 
+export type MergeZodObjectsDeep<A, B> = [A, B] extends [
+  ZodObject<infer ShapeA>,
+  ZodObject<infer ShapeB, infer UnknownKeysB, infer CatchallB>
+]
+  ? ZodObject<
+      {
+        [K in keyof ShapeA | keyof ShapeB]: K extends keyof ShapeB
+          ? K extends keyof ShapeA
+            ? [ShapeA[K], ShapeB[K]] extends [
+                ZodObject<infer ShapeC, infer UnknownKeysC, infer CatchallC>,
+                ZodObject<infer ShapeD, infer UnknownKeysD, infer CatchallD>
+              ]
+              ? MergeZodObjectsDeep<
+                  ZodObject<ShapeC, UnknownKeysC, CatchallC>,
+                  ZodObject<ShapeD, UnknownKeysD, CatchallD>
+                >
+              : ShapeB[K]
+            : ShapeB[K]
+          : ShapeA[K & keyof ShapeA];
+      },
+      UnknownKeysB,
+      CatchallB
+    >
+  : never;
+
 export class ZodObject<
   T extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = "strip",
@@ -2111,6 +2136,35 @@ export class ZodObject<
       typeName: ZodFirstPartyTypeKind.ZodObject,
     }) as any;
     return merged;
+  }
+
+  mergeDeep<Incoming extends AnyZodObject>(
+    merging: Incoming
+  ): MergeZodObjectsDeep<this, Incoming> {
+    const newShape = {} as any;
+    for (const key of [
+      ...util.objectKeys(merging.shape),
+      ...util.objectKeys(this.shape),
+    ]) {
+      if (
+        this.shape[key] instanceof ZodObject &&
+        merging.shape[key] instanceof ZodObject
+      ) {
+        newShape[key] = (this.shape[key] as AnyZodObject).mergeDeep(
+          merging.shape[key]
+        );
+      } else if (merging.shape[key]) {
+        newShape[key] = merging.shape[key];
+      } else if (this.shape[key]) {
+        newShape[key] = this.shape[key];
+      }
+    }
+    return new ZodObject({
+      unknownKeys: merging._def.unknownKeys,
+      catchall: merging._def.catchall,
+      shape: () => newShape,
+      typeName: ZodFirstPartyTypeKind.ZodObject,
+    }) as MergeZodObjectsDeep<this, Incoming>;
   }
 
   catchall<Index extends ZodTypeAny>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1906,6 +1906,31 @@ function deepPartialify(schema: ZodTypeAny): any {
   }
 }
 
+export type MergeZodObjectsDeep<A, B> = [A, B] extends [
+  ZodObject<infer ShapeA>,
+  ZodObject<infer ShapeB, infer UnknownKeysB, infer CatchallB>
+]
+  ? ZodObject<
+      {
+        [K in keyof ShapeA | keyof ShapeB]: K extends keyof ShapeB
+          ? K extends keyof ShapeA
+            ? [ShapeA[K], ShapeB[K]] extends [
+                ZodObject<infer ShapeC, infer UnknownKeysC, infer CatchallC>,
+                ZodObject<infer ShapeD, infer UnknownKeysD, infer CatchallD>
+              ]
+              ? MergeZodObjectsDeep<
+                  ZodObject<ShapeC, UnknownKeysC, CatchallC>,
+                  ZodObject<ShapeD, UnknownKeysD, CatchallD>
+                >
+              : ShapeB[K]
+            : ShapeB[K]
+          : ShapeA[K & keyof ShapeA];
+      },
+      UnknownKeysB,
+      CatchallB
+    >
+  : never;
+
 export class ZodObject<
   T extends ZodRawShape,
   UnknownKeys extends UnknownKeysParam = "strip",
@@ -2111,6 +2136,35 @@ export class ZodObject<
       typeName: ZodFirstPartyTypeKind.ZodObject,
     }) as any;
     return merged;
+  }
+
+  mergeDeep<Incoming extends AnyZodObject>(
+    merging: Incoming
+  ): MergeZodObjectsDeep<this, Incoming> {
+    const newShape = {} as any;
+    for (const key of [
+      ...util.objectKeys(merging.shape),
+      ...util.objectKeys(this.shape),
+    ]) {
+      if (
+        this.shape[key] instanceof ZodObject &&
+        merging.shape[key] instanceof ZodObject
+      ) {
+        newShape[key] = (this.shape[key] as AnyZodObject).mergeDeep(
+          merging.shape[key]
+        );
+      } else if (merging.shape[key]) {
+        newShape[key] = merging.shape[key];
+      } else if (this.shape[key]) {
+        newShape[key] = this.shape[key];
+      }
+    }
+    return new ZodObject({
+      unknownKeys: merging._def.unknownKeys,
+      catchall: merging._def.catchall,
+      shape: () => newShape,
+      typeName: ZodFirstPartyTypeKind.ZodObject,
+    }) as MergeZodObjectsDeep<this, Incoming>;
   }
 
   catchall<Index extends ZodTypeAny>(


### PR DESCRIPTION
This PR adds `mergeDeep` to `ZodObject`. It's now possible to merge two `ZodObjects` deeply.

The method follows the same rules as `merge`—keys of `B` have priority over those from `A`, and the `B`'s `unknownKeys` and `catchall` schema are preserved.

```ts
const A = z.object({
  a: z.string(),
  b: z.object({
    c: z.string(),
    d: z.string(),
    e: z.object({
      f: z.string(),
      g: z.string(),
      h: z.string(),
    }),
  }),
});

const B = z.object({
  b: z.object({
    i: z.string(), // should add this prop deeply inside the shape's `b` key
    j: z.string(), // same
    e: z.object({ // does not completely overwrite this key; instead add properties to it.
      k: z.string(), // will be added
      l: z.string(), // will be added
      h: z.bigint(),  // Overwrite from string to bigint
    }),
  }),
});

const mergedDeep = A.mergeDeep(B);
```

<img width="153" alt="Screenshot 2022-12-22 at 5 35 10 AM" src="https://user-images.githubusercontent.com/98408205/209092433-0d988d29-c1d2-494a-9e9a-de7e8d6caea8.png">
