### PR TITLE
Fix refinement abort early behavior and update tests

### DIFF
--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -243,13 +243,13 @@ test("custom path", () => {
     .refine((val) => val.confirm === val.password);
 
   const result = schema.safeParse({
-    password: "qwer",
-    confirm: "asdf",
+    password: "qwert1",
+    confirm: "asdfgh",
   });
 
   expect(result.success).toEqual(false);
   if (!result.success) {
-    expect(result.error.issues.length).toEqual(3);
+    expect(result.error.issues.length).toEqual(1);
   }
 });
 
@@ -263,7 +263,7 @@ const schema = z.object({
   }),
 });
 
-test("no abort early on refinements", () => {
+test("unreachable second refinement if the first one fails", () => {
   const invalidItem = {
     inner: { name: ["aasd", "asdfasdfasfd"] },
   };
@@ -271,7 +271,7 @@ test("no abort early on refinements", () => {
   const result1 = schema.safeParse(invalidItem);
   expect(result1.success).toEqual(false);
   if (!result1.success) {
-    expect(result1.error.issues.length).toEqual(2);
+    expect(result1.error.issues.length).toEqual(1);
   }
 });
 test("formatting", () => {

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -247,7 +247,7 @@ test("chained refinements", () => {
     size: 3,
   });
   expect(r2.success).toEqual(false);
-  if (!r2.success) expect(r2.error.issues.length).toEqual(2);
+  if (!r2.success) expect(r2.error.issues.length).toEqual(1);
 });
 
 test("fatal superRefine", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4277,7 +4277,6 @@ export class ZodEffects<
           parent: ctx,
         });
         if (inner.status === "aborted") return INVALID;
-        console.log(ctx.common.issues.length);
         if (inner.status === "dirty" && ctx.common.issues.length > 0) {
           status.dirty();
           return inner;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4277,7 +4277,11 @@ export class ZodEffects<
           parent: ctx,
         });
         if (inner.status === "aborted") return INVALID;
-        if (inner.status === "dirty") status.dirty();
+        console.log(ctx.common.issues.length);
+        if (inner.status === "dirty" && ctx.common.issues.length > 0) {
+          status.dirty();
+          return inner;
+        }
 
         // return value is ignored
         executeRefinement(inner.value);
@@ -4287,7 +4291,10 @@ export class ZodEffects<
           ._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx })
           .then((inner) => {
             if (inner.status === "aborted") return INVALID;
-            if (inner.status === "dirty") status.dirty();
+            if (inner.status === "dirty" && ctx.common.issues.length > 0) {
+              status.dirty();
+              return inner;
+            }
 
             return executeRefinement(inner.value).then(() => {
               return { status: status.value, value: inner.value };

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -242,13 +242,13 @@ test("custom path", () => {
     .refine((val) => val.confirm === val.password);
 
   const result = schema.safeParse({
-    password: "qwer",
-    confirm: "asdf",
+    password: "qwert1",
+    confirm: "asdfgh",
   });
 
   expect(result.success).toEqual(false);
   if (!result.success) {
-    expect(result.error.issues.length).toEqual(3);
+    expect(result.error.issues.length).toEqual(1);
   }
 });
 
@@ -262,7 +262,7 @@ const schema = z.object({
   }),
 });
 
-test("no abort early on refinements", () => {
+test("unreachable second refinement if the first one fails", () => {
   const invalidItem = {
     inner: { name: ["aasd", "asdfasdfasfd"] },
   };
@@ -270,7 +270,7 @@ test("no abort early on refinements", () => {
   const result1 = schema.safeParse(invalidItem);
   expect(result1.success).toEqual(false);
   if (!result1.success) {
-    expect(result1.error.issues.length).toEqual(2);
+    expect(result1.error.issues.length).toEqual(1);
   }
 });
 test("formatting", () => {

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -246,7 +246,7 @@ test("chained refinements", () => {
     size: 3,
   });
   expect(r2.success).toEqual(false);
-  if (!r2.success) expect(r2.error.issues.length).toEqual(2);
+  if (!r2.success) expect(r2.error.issues.length).toEqual(1);
 });
 
 test("fatal superRefine", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4277,7 +4277,6 @@ export class ZodEffects<
           parent: ctx,
         });
         if (inner.status === "aborted") return INVALID;
-        console.log(ctx.common.issues.length);
         if (inner.status === "dirty" && ctx.common.issues.length > 0) {
           status.dirty();
           return inner;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4277,7 +4277,11 @@ export class ZodEffects<
           parent: ctx,
         });
         if (inner.status === "aborted") return INVALID;
-        if (inner.status === "dirty") status.dirty();
+        console.log(ctx.common.issues.length);
+        if (inner.status === "dirty" && ctx.common.issues.length > 0) {
+          status.dirty();
+          return inner;
+        }
 
         // return value is ignored
         executeRefinement(inner.value);
@@ -4287,7 +4291,10 @@ export class ZodEffects<
           ._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx })
           .then((inner) => {
             if (inner.status === "aborted") return INVALID;
-            if (inner.status === "dirty") status.dirty();
+            if (inner.status === "dirty" && ctx.common.issues.length > 0) {
+              status.dirty();
+              return inner;
+            }
 
             return executeRefinement(inner.value).then(() => {
               return { status: status.value, value: inner.value };


### PR DESCRIPTION
## Overview

This PR fixes the refinement abort early behavior and updates the corresponding tests (Issue #2192). The previous behavior caused unexpected continuation of the refinement process in some cases even if a previous refinement failed.

## Changes

- Updated the refinement handling code to allow early termination when a refinement fails.
- Updated test cases to reflect the correct behavior and expectations.
- Renamed the test "no abort early on refinements" to "unreachable second refinement if the first one fails" for better clarity.

## Impact

With these changes, the library should now handle refinements more consistently and provide accurate validation results as expected. This also resolves Issue #2192.
