### PR TITLE
chore: move `exports.types` field to first spot @ package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./lib/index.js",
       "import": "./lib/index.mjs",
-      "types": "./index.d.ts"
     },
     "./package.json": "./package.json",
     "./locales/*": "./lib/locales/*"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     ".": {
       "types": "./index.d.ts",
       "require": "./lib/index.js",
-      "import": "./lib/index.mjs",
+      "import": "./lib/index.mjs"
     },
     "./package.json": "./package.json",
     "./locales/*": "./lib/locales/*"


### PR DESCRIPTION
Hey 👋 

This PR re-arranges `package.json`'s `exports` object key order and sets `types` field to first.

This is recommended by TypeScript's official documentation.

> The "types" condition should always come first in "exports".
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

> Ensure types condition to be the first. The [TypeScript docs](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing) recommends so, but it's also because the exports field is order-based.
> For example, a scenario where both the types and import condition could be active, types should be first so that it matches and returns a .d.ts file, rather than a .js file from the import condition.
https://publint.dev/rules#exports_types_should_be_first