### PR TITLE
Readme: Reference `coerce` in "Supporting date strings" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,18 +731,9 @@ z.date().max(new Date(), { message: "Too young!" });
 
 **Supporting date strings**
 
-To write a schema that accepts either a `Date` or a date string, use [`z.preprocess`](#preprocess).
+Since [zod 3.20](https://github.com/colinhacks/zod/releases/tag/v3.20), use [`z.coerce.date()`](#coercion-for-primitives) to pass the input through the `new Date(input)`.
 
-```ts
-const dateSchema = z.preprocess((arg) => {
-  if (typeof arg == "string" || arg instanceof Date) return new Date(arg);
-}, z.date());
-type DateSchema = z.infer<typeof dateSchema>;
-// type DateSchema = Date
-
-dateSchema.safeParse(new Date("1/12/22")); // success: true
-dateSchema.safeParse("2022-01-12T00:00:00.000Z"); // success: true
-```
+For older zod versions, use [`z.preprocess`](#preprocess) like [described in this thread](https://github.com/colinhacks/zod/discussions/879#discussioncomment-2036276).
 
 ## Zod enums
 

--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ z.date().max(new Date(), { message: "Too young!" });
 
 **Supporting date strings**
 
-Since [zod 3.20](https://github.com/colinhacks/zod/releases/tag/v3.20), use [`z.coerce.date()`](#coercion-for-primitives) to pass the input through the `new Date(input)`.
+Since [zod 3.20](https://github.com/colinhacks/zod/releases/tag/v3.20), use [`z.coerce.date()`](#coercion-for-primitives) to pass the input through `new Date(input)`.
 
 For older zod versions, use [`z.preprocess`](#preprocess) like [described in this thread](https://github.com/colinhacks/zod/discussions/879#discussioncomment-2036276).
 


### PR DESCRIPTION
Am I right in assuming that the `coerce` is the new way to solve the question answered by @JacobWeisenburger in https://github.com/colinhacks/zod/discussions/879#discussioncomment-2036276 – if so, this PR offers an update to the docs.

(Let me know if I should squash the typo commit or if you can squash merge via Github.)

---

Ping https://github.com/colinhacks/zod/pull/881