### PR TITLE
docs: add typeschema to ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`nestjs-graphql-zod`](https://github.com/incetarik/nestjs-graphql-zod): Generates NestJS GraphQL model classes from Zod schemas. Provides GraphQL method decorators working with Zod schemas.
 - [`zod-openapi`](https://github.com/samchungy/zod-openapi): Create full OpenAPI v3.x documentation from Zod schemas.
 - [`fastify-zod-openapi`](https://github.com/samchungy/fastify-zod-openapi): Fastify type provider, validation, serialization and @fastify/swagger support for Zod schemas.
+- [`typeschema`](https://typeschema.com/): Universal adapter for schema validation.
 
 #### X to Zod
 


### PR DESCRIPTION
[`typeschema`](https://typeschema.com) offers an universal adapter for `zod` (and any major schema validation lib) that anyone can reuse