### PR TITLE
feat: implement equality between properties from schema

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -57,8 +57,8 @@
 - [Coercion for primitives](#coercion-for-primitives)
 - [Literals](#literals)
 - [Strings](#strings)
-  - [Datetime](#datetime-validation)
-  - [IP](#ip-address-validation)
+  - [Datetime](#iso-datetimes)
+  - [IP](#ip-addresses)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -431,6 +431,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 - [`houseform`](https://github.com/crutchcorn/houseform/): A React form library that uses Zod for validation.
 - [`sveltekit-superforms`](https://github.com/ciscoheat/sveltekit-superforms): Supercharged form library for SvelteKit with Zod validation.
+- [`mobx-zod-form`](https://github.com/MonoidDev/mobx-zod-form): Data-first form builder based on MobX & Zod
 
 #### Zod to X
 
@@ -623,7 +624,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -99,6 +99,7 @@ export type StringValidation =
   | "ulid"
   | "datetime"
   | "ip"
+  | "equalsTo"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -470,3 +470,46 @@ test("IP validation", () => {
     invalidIPs.every((ip) => ipSchema.safeParse(ip).success === false)
   ).toBe(true);
 });
+
+test("equalsTo success", () => {
+  const registrationSchema = z.object({
+    password: z.string(),
+    passwordConfirmation: z.string().equalsTo("password"),
+  });
+
+  expect(() =>
+    registrationSchema.parse({
+      password: "123",
+      passwordConfirmation: "123",
+    })
+  ).not.toThrow();
+});
+
+test("equalsTo unsuccess without message", () => {
+  const registrationSchema = z.object({
+    password: z.string(),
+    passwordConfirmation: z.string().equalsTo("password"),
+  });
+
+  expect(() =>
+    registrationSchema.parse({
+      password: "123",
+      passwordConfirmation: "1234",
+    })
+  ).toThrow(/Invalid input/);
+});
+
+test("equalsTo unsuccess with message", () => {
+  const registrationSchema = z.object({
+    password: z.string(),
+    passwordConfirmation: z.string().equalsTo("password", 'Invalid passwords'),
+  });
+
+  expect(() =>
+    registrationSchema.parse({
+      password: "123",
+      passwordConfirmation: "1234",
+    })
+  ).toThrow(/Invalid passwords/);
+});
+

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -99,6 +99,7 @@ export type StringValidation =
   | "ulid"
   | "datetime"
   | "ip"
+  | "equalsTo"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -469,3 +469,46 @@ test("IP validation", () => {
     invalidIPs.every((ip) => ipSchema.safeParse(ip).success === false)
   ).toBe(true);
 });
+
+test("equalsTo success", () => {
+  const registrationSchema = z.object({
+    password: z.string(),
+    passwordConfirmation: z.string().equalsTo("password"),
+  });
+
+  expect(() =>
+    registrationSchema.parse({
+      password: "123",
+      passwordConfirmation: "123",
+    })
+  ).not.toThrow();
+});
+
+test("equalsTo unsuccess without message", () => {
+  const registrationSchema = z.object({
+    password: z.string(),
+    passwordConfirmation: z.string().equalsTo("password"),
+  });
+
+  expect(() =>
+    registrationSchema.parse({
+      password: "123",
+      passwordConfirmation: "1234",
+    })
+  ).toThrow(/Invalid input/);
+});
+
+test("equalsTo unsuccess with message", () => {
+  const registrationSchema = z.object({
+    password: z.string(),
+    passwordConfirmation: z.string().equalsTo("password", 'Invalid passwords'),
+  });
+
+  expect(() =>
+    registrationSchema.parse({
+      password: "123",
+      passwordConfirmation: "1234",
+    })
+  ).toThrow(/Invalid passwords/);
+});
+


### PR DESCRIPTION
From issue: #2284

**Overview**
In the case of comparing two passwords for instance (password & passwordConfirmation), it would be great to have a way of comparing the two inside the schema.

**Solution**
Was created a new `ZodString` method: `equalsTo(field: string, message?: errorUtil.ErrMessage)`


Test file to look at:
`src/__tests__/string.test.ts`