### PR TITLE
Add support for unions in .deepPartial (Closes #1983)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,7 +1198,7 @@ const deepPartialUser = user.deepPartial();
 */
 ```
 
-> Important limitation: deep partials only work as expected in hierarchies of objects, arrays, tuples and unions.
+> Important limitation: deep partials only work as expected in hierarchies of objects, arrays, tuples, and unions.
 
 ### `.required`
 

--- a/README.md
+++ b/README.md
@@ -1198,7 +1198,7 @@ const deepPartialUser = user.deepPartial();
 */
 ```
 
-> Important limitation: deep partials only work as expected in hierarchies of objects, arrays, and tuples.
+> Important limitation: deep partials only work as expected in hierarchies of objects, arrays, tuples and unions.
 
 ### `.required`
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1198,7 +1198,7 @@ const deepPartialUser = user.deepPartial();
 */
 ```
 
-> Important limitation: deep partials only work as expected in hierarchies of objects, arrays, tuples and unions.
+> Important limitation: deep partials only work as expected in hierarchies of objects, arrays, tuples, and unions.
 
 ### `.required`
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1198,7 +1198,7 @@ const deepPartialUser = user.deepPartial();
 */
 ```
 
-> Important limitation: deep partials only work as expected in hierarchies of objects, arrays, and tuples.
+> Important limitation: deep partials only work as expected in hierarchies of objects, arrays, tuples and unions.
 
 ### `.required`
 

--- a/deno/lib/__tests__/partials.test.ts
+++ b/deno/lib/__tests__/partials.test.ts
@@ -251,3 +251,20 @@ test("deeppartial array", () => {
   // should be false, but is true
   expect(schema.safeParse({ array: [] }).success).toBe(false);
 });
+
+test("deeppartial union", () => {
+  const schema = z
+    .object({
+      union: z.union([
+        z.object({
+          a: z.string(),
+        }),
+        z.object({
+          b: z.string(),
+        }),
+      ]),
+    })
+    .deepPartial();
+
+  expect(schema.safeParse({ union: {} }).success).toBe(true);
+});

--- a/deno/lib/helpers/partialUtil.ts
+++ b/deno/lib/helpers/partialUtil.ts
@@ -7,6 +7,8 @@ import type {
   ZodTuple,
   ZodTupleItems,
   ZodTypeAny,
+  ZodUnion,
+  ZodUnionOptions,
 } from "../index.ts";
 
 export namespace partialUtil {
@@ -56,6 +58,16 @@ export namespace partialUtil {
         } extends infer PI
         ? PI extends ZodTupleItems
           ? ZodTuple<PI>
+          : never
+        : never
+      : T extends ZodUnion<infer Options>
+      ? {
+          [k in keyof Options]: Options[k] extends ZodTypeAny
+            ? DeepPartial<Options[k]>
+            : never;
+        } extends infer PO
+        ? PO extends ZodUnionOptions
+          ? ZodUnion<PO>
           : never
         : never
       : T;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2211,6 +2211,10 @@ function deepPartialify(schema: ZodTypeAny): any {
     return ZodTuple.create(
       schema.items.map((item: any) => deepPartialify(item))
     );
+  } else if (schema instanceof ZodUnion) {
+    return ZodUnion.create(
+      schema.options.map((option: any) => deepPartialify(option))
+    );
   } else {
     return schema;
   }

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -250,3 +250,20 @@ test("deeppartial array", () => {
   // should be false, but is true
   expect(schema.safeParse({ array: [] }).success).toBe(false);
 });
+
+test("deeppartial union", () => {
+  const schema = z
+    .object({
+      union: z.union([
+        z.object({
+          a: z.string(),
+        }),
+        z.object({
+          b: z.string(),
+        }),
+      ]),
+    })
+    .deepPartial();
+
+  expect(schema.safeParse({ union: {} }).success).toBe(true);
+});

--- a/src/helpers/partialUtil.ts
+++ b/src/helpers/partialUtil.ts
@@ -7,6 +7,8 @@ import type {
   ZodTuple,
   ZodTupleItems,
   ZodTypeAny,
+  ZodUnion,
+  ZodUnionOptions,
 } from "../index";
 
 export namespace partialUtil {
@@ -56,6 +58,16 @@ export namespace partialUtil {
         } extends infer PI
         ? PI extends ZodTupleItems
           ? ZodTuple<PI>
+          : never
+        : never
+      : T extends ZodUnion<infer Options>
+      ? {
+          [k in keyof Options]: Options[k] extends ZodTypeAny
+            ? DeepPartial<Options[k]>
+            : never;
+        } extends infer PO
+        ? PO extends ZodUnionOptions
+          ? ZodUnion<PO>
           : never
         : never
       : T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2211,6 +2211,10 @@ function deepPartialify(schema: ZodTypeAny): any {
     return ZodTuple.create(
       schema.items.map((item: any) => deepPartialify(item))
     );
+  } else if (schema instanceof ZodUnion) {
+    return ZodUnion.create(
+      schema.options.map((option: any) => deepPartialify(option))
+    );
   } else {
     return schema;
   }


### PR DESCRIPTION
I added support for unions in the deepPartial function, as proposed in issue #1983.
