### PR TITLE
Fix not working Deno doc link.

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,6 +246,7 @@
           "https://twitter.com/colinhacks",
           "https://trpc.io/",
           "https://zod.dev/",
+          "https://deno.land/x/zod",
         ],
       };
     </script>


### PR DESCRIPTION
Added missing deno land link to crossOriginLinks list for docsify.