### PR TITLE
Add `optionul` function to allow mapping nullish values to undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -2301,6 +2301,17 @@ const nullishString = z.string().nullish(); // string | null | undefined
 z.string().optional().nullable();
 ```
 
+### `.optionul`
+
+A convenience method that is sort of like a mash between `.optional` and `.nullish`. Optionul schemas will accept both `undefined` and `null`, while comverting `null` to `undefined`.
+
+```ts
+const optionul = z.string().optionul(); // string | null | undefined -> string | undefined
+
+// equivalent to
+z.string().nullish().transform(x => x ?? undefined);
+```
+
 ### `.array`
 
 A convenience method that returns an array schema for the given type:

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -57,8 +57,8 @@
 - [Coercion for primitives](#coercion-for-primitives)
 - [Literals](#literals)
 - [Strings](#strings)
-  - [Datetime](#datetime-validation)
-  - [IP](#ip-address-validation)
+  - [Datetime](#iso-datetimes)
+  - [IP](#ip-addresses)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -431,6 +431,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 - [`houseform`](https://github.com/crutchcorn/houseform/): A React form library that uses Zod for validation.
 - [`sveltekit-superforms`](https://github.com/ciscoheat/sveltekit-superforms): Supercharged form library for SvelteKit with Zod validation.
+- [`mobx-zod-form`](https://github.com/MonoidDev/mobx-zod-form): Data-first form builder based on MobX & Zod
 
 #### Zod to X
 
@@ -623,7 +624,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");
@@ -2298,6 +2299,17 @@ const nullishString = z.string().nullish(); // string | null | undefined
 
 // equivalent to
 z.string().optional().nullable();
+```
+
+### `.optionul`
+
+A convenience method that is sort of like a mash between `.optional` and `.nullish`. Optionul schemas will accept both `undefined` and `null`, while comverting `null` to `undefined`.
+
+```ts
+const optionul = z.string().optionul(); // string | null | undefined -> string | undefined
+
+// equivalent to
+z.string().nullish().transform(x => x ?? undefined);
 ```
 
 ### `.array`

--- a/deno/lib/__tests__/nullable.test.ts
+++ b/deno/lib/__tests__/nullable.test.ts
@@ -41,3 +41,9 @@ test("unwrap", () => {
   const unwrapped = z.string().nullable().unwrap();
   expect(unwrapped).toBeInstanceOf(z.ZodString);
 });
+
+test("optionul", () =>
+{
+  const optionul = z.string().optionul();
+  expect(optionul.parse(null)).toBe(undefined);
+})

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -176,3 +176,5 @@ export const isAsync = <T>(
   x: ParseReturnType<T>
 ): x is AsyncParseReturnType<T> =>
   typeof Promise !== "undefined" && x instanceof Promise;
+
+export const nullToUndefined = <T>(x: T | null | undefined): T | undefined => x ?? undefined;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -11,6 +11,7 @@ import {
   isDirty,
   isValid,
   makeIssue,
+  nullToUndefined,
   OK,
   ParseContext,
   ParseInput,
@@ -414,6 +415,13 @@ export abstract class ZodType<
   }
   nullish(): ZodOptional<ZodNullable<this>> {
     return this.nullable().optional();
+  }
+  optionul(): ZodEffects<
+    ZodOptional<ZodNullable<this>>,
+    this["_output"] | undefined,
+    this["_input"] | null | undefined
+  > {
+    return this.nullish().transform(nullToUndefined);
   }
   array(): ZodArray<this> {
     return ZodArray.create(this, this._def);

--- a/src/__tests__/nullable.test.ts
+++ b/src/__tests__/nullable.test.ts
@@ -40,3 +40,9 @@ test("unwrap", () => {
   const unwrapped = z.string().nullable().unwrap();
   expect(unwrapped).toBeInstanceOf(z.ZodString);
 });
+
+test("optionul", () =>
+{
+  const optionul = z.string().optionul();
+  expect(optionul.parse(null)).toBe(undefined);
+})

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -176,3 +176,5 @@ export const isAsync = <T>(
   x: ParseReturnType<T>
 ): x is AsyncParseReturnType<T> =>
   typeof Promise !== "undefined" && x instanceof Promise;
+
+export const nullToUndefined = <T>(x: T | null | undefined): T | undefined => x ?? undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ import {
   isDirty,
   isValid,
   makeIssue,
+  nullToUndefined,
   OK,
   ParseContext,
   ParseInput,
@@ -414,6 +415,13 @@ export abstract class ZodType<
   }
   nullish(): ZodOptional<ZodNullable<this>> {
     return this.nullable().optional();
+  }
+  optionul(): ZodEffects<
+    ZodOptional<ZodNullable<this>>,
+    this["_output"] | undefined,
+    this["_input"] | null | undefined
+  > {
+    return this.nullish().transform(nullToUndefined);
   }
   array(): ZodArray<this> {
     return ZodArray.create(this, this._def);


### PR DESCRIPTION
`optionul` allows accepting nullish values (`null` and `undefined`), but then transforms `null` into `undefined`.

Example:
```ts
const optionul = z.string().optionul(); // string | null | undefined -> string | undefined

// equivalent to
z.string().nullish().transform(x => x ?? undefined);
```

Very useful for me as I need to ensure that I pass old data coming in from a server into a system that uses the `undefined` type.