### PR TITLE
Add `*.md` pattern to prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,11 +68,14 @@
     "src/*.ts": [
       "eslint --cache --fix",
       "prettier --ignore-unknown --write"
+    ],
+    "*.md": [
+      "prettier --ignore-unknown --write"
     ]
   },
   "scripts": {
-    "prettier:check": "prettier --check src/**/*.ts deno/lib/**/*.ts --no-error-on-unmatched-pattern",
-    "prettier:fix": "prettier --write src/**/*.ts deno/lib/**/*.ts --ignore-unknown --no-error-on-unmatched-pattern",
+    "prettier:check": "prettier --check src/**/*.ts deno/lib/**/*.ts *.md --no-error-on-unmatched-pattern",
+    "prettier:fix": "prettier --write src/**/*.ts deno/lib/**/*.ts *.md --ignore-unknown --no-error-on-unmatched-pattern",
     "lint:check": "eslint --cache --ext .ts ./src",
     "lint:fix": "eslint --cache --fix --ext .ts ./src",
     "check": "yarn lint:check && yarn prettier:check",


### PR DESCRIPTION
Prettier can format code blocks within Markdown the same as the rest of the code. In a recent PR, I noticed that most of my feedback was about code formatting within the README, so I thought this would be helpful.