### PR TITLE
Allow Relative Urls

### DIFF
--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -103,11 +103,24 @@ test("more email validations", () => {
 test("url validations", () => {
   const url = z.string().url();
   try {
+    url.parse("google.com");
     url.parse("http://google.com");
     url.parse("https://google.com/asdf?asdf=ljk3lk4&asdf=234#asdf");
     expect(() => url.parse("asdf")).toThrow();
     expect(() => url.parse("https:/")).toThrow();
     expect(() => url.parse("asdfj@lkjsdf.com")).toThrow();
+  } catch (err) {}
+
+  const relativeUrl = z.string().url(true);
+  try {
+    relativeUrl.parse("google.com");
+    relativeUrl.parse("http://google.com");
+    relativeUrl.parse("https://google.com/asdf?asdf=ljk3lk4&asdf=234#asdf");
+    relativeUrl.parse("/asdasd");
+    relativeUrl.parse("../oqweausd");
+    expect(() => relativeUrl.parse("asdf")).toThrow();
+    expect(() => relativeUrl.parse("https:/")).toThrow();
+    expect(() => relativeUrl.parse("asdfj@lkjsdf.com")).toThrow();
   } catch (err) {}
 });
 
@@ -118,12 +131,12 @@ test("url error overrides", () => {
     expect((err as z.ZodError).issues[0].message).toEqual("Invalid url");
   }
   try {
-    z.string().url("badurl").parse("https");
+    z.string().url(false, "badurl").parse("https");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual("badurl");
   }
   try {
-    z.string().url({ message: "badurl" }).parse("https");
+    z.string().url(false, { message: "badurl" }).parse("https");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual("badurl");
   }

--- a/deno/lib/__tests__/validations.test.ts
+++ b/deno/lib/__tests__/validations.test.ts
@@ -151,7 +151,7 @@ test("instantiation", () => {
   z.string().max(5, { message: "Must be 5 or fewer characters long" });
   z.string().length(5, { message: "Must be exactly 5 characters long" });
   z.string().email({ message: "Invalid email address." });
-  z.string().url({ message: "Invalid url" });
+  z.string().url(false, { message: "Invalid url" });
   z.string().uuid({ message: "Invalid UUID" });
 });
 

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -102,11 +102,24 @@ test("more email validations", () => {
 test("url validations", () => {
   const url = z.string().url();
   try {
+    url.parse("google.com");
     url.parse("http://google.com");
     url.parse("https://google.com/asdf?asdf=ljk3lk4&asdf=234#asdf");
     expect(() => url.parse("asdf")).toThrow();
     expect(() => url.parse("https:/")).toThrow();
     expect(() => url.parse("asdfj@lkjsdf.com")).toThrow();
+  } catch (err) {}
+
+  const relativeUrl = z.string().url(true);
+  try {
+    relativeUrl.parse("google.com");
+    relativeUrl.parse("http://google.com");
+    relativeUrl.parse("https://google.com/asdf?asdf=ljk3lk4&asdf=234#asdf");
+    relativeUrl.parse("/asdasd");
+    relativeUrl.parse("../oqweausd");
+    expect(() => relativeUrl.parse("asdf")).toThrow();
+    expect(() => relativeUrl.parse("https:/")).toThrow();
+    expect(() => relativeUrl.parse("asdfj@lkjsdf.com")).toThrow();
   } catch (err) {}
 });
 
@@ -117,12 +130,12 @@ test("url error overrides", () => {
     expect((err as z.ZodError).issues[0].message).toEqual("Invalid url");
   }
   try {
-    z.string().url("badurl").parse("https");
+    z.string().url(false, "badurl").parse("https");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual("badurl");
   }
   try {
-    z.string().url({ message: "badurl" }).parse("https");
+    z.string().url(false, { message: "badurl" }).parse("https");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual("badurl");
   }

--- a/src/__tests__/validations.test.ts
+++ b/src/__tests__/validations.test.ts
@@ -150,7 +150,7 @@ test("instantiation", () => {
   z.string().max(5, { message: "Must be 5 or fewer characters long" });
   z.string().length(5, { message: "Must be exactly 5 characters long" });
   z.string().email({ message: "Invalid email address." });
-  z.string().url({ message: "Invalid url" });
+  z.string().url(false, { message: "Invalid url" });
   z.string().uuid({ message: "Invalid UUID" });
 });
 


### PR DESCRIPTION
This should fix #2025.

In addition, www.example.com is now also a valid url.

Normal URL:
```js
	const url = z.string().url()
	// or 
	const url = z.string().url(false)
```

Relative URL:
```js
	const url = z.string().url(true)
```