### PR TITLE
add xid string validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,7 @@ z.string().nanoid();
 z.string().cuid();
 z.string().cuid2();
 z.string().ulid();
+z.string().xid();
 z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -865,6 +865,7 @@ z.string().nanoid();
 z.string().cuid();
 z.string().cuid2();
 z.string().ulid();
+z.string().xid();
 z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -99,6 +99,7 @@ export type StringValidation =
   | "cuid"
   | "cuid2"
   | "ulid"
+  | "xid"
   | "datetime"
   | "date"
   | "time"

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -333,6 +333,16 @@ test("ulid", () => {
   }
 });
 
+test("xid", () => {
+  const xid = z.string().xid();
+  xid.parse("9m4e2mr0ui3e8a215n4g");
+  const result = xid.safeParse("invalidxid");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("Invalid xid");
+  }
+});
+
 test("regex", () => {
   z.string()
     .regex(/^moo+$/)
@@ -372,6 +382,7 @@ test("checks getters", () => {
   expect(z.string().email().isNANOID).toEqual(false);
   expect(z.string().email().isIP).toEqual(false);
   expect(z.string().email().isULID).toEqual(false);
+  expect(z.string().email().isXID).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
@@ -381,6 +392,7 @@ test("checks getters", () => {
   expect(z.string().url().isNANOID).toEqual(false);
   expect(z.string().url().isIP).toEqual(false);
   expect(z.string().url().isULID).toEqual(false);
+  expect(z.string().url().isXID).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
@@ -390,6 +402,7 @@ test("checks getters", () => {
   expect(z.string().cuid().isNANOID).toEqual(false);
   expect(z.string().cuid().isIP).toEqual(false);
   expect(z.string().cuid().isULID).toEqual(false);
+  expect(z.string().cuid().isXID).toEqual(false);
 
   expect(z.string().cuid2().isEmail).toEqual(false);
   expect(z.string().cuid2().isURL).toEqual(false);
@@ -399,6 +412,7 @@ test("checks getters", () => {
   expect(z.string().cuid2().isNANOID).toEqual(false);
   expect(z.string().cuid2().isIP).toEqual(false);
   expect(z.string().cuid2().isULID).toEqual(false);
+  expect(z.string().cuid2().isXID).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
@@ -408,6 +422,7 @@ test("checks getters", () => {
   expect(z.string().uuid().isNANOID).toEqual(false);
   expect(z.string().uuid().isIP).toEqual(false);
   expect(z.string().uuid().isULID).toEqual(false);
+  expect(z.string().uuid().isXID).toEqual(false);
 
   expect(z.string().nanoid().isEmail).toEqual(false);
   expect(z.string().nanoid().isURL).toEqual(false);
@@ -426,6 +441,7 @@ test("checks getters", () => {
   expect(z.string().ip().isNANOID).toEqual(false);
   expect(z.string().ip().isIP).toEqual(true);
   expect(z.string().ip().isULID).toEqual(false);
+  expect(z.string().ip().isXID).toEqual(false);
 
   expect(z.string().ulid().isEmail).toEqual(false);
   expect(z.string().ulid().isURL).toEqual(false);
@@ -435,6 +451,16 @@ test("checks getters", () => {
   expect(z.string().ulid().isNANOID).toEqual(false);
   expect(z.string().ulid().isIP).toEqual(false);
   expect(z.string().ulid().isULID).toEqual(true);
+  expect(z.string().ulid().isXID).toEqual(false);
+
+  expect(z.string().xid().isEmail).toEqual(false);
+  expect(z.string().xid().isURL).toEqual(false);
+  expect(z.string().xid().isCUID).toEqual(false);
+  expect(z.string().xid().isCUID2).toEqual(false);
+  expect(z.string().xid().isUUID).toEqual(false);
+  expect(z.string().xid().isIP).toEqual(false);
+  expect(z.string().xid().isULID).toEqual(false);
+  expect(z.string().xid().isXID).toEqual(true);
 });
 
 test("min max getters", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -540,6 +540,7 @@ export type ZodStringCheck =
   | { kind: "includes"; value: string; position?: number; message?: string }
   | { kind: "cuid2"; message?: string }
   | { kind: "ulid"; message?: string }
+  | { kind: "xid"; message?: string }
   | { kind: "startsWith"; value: string; message?: string }
   | { kind: "endsWith"; value: string; message?: string }
   | { kind: "regex"; regex: RegExp; message?: string }
@@ -576,6 +577,7 @@ export interface ZodStringDef extends ZodTypeDef {
 const cuidRegex = /^c[^\s-]{8,}$/i;
 const cuid2Regex = /^[0-9a-z]+$/;
 const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const xidRegex = /^[0-9a-v]{20}$/i;
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 const uuidRegex =
@@ -815,6 +817,16 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
+      } else if (check.kind === "xid") {
+        if (!xidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "xid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "url") {
         try {
           new URL(input.data);
@@ -998,6 +1010,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   base64(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "base64", ...errorUtil.errToObj(message) });
+  }
+  xid(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "xid", ...errorUtil.errToObj(message) });
   }
 
   ip(options?: string | { version?: "v4" | "v6"; message?: string }) {
@@ -1193,6 +1208,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   get isULID() {
     return !!this._def.checks.find((ch) => ch.kind === "ulid");
+  }
+  get isXID() {
+    return !!this._def.checks.find((ch) => ch.kind === "xid");
   }
   get isIP() {
     return !!this._def.checks.find((ch) => ch.kind === "ip");

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -99,6 +99,7 @@ export type StringValidation =
   | "cuid"
   | "cuid2"
   | "ulid"
+  | "xid"
   | "datetime"
   | "date"
   | "time"

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -332,6 +332,16 @@ test("ulid", () => {
   }
 });
 
+test("xid", () => {
+  const xid = z.string().xid();
+  xid.parse("9m4e2mr0ui3e8a215n4g");
+  const result = xid.safeParse("invalidxid");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("Invalid xid");
+  }
+});
+
 test("regex", () => {
   z.string()
     .regex(/^moo+$/)
@@ -371,6 +381,7 @@ test("checks getters", () => {
   expect(z.string().email().isNANOID).toEqual(false);
   expect(z.string().email().isIP).toEqual(false);
   expect(z.string().email().isULID).toEqual(false);
+  expect(z.string().email().isXID).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
@@ -380,6 +391,7 @@ test("checks getters", () => {
   expect(z.string().url().isNANOID).toEqual(false);
   expect(z.string().url().isIP).toEqual(false);
   expect(z.string().url().isULID).toEqual(false);
+  expect(z.string().url().isXID).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
@@ -389,6 +401,7 @@ test("checks getters", () => {
   expect(z.string().cuid().isNANOID).toEqual(false);
   expect(z.string().cuid().isIP).toEqual(false);
   expect(z.string().cuid().isULID).toEqual(false);
+  expect(z.string().cuid().isXID).toEqual(false);
 
   expect(z.string().cuid2().isEmail).toEqual(false);
   expect(z.string().cuid2().isURL).toEqual(false);
@@ -398,6 +411,7 @@ test("checks getters", () => {
   expect(z.string().cuid2().isNANOID).toEqual(false);
   expect(z.string().cuid2().isIP).toEqual(false);
   expect(z.string().cuid2().isULID).toEqual(false);
+  expect(z.string().cuid2().isXID).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
@@ -407,6 +421,7 @@ test("checks getters", () => {
   expect(z.string().uuid().isNANOID).toEqual(false);
   expect(z.string().uuid().isIP).toEqual(false);
   expect(z.string().uuid().isULID).toEqual(false);
+  expect(z.string().uuid().isXID).toEqual(false);
 
   expect(z.string().nanoid().isEmail).toEqual(false);
   expect(z.string().nanoid().isURL).toEqual(false);
@@ -425,6 +440,7 @@ test("checks getters", () => {
   expect(z.string().ip().isNANOID).toEqual(false);
   expect(z.string().ip().isIP).toEqual(true);
   expect(z.string().ip().isULID).toEqual(false);
+  expect(z.string().ip().isXID).toEqual(false);
 
   expect(z.string().ulid().isEmail).toEqual(false);
   expect(z.string().ulid().isURL).toEqual(false);
@@ -434,6 +450,16 @@ test("checks getters", () => {
   expect(z.string().ulid().isNANOID).toEqual(false);
   expect(z.string().ulid().isIP).toEqual(false);
   expect(z.string().ulid().isULID).toEqual(true);
+  expect(z.string().ulid().isXID).toEqual(false);
+
+  expect(z.string().xid().isEmail).toEqual(false);
+  expect(z.string().xid().isURL).toEqual(false);
+  expect(z.string().xid().isCUID).toEqual(false);
+  expect(z.string().xid().isCUID2).toEqual(false);
+  expect(z.string().xid().isUUID).toEqual(false);
+  expect(z.string().xid().isIP).toEqual(false);
+  expect(z.string().xid().isULID).toEqual(false);
+  expect(z.string().xid().isXID).toEqual(true);
 });
 
 test("min max getters", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -540,6 +540,7 @@ export type ZodStringCheck =
   | { kind: "includes"; value: string; position?: number; message?: string }
   | { kind: "cuid2"; message?: string }
   | { kind: "ulid"; message?: string }
+  | { kind: "xid"; message?: string }
   | { kind: "startsWith"; value: string; message?: string }
   | { kind: "endsWith"; value: string; message?: string }
   | { kind: "regex"; regex: RegExp; message?: string }
@@ -576,6 +577,7 @@ export interface ZodStringDef extends ZodTypeDef {
 const cuidRegex = /^c[^\s-]{8,}$/i;
 const cuid2Regex = /^[0-9a-z]+$/;
 const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const xidRegex = /^[0-9a-v]{20}$/i;
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 const uuidRegex =
@@ -815,6 +817,16 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
+      } else if (check.kind === "xid") {
+        if (!xidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "xid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "url") {
         try {
           new URL(input.data);
@@ -998,6 +1010,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   base64(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "base64", ...errorUtil.errToObj(message) });
+  }
+  xid(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "xid", ...errorUtil.errToObj(message) });
   }
 
   ip(options?: string | { version?: "v4" | "v6"; message?: string }) {
@@ -1193,6 +1208,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   get isULID() {
     return !!this._def.checks.find((ch) => ch.kind === "ulid");
+  }
+  get isXID() {
+    return !!this._def.checks.find((ch) => ch.kind === "xid");
   }
   get isIP() {
     return !!this._def.checks.find((ch) => ch.kind === "ip");


### PR DESCRIPTION
I've added an additional string validator to validate `xid` formatted strings.

Implements the feature requested by #2639 

I've pretty much just done a global search on the codebase for `cuid2`/`ulid`, and added a matching entry for `xid` at each match, making slight changes where necessary.

Let me know if I'm missing anything!