### PR TITLE
Add unit test 'string coercion with min length validation'

### DIFF
--- a/deno/lib/__tests__/coerce.test.ts
+++ b/deno/lib/__tests__/coerce.test.ts
@@ -28,6 +28,12 @@ test("string coercion", () => {
   );
 });
 
+test("string coercion with min length validation", () => {
+  const schema = z.coerce.string().min(1);
+  expect(() => schema.parse("")).toThrow();
+  expect(() => schema.parse(undefined)).toThrow();
+});
+
 test("number coercion", () => {
   const schema = z.coerce.number();
   expect(schema.parse("12")).toEqual(12);

--- a/src/__tests__/coerce.test.ts
+++ b/src/__tests__/coerce.test.ts
@@ -27,6 +27,12 @@ test("string coercion", () => {
   );
 });
 
+test("string coercion with min length validation", () => {
+  const schema = z.coerce.string().min(1);
+  expect(() => schema.parse("")).toThrow();
+  expect(() => schema.parse(undefined)).toThrow();
+});
+
 test("number coercion", () => {
   const schema = z.coerce.number();
   expect(schema.parse("12")).toEqual(12);


### PR DESCRIPTION
`undefined` parses to `undefined` for `z.coerce.string().min(1)`, I'd expect this to fail? 

So this unit test fails:

```ts
  const schema = z.coerce.string().min(1);
  expect(() => schema.parse(undefined)).toThrow();
```