### PR TITLE
Allow ZodEffects to be discriminatedUnion options

### DIFF
--- a/deno/lib/__tests__/discriminatedUnions.test.ts
+++ b/deno/lib/__tests__/discriminatedUnions.test.ts
@@ -217,3 +217,31 @@ test("valid - literals with .default or .preprocess", () => {
     a: "foo",
   });
 });
+
+test("valid - object with .preprocess can be passed as a discriminatedUnion option", () => {
+  const baseObjectSchema = z.object({ a: z.string(), type: z.literal('foo') })
+  const preprocessedObjectSchema = z.preprocess((data: any) => {
+    if (data && typeof data === 'object' && 'a' in data && data.a  === "foo") {
+      return { ...data, a: "bar" }
+    }
+    return data
+  }, baseObjectSchema)
+
+  const schema = z.discriminatedUnion("type", [
+    preprocessedObjectSchema,
+    z.object({
+      type: z.literal("bar"),
+    }),
+  ]);
+  expect(schema.parse({ type: "foo", a: "foo" })).toEqual({
+    type: "foo",
+    a: "bar",
+  });
+  expect(schema.parse({ type: "foo", a: "notfoo" })).toEqual({
+    type: "foo",
+    a: "notfoo",
+  });
+  expect(schema.parse({ type: "bar" })).toEqual({
+    type: "bar",
+  });
+})

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2893,11 +2893,24 @@ const getDiscriminator = <T extends ZodTypeAny>(
 };
 
 export type ZodDiscriminatedUnionOption<Discriminator extends string> =
-  ZodObject<
-    { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
-    UnknownKeysParam,
-    ZodTypeAny
-  >;
+  | ZodObject<
+      { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
+      UnknownKeysParam,
+      ZodTypeAny
+    >
+  | ZodEffects<
+      ZodObject<
+        { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
+        UnknownKeysParam,
+        ZodTypeAny
+      >,
+      ZodObject<
+        { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
+        UnknownKeysParam,
+        ZodTypeAny
+      >["_output"],
+      unknown
+    >;
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
@@ -2995,7 +3008,9 @@ export class ZodDiscriminatedUnion<
 
     // try {
     for (const type of options) {
-      const discriminatorValues = getDiscriminator(type.shape[discriminator]);
+      const shape =
+        type instanceof ZodEffects ? type.innerType().shape : type.shape;
+      const discriminatorValues = getDiscriminator(shape[discriminator]);
       if (!discriminatorValues) {
         throw new Error(
           `A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`

--- a/src/types.ts
+++ b/src/types.ts
@@ -2893,11 +2893,24 @@ const getDiscriminator = <T extends ZodTypeAny>(
 };
 
 export type ZodDiscriminatedUnionOption<Discriminator extends string> =
-  ZodObject<
-    { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
-    UnknownKeysParam,
-    ZodTypeAny
-  >;
+  | ZodObject<
+      { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
+      UnknownKeysParam,
+      ZodTypeAny
+    >
+  | ZodEffects<
+      ZodObject<
+        { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
+        UnknownKeysParam,
+        ZodTypeAny
+      >,
+      ZodObject<
+        { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
+        UnknownKeysParam,
+        ZodTypeAny
+      >["_output"],
+      unknown
+    >;
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
@@ -2995,7 +3008,9 @@ export class ZodDiscriminatedUnion<
 
     // try {
     for (const type of options) {
-      const discriminatorValues = getDiscriminator(type.shape[discriminator]);
+      const shape =
+        type instanceof ZodEffects ? type.innerType().shape : type.shape;
+      const discriminatorValues = getDiscriminator(shape[discriminator]);
       if (!discriminatorValues) {
         throw new Error(
           `A discriminator value for key \`${discriminator}\` could not be extracted from all schema options`


### PR DESCRIPTION
# Goal
Enable passing ZodEffects w/ valid innerTypes to discriminatedUnions.

# Motivation
I explained my use-case a bit more here
https://github.com/colinhacks/zod/issues/2106#issuecomment-1558060227

Basically I am doing some pre-processing on the object in question but I still want to be able to use it in the union.

# Validation
I added an automated test to validate things still work as expected.
Please LMK if more tests are desired.