### PR TITLE
feat: add `partialRefine` method

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -57,8 +57,8 @@
 - [Coercion for primitives](#coercion-for-primitives)
 - [Literals](#literals)
 - [Strings](#strings)
-  - [Datetime](#datetime-validation)
-  - [IP](#ip-address-validation)
+  - [Datetime](#iso-datetimes)
+  - [IP](#ip-addresses)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -431,6 +431,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 - [`houseform`](https://github.com/crutchcorn/houseform/): A React form library that uses Zod for validation.
 - [`sveltekit-superforms`](https://github.com/ciscoheat/sveltekit-superforms): Supercharged form library for SvelteKit with Zod validation.
+- [`mobx-zod-form`](https://github.com/MonoidDev/mobx-zod-form): Data-first form builder based on MobX & Zod
 
 #### Zod to X
 
@@ -623,7 +624,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -50,6 +50,101 @@ test("refinement 2", () => {
   ).toThrow();
 });
 
+test("partial refinement", () => {
+  const validationSchema = z
+    .object({
+      email: z.string().email(),
+      password: z.string(),
+      confirmPassword: z.string(),
+    })
+    .partialRefine(
+      ["password", "confirmPassword"],
+      data => data.password === data.confirmPassword,
+      "Both password and confirmation must match"
+    );
+
+  const result = validationSchema.safeParse({
+    password: "aaaaaaaa",
+    confirmPassword: "bbbbbbbb",
+  });
+
+  expect(result.success).toBe(false);
+
+  // Check just for Typescript type inference
+  if (result.success === false) {
+    expect(result.error.errors).toHaveLength(2);
+
+    expect(result.error).toMatchInlineSnapshot(`
+      [ZodError: [
+        {
+          "code": "invalid_type",
+          "expected": "string",
+          "received": "undefined",
+          "path": [
+            "email"
+          ],
+          "message": "Required"
+        },
+        {
+          "code": "custom",
+          "message": "Both password and confirmation must match",
+          "path": []
+        }
+      ]]
+    `);
+  }
+});
+
+test("partial refinement options", () => {
+  const validationSchema = z
+    .object({
+      email: z.string().email(),
+      password: z.string(),
+      confirmPassword: z.string(),
+    })
+    .partialRefine(
+      ["password", "confirmPassword"],
+      data => data.password === data.confirmPassword,
+      {
+        path: ["confirmPassword"],
+        message: "Both password and confirmation must match",
+      }
+    );
+
+  const result = validationSchema.safeParse({
+    password: "aaaaaaaa",
+    confirmPassword: "bbbbbbbb",
+  });
+
+  expect(result.success).toBe(false);
+
+  // Check just for Typescript type inference
+  if (result.success === false) {
+    expect(result.error.errors).toHaveLength(2);
+
+    expect(result.error).toMatchInlineSnapshot(`
+      [ZodError: [
+        {
+          "code": "invalid_type",
+          "expected": "string",
+          "received": "undefined",
+          "path": [
+            "email"
+          ],
+          "message": "Required"
+        },
+        {
+          "code": "custom",
+          "path": [
+            "confirmPassword"
+          ],
+          "message": "Both password and confirmation must match"
+        }
+      ]]
+    `);
+  }
+});
+
 test("refinement type guard", () => {
   const validationSchema = z.object({
     a: z.string().refine((s): s is "a" => s === "a"),

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -69,29 +69,13 @@ test("partial refinement", () => {
   });
 
   expect(result.success).toBe(false);
-
-  // Check just for Typescript type inference
   if (result.success === false) {
-    expect(result.error.errors).toHaveLength(2);
-
-    expect(result.error).toMatchInlineSnapshot(`
-      [ZodError: [
-        {
-          "code": "invalid_type",
-          "expected": "string",
-          "received": "undefined",
-          "path": [
-            "email"
-          ],
-          "message": "Required"
-        },
-        {
-          "code": "custom",
-          "message": "Both password and confirmation must match",
-          "path": []
-        }
-      ]]
-    `);
+    expect(result.error.issues.length).toEqual(2);
+    expect(result.error.issues[0].code).toEqual(ZodIssueCode.invalid_type);
+    expect(result.error.issues[0].path).toEqual(["email"]);
+    expect(result.error.issues[1].code).toEqual(ZodIssueCode.custom);
+    expect(result.error.issues[1].path).toEqual([])
+    expect(result.error.issues[1].message).toEqual("Both password and confirmation must match");
   }
 });
 
@@ -117,31 +101,13 @@ test("partial refinement options", () => {
   });
 
   expect(result.success).toBe(false);
-
-  // Check just for Typescript type inference
   if (result.success === false) {
-    expect(result.error.errors).toHaveLength(2);
-
-    expect(result.error).toMatchInlineSnapshot(`
-      [ZodError: [
-        {
-          "code": "invalid_type",
-          "expected": "string",
-          "received": "undefined",
-          "path": [
-            "email"
-          ],
-          "message": "Required"
-        },
-        {
-          "code": "custom",
-          "path": [
-            "confirmPassword"
-          ],
-          "message": "Both password and confirmation must match"
-        }
-      ]]
-    `);
+    expect(result.error.issues.length).toEqual(2);
+    expect(result.error.issues[0].code).toEqual(ZodIssueCode.invalid_type);
+    expect(result.error.issues[0].path).toEqual(["email"]);
+    expect(result.error.issues[1].code).toEqual(ZodIssueCode.custom);
+    expect(result.error.issues[1].path).toEqual(["confirmPassword"]);
+    expect(result.error.issues[1].message).toEqual("Both password and confirmation must match");
   }
 });
 

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -68,29 +68,13 @@ test("partial refinement", () => {
   });
 
   expect(result.success).toBe(false);
-
-  // Check just for Typescript type inference
   if (result.success === false) {
-    expect(result.error.errors).toHaveLength(2);
-
-    expect(result.error).toMatchInlineSnapshot(`
-      [ZodError: [
-        {
-          "code": "invalid_type",
-          "expected": "string",
-          "received": "undefined",
-          "path": [
-            "email"
-          ],
-          "message": "Required"
-        },
-        {
-          "code": "custom",
-          "message": "Both password and confirmation must match",
-          "path": []
-        }
-      ]]
-    `);
+    expect(result.error.issues.length).toEqual(2);
+    expect(result.error.issues[0].code).toEqual(ZodIssueCode.invalid_type);
+    expect(result.error.issues[0].path).toEqual(["email"]);
+    expect(result.error.issues[1].code).toEqual(ZodIssueCode.custom);
+    expect(result.error.issues[1].path).toEqual([])
+    expect(result.error.issues[1].message).toEqual("Both password and confirmation must match");
   }
 });
 
@@ -116,31 +100,13 @@ test("partial refinement options", () => {
   });
 
   expect(result.success).toBe(false);
-
-  // Check just for Typescript type inference
   if (result.success === false) {
-    expect(result.error.errors).toHaveLength(2);
-
-    expect(result.error).toMatchInlineSnapshot(`
-      [ZodError: [
-        {
-          "code": "invalid_type",
-          "expected": "string",
-          "received": "undefined",
-          "path": [
-            "email"
-          ],
-          "message": "Required"
-        },
-        {
-          "code": "custom",
-          "path": [
-            "confirmPassword"
-          ],
-          "message": "Both password and confirmation must match"
-        }
-      ]]
-    `);
+    expect(result.error.issues.length).toEqual(2);
+    expect(result.error.issues[0].code).toEqual(ZodIssueCode.invalid_type);
+    expect(result.error.issues[0].path).toEqual(["email"]);
+    expect(result.error.issues[1].code).toEqual(ZodIssueCode.custom);
+    expect(result.error.issues[1].path).toEqual(["confirmPassword"]);
+    expect(result.error.issues[1].message).toEqual("Both password and confirmation must match");
   }
 });
 


### PR DESCRIPTION
`partialRefine` is equivalent to `refine` but does not require entire object schema to be valid. It will run when all specified fields are valid instead. This allows for validation of dependent fields.

```ts
const validationSchema = z
  .object({
    email: z.string().email(),
    password: z.string(),
    confirmPassword: z.string(),
  })
  .partialRefine(
    ["password", "confirmPassword"],
    data => data.password === data.confirmPassword,
    {
      path: ["confirmPassword"],
      message: "Both password and confirmation must match",
    }
  );
```

Closes: #2284