### PR TITLE
docs: Update ERROR_HANDLING.md - custom error map example

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -232,7 +232,7 @@ Let's look at a practical example of of customized error map:
 ```ts
 import * as z from "zod";
 
-const errorMap: z.ZodErrorMap = (error, ctx) => {
+const customErrorMap: z.ZodErrorMap = (error, ctx) => {
   /*
   This is where you override the various error codes
   */
@@ -257,7 +257,7 @@ const errorMap: z.ZodErrorMap = (error, ctx) => {
   return { message: ctx.defaultError };
 };
 
-z.string().parse(12, { errorMap });
+z.string().parse(12, { errorMap: customErrorMap });
 
 /* throws: 
   ZodError {


### PR DESCRIPTION
Makes the example more consistent with the provided explanations above as well as increasing the clarity of the example. Can for example be easy to miss that you need to name the error map variable exactly the same as the property field when passing it this way.