### PR TITLE
fix: move `types` condition to the front

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
-      "types": "./index.d.ts"
+      "import": "./lib/index.mjs"
     },
     "./package.json": "./package.json",
     "./locales/*": "./lib/locales/*"


### PR DESCRIPTION
I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

⚠️ note that this only fixes one problem (`🐛 Used fallback condition`) but this package still won't be completely correct: [arethetypeswrong](https://arethetypeswrong.github.io/?p=zod%403.21.4). 