### PR TITLE
Add string cuid2() validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
+z.string().cuid2();
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -535,6 +535,7 @@ z.string().email();
 z.string().url();
 z.string().uuid();
 z.string().cuid();
+z.string().cuid2();
 z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
@@ -785,7 +786,7 @@ FishEnum.enum;
 You can also retrieve the list of options as a tuple with the `.options` property:
 
 ```ts
-FishEnum.options; // ["Salmon", "Tuna", "Trout"]);
+FishEnum.options; // ["Salmon", "Tuna", "Trout"];
 ```
 
 ## Native enums

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -94,6 +94,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "cuid2"
   | "datetime"
   | { startsWith: string }
   | { endsWith: string };

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -122,6 +122,27 @@ test("cuid", () => {
   }
 });
 
+test("cuid2", () => {
+  const cuid2 = z.string().cuid2();
+  const validStrings = [
+    "a", // short string
+    "tz4a98xxat96iws9zmbrgj3a", // normal string
+    "kf5vz6ssxe4zjcb409rjgo747tc5qjazgptvotk6", // longer than require("@paralleldrive/cuid2").bigLength
+  ];
+  validStrings.forEach((s) => cuid2.parse(s));
+  const invalidStrings = [
+    "", // empty string
+    "1z4a98xxat96iws9zmbrgj3a", // starts with a number
+    "tz4a98xxat96iws9zMbrgj3a", // include uppercase
+    "tz4a98xxat96iws-zmbrgj3a", // involve symbols
+  ];
+  const results = invalidStrings.map((s) => cuid2.safeParse(s));
+  expect(results.every((r) => !r.success)).toEqual(true);
+  if (!results[0].success) {
+    expect(results[0].error.issues[0].message).toEqual("Invalid cuid2");
+  }
+});
+
 test("regex", () => {
   z.string()
     .regex(/^moo+$/)
@@ -156,21 +177,31 @@ test("checks getters", () => {
   expect(z.string().email().isEmail).toEqual(true);
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
+  expect(z.string().email().isCUID2).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
+  expect(z.string().url().isCUID2).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
+  expect(z.string().cuid().isCUID2).toEqual(false);
   expect(z.string().cuid().isUUID).toEqual(false);
+
+  expect(z.string().cuid2().isEmail).toEqual(false);
+  expect(z.string().cuid2().isURL).toEqual(false);
+  expect(z.string().cuid2().isCUID).toEqual(false);
+  expect(z.string().cuid2().isCUID2).toEqual(true);
+  expect(z.string().cuid2().isUUID).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
+  expect(z.string().uuid().isCUID2).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
 });
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -494,6 +494,7 @@ export type ZodStringCheck =
   | { kind: "url"; message?: string }
   | { kind: "uuid"; message?: string }
   | { kind: "cuid"; message?: string }
+  | { kind: "cuid2"; message?: string }
   | { kind: "startsWith"; value: string; message?: string }
   | { kind: "endsWith"; value: string; message?: string }
   | { kind: "regex"; regex: RegExp; message?: string }
@@ -512,6 +513,7 @@ export interface ZodStringDef extends ZodTypeDef {
 }
 
 const cuidRegex = /^c[^\s-]{8,}$/i;
+const cuid2Regex = /^[a-z][a-z0-9]*$/;
 const uuidRegex =
   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // from https://stackoverflow.com/a/46181/1550155
@@ -668,6 +670,16 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           });
           status.dirty();
         }
+      } else if (check.kind === "cuid2") {
+        if (!cuid2Regex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "cuid2",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "url") {
         try {
           new URL(input.data);
@@ -763,6 +775,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
+  }
+  cuid2(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "cuid2", ...errorUtil.errToObj(message) });
   }
   datetime(
     options?:
@@ -866,6 +881,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
+  }
+  get isCUID2() {
+    return !!this._def.checks.find((ch) => ch.kind === "cuid2");
   }
 
   get minLength() {

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -94,6 +94,7 @@ export type StringValidation =
   | "uuid"
   | "regex"
   | "cuid"
+  | "cuid2"
   | "datetime"
   | { startsWith: string }
   | { endsWith: string };

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -121,6 +121,27 @@ test("cuid", () => {
   }
 });
 
+test("cuid2", () => {
+  const cuid2 = z.string().cuid2();
+  const validStrings = [
+    "a", // short string
+    "tz4a98xxat96iws9zmbrgj3a", // normal string
+    "kf5vz6ssxe4zjcb409rjgo747tc5qjazgptvotk6", // longer than require("@paralleldrive/cuid2").bigLength
+  ];
+  validStrings.forEach((s) => cuid2.parse(s));
+  const invalidStrings = [
+    "", // empty string
+    "1z4a98xxat96iws9zmbrgj3a", // starts with a number
+    "tz4a98xxat96iws9zMbrgj3a", // include uppercase
+    "tz4a98xxat96iws-zmbrgj3a", // involve symbols
+  ];
+  const results = invalidStrings.map((s) => cuid2.safeParse(s));
+  expect(results.every((r) => !r.success)).toEqual(true);
+  if (!results[0].success) {
+    expect(results[0].error.issues[0].message).toEqual("Invalid cuid2");
+  }
+});
+
 test("regex", () => {
   z.string()
     .regex(/^moo+$/)
@@ -155,21 +176,31 @@ test("checks getters", () => {
   expect(z.string().email().isEmail).toEqual(true);
   expect(z.string().email().isURL).toEqual(false);
   expect(z.string().email().isCUID).toEqual(false);
+  expect(z.string().email().isCUID2).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
   expect(z.string().url().isCUID).toEqual(false);
+  expect(z.string().url().isCUID2).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
   expect(z.string().cuid().isCUID).toEqual(true);
+  expect(z.string().cuid().isCUID2).toEqual(false);
   expect(z.string().cuid().isUUID).toEqual(false);
+
+  expect(z.string().cuid2().isEmail).toEqual(false);
+  expect(z.string().cuid2().isURL).toEqual(false);
+  expect(z.string().cuid2().isCUID).toEqual(false);
+  expect(z.string().cuid2().isCUID2).toEqual(true);
+  expect(z.string().cuid2().isUUID).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
   expect(z.string().uuid().isCUID).toEqual(false);
+  expect(z.string().uuid().isCUID2).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -494,6 +494,7 @@ export type ZodStringCheck =
   | { kind: "url"; message?: string }
   | { kind: "uuid"; message?: string }
   | { kind: "cuid"; message?: string }
+  | { kind: "cuid2"; message?: string }
   | { kind: "startsWith"; value: string; message?: string }
   | { kind: "endsWith"; value: string; message?: string }
   | { kind: "regex"; regex: RegExp; message?: string }
@@ -512,6 +513,7 @@ export interface ZodStringDef extends ZodTypeDef {
 }
 
 const cuidRegex = /^c[^\s-]{8,}$/i;
+const cuid2Regex = /^[a-z][a-z0-9]*$/;
 const uuidRegex =
   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // from https://stackoverflow.com/a/46181/1550155
@@ -668,6 +670,16 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           });
           status.dirty();
         }
+      } else if (check.kind === "cuid2") {
+        if (!cuid2Regex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "cuid2",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "url") {
         try {
           new URL(input.data);
@@ -763,6 +775,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
+  }
+  cuid2(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "cuid2", ...errorUtil.errToObj(message) });
   }
   datetime(
     options?:
@@ -866,6 +881,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
+  }
+  get isCUID2() {
+    return !!this._def.checks.find((ch) => ch.kind === "cuid2");
   }
 
   get minLength() {


### PR DESCRIPTION
[`cuid`](https://github.com/paralleldrive/cuid) has been deprecated in favour of [`cuid2`](https://github.com/paralleldrive/cuid2). Now it's not yet widely used but I believe it will catch up with `cuid` soon. This PR adds validation for `cuid2`.

It's my first time contributing here so please tell if I did something wrong. I did update the README with the additional method but feel free to revert the change there.