### PR TITLE
Initial prototype fix for issue #2651

### DIFF
--- a/deno/lib/__tests__/function.test.ts
+++ b/deno/lib/__tests__/function.test.ts
@@ -29,6 +29,19 @@ test("function inference 1", () => {
   util.assertEqual<func1, (k: string) => number>(true);
 });
 
+test("method parsing", () => {
+	const methodObject = z.object({
+		property: z.number(),
+		method: z.function().args(z.string()).returns(z.number())
+	});
+	const methodInstance = {
+		property: 3,
+		method: function(s: string) { return s.length + this.property; }
+	};
+	const parsed = methodObject.parse(methodInstance);
+	expect(parsed.method('length=8')).toBe(11); // 8 length + 3 property
+});
+
 test("args method", () => {
   const t1 = z.function();
   type t1 = z.infer<typeof t1>;

--- a/deno/lib/__tests__/function.test.ts
+++ b/deno/lib/__tests__/function.test.ts
@@ -42,6 +42,19 @@ test("method parsing", () => {
 	expect(parsed.method('length=8')).toBe(11); // 8 length + 3 property
 });
 
+test("async method parsing", async () => {
+	const methodObject = z.object({
+		property: z.number(),
+		method: z.function().args(z.string()).returns(z.promise(z.number()))
+	});
+	const methodInstance = {
+		property: 3,
+		method: async function(s: string) { return s.length + this.property; }
+	};
+	const parsed = methodObject.parse(methodInstance);
+	expect(await parsed.method('length=8')).toBe(11); // 8 length + 3 property
+});
+
 test("args method", () => {
   const t1 = z.function();
   type t1 = z.infer<typeof t1>;

--- a/deno/lib/__tests__/function.test.ts
+++ b/deno/lib/__tests__/function.test.ts
@@ -30,29 +30,29 @@ test("function inference 1", () => {
 });
 
 test("method parsing", () => {
-	const methodObject = z.object({
-		property: z.number(),
-		method: z.function().args(z.string()).returns(z.number())
-	});
-	const methodInstance = {
-		property: 3,
-		method: function(s: string) { return s.length + this.property; }
-	};
-	const parsed = methodObject.parse(methodInstance);
-	expect(parsed.method('length=8')).toBe(11); // 8 length + 3 property
+  const methodObject = z.object({
+    property: z.number(),
+    method: z.function().args(z.string()).returns(z.number())
+  });
+  const methodInstance = {
+    property: 3,
+    method: function(s: string) { return s.length + this.property; }
+  };
+  const parsed = methodObject.parse(methodInstance);
+  expect(parsed.method('length=8')).toBe(11); // 8 length + 3 property
 });
 
 test("async method parsing", async () => {
-	const methodObject = z.object({
-		property: z.number(),
-		method: z.function().args(z.string()).returns(z.promise(z.number()))
-	});
-	const methodInstance = {
-		property: 3,
-		method: async function(s: string) { return s.length + this.property; }
-	};
-	const parsed = methodObject.parse(methodInstance);
-	expect(await parsed.method('length=8')).toBe(11); // 8 length + 3 property
+  const methodObject = z.object({
+    property: z.number(),
+    method: z.function().args(z.string()).returns(z.promise(z.number()))
+  });
+  const methodInstance = {
+    property: 3,
+    method: async function(s: string) { return s.length + this.property; }
+  };
+  const parsed = methodObject.parse(methodInstance);
+  expect(await parsed.method('length=8')).toBe(11); // 8 length + 3 property
 });
 
 test("args method", () => {

--- a/src/__tests__/function.test.ts
+++ b/src/__tests__/function.test.ts
@@ -29,29 +29,29 @@ test("function inference 1", () => {
 });
 
 test("method parsing", () => {
-	const methodObject = z.object({
-		property: z.number(),
-		method: z.function().args(z.string()).returns(z.number())
-	});
-	const methodInstance = {
-		property: 3,
-		method: function(s: string) { return s.length + this.property; }
-	};
-	const parsed = methodObject.parse(methodInstance);
-	expect(parsed.method('length=8')).toBe(11); // 8 length + 3 property
+  const methodObject = z.object({
+    property: z.number(),
+    method: z.function().args(z.string()).returns(z.number())
+  });
+  const methodInstance = {
+    property: 3,
+    method: function(s: string) { return s.length + this.property; }
+  };
+  const parsed = methodObject.parse(methodInstance);
+  expect(parsed.method('length=8')).toBe(11); // 8 length + 3 property
 });
 
 test("async method parsing", async () => {
-	const methodObject = z.object({
-		property: z.number(),
-		method: z.function().args(z.string()).returns(z.promise(z.number()))
-	});
-	const methodInstance = {
-		property: 3,
-		method: async function(s: string) { return s.length + this.property; }
-	};
-	const parsed = methodObject.parse(methodInstance);
-	expect(await parsed.method('length=8')).toBe(11); // 8 length + 3 property
+  const methodObject = z.object({
+    property: z.number(),
+    method: z.function().args(z.string()).returns(z.promise(z.number()))
+  });
+  const methodInstance = {
+    property: 3,
+    method: async function(s: string) { return s.length + this.property; }
+  };
+  const parsed = methodObject.parse(methodInstance);
+  expect(await parsed.method('length=8')).toBe(11); // 8 length + 3 property
 });
 
 test("args method", () => {

--- a/src/__tests__/function.test.ts
+++ b/src/__tests__/function.test.ts
@@ -28,6 +28,19 @@ test("function inference 1", () => {
   util.assertEqual<func1, (k: string) => number>(true);
 });
 
+test("method parsing", () => {
+	const methodObject = z.object({
+		property: z.number(),
+		method: z.function().args(z.string()).returns(z.number())
+	});
+	const methodInstance = {
+		property: 3,
+		method: function(s: string) { return s.length + this.property; }
+	};
+	const parsed = methodObject.parse(methodInstance);
+	expect(parsed.method('length=8')).toBe(11); // 8 length + 3 property
+});
+
 test("args method", () => {
   const t1 = z.function();
   type t1 = z.infer<typeof t1>;

--- a/src/__tests__/function.test.ts
+++ b/src/__tests__/function.test.ts
@@ -41,6 +41,19 @@ test("method parsing", () => {
 	expect(parsed.method('length=8')).toBe(11); // 8 length + 3 property
 });
 
+test("async method parsing", async () => {
+	const methodObject = z.object({
+		property: z.number(),
+		method: z.function().args(z.string()).returns(z.promise(z.number()))
+	});
+	const methodInstance = {
+		property: 3,
+		method: async function(s: string) { return s.length + this.property; }
+	};
+	const parsed = methodObject.parse(methodInstance);
+	expect(await parsed.method('length=8')).toBe(11); // 8 length + 3 property
+});
+
 test("args method", () => {
   const t1 = z.function();
   type t1 = z.infer<typeof t1>;


### PR DESCRIPTION
Uses a non-arrow function to maintain `this`.

Closes #2651 