### PR TITLE
fix typo test name

### DIFF
--- a/deno/lib/__tests__/primitive.test.ts
+++ b/deno/lib/__tests__/primitive.test.ts
@@ -448,7 +448,7 @@ test("get literal value", () => {
   expect(literalStringSchema.value).toEqual("asdf");
 });
 
-test("optional convenience methd", () => {
+test("optional convenience method", () => {
   z.ostring().parse(undefined);
   z.onumber().parse(undefined);
   z.oboolean().parse(undefined);

--- a/src/__tests__/primitive.test.ts
+++ b/src/__tests__/primitive.test.ts
@@ -447,7 +447,7 @@ test("get literal value", () => {
   expect(literalStringSchema.value).toEqual("asdf");
 });
 
-test("optional convenience methd", () => {
+test("optional convenience method", () => {
   z.ostring().parse(undefined);
   z.onumber().parse(undefined);
   z.oboolean().parse(undefined);


### PR DESCRIPTION
While going through the code, I discovered the word "methd", which I believe may be a typographical error for "method". I have proceeded to make the necessary corrections to rectify this typo.

Here's a brief summary of the changes I made:

* All instances of "methd" have been replaced with "method"