### PR TITLE
Cache the evaluation of ParseInputLazyPath.path() for a moderate perf improvement

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -599,11 +599,11 @@ z.string().regex(regex);
 z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().trim(); // trim whitespace
-z.string().toLowerCase(); // toLowerCase
-z.string().toUpperCase(); // toLowerCase
 z.string().datetime(); // defaults to UTC, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 ```
+<!-- z.string().toLowerCase(); // toLowerCase -->
+<!-- z.string().toUpperCase(); // toUpperCase -->
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -63,7 +63,7 @@ class ParseInputLazyPath implements ParseInput {
   data: any;
   _path: ParsePath;
   _key: string | number | (string | number)[];
-  _cachedPath: ParsePath | null = null;
+  _cachedPath: ParsePath = [];
   constructor(
     parent: ParseContext,
     value: any,
@@ -76,9 +76,15 @@ class ParseInputLazyPath implements ParseInput {
     this._key = key;
   }
   get path() {
-    if (this._cachedPath) return this._cachedPath;
-    this._cachedPath = this._path.concat(this._key);
-    return this._cachedPath!;
+    if (!this._cachedPath.length) {
+      if (this._key instanceof Array) {
+        this._cachedPath.push(...this._path, ...this._key);
+      } else {
+        this._cachedPath.push(...this._path, this._key);
+      }
+    }
+
+    return this._cachedPath;
   }
 }
 
@@ -3725,7 +3731,7 @@ export class ZodFunction<
     return this._def.returns;
   }
 
-  args<Items extends Parameters<(typeof ZodTuple)["create"]>[0]>(
+  args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
@@ -4863,18 +4869,18 @@ const oboolean = () => booleanType().optional();
 
 export const coerce = {
   string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
+    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
   number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
+    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
   boolean: ((arg) =>
     ZodBoolean.create({
       ...arg,
       coerce: true,
-    })) as (typeof ZodBoolean)["create"],
+    })) as typeof ZodBoolean["create"],
   bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
+    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
   date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
+    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
 };
 
 export {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -63,7 +63,7 @@ class ParseInputLazyPath implements ParseInput {
   data: any;
   _path: ParsePath;
   _key: string | number | (string | number)[];
-  _cachedPath: ParsePath = [];
+  _cachedPath: ParsePath | null = null;
   constructor(
     parent: ParseContext,
     value: any,
@@ -76,15 +76,9 @@ class ParseInputLazyPath implements ParseInput {
     this._key = key;
   }
   get path() {
-    if (!this._cachedPath.length) {
-      if (this._key instanceof Array) {
-        this._cachedPath.push(...this._path, ...this._key);
-      } else {
-        this._cachedPath.push(...this._path, this._key);
-      }
-    }
-
-    return this._cachedPath;
+    if (this._cachedPath) return this._cachedPath;
+    this._cachedPath = this._path.concat(this._key);
+    return this._cachedPath!;
   }
 }
 
@@ -3731,7 +3725,7 @@ export class ZodFunction<
     return this._def.returns;
   }
 
-  args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
+  args<Items extends Parameters<(typeof ZodTuple)["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
@@ -4869,18 +4863,18 @@ const oboolean = () => booleanType().optional();
 
 export const coerce = {
   string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
+    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
   number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
+    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
   boolean: ((arg) =>
     ZodBoolean.create({
       ...arg,
       coerce: true,
-    })) as typeof ZodBoolean["create"],
+    })) as (typeof ZodBoolean)["create"],
   bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
+    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
   date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
+    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
 };
 
 export {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -63,6 +63,7 @@ class ParseInputLazyPath implements ParseInput {
   data: any;
   _path: ParsePath;
   _key: string | number | (string | number)[];
+  _cachedPath: ParsePath = [];
   constructor(
     parent: ParseContext,
     value: any,
@@ -75,7 +76,15 @@ class ParseInputLazyPath implements ParseInput {
     this._key = key;
   }
   get path() {
-    return this._path.concat(this._key);
+    if (!this._cachedPath.length) {
+      if (this._key instanceof Array) {
+        this._cachedPath.push(...this._path, ...this._key);
+      } else {
+        this._cachedPath.push(...this._path, this._key);
+      }
+    }
+
+    return this._cachedPath;
   }
 }
 
@@ -3722,7 +3731,7 @@ export class ZodFunction<
     return this._def.returns;
   }
 
-  args<Items extends Parameters<(typeof ZodTuple)["create"]>[0]>(
+  args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
@@ -4860,18 +4869,18 @@ const oboolean = () => booleanType().optional();
 
 export const coerce = {
   string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
+    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
   number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
+    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
   boolean: ((arg) =>
     ZodBoolean.create({
       ...arg,
       coerce: true,
-    })) as (typeof ZodBoolean)["create"],
+    })) as typeof ZodBoolean["create"],
   bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
+    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
   date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
+    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
 };
 
 export {

--- a/playground.ts
+++ b/playground.ts
@@ -1,6 +1,6 @@
 import { z } from "./src";
-// const example1 = z.custom<number>((x) => typeof x === "number");
-// example1.parse("asdf");
+const example1 = z.custom<number>((x) => typeof x === "number");
+example1.parse("asdf");
 // const example1 = z
 //   .custom<number>(
 //     (x) => {

--- a/playground.ts
+++ b/playground.ts
@@ -1,6 +1,6 @@
 import { z } from "./src";
-const example1 = z.custom<number>((x) => typeof x === "number");
-example1.parse("asdf");
+// const example1 = z.custom<number>((x) => typeof x === "number");
+// example1.parse("asdf");
 // const example1 = z
 //   .custom<number>(
 //     (x) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ class ParseInputLazyPath implements ParseInput {
   data: any;
   _path: ParsePath;
   _key: string | number | (string | number)[];
-  _cachedPath: ParsePath | null = null;
+  _cachedPath: ParsePath = [];
   constructor(
     parent: ParseContext,
     value: any,
@@ -76,9 +76,15 @@ class ParseInputLazyPath implements ParseInput {
     this._key = key;
   }
   get path() {
-    if (this._cachedPath) return this._cachedPath;
-    this._cachedPath = this._path.concat(this._key);
-    return this._cachedPath!;
+    if (!this._cachedPath.length) {
+      if (this._key instanceof Array) {
+        this._cachedPath.push(...this._path, ...this._key);
+      } else {
+        this._cachedPath.push(...this._path, this._key);
+      }
+    }
+
+    return this._cachedPath;
   }
 }
 
@@ -3725,7 +3731,7 @@ export class ZodFunction<
     return this._def.returns;
   }
 
-  args<Items extends Parameters<(typeof ZodTuple)["create"]>[0]>(
+  args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
@@ -4863,18 +4869,18 @@ const oboolean = () => booleanType().optional();
 
 export const coerce = {
   string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
+    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
   number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
+    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
   boolean: ((arg) =>
     ZodBoolean.create({
       ...arg,
       coerce: true,
-    })) as (typeof ZodBoolean)["create"],
+    })) as typeof ZodBoolean["create"],
   bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
+    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
   date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
+    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
 };
 
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ class ParseInputLazyPath implements ParseInput {
   data: any;
   _path: ParsePath;
   _key: string | number | (string | number)[];
-  _cachedPath: ParsePath = [];
+  _cachedPath: ParsePath | null = null;
   constructor(
     parent: ParseContext,
     value: any,
@@ -76,15 +76,9 @@ class ParseInputLazyPath implements ParseInput {
     this._key = key;
   }
   get path() {
-    if (!this._cachedPath.length) {
-      if (this._key instanceof Array) {
-        this._cachedPath.push(...this._path, ...this._key);
-      } else {
-        this._cachedPath.push(...this._path, this._key);
-      }
-    }
-
-    return this._cachedPath;
+    if (this._cachedPath) return this._cachedPath;
+    this._cachedPath = this._path.concat(this._key);
+    return this._cachedPath!;
   }
 }
 
@@ -3731,7 +3725,7 @@ export class ZodFunction<
     return this._def.returns;
   }
 
-  args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
+  args<Items extends Parameters<(typeof ZodTuple)["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
@@ -4869,18 +4863,18 @@ const oboolean = () => booleanType().optional();
 
 export const coerce = {
   string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
+    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
   number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
+    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
   boolean: ((arg) =>
     ZodBoolean.create({
       ...arg,
       coerce: true,
-    })) as typeof ZodBoolean["create"],
+    })) as (typeof ZodBoolean)["create"],
   bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
+    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
   date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
+    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
 };
 
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ class ParseInputLazyPath implements ParseInput {
   data: any;
   _path: ParsePath;
   _key: string | number | (string | number)[];
+  _cachedPath: ParsePath = [];
   constructor(
     parent: ParseContext,
     value: any,
@@ -75,7 +76,15 @@ class ParseInputLazyPath implements ParseInput {
     this._key = key;
   }
   get path() {
-    return this._path.concat(this._key);
+    if (!this._cachedPath.length) {
+      if (this._key instanceof Array) {
+        this._cachedPath.push(...this._path, ...this._key);
+      } else {
+        this._cachedPath.push(...this._path, this._key);
+      }
+    }
+
+    return this._cachedPath;
   }
 }
 
@@ -3722,7 +3731,7 @@ export class ZodFunction<
     return this._def.returns;
   }
 
-  args<Items extends Parameters<(typeof ZodTuple)["create"]>[0]>(
+  args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
@@ -4860,18 +4869,18 @@ const oboolean = () => booleanType().optional();
 
 export const coerce = {
   string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
+    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
   number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
+    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
   boolean: ((arg) =>
     ZodBoolean.create({
       ...arg,
       coerce: true,
-    })) as (typeof ZodBoolean)["create"],
+    })) as typeof ZodBoolean["create"],
   bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
+    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
   date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
+    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
 };
 
 export {


### PR DESCRIPTION
Hi, thanks for the great library, I adore the API :)

I was looking for ways to make some unintrusive improvements to the performance, and noticed since a ParseInput's path may be evaluated multiple times, caching the evaluation result avoids some extra array allocations.

Around a 10% speedup on 'realworld' on my computer.

Dunno what happened with the rest of the diff, I don't think I touched anything or had "format on save" on...