### PR TITLE
test: add benchmark tests for date and symbol

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -361,6 +361,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 
 #### Zod to X
 

--- a/deno/lib/benchmarks/primitives.ts
+++ b/deno/lib/benchmarks/primitives.ts
@@ -3,7 +3,7 @@ import Benchmark from "benchmark";
 import { Mocker } from "../__tests__/Mocker.ts";
 import { z } from "../index.ts";
 
-const val = new Mocker
+const val = new Mocker();
 
 const enumSuite = new Benchmark.Suite("z.enum");
 const enumSchema = z.enum(["a", "b", "c"]);

--- a/deno/lib/benchmarks/primitives.ts
+++ b/deno/lib/benchmarks/primitives.ts
@@ -1,6 +1,9 @@
 import Benchmark from "benchmark";
 
+import { Mocker } from "../__tests__/Mocker.ts";
 import { z } from "../index.ts";
+
+const val = new Mocker
 
 const enumSuite = new Benchmark.Suite("z.enum");
 const enumSchema = z.enum(["a", "b", "c"]);
@@ -73,6 +76,53 @@ numberSuite
     console.log(`z.number: ${e.target}`);
   });
 
+const dateSuite = new Benchmark.Suite("z.date");
+
+const plainDate = z.date();
+const minMaxDate = z.date().min(new Date("2021-01-01")).max(new Date("2030-01-01"));
+
+dateSuite
+  .add("valid", () => {
+    plainDate.parse(new Date());
+  })
+  .add("invalid", () => {
+    try {
+      plainDate.parse(1);
+    } catch (e) {}
+  })
+  .add("valid min and max", () => {
+    minMaxDate.parse(new Date("2023-01-01"));
+  })
+  .add("invalid min", () => {
+    try {
+      minMaxDate.parse(new Date("2019-01-01"));
+    } catch (e) {}
+  })
+  .add("invalid max", () => {
+    try {
+      minMaxDate.parse(new Date("2031-01-01"));
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`z.date: ${e.target}`);
+  });
+
+const symbolSuite = new Benchmark.Suite("z.symbol");
+const symbolSchema = z.symbol();
+
+symbolSuite
+  .add("valid", () => {
+    symbolSchema.parse(val.symbol)
+  })
+  .add("invalid", () => {
+    try {
+      symbolSchema.parse(1);
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`z.symbol: ${e.target}`);
+  });
+
 export default {
-  suites: [enumSuite, undefinedSuite, literalSuite, numberSuite],
+  suites: [enumSuite, undefinedSuite, literalSuite, numberSuite, dateSuite, symbolSuite],
 };

--- a/src/benchmarks/primitives.ts
+++ b/src/benchmarks/primitives.ts
@@ -3,7 +3,7 @@ import Benchmark from "benchmark";
 import { Mocker } from "../__tests__/Mocker";
 import { z } from "../index";
 
-const val = new Mocker
+const val = new Mocker();
 
 const enumSuite = new Benchmark.Suite("z.enum");
 const enumSchema = z.enum(["a", "b", "c"]);

--- a/src/benchmarks/primitives.ts
+++ b/src/benchmarks/primitives.ts
@@ -1,6 +1,9 @@
 import Benchmark from "benchmark";
 
+import { Mocker } from "../__tests__/Mocker";
 import { z } from "../index";
+
+const val = new Mocker
 
 const enumSuite = new Benchmark.Suite("z.enum");
 const enumSchema = z.enum(["a", "b", "c"]);
@@ -73,6 +76,53 @@ numberSuite
     console.log(`z.number: ${e.target}`);
   });
 
+const dateSuite = new Benchmark.Suite("z.date");
+
+const plainDate = z.date();
+const minMaxDate = z.date().min(new Date("2021-01-01")).max(new Date("2030-01-01"));
+
+dateSuite
+  .add("valid", () => {
+    plainDate.parse(new Date());
+  })
+  .add("invalid", () => {
+    try {
+      plainDate.parse(1);
+    } catch (e) {}
+  })
+  .add("valid min and max", () => {
+    minMaxDate.parse(new Date("2023-01-01"));
+  })
+  .add("invalid min", () => {
+    try {
+      minMaxDate.parse(new Date("2019-01-01"));
+    } catch (e) {}
+  })
+  .add("invalid max", () => {
+    try {
+      minMaxDate.parse(new Date("2031-01-01"));
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`z.date: ${e.target}`);
+  });
+
+const symbolSuite = new Benchmark.Suite("z.symbol");
+const symbolSchema = z.symbol();
+
+symbolSuite
+  .add("valid", () => {
+    symbolSchema.parse(val.symbol)
+  })
+  .add("invalid", () => {
+    try {
+      symbolSchema.parse(1);
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`z.symbol: ${e.target}`);
+  });
+
 export default {
-  suites: [enumSuite, undefinedSuite, literalSuite, numberSuite],
+  suites: [enumSuite, undefinedSuite, literalSuite, numberSuite, dateSuite, symbolSuite],
 };


### PR DESCRIPTION
This PR will add benchmark tests for date and symbol, currently not covered.
<details>
<summary>yarn benchmark output, only new tests shown</summary>

$ tsx src/benchmarks/index.ts
z.date: valid x 3,007,337 ops/sec ±0.49% (91 runs sampled)
z.date: invalid x 34,043 ops/sec ±3.08% (89 runs sampled)
z.date: valid min and max x 2,141,123 ops/sec ±1.73% (88 runs sampled)
z.date: invalid min x 29,310 ops/sec ±2.43% (87 runs sampled)
z.date: invalid max x 26,036 ops/sec ±3.88% (77 runs sampled)
z.symbol: valid x 5,416,457 ops/sec ±4.04% (79 runs sampled)
z.symbol: invalid x 32,293 ops/sec ±1.95% (78 runs sampled)

</details>