### PR TITLE
Bring back check

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -623,7 +623,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");

--- a/deno/lib/__tests__/check.test.ts
+++ b/deno/lib/__tests__/check.test.ts
@@ -1,0 +1,26 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+const stringSchema = z.string();
+
+test("check fail", () => {
+  const safe = stringSchema.check(12);
+  expect(safe).toEqual(false);
+});
+
+test("safeparse pass", () => {
+  const safe = stringSchema.check("12");
+  expect(safe).toEqual(true);
+});
+
+test("safeparse unexpected error", () => {
+  expect(() =>
+    stringSchema
+      .refine((data) => {
+        throw new Error(data);
+      })
+      .check("12")
+  ).toThrow();
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -227,6 +227,10 @@ export abstract class ZodType<
     throw result.error;
   }
 
+  check(data: unknown): data is Output {
+    return this.safeParse(data).success;
+  }
+
   safeParse(
     data: unknown,
     params?: Partial<ParseParams>

--- a/src/__tests__/check.test.ts
+++ b/src/__tests__/check.test.ts
@@ -1,0 +1,25 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+const stringSchema = z.string();
+
+test("check fail", () => {
+  const safe = stringSchema.check(12);
+  expect(safe).toEqual(false);
+});
+
+test("safeparse pass", () => {
+  const safe = stringSchema.check("12");
+  expect(safe).toEqual(true);
+});
+
+test("safeparse unexpected error", () => {
+  expect(() =>
+    stringSchema
+      .refine((data) => {
+        throw new Error(data);
+      })
+      .check("12")
+  ).toThrow();
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -227,6 +227,10 @@ export abstract class ZodType<
     throw result.error;
   }
 
+  check(data: unknown): data is Output {
+    return this.safeParse(data).success;
+  }
+
   safeParse(
     data: unknown,
     params?: Partial<ParseParams>


### PR DESCRIPTION
In case I miss some of the context as to why this was removed, I apologize in advance for wasting maintainers' time. But the ergonomics of `safeParse` are much worse than `check`. More often than not, I want narrow down uncontrolled input type instead of reassigning and parsing it. So it's very tiring to write `newValue = schema.safeParse(data).success` every time.

Also I'm not sure why git hooks updated Deno readme, I tried reverting it but it was generated back 