### PR TITLE
Feature/add resolves method to zod promise

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -786,7 +786,7 @@ FishEnum.enum;
 You can also retrieve the list of options as a tuple with the `.options` property:
 
 ```ts
-FishEnum.options; // ["Salmon", "Tuna", "Trout"]);
+FishEnum.options; // ["Salmon", "Tuna", "Trout"];
 ```
 
 ## Native enums

--- a/deno/lib/__tests__/promise.test.ts
+++ b/deno/lib/__tests__/promise.test.ts
@@ -87,3 +87,9 @@ test("async promise parsing", () => {
   const res = z.promise(z.number()).parseAsync(Promise.resolve(12));
   expect(res).toBeInstanceOf(Promise);
 });
+
+test("resolves", () => {
+  const foo = z.literal('foo');
+  const res = z.promise(foo)
+  expect(res.resolves()).toEqual(foo)
+})

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3326,7 +3326,7 @@ export class ZodFunction<
           });
         const result = await fn(...(parsedArgs as any));
         const parsedReturns = await (
-          this._def.returns as ZodPromise<ZodTypeAny>
+          this._def.returns as unknown as ZodPromise<ZodTypeAny>
         )._def.type
           .parseAsync(result, params)
           .catch((e) => {
@@ -3689,6 +3689,10 @@ export class ZodPromise<T extends ZodTypeAny> extends ZodType<
   ZodPromiseDef<T>,
   Promise<T["_input"]>
 > {
+  resolves() {
+    return this._def.type;
+  }
+
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { ctx } = this._processInputParams(input);
     if (

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3689,7 +3689,7 @@ export class ZodPromise<T extends ZodTypeAny> extends ZodType<
   ZodPromiseDef<T>,
   Promise<T["_input"]>
 > {
-  resolves() {
+  unwrap() {
     return this._def.type;
   }
 

--- a/src/__tests__/promise.test.ts
+++ b/src/__tests__/promise.test.ts
@@ -86,3 +86,9 @@ test("async promise parsing", () => {
   const res = z.promise(z.number()).parseAsync(Promise.resolve(12));
   expect(res).toBeInstanceOf(Promise);
 });
+
+test("resolves", () => {
+  const foo = z.literal('foo');
+  const res = z.promise(foo)
+  expect(res.resolves()).toEqual(foo)
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -3326,7 +3326,7 @@ export class ZodFunction<
           });
         const result = await fn(...(parsedArgs as any));
         const parsedReturns = await (
-          this._def.returns as ZodPromise<ZodTypeAny>
+          this._def.returns as unknown as ZodPromise<ZodTypeAny>
         )._def.type
           .parseAsync(result, params)
           .catch((e) => {
@@ -3689,6 +3689,10 @@ export class ZodPromise<T extends ZodTypeAny> extends ZodType<
   ZodPromiseDef<T>,
   Promise<T["_input"]>
 > {
+  resolves() {
+    return this._def.type;
+  }
+
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { ctx } = this._processInputParams(input);
     if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -3689,7 +3689,7 @@ export class ZodPromise<T extends ZodTypeAny> extends ZodType<
   ZodPromiseDef<T>,
   Promise<T["_input"]>
 > {
-  resolves() {
+  unwrap() {
     return this._def.type;
   }
 


### PR DESCRIPTION
## What it does
* Add `resolves` method to `ZodPromise`. This returns the resolving schema the `ZodPromise` was created with. 

[Related issue](https://github.com/colinhacks/zod/issues/1838)