### PR TITLE
Add zod-error to README ecosystem links

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 
 - [`react-hook-form`](https://github.com/react-hook-form/resolvers#zod): A first-party Zod resolver for React Hook Form.
 - [`zod-validation-error`](https://github.com/causaly/zod-validation-error): Generate user-friendly error messages from `ZodError`s.
+- [`zod-error`] (https://github.com/andrewvo89/zod-error): Utilities to format and customize Zod error messages.
 - [`zod-formik-adapter`](https://github.com/robertLichtnow/zod-formik-adapter): A community-maintained Formik adapter for Zod.
 - [`react-zorm`](https://github.com/esamattis/react-zorm): Standalone `<form>` generation and validation for React using Zod.
 - [`zodix`](https://github.com/rileytomasek/zodix): Zod utilities for FormData and URLSearchParams in Remix loaders and actions.
@@ -2573,7 +2574,7 @@ if (!result.success) {
 
 > For detailed information about the possible error codes and how to customize error messages, check out the dedicated error handling guide: [ERROR_HANDLING.md](ERROR_HANDLING.md)
 
-Zod's error reporting emphasizes _completeness_ and _correctness_. If you are looking to present a useful error message to the end user, you should either override Zod's error messages using an error map (described in detail in the Error Handling guide) or use a third-party library like [`zod-validation-error`](https://github.com/causaly/zod-validation-error)
+Zod's error reporting emphasizes _completeness_ and _correctness_. If you are looking to present a useful error message to the end user, you should either override Zod's error messages using an error map (described in detail in the Error Handling guide) or use a third-party library like [`zod-validation-error`](https://github.com/causaly/zod-validation-error) or [`zod-error`](https://github.com/andrewvo89/zod-error)
 
 ### Error formatting
 


### PR DESCRIPTION
Zod Error converts and formats Zod Issues into a customizable error message string that can be consumed by various applications such as front end error message modals or api error messages.
It was originally requested to be added to the README here: https://github.com/colinhacks/zod/discussions/1534 when it just had 2000 weekly downloads. 
This week it peaked at 40,000 weekly downloads.