### PR TITLE
fix: writable error messages

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -191,6 +191,7 @@ export type inferFormattedError<
 
 export class ZodError<T = any> extends Error {
   issues: ZodIssue[] = [];
+  messageOverride?: string;
 
   get errors() {
     return this.issues;
@@ -270,7 +271,13 @@ export class ZodError<T = any> extends Error {
     return this.message;
   }
   get message() {
-    return JSON.stringify(this.issues, util.jsonStringifyReplacer, 2);
+    return (
+      this.messageOverride ??
+      JSON.stringify(this.issues, util.jsonStringifyReplacer, 2)
+    );
+  }
+  set message(message: string) {
+    this.messageOverride = message;
   }
 
   get isEmpty(): boolean {

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -90,6 +90,16 @@ test("default error message", () => {
   }
 });
 
+test("error message override", () => {
+  try {
+    z.string().parse(2);
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    zerr.message = "Override";
+    expect(zerr.message).toEqual("Override");
+  }
+});
+
 test("override error in refine", () => {
   try {
     z.number()

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -191,6 +191,7 @@ export type inferFormattedError<
 
 export class ZodError<T = any> extends Error {
   issues: ZodIssue[] = [];
+  messageOverride?: string;
 
   get errors() {
     return this.issues;
@@ -270,7 +271,13 @@ export class ZodError<T = any> extends Error {
     return this.message;
   }
   get message() {
-    return JSON.stringify(this.issues, util.jsonStringifyReplacer, 2);
+    return (
+      this.messageOverride ??
+      JSON.stringify(this.issues, util.jsonStringifyReplacer, 2)
+    );
+  }
+  set message(message: string) {
+    this.messageOverride = message;
   }
 
   get isEmpty(): boolean {

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -89,6 +89,16 @@ test("default error message", () => {
   }
 });
 
+test("error message override", () => {
+  try {
+    z.string().parse(2);
+  } catch (err) {
+    const zerr: z.ZodError = err as any;
+    zerr.message = "Override";
+    expect(zerr.message).toEqual("Override");
+  }
+});
+
 test("override error in refine", () => {
   try {
     z.number()


### PR DESCRIPTION
The `message` property on the standard `Error` object is writable. Provide a setter in `ZodError` to allow overwriting the generated message.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message