### PR TITLE
[partial, required]: implement falsy masks and optional/nullable/nullish flavors

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -623,7 +623,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");

--- a/deno/lib/__tests__/partials.test.ts
+++ b/deno/lib/__tests__/partials.test.ts
@@ -5,7 +5,7 @@ const test = Deno.test;
 import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
 import { ZodNullable, ZodOptional } from "../index.ts";
-import { MaskErrorType } from "../types.ts";
+import { MaskErrorType, PartialType } from "../types.ts";
 
 const nested = z.object({
   name: z.string(),
@@ -171,6 +171,62 @@ test("required inference", () => {
   util.assertEqual<expected, required>(true);
 });
 
+test("required without mask and with nullable type", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required(PartialType.NULLABLE);
+
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    nullableField: number;
+    nullishField?: string;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
+});
+
+test("required without mask and with nullish type", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required(PartialType.NULLISH);
+
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age: number;
+    field: string;
+    nullableField: number;
+    nullishField: string;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodString);
+});
+
 test("required with emtpy mask -- throws", () => {
   const object = z.object({
     name: z.string(),
@@ -192,13 +248,88 @@ test("required with truthy mask", () => {
     age: z.number().optional(),
     field: z.string().optional().default("asdf"),
     country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
   });
 
   const requiredObject = object.required({ age: true });
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age: number;
+    field: string;
+    country?: string;
+    nullableField: number | null;
+    nullishField?: string | null;
+  };
+  util.assertEqual<expected, required>(true);
+
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
   expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
   expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
+});
+
+test("required with truthy nullable mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required({ age: true }, PartialType.NULLABLE);
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country?: string;
+    nullableField: number | null;
+    nullishField?: string | null;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
+});
+
+test("required with truthy nullish mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required({ age: true }, PartialType.NULLISH);
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age: number;
+    field: string;
+    country?: string;
+    nullableField: number | null;
+    nullishField?: string | null;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
 });
 
 test("required with falsy mask", () => {
@@ -207,13 +338,88 @@ test("required with falsy mask", () => {
     age: z.number().optional(),
     field: z.string().optional().default("asdf"),
     country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
   });
 
   const requiredObject = object.required({ age: false });
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country: string;
+    nullableField: number | null;
+    nullishField: string | null;
+  };
+  util.assertEqual<expected, required>(true);
+
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
   expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
   expect(requiredObject.shape.country).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodNullable);
+});
+
+test("required with falsy nullable mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required({ age: false }, PartialType.NULLABLE);
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country?: string;
+    nullableField: number;
+    nullishField?: string;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
+});
+
+test("required with falsy nullish mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required({ age: false }, PartialType.NULLISH);
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country: string;
+    nullableField: number;
+    nullishField: string;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodString);
 });
 
 test("required with mask -- throw when mixing truthy and falsy values", () => {
@@ -240,6 +446,15 @@ test("partial without mask", async () => {
   });
 
   const masked = object.partial().strict();
+  type optional = z.infer<typeof masked>;
+  type expected = {
+    name?: string;
+    age?: number;
+    field?: string;
+    country?: string;
+    region?: string;
+  };
+  util.assertEqual<expected, optional>(true);
 
   expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
@@ -248,6 +463,109 @@ test("partial without mask", async () => {
   expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
 
   masked.parse({});
+  await masked.parseAsync({});
+});
+
+test("partial without mask and with nullable type", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object.partial(PartialType.NULLABLE).strict();
+
+  type nullable = z.infer<typeof masked>;
+  type expected = {
+    name: string | null;
+    age?: number | null;
+    field: string | null;
+    country: string | null;
+    region: string | null;
+  };
+  util.assertEqual<expected, nullable>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age.unwrap()).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodNullable);
+
+  masked.parse({ name: null, field: null, country: null, region: null });
+  expect(() =>
+    masked.parse({ name: null, field: null, country: null })
+  ).toThrow();
+  masked.parse({
+    name: null,
+    age: null,
+    field: null,
+    country: null,
+    region: null,
+  });
+  await masked.parseAsync({
+    name: null,
+    age: null,
+    field: null,
+    country: null,
+    region: null,
+  });
+  await expect(
+    masked.parseAsync({
+      name: null,
+      field: null,
+      country: null,
+    })
+  ).rejects.toThrow();
+});
+
+test("partial without mask and with nullish type", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object.partial(PartialType.NULLISH).strict();
+
+  type nullish = z.infer<typeof masked>;
+  type expected = {
+    name?: string | null;
+    age?: number | null;
+    field?: string | null;
+    country?: string | null;
+    region?: string | null;
+  };
+  util.assertEqual<expected, nullish>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.name.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.age.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
+
+  masked.parse({
+    name: null,
+    age: null,
+    field: null,
+    country: null,
+    region: null,
+  });
+  masked.parse({});
+  await masked.parseAsync({
+    name: null,
+    age: null,
+    field: null,
+    country: null,
+    region: null,
+  });
   await masked.parseAsync({});
 });
 
@@ -279,6 +597,16 @@ test("partial with truthy mask", async () => {
     .partial({ age: true, field: true, name: true })
     .strict();
 
+  type optional = z.infer<typeof masked>;
+  type expected = {
+    name?: string;
+    age?: number;
+    field?: string;
+    country: string;
+    region: string;
+  };
+  util.assertEqual<expected, optional>(true);
+
   expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
@@ -286,7 +614,137 @@ test("partial with truthy mask", async () => {
   expect(masked.shape.region).toBeInstanceOf(z.ZodString);
 
   masked.parse({ country: "US", region: "Pacific Coast" });
+  expect(() => masked.parse({ country: "US" })).toThrow();
   await masked.parseAsync({ country: "US", region: "Pacific Coast" });
+  await expect(masked.parseAsync({ country: "US" })).rejects.toThrow();
+});
+
+test("partial with truthy nullable mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object
+    .partial({ age: true, field: true, name: true }, PartialType.NULLABLE)
+    .strict();
+
+  type nullable = z.infer<typeof masked>;
+  type expected = {
+    name: string | null;
+    age?: number | null;
+    field: string | null;
+    country: string;
+    region: string;
+  };
+  util.assertEqual<expected, nullable>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age.unwrap()).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodString);
+
+  masked.parse({
+    name: null,
+    age: null,
+    field: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  masked.parse({ name: null, country: "US", region: "Pacific Coast" });
+  expect(() =>
+    masked.parse({ country: "US", region: "Pacific Coast" })
+  ).toThrow();
+  expect(() => masked.parse({ name: null, country: "US" })).toThrow();
+  await masked.parseAsync({
+    name: null,
+    age: null,
+    field: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  await masked.parseAsync({
+    name: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  await expect(
+    masked.parseAsync({
+      country: "US",
+      region: "Pacific Coast",
+    })
+  ).rejects.toThrow();
+  await expect(
+    masked.parseAsync({
+      name: null,
+      country: "US",
+    })
+  ).rejects.toThrow();
+});
+
+test("partial with truthy nullish mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object
+    .partial({ age: true, field: true, name: true }, PartialType.NULLISH)
+    .strict();
+
+  type nullish = z.infer<typeof masked>;
+  type expected = {
+    name?: string | null;
+    age?: number | null;
+    field?: string | null;
+    country: string;
+    region: string;
+  };
+  util.assertEqual<expected, nullish>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.name.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.age.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodString);
+
+  masked.parse({
+    name: null,
+    age: null,
+    field: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  masked.parse({ country: "US", region: "Pacific Coast" });
+  expect(() => masked.parse({ country: "US" })).toThrow();
+  expect(() => masked.parse({ name: null, country: "US" })).toThrow();
+  await masked.parseAsync({
+    name: null,
+    age: null,
+    field: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  await masked.parseAsync({
+    country: "US",
+    region: "Pacific Coast",
+  });
+  await expect(
+    masked.parseAsync({
+      country: "US",
+    })
+  ).rejects.toThrow();
 });
 
 test("partial with falsy mask", async () => {
@@ -302,6 +760,16 @@ test("partial with falsy mask", async () => {
     .partial({ age: false, field: false, name: false })
     .strict();
 
+  type optional = z.infer<typeof masked>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country?: string;
+    region?: string;
+  };
+  util.assertEqual<expected, optional>(true);
+
   expect(masked.shape.name).toBeInstanceOf(z.ZodString);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
@@ -309,7 +777,87 @@ test("partial with falsy mask", async () => {
   expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
 
   masked.parse({ name: "Abc" });
+  expect(() => masked.parse({})).toThrow();
   await masked.parseAsync({ name: "Abc" });
+  await expect(masked.parseAsync({})).rejects.toThrow();
+});
+
+test("partial with falsy nullable mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object
+    .partial({ age: false, field: false, name: false }, PartialType.NULLABLE)
+    .strict();
+
+  type nullable = z.infer<typeof masked>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country: string | null;
+    region: string | null;
+  };
+  util.assertEqual<expected, nullable>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodNullable);
+
+  masked.parse({ name: "Abc", country: null, region: null });
+  expect(() => masked.parse({ name: "Abc", country: null })).toThrow();
+  expect(() => masked.parse({ ncountry: null, region: null })).toThrow();
+  await masked.parseAsync({ name: "Abc", country: null, region: null });
+  await expect(
+    masked.parseAsync({ name: "Abc", country: null })
+  ).rejects.toThrow();
+  await expect(
+    masked.parseAsync({ country: null, region: null })
+  ).rejects.toThrow();
+});
+
+test("partial with falsy nullish mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object
+    .partial({ age: false, field: false, name: false }, PartialType.NULLISH)
+    .strict();
+
+  type nullable = z.infer<typeof masked>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country?: string | null;
+    region?: string | null;
+  };
+  util.assertEqual<expected, nullable>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.country.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.region.unwrap()).toBeInstanceOf(z.ZodNullable);
+
+  masked.parse({ name: "Abc" });
+  expect(() => masked.parse({})).toThrow();
+  await masked.parseAsync({ name: "Abc" });
+  await expect(masked.parseAsync({})).rejects.toThrow();
 });
 
 test("partial with mask -- throw when mixing truthy and falsy values", async () => {

--- a/deno/lib/__tests__/partials.test.ts
+++ b/deno/lib/__tests__/partials.test.ts
@@ -5,6 +5,7 @@ const test = Deno.test;
 import { util } from "../helpers/util.ts";
 import * as z from "../index.ts";
 import { ZodNullable, ZodOptional } from "../index.ts";
+import { MaskErrorType } from "../types.ts";
 
 const nested = z.object({
   name: z.string(),
@@ -170,7 +171,22 @@ test("required inference", () => {
   util.assertEqual<expected, required>(true);
 });
 
-test("required with mask", () => {
+test("required with emtpy mask -- throws", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  expect(
+    // @ts-expect-error
+    () => object.required({})
+  ).toThrow(MaskErrorType.EMPTY);
+});
+
+test("required with truthy mask", () => {
   const object = z.object({
     name: z.string(),
     age: z.number().optional(),
@@ -185,7 +201,7 @@ test("required with mask", () => {
   expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
 });
 
-test("required with mask -- ignore falsy values", () => {
+test("required with falsy mask", () => {
   const object = z.object({
     name: z.string(),
     age: z.number().optional(),
@@ -193,20 +209,70 @@ test("required with mask -- ignore falsy values", () => {
     country: z.string().optional(),
   });
 
-  // @ts-expect-error
-  const requiredObject = object.required({ age: true, country: false });
+  const requiredObject = object.required({ age: false });
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
-  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
-  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodString);
 });
 
-test("partial with mask", async () => {
+test("required with mask -- throw when mixing truthy and falsy values", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+  });
+
+  expect(
+    // @ts-expect-error
+    () => object.required({ age: true, country: false })
+  ).toThrow(MaskErrorType.MIXED);
+});
+
+test("partial without mask", async () => {
   const object = z.object({
     name: z.string(),
     age: z.number().optional(),
     field: z.string().optional().default("asdf"),
     country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object.partial().strict();
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
+
+  masked.parse({});
+  await masked.parseAsync({});
+});
+
+test("partial with emtpy mask -- throws", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  expect(
+    // @ts-expect-error
+    () => object.partial({}).strict()
+  ).toThrow(MaskErrorType.EMPTY);
+});
+
+test("partial with truthy mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
   });
 
   const masked = object
@@ -217,29 +283,48 @@ test("partial with mask", async () => {
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.country).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodString);
 
-  masked.parse({ country: "US" });
-  await masked.parseAsync({ country: "US" });
+  masked.parse({ country: "US", region: "Pacific Coast" });
+  await masked.parseAsync({ country: "US", region: "Pacific Coast" });
 });
 
-test("partial with mask -- ignore falsy values", async () => {
+test("partial with falsy mask", async () => {
   const object = z.object({
     name: z.string(),
     age: z.number().optional(),
     field: z.string().optional().default("asdf"),
     country: z.string(),
+    region: z.string(),
   });
 
-  // @ts-expect-error
-  const masked = object.partial({ name: true, country: false }).strict();
+  const masked = object
+    .partial({ age: false, field: false, name: false })
+    .strict();
 
-  expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.name).toBeInstanceOf(z.ZodString);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
-  expect(masked.shape.country).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
 
-  masked.parse({ country: "US" });
-  await masked.parseAsync({ country: "US" });
+  masked.parse({ name: "Abc" });
+  await masked.parseAsync({ name: "Abc" });
+});
+
+test("partial with mask -- throw when mixing truthy and falsy values", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  expect(
+    // @ts-expect-error
+    () => object.partial({ name: true, country: false }).strict()
+  ).toThrow(MaskErrorType.MIXED);
 });
 
 test("deeppartial array", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2186,6 +2186,48 @@ export type noUnrecognized<Obj extends object, Shape extends object> = {
   [k in keyof Obj]: k extends keyof Shape ? Obj[k] : never;
 };
 
+export enum MaskErrorType {
+  EMPTY = "Empty mask is not a valid mask",
+  MIXED = "You cannot mix truthy and falsy values in the same mask",
+}
+
+function assertMaskIsNotMixed<
+  T extends object,
+  Mask extends { [k in keyof T]?: boolean }
+>(
+  mask: Mask | undefined
+): asserts mask is
+  | { [k in keyof Mask]: Exclude<Mask[k], true> }
+  | { [k in keyof Mask]: Exclude<Mask[k], false> }
+  | undefined {
+  if (mask !== undefined) {
+    const values = Object.values(mask);
+    if (values.length === 0) {
+      throw new Error(MaskErrorType.EMPTY);
+    } else {
+      let lastValue = values[0];
+      for (let i = 1; i < values.length; i++) {
+        if (lastValue !== values[i]) {
+          throw new Error(MaskErrorType.MIXED);
+        }
+        lastValue = values[i];
+      }
+    }
+  }
+}
+
+function isNotEmpty<T extends object>(
+  mask: { [k in keyof T]?: true } | { [k in keyof T]?: false } | undefined
+): mask is { [k in keyof T]?: true } | { [k in keyof T]?: false } {
+  return mask !== undefined && Object.values(mask)?.length > 0;
+}
+
+function isFalsy<T extends object>(
+  mask: { [k in keyof T]?: true } | { [k in keyof T]?: false } | undefined
+): mask is { [k in keyof T]?: true } {
+  return mask !== undefined && Object.values(mask)?.[0] === false;
+}
+
 function deepPartialify(schema: ZodTypeAny): any {
   if (schema instanceof ZodObject) {
     const newShape: any = {};
@@ -2595,7 +2637,16 @@ export class ZodObject<
     Catchall
   >;
   partial<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: Required<Mask>
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? T[k] : ZodOptional<T[k]>;
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  partial<Mask extends { [k in keyof T]?: false }>(
+    mask: Required<Mask>
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k];
@@ -2603,13 +2654,16 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  partial(mask?: any) {
+  partial<Mask extends { [k in keyof T]?: boolean }>(mask?: Required<Mask>) {
+    assertMaskIsNotMixed(mask);
+    const maskIsNotEmpty = isNotEmpty(mask);
+    const value = isFalsy(mask) ? false : undefined;
     const newShape: any = {};
 
     util.objectKeys(this.shape).forEach((key) => {
       const fieldSchema = this.shape[key];
 
-      if (mask && !mask[key]) {
+      if (maskIsNotEmpty && mask[key] === value) {
         newShape[key] = fieldSchema;
       } else {
         newShape[key] = fieldSchema.optional();
@@ -2628,7 +2682,7 @@ export class ZodObject<
     Catchall
   >;
   required<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: Required<Mask>
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? deoptional<T[k]> : T[k];
@@ -2636,13 +2690,23 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  required(mask?: any) {
+  required<Mask extends { [k in keyof T]?: false }>(
+    mask: Required<Mask>
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? T[k] : deoptional<T[k]>;
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  required<Mask extends { [k in keyof T]?: boolean }>(mask?: Required<Mask>) {
+    assertMaskIsNotMixed(mask);
+    const maskIsNotEmpty = isNotEmpty(mask);
+    const value = isFalsy(mask) ? undefined : true;
     const newShape: any = {};
 
     util.objectKeys(this.shape).forEach((key) => {
-      if (mask && !mask[key]) {
-        newShape[key] = this.shape[key];
-      } else {
+      if (!maskIsNotEmpty || mask[key] === value) {
         const fieldSchema = this.shape[key];
         let newField = fieldSchema;
 
@@ -2651,6 +2715,8 @@ export class ZodObject<
         }
 
         newShape[key] = newField;
+      } else {
+        newShape[key] = this.shape[key];
       }
     });
 

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@jest/globals";
 import { util } from "../helpers/util";
 import * as z from "../index";
 import { ZodNullable, ZodOptional } from "../index";
-import { MaskErrorType } from "../types";
+import { MaskErrorType, PartialType } from "../types";
 
 const nested = z.object({
   name: z.string(),
@@ -170,6 +170,62 @@ test("required inference", () => {
   util.assertEqual<expected, required>(true);
 });
 
+test("required without mask and with nullable type", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required(PartialType.NULLABLE);
+
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    nullableField: number;
+    nullishField?: string;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
+});
+
+test("required without mask and with nullish type", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required(PartialType.NULLISH);
+
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age: number;
+    field: string;
+    nullableField: number;
+    nullishField: string;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodString);
+});
+
 test("required with emtpy mask -- throws", () => {
   const object = z.object({
     name: z.string(),
@@ -191,13 +247,88 @@ test("required with truthy mask", () => {
     age: z.number().optional(),
     field: z.string().optional().default("asdf"),
     country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
   });
 
   const requiredObject = object.required({ age: true });
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age: number;
+    field: string;
+    country?: string;
+    nullableField: number | null;
+    nullishField?: string | null;
+  };
+  util.assertEqual<expected, required>(true);
+
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
   expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
   expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
+});
+
+test("required with truthy nullable mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required({ age: true }, PartialType.NULLABLE);
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country?: string;
+    nullableField: number | null;
+    nullishField?: string | null;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
+});
+
+test("required with truthy nullish mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required({ age: true }, PartialType.NULLISH);
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age: number;
+    field: string;
+    country?: string;
+    nullableField: number | null;
+    nullishField?: string | null;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
 });
 
 test("required with falsy mask", () => {
@@ -206,13 +337,88 @@ test("required with falsy mask", () => {
     age: z.number().optional(),
     field: z.string().optional().default("asdf"),
     country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
   });
 
   const requiredObject = object.required({ age: false });
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country: string;
+    nullableField: number | null;
+    nullishField: string | null;
+  };
+  util.assertEqual<expected, required>(true);
+
   expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
   expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
   expect(requiredObject.shape.country).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNullable);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodNullable);
+});
+
+test("required with falsy nullable mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required({ age: false }, PartialType.NULLABLE);
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country?: string;
+    nullableField: number;
+    nullishField?: string;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodOptional);
+});
+
+test("required with falsy nullish mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string().optional(),
+    nullableField: z.number().nullable(),
+    nullishField: z.string().nullish(),
+  });
+
+  const requiredObject = object.required({ age: false }, PartialType.NULLISH);
+  type required = z.infer<typeof requiredObject>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country: string;
+    nullableField: number;
+    nullishField: string;
+  };
+  util.assertEqual<expected, required>(true);
+
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodString);
+  expect(requiredObject.shape.nullableField).toBeInstanceOf(z.ZodNumber);
+  expect(requiredObject.shape.nullishField).toBeInstanceOf(z.ZodString);
 });
 
 test("required with mask -- throw when mixing truthy and falsy values", () => {
@@ -239,6 +445,15 @@ test("partial without mask", async () => {
   });
 
   const masked = object.partial().strict();
+  type optional = z.infer<typeof masked>;
+  type expected = {
+    name?: string;
+    age?: number;
+    field?: string;
+    country?: string;
+    region?: string;
+  };
+  util.assertEqual<expected, optional>(true);
 
   expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
@@ -247,6 +462,109 @@ test("partial without mask", async () => {
   expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
 
   masked.parse({});
+  await masked.parseAsync({});
+});
+
+test("partial without mask and with nullable type", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object.partial(PartialType.NULLABLE).strict();
+
+  type nullable = z.infer<typeof masked>;
+  type expected = {
+    name: string | null;
+    age?: number | null;
+    field: string | null;
+    country: string | null;
+    region: string | null;
+  };
+  util.assertEqual<expected, nullable>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age.unwrap()).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodNullable);
+
+  masked.parse({ name: null, field: null, country: null, region: null });
+  expect(() =>
+    masked.parse({ name: null, field: null, country: null })
+  ).toThrow();
+  masked.parse({
+    name: null,
+    age: null,
+    field: null,
+    country: null,
+    region: null,
+  });
+  await masked.parseAsync({
+    name: null,
+    age: null,
+    field: null,
+    country: null,
+    region: null,
+  });
+  await expect(
+    masked.parseAsync({
+      name: null,
+      field: null,
+      country: null,
+    })
+  ).rejects.toThrow();
+});
+
+test("partial without mask and with nullish type", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object.partial(PartialType.NULLISH).strict();
+
+  type nullish = z.infer<typeof masked>;
+  type expected = {
+    name?: string | null;
+    age?: number | null;
+    field?: string | null;
+    country?: string | null;
+    region?: string | null;
+  };
+  util.assertEqual<expected, nullish>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.name.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.age.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
+
+  masked.parse({
+    name: null,
+    age: null,
+    field: null,
+    country: null,
+    region: null,
+  });
+  masked.parse({});
+  await masked.parseAsync({
+    name: null,
+    age: null,
+    field: null,
+    country: null,
+    region: null,
+  });
   await masked.parseAsync({});
 });
 
@@ -278,6 +596,16 @@ test("partial with truthy mask", async () => {
     .partial({ age: true, field: true, name: true })
     .strict();
 
+  type optional = z.infer<typeof masked>;
+  type expected = {
+    name?: string;
+    age?: number;
+    field?: string;
+    country: string;
+    region: string;
+  };
+  util.assertEqual<expected, optional>(true);
+
   expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
@@ -285,7 +613,137 @@ test("partial with truthy mask", async () => {
   expect(masked.shape.region).toBeInstanceOf(z.ZodString);
 
   masked.parse({ country: "US", region: "Pacific Coast" });
+  expect(() => masked.parse({ country: "US" })).toThrow();
   await masked.parseAsync({ country: "US", region: "Pacific Coast" });
+  await expect(masked.parseAsync({ country: "US" })).rejects.toThrow();
+});
+
+test("partial with truthy nullable mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object
+    .partial({ age: true, field: true, name: true }, PartialType.NULLABLE)
+    .strict();
+
+  type nullable = z.infer<typeof masked>;
+  type expected = {
+    name: string | null;
+    age?: number | null;
+    field: string | null;
+    country: string;
+    region: string;
+  };
+  util.assertEqual<expected, nullable>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age.unwrap()).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodString);
+
+  masked.parse({
+    name: null,
+    age: null,
+    field: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  masked.parse({ name: null, country: "US", region: "Pacific Coast" });
+  expect(() =>
+    masked.parse({ country: "US", region: "Pacific Coast" })
+  ).toThrow();
+  expect(() => masked.parse({ name: null, country: "US" })).toThrow();
+  await masked.parseAsync({
+    name: null,
+    age: null,
+    field: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  await masked.parseAsync({
+    name: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  await expect(
+    masked.parseAsync({
+      country: "US",
+      region: "Pacific Coast",
+    })
+  ).rejects.toThrow();
+  await expect(
+    masked.parseAsync({
+      name: null,
+      country: "US",
+    })
+  ).rejects.toThrow();
+});
+
+test("partial with truthy nullish mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object
+    .partial({ age: true, field: true, name: true }, PartialType.NULLISH)
+    .strict();
+
+  type nullish = z.infer<typeof masked>;
+  type expected = {
+    name?: string | null;
+    age?: number | null;
+    field?: string | null;
+    country: string;
+    region: string;
+  };
+  util.assertEqual<expected, nullish>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.name.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.age.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodString);
+
+  masked.parse({
+    name: null,
+    age: null,
+    field: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  masked.parse({ country: "US", region: "Pacific Coast" });
+  expect(() => masked.parse({ country: "US" })).toThrow();
+  expect(() => masked.parse({ name: null, country: "US" })).toThrow();
+  await masked.parseAsync({
+    name: null,
+    age: null,
+    field: null,
+    country: "US",
+    region: "Pacific Coast",
+  });
+  await masked.parseAsync({
+    country: "US",
+    region: "Pacific Coast",
+  });
+  await expect(
+    masked.parseAsync({
+      country: "US",
+    })
+  ).rejects.toThrow();
 });
 
 test("partial with falsy mask", async () => {
@@ -301,6 +759,16 @@ test("partial with falsy mask", async () => {
     .partial({ age: false, field: false, name: false })
     .strict();
 
+  type optional = z.infer<typeof masked>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country?: string;
+    region?: string;
+  };
+  util.assertEqual<expected, optional>(true);
+
   expect(masked.shape.name).toBeInstanceOf(z.ZodString);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
@@ -308,7 +776,87 @@ test("partial with falsy mask", async () => {
   expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
 
   masked.parse({ name: "Abc" });
+  expect(() => masked.parse({})).toThrow();
   await masked.parseAsync({ name: "Abc" });
+  await expect(masked.parseAsync({})).rejects.toThrow();
+});
+
+test("partial with falsy nullable mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object
+    .partial({ age: false, field: false, name: false }, PartialType.NULLABLE)
+    .strict();
+
+  type nullable = z.infer<typeof masked>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country: string | null;
+    region: string | null;
+  };
+  util.assertEqual<expected, nullable>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodNullable);
+
+  masked.parse({ name: "Abc", country: null, region: null });
+  expect(() => masked.parse({ name: "Abc", country: null })).toThrow();
+  expect(() => masked.parse({ ncountry: null, region: null })).toThrow();
+  await masked.parseAsync({ name: "Abc", country: null, region: null });
+  await expect(
+    masked.parseAsync({ name: "Abc", country: null })
+  ).rejects.toThrow();
+  await expect(
+    masked.parseAsync({ country: null, region: null })
+  ).rejects.toThrow();
+});
+
+test("partial with falsy nullish mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.number().optional(),
+    field: z.string().optional().default("asdf"),
+    country: z.string(),
+    region: z.string(),
+  });
+
+  const masked = object
+    .partial({ age: false, field: false, name: false }, PartialType.NULLISH)
+    .strict();
+
+  type nullable = z.infer<typeof masked>;
+  type expected = {
+    name: string;
+    age?: number;
+    field: string;
+    country?: string | null;
+    region?: string | null;
+  };
+  util.assertEqual<expected, nullable>(true);
+
+  expect(masked.shape.name).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.country.unwrap()).toBeInstanceOf(z.ZodNullable);
+  expect(masked.shape.region).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.region.unwrap()).toBeInstanceOf(z.ZodNullable);
+
+  masked.parse({ name: "Abc" });
+  expect(() => masked.parse({})).toThrow();
+  await masked.parseAsync({ name: "Abc" });
+  await expect(masked.parseAsync({})).rejects.toThrow();
 });
 
 test("partial with mask -- throw when mixing truthy and falsy values", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2176,6 +2176,12 @@ export type deoptional<T extends ZodTypeAny> = T extends ZodOptional<infer U>
   ? ZodNullable<deoptional<U>>
   : T;
 
+export type denullable<T extends ZodTypeAny> = T extends ZodNullable<infer U>
+  ? denullable<U>
+  : T extends ZodOptional<infer U>
+  ? ZodOptional<denullable<U>>
+  : T;
+
 export type SomeZodObject = ZodObject<
   ZodRawShape,
   UnknownKeysParam,
@@ -2186,9 +2192,35 @@ export type noUnrecognized<Obj extends object, Shape extends object> = {
   [k in keyof Obj]: k extends keyof Shape ? Obj[k] : never;
 };
 
+export enum PartialType {
+  OPTIONAL = "optional",
+  NULLABLE = "nullable",
+  NULLISH = "nullish",
+}
+
 export enum MaskErrorType {
   EMPTY = "Empty mask is not a valid mask",
   MIXED = "You cannot mix truthy and falsy values in the same mask",
+}
+
+function isMask<T extends object, Mask extends { [k in keyof T]?: boolean }>(
+  maskOrType: PartialType | Mask | undefined
+): maskOrType is Mask {
+  if (maskOrType === undefined) {
+    return false;
+  }
+  for (const type of Object.values(PartialType)) {
+    if (maskOrType === type) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isType<T extends object, Mask extends { [k in keyof T]?: boolean }>(
+  maskOrType: PartialType | Mask | undefined
+): maskOrType is PartialType {
+  return maskOrType !== undefined && !isMask(maskOrType);
 }
 
 function assertMaskIsNotMixed<
@@ -2631,13 +2663,22 @@ export class ZodObject<
     return deepPartialify(this) as any;
   }
 
-  partial(): ZodObject<
-    { [k in keyof T]: ZodOptional<T[k]> },
+  partial(
+    type?: PartialType.OPTIONAL
+  ): ZodObject<{ [k in keyof T]: ZodOptional<T[k]> }, UnknownKeys, Catchall>;
+  partial(
+    type: PartialType.NULLABLE
+  ): ZodObject<{ [k in keyof T]: ZodNullable<T[k]> }, UnknownKeys, Catchall>;
+  partial(
+    type: PartialType.NULLISH
+  ): ZodObject<
+    { [k in keyof T]: ZodOptional<ZodNullable<T[k]>> },
     UnknownKeys,
     Catchall
   >;
   partial<Mask extends { [k in keyof T]?: true }>(
-    mask: Required<Mask>
+    mask: Required<Mask>,
+    type?: PartialType.OPTIONAL
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k];
@@ -2645,8 +2686,31 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
+  partial<Mask extends { [k in keyof T]?: true }>(
+    mask: Required<Mask>,
+    type: PartialType.NULLABLE
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? ZodNullable<T[k]> : T[k];
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  partial<Mask extends { [k in keyof T]?: true }>(
+    mask: Required<Mask>,
+    type: PartialType.NULLISH
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask
+        ? ZodOptional<ZodNullable<T[k]>>
+        : T[k];
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
   partial<Mask extends { [k in keyof T]?: false }>(
-    mask: Required<Mask>
+    mask: Required<Mask>,
+    type?: PartialType.OPTIONAL
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? T[k] : ZodOptional<T[k]>;
@@ -2654,7 +2718,34 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  partial<Mask extends { [k in keyof T]?: boolean }>(mask?: Required<Mask>) {
+  partial<Mask extends { [k in keyof T]?: false }>(
+    mask: Required<Mask>,
+    type: PartialType.NULLABLE
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? T[k] : ZodNullable<T[k]>;
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  partial<Mask extends { [k in keyof T]?: false }>(
+    mask: Required<Mask>,
+    type: PartialType.NULLISH
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask
+        ? T[k]
+        : ZodOptional<ZodNullable<T[k]>>;
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  partial<Mask extends { [k in keyof T]?: boolean }>(
+    maskOrType?: Required<Mask> | PartialType,
+    type = PartialType.OPTIONAL
+  ) {
+    const mask = isMask(maskOrType) ? maskOrType : undefined;
+    type = isType(maskOrType) ? maskOrType : type;
     assertMaskIsNotMixed(mask);
     const maskIsNotEmpty = isNotEmpty(mask);
     const value = isFalsy(mask) ? false : undefined;
@@ -2666,7 +2757,7 @@ export class ZodObject<
       if (maskIsNotEmpty && mask[key] === value) {
         newShape[key] = fieldSchema;
       } else {
-        newShape[key] = fieldSchema.optional();
+        newShape[key] = fieldSchema[type]();
       }
     });
 
@@ -2676,13 +2767,22 @@ export class ZodObject<
     }) as any;
   }
 
-  required(): ZodObject<
-    { [k in keyof T]: deoptional<T[k]> },
+  required(
+    type?: PartialType.OPTIONAL
+  ): ZodObject<{ [k in keyof T]: deoptional<T[k]> }, UnknownKeys, Catchall>;
+  required(
+    type: PartialType.NULLABLE
+  ): ZodObject<{ [k in keyof T]: denullable<T[k]> }, UnknownKeys, Catchall>;
+  required(
+    type: PartialType.NULLISH
+  ): ZodObject<
+    { [k in keyof T]: deoptional<denullable<T[k]>> },
     UnknownKeys,
     Catchall
   >;
   required<Mask extends { [k in keyof T]?: true }>(
-    mask: Required<Mask>
+    mask: Required<Mask>,
+    type?: PartialType.OPTIONAL
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? deoptional<T[k]> : T[k];
@@ -2690,8 +2790,31 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
+  required<Mask extends { [k in keyof T]?: true }>(
+    mask: Required<Mask>,
+    type: PartialType.NULLABLE
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? denullable<T[k]> : T[k];
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  required<Mask extends { [k in keyof T]?: true }>(
+    mask: Required<Mask>,
+    type: PartialType.NULLISH
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask
+        ? deoptional<denullable<T[k]>>
+        : T[k];
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
   required<Mask extends { [k in keyof T]?: false }>(
-    mask: Required<Mask>
+    mask: Required<Mask>,
+    type?: PartialType.OPTIONAL
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? T[k] : deoptional<T[k]>;
@@ -2699,7 +2822,34 @@ export class ZodObject<
     UnknownKeys,
     Catchall
   >;
-  required<Mask extends { [k in keyof T]?: boolean }>(mask?: Required<Mask>) {
+  required<Mask extends { [k in keyof T]?: false }>(
+    mask: Required<Mask>,
+    type: PartialType.NULLABLE
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? T[k] : denullable<T[k]>;
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  required<Mask extends { [k in keyof T]?: false }>(
+    mask: Required<Mask>,
+    type: PartialType.NULLISH
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask
+        ? T[k]
+        : deoptional<denullable<T[k]>>;
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  required<Mask extends { [k in keyof T]?: boolean }>(
+    maskOrType?: Required<Mask> | PartialType,
+    type = PartialType.OPTIONAL
+  ) {
+    const mask = isMask(maskOrType) ? maskOrType : undefined;
+    type = isType(maskOrType) ? maskOrType : type;
     assertMaskIsNotMixed(mask);
     const maskIsNotEmpty = isNotEmpty(mask);
     const value = isFalsy(mask) ? undefined : true;
@@ -2710,8 +2860,15 @@ export class ZodObject<
         const fieldSchema = this.shape[key];
         let newField = fieldSchema;
 
-        while (newField instanceof ZodOptional) {
-          newField = (newField as ZodOptional<any>)._def.innerType;
+        while (
+          type === PartialType.OPTIONAL
+            ? newField instanceof ZodOptional
+            : type === PartialType.NULLABLE
+            ? newField instanceof ZodNullable
+            : newField instanceof ZodOptional || newField instanceof ZodNullable
+        ) {
+          newField = (newField as ZodOptional<any> | ZodNullable<any>)._def
+            .innerType;
         }
 
         newShape[key] = newField;


### PR DESCRIPTION
Closes https://github.com/colinhacks/zod/issues/2191 and https://github.com/colinhacks/zod/issues/2190

Previously a mask allowed you to to require/partialize only certain properties while leaving the others intact. I called such old behaviour _thruthy masks_ because you selected the properties assigning a `true` value to them.
I implemented the opposite, meaning that you can require/partialize all properties **except** certain ones. I called this new behaviour _falsy masks_ because you select the properties assigning a `false` value to them.
I've made care of making everything backwards compatible, with the small exception that you can't mix `true` and `false` values in the same mask anymore (previously `false` values were simply ignored) because that would be ambiguous: how should it behave, like a falsy or thruthy mask? I could theoretically treat it as a truthy mask and ignore falsy values but that would be a bad behaviour in my opinion because it wouldn't be intuitive. Also the breaking change is small enough because I see no valid reason why anybody would be mixing true and false values anyway.
Since we're at it I'm also forbidding empty masks (previously `{}` was a valid mask) because again it's not intuitive whether you should treat it as a truthy or falsy mask (I think that particular fix ended up in the second commit, but since I'm upstreaming both of them it shouldn't matter. I can rebase it into the first one if you prefer).

The second feature I'm upstreaming are optional/nullable/nullish flavors for partial and required. That depends on the previous commit because it implements such behaviour for both truthy and falsy masks. Previously partial transformed a field of type `T` into `T | undefined` while required transformed a field of type `T | undefined` into `T`. Since along with the optional method we also have nullable and nullish methods it makes sense to have nullable and nullish flavors of partial and required as well. Naming starts to get messy though, so I've decided to not add any more methods but instead select the "flavor" via parameters. I've made sure to keep everything 100% backwards compatible so the default is still the optional flavor and the number and the position of the parameters changes depending on the overloaded function: parameters get processed and mask and type get reassembled in the function implementation so this is completely transparent to the end user.
A nullable flavor of required will strip out ZodNullable instead of ZodOptional (`T | null` becomes `T`) while the nullish flavor will 
strip out both ZodNullable and ZodOptional (`T | undefined | null` becomes `T`).
Similarly a nullable flavor of partial will wrap with ZodNullable instead of ZodOptional (`T` becomes `T | null`) while the nullish flavor will wrap with both ZodNullable and ZodOptional (`T` becomes `T | undefined | null`).

While bad behaviours are already enforced via typings (not mixing falsy and truthy masks, not passing empty masks which are ambiguous and cannot be discerned to a specific mask type) I also enforce these checks via type assertions (`assertMaskIsNotMixed`). While special care has been taken to optimize such function, a small (IMO negligible) performance impact is inevitable. If you prefer we can get rid of it and assume all our users will use TypeScript, but in my opinion it's better to keep it. I've also been careful to compute conditions outside of for loops to achieve some small performance improvements whenever possible, so I wouldn't worry about that.

I might have been over zealous  with the tests and they are probably too much and too many, but I didn't want you to get mad about testing every single possible corner case so the more the better. Feel free to cut them down as you see fit.

I still didn't update the documentation because I was looking for some feedback first. You didn't answer to my feature requests yet so I hope this will be enough to get your attention because I'd really love to have these features merged ASAP.
I'm currently working on a zod types generator so I will hopefully be able to test this on a larger project of my own soon. Tests are probably enough to cover every possible corner case, but the more testing the better.