### PR TITLE
fix(#1682): Fix `preprocess`

### DIFF
--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -202,7 +202,7 @@ test("preprocess", () => {
 
   const value = schema.parse("asdf");
   expect(value).toEqual(["asdf"]);
-  util.assertEqual<typeof schema["_input"], unknown>(true);
+  util.assertEqual<typeof schema["_input"], unknown[]>(true);
 });
 
 test("async preprocess", async () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3889,7 +3889,7 @@ export class ZodEffects<
   };
 
   static createWithPreprocess = <I, S extends ZodType<any, ZodTypeDef, I>>(
-    preprocess: (arg: unknown) => I,
+    preprocess: (arg: unknown) => I | Promise<I>,
     schema: S,
     params?: RawCreateParams
   ): ZodEffects<S, S["_output"], I> => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3888,11 +3888,11 @@ export class ZodEffects<
     });
   };
 
-  static createWithPreprocess = <I extends ZodTypeAny>(
-    preprocess: (arg: unknown) => unknown,
-    schema: I,
+  static createWithPreprocess = <I, S extends ZodType<any, ZodTypeDef, I>>(
+    preprocess: (arg: unknown) => I,
+    schema: S,
     params?: RawCreateParams
-  ): ZodEffects<I, I["_output"], unknown> => {
+  ): ZodEffects<S, S["_output"], I> => {
     return new ZodEffects({
       schema,
       effect: { type: "preprocess", transform: preprocess },

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -201,7 +201,7 @@ test("preprocess", () => {
 
   const value = schema.parse("asdf");
   expect(value).toEqual(["asdf"]);
-  util.assertEqual<typeof schema["_input"], unknown>(true);
+  util.assertEqual<typeof schema["_input"], unknown[]>(true);
 });
 
 test("async preprocess", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3889,7 +3889,7 @@ export class ZodEffects<
   };
 
   static createWithPreprocess = <I, S extends ZodType<any, ZodTypeDef, I>>(
-    preprocess: (arg: unknown) => I,
+    preprocess: (arg: unknown) => I | Promise<I>,
     schema: S,
     params?: RawCreateParams
   ): ZodEffects<S, S["_output"], I> => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3888,11 +3888,11 @@ export class ZodEffects<
     });
   };
 
-  static createWithPreprocess = <I extends ZodTypeAny>(
-    preprocess: (arg: unknown) => unknown,
-    schema: I,
+  static createWithPreprocess = <I, S extends ZodType<any, ZodTypeDef, I>>(
+    preprocess: (arg: unknown) => I,
+    schema: S,
     params?: RawCreateParams
-  ): ZodEffects<I, I["_output"], unknown> => {
+  ): ZodEffects<S, S["_output"], I> => {
     return new ZodEffects({
       schema,
       effect: { type: "preprocess", transform: preprocess },


### PR DESCRIPTION
This PR fixes `preprocess`.

Previously, it was setting the schema's `Input` to `unknown`, even in cases where we were certain of the input type.

### Before the fix

<img width="448" alt="Screenshot 2022-12-24 at 3 09 06 AM" src="https://user-images.githubusercontent.com/98408205/209423850-b23271fe-0e40-4172-a4e8-18f8544809e1.png">

Even though I'm coercing the input to a `Date` object, `preprocess` is unaware of that and is typing the `Input` of my schema as `unknown`.

## After the fix

<img width="448" alt="Screenshot 2022-12-24 at 3 11 14 AM" src="https://user-images.githubusercontent.com/98408205/209423921-5b31b566-4653-4e9a-afea-7380ed73a291.png">

Now, `preprocess` knows that the input will always be a `Date`, so it correctly sets the `Input` type of my schema to `Date`, _**and**_ also enforces that I pass a schema that is able to receive `Date` as input.

For example, the following throws a TS error:

<img width="323" alt="Screenshot 2022-12-24 at 3 12 54 AM" src="https://user-images.githubusercontent.com/98408205/209423970-3cd1a3a3-2381-4615-b579-0c3e1e8e708f.png">
<img width="615" alt="Screenshot 2022-12-24 at 3 13 09 AM" src="https://user-images.githubusercontent.com/98408205/209423975-e5f4a27e-d09f-45dd-b26d-0b76f895ea00.png">

Of course, because `z.string()` can't receive a `Date` object—it would certainly fail to parse.

Now, if I explicitly type the return of the preprocessor function, I can bypass this enforcement (this is not recommended, though):

<img width="436" alt="Screenshot 2022-12-24 at 3 15 11 AM" src="https://user-images.githubusercontent.com/98408205/209424032-be03a1d7-9e1e-46bf-9d83-b7d3b4653586.png">