### PR TITLE
Proposal: ZodObject.omitIfExists()

### DIFF
--- a/deno/lib/__tests__/pickomit.test.ts
+++ b/deno/lib/__tests__/pickomit.test.ts
@@ -77,6 +77,28 @@ test("omit parse - fail", () => {
   expect(bad4).toThrow();
 });
 
+test("omitIfExists type inference", () => {
+  const nonameFish = fish.omitIfExists({ name: true, nonExistent: true });
+  type nonameFish = z.infer<typeof nonameFish>;
+  util.assertEqual<nonameFish, { age: number; nested: {} }>(true);
+});
+
+test("omitIfExists parse - success", () => {
+  const nonameFish = fish.omitIfExists({ name: true, nonExistent: true });
+  nonameFish.parse({ age: 12, nested: {} });
+});
+
+test("omitIfExists parse - fail", () => {
+  const nonameFish = fish.omitIfExists({ name: true, nonExistent: true });
+  const bad1 = () => nonameFish.parse({ name: 12 } as any);
+  const bad2 = () => nonameFish.parse({ age: 12 } as any);
+  const bad3 = () => nonameFish.parse({} as any);
+
+  expect(bad1).toThrow();
+  expect(bad2).toThrow();
+  expect(bad3).toThrow();
+});
+
 test("nonstrict inference", () => {
   const laxfish = fish.pick({ name: true }).catchall(z.any());
   type laxfish = z.infer<typeof laxfish>;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2604,6 +2604,27 @@ export class ZodObject<
     }) as any;
   }
 
+  omitIfExists<Wider extends T, Mask extends objectKeyMask<Wider>>(
+    mask: Mask
+  ): ZodObject<
+    Omit<T, keyof Pick<Mask, keyof T & keyof Mask>>,
+    UnknownKeys,
+    Catchall
+  > {
+    const shape: any = {};
+
+    util.objectKeys(this.shape).forEach((key) => {
+      if (!mask[key as keyof Mask]) {
+        shape[key] = this.shape[key];
+      }
+    });
+
+    return new ZodObject({
+      ...this._def,
+      shape: () => shape,
+    }) as any;
+  }
+
   /**
    * @deprecated
    */
@@ -3781,7 +3802,7 @@ export class ZodFunction<
     return this._def.returns;
   }
 
-  args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
+  args<Items extends Parameters<(typeof ZodTuple)["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
@@ -4919,18 +4940,18 @@ const oboolean = () => booleanType().optional();
 
 export const coerce = {
   string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
+    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
   number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
+    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
   boolean: ((arg) =>
     ZodBoolean.create({
       ...arg,
       coerce: true,
-    })) as typeof ZodBoolean["create"],
+    })) as (typeof ZodBoolean)["create"],
   bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
+    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
   date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
+    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
 };
 
 export {

--- a/src/__tests__/languageServerFeatures.source.ts
+++ b/src/__tests__/languageServerFeatures.source.ts
@@ -77,7 +77,10 @@ export const instanceOfTestOmit: TestOmit = {
 
 // z.object().omitIfExists()
 
-export const TestOmitIfExists = TestMerge.omitIfExists({ f2: true, nonExistent: true });
+export const TestOmitIfExists = TestMerge.omitIfExists({
+  f2: true,
+  nonExistent: true,
+});
 
 export type TestOmitIfExists = z.infer<typeof TestOmitIfExists>;
 

--- a/src/__tests__/languageServerFeatures.source.ts
+++ b/src/__tests__/languageServerFeatures.source.ts
@@ -74,3 +74,13 @@ export type TestOmit = z.infer<typeof TestOmit>;
 export const instanceOfTestOmit: TestOmit = {
   f1: 1,
 };
+
+// z.object().omitIfExists()
+
+export const TestOmitIfExists = TestMerge.omitIfExists({ f2: true, nonExistent: true });
+
+export type TestOmitIfExists = z.infer<typeof TestOmitIfExists>;
+
+export const instanceOfTestOmitIfExists: TestOmitIfExists = {
+  f1: 1,
+};

--- a/src/__tests__/languageServerFeatures.test.ts
+++ b/src/__tests__/languageServerFeatures.test.ts
@@ -184,6 +184,27 @@ describe("Executing Go To Definition (and therefore Find Usages and Rename Refac
     expect(definitionOfProperty?.getText()).toEqual("f1: z.number()");
     expect(parentOfProperty?.getName()).toEqual("Test");
   });
+
+  test("works for object properties inferred from z.object().omitIfExists()", () => {
+    // Find usage of TestOmitIfExists.f1 property
+    const instanceVariable = sourceFile.getVariableDeclarationOrThrow(
+      "instanceOfTestOmitIfExists"
+    );
+    const propertyBeingAssigned = getPropertyBeingAssigned(
+      instanceVariable,
+      "f1"
+    );
+
+    // Find definition of TestOmitIfExists.f1 property
+    const definitionOfProperty = propertyBeingAssigned?.getDefinitionNodes()[0];
+    const parentOfProperty = definitionOfProperty?.getFirstAncestorByKind(
+      SyntaxKind.VariableDeclaration
+    );
+
+    // Assert that find definition returned the Zod definition of Test
+    expect(definitionOfProperty?.getText()).toEqual("f1: z.number()");
+    expect(parentOfProperty?.getName()).toEqual("Test");
+  });
 });
 
 const getPropertyBeingAssigned = (node: Node, name: string) => {

--- a/src/__tests__/pickomit.test.ts
+++ b/src/__tests__/pickomit.test.ts
@@ -76,6 +76,28 @@ test("omit parse - fail", () => {
   expect(bad4).toThrow();
 });
 
+test("omitIfExists type inference", () => {
+  const nonameFish = fish.omitIfExists({ name: true, nonExistent: true });
+  type nonameFish = z.infer<typeof nonameFish>;
+  util.assertEqual<nonameFish, { age: number; nested: {} }>(true);
+});
+
+test("omitIfExists parse - success", () => {
+  const nonameFish = fish.omitIfExists({ name: true, nonExistent: true });
+  nonameFish.parse({ age: 12, nested: {} });
+});
+
+test("omitIfExists parse - fail", () => {
+  const nonameFish = fish.omitIfExists({ name: true, nonExistent: true });
+  const bad1 = () => nonameFish.parse({ name: 12 } as any);
+  const bad2 = () => nonameFish.parse({ age: 12 } as any);
+  const bad3 = () => nonameFish.parse({} as any);
+
+  expect(bad1).toThrow();
+  expect(bad2).toThrow();
+  expect(bad3).toThrow();
+});
+
 test("nonstrict inference", () => {
   const laxfish = fish.pick({ name: true }).catchall(z.any());
   type laxfish = z.infer<typeof laxfish>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2604,6 +2604,27 @@ export class ZodObject<
     }) as any;
   }
 
+  omitIfExists<Wider extends T, Mask extends objectKeyMask<Wider>>(
+    mask: Mask
+  ): ZodObject<
+    Omit<T, keyof Pick<Mask, keyof T & keyof Mask>>,
+    UnknownKeys,
+    Catchall
+  > {
+    const shape: any = {};
+
+    util.objectKeys(this.shape).forEach((key) => {
+      if (!mask[key as keyof Mask]) {
+        shape[key] = this.shape[key];
+      }
+    });
+
+    return new ZodObject({
+      ...this._def,
+      shape: () => shape,
+    }) as any;
+  }
+
   /**
    * @deprecated
    */
@@ -3781,7 +3802,7 @@ export class ZodFunction<
     return this._def.returns;
   }
 
-  args<Items extends Parameters<typeof ZodTuple["create"]>[0]>(
+  args<Items extends Parameters<(typeof ZodTuple)["create"]>[0]>(
     ...items: Items
   ): ZodFunction<ZodTuple<Items, ZodUnknown>, Returns> {
     return new ZodFunction({
@@ -4919,18 +4940,18 @@ const oboolean = () => booleanType().optional();
 
 export const coerce = {
   string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as typeof ZodString["create"],
+    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
   number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as typeof ZodNumber["create"],
+    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
   boolean: ((arg) =>
     ZodBoolean.create({
       ...arg,
       coerce: true,
-    })) as typeof ZodBoolean["create"],
+    })) as (typeof ZodBoolean)["create"],
   bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as typeof ZodBigInt["create"],
+    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
   date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as typeof ZodDate["create"],
+    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
 };
 
 export {


### PR DESCRIPTION
I found myself wanting to predefine a set of keys that would always be omitted from certain schemas if present. Example scenario:

```
const OMIT_AUTOGENERATED = {
  id: true,
  uuid: true,
  createdAt: true,
  updatedAt: true
}

const someSchema = someSchemaRaw.omit(OMIT_AUTOGENERATED);
const someSchema2 = someSchema2Raw.omit(OMIT_AUTOGENERATED);
```

If there are certain "Raw schemas" (using the above nomenclature) that don't have all the properties defined in OMIT_AUTOGENERATED, then I can't use it on them.

With something like ZodType.omitIfExists() one could blanket-exclude a set of keys from schemas without necessarily requiring them to be present in all of them.