### PR TITLE
docs: update ref to discriminated-unions

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -24,7 +24,7 @@ Each ZodError has an `issues` property that is an array of `ZodIssues`. Each iss
 
 ## ZodIssue
 
-`ZodIssue` is _not_ a class. It is a [discriminated union](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions).
+`ZodIssue` is _not_ a class. It is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions).
 
 The link above is the best way to learn about the concept. Discriminated unions are an ideal way to represent a data structures that may be one of many possible variants. You can see all the possible variants defined [here](./src/ZodError.ts). They are also described in the table below if you prefer.
 


### PR DESCRIPTION
## Scope
A developer girl should be able to follow the link in the readme to read about discriminated unions and be directed to the new improved documentation.

## Work done
- Followed original link which informed me of the new documentation. 
- Copy pasted new url
- Opened this here PR

## Steps to test
- View old url (https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions) and notice the message.
- Click the link and confirm new url is correct.


## GIF tax
![simsons](https://github.com/colinhacks/zod/assets/22392943/11f0de6f-6be6-41e8-9810-01599660f8fc)