### PR TITLE
Implemented `ZodNumber#multipleOfValue` (closes #1889)

### DIFF
--- a/deno/lib/__tests__/number.test.ts
+++ b/deno/lib/__tests__/number.test.ts
@@ -166,3 +166,16 @@ test("finite getter", () => {
   expect(multipleOfFive.isFinite).toEqual(true);
   expect(z.number().min(5).max(10).isFinite).toEqual(true);
 });
+
+test("multipleOf getter", () => {
+  expect(z.number().multipleOfValue).toEqual(null);
+  expect(z.number().multipleOf(2).multipleOfValue).toEqual(2);
+  expect(z.number().multipleOf(-2).multipleOfValue).toEqual(-2);
+
+  // Only the first value is used. In the future it can be extended to calculate
+  // Least Common Multiple of them.
+  expect(z.number().multipleOf(2).multipleOf(3).multipleOfValue).toEqual(2);
+  expect(z.number().multipleOf(-2).multipleOf(3).multipleOfValue).toEqual(-2);
+  expect(z.number().multipleOf(2).multipleOf(-3).multipleOfValue).toEqual(2);
+  expect(z.number().multipleOf(-2).multipleOf(-3).multipleOfValue).toEqual(-2);
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1174,6 +1174,16 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
     return max;
   }
 
+  get multipleOfValue() {
+    for (const ch of this._def.checks) {
+      if (ch.kind === "multipleOf") {
+        return ch.value;
+      }
+    }
+
+    return null;
+  }
+
   get isInt() {
     return !!this._def.checks.find(
       (ch) =>

--- a/src/__tests__/number.test.ts
+++ b/src/__tests__/number.test.ts
@@ -165,3 +165,16 @@ test("finite getter", () => {
   expect(multipleOfFive.isFinite).toEqual(true);
   expect(z.number().min(5).max(10).isFinite).toEqual(true);
 });
+
+test("multipleOf getter", () => {
+  expect(z.number().multipleOfValue).toEqual(null);
+  expect(z.number().multipleOf(2).multipleOfValue).toEqual(2);
+  expect(z.number().multipleOf(-2).multipleOfValue).toEqual(-2);
+
+  // Only the first value is used. In the future it can be extended to calculate
+  // Least Common Multiple of them.
+  expect(z.number().multipleOf(2).multipleOf(3).multipleOfValue).toEqual(2);
+  expect(z.number().multipleOf(-2).multipleOf(3).multipleOfValue).toEqual(-2);
+  expect(z.number().multipleOf(2).multipleOf(-3).multipleOfValue).toEqual(2);
+  expect(z.number().multipleOf(-2).multipleOf(-3).multipleOfValue).toEqual(-2);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1174,6 +1174,16 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
     return max;
   }
 
+  get multipleOfValue() {
+    for (const ch of this._def.checks) {
+      if (ch.kind === "multipleOf") {
+        return ch.value;
+      }
+    }
+
+    return null;
+  }
+
   get isInt() {
     return !!this._def.checks.find(
       (ch) =>


### PR DESCRIPTION
In this pull request, I added a getter for `multipleOf` value on `ZodNumber`, as proposed in #1889. I decided to go with the simple solution first, i.e., take only the first value - if needed, it can be changed in the future to calculate the Least Common Multiple (it's mentioned in the tests).

I wasn't sure about two things, though:
1. It looks like other getters (e.g., `maxValue`) are not documented. If there's a place where I could add documentation for `multipleOfValue`, I'll gladly add it as well.
2. There's only a few usages of `Array#find` in the project, and all of them should actually be replaced with `some` (as all of them do `!!this._def.checks.find(...)`). That's why I decided to go with `for..of` and return `null` instead of `undefined` when nothing is found. Let me know whether a different implementation is preferred.