### PR TITLE
fix: super refinement function types

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -371,10 +371,10 @@ export abstract class ZodType<
     refinement: (arg: Output, ctx: RefinementCtx) => arg is RefinedOutput
   ): ZodEffects<this, RefinedOutput, Input>;
   superRefine(
-    refinement: (arg: Output, ctx: RefinementCtx) => void
+    refinement: (arg: Output, ctx: RefinementCtx) => void | Promise<void>
   ): ZodEffects<this, Output, Input>;
   superRefine(
-    refinement: (arg: Output, ctx: RefinementCtx) => unknown
+    refinement: (arg: Output, ctx: RefinementCtx) => unknown | Promise<unknown>
   ): ZodEffects<this, Output, Input> {
     return this._refinement(refinement);
   }
@@ -4174,7 +4174,7 @@ export class ZodPromise<T extends ZodTypeAny> extends ZodType<
 //////////////////////////////////////////////
 
 export type Refinement<T> = (arg: T, ctx: RefinementCtx) => any;
-export type SuperRefinement<T> = (arg: T, ctx: RefinementCtx) => void;
+export type SuperRefinement<T> = (arg: T, ctx: RefinementCtx) => void | Promise<void>;
 
 export type RefinementEffect<T> = {
   type: "refinement";

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -155,6 +155,35 @@ test("superRefine", () => {
   Strings.parse(["asfd", "qwer"]);
 });
 
+test("superRefine async", async () => {
+  const Strings = z.array(z.string()).superRefine(async (val, ctx) => {
+    if (val.length > 3) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.too_big,
+        maximum: 3,
+        type: "array",
+        inclusive: true,
+        exact: true,
+        message: "Too many items 😡",
+      });
+    }
+
+    if (val.length !== new Set(val).size) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `No duplicates allowed.`,
+      });
+    }
+  });
+
+  const result = await Strings.safeParseAsync(["asfd", "asfd", "asfd", "asfd"]);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) expect(result.error.issues.length).toEqual(2);
+
+  Strings.parseAsync(["asfd", "qwer"]);
+});
+
 test("superRefine - type narrowing", () => {
   type NarrowType = { type: string; age: number };
   const schema = z

--- a/src/types.ts
+++ b/src/types.ts
@@ -371,10 +371,10 @@ export abstract class ZodType<
     refinement: (arg: Output, ctx: RefinementCtx) => arg is RefinedOutput
   ): ZodEffects<this, RefinedOutput, Input>;
   superRefine(
-    refinement: (arg: Output, ctx: RefinementCtx) => void
+    refinement: (arg: Output, ctx: RefinementCtx) => void | Promise<void>
   ): ZodEffects<this, Output, Input>;
   superRefine(
-    refinement: (arg: Output, ctx: RefinementCtx) => unknown
+    refinement: (arg: Output, ctx: RefinementCtx) => unknown | Promise<unknown>
   ): ZodEffects<this, Output, Input> {
     return this._refinement(refinement);
   }
@@ -4174,7 +4174,7 @@ export class ZodPromise<T extends ZodTypeAny> extends ZodType<
 //////////////////////////////////////////////
 
 export type Refinement<T> = (arg: T, ctx: RefinementCtx) => any;
-export type SuperRefinement<T> = (arg: T, ctx: RefinementCtx) => void;
+export type SuperRefinement<T> = (arg: T, ctx: RefinementCtx) => void | Promise<void>;
 
 export type RefinementEffect<T> = {
   type: "refinement";


### PR DESCRIPTION
Typescript was complaining about the `.superRefine` argument returning a `Promise` when it was expecting a `void` return.

This fixes it so it accepts `Promise<void>` as a valid return value

Attachment of error:
<img width="627" alt="Screenshot 2023-05-11 at 11 36 09" src="https://github.com/colinhacks/zod/assets/42137191/a4be5487-637d-43ba-bb82-73ea99baf5ab">
