### PR TITLE
Add variadic args overload to enum().extract(), and enum().exclude()

### DIFF
--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -58,3 +58,14 @@ test("extract/exclude", () => {
   util.assertEqual<typeof EmptyFoodEnum, z.ZodEnum<[]>>(true);
   util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });
+
+test("variadic extract/exclude", () => {
+  const NumbersEnum = z.enum(["One", "Two", "Three"]);
+
+  expect(NumbersEnum.extract("One", "Two").options).toEqual(
+    z.enum(["One", "Two"]).options
+  );
+  expect(NumbersEnum.exclude("One", "Two").options).toEqual(
+    z.enum(["Three"]).options
+  );
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4015,17 +4015,38 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
 
   extract<ToExtract extends readonly [T[number], ...T[number][]]>(
     values: ToExtract
+  ): ZodEnum<Writeable<ToExtract>>;
+  extract<ToExtract extends readonly [T[number], ...T[number][]]>(
+    ...values: ToExtract
+  ): ZodEnum<Writeable<ToExtract>>;
+  extract<ToExtract extends readonly [T[number], ...T[number][]]>(
+    ...values: ToExtract
   ): ZodEnum<Writeable<ToExtract>> {
-    return ZodEnum.create(values) as any;
+    const valuesArray =
+      (values[0] as any) instanceof Array ? (values[0] as any) : values;
+    return ZodEnum.create(valuesArray);
   }
 
   exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
     values: ToExclude
   ): ZodEnum<
     typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
+  >;
+  exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
+    ...values: ToExclude
+  ): ZodEnum<
+    typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
+  >;
+  exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
+    ...values: ToExclude
+  ): ZodEnum<
+    typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
   > {
+    const valuesArray =
+      (values[0] as any) instanceof Array ? values[0] : values;
+
     return ZodEnum.create(
-      this.options.filter((opt) => !values.includes(opt)) as FilterEnum<
+      this.options.filter((opt) => !valuesArray.includes(opt)) as FilterEnum<
         T,
         ToExclude[number]
       >

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -57,3 +57,14 @@ test("extract/exclude", () => {
   util.assertEqual<typeof EmptyFoodEnum, z.ZodEnum<[]>>(true);
   util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });
+
+test("variadic extract/exclude", () => {
+  const NumbersEnum = z.enum(["One", "Two", "Three"]);
+
+  expect(NumbersEnum.extract("One", "Two").options).toEqual(
+    z.enum(["One", "Two"]).options
+  );
+  expect(NumbersEnum.exclude("One", "Two").options).toEqual(
+    z.enum(["Three"]).options
+  );
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -4015,17 +4015,38 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
 
   extract<ToExtract extends readonly [T[number], ...T[number][]]>(
     values: ToExtract
+  ): ZodEnum<Writeable<ToExtract>>;
+  extract<ToExtract extends readonly [T[number], ...T[number][]]>(
+    ...values: ToExtract
+  ): ZodEnum<Writeable<ToExtract>>;
+  extract<ToExtract extends readonly [T[number], ...T[number][]]>(
+    ...values: ToExtract
   ): ZodEnum<Writeable<ToExtract>> {
-    return ZodEnum.create(values) as any;
+    const valuesArray =
+      (values[0] as any) instanceof Array ? (values[0] as any) : values;
+    return ZodEnum.create(valuesArray);
   }
 
   exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
     values: ToExclude
   ): ZodEnum<
     typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
+  >;
+  exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
+    ...values: ToExclude
+  ): ZodEnum<
+    typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
+  >;
+  exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
+    ...values: ToExclude
+  ): ZodEnum<
+    typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
   > {
+    const valuesArray =
+      (values[0] as any) instanceof Array ? values[0] : values;
+
     return ZodEnum.create(
-      this.options.filter((opt) => !values.includes(opt)) as FilterEnum<
+      this.options.filter((opt) => !valuesArray.includes(opt)) as FilterEnum<
         T,
         ToExclude[number]
       >


### PR DESCRIPTION
Created this PR to show how changes proposed in #2168 might look like in the code in my understanding. 
Added overload for `z.enum().extract` and `z.enum().exclude`, to also accept variadic args.
@JacobWeisenburger thoughts?