### PR TITLE
[Issue #2285] New feature: z.date().utc()

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -623,7 +623,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");

--- a/deno/lib/__tests__/date.test.ts
+++ b/deno/lib/__tests__/date.test.ts
@@ -33,3 +33,11 @@ test("min max getters", () => {
     beforeBenchmarkDate
   );
 });
+
+test("UTC parser", () => {
+  const schemaUTCDate = z.date().utc();
+
+  const date = new Date("2023-04-04");
+
+  expect(schemaUTCDate.parse(date).toString()).toEqual('Mon Apr 04 2023 00:00:00 GMT+0000 (Coordinated Universal Time)');
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1693,6 +1693,38 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     });
   }
 
+  utc() {
+    const convertDateToUTC = (date: Date) => {
+      const utc = new Date(
+        Date.UTC(
+          date.getUTCFullYear(),
+          date.getUTCMonth(),
+          date.getUTCDate(),
+          date.getUTCHours(),
+          date.getUTCMinutes(),
+          date.getUTCSeconds(),
+          date.getUTCMilliseconds()
+        )
+      );
+
+      utc.toString = function () {
+        const weekDay = utc.toLocaleString("default", { weekday: "short" });
+        const monthName = utc.toLocaleString("default", { month: "short" });
+        const day = this.getUTCDate().toString().padStart(2, "0");
+        const year = this.getUTCFullYear().toString().padStart(4, "0");
+        const hour = this.getUTCHours().toString().padStart(2, "0");
+        const minute = this.getUTCMinutes().toString().padStart(2, "0");
+        const second = this.getUTCSeconds().toString().padStart(2, "0");
+
+        return `${weekDay} ${monthName} ${day} ${year} ${hour}:${minute}:${second} GMT+0000 (Coordinated Universal Time)`;
+      };
+
+      return utc;
+    };
+
+    return this.transform(convertDateToUTC);
+  }
+
   get minDate() {
     let min: number | null = null;
     for (const ch of this._def.checks) {

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -32,3 +32,11 @@ test("min max getters", () => {
     beforeBenchmarkDate
   );
 });
+
+test("UTC parser", () => {
+  const schemaUTCDate = z.date().utc();
+
+  const date = new Date("2023-04-04");
+
+  expect(schemaUTCDate.parse(date).toString()).toEqual('Mon Apr 04 2023 00:00:00 GMT+0000 (Coordinated Universal Time)');
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1693,6 +1693,38 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
     });
   }
 
+  utc() {
+    const convertDateToUTC = (date: Date) => {
+      const utc = new Date(
+        Date.UTC(
+          date.getUTCFullYear(),
+          date.getUTCMonth(),
+          date.getUTCDate(),
+          date.getUTCHours(),
+          date.getUTCMinutes(),
+          date.getUTCSeconds(),
+          date.getUTCMilliseconds()
+        )
+      );
+
+      utc.toString = function () {
+        const weekDay = utc.toLocaleString("default", { weekday: "short" });
+        const monthName = utc.toLocaleString("default", { month: "short" });
+        const day = this.getUTCDate().toString().padStart(2, "0");
+        const year = this.getUTCFullYear().toString().padStart(4, "0");
+        const hour = this.getUTCHours().toString().padStart(2, "0");
+        const minute = this.getUTCMinutes().toString().padStart(2, "0");
+        const second = this.getUTCSeconds().toString().padStart(2, "0");
+
+        return `${weekDay} ${monthName} ${day} ${year} ${hour}:${minute}:${second} GMT+0000 (Coordinated Universal Time)`;
+      };
+
+      return utc;
+    };
+
+    return this.transform(convertDateToUTC);
+  }
+
   get minDate() {
     let min: number | null = null;
     for (const ch of this._def.checks) {


### PR DESCRIPTION
Closes: #2285

**Overview**

Because of the differences when the date field goes from backend(probably UTC) to client(local timezone) it's easy to get a date(YYYY-mm-dd) 1 day behind/forward and have to deal with it manually, specially when using form inputs with type=date.

**What was made:**
- New Code implemented
- Added new test case on `src/__tests__/date.test.ts`

Thanks for helped me @ramos-ph
