### PR TITLE
feat: Add `was` to `too_small` and `too_big` issues

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -138,6 +138,7 @@ Here are the errors that will be printed:
   {
     code: "too_small",
     minimum: 10000,
+    had: 123,
     type: "number",
     inclusive: true,
     path: ["address", "zipCode"],

--- a/README.md
+++ b/README.md
@@ -2054,6 +2054,7 @@ const Strings = z.array(z.string()).superRefine((val, ctx) => {
     ctx.addIssue({
       code: z.ZodIssueCode.too_big,
       maximum: 3,
+      had: val.length,
       type: "array",
       inclusive: true,
       message: "Too many items 😡",

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -2053,6 +2053,7 @@ const Strings = z.array(z.string()).superRefine((val, ctx) => {
     ctx.addIssue({
       code: z.ZodIssueCode.too_big,
       maximum: 3,
+      had: val.length,
       type: "array",
       inclusive: true,
       message: "Too many items 😡",

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -111,6 +111,7 @@ export interface ZodInvalidStringIssue extends ZodIssueBase {
 export interface ZodTooSmallIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_small;
   minimum: number | bigint;
+  had: number | bigint;
   inclusive: boolean;
   exact?: boolean;
   type: "array" | "string" | "number" | "set" | "date" | "bigint";
@@ -119,6 +120,7 @@ export interface ZodTooSmallIssue extends ZodIssueBase {
 export interface ZodTooBigIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_big;
   maximum: number | bigint;
+  had: number | bigint;
   inclusive: boolean;
   exact?: boolean;
   type: "array" | "string" | "number" | "set" | "date" | "bigint";

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -133,6 +133,7 @@ test("superRefine", () => {
       ctx.addIssue({
         code: z.ZodIssueCode.too_big,
         maximum: 3,
+        had: val.length,
         type: "array",
         inclusive: true,
         exact: true,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -636,6 +636,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_small,
             minimum: check.value,
+            had: input.data.length,
             type: "string",
             inclusive: true,
             exact: false,
@@ -649,6 +650,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_big,
             maximum: check.value,
+            had: input.data.length,
             type: "string",
             inclusive: true,
             exact: false,
@@ -665,6 +667,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
             addIssueToContext(ctx, {
               code: ZodIssueCode.too_big,
               maximum: check.value,
+              had: input.data.length,
               type: "string",
               inclusive: true,
               exact: true,
@@ -674,6 +677,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
             addIssueToContext(ctx, {
               code: ZodIssueCode.too_small,
               minimum: check.value,
+              had: input.data.length,
               type: "string",
               inclusive: true,
               exact: true,
@@ -1112,6 +1116,7 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_small,
             minimum: check.value,
+            had: input.data,
             type: "number",
             inclusive: check.inclusive,
             exact: false,
@@ -1128,6 +1133,7 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_big,
             maximum: check.value,
+            had: input.data,
             type: "number",
             inclusive: check.inclusive,
             exact: false,
@@ -1386,6 +1392,7 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_small,
             type: "bigint",
+            had: input.data,
             minimum: check.value,
             inclusive: check.inclusive,
             message: check.message,
@@ -1401,6 +1408,7 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_big,
             type: "bigint",
+            had: input.data,
             maximum: check.value,
             inclusive: check.inclusive,
             message: check.message,
@@ -1642,6 +1650,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
             inclusive: true,
             exact: false,
             minimum: check.value,
+            had: input.data.getTime(),
             type: "date",
           });
           status.dirty();
@@ -1655,6 +1664,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
             inclusive: true,
             exact: false,
             maximum: check.value,
+            had: input.data.getTime(),
             type: "date",
           });
           status.dirty();
@@ -2000,6 +2010,7 @@ export class ZodArray<
           code: tooBig ? ZodIssueCode.too_big : ZodIssueCode.too_small,
           minimum: (tooSmall ? def.exactLength.value : undefined) as number,
           maximum: (tooBig ? def.exactLength.value : undefined) as number,
+          had: ctx.data.length,
           type: "array",
           inclusive: true,
           exact: true,
@@ -2014,6 +2025,7 @@ export class ZodArray<
         addIssueToContext(ctx, {
           code: ZodIssueCode.too_small,
           minimum: def.minLength.value,
+          had: ctx.data.length,
           type: "array",
           inclusive: true,
           exact: false,
@@ -2028,6 +2040,7 @@ export class ZodArray<
         addIssueToContext(ctx, {
           code: ZodIssueCode.too_big,
           maximum: def.maxLength.value,
+          had: ctx.data.length,
           type: "array",
           inclusive: true,
           exact: false,
@@ -3231,6 +3244,7 @@ export class ZodTuple<
       addIssueToContext(ctx, {
         code: ZodIssueCode.too_small,
         minimum: this._def.items.length,
+        had: ctx.data.length,
         inclusive: true,
         exact: false,
         type: "array",
@@ -3245,6 +3259,7 @@ export class ZodTuple<
       addIssueToContext(ctx, {
         code: ZodIssueCode.too_big,
         maximum: this._def.items.length,
+        had: ctx.data.length,
         inclusive: true,
         exact: false,
         type: "array",
@@ -3547,6 +3562,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
         addIssueToContext(ctx, {
           code: ZodIssueCode.too_small,
           minimum: def.minSize.value,
+          had: ctx.data.size,
           type: "set",
           inclusive: true,
           exact: false,
@@ -3561,6 +3577,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
         addIssueToContext(ctx, {
           code: ZodIssueCode.too_big,
           maximum: def.maxSize.value,
+          had: ctx.data.size,
           type: "set",
           inclusive: true,
           exact: false,

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -111,6 +111,7 @@ export interface ZodInvalidStringIssue extends ZodIssueBase {
 export interface ZodTooSmallIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_small;
   minimum: number | bigint;
+  had: number | bigint;
   inclusive: boolean;
   exact?: boolean;
   type: "array" | "string" | "number" | "set" | "date" | "bigint";
@@ -119,6 +120,7 @@ export interface ZodTooSmallIssue extends ZodIssueBase {
 export interface ZodTooBigIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.too_big;
   maximum: number | bigint;
+  had: number | bigint;
   inclusive: boolean;
   exact?: boolean;
   type: "array" | "string" | "number" | "set" | "date" | "bigint";

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -132,6 +132,7 @@ test("superRefine", () => {
       ctx.addIssue({
         code: z.ZodIssueCode.too_big,
         maximum: 3,
+        had: val.length,
         type: "array",
         inclusive: true,
         exact: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -636,6 +636,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_small,
             minimum: check.value,
+            had: input.data.length,
             type: "string",
             inclusive: true,
             exact: false,
@@ -649,6 +650,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_big,
             maximum: check.value,
+            had: input.data.length,
             type: "string",
             inclusive: true,
             exact: false,
@@ -665,6 +667,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
             addIssueToContext(ctx, {
               code: ZodIssueCode.too_big,
               maximum: check.value,
+              had: input.data.length,
               type: "string",
               inclusive: true,
               exact: true,
@@ -674,6 +677,7 @@ export class ZodString extends ZodType<string, ZodStringDef> {
             addIssueToContext(ctx, {
               code: ZodIssueCode.too_small,
               minimum: check.value,
+              had: input.data.length,
               type: "string",
               inclusive: true,
               exact: true,
@@ -1112,6 +1116,7 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_small,
             minimum: check.value,
+            had: input.data,
             type: "number",
             inclusive: check.inclusive,
             exact: false,
@@ -1128,6 +1133,7 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
           addIssueToContext(ctx, {
             code: ZodIssueCode.too_big,
             maximum: check.value,
+            had: input.data,
             type: "number",
             inclusive: check.inclusive,
             exact: false,
@@ -1387,6 +1393,7 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
             code: ZodIssueCode.too_small,
             type: "bigint",
             minimum: check.value,
+            had: input.data,
             inclusive: check.inclusive,
             message: check.message,
           });
@@ -1402,6 +1409,7 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef> {
             code: ZodIssueCode.too_big,
             type: "bigint",
             maximum: check.value,
+            had: input.data,
             inclusive: check.inclusive,
             message: check.message,
           });
@@ -1642,6 +1650,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
             inclusive: true,
             exact: false,
             minimum: check.value,
+            had: input.data.getTime(),
             type: "date",
           });
           status.dirty();
@@ -1655,6 +1664,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef> {
             inclusive: true,
             exact: false,
             maximum: check.value,
+            had: input.data.getTime(),
             type: "date",
           });
           status.dirty();
@@ -2000,6 +2010,7 @@ export class ZodArray<
           code: tooBig ? ZodIssueCode.too_big : ZodIssueCode.too_small,
           minimum: (tooSmall ? def.exactLength.value : undefined) as number,
           maximum: (tooBig ? def.exactLength.value : undefined) as number,
+          had: input.data.length,
           type: "array",
           inclusive: true,
           exact: true,
@@ -2014,6 +2025,7 @@ export class ZodArray<
         addIssueToContext(ctx, {
           code: ZodIssueCode.too_small,
           minimum: def.minLength.value,
+          had: input.data.length,
           type: "array",
           inclusive: true,
           exact: false,
@@ -2028,6 +2040,7 @@ export class ZodArray<
         addIssueToContext(ctx, {
           code: ZodIssueCode.too_big,
           maximum: def.maxLength.value,
+          had: input.data.length,
           type: "array",
           inclusive: true,
           exact: false,
@@ -3231,6 +3244,7 @@ export class ZodTuple<
       addIssueToContext(ctx, {
         code: ZodIssueCode.too_small,
         minimum: this._def.items.length,
+        had: input.data.length,
         inclusive: true,
         exact: false,
         type: "array",
@@ -3245,6 +3259,7 @@ export class ZodTuple<
       addIssueToContext(ctx, {
         code: ZodIssueCode.too_big,
         maximum: this._def.items.length,
+        had: input.data.length,
         inclusive: true,
         exact: false,
         type: "array",
@@ -3547,6 +3562,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
         addIssueToContext(ctx, {
           code: ZodIssueCode.too_small,
           minimum: def.minSize.value,
+          had: input.data.size,
           type: "set",
           inclusive: true,
           exact: false,
@@ -3561,6 +3577,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
         addIssueToContext(ctx, {
           code: ZodIssueCode.too_big,
           maximum: def.maxSize.value,
+          had: input.data.size,
           type: "set",
           inclusive: true,
           exact: false,


### PR DESCRIPTION
This adds a `had` field to the `too_small` and `too_big` issue types, with the length/size/amount the subject actually had, which can be used when generating error messages. So, similar to how `invalid_type` has `expected` and `received`, `too_small` then has `minimum` and `had`, and `too_big` has `maximum` and `had`.

Usage is for example if you have a schema that is `z.string().min(5)`, and you want to differ between an empty string and a string that is too short.
```ts
// E.g. in an error map, for a too small string
return issue.had === 0
  ? 'must be filled out'
  : `must be at least ${issue.minimum} characters`
```