### PR TITLE
docs: add tapiduck to API libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`domain-functions`](https://github.com/SeasonedSoftware/domain-functions/): Decouple your business logic from your framework using composable functions. With first-class type inference from end to end powered by Zod schemas.
 - [`@zodios/core`](https://github.com/ecyrbe/zodios): A typescript API client with runtime and compile time validation backed by axios and zod.
 - [`express-zod-api`](https://github.com/RobinTail/express-zod-api): Build Express-based APIs with I/O schema validation and custom middlewares.
+- [`tapiduck`](https://github.com/sumukhbarve/monoduck/blob/main/src/tapiduck/README.md): End-to-end typesafe JSON APIs with Zod and Express; a bit like tRPC, but simpler.
 
 #### Form integrations
 


### PR DESCRIPTION
Zod is brilliant. Thank you for creating and maintaining it.

tRPC is amazing too. It gives you fullstack intellisense without the need for GraphQL (or codegen.) But it still uses GraphQL-like "query" and "mutation" terminology. And [it isn't natively compatible](https://github.com/trpc/trpc/issues/755) with OpenAPI.

Tapiduck is a simpler and RESTful alternative to tRPC. It uses Zod for inferring shape definitions, and for enforcing runtime type validations. It is OpenAPI compatible, built on Express, and should feel familiar to most Node devs.