### PR TITLE
Use Set.has instead of Array.indexOf for enum comparison (perf improvement)

### DIFF
--- a/deno/lib/benchmarks/index.ts
+++ b/deno/lib/benchmarks/index.ts
@@ -43,3 +43,9 @@ if (!argv.length) {
 for (const suite of suites) {
   suite.run();
 }
+
+// exit on Ctrl-C
+process.on("SIGINT", function () {
+  console.log("Exiting...");
+  process.exit();
+});

--- a/deno/lib/benchmarks/primitives.ts
+++ b/deno/lib/benchmarks/primitives.ts
@@ -21,6 +21,40 @@ enumSuite
     console.log(`z.enum: ${e.target}`);
   });
 
+const longEnumSuite = new Benchmark.Suite("long z.enum");
+const longEnumSchema = z.enum([
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten",
+  "eleven",
+  "twelve",
+  "thirteen",
+  "fourteen",
+  "fifteen",
+  "sixteen",
+  "seventeen",
+]);
+
+longEnumSuite
+  .add("valid", () => {
+    longEnumSchema.parse("five");
+  })
+  .add("invalid", () => {
+    try {
+      longEnumSchema.parse("invalid");
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`long z.enum: ${e.target}`);
+  });
+
 const undefinedSuite = new Benchmark.Suite("z.undefined");
 const undefinedSchema = z.undefined();
 
@@ -129,6 +163,7 @@ symbolSuite
 export default {
   suites: [
     enumSuite,
+    longEnumSuite,
     undefinedSuite,
     literalSuite,
     numberSuite,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4083,6 +4083,7 @@ export interface ZodEnumDef<T extends EnumValues = EnumValues>
   extends ZodTypeDef {
   values: T;
   typeName: ZodFirstPartyTypeKind.ZodEnum;
+  valueSet: Set<T[number]>;
 }
 
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] };
@@ -4111,6 +4112,7 @@ function createZodEnum(
 ) {
   return new ZodEnum({
     values,
+    valueSet: new Set(values),
     typeName: ZodFirstPartyTypeKind.ZodEnum,
     ...processCreateParams(params),
   });
@@ -4132,8 +4134,7 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
       return INVALID;
     }
 
-    const set = new Set(this._def.values);
-    if (!set.has(input.data)) {
+    if (!this._def.valueSet.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
 
@@ -4216,6 +4217,7 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
 export interface ZodNativeEnumDef<T extends EnumLike = EnumLike>
   extends ZodTypeDef {
   values: T;
+  valueSet: Set<T[keyof T]>;
   typeName: ZodFirstPartyTypeKind.ZodNativeEnum;
 }
 
@@ -4242,8 +4244,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       return INVALID;
     }
 
-    const set = new Set(nativeEnumValues);
-    if (!set.has(input.data)) {
+    if (!this._def.valueSet.has(input.data)) {
       const expectedValues = util.objectValues(nativeEnumValues);
 
       addIssueToContext(ctx, {
@@ -4266,6 +4267,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
   ): ZodNativeEnum<T> => {
     return new ZodNativeEnum({
       values: values,
+      valueSet: new Set(util.getValidEnumValues(values)),
       typeName: ZodFirstPartyTypeKind.ZodNativeEnum,
       ...processCreateParams(params),
     });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4132,7 +4132,8 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
       return INVALID;
     }
 
-    if (this._def.values.indexOf(input.data) === -1) {
+    const set = new Set(this._def.values);
+    if (!set.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
 
@@ -4241,7 +4242,8 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       return INVALID;
     }
 
-    if (nativeEnumValues.indexOf(input.data) === -1) {
+    const set = new Set(nativeEnumValues);
+    if (!set.has(input.data)) {
       const expectedValues = util.objectValues(nativeEnumValues);
 
       addIssueToContext(ctx, {

--- a/src/benchmarks/index.ts
+++ b/src/benchmarks/index.ts
@@ -43,3 +43,9 @@ if (!argv.length) {
 for (const suite of suites) {
   suite.run();
 }
+
+// exit on Ctrl-C
+process.on("SIGINT", function () {
+  console.log("Exiting...");
+  process.exit();
+});

--- a/src/benchmarks/primitives.ts
+++ b/src/benchmarks/primitives.ts
@@ -21,6 +21,40 @@ enumSuite
     console.log(`z.enum: ${e.target}`);
   });
 
+const longEnumSuite = new Benchmark.Suite("long z.enum");
+const longEnumSchema = z.enum([
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten",
+  "eleven",
+  "twelve",
+  "thirteen",
+  "fourteen",
+  "fifteen",
+  "sixteen",
+  "seventeen",
+]);
+
+longEnumSuite
+  .add("valid", () => {
+    longEnumSchema.parse("five");
+  })
+  .add("invalid", () => {
+    try {
+      longEnumSchema.parse("invalid");
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`long z.enum: ${e.target}`);
+  });
+
 const undefinedSuite = new Benchmark.Suite("z.undefined");
 const undefinedSchema = z.undefined();
 
@@ -129,6 +163,7 @@ symbolSuite
 export default {
   suites: [
     enumSuite,
+    longEnumSuite,
     undefinedSuite,
     literalSuite,
     numberSuite,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4083,6 +4083,7 @@ export interface ZodEnumDef<T extends EnumValues = EnumValues>
   extends ZodTypeDef {
   values: T;
   typeName: ZodFirstPartyTypeKind.ZodEnum;
+  valueSet: Set<T[number]>;
 }
 
 export type Writeable<T> = { -readonly [P in keyof T]: T[P] };
@@ -4111,6 +4112,7 @@ function createZodEnum(
 ) {
   return new ZodEnum({
     values,
+    valueSet: new Set(values),
     typeName: ZodFirstPartyTypeKind.ZodEnum,
     ...processCreateParams(params),
   });
@@ -4132,8 +4134,7 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
       return INVALID;
     }
 
-    const set = new Set(this._def.values);
-    if (!set.has(input.data)) {
+    if (!this._def.valueSet.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
 
@@ -4216,6 +4217,7 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
 export interface ZodNativeEnumDef<T extends EnumLike = EnumLike>
   extends ZodTypeDef {
   values: T;
+  valueSet: Set<T[keyof T]>;
   typeName: ZodFirstPartyTypeKind.ZodNativeEnum;
 }
 
@@ -4242,8 +4244,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       return INVALID;
     }
 
-    const set = new Set(nativeEnumValues);
-    if (!set.has(input.data)) {
+    if (!this._def.valueSet.has(input.data)) {
       const expectedValues = util.objectValues(nativeEnumValues);
 
       addIssueToContext(ctx, {
@@ -4266,6 +4267,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
   ): ZodNativeEnum<T> => {
     return new ZodNativeEnum({
       values: values,
+      valueSet: new Set(util.getValidEnumValues(values)),
       typeName: ZodFirstPartyTypeKind.ZodNativeEnum,
       ...processCreateParams(params),
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -4132,7 +4132,8 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
       return INVALID;
     }
 
-    if (this._def.values.indexOf(input.data) === -1) {
+    const set = new Set(this._def.values);
+    if (!set.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
 
@@ -4241,7 +4242,8 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       return INVALID;
     }
 
-    if (nativeEnumValues.indexOf(input.data) === -1) {
+    const set = new Set(nativeEnumValues);
+    if (!set.has(input.data)) {
       const expectedValues = util.objectValues(nativeEnumValues);
 
       addIssueToContext(ctx, {


### PR DESCRIPTION
Improve zod's performance by using `Set.has` instead of `Array.indexOf` when checking for the presence of a value inside `ZodEnum` or `ZodNativeEnum`.

`Array.indexOf` is especially problematic when passing multiple (e.g. 30+) values to an enum. This PR introduces a very simple change that turns an `O(n)` operation to `O(1)`.

### Benchmarks

#### Before this PR

<img width="522" alt="benchmark-results-latest-master" src="https://github.com/colinhacks/zod/assets/1032064/974c8a44-53ce-4075-86db-b9c3a1caa0f7">

#### After this PR

<img width="533" alt="benchmark-results-using-set" src="https://github.com/colinhacks/zod/assets/1032064/8557d80f-8f2a-43f0-a03c-c96adb940f2e">

### Conclusions

- Using `Set.has` we were able to increase the performance of the `parse` method in `ZodEnum` and `ZodNativeEnum` by 20%.
- The more the enum values the greater the benefit by using `Set` instead of `Array`.

