### PR TITLE
[docs] add notice about strictObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -1340,6 +1340,8 @@ person.parse({
 // => throws ZodError
 ```
 
+For convenience, you can use `z.strictObject({})`, which is the equivalent of `z.object({}).strict()`.
+
 ### `.strip`
 
 You can use the `.strip` method to reset an object schema to the default behavior (stripping unrecognized keys).


### PR DESCRIPTION
Found `strictObject` in [this ticket](https://github.com/colinhacks/zod/issues/2062) and i wondered if i missed it in the docs, but it cannot be found.