### PR TITLE
feat(#1747): Add `Start` and `End` to ZodString

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -557,8 +557,11 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
   }
 };
 
-export class ZodString extends ZodType<string, ZodStringDef> {
-  _parse(input: ParseInput): ParseReturnType<string> {
+export class ZodString<
+  Start extends string = string,
+  End extends string = string
+> extends ZodType<`${Start}${string}${End}`, ZodStringDef> {
+  _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     if (this._def.coerce) {
       input.data = String(input.data);
     }
@@ -794,20 +797,26 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     });
   }
 
-  startsWith(value: string, message?: errorUtil.ErrMessage) {
+  startsWith<V extends string>(
+    value: V,
+    message?: errorUtil.ErrMessage
+  ): ZodString<V, End> {
     return this._addCheck({
       kind: "startsWith",
       value: value,
       ...errorUtil.errToObj(message),
-    });
+    }) as ZodString<V, End>;
   }
 
-  endsWith(value: string, message?: errorUtil.ErrMessage) {
+  endsWith<V extends string>(
+    value: V,
+    message?: errorUtil.ErrMessage
+  ): ZodString<Start, V> {
     return this._addCheck({
       kind: "endsWith",
       value: value,
       ...errorUtil.errToObj(message),
-    });
+    }) as ZodString<Start, V>;
   }
 
   min(minLength: number, message?: errorUtil.ErrMessage) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -557,8 +557,11 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
   }
 };
 
-export class ZodString extends ZodType<string, ZodStringDef> {
-  _parse(input: ParseInput): ParseReturnType<string> {
+export class ZodString<
+  Start extends string = string,
+  End extends string = string
+> extends ZodType<`${Start}${string}${End}`, ZodStringDef> {
+  _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     if (this._def.coerce) {
       input.data = String(input.data);
     }
@@ -794,20 +797,26 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     });
   }
 
-  startsWith(value: string, message?: errorUtil.ErrMessage) {
+  startsWith<V extends string>(
+    value: V,
+    message?: errorUtil.ErrMessage
+  ): ZodString<V, End> {
     return this._addCheck({
       kind: "startsWith",
       value: value,
       ...errorUtil.errToObj(message),
-    });
+    }) as ZodString<V, End>;
   }
 
-  endsWith(value: string, message?: errorUtil.ErrMessage) {
+  endsWith<V extends string>(
+    value: V,
+    message?: errorUtil.ErrMessage
+  ): ZodString<Start, V> {
     return this._addCheck({
       kind: "endsWith",
       value: value,
       ...errorUtil.errToObj(message),
-    });
+    }) as ZodString<Start, V>;
   }
 
   min(minLength: number, message?: errorUtil.ErrMessage) {


### PR DESCRIPTION
This PR adds two type parameters to `ZodString`: `Start` and `End`. They are populated by the `.startsWith()` and `.endsWith()` methods to improve inference.

<img width="307" alt="Screenshot 2022-12-24 at 2 39 56 AM" src="https://user-images.githubusercontent.com/98408205/209423107-0b44dd12-00dc-4e43-98bd-451873fbaea8.png">
