### PR TITLE
BRAND Record to Non Partial

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1409,7 +1409,7 @@ type NumberSet = z.infer<typeof numberSet>;
 // type NumberSet = Set<number>
 ```
 
-Set schemas can be further contrainted with the following utility methods.
+Set schemas can be further constrained with the following utility methods.
 
 ```ts
 z.set(z.string()).nonempty(); // must contain at least one item
@@ -1712,6 +1712,12 @@ If you don't provide a validation function, Zod will allow any value. This can b
 
 ```ts
 z.custom<{ arg: string }>(); // performs no validation
+```
+
+You can customize the error message and other options by passing a second argument. This parameter works the same way as the params parameter of [`.refine`](#refine).
+
+```ts
+z.custom<...>((val) => ..., "custom error message");
 ```
 
 ## Schema methods
@@ -2349,14 +2355,14 @@ makeSchemaOptional(z.number());
 Zod provides a subclass of Error called `ZodError`. ZodErrors contain an `issues` array containing detailed information about the validation problems.
 
 ```ts
-const data = z
+const result = z
   .object({
     name: z.string(),
   })
   .safeParse({ name: 12 });
 
-if (!data.success) {
-  data.error.issues;
+if (!result.success) {
+  result.error.issues;
   /* [
       {
         "code": "invalid_type",
@@ -2378,14 +2384,14 @@ Zod's error reporting emphasizes _completeness_ and _correctness_. If you are lo
 You can use the `.format()` method to convert this error into a nested object.
 
 ```ts
-const data = z
+const result = z
   .object({
     name: z.string(),
   })
   .safeParse({ name: 12 });
 
-if (!data.success) {
-  const formatted = data.error.format();
+if (!result.success) {
+  const formatted = result.error.format();
   /* {
     name: { _errors: [ 'Expected string, received number' ] }
   } */

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3066,6 +3066,8 @@ export type RecordType<K extends string | number | symbol, V> = [
   ? Record<K, V>
   : [symbol] extends [K]
   ? Record<K, V>
+  : K extends BRAND<string | number | symbol>
+  ? Record<K, V>
   : Partial<Record<K, V>>;
 export class ZodRecord<
   Key extends KeySchema = ZodString,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3066,6 +3066,8 @@ export type RecordType<K extends string | number | symbol, V> = [
   ? Record<K, V>
   : [symbol] extends [K]
   ? Record<K, V>
+  : K extends BRAND<string | number | symbol>
+  ? Record<K, V>
   : Partial<Record<K, V>>;
 export class ZodRecord<
   Key extends KeySchema = ZodString,


### PR DESCRIPTION
This PR is an artifact of the discussion.
https://github.com/colinhacks/zod/discussions/2069#discussioncomment-5091931

A `Record` keyed by `string`, `number` or `symbol` is `Non Partial`, but `BRAND` (which should behave similarly) is `Partial`.
This PR ensures that a key with `BRAND` will also be `Non Partial`.