### PR TITLE
docs: add conform form integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 
 #### Form integrations
 
+- [`conform`](https://conform.guide/api/zod): A progressive enhancement first form validation library for Remix and React Router
 - [`react-hook-form`](https://github.com/react-hook-form/resolvers#zod): A first-party Zod resolver for React Hook Form.
 - [`zod-validation-error`](https://github.com/causaly/zod-validation-error): Generate user-friendly error messages from `ZodError`s.
 - [`zod-formik-adapter`](https://github.com/robertLichtnow/zod-formik-adapter): A community-maintained Formik adapter for Zod.


### PR DESCRIPTION
This adds conform. It didn't look like there was much of an order so I put it at the top since that's where it'd go in alphabetical order anyway 🤷‍♂️