### PR TITLE
Adds `.assert` schema method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1922,6 +1922,18 @@ For convenience, this has been aliased to `.spa`:
 await stringSchema.spa("billie");
 ```
 
+### `.assert`
+
+Uses safeParse under the hood to assert the input type of the schema. Useful for inlining quick checks on unknown data that does not need to be transformed.
+
+```ts
+const data = JSON.parse('"billie"') as unknown
+
+if (z.string().assert(data)) {
+  // data is now recognized as a string by TS
+  data.toUpperCase().startsWith("B")
+}
+```
 ### `.refine`
 
 `.refine(validator: (data:T)=>any, params?: RefineParams)`

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -57,8 +57,8 @@
 - [Coercion for primitives](#coercion-for-primitives)
 - [Literals](#literals)
 - [Strings](#strings)
-  - [Datetime](#datetime-validation)
-  - [IP](#ip-address-validation)
+  - [Datetime](#iso-datetimes)
+  - [IP](#ip-addresses)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -431,6 +431,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 - [`houseform`](https://github.com/crutchcorn/houseform/): A React form library that uses Zod for validation.
 - [`sveltekit-superforms`](https://github.com/ciscoheat/sveltekit-superforms): Supercharged form library for SvelteKit with Zod validation.
+- [`mobx-zod-form`](https://github.com/MonoidDev/mobx-zod-form): Data-first form builder based on MobX & Zod
 
 #### Zod to X
 
@@ -460,6 +461,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 
 - [`@anatine/zod-mock`](https://github.com/anatine/zod-plugins/tree/main/packages/zod-mock): Generate mock data from a Zod schema. Powered by [faker.js](https://github.com/faker-js/faker).
 - [`zod-mocking`](https://github.com/dipasqualew/zod-mocking): Generate mock data from your Zod schemas.
+- [`zocker`](https://zocker.sigrist.dev): Generate plausible mock-data from your schemas. 
 
 #### Powered by Zod
 
@@ -623,7 +625,7 @@ z.coerce.boolean().parse(null); // => false
 
 ## Literals
 
-Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/literal-types.html), like `"hello world"` or `5`.
+Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
 
 ```ts
 const tuna = z.literal("tuna");
@@ -1920,6 +1922,18 @@ For convenience, this has been aliased to `.spa`:
 await stringSchema.spa("billie");
 ```
 
+### `.assert`
+
+Uses safeParse under the hood to assert the input type of the schema. Useful for inlining quick checks on unknown data that does not need to be transformed.
+
+```ts
+const data = JSON.parse('"billie"') as unknown
+
+if (z.string().assert(data)) {
+  // data is now recognized as a string by TS
+  data.toUpperCase().startsWith("B")
+}
+```
 ### `.refine`
 
 `.refine(validator: (data:T)=>any, params?: RefineParams)`

--- a/deno/lib/__tests__/assert.test.ts
+++ b/deno/lib/__tests__/assert.test.ts
@@ -1,0 +1,44 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+const stringSchema = z.string();
+
+test("assert fail", () => {
+  const data = 12 as unknown;
+  const asserted = stringSchema.assert(data);
+  let output = data;
+
+  if (asserted) {
+    // Type coerced from unknown to string. Should NOT happen in runtime.
+    output = data.toLowerCase?.();
+  }
+
+  expect(output).toBe(12);
+  expect(asserted).toBe(false);
+});
+
+test("assert pass", () => {
+  const data = "ABC" as unknown;
+  const asserted = stringSchema.assert(data);
+  let output = data;
+
+  if (asserted) {
+    // Type coerced from unknown to string. SHOULD happen in runtime.
+    output = data.toLowerCase();
+  }
+
+  expect(output).toBe("abc");
+  expect(asserted).toBe(true);
+});
+
+test("assert unexpected error", () => {
+  expect(() =>
+    stringSchema
+      .refine((data) => {
+        throw new Error(data);
+      })
+      .assert("12")
+  ).toThrow();
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -248,6 +248,10 @@ export abstract class ZodType<
     return handleResult(ctx, result);
   }
 
+  assert(data: unknown): data is Input {
+    return this.safeParse(data).success;
+  }
+
   async parseAsync(
     data: unknown,
     params?: Partial<ParseParams>

--- a/src/__tests__/assert.test.ts
+++ b/src/__tests__/assert.test.ts
@@ -1,0 +1,43 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+const stringSchema = z.string();
+
+test("assert fail", () => {
+  const data = 12 as unknown;
+  const asserted = stringSchema.assert(data);
+  let output = data;
+
+  if (asserted) {
+    // Type coerced from unknown to string. Should NOT happen in runtime.
+    output = data.toLowerCase?.();
+  }
+
+  expect(output).toBe(12);
+  expect(asserted).toBe(false);
+});
+
+test("assert pass", () => {
+  const data = "ABC" as unknown;
+  const asserted = stringSchema.assert(data);
+  let output = data;
+
+  if (asserted) {
+    // Type coerced from unknown to string. SHOULD happen in runtime.
+    output = data.toLowerCase();
+  }
+
+  expect(output).toBe("abc");
+  expect(asserted).toBe(true);
+});
+
+test("assert unexpected error", () => {
+  expect(() =>
+    stringSchema
+      .refine((data) => {
+        throw new Error(data);
+      })
+      .assert("12")
+  ).toThrow();
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -248,6 +248,10 @@ export abstract class ZodType<
     return handleResult(ctx, result);
   }
 
+  assert(data: unknown): data is Input {
+    return this.safeParse(data).success;
+  }
+
   async parseAsync(
     data: unknown,
     params?: Partial<ParseParams>


### PR DESCRIPTION
### Reasoning
I find myself doing these types of "quick and dirty" checks a lot, especially when first transitioning old code from the dreaded `"x" in y and typeof y.x === "object" && y.x !== null && z in y.x && [etc, etc]`, especially when there's already error handling present. This would speed up the process a bit and leave the flow of the old code a bit more intact.

### Examples

#### From the readme:

> ### `.assert`
> 
> Uses safeParse under the hood to assert the input type of the schema. Useful for inlining quick checks on unknown data that does not need to be transformed.
> 
> ```ts
> const data = JSON.parse('"billie"') as unknown
> 
> if (z.string().assert(data)) {
>   // data is now recognized as a string by TS
>   data.toUpperCase().startsWith("B")
> }
> ```

#### Comparison to safeParse

Example legacy code:
```ts
if (typeof data === "object" && data !== null && "prop" in data && typeof data.prop === "string") {
  handleData(data)
} else {
  handleError()
}
```

Example using assert:
```ts
const schema = z.object({ prop: z.string() })

if (schema.assert(data)) {
  handleData(data)
} else {
  handleError()
}
```

Example using safeParse:
```ts
const schema = z.object({ prop: z.string() })

const safeParseResult = schema.safeParse(data)

if (safeParseResult.success) {
  const data = safeParseResult.data;

  handleData(data)
} else {
  handleError()
}
```