### PR TITLE
docs: adapt demonstrative example

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -130,12 +130,6 @@ Here are the errors that will be printed:
     message: "Invalid input: expected string, received number",
   },
   {
-    code: "unrecognized_keys",
-    keys: ["extra"],
-    path: ["address"],
-    message: "Unrecognized key(s) in object: 'extra'",
-  },
-  {
     code: "too_small",
     minimum: 10000,
     type: "number",

--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -108,7 +108,7 @@ try {
     address: {
       line1: "123 Maple Ave",
       zipCode: 123, // zip code isn't 5 digits
-      extra: "other stuff", // unrecognized key
+      extra: "other stuff",
     },
   });
 } catch (err) {
@@ -146,7 +146,7 @@ Here are the errors that will be printed:
 ];
 ```
 
-As you can see three different issues were identified. Every ZodIssue has a `code` property and additional metadata about the validation failure. For instance the `unrecognized_keys` error provides a list of the unrecognized keys detected in the input.
+As you can see three different issues were identified. Every ZodIssue has a `code` property and additional metadata about the validation failure. For instance the `invalid_type` error provides information about the expected and received types.
 
 ## Customizing errors with ZodErrorMap
 


### PR DESCRIPTION
To the best of my knowledge, it is not true that zod will throw an error for extra fields per default. According to the docs, to achieve this, we'd need to use `.strict()` our object. See: https://zod.dev/?id=strict

I've opted for just removing this one validation from the example, but we can replace it with a different one if you prefer to have 3 errors in the result set.