### PR TITLE
add `.lowercase`/`.uppercase` checks @ `ZodString`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,8 @@ z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().datetime(); // defaults to UTC, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
+z.string().lowercase();
+z.string().uppercase();
 
 // transformations
 z.string().trim(); // trim whitespace

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -623,7 +623,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");
@@ -662,6 +662,8 @@ z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().datetime(); // defaults to UTC, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
+z.string().lowercase();
+z.string().uppercase();
 
 // transformations
 z.string().trim(); // trim whitespace

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -99,6 +99,8 @@ export type StringValidation =
   | "ulid"
   | "datetime"
   | "ip"
+  | "lowercase"
+  | "uppercase"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -12,6 +12,8 @@ const includes = z.string().includes("includes");
 const includesFromIndex2 = z.string().includes("includes", { position: 2 });
 const startsWith = z.string().startsWith("startsWith");
 const endsWith = z.string().endsWith("endsWith");
+const uppercase = z.string().uppercase();
+const lowercase = z.string().lowercase();
 
 test("passing validations", () => {
   minFive.parse("12345");
@@ -24,6 +26,8 @@ test("passing validations", () => {
   includesFromIndex2.parse("XXXincludesXX");
   startsWith.parse("startsWithX");
   endsWith.parse("XendsWith");
+  uppercase.parse("ABC");
+  lowercase.parse("abc");
 });
 
 test("failing validations", () => {
@@ -36,6 +40,8 @@ test("failing validations", () => {
   expect(() => includesFromIndex2.parse("XincludesXX")).toThrow();
   expect(() => startsWith.parse("x")).toThrow();
   expect(() => endsWith.parse("x")).toThrow();
+  expect(() => uppercase.parse("aBC")).toThrow();
+  expect(() => lowercase.parse("Abc")).toThrow();
 });
 
 test("email validations", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -607,11 +607,8 @@ function isValidIP(ip: string, version?: IpVersion) {
   return false;
 }
 
-export class ZodString<T extends string = string> extends ZodType<
-  T,
-  ZodStringDef
-> {
-  _parse(input: ParseInput): ParseReturnType<T> {
+export class ZodString extends ZodType<string, ZodStringDef> {
+  _parse(input: ParseInput): ParseReturnType<string> {
     if (this._def.coerce) {
       input.data = String(input.data);
     }
@@ -868,8 +865,8 @@ export class ZodString<T extends string = string> extends ZodType<
       ...errorUtil.errToObj(message),
     });
 
-  _addCheck<R extends string = T>(check: ZodStringCheck) {
-    return new ZodString<R>({
+  _addCheck(check: ZodStringCheck) {
+    return new ZodString({
       ...this._def,
       checks: [...this._def.checks, check],
     });
@@ -1012,13 +1009,13 @@ export class ZodString<T extends string = string> extends ZodType<
     });
 
   toLowerCase = () =>
-    new ZodString<Lowercase<string>>({
+    new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "toLowerCase" }],
     });
 
   toUpperCase = () =>
-    new ZodString<Uppercase<string>>({
+    new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "toUpperCase" }],
     });
@@ -1050,6 +1047,30 @@ export class ZodString<T extends string = string> extends ZodType<
   }
   get isIP() {
     return !!this._def.checks.find((ch) => ch.kind === "ip");
+  }
+
+  get isUpperCase() {
+    for (let i = this._def.checks.length - 1; i >= 0; i--) {
+      const { kind } = this._def.checks[i];
+
+      if (kind === "uppercase" || kind === "toUpperCase") {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  get isLowerCase() {
+    for (let i = this._def.checks.length - 1; i >= 0; i--) {
+      const { kind } = this._def.checks[i];
+
+      if (kind === "lowercase" || kind === "toLowerCase") {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   get minLength() {

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -99,6 +99,8 @@ export type StringValidation =
   | "ulid"
   | "datetime"
   | "ip"
+  | "lowercase"
+  | "uppercase"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -11,6 +11,8 @@ const includes = z.string().includes("includes");
 const includesFromIndex2 = z.string().includes("includes", { position: 2 });
 const startsWith = z.string().startsWith("startsWith");
 const endsWith = z.string().endsWith("endsWith");
+const uppercase = z.string().uppercase();
+const lowercase = z.string().lowercase();
 
 test("passing validations", () => {
   minFive.parse("12345");
@@ -23,6 +25,8 @@ test("passing validations", () => {
   includesFromIndex2.parse("XXXincludesXX");
   startsWith.parse("startsWithX");
   endsWith.parse("XendsWith");
+  uppercase.parse("ABC");
+  lowercase.parse("abc");
 });
 
 test("failing validations", () => {
@@ -35,6 +39,8 @@ test("failing validations", () => {
   expect(() => includesFromIndex2.parse("XincludesXX")).toThrow();
   expect(() => startsWith.parse("x")).toThrow();
   expect(() => endsWith.parse("x")).toThrow();
+  expect(() => uppercase.parse("aBC")).toThrow();
+  expect(() => lowercase.parse("Abc")).toThrow();
 });
 
 test("email validations", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -607,11 +607,8 @@ function isValidIP(ip: string, version?: IpVersion) {
   return false;
 }
 
-export class ZodString<T extends string = string> extends ZodType<
-  T,
-  ZodStringDef
-> {
-  _parse(input: ParseInput): ParseReturnType<T> {
+export class ZodString extends ZodType<string, ZodStringDef> {
+  _parse(input: ParseInput): ParseReturnType<string> {
     if (this._def.coerce) {
       input.data = String(input.data);
     }
@@ -868,8 +865,8 @@ export class ZodString<T extends string = string> extends ZodType<
       ...errorUtil.errToObj(message),
     });
 
-  _addCheck<R extends string = T>(check: ZodStringCheck) {
-    return new ZodString<R>({
+  _addCheck(check: ZodStringCheck) {
+    return new ZodString({
       ...this._def,
       checks: [...this._def.checks, check],
     });
@@ -1012,13 +1009,13 @@ export class ZodString<T extends string = string> extends ZodType<
     });
 
   toLowerCase = () =>
-    new ZodString<Lowercase<string>>({
+    new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "toLowerCase" }],
     });
 
   toUpperCase = () =>
-    new ZodString<Uppercase<string>>({
+    new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "toUpperCase" }],
     });
@@ -1050,6 +1047,30 @@ export class ZodString<T extends string = string> extends ZodType<
   }
   get isIP() {
     return !!this._def.checks.find((ch) => ch.kind === "ip");
+  }
+
+  get isUpperCase() {
+    for (let i = this._def.checks.length - 1; i >= 0; i--) {
+      const { kind } = this._def.checks[i];
+
+      if (kind === "uppercase" || kind === "toUpperCase") {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  get isLowerCase() {
+    for (let i = this._def.checks.length - 1; i >= 0; i--) {
+      const { kind } = this._def.checks[i];
+
+      if (kind === "lowercase" || kind === "toLowerCase") {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   get minLength() {


### PR DESCRIPTION
This PR adds `.lowercase()`/`.uppercase()` validations to `ZodString`.
  Transformation only methods are cool and all, but sometimes we want to make sure the input is lowercase.