### PR TITLE
Add support coercion parse for Map and Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,8 @@ z.coerce.number(); // Number(input)
 z.coerce.boolean(); // Boolean(input)
 z.coerce.bigint(); // BigInt(input)
 z.coerce.date(); // new Date(input)
+z.coerce.map(); // new Map(Object.entries(input)) // if input is Key-Value Object
+z.coerce.set(); // new Set(input)
 ```
 
 **Boolean coercion**
@@ -2399,51 +2401,55 @@ The `.pipe()` method returns a `ZodPipeline` instance.
 You can constrain the input to types that work well with your chosen coercion. Then use `.pipe()` to apply the coercion.
 
 without constrained input:
+
 ```ts
-const toDate = z.coerce.date()
+const toDate = z.coerce.date();
 
 // works intuitively
-console.log(toDate.safeParse('2023-01-01').success) // true
+console.log(toDate.safeParse("2023-01-01").success); // true
 
 // might not be what you want
-console.log(toDate.safeParse(null).success) // true
+console.log(toDate.safeParse(null).success); // true
 ```
 
 with constrained input:
+
 ```ts
-const datelike = z.union([z.number(), z.string(), z.date()])
-const datelikeToDate = datelike.pipe(z.coerce.date())
+const datelike = z.union([z.number(), z.string(), z.date()]);
+const datelikeToDate = datelike.pipe(z.coerce.date());
 
 // still works intuitively
-console.log(datelikeToDate.safeParse('2023-01-01').success) // true
+console.log(datelikeToDate.safeParse("2023-01-01").success); // true
 
 // more likely what you want
-console.log(datelikeToDate.safeParse(null).success) // false
+console.log(datelikeToDate.safeParse(null).success); // false
 ```
 
 You can also use this technique to avoid coercions that throw uncaught errors.
 
 without constrained input:
+
 ```ts
-const toBigInt = z.coerce.bigint()
+const toBigInt = z.coerce.bigint();
 
 // works intuitively
-console.log( toBigInt.safeParse( '42' ) ) // true
+console.log(toBigInt.safeParse("42")); // true
 
 // probably not what you want
-console.log( toBigInt.safeParse( null ) ) // throws uncaught error
+console.log(toBigInt.safeParse(null)); // throws uncaught error
 ```
 
 with constrained input:
+
 ```ts
-const toNumber = z.number().or( z.string() ).pipe( z.coerce.number() )
-const toBigInt = z.bigint().or( toNumber ).pipe( z.coerce.bigint() )
+const toNumber = z.number().or(z.string()).pipe(z.coerce.number());
+const toBigInt = z.bigint().or(toNumber).pipe(z.coerce.bigint());
 
 // still works intuitively
-console.log( toBigInt.safeParse( '42' ).success ) // true
+console.log(toBigInt.safeParse("42").success); // true
 
 // error handled by zod, more likely what you want
-console.log( toBigInt.safeParse( null ).success ) // false
+console.log(toBigInt.safeParse(null).success); // false
 ```
 
 ## Guides and concepts

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -598,6 +598,8 @@ z.coerce.number(); // Number(input)
 z.coerce.boolean(); // Boolean(input)
 z.coerce.bigint(); // BigInt(input)
 z.coerce.date(); // new Date(input)
+z.coerce.map(); // new Map(Object.entries(input)) // if input is Key-Value Object
+z.coerce.set(); // new Set(input)
 ```
 
 **Boolean coercion**
@@ -2399,51 +2401,55 @@ The `.pipe()` method returns a `ZodPipeline` instance.
 You can constrain the input to types that work well with your chosen coercion. Then use `.pipe()` to apply the coercion.
 
 without constrained input:
+
 ```ts
-const toDate = z.coerce.date()
+const toDate = z.coerce.date();
 
 // works intuitively
-console.log(toDate.safeParse('2023-01-01').success) // true
+console.log(toDate.safeParse("2023-01-01").success); // true
 
 // might not be what you want
-console.log(toDate.safeParse(null).success) // true
+console.log(toDate.safeParse(null).success); // true
 ```
 
 with constrained input:
+
 ```ts
-const datelike = z.union([z.number(), z.string(), z.date()])
-const datelikeToDate = datelike.pipe(z.coerce.date())
+const datelike = z.union([z.number(), z.string(), z.date()]);
+const datelikeToDate = datelike.pipe(z.coerce.date());
 
 // still works intuitively
-console.log(datelikeToDate.safeParse('2023-01-01').success) // true
+console.log(datelikeToDate.safeParse("2023-01-01").success); // true
 
 // more likely what you want
-console.log(datelikeToDate.safeParse(null).success) // false
+console.log(datelikeToDate.safeParse(null).success); // false
 ```
 
 You can also use this technique to avoid coercions that throw uncaught errors.
 
 without constrained input:
+
 ```ts
-const toBigInt = z.coerce.bigint()
+const toBigInt = z.coerce.bigint();
 
 // works intuitively
-console.log( toBigInt.safeParse( '42' ) ) // true
+console.log(toBigInt.safeParse("42")); // true
 
 // probably not what you want
-console.log( toBigInt.safeParse( null ) ) // throws uncaught error
+console.log(toBigInt.safeParse(null)); // throws uncaught error
 ```
 
 with constrained input:
+
 ```ts
-const toNumber = z.number().or( z.string() ).pipe( z.coerce.number() )
-const toBigInt = z.bigint().or( toNumber ).pipe( z.coerce.bigint() )
+const toNumber = z.number().or(z.string()).pipe(z.coerce.number());
+const toBigInt = z.bigint().or(toNumber).pipe(z.coerce.bigint());
 
 // still works intuitively
-console.log( toBigInt.safeParse( '42' ).success ) // true
+console.log(toBigInt.safeParse("42").success); // true
 
 // error handled by zod, more likely what you want
-console.log( toBigInt.safeParse( null ).success ) // false
+console.log(toBigInt.safeParse(null).success); // false
 ```
 
 ## Guides and concepts

--- a/deno/lib/__tests__/coerce.test.ts
+++ b/deno/lib/__tests__/coerce.test.ts
@@ -133,3 +133,30 @@ test("date coercion", () => {
   expect(() => schema.parse([])).toThrow; // z.ZodError
   expect(schema.parse(new Date())).toBeInstanceOf(Date);
 });
+
+test("map coercion", () => {
+  const schema = z.coerce.map(z.string(), z.string());
+  const obj = { first: "foo", second: "bar" };
+  expect(schema.parse(obj)).toBeInstanceOf(Map);
+  expect(schema.parse(obj).has("first")).toEqual(true);
+  expect(schema.parse(obj).has("second")).toEqual(true);
+  expect(schema.parse(obj).get("first")).toEqual("foo");
+  expect(schema.parse(obj).get("second")).toEqual("bar");
+  expect(() => schema.parse("")).toThrow; // z.ZodError
+  expect(() => schema.parse("NOT_A_MAP")).toThrow; // z.ZodError
+  expect(() => schema.parse(5)).toThrow; // z.ZodError
+  expect(() => schema.parse(0)).toThrow; // z.ZodError
+  expect(() => schema.parse(-5)).toThrow; // z.ZodError
+  expect(() => schema.parse(3.14)).toThrow; // z.ZodError
+  expect(() => schema.parse(BigInt(5))).toThrow; // z.ZodError
+  expect(() => schema.parse(NaN)).toThrow; // z.ZodError
+  expect(() => schema.parse(Infinity)).toThrow; // z.ZodError
+  expect(() => schema.parse(-Infinity)).toThrow; // z.ZodError
+  expect(() => schema.parse(true)).toThrow; // z.ZodError
+  expect(() => schema.parse(false)).toThrow; // z.ZodError
+  expect(() => schema.parse(null)).toThrow; // z.ZodError
+  expect(() => schema.parse(undefined)).toThrow; // z.ZodError
+  expect(() => schema.parse(["item", "another_item"])).toThrow; // z.ZodError
+  expect(() => schema.parse([])).toThrow; // z.ZodError
+  expect(schema.parse(new Map())).toBeInstanceOf(Map);
+});

--- a/deno/lib/__tests__/coerce.test.ts
+++ b/deno/lib/__tests__/coerce.test.ts
@@ -160,3 +160,30 @@ test("map coercion", () => {
   expect(() => schema.parse([])).toThrow; // z.ZodError
   expect(schema.parse(new Map())).toBeInstanceOf(Map);
 });
+
+test("set coercion", () => {
+  const schema = z.coerce.set(z.string());
+  expect(schema.parse(["first", "second"])).toBeInstanceOf(Set);
+  expect(schema.parse(["first", "second"]).has("first")).toEqual(true);
+  expect(schema.parse(["first", "second"]).has("second")).toEqual(true);
+  expect(schema.parse(["first", "second"]).has("third")).toEqual(false);
+  expect(() => schema.parse("")).toThrow; // z.ZodError
+  expect(() => schema.parse("NOT_A_SET")).toThrow; // z.ZodError
+  expect(() => schema.parse(5)).toThrow; // z.ZodError
+  expect(() => schema.parse(0)).toThrow; // z.ZodError
+  expect(() => schema.parse(-5)).toThrow; // z.ZodError
+  expect(() => schema.parse(3.14)).toThrow; // z.ZodError
+  expect(() => schema.parse(BigInt(5))).toThrow; // z.ZodError
+  expect(() => schema.parse(NaN)).toThrow; // z.ZodError
+  expect(() => schema.parse(Infinity)).toThrow; // z.ZodError
+  expect(() => schema.parse(-Infinity)).toThrow; // z.ZodError
+  expect(() => schema.parse(true)).toThrow; // z.ZodError
+  expect(() => schema.parse(false)).toThrow; // z.ZodError
+  expect(() => schema.parse(null)).toThrow; // z.ZodError
+  expect(() => schema.parse(undefined)).toThrow; // z.ZodError
+  expect(schema.parse(["item", "another_item"])).toBeInstanceOf(Set);
+  expect(schema.parse([])).toBeInstanceOf(Set);
+  expect(() => schema.parse([1, 2])).toThrow; // z.ZodError
+  expect(() => schema.parse(["first", 2])).toThrow; // z.ZodError
+  expect(schema.parse(new Set())).toBeInstanceOf(Set);
+});

--- a/src/__tests__/coerce.test.ts
+++ b/src/__tests__/coerce.test.ts
@@ -159,3 +159,30 @@ test("map coercion", () => {
   expect(() => schema.parse([])).toThrow; // z.ZodError
   expect(schema.parse(new Map())).toBeInstanceOf(Map);
 });
+
+test("set coercion", () => {
+  const schema = z.coerce.set(z.string());
+  expect(schema.parse(["first", "second"])).toBeInstanceOf(Set);
+  expect(schema.parse(["first", "second"]).has("first")).toEqual(true);
+  expect(schema.parse(["first", "second"]).has("second")).toEqual(true);
+  expect(schema.parse(["first", "second"]).has("third")).toEqual(false);
+  expect(() => schema.parse("")).toThrow; // z.ZodError
+  expect(() => schema.parse("NOT_A_SET")).toThrow; // z.ZodError
+  expect(() => schema.parse(5)).toThrow; // z.ZodError
+  expect(() => schema.parse(0)).toThrow; // z.ZodError
+  expect(() => schema.parse(-5)).toThrow; // z.ZodError
+  expect(() => schema.parse(3.14)).toThrow; // z.ZodError
+  expect(() => schema.parse(BigInt(5))).toThrow; // z.ZodError
+  expect(() => schema.parse(NaN)).toThrow; // z.ZodError
+  expect(() => schema.parse(Infinity)).toThrow; // z.ZodError
+  expect(() => schema.parse(-Infinity)).toThrow; // z.ZodError
+  expect(() => schema.parse(true)).toThrow; // z.ZodError
+  expect(() => schema.parse(false)).toThrow; // z.ZodError
+  expect(() => schema.parse(null)).toThrow; // z.ZodError
+  expect(() => schema.parse(undefined)).toThrow; // z.ZodError
+  expect(schema.parse(["item", "another_item"])).toBeInstanceOf(Set);
+  expect(schema.parse([])).toBeInstanceOf(Set);
+  expect(() => schema.parse([1, 2])).toThrow; // z.ZodError
+  expect(() => schema.parse(["first", 2])).toThrow; // z.ZodError
+  expect(schema.parse(new Set())).toBeInstanceOf(Set);
+});

--- a/src/__tests__/coerce.test.ts
+++ b/src/__tests__/coerce.test.ts
@@ -132,3 +132,30 @@ test("date coercion", () => {
   expect(() => schema.parse([])).toThrow; // z.ZodError
   expect(schema.parse(new Date())).toBeInstanceOf(Date);
 });
+
+test("map coercion", () => {
+  const schema = z.coerce.map(z.string(), z.string());
+  const obj = { first: "foo", second: "bar" };
+  expect(schema.parse(obj)).toBeInstanceOf(Map);
+  expect(schema.parse(obj).has("first")).toEqual(true);
+  expect(schema.parse(obj).has("second")).toEqual(true);
+  expect(schema.parse(obj).get("first")).toEqual("foo");
+  expect(schema.parse(obj).get("second")).toEqual("bar");
+  expect(() => schema.parse("")).toThrow; // z.ZodError
+  expect(() => schema.parse("NOT_A_MAP")).toThrow; // z.ZodError
+  expect(() => schema.parse(5)).toThrow; // z.ZodError
+  expect(() => schema.parse(0)).toThrow; // z.ZodError
+  expect(() => schema.parse(-5)).toThrow; // z.ZodError
+  expect(() => schema.parse(3.14)).toThrow; // z.ZodError
+  expect(() => schema.parse(BigInt(5))).toThrow; // z.ZodError
+  expect(() => schema.parse(NaN)).toThrow; // z.ZodError
+  expect(() => schema.parse(Infinity)).toThrow; // z.ZodError
+  expect(() => schema.parse(-Infinity)).toThrow; // z.ZodError
+  expect(() => schema.parse(true)).toThrow; // z.ZodError
+  expect(() => schema.parse(false)).toThrow; // z.ZodError
+  expect(() => schema.parse(null)).toThrow; // z.ZodError
+  expect(() => schema.parse(undefined)).toThrow; // z.ZodError
+  expect(() => schema.parse(["item", "another_item"])).toThrow; // z.ZodError
+  expect(() => schema.parse([])).toThrow; // z.ZodError
+  expect(schema.parse(new Map())).toBeInstanceOf(Map);
+});


### PR DESCRIPTION
This change will add support coercion parse for Map and Set.

When use `JSON.parse(data)`, Map in data is parsed as Object.
If we parse with a schema containing `ZodMap`, it will fail.
The problem is solved by adding a function to parse Object as Map.

```ts
z.coerce.map(z.string(), z.string()).parse({ first: "foo", second: "bar" });
```

Also, we can't use a set in JSON.
That's why in JSON, it's common practice to treat Set as Array.
ZodSet doesn't support to parse Array.
The problem is solved by adding a function to parse Array as Set.

```ts
z.coerce.set(z.string()).parse(["first", "second"]);
```