### PR TITLE
update homepage link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "bugs": {
     "url": "https://github.com/colinhacks/zod/issues"
   },
-  "homepage": "https://github.com/colinhacks/zod",
+  "homepage": "https://zod.dev",
   "funding": "https://github.com/sponsors/colinhacks",
   "support": {
     "backing": {


### PR DESCRIPTION
This PR updates the `homepage` field in the `package.json` file. This way, it will show up on the NPM website. The GH repo link will still be available under "Repository".

<img width="403" alt="Screenshot 2023-01-06 at 09 46 50" src="https://user-images.githubusercontent.com/767959/210965230-b2db9fdb-0950-4adb-9f87-6861e5f16450.png">
