### PR TITLE
docs: update deprecated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");


### PR DESCRIPTION
The old link https://www.typescriptlang.org/docs/handbook/literal-types.html brings us to a deprecated page. This PR update the link to the new page.

![image](https://user-images.githubusercontent.com/20135478/226367359-4bcbba9e-fd2b-4f89-bfe8-35b65ac37121.png)
