### PR TITLE
Faster array parsing

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2049,13 +2049,20 @@ export class ZodArray<
       });
     }
 
-    const result = ([...ctx.data] as any[]).map((item, i) => {
-      return def.type._parseSync(
+    const arrayValue: any[] = new Array(ctx.data.length);
+    const len = ctx.data.length;
+
+    for (let i = 0; i < len; i++) {
+      const item = ctx.data[i];
+      const s = def.type._parseSync(
         new ParseInputLazyPath(ctx, item, ctx.path, i)
       );
-    });
+      if (s.status === "aborted") return INVALID;
+      if (s.status === "dirty") status.dirty();
+      arrayValue[i] = s.value;
+    }
 
-    return ParseStatus.mergeArray(status, result);
+    return { status: status.value, value: arrayValue } as SyncParseReturnType;
   }
 
   get element() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2049,13 +2049,20 @@ export class ZodArray<
       });
     }
 
-    const result = ([...ctx.data] as any[]).map((item, i) => {
-      return def.type._parseSync(
+    const arrayValue: any[] = new Array(ctx.data.length);
+    const len = ctx.data.length;
+
+    for (let i = 0; i < len; i++) {
+      const item = ctx.data[i];
+      const s = def.type._parseSync(
         new ParseInputLazyPath(ctx, item, ctx.path, i)
       );
-    });
+      if (s.status === "aborted") return INVALID;
+      if (s.status === "dirty") status.dirty();
+      arrayValue[i] = s.value;
+    }
 
-    return ParseStatus.mergeArray(status, result);
+    return { status: status.value, value: arrayValue } as SyncParseReturnType;
   }
 
   get element() {


### PR DESCRIPTION
This is kind of experimental and unfortunately not a huge boost, but basically: eeking 5% extra perf out of array parsing by avoiding the overhead of creating and mapping an intermediate value. Currently is only for sync parsing. Refs #205



```
➜  zod git:(faster-array-parsing) y benchmark --realworld
yarn run v1.22.19
$ tsx src/benchmarks/index.ts --realworld
realworld: valid x 7,308 ops/sec ±0.13% (100 runs sampled)
✨  Done in 5.78s.
➜  zod git:(faster-array-parsing) y benchmark --realworld
yarn run v1.22.19
$ tsx src/benchmarks/index.ts --realworld
realworld: valid x 7,383 ops/sec ±0.12% (98 runs sampled)
✨  Done in 5.62s.
➜  zod git:(faster-array-parsing) y benchmark --realworld
yarn run v1.22.19
$ tsx src/benchmarks/index.ts --realworld
realworld: valid x 7,326 ops/sec ±0.13% (100 runs sampled)
✨  Done in 5.63s
```

```
➜  zod git:(master) y benchmark --realworld
yarn run v1.22.19
$ tsx src/benchmarks/index.ts --realworld
realworld: valid x 7,031 ops/sec ±0.12% (99 runs sampled)
✨  Done in 5.67s.
➜  zod git:(master) y benchmark --realworld
yarn run v1.22.19
$ tsx src/benchmarks/index.ts --realworld
realworld: valid x 7,040 ops/sec ±0.13% (98 runs sampled)
✨  Done in 5.67s.
➜  zod git:(master) y benchmark --realworld
yarn run v1.22.19
$ tsx src/benchmarks/index.ts --realworld
realworld: valid x 7,023 ops/sec ±0.13% (99 runs sampled)
✨  Done in 5.70s
```