### PR TITLE
re-introduce `ZodBigInt.(un)safe`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,11 @@ z.bigint().negative(); // < 0n
 z.bigint().nonpositive(); // <= 0n
 
 z.bigint().multipleOf(5n); // Evenly divisible by 5n.
+
+z.bigint().safe(); // Safe integer. Number.MIN_SAFE_INTEGER <= x <= Number.MAX_SAFE_INTEGER
+z.bigint().safe().transform(Number); // When you know you're safe, you can transform to a number and still sleep at night.
+
+z.bigint().unsafe(); // "Unsafe" integer. x > Number.MAX_SAFE_INTEGER or x < Number.MIN_SAFE_INTEGER. Alias `.gigantic()`
 ```
 
 ## NaNs

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -599,11 +599,11 @@ z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().trim(); // trim whitespace
-z.string().toLowerCase(); // toLowerCase
-z.string().toUpperCase(); // toLowerCase
 z.string().datetime(); // defaults to UTC, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 ```
+<!-- z.string().toLowerCase(); // toLowerCase -->
+<!-- z.string().toUpperCase(); // toUpperCase -->
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
 
@@ -745,6 +745,11 @@ z.bigint().negative(); // < 0n
 z.bigint().nonpositive(); // <= 0n
 
 z.bigint().multipleOf(5n); // Evenly divisible by 5n.
+
+z.bigint().safe(); // Safe integer. Number.MIN_SAFE_INTEGER <= x <= Number.MAX_SAFE_INTEGER
+z.bigint().safe().transform(Number); // When you know you're safe, you can transform to a number and still sleep at night.
+
+z.bigint().unsafe(); // "Unsafe" integer. x > Number.MAX_SAFE_INTEGER or x < Number.MIN_SAFE_INTEGER. Alias `.gigantic()`
 ```
 
 ## NaNs

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -32,6 +32,7 @@ export const ZodIssueCode = util.arrayToEnum([
   "invalid_intersection_types",
   "not_multiple_of",
   "not_finite",
+  "not_unsafe",
 ]);
 
 export type ZodIssueCode = keyof typeof ZodIssueCode;
@@ -135,6 +136,10 @@ export interface ZodNotFiniteIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.not_finite;
 }
 
+export interface ZodNotUnsafeIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.not_unsafe;
+}
+
 export interface ZodCustomIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.custom;
   params?: { [k: string]: any };
@@ -158,6 +163,7 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidIntersectionTypesIssue
   | ZodNotMultipleOfIssue
   | ZodNotFiniteIssue
+  | ZodNotUnsafeIssue
   | ZodCustomIssue;
 
 export type ZodIssue = ZodIssueOptionalMessage & {

--- a/deno/lib/__tests__/bigint.test.ts
+++ b/deno/lib/__tests__/bigint.test.ts
@@ -13,6 +13,8 @@ const negative = z.bigint().negative();
 const nonnegative = z.bigint().nonnegative();
 const nonpositive = z.bigint().nonpositive();
 const multipleOfFive = z.bigint().multipleOf(BigInt(5));
+const unsafe = z.bigint().unsafe();
+const safe = z.bigint().safe();
 
 test("passing validations", () => {
   z.bigint().parse(BigInt(1));
@@ -31,6 +33,11 @@ test("passing validations", () => {
   nonpositive.parse(BigInt(0));
   nonpositive.parse(BigInt(-12));
   multipleOfFive.parse(BigInt(15));
+  unsafe.parse(BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1));
+  unsafe.parse(BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1));
+  safe.parse(BigInt(Number.MAX_SAFE_INTEGER));
+  safe.parse(BigInt(0));
+  safe.parse(BigInt(Number.MIN_SAFE_INTEGER));
 });
 
 test("failing validations", () => {
@@ -45,6 +52,14 @@ test("failing validations", () => {
   expect(() => nonnegative.parse(BigInt(-1))).toThrow();
   expect(() => nonpositive.parse(BigInt(1))).toThrow();
   expect(() => multipleOfFive.parse(BigInt(13))).toThrow();
+  expect(() => unsafe.parse(BigInt(Number.MAX_SAFE_INTEGER))).toThrow();
+  expect(() => unsafe.parse(BigInt(Number.MIN_SAFE_INTEGER))).toThrow();
+  expect(() =>
+    safe.parse(BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1))
+  ).toThrow();
+  expect(() =>
+    safe.parse(BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1))
+  ).toThrow();
 });
 
 test("min max getters", () => {
@@ -52,7 +67,25 @@ test("min max getters", () => {
   expect(z.bigint().min(BigInt(5)).min(BigInt(10)).minValue).toEqual(
     BigInt(10)
   );
+  expect(z.bigint().safe().minValue).toEqual(BigInt(Number.MIN_SAFE_INTEGER));
+  expect(z.bigint().safe().min(BigInt(5)).minValue).toEqual(BigInt(5));
 
   expect(z.bigint().max(BigInt(5)).maxValue).toEqual(BigInt(5));
   expect(z.bigint().max(BigInt(5)).max(BigInt(1)).maxValue).toEqual(BigInt(1));
+  expect(z.bigint().safe().maxValue).toEqual(BigInt(Number.MAX_SAFE_INTEGER));
+  expect(z.bigint().safe().max(BigInt(5)).maxValue).toEqual(BigInt(5));
+});
+
+test("safe unsafe getters", () => {
+  expect(z.bigint().unsafe().isUnsafe).toEqual(true);
+  expect(z.bigint().unsafe().isSafe).toEqual(false);
+  expect(z.bigint().min(BigInt(5)).isUnsafe).toEqual(true);
+  expect(z.bigint().min(BigInt(5)).isSafe).toEqual(false);
+  expect(z.bigint().max(BigInt(5)).isUnsafe).toEqual(true);
+  expect(z.bigint().max(BigInt(5)).isSafe).toEqual(false);
+
+  expect(z.bigint().safe().isSafe).toEqual(true);
+  expect(z.bigint().safe().isUnsafe).toEqual(false);
+  expect(z.bigint().min(BigInt(5)).max(BigInt(10)).isSafe).toEqual(true);
+  expect(z.bigint().min(BigInt(5)).max(BigInt(10)).isUnsafe).toEqual(false);
 });

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -134,6 +134,9 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.not_finite:
       message = "Number must be finite";
       break;
+    case ZodIssueCode.not_unsafe:
+      message = "Input must be unsafe";
+      break;
     default:
       message = _ctx.defaultError;
       util.assertNever(issue);

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -32,6 +32,7 @@ export const ZodIssueCode = util.arrayToEnum([
   "invalid_intersection_types",
   "not_multiple_of",
   "not_finite",
+  "not_unsafe",
 ]);
 
 export type ZodIssueCode = keyof typeof ZodIssueCode;
@@ -135,6 +136,10 @@ export interface ZodNotFiniteIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.not_finite;
 }
 
+export interface ZodNotUnsafeIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.not_unsafe;
+}
+
 export interface ZodCustomIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.custom;
   params?: { [k: string]: any };
@@ -158,6 +163,7 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidIntersectionTypesIssue
   | ZodNotMultipleOfIssue
   | ZodNotFiniteIssue
+  | ZodNotUnsafeIssue
   | ZodCustomIssue;
 
 export type ZodIssue = ZodIssueOptionalMessage & {

--- a/src/__tests__/bigint.test.ts
+++ b/src/__tests__/bigint.test.ts
@@ -12,6 +12,8 @@ const negative = z.bigint().negative();
 const nonnegative = z.bigint().nonnegative();
 const nonpositive = z.bigint().nonpositive();
 const multipleOfFive = z.bigint().multipleOf(BigInt(5));
+const unsafe = z.bigint().unsafe();
+const safe = z.bigint().safe();
 
 test("passing validations", () => {
   z.bigint().parse(BigInt(1));
@@ -30,6 +32,11 @@ test("passing validations", () => {
   nonpositive.parse(BigInt(0));
   nonpositive.parse(BigInt(-12));
   multipleOfFive.parse(BigInt(15));
+  unsafe.parse(BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1));
+  unsafe.parse(BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1));
+  safe.parse(BigInt(Number.MAX_SAFE_INTEGER));
+  safe.parse(BigInt(0));
+  safe.parse(BigInt(Number.MIN_SAFE_INTEGER));
 });
 
 test("failing validations", () => {
@@ -44,6 +51,14 @@ test("failing validations", () => {
   expect(() => nonnegative.parse(BigInt(-1))).toThrow();
   expect(() => nonpositive.parse(BigInt(1))).toThrow();
   expect(() => multipleOfFive.parse(BigInt(13))).toThrow();
+  expect(() => unsafe.parse(BigInt(Number.MAX_SAFE_INTEGER))).toThrow();
+  expect(() => unsafe.parse(BigInt(Number.MIN_SAFE_INTEGER))).toThrow();
+  expect(() =>
+    safe.parse(BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1))
+  ).toThrow();
+  expect(() =>
+    safe.parse(BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1))
+  ).toThrow();
 });
 
 test("min max getters", () => {
@@ -51,7 +66,25 @@ test("min max getters", () => {
   expect(z.bigint().min(BigInt(5)).min(BigInt(10)).minValue).toEqual(
     BigInt(10)
   );
+  expect(z.bigint().safe().minValue).toEqual(BigInt(Number.MIN_SAFE_INTEGER));
+  expect(z.bigint().safe().min(BigInt(5)).minValue).toEqual(BigInt(5));
 
   expect(z.bigint().max(BigInt(5)).maxValue).toEqual(BigInt(5));
   expect(z.bigint().max(BigInt(5)).max(BigInt(1)).maxValue).toEqual(BigInt(1));
+  expect(z.bigint().safe().maxValue).toEqual(BigInt(Number.MAX_SAFE_INTEGER));
+  expect(z.bigint().safe().max(BigInt(5)).maxValue).toEqual(BigInt(5));
+});
+
+test("safe unsafe getters", () => {
+  expect(z.bigint().unsafe().isUnsafe).toEqual(true);
+  expect(z.bigint().unsafe().isSafe).toEqual(false);
+  expect(z.bigint().min(BigInt(5)).isUnsafe).toEqual(true);
+  expect(z.bigint().min(BigInt(5)).isSafe).toEqual(false);
+  expect(z.bigint().max(BigInt(5)).isUnsafe).toEqual(true);
+  expect(z.bigint().max(BigInt(5)).isSafe).toEqual(false);
+
+  expect(z.bigint().safe().isSafe).toEqual(true);
+  expect(z.bigint().safe().isUnsafe).toEqual(false);
+  expect(z.bigint().min(BigInt(5)).max(BigInt(10)).isSafe).toEqual(true);
+  expect(z.bigint().min(BigInt(5)).max(BigInt(10)).isUnsafe).toEqual(false);
 });

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -134,6 +134,9 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.not_finite:
       message = "Number must be finite";
       break;
+    case ZodIssueCode.not_unsafe:
+      message = "Input must be unsafe";
+      break;
     default:
       message = _ctx.defaultError;
       util.assertNever(issue);


### PR DESCRIPTION
Re-introducing (un)safe checks @ `ZodBigInt` following [comment](https://github.com/colinhacks/zod/pull/1711#issuecomment-1445514486).