### PR TITLE
docs(comparison-yup): Yup added partial() and deepPartial() in v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2718,7 +2718,6 @@ Yup is a full-featured library that was implemented first in vanilla JS, and lat
 
 - Supports casting and transforms
 - All object fields are optional by default
-- Missing object methods: (partial, deepPartial)
 <!-- - Missing nonempty arrays with proper typing (`[T, ...T[]]`) -->
 - Missing promise schemas
 - Missing function schemas


### PR DESCRIPTION
So update Yup's section of the Zod comparison accordingly.

See: https://github.com/jquense/yup/issues/1906