### PR TITLE
Making `coerce` to be a type argument

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -505,10 +505,11 @@ export type ZodStringCheck =
       message?: string;
     };
 
-export interface ZodStringDef extends ZodTypeDef {
+export interface ZodStringDef<Coerce extends boolean = false>
+  extends ZodTypeDef {
   checks: ZodStringCheck[];
   typeName: ZodFirstPartyTypeKind.ZodString;
-  coerce: boolean;
+  coerce: Coerce;
 }
 
 const cuidRegex = /^c[^\s-]{8,}$/i;
@@ -561,7 +562,11 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
   }
 };
 
-export class ZodString extends ZodType<string, ZodStringDef> {
+export class ZodString<Coerce extends boolean = false> extends ZodType<
+  string,
+  ZodStringDef<Coerce>,
+  Coerce extends true ? any : string
+> {
   _parse(input: ParseInput): ParseReturnType<string> {
     if (this._def.coerce) {
       input.data = String(input.data);
@@ -887,11 +892,13 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     return max;
   }
 
-  static create = (params?: RawCreateParams & { coerce?: true }): ZodString => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodString<Coerce> => {
     return new ZodString({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodString,
-      coerce: params?.coerce ?? false,
+      coerce: (params?.coerce ?? false) as Coerce,
       ...processCreateParams(params),
     });
   };
@@ -921,13 +928,18 @@ function floatSafeRemainder(val: number, step: number) {
   return (valInt % stepInt) / Math.pow(10, decCount);
 }
 
-export interface ZodNumberDef extends ZodTypeDef {
+export interface ZodNumberDef<Coerce extends boolean = false>
+  extends ZodTypeDef {
   checks: ZodNumberCheck[];
   typeName: ZodFirstPartyTypeKind.ZodNumber;
-  coerce: boolean;
+  coerce: Coerce;
 }
 
-export class ZodNumber extends ZodType<number, ZodNumberDef> {
+export class ZodNumber<Coerce extends boolean = false> extends ZodType<
+  number,
+  ZodNumberDef<Coerce>,
+  Coerce extends true ? any : number
+> {
   _parse(input: ParseInput): ParseReturnType<number> {
     if (this._def.coerce) {
       input.data = Number(input.data);
@@ -1017,13 +1029,13 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
     return { status: status.value, value: input.data };
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodNumber => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodNumber<Coerce> => {
     return new ZodNumber({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodNumber,
-      coerce: params?.coerce || false,
+      coerce: (params?.coerce || false) as Coerce,
       ...processCreateParams(params),
     });
   };
@@ -1189,12 +1201,17 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
 /////////////////////////////////////////
 /////////////////////////////////////////
 
-export interface ZodBigIntDef extends ZodTypeDef {
+export interface ZodBigIntDef<Coerce extends boolean = false>
+  extends ZodTypeDef {
   typeName: ZodFirstPartyTypeKind.ZodBigInt;
-  coerce: boolean;
+  coerce: Coerce;
 }
 
-export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
+export class ZodBigInt<Coerce extends boolean = false> extends ZodType<
+  bigint,
+  ZodBigIntDef<Coerce>,
+  Coerce extends true ? any : bigint
+> {
   _parse(input: ParseInput): ParseReturnType<bigint> {
     if (this._def.coerce) {
       input.data = BigInt(input.data);
@@ -1212,12 +1229,12 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
     return OK(input.data);
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodBigInt => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodBigInt<Coerce> => {
     return new ZodBigInt({
       typeName: ZodFirstPartyTypeKind.ZodBigInt,
-      coerce: params?.coerce ?? false,
+      coerce: (params?.coerce ?? false) as Coerce,
       ...processCreateParams(params),
     });
   };
@@ -1230,12 +1247,17 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
 //////////                     ///////////
 //////////////////////////////////////////
 //////////////////////////////////////////
-export interface ZodBooleanDef extends ZodTypeDef {
+export interface ZodBooleanDef<Coerce extends boolean = false>
+  extends ZodTypeDef {
   typeName: ZodFirstPartyTypeKind.ZodBoolean;
-  coerce: boolean;
+  coerce: Coerce;
 }
 
-export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
+export class ZodBoolean<Coerce extends boolean = false> extends ZodType<
+  boolean,
+  ZodBooleanDef<Coerce>,
+  Coerce extends true ? any : boolean
+> {
   _parse(input: ParseInput): ParseReturnType<boolean> {
     if (this._def.coerce) {
       input.data = Boolean(input.data);
@@ -1254,12 +1276,12 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
     return OK(input.data);
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodBoolean => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodBoolean<Coerce> => {
     return new ZodBoolean({
       typeName: ZodFirstPartyTypeKind.ZodBoolean,
-      coerce: params?.coerce || false,
+      coerce: (params?.coerce || false) as Coerce,
       ...processCreateParams(params),
     });
   };
@@ -1275,13 +1297,17 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
 export type ZodDateCheck =
   | { kind: "min"; value: number; message?: string }
   | { kind: "max"; value: number; message?: string };
-export interface ZodDateDef extends ZodTypeDef {
+export interface ZodDateDef<Coerce extends boolean = false> extends ZodTypeDef {
   checks: ZodDateCheck[];
-  coerce: boolean;
+  coerce: Coerce;
   typeName: ZodFirstPartyTypeKind.ZodDate;
 }
 
-export class ZodDate extends ZodType<Date, ZodDateDef> {
+export class ZodDate<Coerce extends boolean = false> extends ZodType<
+  Date,
+  ZodDateDef<Coerce>,
+  Coerce extends true ? any : Date
+> {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     if (this._def.coerce) {
       input.data = new Date(input.data);
@@ -1392,12 +1418,12 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     return max != null ? new Date(max) : null;
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodDate => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodDate<Coerce> => {
     return new ZodDate({
       checks: [],
-      coerce: params?.coerce || false,
+      coerce: (params?.coerce || false) as Coerce,
       typeName: ZodFirstPartyTypeKind.ZodDate,
       ...processCreateParams(params),
     });
@@ -4437,16 +4463,16 @@ const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
 
 export const coerce = {
-  string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
-  number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
-  boolean: ((arg) =>
-    ZodBoolean.create({ ...arg, coerce: true })) as typeof ZodBoolean["create"],
-  bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
-  date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
+  string: (arg?: Parameters<typeof ZodString.create>[0]) =>
+    ZodString.create({ ...arg, coerce: true }),
+  number: (arg?: Parameters<typeof ZodNumber.create>[0]) =>
+    ZodNumber.create({ ...arg, coerce: true }),
+  boolean: (arg?: Parameters<typeof ZodBoolean.create>[0]) =>
+    ZodBoolean.create({ ...arg, coerce: true }),
+  bigint: (arg?: Parameters<typeof ZodBigInt.create>[0]) =>
+    ZodBigInt.create({ ...arg, coerce: true }),
+  date: (arg?: Parameters<typeof ZodDate.create>[0]) =>
+    ZodDate.create({ ...arg, coerce: true }),
 };
 
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -505,10 +505,11 @@ export type ZodStringCheck =
       message?: string;
     };
 
-export interface ZodStringDef extends ZodTypeDef {
+export interface ZodStringDef<Coerce extends boolean = false>
+  extends ZodTypeDef {
   checks: ZodStringCheck[];
   typeName: ZodFirstPartyTypeKind.ZodString;
-  coerce: boolean;
+  coerce: Coerce;
 }
 
 const cuidRegex = /^c[^\s-]{8,}$/i;
@@ -561,7 +562,11 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
   }
 };
 
-export class ZodString extends ZodType<string, ZodStringDef> {
+export class ZodString<Coerce extends boolean = false> extends ZodType<
+  string,
+  ZodStringDef<Coerce>,
+  Coerce extends true ? any : string
+> {
   _parse(input: ParseInput): ParseReturnType<string> {
     if (this._def.coerce) {
       input.data = String(input.data);
@@ -887,11 +892,13 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     return max;
   }
 
-  static create = (params?: RawCreateParams & { coerce?: true }): ZodString => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodString<Coerce> => {
     return new ZodString({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodString,
-      coerce: params?.coerce ?? false,
+      coerce: (params?.coerce ?? false) as Coerce,
       ...processCreateParams(params),
     });
   };
@@ -921,13 +928,18 @@ function floatSafeRemainder(val: number, step: number) {
   return (valInt % stepInt) / Math.pow(10, decCount);
 }
 
-export interface ZodNumberDef extends ZodTypeDef {
+export interface ZodNumberDef<Coerce extends boolean = false>
+  extends ZodTypeDef {
   checks: ZodNumberCheck[];
   typeName: ZodFirstPartyTypeKind.ZodNumber;
-  coerce: boolean;
+  coerce: Coerce;
 }
 
-export class ZodNumber extends ZodType<number, ZodNumberDef> {
+export class ZodNumber<Coerce extends boolean = false> extends ZodType<
+  number,
+  ZodNumberDef<Coerce>,
+  Coerce extends true ? any : number
+> {
   _parse(input: ParseInput): ParseReturnType<number> {
     if (this._def.coerce) {
       input.data = Number(input.data);
@@ -1017,13 +1029,13 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
     return { status: status.value, value: input.data };
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodNumber => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodNumber<Coerce> => {
     return new ZodNumber({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodNumber,
-      coerce: params?.coerce || false,
+      coerce: (params?.coerce || false) as Coerce,
       ...processCreateParams(params),
     });
   };
@@ -1189,12 +1201,17 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
 /////////////////////////////////////////
 /////////////////////////////////////////
 
-export interface ZodBigIntDef extends ZodTypeDef {
+export interface ZodBigIntDef<Coerce extends boolean = false>
+  extends ZodTypeDef {
   typeName: ZodFirstPartyTypeKind.ZodBigInt;
-  coerce: boolean;
+  coerce: Coerce;
 }
 
-export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
+export class ZodBigInt<Coerce extends boolean = false> extends ZodType<
+  bigint,
+  ZodBigIntDef<Coerce>,
+  Coerce extends true ? any : bigint
+> {
   _parse(input: ParseInput): ParseReturnType<bigint> {
     if (this._def.coerce) {
       input.data = BigInt(input.data);
@@ -1212,12 +1229,12 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
     return OK(input.data);
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodBigInt => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodBigInt<Coerce> => {
     return new ZodBigInt({
       typeName: ZodFirstPartyTypeKind.ZodBigInt,
-      coerce: params?.coerce ?? false,
+      coerce: (params?.coerce ?? false) as Coerce,
       ...processCreateParams(params),
     });
   };
@@ -1230,12 +1247,17 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
 //////////                     ///////////
 //////////////////////////////////////////
 //////////////////////////////////////////
-export interface ZodBooleanDef extends ZodTypeDef {
+export interface ZodBooleanDef<Coerce extends boolean = false>
+  extends ZodTypeDef {
   typeName: ZodFirstPartyTypeKind.ZodBoolean;
-  coerce: boolean;
+  coerce: Coerce;
 }
 
-export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
+export class ZodBoolean<Coerce extends boolean = false> extends ZodType<
+  boolean,
+  ZodBooleanDef<Coerce>,
+  Coerce extends true ? any : boolean
+> {
   _parse(input: ParseInput): ParseReturnType<boolean> {
     if (this._def.coerce) {
       input.data = Boolean(input.data);
@@ -1254,12 +1276,12 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
     return OK(input.data);
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodBoolean => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodBoolean<Coerce> => {
     return new ZodBoolean({
       typeName: ZodFirstPartyTypeKind.ZodBoolean,
-      coerce: params?.coerce || false,
+      coerce: (params?.coerce || false) as Coerce,
       ...processCreateParams(params),
     });
   };
@@ -1275,13 +1297,17 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
 export type ZodDateCheck =
   | { kind: "min"; value: number; message?: string }
   | { kind: "max"; value: number; message?: string };
-export interface ZodDateDef extends ZodTypeDef {
+export interface ZodDateDef<Coerce extends boolean = false> extends ZodTypeDef {
   checks: ZodDateCheck[];
-  coerce: boolean;
+  coerce: Coerce;
   typeName: ZodFirstPartyTypeKind.ZodDate;
 }
 
-export class ZodDate extends ZodType<Date, ZodDateDef> {
+export class ZodDate<Coerce extends boolean = false> extends ZodType<
+  Date,
+  ZodDateDef<Coerce>,
+  Coerce extends true ? any : Date
+> {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     if (this._def.coerce) {
       input.data = new Date(input.data);
@@ -1392,12 +1418,12 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     return max != null ? new Date(max) : null;
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodDate => {
+  static create = <Coerce extends boolean = false>(
+    params?: RawCreateParams & { coerce?: Coerce }
+  ): ZodDate<Coerce> => {
     return new ZodDate({
       checks: [],
-      coerce: params?.coerce || false,
+      coerce: (params?.coerce || false) as Coerce,
       typeName: ZodFirstPartyTypeKind.ZodDate,
       ...processCreateParams(params),
     });
@@ -4437,16 +4463,16 @@ const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
 
 export const coerce = {
-  string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
-  number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
-  boolean: ((arg) =>
-    ZodBoolean.create({ ...arg, coerce: true })) as typeof ZodBoolean["create"],
-  bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
-  date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
+  string: (arg?: Parameters<typeof ZodString.create>[0]) =>
+    ZodString.create({ ...arg, coerce: true }),
+  number: (arg?: Parameters<typeof ZodNumber.create>[0]) =>
+    ZodNumber.create({ ...arg, coerce: true }),
+  boolean: (arg?: Parameters<typeof ZodBoolean.create>[0]) =>
+    ZodBoolean.create({ ...arg, coerce: true }),
+  bigint: (arg?: Parameters<typeof ZodBigInt.create>[0]) =>
+    ZodBigInt.create({ ...arg, coerce: true }),
+  date: (arg?: Parameters<typeof ZodDate.create>[0]) =>
+    ZodDate.create({ ...arg, coerce: true }),
 };
 
 export {


### PR DESCRIPTION
Fixes #1760 

This PR makes the schema types, that support `coerce` feature, to have the correct type of the input schema if this feature is enabled.

Thus, `z.coerce.number()` will have the type compatible to `ZodType<number, ZodNumberDef, any>`.
Third type argument stands for input type, which in case of `coerce` accepts anything.

Therefore, taking `z.input<>` on such schema will return `any`.

The behavior of schemas and methods without `coerce` feature, of having that feature disabled, remains the same.

Thanks to the default values of the new type argument, this change is backward compatible.