### PR TITLE
Refactoring of ZodFormattedError type to improve tsc check time

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -170,15 +170,17 @@ export const quotelessJson = (obj: any) => {
   return json.replace(/"([^"]+)":/g, "$1:");
 };
 
+type recursiveZodFormattedError<T> = T extends [any, ...any[]]
+  ? { [K in keyof T]?: ZodFormattedError<T[K]> }
+  : T extends any[]
+  ? { [k: number]: ZodFormattedError<T[number]> }
+  : T extends object
+  ? { [K in keyof T]?: ZodFormattedError<T[K]> }
+  : unknown;
+
 export type ZodFormattedError<T, U = string> = {
   _errors: U[];
-} & (NonNullable<T> extends [any, ...any[]]
-  ? { [K in keyof NonNullable<T>]?: ZodFormattedError<NonNullable<T>[K], U> }
-  : NonNullable<T> extends any[]
-  ? { [k: number]: ZodFormattedError<NonNullable<T>[number], U> }
-  : NonNullable<T> extends object
-  ? { [K in keyof NonNullable<T>]?: ZodFormattedError<NonNullable<T>[K], U> }
-  : unknown);
+} & recursiveZodFormattedError<NonNullable<T>>;
 
 export type inferFormattedError<
   T extends ZodType<any, any, any>,

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -170,15 +170,17 @@ export const quotelessJson = (obj: any) => {
   return json.replace(/"([^"]+)":/g, "$1:");
 };
 
+type recursiveZodFormattedError<T> = T extends [any, ...any[]]
+  ? { [K in keyof T]?: ZodFormattedError<T[K]> }
+  : T extends any[]
+  ? { [k: number]: ZodFormattedError<T[number]> }
+  : T extends object
+  ? { [K in keyof T]?: ZodFormattedError<T[K]> }
+  : unknown;
+
 export type ZodFormattedError<T, U = string> = {
   _errors: U[];
-} & (NonNullable<T> extends [any, ...any[]]
-  ? { [K in keyof NonNullable<T>]?: ZodFormattedError<NonNullable<T>[K], U> }
-  : NonNullable<T> extends any[]
-  ? { [k: number]: ZodFormattedError<NonNullable<T>[number], U> }
-  : NonNullable<T> extends object
-  ? { [K in keyof NonNullable<T>]?: ZodFormattedError<NonNullable<T>[K], U> }
-  : unknown);
+} & recursiveZodFormattedError<NonNullable<T>>;
 
 export type inferFormattedError<
   T extends ZodType<any, any, any>,


### PR DESCRIPTION
This small refactoring of ZodFormattedError fix several  performance issues in some edge cases.

I did some benchmarks with simple case with typescript compiler option **strict: false**   https://github.com/gydroperit/zod-test-regression



1. Now amount of generated types three times less than before, while  building typescript project, thus almost halves **Check time**

Without fix

```Files:              72
Lines:           30507
Identifiers:     49830
Symbols:         47942
Types:           17794
Instantiations:  29270
Memory used:    77234K
I/O read:        0.00s
I/O write:       0.00s
Parse time:      0.31s
Bind time:       0.13s
Check time:      0.31s
Emit time:       0.01s
Total time:      0.75s
```
with this fix
```
Files:              72
Lines:           30508
Identifiers:     49824
Symbols:         44537
Types:            5659
Instantiations:  17489
Memory used:    70989K
I/O read:        0.00s
I/O write:       0.00s
Parse time:      0.31s
Bind time:       0.12s
Check time:      0.20s
Emit time:       0.01s
Total time:      0.63s
```

2. Second issue is maybe more  important than 15 ms of build time. On some reason VS Code on latest  version of zod has very laggy intellisense autocompletion(about 1 to 3 seconds to show autocomplete list) and slow ESLint check time in source files with zod used(About 8 seconds in my case). Even this strict option set to true.
After fix - it will run smooth like in previous version,

This problem also described in https://stackoverflow.com/questions/74881472/slow-typescript-autocompletion-in-vs-code-for-zod
https://github.com/colinhacks/zod/issues/1741
https://github.com/microsoft/TypeScript/issues/45824

