### PR TITLE
Adds support for Nano ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ z.string().email();
 z.string().url();
 z.string().emoji();
 z.string().uuid();
+z.string().nanoid();
 z.string().cuid();
 z.string().cuid2();
 z.string().ulid();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -843,6 +843,7 @@ z.string().email();
 z.string().url();
 z.string().emoji();
 z.string().uuid();
+z.string().nanoid();
 z.string().cuid();
 z.string().cuid2();
 z.string().ulid();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -900,9 +900,9 @@ date/time library. However, they are very convenient for validating user input.
 
 The `z.string().date()` method validates strings in the format `YYYY-MM-DD`.
 
-The `z.string().time()` method validates strings in the format `HH:mm:ss[.SSSSSS][Z|(+|-)hh[:]mm]` 
-(the time portion of [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)). It defaults 
-to `HH:mm:ss[.SSSSSS]` validation: no timezone offsets or `Z`, with arbitrary sub-second 
+The `z.string().time()` method validates strings in the format `HH:mm:ss[.SSSSSS][Z|(+|-)hh[:]mm]`
+(the time portion of [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)). It defaults
+to `HH:mm:ss[.SSSSSS]` validation: no timezone offsets or `Z`, with arbitrary sub-second
 decimal.
 
 The `z.string().datetime()` method enforces ISO 8601; default is no timezone offsets and arbitrary sub-second decimal precision.

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -93,6 +93,7 @@ export type StringValidation =
   | "url"
   | "emoji"
   | "uuid"
+  | "nanoid"
   | "regex"
   | "cuid"
   | "cuid2"

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -230,6 +230,29 @@ test("bad uuid", () => {
   }
 });
 
+test("nanoid", () => {
+  const nanoid = z.string().nanoid("custom error");
+  nanoid.parse("lfNZluvAxMkf7Q8C5H-QS");
+  nanoid.parse("mIU_4PJWikaU8fMbmkouz");
+  nanoid.parse("Hb9ZUtUa2JDm_dD-47EGv"); 
+  nanoid.parse("5Noocgv_8vQ9oPijj4ioQ"); 
+  const result = nanoid.safeParse("Xq90uDyhddC53KsoASYJGX");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
+test("bad nanoid", () => {
+  const nanoid = z.string().nanoid("custom error");
+  nanoid.parse("ySh_984wpDUu7IQRrLXAp");
+  const result = nanoid.safeParse("invalid nanoid");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
 test("cuid", () => {
   const cuid = z.string().cuid();
   cuid.parse("ckopqwooh000001la8mbi2im9");
@@ -309,6 +332,7 @@ test("checks getters", () => {
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isCUID2).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
+  expect(z.string().email().isNANOID).toEqual(false);
   expect(z.string().email().isIP).toEqual(false);
   expect(z.string().email().isULID).toEqual(false);
 
@@ -317,6 +341,7 @@ test("checks getters", () => {
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isCUID2).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
+  expect(z.string().url().isNANOID).toEqual(false);
   expect(z.string().url().isIP).toEqual(false);
   expect(z.string().url().isULID).toEqual(false);
 
@@ -325,6 +350,7 @@ test("checks getters", () => {
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isCUID2).toEqual(false);
   expect(z.string().cuid().isUUID).toEqual(false);
+  expect(z.string().cuid().isNANOID).toEqual(false);
   expect(z.string().cuid().isIP).toEqual(false);
   expect(z.string().cuid().isULID).toEqual(false);
 
@@ -333,6 +359,7 @@ test("checks getters", () => {
   expect(z.string().cuid2().isCUID).toEqual(false);
   expect(z.string().cuid2().isCUID2).toEqual(true);
   expect(z.string().cuid2().isUUID).toEqual(false);
+  expect(z.string().cuid2().isNANOID).toEqual(false);
   expect(z.string().cuid2().isIP).toEqual(false);
   expect(z.string().cuid2().isULID).toEqual(false);
 
@@ -341,14 +368,25 @@ test("checks getters", () => {
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isCUID2).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
+  expect(z.string().uuid().isNANOID).toEqual(false);
   expect(z.string().uuid().isIP).toEqual(false);
   expect(z.string().uuid().isULID).toEqual(false);
+
+  expect(z.string().nanoid().isEmail).toEqual(false);
+  expect(z.string().nanoid().isURL).toEqual(false);
+  expect(z.string().nanoid().isCUID).toEqual(false);
+  expect(z.string().nanoid().isCUID2).toEqual(false);
+  expect(z.string().nanoid().isUUID).toEqual(false);
+  expect(z.string().nanoid().isNANOID).toEqual(true);
+  expect(z.string().nanoid().isIP).toEqual(false);
+  expect(z.string().nanoid().isULID).toEqual(false);
 
   expect(z.string().ip().isEmail).toEqual(false);
   expect(z.string().ip().isURL).toEqual(false);
   expect(z.string().ip().isCUID).toEqual(false);
   expect(z.string().ip().isCUID2).toEqual(false);
   expect(z.string().ip().isUUID).toEqual(false);
+  expect(z.string().ip().isNANOID).toEqual(false);
   expect(z.string().ip().isIP).toEqual(true);
   expect(z.string().ip().isULID).toEqual(false);
 
@@ -357,6 +395,7 @@ test("checks getters", () => {
   expect(z.string().ulid().isCUID).toEqual(false);
   expect(z.string().ulid().isCUID2).toEqual(false);
   expect(z.string().ulid().isUUID).toEqual(false);
+  expect(z.string().ulid().isNANOID).toEqual(false);
   expect(z.string().ulid().isIP).toEqual(false);
   expect(z.string().ulid().isULID).toEqual(true);
 });

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -112,9 +112,11 @@ export class ParseStatus {
   ): Promise<SyncParseReturnType<any>> {
     const syncPairs: ObjectPair[] = [];
     for (const pair of pairs) {
+      const key = await pair.key;
+      const value = await pair.value;
       syncPairs.push({
-        key: await pair.key,
-        value: await pair.value,
+        key,
+        value,
       });
     }
     return ParseStatus.mergeObjectSync(status, syncPairs);

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -529,6 +529,7 @@ export type ZodStringCheck =
   | { kind: "url"; message?: string }
   | { kind: "emoji"; message?: string }
   | { kind: "uuid"; message?: string }
+  | { kind: "nanoid"; message?: string }
   | { kind: "cuid"; message?: string }
   | { kind: "includes"; value: string; position?: number; message?: string }
   | { kind: "cuid2"; message?: string }
@@ -570,6 +571,7 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 const uuidRegex =
   /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+const nanoidRegex = /^[a-z0-9_-]{21}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
@@ -755,6 +757,16 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           });
           status.dirty();
         }
+      } else if (check.kind === "nanoid") {
+        if (!nanoidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "nanoid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "cuid") {
         if (!cuidRegex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
@@ -933,7 +945,13 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   uuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "uuid", ...errorUtil.errToObj(message) });
   }
+<<<<<<< HEAD
 
+=======
+  nanoid(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "nanoid", ...errorUtil.errToObj(message) });
+  }
+>>>>>>> f2615c0 (Added support for nanoid)
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
   }
@@ -1124,7 +1142,13 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   get isUUID() {
     return !!this._def.checks.find((ch) => ch.kind === "uuid");
   }
+<<<<<<< HEAD
 
+=======
+  get isNANOID() {
+    return !!this._def.checks.find((ch) => ch.kind === "nanoid");
+  }
+>>>>>>> f2615c0 (Added support for nanoid)
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
   }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -570,7 +570,7 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 const uuidRegex =
-  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+  /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 const nanoidRegex = /^[a-z0-9_-]{21}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
@@ -945,13 +945,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   uuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "uuid", ...errorUtil.errToObj(message) });
   }
-<<<<<<< HEAD
-
-=======
   nanoid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "nanoid", ...errorUtil.errToObj(message) });
   }
->>>>>>> f2615c0 (Added support for nanoid)
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
   }
@@ -1142,13 +1138,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   get isUUID() {
     return !!this._def.checks.find((ch) => ch.kind === "uuid");
   }
-<<<<<<< HEAD
-
-=======
   get isNANOID() {
     return !!this._def.checks.find((ch) => ch.kind === "nanoid");
   }
->>>>>>> f2615c0 (Added support for nanoid)
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
   }
@@ -2474,9 +2466,10 @@ export class ZodObject<
           const syncPairs: any[] = [];
           for (const pair of pairs) {
             const key = await pair.key;
+            const value = await pair.value;
             syncPairs.push({
               key,
-              value: await pair.value,
+              value,
               alwaysSet: pair.alwaysSet,
             });
           }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -570,7 +570,7 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 const uuidRegex =
-  /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
+  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 const nanoidRegex = /^[a-z0-9_-]{21}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -93,6 +93,7 @@ export type StringValidation =
   | "url"
   | "emoji"
   | "uuid"
+  | "nanoid"
   | "regex"
   | "cuid"
   | "cuid2"

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -229,6 +229,29 @@ test("bad uuid", () => {
   }
 });
 
+test("nanoid", () => {
+  const nanoid = z.string().nanoid("custom error");
+  nanoid.parse("lfNZluvAxMkf7Q8C5H-QS");
+  nanoid.parse("mIU_4PJWikaU8fMbmkouz");
+  nanoid.parse("Hb9ZUtUa2JDm_dD-47EGv"); 
+  nanoid.parse("5Noocgv_8vQ9oPijj4ioQ"); 
+  const result = nanoid.safeParse("Xq90uDyhddC53KsoASYJGX");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
+test("bad nanoid", () => {
+  const nanoid = z.string().nanoid("custom error");
+  nanoid.parse("ySh_984wpDUu7IQRrLXAp");
+  const result = nanoid.safeParse("invalid nanoid");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
 test("cuid", () => {
   const cuid = z.string().cuid();
   cuid.parse("ckopqwooh000001la8mbi2im9");
@@ -308,6 +331,7 @@ test("checks getters", () => {
   expect(z.string().email().isCUID).toEqual(false);
   expect(z.string().email().isCUID2).toEqual(false);
   expect(z.string().email().isUUID).toEqual(false);
+  expect(z.string().email().isNANOID).toEqual(false);
   expect(z.string().email().isIP).toEqual(false);
   expect(z.string().email().isULID).toEqual(false);
 
@@ -316,6 +340,7 @@ test("checks getters", () => {
   expect(z.string().url().isCUID).toEqual(false);
   expect(z.string().url().isCUID2).toEqual(false);
   expect(z.string().url().isUUID).toEqual(false);
+  expect(z.string().url().isNANOID).toEqual(false);
   expect(z.string().url().isIP).toEqual(false);
   expect(z.string().url().isULID).toEqual(false);
 
@@ -324,6 +349,7 @@ test("checks getters", () => {
   expect(z.string().cuid().isCUID).toEqual(true);
   expect(z.string().cuid().isCUID2).toEqual(false);
   expect(z.string().cuid().isUUID).toEqual(false);
+  expect(z.string().cuid().isNANOID).toEqual(false);
   expect(z.string().cuid().isIP).toEqual(false);
   expect(z.string().cuid().isULID).toEqual(false);
 
@@ -332,6 +358,7 @@ test("checks getters", () => {
   expect(z.string().cuid2().isCUID).toEqual(false);
   expect(z.string().cuid2().isCUID2).toEqual(true);
   expect(z.string().cuid2().isUUID).toEqual(false);
+  expect(z.string().cuid2().isNANOID).toEqual(false);
   expect(z.string().cuid2().isIP).toEqual(false);
   expect(z.string().cuid2().isULID).toEqual(false);
 
@@ -340,14 +367,25 @@ test("checks getters", () => {
   expect(z.string().uuid().isCUID).toEqual(false);
   expect(z.string().uuid().isCUID2).toEqual(false);
   expect(z.string().uuid().isUUID).toEqual(true);
+  expect(z.string().uuid().isNANOID).toEqual(false);
   expect(z.string().uuid().isIP).toEqual(false);
   expect(z.string().uuid().isULID).toEqual(false);
+
+  expect(z.string().nanoid().isEmail).toEqual(false);
+  expect(z.string().nanoid().isURL).toEqual(false);
+  expect(z.string().nanoid().isCUID).toEqual(false);
+  expect(z.string().nanoid().isCUID2).toEqual(false);
+  expect(z.string().nanoid().isUUID).toEqual(false);
+  expect(z.string().nanoid().isNANOID).toEqual(true);
+  expect(z.string().nanoid().isIP).toEqual(false);
+  expect(z.string().nanoid().isULID).toEqual(false);
 
   expect(z.string().ip().isEmail).toEqual(false);
   expect(z.string().ip().isURL).toEqual(false);
   expect(z.string().ip().isCUID).toEqual(false);
   expect(z.string().ip().isCUID2).toEqual(false);
   expect(z.string().ip().isUUID).toEqual(false);
+  expect(z.string().ip().isNANOID).toEqual(false);
   expect(z.string().ip().isIP).toEqual(true);
   expect(z.string().ip().isULID).toEqual(false);
 
@@ -356,6 +394,7 @@ test("checks getters", () => {
   expect(z.string().ulid().isCUID).toEqual(false);
   expect(z.string().ulid().isCUID2).toEqual(false);
   expect(z.string().ulid().isUUID).toEqual(false);
+  expect(z.string().ulid().isNANOID).toEqual(false);
   expect(z.string().ulid().isIP).toEqual(false);
   expect(z.string().ulid().isULID).toEqual(true);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -529,6 +529,7 @@ export type ZodStringCheck =
   | { kind: "url"; message?: string }
   | { kind: "emoji"; message?: string }
   | { kind: "uuid"; message?: string }
+  | { kind: "nanoid"; message?: string }
   | { kind: "cuid"; message?: string }
   | { kind: "includes"; value: string; position?: number; message?: string }
   | { kind: "cuid2"; message?: string }
@@ -569,7 +570,8 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 const uuidRegex =
-  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+  /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
+const nanoidRegex = /^[a-z0-9_-]{21}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
@@ -755,6 +757,16 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           });
           status.dirty();
         }
+      } else if (check.kind === "nanoid") {
+        if (!nanoidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "nanoid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "cuid") {
         if (!cuidRegex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
@@ -933,7 +945,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   uuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "uuid", ...errorUtil.errToObj(message) });
   }
-
+  nanoid(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "nanoid", ...errorUtil.errToObj(message) });
+  }
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });
   }
@@ -1124,7 +1138,9 @@ export class ZodString extends ZodType<string, ZodStringDef> {
   get isUUID() {
     return !!this._def.checks.find((ch) => ch.kind === "uuid");
   }
-
+  get isNANOID() {
+    return !!this._def.checks.find((ch) => ch.kind === "nanoid");
+  }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -570,7 +570,7 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 const uuidRegex =
-  /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
+  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 const nanoidRegex = /^[a-z0-9_-]{21}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode


### PR DESCRIPTION
This adds support for [Nano ID](https://www.npmjs.com/package/nanoid), a unique string/id standard. Nano ID is great because it's url friendly, a fixed length, and significantly shorter than UUIDs.

Note: The Nano ID package does allow for a custom character dictionary and id length, however the regex in this PR only matches the default Nano ID specification.