### PR TITLE
Add ZodReadonly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: yarn install
-      - run: yarn add typescript@${{ matrix.typescript }}
-      - run: yarn build
-      - run: yarn test
-
+      - uses: actions/setup-bun@v1
+      - run: bun install
+      - run: bun add typescript@${{ matrix.typescript }}
+      - run: bun run build
+      - run: bun run test
 
   test-deno:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/setup-bun@v1
+      - uses: oven-sh/setup-bun@v1
       - run: bun install
       - run: bun add typescript@${{ matrix.typescript }}
       - run: bun run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,10 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - uses: oven-sh/setup-bun@v1
-      - run: bun install
-      - run: bun add typescript@${{ matrix.typescript }}
-      - run: bun run build
-      - run: bun run test
+      - run: yarn install
+      - run: yarn add typescript@${{ matrix.typescript }}
+      - run: yarn build
+      - run: yarn test
 
   test-deno:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@
   - [`.or`](#or)
   - [`.and`](#and)
   - [`.brand`](#brand)
-  - [`.pipe()`](#pipe)
+  - [`.readonly`](#readonly)
+  - [`.pipe`](#pipe)
     - [You can use `.pipe()` to fix common issues with `z.coerce`.](#you-can-use-pipe-to-fix-common-issues-with-zcoerce)
 - [Guides and concepts](#guides-and-concepts)
   - [Type inference](#type-inference)
@@ -2453,7 +2454,38 @@ type Cat = z.infer<typeof Cat>;
 
 Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
 
-### `.pipe()`
+### `.readonly`
+
+`.readonly() => ZodReadonly<this>`
+
+This method returns a `ZodReadonly` schema instance that parses the input using the base schema, then calls `Object.freeze()` on the result. The inferred type is also marked as `readonly`.
+
+```ts
+const schema = z.object({ name: string }).readonly();
+type schema = z.infer<typeof schema>;
+// Readonly<{name: string}>
+
+const result = schema.parse({ name: "fido" });
+result.name = "simba"; // error
+```
+
+The inferred type uses TypeScript's built-in readonly types when relevant.
+
+```ts
+z.array(z.string()).readonly();
+// readonly string[]
+
+z.tuple([z.string(), z.number()]).readonly();
+// readonly [string, number]
+
+z.map(z.string(), z.date()).readonly();
+// ReadonlyMap<string, Date>
+
+z.set(z.string()).readonly();
+// ReadonlySet<Promise<string>>
+```
+
+### `.pipe`
 
 Schemas can be chained into validation "pipelines". It's useful for easily validating the result after a `.transform()`:
 

--- a/README.md
+++ b/README.md
@@ -1270,10 +1270,12 @@ Contrary to the `.partial` method, the `.required` method makes all properties r
 Starting from this object:
 
 ```ts
-const user = z.object({
-  email: z.string(),
-  username: z.string(),
-}).partial();
+const user = z
+  .object({
+    email: z.string(),
+    username: z.string(),
+  })
+  .partial();
 // { email?: string | undefined; username?: string | undefined }
 ```
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -143,7 +143,8 @@
   - [`.or`](#or)
   - [`.and`](#and)
   - [`.brand`](#brand)
-  - [`.pipe()`](#pipe)
+  - [`.readonly`](#readonly)
+  - [`.pipe`](#pipe)
     - [You can use `.pipe()` to fix common issues with `z.coerce`.](#you-can-use-pipe-to-fix-common-issues-with-zcoerce)
 - [Guides and concepts](#guides-and-concepts)
   - [Type inference](#type-inference)
@@ -2453,7 +2454,38 @@ type Cat = z.infer<typeof Cat>;
 
 Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
 
-### `.pipe()`
+### `.readonly`
+
+`.readonly() => ZodReadonly<this>`
+
+This method returns a `ZodReadonly` schema instance that parses the input using the base schema, then calls `Object.freeze()` on the result. The inferred type is also marked as `readonly`.
+
+```ts
+const schema = z.object({ name: string }).readonly();
+type schema = z.infer<typeof schema>;
+// Readonly<{name: string}>
+
+const result = schema.parse({ name: "fido" });
+result.name = "simba"; // error
+```
+
+The inferred type uses TypeScript's built-in readonly types when relevant.
+
+```ts
+z.array(z.string()).readonly();
+// readonly string[]
+
+z.tuple([z.string(), z.number()]).readonly();
+// readonly [string, number]
+
+z.map(z.string(), z.date()).readonly();
+// ReadonlyMap<string, Date>
+
+z.set(z.string()).readonly();
+// ReadonlySet<Promise<string>>
+```
+
+### `.pipe`
 
 Schemas can be chained into validation "pipelines". It's useful for easily validating the result after a `.transform()`:
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1270,10 +1270,12 @@ Contrary to the `.partial` method, the `.required` method makes all properties r
 Starting from this object:
 
 ```ts
-const user = z.object({
-  email: z.string(),
-  username: z.string(),
-}).partial();
+const user = z
+  .object({
+    email: z.string(),
+    username: z.string(),
+  })
+  .partial();
 // { email?: string | undefined; username?: string | undefined }
 ```
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -460,6 +460,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 
 #### Form integrations
 
+- [`conform`](https://conform.guide/api/zod): A progressive enhancement first form validation library for Remix and React Router
 - [`react-hook-form`](https://github.com/react-hook-form/resolvers#zod): A first-party Zod resolver for React Hook Form.
 - [`zod-validation-error`](https://github.com/causaly/zod-validation-error): Generate user-friendly error messages from `ZodError`s.
 - [`zod-formik-adapter`](https://github.com/robertLichtnow/zod-formik-adapter): A community-maintained Formik adapter for Zod.
@@ -471,7 +472,8 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`@modular-forms/solid`](https://github.com/fabian-hiller/modular-forms): Modular form library for SolidJS that supports Zod for validation.
 - [`houseform`](https://github.com/crutchcorn/houseform/): A React form library that uses Zod for validation.
 - [`sveltekit-superforms`](https://github.com/ciscoheat/sveltekit-superforms): Supercharged form library for SvelteKit with Zod validation.
-- [`mobx-zod-form`](https://github.com/MonoidDev/mobx-zod-form): Data-first form builder based on MobX & Zod
+- [`mobx-zod-form`](https://github.com/MonoidDev/mobx-zod-form): Data-first form builder based on MobX & Zod.
+- [`@vee-validate/zod`](https://github.com/logaretm/vee-validate/tree/main/packages/zod): Form library for Vue.js with Zod schema validation.
 
 #### Zod to X
 
@@ -483,7 +485,8 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod): Create Fastify type providers from Zod schemas.
 - [`zod-to-openapi`](https://github.com/asteasolutions/zod-to-openapi): Generate full OpenAPI (Swagger) docs from Zod, including schemas, endpoints & parameters.
 - [`nestjs-graphql-zod`](https://github.com/incetarik/nestjs-graphql-zod): Generates NestJS GraphQL model classes from Zod schemas. Provides GraphQL method decorators working with Zod schemas.
-- [`zod-openapi`](https://github.com/samchungy/zod-openapi): Create full OpenAPI v3.x documentation from Zod Schemas.
+- [`zod-openapi`](https://github.com/samchungy/zod-openapi): Create full OpenAPI v3.x documentation from Zod schemas.
+- [`fastify-zod-openapi`](https://github.com/samchungy/fastify-zod-openapi): Fastify type provider, validation, serialization and @fastify/swagger support for Zod schemas.
 
 #### X to Zod
 
@@ -1203,7 +1206,7 @@ Starting from this object:
 
 ```ts
 const user = z.object({
-  email: z.string()
+  email: z.string(),
   username: z.string(),
 });
 // { email: string; username: string }
@@ -1268,7 +1271,7 @@ Starting from this object:
 
 ```ts
 const user = z.object({
-  email: z.string()
+  email: z.string(),
   username: z.string(),
 }).partial();
 // { email?: string | undefined; username?: string | undefined }
@@ -2724,7 +2727,6 @@ Yup is a full-featured library that was implemented first in vanilla JS, and lat
 
 - Supports casting and transforms
 - All object fields are optional by default
-- Missing object methods: (partial, deepPartial)
 <!-- - Missing nonempty arrays with proper typing (`[T, ...T[]]`) -->
 - Missing promise schemas
 - Missing function schemas
@@ -2787,7 +2789,7 @@ This more declarative API makes schema definitions vastly more concise.
 
 [https://github.com/pelotom/runtypes](https://github.com/pelotom/runtypes)
 
-Good type inference support, but limited options for object type masking (no `.pick` , `.omit` , `.extend` , etc.). No support for `Record` s (their `Record` is equivalent to Zod's `object` ). They DO support readonly types, which Zod does not.
+Good type inference support. They DO support readonly types, which Zod does not.
 
 - Supports "pattern matching": computed properties that distribute over unions
 - Supports readonly types

--- a/deno/lib/__tests__/readonly.test.ts
+++ b/deno/lib/__tests__/readonly.test.ts
@@ -1,0 +1,205 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { util } from "../helpers/util.ts";
+import * as z from "../index.ts";
+
+enum testEnum {
+  A,
+  B,
+}
+
+const schemas = [
+  z.string().readonly(),
+  z.number().readonly(),
+  z.nan().readonly(),
+  z.bigint().readonly(),
+  z.boolean().readonly(),
+  z.date().readonly(),
+  z.undefined().readonly(),
+  z.null().readonly(),
+  z.any().readonly(),
+  z.unknown().readonly(),
+  z.void().readonly(),
+  z.function().args(z.string(), z.number()).readonly(),
+
+  z.array(z.string()).readonly(),
+  z.tuple([z.string(), z.number()]).readonly(),
+  z.map(z.string(), z.date()).readonly(),
+  z.set(z.promise(z.string())).readonly(),
+  z.record(z.string()).readonly(),
+  z.record(z.string(), z.number()).readonly(),
+  z.object({ a: z.string(), 1: z.number() }).readonly(),
+  z.nativeEnum(testEnum).readonly(),
+  z.promise(z.string()).readonly(),
+] as const;
+
+test("flat inference", () => {
+  util.assertEqual<z.infer<(typeof schemas)[0]>, string>(true);
+  util.assertEqual<z.infer<(typeof schemas)[1]>, number>(true);
+  util.assertEqual<z.infer<(typeof schemas)[2]>, number>(true);
+  util.assertEqual<z.infer<(typeof schemas)[3]>, bigint>(true);
+  util.assertEqual<z.infer<(typeof schemas)[4]>, boolean>(true);
+  util.assertEqual<z.infer<(typeof schemas)[5]>, Date>(true);
+  util.assertEqual<z.infer<(typeof schemas)[6]>, undefined>(true);
+  util.assertEqual<z.infer<(typeof schemas)[7]>, null>(true);
+  util.assertEqual<z.infer<(typeof schemas)[8]>, any>(true);
+  util.assertEqual<z.infer<(typeof schemas)[9]>, Readonly<unknown>>(true);
+  util.assertEqual<z.infer<(typeof schemas)[10]>, void>(true);
+  util.assertEqual<
+    z.infer<(typeof schemas)[11]>,
+    (args_0: string, args_1: number, ...args_2: unknown[]) => unknown
+  >(true);
+  util.assertEqual<z.infer<(typeof schemas)[12]>, readonly string[]>(true);
+
+  util.assertEqual<z.infer<(typeof schemas)[13]>, readonly [string, number]>(
+    true
+  );
+  util.assertEqual<z.infer<(typeof schemas)[14]>, ReadonlyMap<string, Date>>(
+    true
+  );
+  util.assertEqual<z.infer<(typeof schemas)[15]>, ReadonlySet<Promise<string>>>(
+    true
+  );
+  util.assertEqual<
+    z.infer<(typeof schemas)[16]>,
+    Readonly<Record<string, string>>
+  >(true);
+  util.assertEqual<
+    z.infer<(typeof schemas)[17]>,
+    Readonly<Record<string, number>>
+  >(true);
+  util.assertEqual<
+    z.infer<(typeof schemas)[18]>,
+    { readonly a: string; readonly 1: number }
+  >(true);
+  util.assertEqual<z.infer<(typeof schemas)[19]>, Readonly<testEnum>>(true);
+  util.assertEqual<z.infer<(typeof schemas)[20]>, Promise<string>>(true);
+});
+
+// test("deep inference", () => {
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[0]>, string>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[1]>, number>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[2]>, number>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[3]>, bigint>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[4]>, boolean>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[5]>, Date>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[6]>, undefined>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[7]>, null>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[8]>, any>(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[9]>,
+//     Readonly<unknown>
+//   >(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[10]>, void>(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[11]>,
+//     (args_0: string, args_1: number, ...args_2: unknown[]) => unknown
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[12]>,
+//     readonly string[]
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[13]>,
+//     readonly [string, number]
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[14]>,
+//     ReadonlyMap<string, Date>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[15]>,
+//     ReadonlySet<Promise<string>>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[16]>,
+//     Readonly<Record<string, string>>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[17]>,
+//     Readonly<Record<string, number>>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[18]>,
+//     { readonly a: string; readonly 1: number }
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[19]>,
+//     Readonly<testEnum>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[20]>,
+//     Promise<string>
+//   >(true);
+
+//   util.assertEqual<
+//     z.infer<typeof crazyDeepReadonlySchema>,
+//     ReadonlyMap<
+//       ReadonlySet<readonly [string, number]>,
+//       {
+//         readonly a: {
+//           readonly [x: string]: readonly any[];
+//         };
+//         readonly b: {
+//           readonly c: {
+//             readonly d: {
+//               readonly e: {
+//                 readonly f: {
+//                   readonly g?: {};
+//                 };
+//               };
+//             };
+//           };
+//         };
+//       }
+//     >
+//   >(true);
+// });
+
+test("object freezing", () => {
+  expect(Object.isFrozen(z.array(z.string()).readonly().parse(["a"]))).toBe(
+    true
+  );
+  expect(
+    Object.isFrozen(
+      z.tuple([z.string(), z.number()]).readonly().parse(["a", 1])
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      z
+        .map(z.string(), z.date())
+        .readonly()
+        .parse(new Map([["a", new Date()]]))
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      z
+        .set(z.promise(z.string()))
+        .readonly()
+        .parse(new Set([Promise.resolve("a")]))
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(z.record(z.string()).readonly().parse({ a: "b" }))
+  ).toBe(true);
+  expect(
+    Object.isFrozen(z.record(z.string(), z.number()).readonly().parse({ a: 1 }))
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      z
+        .object({ a: z.string(), 1: z.number() })
+        .readonly()
+        .parse({ a: "b", 1: 2 })
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      z.promise(z.string()).readonly().parse(Promise.resolve("a"))
+    )
+  ).toBe(true);
+});

--- a/playground.ts
+++ b/playground.ts
@@ -1,8 +1,3 @@
 import { z } from "./src";
-z;
 
-const schema = z.coerce.date();
-// console.log(schema.parse("3.14"));
-test("asdf", () => {
-  expect(schema.parse("3.14")).toBeInstanceOf(Date);
-});
+z;

--- a/src/__tests__/readonly.test.ts
+++ b/src/__tests__/readonly.test.ts
@@ -1,0 +1,204 @@
+// @ts-ignore TS6133
+import { test, expect } from "@jest/globals";
+
+import { util } from "../helpers/util";
+import * as z from "../index";
+
+enum testEnum {
+  A,
+  B,
+}
+
+const schemas = [
+  z.string().readonly(),
+  z.number().readonly(),
+  z.nan().readonly(),
+  z.bigint().readonly(),
+  z.boolean().readonly(),
+  z.date().readonly(),
+  z.undefined().readonly(),
+  z.null().readonly(),
+  z.any().readonly(),
+  z.unknown().readonly(),
+  z.void().readonly(),
+  z.function().args(z.string(), z.number()).readonly(),
+
+  z.array(z.string()).readonly(),
+  z.tuple([z.string(), z.number()]).readonly(),
+  z.map(z.string(), z.date()).readonly(),
+  z.set(z.promise(z.string())).readonly(),
+  z.record(z.string()).readonly(),
+  z.record(z.string(), z.number()).readonly(),
+  z.object({ a: z.string(), 1: z.number() }).readonly(),
+  z.nativeEnum(testEnum).readonly(),
+  z.promise(z.string()).readonly(),
+] as const;
+
+test("flat inference", () => {
+  util.assertEqual<z.infer<(typeof schemas)[0]>, string>(true);
+  util.assertEqual<z.infer<(typeof schemas)[1]>, number>(true);
+  util.assertEqual<z.infer<(typeof schemas)[2]>, number>(true);
+  util.assertEqual<z.infer<(typeof schemas)[3]>, bigint>(true);
+  util.assertEqual<z.infer<(typeof schemas)[4]>, boolean>(true);
+  util.assertEqual<z.infer<(typeof schemas)[5]>, Date>(true);
+  util.assertEqual<z.infer<(typeof schemas)[6]>, undefined>(true);
+  util.assertEqual<z.infer<(typeof schemas)[7]>, null>(true);
+  util.assertEqual<z.infer<(typeof schemas)[8]>, any>(true);
+  util.assertEqual<z.infer<(typeof schemas)[9]>, Readonly<unknown>>(true);
+  util.assertEqual<z.infer<(typeof schemas)[10]>, void>(true);
+  util.assertEqual<
+    z.infer<(typeof schemas)[11]>,
+    (args_0: string, args_1: number, ...args_2: unknown[]) => unknown
+  >(true);
+  util.assertEqual<z.infer<(typeof schemas)[12]>, readonly string[]>(true);
+
+  util.assertEqual<z.infer<(typeof schemas)[13]>, readonly [string, number]>(
+    true
+  );
+  util.assertEqual<z.infer<(typeof schemas)[14]>, ReadonlyMap<string, Date>>(
+    true
+  );
+  util.assertEqual<z.infer<(typeof schemas)[15]>, ReadonlySet<Promise<string>>>(
+    true
+  );
+  util.assertEqual<
+    z.infer<(typeof schemas)[16]>,
+    Readonly<Record<string, string>>
+  >(true);
+  util.assertEqual<
+    z.infer<(typeof schemas)[17]>,
+    Readonly<Record<string, number>>
+  >(true);
+  util.assertEqual<
+    z.infer<(typeof schemas)[18]>,
+    { readonly a: string; readonly 1: number }
+  >(true);
+  util.assertEqual<z.infer<(typeof schemas)[19]>, Readonly<testEnum>>(true);
+  util.assertEqual<z.infer<(typeof schemas)[20]>, Promise<string>>(true);
+});
+
+// test("deep inference", () => {
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[0]>, string>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[1]>, number>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[2]>, number>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[3]>, bigint>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[4]>, boolean>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[5]>, Date>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[6]>, undefined>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[7]>, null>(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[8]>, any>(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[9]>,
+//     Readonly<unknown>
+//   >(true);
+//   util.assertEqual<z.infer<(typeof deepReadonlySchemas_0)[10]>, void>(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[11]>,
+//     (args_0: string, args_1: number, ...args_2: unknown[]) => unknown
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[12]>,
+//     readonly string[]
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[13]>,
+//     readonly [string, number]
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[14]>,
+//     ReadonlyMap<string, Date>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[15]>,
+//     ReadonlySet<Promise<string>>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[16]>,
+//     Readonly<Record<string, string>>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[17]>,
+//     Readonly<Record<string, number>>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[18]>,
+//     { readonly a: string; readonly 1: number }
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[19]>,
+//     Readonly<testEnum>
+//   >(true);
+//   util.assertEqual<
+//     z.infer<(typeof deepReadonlySchemas_0)[20]>,
+//     Promise<string>
+//   >(true);
+
+//   util.assertEqual<
+//     z.infer<typeof crazyDeepReadonlySchema>,
+//     ReadonlyMap<
+//       ReadonlySet<readonly [string, number]>,
+//       {
+//         readonly a: {
+//           readonly [x: string]: readonly any[];
+//         };
+//         readonly b: {
+//           readonly c: {
+//             readonly d: {
+//               readonly e: {
+//                 readonly f: {
+//                   readonly g?: {};
+//                 };
+//               };
+//             };
+//           };
+//         };
+//       }
+//     >
+//   >(true);
+// });
+
+test("object freezing", () => {
+  expect(Object.isFrozen(z.array(z.string()).readonly().parse(["a"]))).toBe(
+    true
+  );
+  expect(
+    Object.isFrozen(
+      z.tuple([z.string(), z.number()]).readonly().parse(["a", 1])
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      z
+        .map(z.string(), z.date())
+        .readonly()
+        .parse(new Map([["a", new Date()]]))
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      z
+        .set(z.promise(z.string()))
+        .readonly()
+        .parse(new Set([Promise.resolve("a")]))
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(z.record(z.string()).readonly().parse({ a: "b" }))
+  ).toBe(true);
+  expect(
+    Object.isFrozen(z.record(z.string(), z.number()).readonly().parse({ a: 1 }))
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      z
+        .object({ a: z.string(), 1: z.number() })
+        .readonly()
+        .parse({ a: "b", 1: 2 })
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      z.promise(z.string()).readonly().parse(Promise.resolve("a"))
+    )
+  ).toBe(true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./configs/tsconfig.base.json"
+  "extends": "./configs/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../lib"
+  }
 }


### PR DESCRIPTION
A stripped down version of some excellent earlier work by @santosmarco. Marco - at the moment I think it makes sense to always freeze until someone asks to disable it (I don't think they will). I'm also holding off on `.deep()` for the same reason - too much complexity overhead for a feature I'm not sure anyone needs.

cc @tkdodo

 