### PR TITLE
fix ZodInvalidEnumValueIssue.options typings

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -69,9 +69,9 @@ export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
-  received: string | number;
+  received: string;
   code: typeof ZodIssueCode.invalid_enum_value;
-  options: (string | number)[];
+  options: string[];
 }
 
 export interface ZodInvalidArgumentsIssue extends ZodIssueBase {

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -69,9 +69,9 @@ export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
-  received: string | number;
+  received: string;
   code: typeof ZodIssueCode.invalid_enum_value;
-  options: (string | number)[];
+  options: string[];
 }
 
 export interface ZodInvalidArgumentsIssue extends ZodIssueBase {


### PR DESCRIPTION
ZodInvalidEnumValueIssue.options is incorrectly typed as if it could have numbers:
https://github.com/colinhacks/zod/blob/502384e56fe2b1f8173735df6c3b0d41bce04edc/src/ZodError.ts#L74

this contradicts `zod.enum` contract (which only accepts strings for options) and even contradicts the error handling documentation:

https://github.com/colinhacks/zod/blob/502384e56fe2b1f8173735df6c3b0d41bce04edc/ERROR_HANDLING.md?plain=1#L48

The PR updates the typings to only allow `string[]`.