### PR TITLE
Add this parameter to function

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -47,8 +47,9 @@
   - [Sponsors](#sponsors)
   - [Ecosystem](#ecosystem)
 - [Installation](#installation)
-  - [Node/npm](#nodenpm)
-  - [Deno](#deno)
+  - [Requirements](#requirements)
+  - [Node/npm](#from-npm-nodebun)
+  - [Deno](#from-denolandx-deno)
 - [Basic usage](#basic-usage)
 - [Primitives](#primitives)
 - [Literals](#literals)
@@ -1294,7 +1295,7 @@ const myUnion = z.discriminatedUnion("status", [
   z.object({ status: z.literal("failed"), error: z.instanceof(Error) }),
 ]);
 
-myUnion.parse({ type: "success", data: "yippie ki yay" });
+myUnion.parse({ status: "success", data: "yippie ki yay" });
 ```
 
 ## Records
@@ -1682,7 +1683,7 @@ Given any Zod schema, you can call its `.parse` method to check `data` is valid.
 const stringSchema = z.string();
 
 stringSchema.parse("fish"); // => returns "fish"
-stringSchema.parse(12); // throws Error('Non-string type: number');
+stringSchema.parse(12); // throws error
 ```
 
 ### `.parseAsync`
@@ -1692,11 +1693,10 @@ stringSchema.parse(12); // throws Error('Non-string type: number');
 If you use asynchronous [refinements](#refine) or [transforms](#transform) (more on those later), you'll need to use `.parseAsync`
 
 ```ts
-const stringSchema1 = z.string().refine(async (val) => val.length < 20);
-const value1 = await stringSchema.parseAsync("hello"); // => hello
+const stringSchema = z.string().refine(async (val) => val.length <= 8);
 
-const stringSchema2 = z.string().refine(async (val) => val.length > 20);
-const value2 = await stringSchema.parseAsync("hello"); // => throws
+await stringSchema.parseAsync("hello"); // => returns "hello"
+await stringSchema.parseAsync("hello world"); // => throws error
 ```
 
 ### `.safeParse`
@@ -1781,7 +1781,7 @@ type RefineParams = {
 };
 ```
 
-For advanced cases, the second argument can also be a function that returns `RefineParams`/
+For advanced cases, the second argument can also be a function that returns `RefineParams`.
 
 ```ts
 const longString = z.string().refine(
@@ -1921,7 +1921,7 @@ const schema = z.number().superRefine((val, ctx) => {
 
 #### Type refinements
 
-If you provide a [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) to `.refine()` or `superRefine()`, the resulting type will be narrowed down to your predicate's type. This is useful if you are mixing multiple chained refinements and transformations:
+If you provide a [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) to `.refine()` or `.superRefine()`, the resulting type will be narrowed down to your predicate's type. This is useful if you are mixing multiple chained refinements and transformations:
 
 ```ts
 const schema = z
@@ -1936,15 +1936,15 @@ const schema = z
         code: z.ZodIssueCode.custom, // customize your issue
         message: "object should exist",
       });
-      return false;
     }
-    return true;
+
+    return z.NEVER; // The return value is not used, but we need to return something to satisfy the typing
   })
   // here, TS knows that arg is not null
   .refine((arg) => arg.first === "bob", "`first` is not `bob`!");
 ```
 
-> ⚠️ You must **still** call `ctx.addIssue()` if using `superRefine()` with a type predicate function. Otherwise the refinement won't be validated.
+> ⚠️ You **must** use `ctx.addIssue()` instead of returning a boolean value to indicate whether the validation passes. If `ctx.addIssue` is _not_ called during the execution of the function, validation passes.
 
 ### `.transform`
 
@@ -1971,12 +1971,12 @@ emailToDomain.parse("colinhacks@example.com"); // => example.com
 
 #### Validating during transform
 
-The `.transform` method can simultaneously validate and transform the value. This is often simpler and less duplicative than chaining `refine` and `validate`.
+The `.transform` method can simultaneously validate and transform the value. This is often simpler and less duplicative than chaining `transform` and `refine`.
 
 As with `.superRefine`, the transform function receives a `ctx` object with a `addIssue` method that can be used to register validation issues.
 
 ```ts
-const Strings = z.string().transform((val, ctx) => {
+const numberInString = z.string().transform((val, ctx) => {
   const parsed = parseInt(val);
   if (isNaN(parsed)) {
     ctx.addIssue({

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -23,6 +23,7 @@ export const ZodIssueCode = util.arrayToEnum([
   "invalid_union_discriminator",
   "invalid_enum_value",
   "unrecognized_keys",
+  "invalid_this_type",
   "invalid_arguments",
   "invalid_return_type",
   "invalid_date",
@@ -71,6 +72,11 @@ export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
   received: string | number;
   code: typeof ZodIssueCode.invalid_enum_value;
   options: (string | number)[];
+}
+
+export interface ZodInvalidThisTypeIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.invalid_this_type;
+  thisTypeError: ZodError;
 }
 
 export interface ZodInvalidArgumentsIssue extends ZodIssueBase {
@@ -145,6 +151,7 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidUnionIssue
   | ZodInvalidUnionDiscriminatorIssue
   | ZodInvalidEnumValueIssue
+  | ZodInvalidThisTypeIssue
   | ZodInvalidArgumentsIssue
   | ZodInvalidReturnTypeIssue
   | ZodInvalidDateIssue

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -36,6 +36,9 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
         issue.options
       )}, received '${issue.received}'`;
       break;
+    case ZodIssueCode.invalid_this_type:
+      message = "Invalid `this` type provided to function";
+      break;
     case ZodIssueCode.invalid_arguments:
       message = `Invalid function arguments`;
       break;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1713,7 +1713,7 @@ export class ZodArray<
 
     if (ctx.common.async) {
       return Promise.all(
-        (ctx.data as any[]).map((item, i) => {
+        ([...ctx.data] as any[]).map((item, i) => {
           return def.type._parseAsync(
             new ParseInputLazyPath(ctx, item, ctx.path, i)
           );
@@ -1723,7 +1723,7 @@ export class ZodArray<
       });
     }
 
-    const result = (ctx.data as any[]).map((item, i) => {
+    const result = ([...ctx.data] as any[]).map((item, i) => {
       return def.type._parseSync(
         new ParseInputLazyPath(ctx, item, ctx.path, i)
       );
@@ -3234,35 +3234,40 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
 ///////////////////////////////////////////
 ///////////////////////////////////////////
 export interface ZodFunctionDef<
+  ThisType extends ZodTypeAny = ZodVoid,
   Args extends ZodTuple<any, any> = ZodTuple<any, any>,
   Returns extends ZodTypeAny = ZodTypeAny
 > extends ZodTypeDef {
+  thisType: ThisType;
   args: Args;
   returns: Returns;
   typeName: ZodFirstPartyTypeKind.ZodFunction;
 }
 
 export type OuterTypeOfFunction<
+  ThisType extends ZodTypeAny,
   Args extends ZodTuple<any, any>,
   Returns extends ZodTypeAny
 > = Args["_input"] extends Array<any>
-  ? (...args: Args["_input"]) => Returns["_output"]
+  ? (this: ThisType["_input"], ...args: Args["_input"]) => Returns["_output"]
   : never;
 
 export type InnerTypeOfFunction<
+  ThisType extends ZodTypeAny,
   Args extends ZodTuple<any, any>,
   Returns extends ZodTypeAny
 > = Args["_output"] extends Array<any>
-  ? (...args: Args["_output"]) => Returns["_input"]
+  ? (this: ThisType["_output"], ...args: Args["_output"]) => Returns["_input"]
   : never;
 
 export class ZodFunction<
+  ThisType extends ZodTypeAny,
   Args extends ZodTuple<any, any>,
   Returns extends ZodTypeAny
 > extends ZodType<
-  OuterTypeOfFunction<Args, Returns>,
-  ZodFunctionDef<Args, Returns>,
-  InnerTypeOfFunction<Args, Returns>
+  OuterTypeOfFunction<ThisType, Args, Returns>,
+  ZodFunctionDef<ThisType, Args, Returns>,
+  InnerTypeOfFunction<ThisType, Args, Returns>
 > {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
@@ -3273,6 +3278,26 @@ export class ZodFunction<
         received: ctx.parsedType,
       });
       return INVALID;
+    }
+
+    function makeInvalidThisTypeIssue(
+      thisType: any,
+      error: ZodError
+    ): ZodIssue {
+      return makeIssue({
+        data: thisType,
+        path: ctx.path,
+        errorMaps: [
+          ctx.common.contextualErrorMap,
+          ctx.schemaErrorMap,
+          getErrorMap(),
+          defaultErrorMap,
+        ].filter((x) => !!x) as ZodErrorMap[],
+        issueData: {
+          code: ZodIssueCode.invalid_this_type,
+          thisTypeError: error,
+        },
+      });
     }
 
     function makeArgsIssue(args: any, error: ZodError): ZodIssue {
@@ -3312,18 +3337,31 @@ export class ZodFunction<
     const params = { errorMap: ctx.common.contextualErrorMap };
     const fn = ctx.data;
 
+    const {
+      thisType: thisTypeSchema,
+      args: argsSchema,
+      returns: returnsSchema,
+    } = this._def;
+
     if (this._def.returns instanceof ZodPromise) {
-      return OK(async (...args: any[]) => {
+      return OK(async function (this: any, ...args: any[]) {
         const error = new ZodError([]);
-        const parsedArgs = await this._def.args
+        const parsedThis = await thisTypeSchema
+          .parseAsync(this, params)
+          .catch((e) => {
+            error.addIssue(makeInvalidThisTypeIssue(this, e));
+            throw error;
+          });
+        const parsedArgs = await argsSchema
           .parseAsync(args, params)
           .catch((e) => {
             error.addIssue(makeArgsIssue(args, e));
             throw error;
           });
-        const result = await fn(...(parsedArgs as any));
+        const boundFn = fn.bind(parsedThis);
+        const result = await boundFn(...(parsedArgs as any));
         const parsedReturns = await (
-          this._def.returns as ZodPromise<ZodTypeAny>
+          returnsSchema as ZodPromise<ZodTypeAny>
         )._def.type
           .parseAsync(result, params)
           .catch((e) => {
@@ -3333,13 +3371,20 @@ export class ZodFunction<
         return parsedReturns;
       });
     } else {
-      return OK((...args: any[]) => {
-        const parsedArgs = this._def.args.safeParse(args, params);
+      return OK(function (this: any, ...args: any[]) {
+        const parsedThis = thisTypeSchema.safeParse(this, params);
+        if (!parsedThis.success) {
+          throw new ZodError([
+            makeInvalidThisTypeIssue(this, parsedThis.error),
+          ]);
+        }
+        const parsedArgs = argsSchema.safeParse(args, params);
         if (!parsedArgs.success) {
           throw new ZodError([makeArgsIssue(args, parsedArgs.error)]);
         }
-        const result = fn(...(parsedArgs.data as any));
-        const parsedReturns = this._def.returns.safeParse(result, params);
+        const boundFn = fn.bind(parsedThis.data);
+        const result = boundFn(...(parsedArgs.data as any));
+        const parsedReturns = returnsSchema.safeParse(result, params);
         if (!parsedReturns.success) {
           throw new ZodError([makeReturnsIssue(result, parsedReturns.error)]);
         }
@@ -3356,9 +3401,20 @@ export class ZodFunction<
     return this._def.returns;
   }
 
+  thisParameterType() {
+    return this._def.thisType;
+  }
+
+  omitThisParameter() {
+    return new ZodFunction({
+      ...this._def,
+      thisType: ZodVoid.create(),
+    });
+  }
+
   args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
     ...items: Items
-  ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
+  ): ZodFunction<ThisType, ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
       ...this._def,
       args: ZodTuple.create(items).rest(ZodUnknown.create()) as any,
@@ -3367,49 +3423,57 @@ export class ZodFunction<
 
   returns<NewReturnType extends ZodType<any, any>>(
     returnType: NewReturnType
-  ): ZodFunction<Args, NewReturnType> {
+  ): ZodFunction<ThisType, Args, NewReturnType> {
     return new ZodFunction({
       ...this._def,
       returns: returnType,
     });
   }
 
-  implement<F extends InnerTypeOfFunction<Args, Returns>>(
+  this<T extends ZodTypeAny>(schema: T): ZodFunction<T, Args, Returns> {
+    return new ZodFunction({
+      ...this._def,
+      thisType: schema,
+    });
+  }
+
+  implement<F extends InnerTypeOfFunction<ThisType, Args, Returns>>(
     func: F
   ): ReturnType<F> extends Returns["_output"]
-    ? (...args: Args["_input"]) => ReturnType<F>
-    : OuterTypeOfFunction<Args, Returns> {
+    ? (this: ThisType["_input"], ...args: Args["_input"]) => ReturnType<F>
+    : OuterTypeOfFunction<ThisType, Args, Returns> {
     const validatedFunc = this.parse(func);
     return validatedFunc as any;
   }
 
   strictImplement(
-    func: InnerTypeOfFunction<Args, Returns>
-  ): InnerTypeOfFunction<Args, Returns> {
+    func: InnerTypeOfFunction<ThisType, Args, Returns>
+  ): InnerTypeOfFunction<ThisType, Args, Returns> {
     const validatedFunc = this.parse(func);
     return validatedFunc as any;
   }
 
   validate = this.implement;
 
-  static create(): ZodFunction<ZodTuple<[], ZodUnknown>, ZodUnknown>;
+  static create(): ZodFunction<ZodVoid, ZodTuple<[], ZodUnknown>, ZodUnknown>;
   static create<T extends AnyZodTuple = ZodTuple<[], ZodUnknown>>(
     args: T
-  ): ZodFunction<T, ZodUnknown>;
+  ): ZodFunction<ZodVoid, T, ZodUnknown>;
   static create<T extends AnyZodTuple, U extends ZodTypeAny>(
     args: T,
     returns: U
-  ): ZodFunction<T, U>;
+  ): ZodFunction<ZodVoid, T, U>;
   static create<
     T extends AnyZodTuple = ZodTuple<[], ZodUnknown>,
     U extends ZodTypeAny = ZodUnknown
-  >(args: T, returns: U, params?: RawCreateParams): ZodFunction<T, U>;
+  >(args: T, returns: U, params?: RawCreateParams): ZodFunction<ZodVoid, T, U>;
   static create(
     args?: AnyZodTuple,
     returns?: ZodTypeAny,
     params?: RawCreateParams
   ) {
     return new ZodFunction({
+      thisType: ZodVoid.create(),
       args: (args
         ? args
         : ZodTuple.create([]).rest(ZodUnknown.create())) as any,
@@ -4367,7 +4431,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodRecord<any, any>
   | ZodMap<any>
   | ZodSet<any>
-  | ZodFunction<any, any>
+  | ZodFunction<any, any, any>
   | ZodLazy<any>
   | ZodLiteral<any>
   | ZodEnum<any>

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -23,6 +23,7 @@ export const ZodIssueCode = util.arrayToEnum([
   "invalid_union_discriminator",
   "invalid_enum_value",
   "unrecognized_keys",
+  "invalid_this_type",
   "invalid_arguments",
   "invalid_return_type",
   "invalid_date",
@@ -71,6 +72,11 @@ export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
   received: string | number;
   code: typeof ZodIssueCode.invalid_enum_value;
   options: (string | number)[];
+}
+
+export interface ZodInvalidThisTypeIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.invalid_this_type;
+  thisTypeError: ZodError;
 }
 
 export interface ZodInvalidArgumentsIssue extends ZodIssueBase {
@@ -145,6 +151,7 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidUnionIssue
   | ZodInvalidUnionDiscriminatorIssue
   | ZodInvalidEnumValueIssue
+  | ZodInvalidThisTypeIssue
   | ZodInvalidArgumentsIssue
   | ZodInvalidReturnTypeIssue
   | ZodInvalidDateIssue

--- a/src/__tests__/function.test.ts
+++ b/src/__tests__/function.test.ts
@@ -239,3 +239,80 @@ test("fallback to OuterTypeOfFunction", () => {
     (arg: string, ...args_1: unknown[]) => number
   >(true);
 });
+
+test("Function with this parameter", () => {
+  const funcSchema = z
+    .function()
+    .args(z.string())
+    .returns(z.string())
+    .this(z.object({ val: z.number() }));
+
+  const myFunc = funcSchema.implement(function (this: { val: number }, val) {
+    return val + this.val;
+  });
+
+  expect(myFunc.call({ val: 5 }, "asdf")).toBe("asdf5");
+
+  util.assertEqual<
+    typeof myFunc,
+    (this: { val: number }, arg: string, ...args_1: unknown[]) => string
+  >(true);
+});
+
+test("Function with this parameter and no args", () => {
+  const funcSchema = z
+    .function()
+    .returns(z.string())
+    .this(z.object({ val: z.number() }));
+
+  const myFunc = funcSchema.implement(function (this: { val: number }) {
+    return this.val.toString();
+  });
+
+  expect(myFunc.call({ val: 5 })).toBe("5");
+
+  util.assertEqual<
+    typeof myFunc,
+    (this: { val: number }, ...args_1: unknown[]) => string
+  >(true);
+});
+
+test("Function with this parameters that changes and returns This", () => {
+  const funcSchema = z
+    .function()
+    .args(z.string())
+    .this(z.object({ val: z.number() }));
+
+  const myFunc = funcSchema.implement(function (this: { val: number }, val) {
+    this.val = val.length;
+    return this;
+  });
+
+  expect(myFunc.call({ val: 5 }, "asdf")).toEqual({ val: 4 });
+
+  util.assertEqual<
+    typeof myFunc,
+    (
+      this: { val: number },
+      arg: string,
+      ...args_1: unknown[]
+    ) => { val: number }
+  >(true);
+});
+
+test("Function without this parameter does not get bound", () => {
+  const funcSchema = z.function().args(z.string());
+
+  // @ts-expect-error `this` parameter type should be `void` since it was not specified in the schema
+  const myFunc = funcSchema.implement(function (this: { val: number }, val) {
+    return val + this.val;
+  });
+
+  // @ts-expect-error can't bind to a function that should have had a `this` parameters typed as `void`
+  expect(() => myFunc.bind({ val: 5 })("asdf")).toThrow();
+
+  util.assertEqual<
+    typeof myFunc,
+    (arg: string, ...args_1: unknown[]) => unknown // we couldn't infer the return type since the function was implemented incorrectly
+  >(true);
+});

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -36,6 +36,9 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
         issue.options
       )}, received '${issue.received}'`;
       break;
+    case ZodIssueCode.invalid_this_type:
+      message = "Invalid `this` type provided to function";
+      break;
     case ZodIssueCode.invalid_arguments:
       message = `Invalid function arguments`;
       break;


### PR DESCRIPTION
### Introducing `this` parameter type to `ZodFunction.`

This PR adds a method to pass a schema for parsing the `this` binding at runtime. And, as always, it also adds its inferred type to the inferred function type.

It's now possible to parse class methods, for example, that use `this` inside it. Previously, we were not only not parsing it but also transforming the function passed to `.implement()` to an arrow function, thus making it unbound.

The `this` context is one of the most tricky concepts of JavaScript while being also one of the most important since JS is pretty object-oriented. Being able to parse correctly bound functions _and_ their `this` type opens some doors for us to start thinking about a `ZodClass` or something like that. 

## Features

1. `ZodFunction` have their `this` type schema set to `ZodVoid` by default. This ensures that people don't use `this` incorrectly in the function implementation. 
2. Added the `this()` method to add the `this` schema.
3. Added the `thisParameterType()` method, [based on the TS utility type of the same name](https://www.typescriptlang.org/docs/handbook/utility-types.html#thisparametertypetype). It returns the schema associated with `ThisType`.
4. Added the `omitThisParameter()` method, [also based on the utility type of the same name](https://www.typescriptlang.org/docs/handbook/utility-types.html#omitthisparametertype).
5. Added the `invalid_this_type` issue.
6. Fixed the function passed to the `OK` function to be a `function ()` instead of an arrow one. This ensures that we will receive the `this` binding correctly and be able to parse it.