### PR TITLE
feat: add `.catch` error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2124,29 +2124,17 @@ numberWithCatch.parse(5); // => 5
 numberWithCatch.parse("tuna"); // => 42
 ```
 
-Optionally, you can pass a function into `.catch` that will be re-executed whenever a default value needs to be generated:
+Optionally, you can pass a function into `.catch` that will be re-executed whenever a default value needs to be generated. A `ctx` object containing the caught error will be passed into this function.
 
 ```ts
-const numberWithRandomCatch = z.number().catch(Math.random);
+const numberWithRandomCatch = z.number().catch((ctx) => {
+  ctx.error; // the caught ZodError
+  return Math.random();
+});
 
 numberWithRandomCatch.parse("sup"); // => 0.4413456736055323
 numberWithRandomCatch.parse("sup"); // => 0.1871840107401901
 numberWithRandomCatch.parse("sup"); // => 0.7223408162401552
-```
-
-Optionally, you can collect a `ZodError` whenever a default value is generated when passing a function into `.catch`:
-```ts
-const numberWithErrorCatch = z.number().catch((e) => {
-  console.error(e);
-
-  return 42;
-});
-
-// No error shown in console.
-numberWithErrorCatch.parse(5); // => 5
-
-// Default value is returned, an error will be shown in console.
-numberWithErrorCatch.parse("tuna"); // => 42
 ```
 
 Conceptually, this is how Zod processes "catch values":

--- a/README.md
+++ b/README.md
@@ -2129,9 +2129,9 @@ Optionally, you can pass a function into `.catch` that will be re-executed whene
 ```ts
 const numberWithRandomCatch = z.number().catch(Math.random);
 
-numberWithRandomDefault.parse("sup"); // => 0.4413456736055323
-numberWithRandomDefault.parse("sup"); // => 0.1871840107401901
-numberWithRandomDefault.parse("sup"); // => 0.7223408162401552
+numberWithRandomCatch.parse("sup"); // => 0.4413456736055323
+numberWithRandomCatch.parse("sup"); // => 0.1871840107401901
+numberWithRandomCatch.parse("sup"); // => 0.7223408162401552
 ```
 
 Optionally, you can collect a `ZodError` whenever a default value is generated when passing a function into `.catch`:
@@ -2143,10 +2143,10 @@ const numberWithErrorCatch = z.number().catch((e) => {
 });
 
 // No error shown in console.
-numberWithCatch.parse(5); // => 5
+numberWithErrorCatch.parse(5); // => 5
 
 // Default value is returned, an error will be shown in console.
-numberWithCatch.parse("tuna"); // => 42
+numberWithErrorCatch.parse("tuna"); // => 42
 ```
 
 Conceptually, this is how Zod processes "catch values":

--- a/README.md
+++ b/README.md
@@ -2134,6 +2134,21 @@ numberWithRandomDefault.parse("sup"); // => 0.1871840107401901
 numberWithRandomDefault.parse("sup"); // => 0.7223408162401552
 ```
 
+Optionally, you can collect a `ZodError` whenever a default value is generated when passing a function into `.catch`:
+```ts
+const numberWithErrorCatch = z.number().catch((e) => {
+  console.error(e);
+
+  return 42;
+});
+
+// No error shown in console.
+numberWithCatch.parse(5); // => 5
+
+// Default value is returned, an error will be shown in console.
+numberWithCatch.parse("tuna"); // => 42
+```
+
 Conceptually, this is how Zod processes "catch values":
 
 1. The data is parsed using the base schema

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -2124,29 +2124,17 @@ numberWithCatch.parse(5); // => 5
 numberWithCatch.parse("tuna"); // => 42
 ```
 
-Optionally, you can pass a function into `.catch` that will be re-executed whenever a default value needs to be generated:
+Optionally, you can pass a function into `.catch` that will be re-executed whenever a default value needs to be generated. A `ctx` object containing the caught error will be passed into this function.
 
 ```ts
-const numberWithRandomCatch = z.number().catch(Math.random);
+const numberWithRandomCatch = z.number().catch((ctx) => {
+  ctx.error; // the caught ZodError
+  return Math.random();
+});
 
 numberWithRandomCatch.parse("sup"); // => 0.4413456736055323
 numberWithRandomCatch.parse("sup"); // => 0.1871840107401901
 numberWithRandomCatch.parse("sup"); // => 0.7223408162401552
-```
-
-Optionally, you can collect a `ZodError` whenever a default value is generated when passing a function into `.catch`:
-```ts
-const numberWithErrorCatch = z.number().catch((e) => {
-  console.error(e);
-
-  return 42;
-});
-
-// No error shown in console.
-numberWithErrorCatch.parse(5); // => 5
-
-// Default value is returned, an error will be shown in console.
-numberWithErrorCatch.parse("tuna"); // => 42
 ```
 
 Conceptually, this is how Zod processes "catch values":

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1409,7 +1409,7 @@ type NumberSet = z.infer<typeof numberSet>;
 // type NumberSet = Set<number>
 ```
 
-Set schemas can be further contrainted with the following utility methods.
+Set schemas can be further constrained with the following utility methods.
 
 ```ts
 z.set(z.string()).nonempty(); // must contain at least one item
@@ -1712,6 +1712,12 @@ If you don't provide a validation function, Zod will allow any value. This can b
 
 ```ts
 z.custom<{ arg: string }>(); // performs no validation
+```
+
+You can customize the error message and other options by passing a second argument. This parameter works the same way as the params parameter of [`.refine`](#refine).
+
+```ts
+z.custom<...>((val) => ..., "custom error message");
 ```
 
 ## Schema methods
@@ -2128,6 +2134,21 @@ numberWithRandomDefault.parse("sup"); // => 0.1871840107401901
 numberWithRandomDefault.parse("sup"); // => 0.7223408162401552
 ```
 
+Optionally, you can collect a `ZodError` whenever a default value is generated when passing a function into `.catch`:
+```ts
+const numberWithErrorCatch = z.number().catch((e) => {
+  console.error(e);
+
+  return 42;
+});
+
+// No error shown in console.
+numberWithCatch.parse(5); // => 5
+
+// Default value is returned, an error will be shown in console.
+numberWithCatch.parse("tuna"); // => 42
+```
+
 Conceptually, this is how Zod processes "catch values":
 
 1. The data is parsed using the base schema
@@ -2349,14 +2370,14 @@ makeSchemaOptional(z.number());
 Zod provides a subclass of Error called `ZodError`. ZodErrors contain an `issues` array containing detailed information about the validation problems.
 
 ```ts
-const data = z
+const result = z
   .object({
     name: z.string(),
   })
   .safeParse({ name: 12 });
 
-if (!data.success) {
-  data.error.issues;
+if (!result.success) {
+  result.error.issues;
   /* [
       {
         "code": "invalid_type",
@@ -2378,14 +2399,14 @@ Zod's error reporting emphasizes _completeness_ and _correctness_. If you are lo
 You can use the `.format()` method to convert this error into a nested object.
 
 ```ts
-const data = z
+const result = z
   .object({
     name: z.string(),
   })
   .safeParse({ name: 12 });
 
-if (!data.success) {
-  const formatted = data.error.format();
+if (!result.success) {
+  const formatted = result.error.format();
   /* {
     name: { _errors: [ 'Expected string, received number' ] }
   } */

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -2129,9 +2129,9 @@ Optionally, you can pass a function into `.catch` that will be re-executed whene
 ```ts
 const numberWithRandomCatch = z.number().catch(Math.random);
 
-numberWithRandomDefault.parse("sup"); // => 0.4413456736055323
-numberWithRandomDefault.parse("sup"); // => 0.1871840107401901
-numberWithRandomDefault.parse("sup"); // => 0.7223408162401552
+numberWithRandomCatch.parse("sup"); // => 0.4413456736055323
+numberWithRandomCatch.parse("sup"); // => 0.1871840107401901
+numberWithRandomCatch.parse("sup"); // => 0.7223408162401552
 ```
 
 Optionally, you can collect a `ZodError` whenever a default value is generated when passing a function into `.catch`:
@@ -2143,10 +2143,10 @@ const numberWithErrorCatch = z.number().catch((e) => {
 });
 
 // No error shown in console.
-numberWithCatch.parse(5); // => 5
+numberWithErrorCatch.parse(5); // => 5
 
 // Default value is returned, an error will be shown in console.
-numberWithCatch.parse("tuna"); // => 42
+numberWithErrorCatch.parse("tuna"); // => 42
 ```
 
 Conceptually, this is how Zod processes "catch values":

--- a/deno/lib/__tests__/catch.test.ts
+++ b/deno/lib/__tests__/catch.test.ts
@@ -189,3 +189,29 @@ test("reported issues with nested usage", () => {
     expect(issues[2].message).toMatch("boolean");
   }
 });
+
+test("catch error", () => {
+  let catchError: z.ZodError | undefined = undefined;
+
+  const schema = z.object({
+    age: z.number(),
+    name: z.string().catch((error) => {
+      catchError = error;
+
+      return "John Doe"
+    })
+  });
+
+  const result = schema.safeParse({
+    age: null,
+    name: null
+  });
+
+  expect(result.success).toEqual(false);
+  expect(!result.success && result.error.issues.length).toEqual(1);
+  expect(!result.success && result.error.issues[0].message).toMatch("number");
+
+  expect(catchError).toBeInstanceOf(z.ZodError);
+  expect(catchError !== undefined && (catchError as z.ZodError).issues.length).toEqual(1);
+  expect(catchError !== undefined && (catchError as z.ZodError).issues[0].message).toMatch("string");
+})

--- a/deno/lib/__tests__/catch.test.ts
+++ b/deno/lib/__tests__/catch.test.ts
@@ -195,16 +195,16 @@ test("catch error", () => {
 
   const schema = z.object({
     age: z.number(),
-    name: z.string().catch((error) => {
-      catchError = error;
+    name: z.string().catch((ctx) => {
+      catchError = ctx.error;
 
-      return "John Doe"
-    })
+      return "John Doe";
+    }),
   });
 
   const result = schema.safeParse({
     age: null,
-    name: null
+    name: null,
   });
 
   expect(result.success).toEqual(false);
@@ -212,6 +212,10 @@ test("catch error", () => {
   expect(!result.success && result.error.issues[0].message).toMatch("number");
 
   expect(catchError).toBeInstanceOf(z.ZodError);
-  expect(catchError !== undefined && (catchError as z.ZodError).issues.length).toEqual(1);
-  expect(catchError !== undefined && (catchError as z.ZodError).issues[0].message).toMatch("string");
-})
+  expect(
+    catchError !== undefined && (catchError as z.ZodError).issues.length
+  ).toEqual(1);
+  expect(
+    catchError !== undefined && (catchError as z.ZodError).issues[0].message
+  ).toMatch("string");
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -447,7 +447,7 @@ export abstract class ZodType<
   }
 
   catch(def: Output): ZodCatch<this>;
-  catch(def: (error: ZodError) => Output): ZodCatch<this>;
+  catch(def: (ctx: { error: ZodError }) => Output): ZodCatch<this>;
   catch(def: any) {
     const catchValueFunc = typeof def === "function" ? def : () => def;
 
@@ -4260,7 +4260,7 @@ export interface ZodCatchDef<
   C extends T["_input"] = T["_input"]
 > extends ZodTypeDef {
   innerType: T;
-  catchValue: (error: ZodError) => C;
+  catchValue: (ctx: { error: ZodError }) => C;
   typeName: ZodFirstPartyTypeKind.ZodCatch;
 }
 
@@ -4296,7 +4296,11 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
           value:
             result.status === "valid"
               ? result.value
-              : this._def.catchValue(new ZodError(newCtx.common.issues)),
+              : this._def.catchValue({
+                  get error() {
+                    return new ZodError(newCtx.common.issues);
+                  },
+                }),
         };
       });
     } else {
@@ -4305,7 +4309,11 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
         value:
           result.status === "valid"
             ? result.value
-            : this._def.catchValue(new ZodError(newCtx.common.issues)),
+            : this._def.catchValue({
+                get error() {
+                  return new ZodError(newCtx.common.issues);
+                },
+              }),
       };
     }
   }

--- a/playground.ts
+++ b/playground.ts
@@ -1,16 +1,9 @@
 import { z } from "./src";
 
-// const emoji = z.string().emoji();
-
-const emojiRegex =
-  /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|\uFE0E|\uFE0F)/;
-
-function isEmoji(val: string) {
-  return [...val].every((char) => emojiRegex.test(char));
+// benchmark
+// run 10000 times
+console.time("bench");
+for (let i = 0; i < 10000; i++) {
+  z.string().catch("asdf").parse(5);
 }
-console.log(isEmoji("🍺👩‍🚀🫡"));
-console.log(isEmoji("💚💙💜💛❤️"));
-console.log(isEmoji(":-)"));
-console.log(isEmoji("asdf"));
-console.log(isEmoji("😀stuff"));
-console.log(isEmoji("stuff😀"));
+console.timeEnd("bench");

--- a/src/__tests__/catch.test.ts
+++ b/src/__tests__/catch.test.ts
@@ -194,16 +194,16 @@ test("catch error", () => {
 
   const schema = z.object({
     age: z.number(),
-    name: z.string().catch((error) => {
-      catchError = error;
+    name: z.string().catch((ctx) => {
+      catchError = ctx.error;
 
-      return "John Doe"
-    })
+      return "John Doe";
+    }),
   });
 
   const result = schema.safeParse({
     age: null,
-    name: null
+    name: null,
   });
 
   expect(result.success).toEqual(false);
@@ -211,6 +211,10 @@ test("catch error", () => {
   expect(!result.success && result.error.issues[0].message).toMatch("number");
 
   expect(catchError).toBeInstanceOf(z.ZodError);
-  expect(catchError !== undefined && (catchError as z.ZodError).issues.length).toEqual(1);
-  expect(catchError !== undefined && (catchError as z.ZodError).issues[0].message).toMatch("string");
-})
+  expect(
+    catchError !== undefined && (catchError as z.ZodError).issues.length
+  ).toEqual(1);
+  expect(
+    catchError !== undefined && (catchError as z.ZodError).issues[0].message
+  ).toMatch("string");
+});

--- a/src/__tests__/catch.test.ts
+++ b/src/__tests__/catch.test.ts
@@ -188,3 +188,29 @@ test("reported issues with nested usage", () => {
     expect(issues[2].message).toMatch("boolean");
   }
 });
+
+test("catch error", () => {
+  let catchError: z.ZodError | undefined = undefined;
+
+  const schema = z.object({
+    age: z.number(),
+    name: z.string().catch((error) => {
+      catchError = error;
+
+      return "John Doe"
+    })
+  });
+
+  const result = schema.safeParse({
+    age: null,
+    name: null
+  });
+
+  expect(result.success).toEqual(false);
+  expect(!result.success && result.error.issues.length).toEqual(1);
+  expect(!result.success && result.error.issues[0].message).toMatch("number");
+
+  expect(catchError).toBeInstanceOf(z.ZodError);
+  expect(catchError !== undefined && (catchError as z.ZodError).issues.length).toEqual(1);
+  expect(catchError !== undefined && (catchError as z.ZodError).issues[0].message).toMatch("string");
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -447,7 +447,7 @@ export abstract class ZodType<
   }
 
   catch(def: Output): ZodCatch<this>;
-  catch(def: (error: ZodError) => Output): ZodCatch<this>;
+  catch(def: (ctx: { error: ZodError }) => Output): ZodCatch<this>;
   catch(def: any) {
     const catchValueFunc = typeof def === "function" ? def : () => def;
 
@@ -4260,7 +4260,7 @@ export interface ZodCatchDef<
   C extends T["_input"] = T["_input"]
 > extends ZodTypeDef {
   innerType: T;
-  catchValue: (error: ZodError) => C;
+  catchValue: (ctx: { error: ZodError }) => C;
   typeName: ZodFirstPartyTypeKind.ZodCatch;
 }
 
@@ -4296,7 +4296,11 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
           value:
             result.status === "valid"
               ? result.value
-              : this._def.catchValue(new ZodError(newCtx.common.issues)),
+              : this._def.catchValue({
+                  get error() {
+                    return new ZodError(newCtx.common.issues);
+                  },
+                }),
         };
       });
     } else {
@@ -4305,7 +4309,11 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
         value:
           result.status === "valid"
             ? result.value
-            : this._def.catchValue(new ZodError(newCtx.common.issues)),
+            : this._def.catchValue({
+                get error() {
+                  return new ZodError(newCtx.common.issues);
+                },
+              }),
       };
     }
   }


### PR DESCRIPTION
# Introduction

Hey 👋🏻

This PR introduces a way to collect a `ZodError` when using `.catch` method, which can be useful in many case when wanting to collect logs whenever default value is used.

# Example
```ts
const numberWithErrorCatch = z.number().catch((e) => {
  console.error(e);

  return 42;
});

// No error shown in console.
numberWithErrorCatch.parse(5); // => 5

// Default value is returned, an error will be shown in console.
numberWithErrorCatch.parse("tuna"); // => 42
```