### PR TITLE
Fix branded Record keys in ZodRecord

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -721,7 +721,7 @@ z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);
 z.string().endsWith(string);
-z.string().datetime(); // defaults to UTC, see below for options
+z.string().datetime(); // ISO 8601; default is without UTC offset, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 
 // transformations
@@ -760,7 +760,7 @@ z.string().ip({ message: "Invalid IP address" });
 
 ### ISO datetimes
 
-The `z.string().datetime()` method defaults to UTC validation: no timezone offsets with arbitrary sub-second decimal precision.
+The `z.string().datetime()` method enforces ISO 8601; default is no timezone offsets and arbitrary sub-second decimal precision.
 
 ```ts
 const datetime = z.string().datetime();
@@ -2825,10 +2825,9 @@ This more declarative API makes schema definitions vastly more concise.
 
 [https://github.com/pelotom/runtypes](https://github.com/pelotom/runtypes)
 
-Good type inference support. They DO support readonly types, which Zod does not.
+Good type inference support.
 
 - Supports "pattern matching": computed properties that distribute over unions
-- Supports readonly types
 - Missing object methods: (deepPartial, merge)
 - Missing nonempty arrays with proper typing (`[T, ...T[]]`)
 - Missing promise schemas

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3340,7 +3340,7 @@ export type RecordType<K extends string | number | symbol, V> = [
   ? Record<K, V>
   : [symbol] extends [K]
   ? Record<K, V>
-  : [BRAND<string | number | symbol>] extends [K]
+  : [K] extends [BRAND<string | number | symbol>]
   ? Record<K, V>
   : Partial<Record<K, V>>;
 export class ZodRecord<

--- a/src/types.ts
+++ b/src/types.ts
@@ -3340,7 +3340,7 @@ export type RecordType<K extends string | number | symbol, V> = [
   ? Record<K, V>
   : [symbol] extends [K]
   ? Record<K, V>
-  : [BRAND<string | number | symbol>] extends [K]
+  : [K] extends [BRAND<string | number | symbol>]
   ? Record<K, V>
   : Partial<Record<K, V>>;
 export class ZodRecord<


### PR DESCRIPTION
Because of a quirk of the extends syntax of typescript conditional
types, the previous version of this check for a branded key didn't work
as expected.

Thank you @akomm for the explanation of why the extends sides need to be
swapped at https://github.com/colinhacks/zod/pull/2287#issuecomment-1689922672

Originally I intended to remove the RecordType type entirely, since it
would seem initially that it is only there to work around earlier
versions of typescript not having the `noUncheckedIndexedAccess` option.
However, it is really meant to work around a problem with using ZodEnum
as the key, see this comment: https://github.com/colinhacks/zod/pull/2287#issuecomment-1676624932


~The RecordType conditional type seems to exist for handling the partialness of indexed objects. However that is handled by the tsconfig option noUncheckedIndexedAccess in TS@4.1 and later.~