### PR TITLE
Feat/1768 discriminated union object functions <<please review>>

### DIFF
--- a/README.md
+++ b/README.md
@@ -1335,9 +1335,32 @@ const myUnion = z.discriminatedUnion("status", [
 myUnion.parse({ status: "success", data: "yippie ki yay" });
 ```
 
-### `.strict`, `.strip`, `.passthrough`, `.catchall`, `.pick`, `.omit`, `.deepPartial`, `.partial`, `.required`
+### `.strict/.strip/.passthrough/.catchall/.pick/.omit/.deepPartial/.partial/.required`
 
 These methods apply schema alterations to all the "options", similar to the methods on the [Objects](#objects) schema, but they do not effect the _discriminator_.
+
+```ts
+const myUnion = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("success"), data: z.string() }),
+  z.object({ status: z.literal("failed"), error: z.instanceof(Error) }),
+]);
+
+const strictSchema = myUnion.strict();
+const stripSchema = myUnion.strip();
+const pasthroughSchema = myUnion.pasthrough();
+const catchallSchema = myUnion.catchall(z.number());
+
+const pickSchema = myUnion.pick({ data: true }); // discriminator is allways picked
+const omitSchema = myUnion.omit({ error: true }); // discriminator cannot be omitted
+
+const deepPartialSchema = myUnion.deepPartial(); // discriminator is still required
+
+const partialSchema = myUnion.partial();  // discriminator is still required
+const partialWithMaskSchema = myUnion.partial({ error: true }); // discriminator cannot be made optional
+
+const requiredSchema = myUnion.required();
+const requiredWithMaskSchema = myUnion.required({ data: true });
+```
 
 ## Records
 
@@ -2100,8 +2123,10 @@ Conceptually, this is how Zod processes default values:
 Use `.describe()` to add a `description` property to the resulting schema.
 
 ```ts
-const documentedString = z.string().describe("A useful bit of text, if you know what to do with it.");
-documentedString.description // A useful bit of text…
+const documentedString = z
+  .string()
+  .describe("A useful bit of text, if you know what to do with it.");
+documentedString.description; // A useful bit of text…
 ```
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).

--- a/README.md
+++ b/README.md
@@ -1335,6 +1335,10 @@ const myUnion = z.discriminatedUnion("status", [
 myUnion.parse({ status: "success", data: "yippie ki yay" });
 ```
 
+### `.strict`, `.strip`, `.passthrough`, `.catchall`, `.pick`, `.omit`, `.deepPartial`, `.partial`, `.required`
+
+These methods apply schema alterations to all the "options", similar to the methods on the [Objects](#objects) schema, but they do not effect the _discriminator_.
+
 ## Records
 
 Record schemas are used to validate types such as `{ [k: string]: number }`.

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1335,9 +1335,32 @@ const myUnion = z.discriminatedUnion("status", [
 myUnion.parse({ status: "success", data: "yippie ki yay" });
 ```
 
-### `.strict`, `.strip`, `.passthrough`, `.catchall`, `.pick`, `.omit`, `.deepPartial`, `.partial`, `.required`
+### `.strict/.strip/.passthrough/.catchall/.pick/.omit/.deepPartial/.partial/.required`
 
 These methods apply schema alterations to all the "options", similar to the methods on the [Objects](#objects) schema, but they do not effect the _discriminator_.
+
+```ts
+const myUnion = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("success"), data: z.string() }),
+  z.object({ status: z.literal("failed"), error: z.instanceof(Error) }),
+]);
+
+const strictSchema = myUnion.strict();
+const stripSchema = myUnion.strip();
+const pasthroughSchema = myUnion.pasthrough();
+const catchallSchema = myUnion.catchall(z.number());
+
+const pickSchema = myUnion.pick({ data: true }); // discriminator is allways picked
+const omitSchema = myUnion.omit({ error: true }); // discriminator cannot be omitted
+
+const deepPartialSchema = myUnion.deepPartial(); // discriminator is still required
+
+const partialSchema = myUnion.partial();  // discriminator is still required
+const partialWithMaskSchema = myUnion.partial({ error: true }); // discriminator cannot be made optional
+
+const requiredSchema = myUnion.required();
+const requiredWithMaskSchema = myUnion.required({ data: true });
+```
 
 ## Records
 
@@ -2100,8 +2123,10 @@ Conceptually, this is how Zod processes default values:
 Use `.describe()` to add a `description` property to the resulting schema.
 
 ```ts
-const documentedString = z.string().describe("A useful bit of text, if you know what to do with it.");
-documentedString.description // A useful bit of text…
+const documentedString = z
+  .string()
+  .describe("A useful bit of text, if you know what to do with it.");
+documentedString.description; // A useful bit of text…
 ```
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1335,6 +1335,10 @@ const myUnion = z.discriminatedUnion("status", [
 myUnion.parse({ status: "success", data: "yippie ki yay" });
 ```
 
+### `.strict`, `.strip`, `.passthrough`, `.catchall`, `.pick`, `.omit`, `.deepPartial`, `.partial`, `.required`
+
+These methods apply schema alterations to all the "options", similar to the methods on the [Objects](#objects) schema, but they do not effect the _discriminator_.
+
 ## Records
 
 Record schemas are used to validate types such as `{ [k: string]: number }`.

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -227,5 +227,5 @@ test("valid - pick", () => {
 
   expect(pickFromSchema.parse({ c: 1, b: 'bla', d: 'hi' })).toEqual({ c: 1 });
   expect(pickFromSchema.parse({ c: 2, b: 'bla', d: 'hi' })).toEqual({ c: 2, d: 'hi' })
-  expect(pickFromSchema.safeParse({ c: 3 })).toEqual({ c: 1 });
+  expect(pickFromSchema.parse({ c: 3 })).toEqual({ c: 3 });
 })

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -218,7 +218,7 @@ test("valid - literals with .default or .preprocess", () => {
   });
 });
 
-test('strict', () => {
+test("strict", () => {
   const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).passthrough(),
     z.object({ type: z.literal("b"), baz: z.string() }).passthrough(),
@@ -231,17 +231,17 @@ test('strict', () => {
 
   expect(output).toEqual({
     success: false,
-    error: expect.objectContaining({ issues: [expect.objectContaining({ code: 'unrecognized_keys' })] })
+    error: expect.objectContaining({ issues: [expect.objectContaining({ code: "unrecognized_keys" })] })
   });
 
   expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(strictSchema);
   expect(strictSchema.options).toHaveLength(2);
   strictSchema.options.forEach(option => {
-    expect(option._def.unknownKeys).toEqual('strict');
+    expect(option._def.unknownKeys).toEqual("strict");
   })
 });
 
-test('strip', () => {
+test("strip", () => {
   const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strict(),
     z.object({ type: z.literal("b"), baz: z.string() }).strict(),
@@ -257,11 +257,11 @@ test('strip', () => {
   expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(stripSchema);
   expect(stripSchema.options).toHaveLength(2);
   stripSchema.options.forEach(option => {
-    expect(option._def.unknownKeys).toEqual('strip');
+    expect(option._def.unknownKeys).toEqual("strip");
   })
 });
 
-test('passthrough', () => {
+test("passthrough", () => {
   const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strict(),
     z.object({ type: z.literal("b"), baz: z.string() }).strict(),
@@ -277,11 +277,11 @@ test('passthrough', () => {
   expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(passthroughSchema);
   expect(passthroughSchema.options).toHaveLength(2);
   passthroughSchema.options.forEach(option => {
-    expect(option._def.unknownKeys).toEqual('passthrough');
+    expect(option._def.unknownKeys).toEqual("passthrough");
   })
 });
 
-test('catchall', () => {
+test("catchall", () => {
   const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strict(),
     z.object({ type: z.literal("b"), baz: z.string() }).strict(),
@@ -290,7 +290,7 @@ test('catchall', () => {
   const catchallSchema = schema.catchall(z.number());
 
   const validInput = { type: "a", foo: "bar", test: 123 };
-  const invalidInput = { type: "a", foo: "bar", test: 'this is a string' };
+  const invalidInput = { type: "a", foo: "bar", test: "this is a string" };
 
   expect(catchallSchema.parse(validInput)).toEqual({ type: "a", foo: "bar", test: 123 });
 
@@ -299,14 +299,14 @@ test('catchall', () => {
     success: false,
     error: expect.objectContaining({
       issues: [expect.objectContaining({
-        code: 'invalid_type', expected: 'number', received: 'string', path: ['test']
+        code: "invalid_type", expected: "number", received: "string", path: ["test"]
       })]
     })
   });
 });
 
 test("pick including discriminator", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
@@ -320,7 +320,7 @@ test("pick including discriminator", () => {
 });
 
 test("pick without discriminator adds discriminator", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
@@ -334,7 +334,7 @@ test("pick without discriminator adds discriminator", () => {
 });
 
 test("omit without discriminator", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
@@ -348,7 +348,7 @@ test("omit without discriminator", () => {
 });
 
 test("try to omit discriminator", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
@@ -359,58 +359,58 @@ test("try to omit discriminator", () => {
   expect(omitSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 });
 
-test('deepPartial, keeps discriminator required', () => {
-  const schema = z.discriminatedUnion('type', [
+test("deepPartial, keeps discriminator required", () => {
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.object({ bar: z.string(), baz: z.number() }) }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
 
   const deepPartialSchema = schema.deepPartial();
 
-  expect(deepPartialSchema.parse({ type: "a", foo: { bar: 'test', baz: 123 } })).toEqual({ type: "a", foo: { bar: 'test', baz: 123 } });
-  expect(deepPartialSchema.parse({ type: "a", foo: { bar: 'test' } })).toEqual({ type: "a", foo: { bar: 'test' } });
+  expect(deepPartialSchema.parse({ type: "a", foo: { bar: "test", baz: 123 } })).toEqual({ type: "a", foo: { bar: "test", baz: 123 } });
+  expect(deepPartialSchema.parse({ type: "a", foo: { bar: "test" } })).toEqual({ type: "a", foo: { bar: "test" } });
   expect(deepPartialSchema.parse({ type: "a" })).toEqual({ type: "a" });
   expect(deepPartialSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 
   expect(deepPartialSchema.safeParse({})).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
     }),
   });
   expectShape<{ type: "a", foo?: { bar?: string, baz?: number } } | { type: "b", baz?: string }>().forSchema(deepPartialSchema);
 });
 
 test("partial, without mask, keeps discriminator required", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.object({ bar: z.string(), baz: z.number() }) }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
 
   const partialSchema = schema.partial();
 
-  expect(partialSchema.parse({ type: "a", foo: { bar: 'test', baz: 123 } })).toEqual({ type: "a", foo: { bar: 'test', baz: 123 } });
+  expect(partialSchema.parse({ type: "a", foo: { bar: "test", baz: 123 } })).toEqual({ type: "a", foo: { bar: "test", baz: 123 } });
   expect(partialSchema.parse({ type: "a" })).toEqual({ type: "a" });
   expect(partialSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 
-  expect(partialSchema.safeParse({ type: "a", foo: { bar: 'test' } })).toEqual({
+  expect(partialSchema.safeParse({ type: "a", foo: { bar: "test" } })).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'number', received: 'undefined', path: ['foo', 'baz'] })]
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "number", received: "undefined", path: ["foo", "baz"] })]
     }),
   });
 
   expect(partialSchema.safeParse({})).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
     }),
   });
   expectShape<{ type: "a", foo?: { bar: string, baz: number } } | { type: "b", baz?: string }>().forSchema(partialSchema);
 });
 
 test("partial, with mask", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
@@ -424,7 +424,7 @@ test("partial, with mask", () => {
   expect(partialSchema.safeParse({ type: "b" })).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'string', received: 'undefined', path: ['baz'] })]
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "string", received: "undefined", path: ["baz"] })]
     })
   });
 
@@ -432,7 +432,7 @@ test("partial, with mask", () => {
 });
 
 test("partial, with mask including discriminator keeps discriminator required", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
@@ -446,14 +446,71 @@ test("partial, with mask including discriminator keeps discriminator required", 
   expect(partialSchema.safeParse({ type: "a" })).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'string', received: 'undefined', path: ['foo'] })]
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "string", received: "undefined", path: ["foo"] })]
     })
   });
 
   expect(partialSchema.safeParse({})).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
     }),
   });
+});
+
+test("required, without a mask", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), foo: z.object({ bar: z.string().optional() }).optional() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string().optional() }).strip(),
+  ]);
+
+  const requiredSchema = schema.required();
+
+  expect(requiredSchema.parse({ type: "a", foo: { bar: "baz" } })).toEqual({ type: "a", foo: { bar: "baz" } });
+  expect(requiredSchema.parse({ type: "a", foo: {} })).toEqual({ type: "a", foo: {} });
+  expect(requiredSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+
+  expect(requiredSchema.safeParse({ type: "a" })).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "object", received: "undefined", path: ["foo"] })]
+    }),
+  });
+
+  expect(requiredSchema.safeParse({})).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
+    }),
+  });
+  expectShape<{ type: "a", foo: { bar?: string } } | { type: "b", baz: string }>().forSchema(requiredSchema);
+});
+
+test("required, with a mask", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), foo: z.object({ bar: z.string().optional() }).optional() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string().optional() }).strip(),
+  ]);
+
+  const requiredSchema = schema.required({ foo: true });
+
+  expect(requiredSchema.parse({ type: "a", foo: { bar: "baz" } })).toEqual({ type: "a", foo: { bar: "baz" } });
+  expect(requiredSchema.parse({ type: "a", foo: {} })).toEqual({ type: "a", foo: {} });
+  expect(requiredSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+  expect(requiredSchema.parse({ type: "b" })).toEqual({ type: "b" });
+
+  expect(requiredSchema.safeParse({ type: "a" })).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "object", received: "undefined", path: ["foo"] })]
+    }),
+  });
+
+  expect(requiredSchema.safeParse({})).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
+    }),
+  });
+  expectShape<{ type: "a", foo: { bar?: string } } | { type: "b", baz?: string }>().forSchema(requiredSchema);
 });

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -216,3 +216,16 @@ test("valid - literals with .default or .preprocess", () => {
     a: "foo",
   });
 });
+
+test("valid - pick", () => {
+  const obj1 = z.object({ a: z.number(), b: z.string(), c: z.literal(1) });
+  const obj2 = z.object({ b: z.string(), c: z.literal(2), d: z.string() });
+  const obj3 = z.object({ a: z.number(), b: z.string(), c: z.literal(3) }).strict();
+
+  const unionSchema = z.discriminatedUnion('c', [obj1, obj2, obj3]);
+  const pickFromSchema = unionSchema.pick({ d: true });
+
+  expect(pickFromSchema.parse({ c: 1, b: 'bla', d: 'hi' })).toEqual({ c: 1 });
+  expect(pickFromSchema.parse({ c: 2, b: 'bla', d: 'hi' })).toEqual({ c: 2, d: 'hi' })
+  expect(pickFromSchema.safeParse({ c: 3 })).toEqual({ c: 1 });
+})

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -329,10 +329,10 @@ test("omit without discriminator", () => {
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
 
-  const pickSchema = schema.omit({ foo: true });
+  const omitSchema = schema.omit({ foo: true });
 
-  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a" });
-  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+  expect(omitSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a" });
+  expect(omitSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 });
 
 test("try to omit discriminator", () => {
@@ -341,10 +341,10 @@ test("try to omit discriminator", () => {
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
 
-  const pickSchema = schema.omit({ type: true } as any);
+  const omitSchema = schema.omit({ type: true } as any);
 
-  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
-  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+  expect(omitSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(omitSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 });
 
 test('deepPartial, keeps discriminator required', () => {
@@ -363,4 +363,7 @@ test('deepPartial, keeps discriminator required', () => {
       issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
     }),
   });
+
+  // TODO: type is not correct
+  type x = z.infer<typeof deepPartialSchema>
 });

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -299,16 +299,26 @@ test('catchall', () => {
   });
 });
 
+test("pick including discriminator", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ])
 
-test("valid - pick", () => {
-  const obj1 = z.object({ a: z.number(), b: z.string(), c: z.literal(1) });
-  const obj2 = z.object({ b: z.string(), c: z.literal(2), d: z.string() });
-  const obj3 = z.object({ a: z.number(), b: z.string(), c: z.literal(3) }).strict();
+  const pickSchema = schema.pick({ type: true, foo: true });
 
-  const unionSchema = z.discriminatedUnion('c', [obj1, obj2, obj3]);
-  const pickFromSchema = unionSchema.pick({ d: true });
+  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
+});
 
-  expect(pickFromSchema.parse({ c: 1, b: 'bla', d: 'hi' })).toEqual({ c: 1 });
-  expect(pickFromSchema.parse({ c: 2, b: 'bla', d: 'hi' })).toEqual({ c: 2, d: 'hi' })
-  expect(pickFromSchema.parse({ c: 3 })).toEqual({ c: 3 });
-})
+test("pick without discriminator", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ])
+
+  const pickSchema = schema.pick({ foo: true });
+
+  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
+});

--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -2,6 +2,7 @@ import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
 import * as z from "../index.ts";
+import { expectShape } from "./testUtil.ts";
 
 test("valid", () => {
   expect(
@@ -224,9 +225,8 @@ test('strict', () => {
   ]);
 
   const strictSchema = schema.strict();
-  type SchemaType = z.infer<typeof strictSchema>;
 
-  const input = { type: "a", foo: "bar", test: 123 } as SchemaType;
+  const input = { type: "a", foo: "bar", test: 123 };
   const output = strictSchema.safeParse(input);
 
   expect(output).toEqual({
@@ -234,6 +234,7 @@ test('strict', () => {
     error: expect.objectContaining({ issues: [expect.objectContaining({ code: 'unrecognized_keys' })] })
   });
 
+  expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(strictSchema);
   expect(strictSchema.options).toHaveLength(2);
   strictSchema.options.forEach(option => {
     expect(option._def.unknownKeys).toEqual('strict');
@@ -247,13 +248,13 @@ test('strip', () => {
   ]);
 
   const stripSchema = schema.strip();
-  type SchemaType = z.infer<typeof stripSchema>;
 
-  const input = { type: "a", foo: "bar", test: 123 } as SchemaType;
+  const input = { type: "a", foo: "bar", test: 123 };
   const output = stripSchema.parse(input);
 
   expect(output).toEqual({ type: "a", foo: "bar" });
 
+  expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(stripSchema);
   expect(stripSchema.options).toHaveLength(2);
   stripSchema.options.forEach(option => {
     expect(option._def.unknownKeys).toEqual('strip');
@@ -267,13 +268,13 @@ test('passthrough', () => {
   ]);
 
   const passthroughSchema = schema.passthrough();
-  type SchemaType = z.infer<typeof passthroughSchema>;
 
-  const input = { type: "a", foo: "bar", test: 123 } as SchemaType;
+  const input = { type: "a", foo: "bar", test: 123 };
   const output = passthroughSchema.parse(input);
 
   expect(output).toEqual({ type: "a", foo: "bar", test: 123 });
 
+  expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(passthroughSchema);
   expect(passthroughSchema.options).toHaveLength(2);
   passthroughSchema.options.forEach(option => {
     expect(option._def.unknownKeys).toEqual('passthrough');
@@ -292,6 +293,8 @@ test('catchall', () => {
   const invalidInput = { type: "a", foo: "bar", test: 'this is a string' };
 
   expect(catchallSchema.parse(validInput)).toEqual({ type: "a", foo: "bar", test: 123 });
+
+  expectShape<({ type: "a", foo: string } | { type: "b", baz: string }) & Record<string, number>>().forSchema(catchallSchema);
   expect(catchallSchema.safeParse(invalidInput)).toEqual({
     success: false,
     error: expect.objectContaining({
@@ -309,13 +312,11 @@ test("pick including discriminator", () => {
   ])
 
   const pickSchema = schema.pick({ type: true, foo: true });
-  type SchemaType = z.infer<typeof pickSchema>;
 
-  const inputA: SchemaType = { type: "a", foo: "bar" };
-  const inputB = { type: "b", baz: "bar" } as SchemaType;
+  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
 
-  expect(pickSchema.parse(inputA)).toEqual({ type: "a", foo: "bar" });
-  expect(pickSchema.parse(inputB)).toEqual({ type: "b" });
+  expectShape<{ type: "a", foo: string } | { type: "b" }>().forSchema(pickSchema);
 });
 
 test("pick without discriminator adds discriminator", () => {
@@ -325,13 +326,11 @@ test("pick without discriminator adds discriminator", () => {
   ])
 
   const pickSchema = schema.pick({ foo: true });
-  type SchemaType = z.infer<typeof pickSchema>;
 
-  const inputA: SchemaType = { type: "a", foo: "bar" };
-  const inputB = { type: "b", baz: "bar" } as SchemaType;
+  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
 
-  expect(pickSchema.parse(inputA)).toEqual({ type: "a", foo: "bar" });
-  expect(pickSchema.parse(inputB)).toEqual({ type: "b" });
+  expectShape<{ type: "a", foo: string } | { type: "b" }>().forSchema(pickSchema);
 });
 
 test("omit without discriminator", () => {
@@ -341,13 +340,11 @@ test("omit without discriminator", () => {
   ])
 
   const omitSchema = schema.omit({ foo: true });
-  type SchemaType = z.infer<typeof omitSchema>;
 
-  const inputA = { type: "a", foo: "bar" } as SchemaType;
-  const inputB: SchemaType = { type: "b", baz: "bar" };
+  expect(omitSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a" });
+  expect(omitSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 
-  expect(omitSchema.parse(inputA)).toEqual({ type: "a" });
-  expect(omitSchema.parse(inputB)).toEqual({ type: "b", baz: "bar" });
+  expectShape<{ type: "a" } | { type: "b", baz: string }>().forSchema(omitSchema);
 });
 
 test("try to omit discriminator", () => {
@@ -369,15 +366,10 @@ test('deepPartial, keeps discriminator required', () => {
   ]);
 
   const deepPartialSchema = schema.deepPartial();
-  type SchemaType = z.infer<typeof deepPartialSchema>
 
-  const fullA: SchemaType = { type: "a", foo: { bar: 'test', baz: 123 } };
-  const fullApartialFoo: SchemaType = { type: "a", foo: { bar: 'test' } };
-  const partialA: SchemaType = { type: "a" };
-
-  expect(deepPartialSchema.parse(fullA)).toEqual({ type: "a", foo: { bar: 'test', baz: 123 } });
-  expect(deepPartialSchema.parse(fullApartialFoo)).toEqual({ type: "a", foo: { bar: 'test' } });
-  expect(deepPartialSchema.parse(partialA)).toEqual({ type: "a" });
+  expect(deepPartialSchema.parse({ type: "a", foo: { bar: 'test', baz: 123 } })).toEqual({ type: "a", foo: { bar: 'test', baz: 123 } });
+  expect(deepPartialSchema.parse({ type: "a", foo: { bar: 'test' } })).toEqual({ type: "a", foo: { bar: 'test' } });
+  expect(deepPartialSchema.parse({ type: "a" })).toEqual({ type: "a" });
   expect(deepPartialSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 
   expect(deepPartialSchema.safeParse({})).toEqual({
@@ -386,5 +378,82 @@ test('deepPartial, keeps discriminator required', () => {
       issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
     }),
   });
+  expectShape<{ type: "a", foo?: { bar?: string, baz?: number } } | { type: "b", baz?: string }>().forSchema(deepPartialSchema);
+});
 
+test("partial, without mask, keeps discriminator required", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.object({ bar: z.string(), baz: z.number() }) }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ]);
+
+  const partialSchema = schema.partial();
+
+  expect(partialSchema.parse({ type: "a", foo: { bar: 'test', baz: 123 } })).toEqual({ type: "a", foo: { bar: 'test', baz: 123 } });
+  expect(partialSchema.parse({ type: "a" })).toEqual({ type: "a" });
+  expect(partialSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+
+  expect(partialSchema.safeParse({ type: "a", foo: { bar: 'test' } })).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'number', received: 'undefined', path: ['foo', 'baz'] })]
+    }),
+  });
+
+  expect(partialSchema.safeParse({})).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+    }),
+  });
+  expectShape<{ type: "a", foo?: { bar: string, baz: number } } | { type: "b", baz?: string }>().forSchema(partialSchema);
+});
+
+test("partial, with mask", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ]);
+
+  const partialSchema = schema.partial({ foo: true });
+
+  expect(partialSchema.parse({ type: "a" })).toEqual({ type: "a" });
+  expect(partialSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+
+  expect(partialSchema.parse({ type: "b", baz: "foo" })).toEqual({ type: "b", baz: "foo" })
+  expect(partialSchema.safeParse({ type: "b" })).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'string', received: 'undefined', path: ['baz'] })]
+    })
+  });
+
+  expectShape<{ type: "a", foo?: string } | { type: "b", baz: string }>().forSchema(partialSchema);
+});
+
+test("partial, with mask including discriminator keeps discriminator required", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ]);
+
+  const partialSchema = schema.partial({ type: true, baz: true } as any);
+
+  expect(partialSchema.parse({ type: "b" })).toEqual({ type: "b" });
+  expect(partialSchema.parse({ type: "b", baz: "foo" })).toEqual({ type: "b", baz: "foo" })
+
+  expect(partialSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(partialSchema.safeParse({ type: "a" })).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'string', received: 'undefined', path: ['foo'] })]
+    })
+  });
+
+  expect(partialSchema.safeParse({})).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+    }),
+  });
 });

--- a/deno/lib/__tests__/testUtil.ts
+++ b/deno/lib/__tests__/testUtil.ts
@@ -1,0 +1,20 @@
+import * as z from "../index.ts";
+
+/**
+ * Creates shape validator for schema
+ */
+export const expectShape = <TExpected>() => ({
+  /**
+   * Pass your schema to this function. If the schema does not comply to the shape of this validator, you'll get a typescript error
+   * @param _schema the schema to validate 
+   */
+  forSchema: <TSchema extends z.ZodTypeAny>(
+    _schema: [TSchema["_output"]] extends [TExpected]
+      ? [TExpected] extends [TSchema["_output"]]
+      ? TSchema
+      : never
+      : never
+  ) => {
+    /* irrelevant */
+  }
+});

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -45,7 +45,7 @@ export namespace util {
 
   export const objectKeys: ObjectConstructor["keys"] =
     typeof Object.keys === "function" // eslint-disable-line ban/ban
-      ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
+      ? Object.keys // eslint-disable-line ban/ban
       : (object: any) => {
           const keys = [];
           for (const key in object) {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2856,7 +2856,7 @@ export class ZodDiscriminatedUnion<
 
   omit<
     Mask extends {
-      [k in keyof Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
+      [k in Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
     }
   >(
     mask: Mask

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2597,6 +2597,25 @@ type ZodUnknownKeysDiscriminatedUnionOptions<
     : never;
 };
 
+type ZodCatchAllDiscriminatedUnionOptions<
+  Discriminator extends string,
+  Options extends ZodDiscriminatedUnionOption<Discriminator>[],
+  Catchall extends ZodTypeAny
+> = AsDiscriminatorUnionOptions<
+  {
+    [I in keyof Options]: Options[I] extends ZodObject<
+      infer T,
+      infer UnknownKeys,
+      any,
+      any,
+      any
+    >
+      ? ZodObject<T, UnknownKeys, Catchall>
+      : never;
+  },
+  Discriminator
+>;
+
 type ZodPartialDiscriminatedUnionOptions<
   Discriminator extends string,
   Options extends ZodDiscriminatedUnionOption<Discriminator>[],
@@ -2805,6 +2824,18 @@ export class ZodDiscriminatedUnion<
     >
   > {
     return this._map((option) => option.passthrough());
+  }
+
+  catchall<Index extends ZodTypeAny>(
+    index: Index
+  ): ZodDiscriminatedUnion<
+    Discriminator,
+    ZodCatchAllDiscriminatedUnionOptions<Discriminator, Options, Index>
+  > {
+    return this._map(
+      (option) =>
+        option.catchall(index) as ZodDiscriminatedUnionOption<Discriminator>
+    );
   }
 
   pick<Mask extends { [k in KeyofObjectUnion<Options>]?: true }>(

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1825,6 +1825,7 @@ export namespace objectUtil {
     Pick<T, requiredKeys<T>>;
 
   export type identity<T> = T;
+  export type keys<T> = T extends T ? keyof T : never;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;
 
   export type noNeverKeys<T extends ZodRawShape> = {
@@ -2194,7 +2195,11 @@ export class ZodObject<
     }) as any;
   }
 
-  deepPartial(): partialUtil.DeepPartial<this> {
+  deepPartial(): ZodObject<
+    { [k in keyof T]: ZodOptional<partialUtil.DeepPartial<T[k]>> },
+    UnknownKeys,
+    Catchall
+  > {
     return deepPartialify(this) as any;
   }
 
@@ -2542,9 +2547,8 @@ const toOptionsMap = <
   return optionsMap;
 };
 
-type ExtractKeys<T> = T extends T ? keyof T : never;
 type KeyofObjectUnion<Options extends ZodDiscriminatedUnionOption<any>[]> =
-  ExtractKeys<
+  objectUtil.keys<
     Options[number] extends ZodObject<infer Shape, any, any, any, any>
       ? Shape
       : never

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2900,7 +2900,7 @@ export class ZodDiscriminatedUnion<
   >;
   partial<
     Mask extends {
-      [k in keyof Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
+      [k in Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
     }
   >(
     mask: Mask
@@ -2930,7 +2930,7 @@ export class ZodDiscriminatedUnion<
   >;
   required<
     Mask extends {
-      [k in keyof Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
+      [k in KeyofObjectUnion<Options>]?: true;
     }
   >(
     mask: Mask

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2613,7 +2613,7 @@ type ZodUnknownKeysDiscriminatedUnionOptions<
     : never;
 };
 
-type ZodCatchAllDiscriminatedUnionOptions<
+type ZodCatchallDiscriminatedUnionOptions<
   Discriminator extends string,
   Options extends ZodDiscriminatedUnionOption<Discriminator>[],
   Catchall extends ZodTypeAny
@@ -2831,7 +2831,7 @@ export class ZodDiscriminatedUnion<
     index: Index
   ): ZodDiscriminatedUnion<
     Discriminator,
-    ZodCatchAllDiscriminatedUnionOptions<Discriminator, Options, Index>
+    ZodCatchallDiscriminatedUnionOptions<Discriminator, Options, Index>
   > {
     return this._map(
       (option) =>
@@ -2884,11 +2884,9 @@ export class ZodDiscriminatedUnion<
   > {
     return this._map(
       (option) =>
-        option
-          .deepPartial()
-          .required({
-            [this.discriminator]: true,
-          } as any) as unknown as ZodDiscriminatedUnionOption<Discriminator>
+        option.deepPartial().required({
+          [this.discriminator]: true,
+        } as any) as unknown as ZodDiscriminatedUnionOption<Discriminator>
     );
   }
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2702,7 +2702,7 @@ type ZodDeepPartialDiscriminatedUnionOptions<
           {
             [k in keyof Shape]: k extends Discriminator
               ? Shape[k]
-              : partialUtil.DeepPartial<Shape[k]>;
+              : ZodOptional<partialUtil.DeepPartial<Shape[k]>>;
           },
           UnknownKeys,
           Catchall

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -328,10 +328,10 @@ test("omit without discriminator", () => {
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
 
-  const pickSchema = schema.omit({ foo: true });
+  const omitSchema = schema.omit({ foo: true });
 
-  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a" });
-  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+  expect(omitSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a" });
+  expect(omitSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 });
 
 test("try to omit discriminator", () => {
@@ -340,10 +340,10 @@ test("try to omit discriminator", () => {
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
 
-  const pickSchema = schema.omit({ type: true } as any);
+  const omitSchema = schema.omit({ type: true } as any);
 
-  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
-  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+  expect(omitSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(omitSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 });
 
 test('deepPartial, keeps discriminator required', () => {
@@ -362,4 +362,7 @@ test('deepPartial, keeps discriminator required', () => {
       issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
     }),
   });
+
+  // TODO: type is not correct
+  type x = z.infer<typeof deepPartialSchema>
 });

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -216,6 +216,89 @@ test("valid - literals with .default or .preprocess", () => {
   });
 });
 
+test('strict', () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), foo: z.string() }).passthrough(),
+    z.object({ type: z.literal("b"), baz: z.string() }).passthrough(),
+  ]);
+
+  const input = { type: "a", foo: "bar", test: 123 };
+
+  const strictSchema = schema.strict();
+  const output = strictSchema.safeParse(input);
+
+  expect(output).toEqual({
+    success: false,
+    error: expect.objectContaining({ issues: [expect.objectContaining({ code: 'unrecognized_keys' })] })
+  });
+
+  expect(strictSchema.options).toHaveLength(2);
+  strictSchema.options.forEach(option => {
+    expect(option._def.unknownKeys).toEqual('strict');
+  })
+});
+
+test('strip', () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), foo: z.string() }).strict(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strict(),
+  ]);
+
+  const input = { type: "a", foo: "bar", test: 123 };
+
+  const stripSchema = schema.strip();
+  const output = stripSchema.parse(input);
+
+  expect(output).toEqual({ type: "a", foo: "bar" });
+
+  expect(stripSchema.options).toHaveLength(2);
+  stripSchema.options.forEach(option => {
+    expect(option._def.unknownKeys).toEqual('strip');
+  })
+});
+
+test('passthrough', () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), foo: z.string() }).strict(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strict(),
+  ]);
+
+  const input = { type: "a", foo: "bar", test: 123 };
+
+  const passthroughSchema = schema.passthrough();
+  const output = passthroughSchema.parse(input);
+
+  expect(output).toEqual({ type: "a", foo: "bar", test: 123 });
+
+  expect(passthroughSchema.options).toHaveLength(2);
+  passthroughSchema.options.forEach(option => {
+    expect(option._def.unknownKeys).toEqual('passthrough');
+  })
+});
+
+test('catchall', () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), foo: z.string() }).strict(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strict(),
+  ]);
+
+  const catchallSchema = schema.catchall(z.number());
+
+  const validInput = { type: "a", foo: "bar", test: 123 };
+  const invalidInput = { type: "a", foo: "bar", test: 'this is a string' };
+
+  expect(catchallSchema.parse(validInput)).toEqual({ type: "a", foo: "bar", test: 123 });
+  expect(catchallSchema.safeParse(invalidInput)).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({
+        code: 'invalid_type', expected: 'number', received: 'string', path: ['test']
+      })]
+    })
+  });
+});
+
+
 test("valid - pick", () => {
   const obj1 = z.object({ a: z.number(), b: z.string(), c: z.literal(1) });
   const obj2 = z.object({ b: z.string(), c: z.literal(2), d: z.string() });

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -217,7 +217,7 @@ test("valid - literals with .default or .preprocess", () => {
   });
 });
 
-test('strict', () => {
+test("strict", () => {
   const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).passthrough(),
     z.object({ type: z.literal("b"), baz: z.string() }).passthrough(),
@@ -230,17 +230,17 @@ test('strict', () => {
 
   expect(output).toEqual({
     success: false,
-    error: expect.objectContaining({ issues: [expect.objectContaining({ code: 'unrecognized_keys' })] })
+    error: expect.objectContaining({ issues: [expect.objectContaining({ code: "unrecognized_keys" })] })
   });
 
   expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(strictSchema);
   expect(strictSchema.options).toHaveLength(2);
   strictSchema.options.forEach(option => {
-    expect(option._def.unknownKeys).toEqual('strict');
+    expect(option._def.unknownKeys).toEqual("strict");
   })
 });
 
-test('strip', () => {
+test("strip", () => {
   const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strict(),
     z.object({ type: z.literal("b"), baz: z.string() }).strict(),
@@ -256,11 +256,11 @@ test('strip', () => {
   expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(stripSchema);
   expect(stripSchema.options).toHaveLength(2);
   stripSchema.options.forEach(option => {
-    expect(option._def.unknownKeys).toEqual('strip');
+    expect(option._def.unknownKeys).toEqual("strip");
   })
 });
 
-test('passthrough', () => {
+test("passthrough", () => {
   const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strict(),
     z.object({ type: z.literal("b"), baz: z.string() }).strict(),
@@ -276,11 +276,11 @@ test('passthrough', () => {
   expectShape<{ type: "a", foo: string } | { type: "b", baz: string }>().forSchema(passthroughSchema);
   expect(passthroughSchema.options).toHaveLength(2);
   passthroughSchema.options.forEach(option => {
-    expect(option._def.unknownKeys).toEqual('passthrough');
+    expect(option._def.unknownKeys).toEqual("passthrough");
   })
 });
 
-test('catchall', () => {
+test("catchall", () => {
   const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strict(),
     z.object({ type: z.literal("b"), baz: z.string() }).strict(),
@@ -289,7 +289,7 @@ test('catchall', () => {
   const catchallSchema = schema.catchall(z.number());
 
   const validInput = { type: "a", foo: "bar", test: 123 };
-  const invalidInput = { type: "a", foo: "bar", test: 'this is a string' };
+  const invalidInput = { type: "a", foo: "bar", test: "this is a string" };
 
   expect(catchallSchema.parse(validInput)).toEqual({ type: "a", foo: "bar", test: 123 });
 
@@ -298,14 +298,14 @@ test('catchall', () => {
     success: false,
     error: expect.objectContaining({
       issues: [expect.objectContaining({
-        code: 'invalid_type', expected: 'number', received: 'string', path: ['test']
+        code: "invalid_type", expected: "number", received: "string", path: ["test"]
       })]
     })
   });
 });
 
 test("pick including discriminator", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
@@ -319,7 +319,7 @@ test("pick including discriminator", () => {
 });
 
 test("pick without discriminator adds discriminator", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
@@ -333,7 +333,7 @@ test("pick without discriminator adds discriminator", () => {
 });
 
 test("omit without discriminator", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
@@ -347,7 +347,7 @@ test("omit without discriminator", () => {
 });
 
 test("try to omit discriminator", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ])
@@ -358,58 +358,58 @@ test("try to omit discriminator", () => {
   expect(omitSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 });
 
-test('deepPartial, keeps discriminator required', () => {
-  const schema = z.discriminatedUnion('type', [
+test("deepPartial, keeps discriminator required", () => {
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.object({ bar: z.string(), baz: z.number() }) }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
 
   const deepPartialSchema = schema.deepPartial();
 
-  expect(deepPartialSchema.parse({ type: "a", foo: { bar: 'test', baz: 123 } })).toEqual({ type: "a", foo: { bar: 'test', baz: 123 } });
-  expect(deepPartialSchema.parse({ type: "a", foo: { bar: 'test' } })).toEqual({ type: "a", foo: { bar: 'test' } });
+  expect(deepPartialSchema.parse({ type: "a", foo: { bar: "test", baz: 123 } })).toEqual({ type: "a", foo: { bar: "test", baz: 123 } });
+  expect(deepPartialSchema.parse({ type: "a", foo: { bar: "test" } })).toEqual({ type: "a", foo: { bar: "test" } });
   expect(deepPartialSchema.parse({ type: "a" })).toEqual({ type: "a" });
   expect(deepPartialSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 
   expect(deepPartialSchema.safeParse({})).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
     }),
   });
   expectShape<{ type: "a", foo?: { bar?: string, baz?: number } } | { type: "b", baz?: string }>().forSchema(deepPartialSchema);
 });
 
 test("partial, without mask, keeps discriminator required", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.object({ bar: z.string(), baz: z.number() }) }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
 
   const partialSchema = schema.partial();
 
-  expect(partialSchema.parse({ type: "a", foo: { bar: 'test', baz: 123 } })).toEqual({ type: "a", foo: { bar: 'test', baz: 123 } });
+  expect(partialSchema.parse({ type: "a", foo: { bar: "test", baz: 123 } })).toEqual({ type: "a", foo: { bar: "test", baz: 123 } });
   expect(partialSchema.parse({ type: "a" })).toEqual({ type: "a" });
   expect(partialSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
 
-  expect(partialSchema.safeParse({ type: "a", foo: { bar: 'test' } })).toEqual({
+  expect(partialSchema.safeParse({ type: "a", foo: { bar: "test" } })).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'number', received: 'undefined', path: ['foo', 'baz'] })]
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "number", received: "undefined", path: ["foo", "baz"] })]
     }),
   });
 
   expect(partialSchema.safeParse({})).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
     }),
   });
   expectShape<{ type: "a", foo?: { bar: string, baz: number } } | { type: "b", baz?: string }>().forSchema(partialSchema);
 });
 
 test("partial, with mask", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
@@ -423,7 +423,7 @@ test("partial, with mask", () => {
   expect(partialSchema.safeParse({ type: "b" })).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'string', received: 'undefined', path: ['baz'] })]
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "string", received: "undefined", path: ["baz"] })]
     })
   });
 
@@ -431,7 +431,7 @@ test("partial, with mask", () => {
 });
 
 test("partial, with mask including discriminator keeps discriminator required", () => {
-  const schema = z.discriminatedUnion('type', [
+  const schema = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
@@ -445,14 +445,71 @@ test("partial, with mask including discriminator keeps discriminator required", 
   expect(partialSchema.safeParse({ type: "a" })).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_type', expected: 'string', received: 'undefined', path: ['foo'] })]
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "string", received: "undefined", path: ["foo"] })]
     })
   });
 
   expect(partialSchema.safeParse({})).toEqual({
     success: false,
     error: expect.objectContaining({
-      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
     }),
   });
+});
+
+test("required, without a mask", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), foo: z.object({ bar: z.string().optional() }).optional() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string().optional() }).strip(),
+  ]);
+
+  const requiredSchema = schema.required();
+
+  expect(requiredSchema.parse({ type: "a", foo: { bar: "baz" } })).toEqual({ type: "a", foo: { bar: "baz" } });
+  expect(requiredSchema.parse({ type: "a", foo: {} })).toEqual({ type: "a", foo: {} });
+  expect(requiredSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+
+  expect(requiredSchema.safeParse({ type: "a" })).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "object", received: "undefined", path: ["foo"] })]
+    }),
+  });
+
+  expect(requiredSchema.safeParse({})).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
+    }),
+  });
+  expectShape<{ type: "a", foo: { bar?: string } } | { type: "b", baz: string }>().forSchema(requiredSchema);
+});
+
+test("required, with a mask", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), foo: z.object({ bar: z.string().optional() }).optional() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string().optional() }).strip(),
+  ]);
+
+  const requiredSchema = schema.required({ foo: true });
+
+  expect(requiredSchema.parse({ type: "a", foo: { bar: "baz" } })).toEqual({ type: "a", foo: { bar: "baz" } });
+  expect(requiredSchema.parse({ type: "a", foo: {} })).toEqual({ type: "a", foo: {} });
+  expect(requiredSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+  expect(requiredSchema.parse({ type: "b" })).toEqual({ type: "b" });
+
+  expect(requiredSchema.safeParse({ type: "a" })).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: "invalid_type", expected: "object", received: "undefined", path: ["foo"] })]
+    }),
+  });
+
+  expect(requiredSchema.safeParse({})).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: "invalid_union_discriminator", options: ["a", "b"] })]
+    }),
+  });
+  expectShape<{ type: "a", foo: { bar?: string } } | { type: "b", baz?: string }>().forSchema(requiredSchema);
 });

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -215,3 +215,16 @@ test("valid - literals with .default or .preprocess", () => {
     a: "foo",
   });
 });
+
+test("valid - pick", () => {
+  const obj1 = z.object({ a: z.number(), b: z.string(), c: z.literal(1) });
+  const obj2 = z.object({ b: z.string(), c: z.literal(2), d: z.string() });
+  const obj3 = z.object({ a: z.number(), b: z.string(), c: z.literal(3) }).strict();
+
+  const unionSchema = z.discriminatedUnion('c', [obj1, obj2, obj3]);
+  const pickFromSchema = unionSchema.pick({ d: true });
+
+  expect(pickFromSchema.parse({ c: 1, b: 'bla', d: 'hi' })).toEqual({ c: 1 });
+  expect(pickFromSchema.parse({ c: 2, b: 'bla', d: 'hi' })).toEqual({ c: 2, d: 'hi' })
+  expect(pickFromSchema.safeParse({ c: 3 })).toEqual({ c: 1 });
+})

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -222,9 +222,10 @@ test('strict', () => {
     z.object({ type: z.literal("b"), baz: z.string() }).passthrough(),
   ]);
 
-  const input = { type: "a", foo: "bar", test: 123 };
-
   const strictSchema = schema.strict();
+  type SchemaType = z.infer<typeof strictSchema>;
+
+  const input = { type: "a", foo: "bar", test: 123 } as SchemaType;
   const output = strictSchema.safeParse(input);
 
   expect(output).toEqual({
@@ -244,9 +245,10 @@ test('strip', () => {
     z.object({ type: z.literal("b"), baz: z.string() }).strict(),
   ]);
 
-  const input = { type: "a", foo: "bar", test: 123 };
-
   const stripSchema = schema.strip();
+  type SchemaType = z.infer<typeof stripSchema>;
+
+  const input = { type: "a", foo: "bar", test: 123 } as SchemaType;
   const output = stripSchema.parse(input);
 
   expect(output).toEqual({ type: "a", foo: "bar" });
@@ -263,9 +265,10 @@ test('passthrough', () => {
     z.object({ type: z.literal("b"), baz: z.string() }).strict(),
   ]);
 
-  const input = { type: "a", foo: "bar", test: 123 };
-
   const passthroughSchema = schema.passthrough();
+  type SchemaType = z.infer<typeof passthroughSchema>;
+
+  const input = { type: "a", foo: "bar", test: 123 } as SchemaType;
   const output = passthroughSchema.parse(input);
 
   expect(output).toEqual({ type: "a", foo: "bar", test: 123 });
@@ -305,9 +308,13 @@ test("pick including discriminator", () => {
   ])
 
   const pickSchema = schema.pick({ type: true, foo: true });
+  type SchemaType = z.infer<typeof pickSchema>;
 
-  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
-  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
+  const inputA: SchemaType = { type: "a", foo: "bar" };
+  const inputB = { type: "b", baz: "bar" } as SchemaType;
+
+  expect(pickSchema.parse(inputA)).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse(inputB)).toEqual({ type: "b" });
 });
 
 test("pick without discriminator adds discriminator", () => {
@@ -317,9 +324,13 @@ test("pick without discriminator adds discriminator", () => {
   ])
 
   const pickSchema = schema.pick({ foo: true });
+  type SchemaType = z.infer<typeof pickSchema>;
 
-  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
-  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
+  const inputA: SchemaType = { type: "a", foo: "bar" };
+  const inputB = { type: "b", baz: "bar" } as SchemaType;
+
+  expect(pickSchema.parse(inputA)).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse(inputB)).toEqual({ type: "b" });
 });
 
 test("omit without discriminator", () => {
@@ -329,9 +340,13 @@ test("omit without discriminator", () => {
   ])
 
   const omitSchema = schema.omit({ foo: true });
+  type SchemaType = z.infer<typeof omitSchema>;
 
-  expect(omitSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a" });
-  expect(omitSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+  const inputA = { type: "a", foo: "bar" } as SchemaType;
+  const inputB: SchemaType = { type: "b", baz: "bar" };
+
+  expect(omitSchema.parse(inputA)).toEqual({ type: "a" });
+  expect(omitSchema.parse(inputB)).toEqual({ type: "b", baz: "bar" });
 });
 
 test("try to omit discriminator", () => {
@@ -348,14 +363,22 @@ test("try to omit discriminator", () => {
 
 test('deepPartial, keeps discriminator required', () => {
   const schema = z.discriminatedUnion('type', [
-    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("a"), foo: z.object({ bar: z.string(), baz: z.number() }) }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
   ]);
 
   const deepPartialSchema = schema.deepPartial();
+  type SchemaType = z.infer<typeof deepPartialSchema>
 
-  expect(deepPartialSchema.parse({ type: "a" })).toEqual({ type: "a" });
+  const fullA: SchemaType = { type: "a", foo: { bar: 'test', baz: 123 } };
+  const fullApartialFoo: SchemaType = { type: "a", foo: { bar: 'test' } };
+  const partialA: SchemaType = { type: "a" };
+
+  expect(deepPartialSchema.parse(fullA)).toEqual({ type: "a", foo: { bar: 'test', baz: 123 } });
+  expect(deepPartialSchema.parse(fullApartialFoo)).toEqual({ type: "a", foo: { bar: 'test' } });
+  expect(deepPartialSchema.parse(partialA)).toEqual({ type: "a" });
   expect(deepPartialSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+
   expect(deepPartialSchema.safeParse({})).toEqual({
     success: false,
     error: expect.objectContaining({
@@ -363,6 +386,4 @@ test('deepPartial, keeps discriminator required', () => {
     }),
   });
 
-  // TODO: type is not correct
-  type x = z.infer<typeof deepPartialSchema>
 });

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -298,16 +298,26 @@ test('catchall', () => {
   });
 });
 
+test("pick including discriminator", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ])
 
-test("valid - pick", () => {
-  const obj1 = z.object({ a: z.number(), b: z.string(), c: z.literal(1) });
-  const obj2 = z.object({ b: z.string(), c: z.literal(2), d: z.string() });
-  const obj3 = z.object({ a: z.number(), b: z.string(), c: z.literal(3) }).strict();
+  const pickSchema = schema.pick({ type: true, foo: true });
 
-  const unionSchema = z.discriminatedUnion('c', [obj1, obj2, obj3]);
-  const pickFromSchema = unionSchema.pick({ d: true });
+  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
+});
 
-  expect(pickFromSchema.parse({ c: 1, b: 'bla', d: 'hi' })).toEqual({ c: 1 });
-  expect(pickFromSchema.parse({ c: 2, b: 'bla', d: 'hi' })).toEqual({ c: 2, d: 'hi' })
-  expect(pickFromSchema.parse({ c: 3 })).toEqual({ c: 3 });
-})
+test("pick without discriminator", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ])
+
+  const pickSchema = schema.pick({ foo: true });
+
+  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
+});

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -226,5 +226,5 @@ test("valid - pick", () => {
 
   expect(pickFromSchema.parse({ c: 1, b: 'bla', d: 'hi' })).toEqual({ c: 1 });
   expect(pickFromSchema.parse({ c: 2, b: 'bla', d: 'hi' })).toEqual({ c: 2, d: 'hi' })
-  expect(pickFromSchema.safeParse({ c: 3 })).toEqual({ c: 1 });
+  expect(pickFromSchema.parse({ c: 3 })).toEqual({ c: 3 });
 })

--- a/src/__tests__/discriminatedUnions.test.ts
+++ b/src/__tests__/discriminatedUnions.test.ts
@@ -310,7 +310,7 @@ test("pick including discriminator", () => {
   expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
 });
 
-test("pick without discriminator", () => {
+test("pick without discriminator adds discriminator", () => {
   const schema = z.discriminatedUnion('type', [
     z.object({ type: z.literal("a"), foo: z.string() }).strip(),
     z.object({ type: z.literal("b"), baz: z.string() }).strip(),
@@ -320,4 +320,46 @@ test("pick without discriminator", () => {
 
   expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
   expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b" });
+});
+
+test("omit without discriminator", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ])
+
+  const pickSchema = schema.omit({ foo: true });
+
+  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a" });
+  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+});
+
+test("try to omit discriminator", () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ])
+
+  const pickSchema = schema.omit({ type: true } as any);
+
+  expect(pickSchema.parse({ type: "a", foo: "bar" })).toEqual({ type: "a", foo: "bar" });
+  expect(pickSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+});
+
+test('deepPartial, keeps discriminator required', () => {
+  const schema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal("a"), foo: z.string() }).strip(),
+    z.object({ type: z.literal("b"), baz: z.string() }).strip(),
+  ]);
+
+  const deepPartialSchema = schema.deepPartial();
+
+  expect(deepPartialSchema.parse({ type: "a" })).toEqual({ type: "a" });
+  expect(deepPartialSchema.parse({ type: "b", baz: "bar" })).toEqual({ type: "b", baz: "bar" });
+  expect(deepPartialSchema.safeParse({})).toEqual({
+    success: false,
+    error: expect.objectContaining({
+      issues: [expect.objectContaining({ code: 'invalid_union_discriminator', options: ["a", "b"] })]
+    }),
+  });
 });

--- a/src/__tests__/testUtil.ts
+++ b/src/__tests__/testUtil.ts
@@ -1,0 +1,20 @@
+import * as z from "../index";
+
+/**
+ * Creates shape validator for schema
+ */
+export const expectShape = <TExpected>() => ({
+  /**
+   * Pass your schema to this function. If the schema does not comply to the shape of this validator, you'll get a typescript error
+   * @param _schema the schema to validate 
+   */
+  forSchema: <TSchema extends z.ZodTypeAny>(
+    _schema: [TSchema["_output"]] extends [TExpected]
+      ? [TExpected] extends [TSchema["_output"]]
+      ? TSchema
+      : never
+      : never
+  ) => {
+    /* irrelevant */
+  }
+});

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -45,7 +45,7 @@ export namespace util {
 
   export const objectKeys: ObjectConstructor["keys"] =
     typeof Object.keys === "function" // eslint-disable-line ban/ban
-      ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
+      ? Object.keys // eslint-disable-line ban/ban
       : (object: any) => {
           const keys = [];
           for (const key in object) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2852,7 +2852,7 @@ export class ZodDiscriminatedUnion<
 
   omit<
     Mask extends {
-      [k in keyof Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
+      [k in Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
     }
   >(
     mask: Mask

--- a/src/types.ts
+++ b/src/types.ts
@@ -2896,7 +2896,7 @@ export class ZodDiscriminatedUnion<
   >;
   partial<
     Mask extends {
-      [k in keyof Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
+      [k in Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
     }
   >(
     mask: Mask
@@ -2926,7 +2926,7 @@ export class ZodDiscriminatedUnion<
   >;
   required<
     Mask extends {
-      [k in keyof Exclude<KeyofObjectUnion<Options>, Discriminator>]?: true;
+      [k in KeyofObjectUnion<Options>]?: true;
     }
   >(
     mask: Mask

--- a/src/types.ts
+++ b/src/types.ts
@@ -2609,7 +2609,7 @@ type ZodUnknownKeysDiscriminatedUnionOptions<
     : never;
 };
 
-type ZodCatchAllDiscriminatedUnionOptions<
+type ZodCatchallDiscriminatedUnionOptions<
   Discriminator extends string,
   Options extends ZodDiscriminatedUnionOption<Discriminator>[],
   Catchall extends ZodTypeAny
@@ -2827,7 +2827,7 @@ export class ZodDiscriminatedUnion<
     index: Index
   ): ZodDiscriminatedUnion<
     Discriminator,
-    ZodCatchAllDiscriminatedUnionOptions<Discriminator, Options, Index>
+    ZodCatchallDiscriminatedUnionOptions<Discriminator, Options, Index>
   > {
     return this._map(
       (option) =>
@@ -2880,11 +2880,9 @@ export class ZodDiscriminatedUnion<
   > {
     return this._map(
       (option) =>
-        option
-          .deepPartial()
-          .required({
-            [this.discriminator]: true,
-          } as any) as unknown as ZodDiscriminatedUnionOption<Discriminator>
+        option.deepPartial().required({
+          [this.discriminator]: true,
+        } as any) as unknown as ZodDiscriminatedUnionOption<Discriminator>
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2597,6 +2597,25 @@ type ZodUnknownKeysDiscriminatedUnionOptions<
     : never;
 };
 
+type ZodCatchAllDiscriminatedUnionOptions<
+  Discriminator extends string,
+  Options extends ZodDiscriminatedUnionOption<Discriminator>[],
+  Catchall extends ZodTypeAny
+> = AsDiscriminatorUnionOptions<
+  {
+    [I in keyof Options]: Options[I] extends ZodObject<
+      infer T,
+      infer UnknownKeys,
+      any,
+      any,
+      any
+    >
+      ? ZodObject<T, UnknownKeys, Catchall>
+      : never;
+  },
+  Discriminator
+>;
+
 type ZodPartialDiscriminatedUnionOptions<
   Discriminator extends string,
   Options extends ZodDiscriminatedUnionOption<Discriminator>[],
@@ -2805,6 +2824,18 @@ export class ZodDiscriminatedUnion<
     >
   > {
     return this._map((option) => option.passthrough());
+  }
+
+  catchall<Index extends ZodTypeAny>(
+    index: Index
+  ): ZodDiscriminatedUnion<
+    Discriminator,
+    ZodCatchAllDiscriminatedUnionOptions<Discriminator, Options, Index>
+  > {
+    return this._map(
+      (option) =>
+        option.catchall(index) as ZodDiscriminatedUnionOption<Discriminator>
+    );
   }
 
   pick<Mask extends { [k in KeyofObjectUnion<Options>]?: true }>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1825,6 +1825,7 @@ export namespace objectUtil {
     Pick<T, requiredKeys<T>>;
 
   export type identity<T> = T;
+  export type keys<T> = T extends T ? keyof T : never;
   export type flatten<T extends object> = identity<{ [k in keyof T]: T[k] }>;
 
   export type noNeverKeys<T extends ZodRawShape> = {
@@ -2194,7 +2195,11 @@ export class ZodObject<
     }) as any;
   }
 
-  deepPartial(): partialUtil.DeepPartial<this> {
+  deepPartial(): ZodObject<
+    { [k in keyof T]: ZodOptional<partialUtil.DeepPartial<T[k]>> },
+    UnknownKeys,
+    Catchall
+  > {
     return deepPartialify(this) as any;
   }
 
@@ -2542,9 +2547,8 @@ const toOptionsMap = <
   return optionsMap;
 };
 
-type ExtractKeys<T> = T extends T ? keyof T : never;
 type KeyofObjectUnion<Options extends ZodDiscriminatedUnionOption<any>[]> =
-  ExtractKeys<
+  objectUtil.keys<
     Options[number] extends ZodObject<infer Shape, any, any, any, any>
       ? Shape
       : never

--- a/src/types.ts
+++ b/src/types.ts
@@ -2698,7 +2698,7 @@ type ZodDeepPartialDiscriminatedUnionOptions<
           {
             [k in keyof Shape]: k extends Discriminator
               ? Shape[k]
-              : partialUtil.DeepPartial<Shape[k]>;
+              : ZodOptional<partialUtil.DeepPartial<Shape[k]>>;
           },
           UnknownKeys,
           Catchall

--- a/src/types.ts
+++ b/src/types.ts
@@ -2498,8 +2498,7 @@ const getDiscriminator = <T extends ZodTypeAny>(
   } else if (type instanceof ZodEnum) {
     return type.options;
   } else if (type instanceof ZodNativeEnum) {
-    // eslint-disable-next-line ban/ban
-    return Object.keys(type.enum as any);
+    return util.objectKeys(type.enum as any);
   } else if (type instanceof ZodDefault) {
     return getDiscriminator(type._def.innerType);
   } else if (type instanceof ZodUndefined) {
@@ -2546,6 +2545,19 @@ const toOptionsMap = <
   return optionsMap;
 };
 
+export type ZodDiscriminatedUnionOption<Discriminator extends string> =
+  ZodObject<{ [key in Discriminator]: ZodTypeAny } & ZodRawShape, any, any>;
+
+export interface ZodDiscriminatedUnionDef<
+  Discriminator extends string,
+  Options extends ZodDiscriminatedUnionOption<any>[] = ZodDiscriminatedUnionOption<any>[]
+> extends ZodTypeDef {
+  discriminator: Discriminator;
+  options: Options;
+  optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<Discriminator>>;
+  typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion;
+}
+
 type KeyofObjectUnion<Options extends ZodDiscriminatedUnionOption<any>[]> =
   objectUtil.keys<
     Options[number] extends ZodObject<infer Shape, any, any, any, any>
@@ -2565,14 +2577,14 @@ type ZodPickedDiscriminatedUnionOptions<
 > = AsDiscriminatorUnionOptions<
   {
     [I in keyof Options]: Options[I] extends ZodObject<
-      infer T,
+      infer Shape,
       infer UnknownKeys,
       infer Catchall,
       any,
       any
     >
       ? ZodObject<
-          Pick<T, Extract<keyof T, K> | Discriminator>,
+          Pick<Shape, Extract<keyof Shape, K> | Discriminator>,
           UnknownKeys,
           Catchall
         >
@@ -2587,13 +2599,13 @@ type ZodUnknownKeysDiscriminatedUnionOptions<
   UnknownKeys extends UnknownKeysParam
 > = {
   [I in keyof Options]: Options[I] extends ZodObject<
-    infer T,
+    infer Shape,
     any,
     infer Catchall,
     any,
     any
   >
-    ? ZodObject<T, UnknownKeys, Catchall>
+    ? ZodObject<Shape, UnknownKeys, Catchall>
     : never;
 };
 
@@ -2604,13 +2616,13 @@ type ZodCatchAllDiscriminatedUnionOptions<
 > = AsDiscriminatorUnionOptions<
   {
     [I in keyof Options]: Options[I] extends ZodObject<
-      infer T,
+      infer Shape,
       infer UnknownKeys,
       any,
       any,
       any
     >
-      ? ZodObject<T, UnknownKeys, Catchall>
+      ? ZodObject<Shape, UnknownKeys, Catchall>
       : never;
   },
   Discriminator
@@ -2623,7 +2635,7 @@ type ZodPartialDiscriminatedUnionOptions<
 > = AsDiscriminatorUnionOptions<
   {
     [I in keyof Options]: Options[I] extends ZodObject<
-      infer T,
+      infer Shape,
       infer UnknownKeys,
       infer Catchall,
       any,
@@ -2631,9 +2643,9 @@ type ZodPartialDiscriminatedUnionOptions<
     >
       ? ZodObject<
           objectUtil.noNever<{
-            [k in keyof T]: k extends Exclude<Keys, Discriminator>
-              ? ZodOptional<T[k]>
-              : T[k];
+            [k in keyof Shape]: k extends Exclude<Keys, Discriminator>
+              ? ZodOptional<Shape[k]>
+              : Shape[k];
           }>,
           UnknownKeys,
           Catchall
@@ -2650,7 +2662,7 @@ type ZodRequiredDiscriminatedUnionOptions<
 > = AsDiscriminatorUnionOptions<
   {
     [I in keyof Options]: Options[I] extends ZodObject<
-      infer T,
+      infer Shape,
       infer UnknownKeys,
       infer Catchall,
       any,
@@ -2658,7 +2670,9 @@ type ZodRequiredDiscriminatedUnionOptions<
     >
       ? ZodObject<
           objectUtil.noNever<{
-            [k in keyof T]: k extends Keys ? deoptional<T[k]> : T[k];
+            [k in keyof Shape]: k extends Keys
+              ? deoptional<Shape[k]>
+              : Shape[k];
           }>,
           UnknownKeys,
           Catchall
@@ -2693,23 +2707,6 @@ type ZodDeepPartialDiscriminatedUnionOptions<
   },
   Discriminator
 >;
-
-export type ZodDiscriminatedUnionOption<Discriminator extends string> =
-  ZodObject<
-    { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
-    UnknownKeysParam,
-    ZodTypeAny
-  >;
-
-export interface ZodDiscriminatedUnionDef<
-  Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<string>[] = ZodDiscriminatedUnionOption<string>[]
-> extends ZodTypeDef {
-  discriminator: Discriminator;
-  options: Options;
-  optionsMap: Map<Primitive, ZodDiscriminatedUnionOption<Discriminator>>;
-  typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion;
-}
 
 export class ZodDiscriminatedUnion<
   Discriminator extends string,
@@ -2883,9 +2880,11 @@ export class ZodDiscriminatedUnion<
   > {
     return this._map(
       (option) =>
-        option.deepPartial().required({
-          [this.discriminator]: true,
-        } as any) as unknown as ZodDiscriminatedUnionOption<Discriminator>
+        option
+          .deepPartial()
+          .required({
+            [this.discriminator]: true,
+          } as any) as unknown as ZodDiscriminatedUnionOption<Discriminator>
     );
   }
 
@@ -2965,11 +2964,7 @@ export class ZodDiscriminatedUnion<
     options: Types,
     params?: RawCreateParams
   ): ZodDiscriminatedUnion<Discriminator, Types> {
-    return new ZodDiscriminatedUnion<
-      Discriminator,
-      // DiscriminatorValue,
-      Types
-    >({
+    return new ZodDiscriminatedUnion<Discriminator, Types>({
       typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion,
       discriminator,
       options,


### PR DESCRIPTION
Implements #1768

This PR adds the following functions to the `ZodDiscriminatedUnion` with same functionality as the ones on `ZodObject`:
- strict
- strip
- passthrough
- catchall
- pick
- omit
- deepPartial
- partial
- required
The discriminator is not affected by any of these functions.

I've also added an `expectShape` test util to validate the shape of a schema.
