### PR TITLE
#2548 #1439 support for `exemplify()` and `.examples`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
     - [Async transforms](#async-transforms)
   - [`.default`](#default)
   - [`.describe`](#describe)
+  - [`.exemplify`](#exemplify)
   - [`.catch`](#catch)
   - [`.optional`](#optional)
   - [`.nullable`](#nullable)
@@ -2289,6 +2290,17 @@ const documentedString = z
   .string()
   .describe("A useful bit of text, if you know what to do with it.");
 documentedString.description; // A useful bit of text…
+```
+
+This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
+
+### `.exemplify`
+
+Use `.exemplify()` to add to the `examples` property to the resulting schema.
+
+```ts
+const exemplifiedString = z.string().example("Lorem ipsum dolor sit amet.");
+documentedString.examples; // ['Lorem ipsum dolor…
 ```
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -134,6 +134,7 @@
     - [Async transforms](#async-transforms)
   - [`.default`](#default)
   - [`.describe`](#describe)
+  - [`.exemplify`](#exemplify)
   - [`.catch`](#catch)
   - [`.optional`](#optional)
   - [`.nullable`](#nullable)
@@ -2289,6 +2290,17 @@ const documentedString = z
   .string()
   .describe("A useful bit of text, if you know what to do with it.");
 documentedString.description; // A useful bit of text…
+```
+
+This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
+
+### `.exemplify`
+
+Use `.exemplify()` to add to the `examples` property to the resulting schema.
+
+```ts
+const exemplifiedString = z.string().example("Lorem ipsum dolor sit amet.");
+documentedString.examples; // ['Lorem ipsum dolor…
 ```
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).

--- a/deno/lib/__tests__/examples.test.ts
+++ b/deno/lib/__tests__/examples.test.ts
@@ -1,0 +1,42 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+const examples = [ "an example" ];
+
+test("passing `examples` to schema should add a examples", () => {
+  expect(z.string({ examples }).examples).toEqual(examples);
+  expect(z.number({ examples }).examples).toEqual(examples);
+  expect(z.boolean({ examples }).examples).toEqual(examples);
+});
+
+test("`.exemplify` should add an example", () => {
+  expect(z.string().exemplify(examples[0]).examples).toEqual(examples);
+  expect(z.number().exemplify(examples[0]).examples).toEqual(examples);
+  expect(z.boolean().exemplify(examples[0]).examples).toEqual(examples);
+});
+
+test("examples should carry over to chained schemas", () => {
+  const schema = z.string({ examples });
+  expect(schema.examples).toEqual(examples);
+  expect(schema.optional().examples).toEqual(examples);
+  expect(schema.optional().nullable().default("default").examples).toEqual(
+    examples
+  );
+});
+
+test("`.exemplify` should be chainable", () => {
+  const schema = z.string({ examples: [123] });
+  expect(schema.examples).toEqual([123]);
+
+  schema.exemplify('example 1');
+  expect(schema.examples).toEqual([123, 'example 1']);
+
+  schema.exemplify(true);
+  expect(schema.examples).toEqual([123, 'example 1', true]);
+
+  schema.exemplify({ foo: 'bar' });
+  expect(schema.examples).toEqual([123, 'example 1', true, { foo: 'bar' }]);
+});

--- a/src/__tests__/examples.test.ts
+++ b/src/__tests__/examples.test.ts
@@ -1,0 +1,41 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+
+const examples = [ "an example" ];
+
+test("passing `examples` to schema should add a examples", () => {
+  expect(z.string({ examples }).examples).toEqual(examples);
+  expect(z.number({ examples }).examples).toEqual(examples);
+  expect(z.boolean({ examples }).examples).toEqual(examples);
+});
+
+test("`.exemplify` should add an example", () => {
+  expect(z.string().exemplify(examples[0]).examples).toEqual(examples);
+  expect(z.number().exemplify(examples[0]).examples).toEqual(examples);
+  expect(z.boolean().exemplify(examples[0]).examples).toEqual(examples);
+});
+
+test("examples should carry over to chained schemas", () => {
+  const schema = z.string({ examples });
+  expect(schema.examples).toEqual(examples);
+  expect(schema.optional().examples).toEqual(examples);
+  expect(schema.optional().nullable().default("default").examples).toEqual(
+    examples
+  );
+});
+
+test("`.exemplify` should be chainable", () => {
+  const schema = z.string({ examples: [123] });
+  expect(schema.examples).toEqual([123]);
+
+  schema.exemplify('example 1');
+  expect(schema.examples).toEqual([123, 'example 1']);
+
+  schema.exemplify(true);
+  expect(schema.examples).toEqual([123, 'example 1', true]);
+
+  schema.exemplify({ foo: 'bar' });
+  expect(schema.examples).toEqual([123, 'example 1', true, { foo: 'bar' }]);
+});


### PR DESCRIPTION
See:
- #2548 
- #1439 