### PR TITLE
docs: Add `zocker` to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 
 - [`@anatine/zod-mock`](https://github.com/anatine/zod-plugins/tree/main/packages/zod-mock): Generate mock data from a Zod schema. Powered by [faker.js](https://github.com/faker-js/faker).
 - [`zod-mocking`](https://github.com/dipasqualew/zod-mocking): Generate mock data from your Zod schemas.
+- [`zocker`](https://zocker.sigrist.dev): Generate plausible mock-data from your schemas. 
 
 #### Powered by Zod
 


### PR DESCRIPTION
About a week ago I posted on the zod-discord about my project `Zocker`. It was then suggested I make a PR to add it to the added to the Ecosystem section, so here I am. 

Zocker is a mock-data generation library that generates plausible mock-data from zod-schemas, similar to `@anatine/zod-mock`, but supports a wider subset of `zod`. It too uses `faker` under the hood for semantically meaningful data.

A quick overview of what Zocker provides:
- Generation for most zod types (unfortunately not all types are possible to support in a library like this)
- Generation for Regex schemas on strings (thanks to the `randexp` package)
- Cyclic schemas
- Genration for `any` and `unknown` types
- Generation for `map`, `set`, `tuple`, `union` and `record` types
- An API for customising the generation process

For a full list of features & limitations check out the [docs](https://zocker.sigrist.dev)

I'm still working on the library, but don't plan on making breaking changes soon. 

Thank you for your consideration.