### PR TITLE
fix deno literal test.

### DIFF
--- a/deno/lib/__tests__/literal.test.ts
+++ b/deno/lib/__tests__/literal.test.ts
@@ -1,3 +1,7 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
 import * as z from "../index.ts";
 
 const literalTuna = z.literal("tuna");

--- a/src/__tests__/literal.test.ts
+++ b/src/__tests__/literal.test.ts
@@ -1,3 +1,6 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
 import * as z from "../index";
 
 const literalTuna = z.literal("tuna");


### PR DESCRIPTION
It is currently throwing due to missing `expect` import.