### PR TITLE
Add Qwik package of Modular Forms to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,8 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`remix-params-helper`](https://github.com/kiliman/remix-params-helper): Simplify integration of Zod with standard URLSearchParams and FormData for Remix apps.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
-- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular and type-safe form library for SolidJS that supports Zod for validation.
+- [`@modular-forms/qwik`](https://github.com/fabian-hiller/modular-forms): Modular and type-safe form library for Qwik that supports Zod for validation.
 - [`houseform`](https://github.com/crutchcorn/houseform/): A React form library that uses Zod for validation.
 - [`sveltekit-superforms`](https://github.com/ciscoheat/sveltekit-superforms): Supercharged form library for SvelteKit with Zod validation.
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -428,7 +428,8 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`remix-params-helper`](https://github.com/kiliman/remix-params-helper): Simplify integration of Zod with standard URLSearchParams and FormData for Remix apps.
 - [`formik-validator-zod`](https://github.com/glazy/formik-validator-zod): Formik-compliant validator library that simplifies using Zod with Formik.
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): Useful for translating Zod error messages.
-- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
+- [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular and type-safe form library for SolidJS that supports Zod for validation.
+- [`@modular-forms/qwik`](https://github.com/fabian-hiller/modular-forms): Modular and type-safe form library for Qwik that supports Zod for validation.
 - [`houseform`](https://github.com/crutchcorn/houseform/): A React form library that uses Zod for validation.
 - [`sveltekit-superforms`](https://github.com/ciscoheat/sveltekit-superforms): Supercharged form library for SvelteKit with Zod validation.
 


### PR DESCRIPTION
Hi Colin, the Qwik version of Modular Forms is now available. Using Zod, you can now create progressively enhanced forms with client and server side validation that work entirely without JavaScript in the browser if needed.

If you prefer to call Modular Forms only once and not every package, I can update that. Thanks for your work!