### PR TITLE
feat: added latitude and longitude in number

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,9 @@ z.number().multipleOf(5); // Evenly divisible by 5. Alias .step(5)
 
 z.number().finite(); // value must be finite, not Infinity or -Infinity
 z.number().safe(); // value must be between Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER
+
+z.number().latitude(); // value must be a valid latitude, between -90 and 90
+z.number().longitude(); // value must be a valid longitude, between -180 and 180
 ```
 
 Optionally, you can pass in a second argument to provide a custom error message.
@@ -1238,8 +1241,8 @@ The `.partial` method is shallow — it only applies one level deep. There is al
 const user = z.object({
   username: z.string(),
   location: z.object({
-    latitude: z.number(),
-    longitude: z.number(),
+    latitude: z.number().latitude(),
+    longitude: z.number().longitude(),
   }),
   strings: z.array(z.object({ value: z.string() })),
 });

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -842,6 +842,9 @@ z.number().multipleOf(5); // Evenly divisible by 5. Alias .step(5)
 
 z.number().finite(); // value must be finite, not Infinity or -Infinity
 z.number().safe(); // value must be between Number.MIN_SAFE_INTEGER and Number.MAX_SAFE_INTEGER
+
+z.number().latitude(); // value must be a valid latitude, between -90 and 90
+z.number().longitude(); // value must be a valid longitude, between -180 and 180
 ```
 
 Optionally, you can pass in a second argument to provide a custom error message.
@@ -1238,8 +1241,8 @@ The `.partial` method is shallow — it only applies one level deep. There is al
 const user = z.object({
   username: z.string(),
   location: z.object({
-    latitude: z.number(),
-    longitude: z.number(),
+    latitude: z.number().latitude(),
+    longitude: z.number().longitude(),
   }),
   strings: z.array(z.object({ value: z.string() })),
 });

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -32,6 +32,8 @@ export const ZodIssueCode = util.arrayToEnum([
   "invalid_intersection_types",
   "not_multiple_of",
   "not_finite",
+  "not_latitude",
+  "not_longitude",
 ]);
 
 export type ZodIssueCode = keyof typeof ZodIssueCode;
@@ -137,6 +139,14 @@ export interface ZodNotFiniteIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.not_finite;
 }
 
+export interface ZodNotLatitudeIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.not_latitude;
+}
+
+export interface ZodNotLongitudeIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.not_longitude;
+}
+
 export interface ZodCustomIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.custom;
   params?: { [k: string]: any };
@@ -160,6 +170,8 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidIntersectionTypesIssue
   | ZodNotMultipleOfIssue
   | ZodNotFiniteIssue
+  | ZodNotLatitudeIssue
+  | ZodNotLongitudeIssue
   | ZodCustomIssue;
 
 export type ZodIssue = ZodIssueOptionalMessage & {

--- a/deno/lib/__tests__/number.test.ts
+++ b/deno/lib/__tests__/number.test.ts
@@ -18,6 +18,8 @@ const nonnegative = z.number().nonnegative();
 const multipleOfFive = z.number().multipleOf(5);
 const multipleOfNegativeFive = z.number().multipleOf(-5);
 const finite = z.number().finite();
+const latitude = z.number().latitude();
+const longitude = z.number().longitude();
 const safe = z.number().safe();
 const stepPointOne = z.number().step(0.1);
 const stepPointZeroZeroZeroOne = z.number().step(0.0001);
@@ -59,6 +61,8 @@ test("passing validations", () => {
   multipleOfNegativeFive.parse(-15);
   multipleOfNegativeFive.parse(15);
   finite.parse(123);
+  latitude.parse(0);
+  longitude.parse(0);
   safe.parse(Number.MIN_SAFE_INTEGER);
   safe.parse(Number.MAX_SAFE_INTEGER);
   stepPointOne.parse(6);
@@ -88,6 +92,8 @@ test("failing validations", () => {
   expect(() => multipleOfNegativeFive.parse(7.5)).toThrow();
   expect(() => finite.parse(Infinity)).toThrow();
   expect(() => finite.parse(-Infinity)).toThrow();
+  expect(() => latitude.parse(91)).toThrow();
+  expect(() => longitude.parse(181)).toThrow();
   expect(() => safe.parse(Number.MIN_SAFE_INTEGER - 1)).toThrow();
   expect(() => safe.parse(Number.MAX_SAFE_INTEGER + 1)).toThrow();
 
@@ -110,6 +116,8 @@ test("min max getters", () => {
   expect(intNum.minValue).toBeNull;
   expect(multipleOfFive.minValue).toBeNull;
   expect(finite.minValue).toBeNull;
+  expect(latitude.minValue).toEqual(-90);
+  expect(longitude.minValue).toEqual(-180);
   expect(gtFive.minValue).toEqual(5);
   expect(gteFive.minValue).toEqual(5);
   expect(minFive.minValue).toEqual(5);
@@ -127,6 +135,8 @@ test("min max getters", () => {
   expect(intNum.minValue).toBeNull;
   expect(multipleOfFive.minValue).toBeNull;
   expect(finite.minValue).toBeNull;
+  expect(latitude.maxValue).toEqual(90);
+  expect(longitude.maxValue).toEqual(180);
   expect(ltFive.maxValue).toEqual(5);
   expect(lteFive.maxValue).toEqual(5);
   expect(maxFive.maxValue).toEqual(5);
@@ -151,6 +161,8 @@ test("int getter", () => {
   expect(negative.isInt).toEqual(false);
   expect(nonpositive.isInt).toEqual(false);
   expect(safe.isInt).toEqual(false);
+  expect(latitude.isInt).toEqual(false);
+  expect(longitude.isInt).toEqual(false);
 
   expect(intNum.isInt).toEqual(true);
   expect(multipleOfFive.isInt).toEqual(true);
@@ -170,6 +182,8 @@ test("finite getter", () => {
   expect(nonpositive.isFinite).toEqual(false);
 
   expect(finite.isFinite).toEqual(true);
+  expect(latitude.isFinite).toEqual(true);
+  expect(longitude.isFinite).toEqual(true);
   expect(intNum.isFinite).toEqual(true);
   expect(multipleOfFive.isFinite).toEqual(true);
   expect(z.number().min(5).max(10).isFinite).toEqual(true);

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -140,6 +140,12 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.not_finite:
       message = "Number must be finite";
       break;
+    case ZodIssueCode.not_latitude:
+      message = "Number must be a valid latitude";
+      break;
+    case ZodIssueCode.not_longitude:
+      message = "Number must be a valid longitude";
+      break;
     default:
       message = _ctx.defaultError;
       util.assertNever(issue);

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -32,6 +32,8 @@ export const ZodIssueCode = util.arrayToEnum([
   "invalid_intersection_types",
   "not_multiple_of",
   "not_finite",
+  "not_latitude",
+  "not_longitude",
 ]);
 
 export type ZodIssueCode = keyof typeof ZodIssueCode;
@@ -137,6 +139,14 @@ export interface ZodNotFiniteIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.not_finite;
 }
 
+export interface ZodNotLatitudeIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.not_latitude;
+}
+
+export interface ZodNotLongitudeIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.not_longitude;
+}
+
 export interface ZodCustomIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.custom;
   params?: { [k: string]: any };
@@ -160,6 +170,8 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidIntersectionTypesIssue
   | ZodNotMultipleOfIssue
   | ZodNotFiniteIssue
+  | ZodNotLatitudeIssue
+  | ZodNotLongitudeIssue
   | ZodCustomIssue;
 
 export type ZodIssue = ZodIssueOptionalMessage & {

--- a/src/__tests__/number.test.ts
+++ b/src/__tests__/number.test.ts
@@ -17,6 +17,8 @@ const nonnegative = z.number().nonnegative();
 const multipleOfFive = z.number().multipleOf(5);
 const multipleOfNegativeFive = z.number().multipleOf(-5);
 const finite = z.number().finite();
+const latitude = z.number().latitude();
+const longitude = z.number().longitude();
 const safe = z.number().safe();
 const stepPointOne = z.number().step(0.1);
 const stepPointZeroZeroZeroOne = z.number().step(0.0001);
@@ -58,6 +60,8 @@ test("passing validations", () => {
   multipleOfNegativeFive.parse(-15);
   multipleOfNegativeFive.parse(15);
   finite.parse(123);
+  latitude.parse(0);
+  longitude.parse(0);
   safe.parse(Number.MIN_SAFE_INTEGER);
   safe.parse(Number.MAX_SAFE_INTEGER);
   stepPointOne.parse(6);
@@ -87,6 +91,8 @@ test("failing validations", () => {
   expect(() => multipleOfNegativeFive.parse(7.5)).toThrow();
   expect(() => finite.parse(Infinity)).toThrow();
   expect(() => finite.parse(-Infinity)).toThrow();
+  expect(() => latitude.parse(91)).toThrow();
+  expect(() => longitude.parse(181)).toThrow();
   expect(() => safe.parse(Number.MIN_SAFE_INTEGER - 1)).toThrow();
   expect(() => safe.parse(Number.MAX_SAFE_INTEGER + 1)).toThrow();
 
@@ -109,6 +115,8 @@ test("min max getters", () => {
   expect(intNum.minValue).toBeNull;
   expect(multipleOfFive.minValue).toBeNull;
   expect(finite.minValue).toBeNull;
+  expect(latitude.minValue).toEqual(-90);
+  expect(longitude.minValue).toEqual(-180);
   expect(gtFive.minValue).toEqual(5);
   expect(gteFive.minValue).toEqual(5);
   expect(minFive.minValue).toEqual(5);
@@ -126,6 +134,8 @@ test("min max getters", () => {
   expect(intNum.minValue).toBeNull;
   expect(multipleOfFive.minValue).toBeNull;
   expect(finite.minValue).toBeNull;
+  expect(latitude.maxValue).toEqual(90);
+  expect(longitude.maxValue).toEqual(180);
   expect(ltFive.maxValue).toEqual(5);
   expect(lteFive.maxValue).toEqual(5);
   expect(maxFive.maxValue).toEqual(5);
@@ -150,6 +160,8 @@ test("int getter", () => {
   expect(negative.isInt).toEqual(false);
   expect(nonpositive.isInt).toEqual(false);
   expect(safe.isInt).toEqual(false);
+  expect(latitude.isInt).toEqual(false);
+  expect(longitude.isInt).toEqual(false);
 
   expect(intNum.isInt).toEqual(true);
   expect(multipleOfFive.isInt).toEqual(true);
@@ -169,6 +181,8 @@ test("finite getter", () => {
   expect(nonpositive.isFinite).toEqual(false);
 
   expect(finite.isFinite).toEqual(true);
+  expect(latitude.isFinite).toEqual(true);
+  expect(longitude.isFinite).toEqual(true);
   expect(intNum.isFinite).toEqual(true);
   expect(multipleOfFive.isFinite).toEqual(true);
   expect(z.number().min(5).max(10).isFinite).toEqual(true);

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -140,6 +140,12 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.not_finite:
       message = "Number must be finite";
       break;
+    case ZodIssueCode.not_latitude:
+      message = "Number must be a valid latitude";
+      break;
+    case ZodIssueCode.not_longitude:
+      message = "Number must be a valid longitude";
+      break;
     default:
       message = _ctx.defaultError;
       util.assertNever(issue);


### PR DESCRIPTION
This pull request solves https://github.com/colinhacks/zod/issues/2600 adding [Latitude](https://en.wikipedia.org/wiki/Latitude#:~:text=Latitude%20is%20given%20as%20an%20angle%20that%20ranges%20from%20%E2%80%9390%C2%B0%20at%20the%20south%20pole%20to%2090%C2%B0%20at%20the%20north%20pole%2C%20with%200%C2%B0%20at%20the%20Equator.) and [Longitude](https://en.wikipedia.org/wiki/Longitude#:~:text=Longitude%20is%20given%20as%20an%20angular%20measurement%20ranging%20from%200%C2%B0%20at%20the%20Prime%20Meridian%20to%20%2B180%C2%B0%20eastward%20and%20%E2%88%92180%C2%B0%20westward) validation in zod number