### PR TITLE
Add `fastify-zod-openapi` to ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,8 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod): Create Fastify type providers from Zod schemas.
 - [`zod-to-openapi`](https://github.com/asteasolutions/zod-to-openapi): Generate full OpenAPI (Swagger) docs from Zod, including schemas, endpoints & parameters.
 - [`nestjs-graphql-zod`](https://github.com/incetarik/nestjs-graphql-zod): Generates NestJS GraphQL model classes from Zod schemas. Provides GraphQL method decorators working with Zod schemas.
-- [`zod-openapi`](https://github.com/samchungy/zod-openapi): Create full OpenAPI v3.x documentation from Zod Schemas.
+- [`zod-openapi`](https://github.com/samchungy/zod-openapi): Create full OpenAPI v3.x documentation from Zod schemas.
+- [`fastify-zod-openapi`](https://github.com/samchungy/fastify-zod-openapi): Fastify type provider, validation, serialization and @fastify/swagger support for Zod schemas.
 
 #### X to Zod
 


### PR DESCRIPTION
Adding another plugin I maintain to the list.

For those of you 👀 in this PR:

[fastify-zod-openapi](https://github.com/samchungy/fastify-zod-openapi) adds native Fastify type provider, validator, serializer and @fastify/swagger support for [zod-openapi](https://github.com/samchungy/zod-openapi).

The main difference between this library and `fastify-type-provider-zod` is that it enables support between zod-openapi and Fastify.