### PR TITLE
perf: avoid unnecessary error maps

### DIFF
--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -16,19 +16,31 @@ export const makeIssue = (params: {
     path: fullPath,
   };
 
-  let errorMessage = "";
-  const maps = errorMaps
-    .filter((m) => !!m)
-    .slice()
-    .reverse() as ZodErrorMap[];
-  for (const map of maps) {
-    errorMessage = map(fullIssue, { data, defaultError: errorMessage }).message;
+  let errorMessage = issueData.message || "";
+  if (!errorMessage) {
+    const maps: ZodErrorMap[] = [];
+    for (let i = errorMaps.length - 1; i >= 0; i--) {
+      const map = errorMaps[i];
+      if (!map || maps.includes(map)) {
+        continue;
+      }
+      maps.push(map);
+
+      errorMessage = map(fullIssue, {
+        data,
+        defaultError: errorMessage,
+      }).message;
+    }
   }
 
   return {
     ...issueData,
     path: fullPath,
+<<<<<<< HEAD
     message: issueData.message ?? errorMessage,
+=======
+    message: errorMessage,
+>>>>>>> e5b2228 (perf: avoid unnecessary error maps)
   };
 };
 

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -16,7 +16,7 @@ export const makeIssue = (params: {
     path: fullPath,
   };
 
-  if (issueData.message) {
+  if (issueData.message !== undefined) {
     return {
       ...issueData,
       path: fullPath,
@@ -36,11 +36,7 @@ export const makeIssue = (params: {
   return {
     ...issueData,
     path: fullPath,
-<<<<<<< HEAD
-    message: issueData.message ?? errorMessage,
-=======
     message: errorMessage,
->>>>>>> e5b2228 (perf: avoid unnecessary error maps)
   };
 };
 

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -16,19 +16,27 @@ export const makeIssue = (params: {
     path: fullPath,
   };
 
-  let errorMessage = "";
-  const maps = errorMaps
-    .filter((m) => !!m)
-    .slice()
-    .reverse() as ZodErrorMap[];
-  for (const map of maps) {
-    errorMessage = map(fullIssue, { data, defaultError: errorMessage }).message;
+  let errorMessage = issueData.message || "";
+  if (!errorMessage) {
+    const maps: ZodErrorMap[] = [];
+    for (let i = errorMaps.length - 1; i >= 0; i--) {
+      const map = errorMaps[i];
+      if (!map || maps.includes(map)) {
+        continue;
+      }
+      maps.push(map);
+
+      errorMessage = map(fullIssue, {
+        data,
+        defaultError: errorMessage,
+      }).message;
+    }
   }
 
   return {
     ...issueData,
     path: fullPath,
-    message: issueData.message ?? errorMessage,
+    message: errorMessage,
   };
 };
 

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -16,7 +16,7 @@ export const makeIssue = (params: {
     path: fullPath,
   };
 
-  if (issueData.message) {
+  if (issueData.message !== undefined) {
     return {
       ...issueData,
       path: fullPath,

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -16,21 +16,21 @@ export const makeIssue = (params: {
     path: fullPath,
   };
 
-  let errorMessage = issueData.message || "";
-  if (!errorMessage) {
-    const maps: ZodErrorMap[] = [];
-    for (let i = errorMaps.length - 1; i >= 0; i--) {
-      const map = errorMaps[i];
-      if (!map || maps.includes(map)) {
-        continue;
-      }
-      maps.push(map);
+  if (issueData.message) {
+    return {
+      ...issueData,
+      path: fullPath,
+      message: issueData.message,
+    };
+  }
 
-      errorMessage = map(fullIssue, {
-        data,
-        defaultError: errorMessage,
-      }).message;
-    }
+  let errorMessage = "";
+  const maps = errorMaps
+    .filter((m) => !!m)
+    .slice()
+    .reverse() as ZodErrorMap[];
+  for (const map of maps) {
+    errorMessage = map(fullIssue, { data, defaultError: errorMessage }).message;
   }
 
   return {
@@ -73,6 +73,7 @@ export function addIssueToContext(
   ctx: ParseContext,
   issueData: IssueData
 ): void {
+  const overrideMap = getErrorMap();
   const issue = makeIssue({
     issueData: issueData,
     data: ctx.data,
@@ -80,8 +81,8 @@ export function addIssueToContext(
     errorMaps: [
       ctx.common.contextualErrorMap, // contextual error map is first priority
       ctx.schemaErrorMap, // then schema-bound map if available
-      getErrorMap(), // then global override map
-      defaultErrorMap, // then global default map
+      overrideMap, // then global override map
+      overrideMap === defaultErrorMap ? undefined : defaultErrorMap, // then global default map
     ].filter((x) => !!x) as ZodErrorMap[],
   });
   ctx.common.issues.push(issue);


### PR DESCRIPTION
Since `defaultErrorMap` and `getErrorMap()` may return the same one, leads to duplicate in `ZodErrorMap` array. And error mapping can be totally skipped if check message is provided.

https://github.com/colinhacks/zod/blob/master/src/errors.ts#L4-L5
```diff
import defaultErrorMap from "./locales/en";
import type { ZodErrorMap } from "./ZodError";

let overrideErrorMap = defaultErrorMap;
+export { defaultErrorMap };

export function setErrorMap(map: ZodErrorMap) {
  overrideErrorMap = map;
}

+export function getErrorMap() {
  return overrideErrorMap;
}
```