### PR TITLE
Update README for z.enum dynamic values 

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,6 +962,13 @@ const fish = ["Salmon", "Tuna", "Trout"];
 const FishEnum = z.enum(fish);
 ```
 
+But you may assert with `[string]` to let `z.enum` accept dynamic values.
+
+```ts
+const fish = ["Salmon", "Tuna", "Trout"];
+const FishEnum = z.enum(fish as [string]);
+```
+
 **Autocompletion**
 
 To get autocompletion with a Zod enum, use the `.enum` property of your schema:

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -962,6 +962,13 @@ const fish = ["Salmon", "Tuna", "Trout"];
 const FishEnum = z.enum(fish);
 ```
 
+But you may assert with `[string]` to let `z.enum` accept dynamic values.
+
+```ts
+const fish = ["Salmon", "Tuna", "Trout"];
+const FishEnum = z.enum(fish as [string]);
+```
+
 **Autocompletion**
 
 To get autocompletion with a Zod enum, use the `.enum` property of your schema:


### PR DESCRIPTION
# What this PR do

* Updates the `README.md` and add details on how to let `z.enum()` accepts dynamic values

## Current Doc
It says about `zod.enum` not able to infer 
<img width="759" alt="Screenshot 2023-08-11 at 9 06 10 PM" src="https://github.com/colinhacks/zod/assets/30344224/bc60b169-cfb8-4ed5-9f73-303b06e8c17e">

## Updated Doc
Suggests type assertion that will allow dynamic values to `z.enum()`
<img width="775" alt="Screenshot 2023-08-11 at 9 06 05 PM" src="https://github.com/colinhacks/zod/assets/30344224/831e76cc-85b9-4fb0-aceb-414c7598f2ef">

