### PR TITLE
Add string jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,7 +860,7 @@ z.string().length(5);
 z.string().email();
 z.string().url();
 z.string().emoji();
-z.string().jwt(); // validates format, NOT signature
+z.string().jwt(); // validates format, NOT signature. Accepts algorithm as optional options
 z.string().uuid();
 z.string().nanoid();
 z.string().cuid();

--- a/README.md
+++ b/README.md
@@ -860,7 +860,8 @@ z.string().length(5);
 z.string().email();
 z.string().url();
 z.string().emoji();
-z.string().jwt(); // validates format, NOT signature. Accepts algorithm as optional options
+z.string().jwt(); // validates format, NOT signature
+z.string().jwt({ alg: "HS256" }); // specify algorithm
 z.string().uuid();
 z.string().nanoid();
 z.string().cuid();

--- a/README.md
+++ b/README.md
@@ -860,6 +860,7 @@ z.string().length(5);
 z.string().email();
 z.string().url();
 z.string().emoji();
+z.string().jwt(); // validates format, NOT signature
 z.string().uuid();
 z.string().nanoid();
 z.string().cuid();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -860,7 +860,7 @@ z.string().length(5);
 z.string().email();
 z.string().url();
 z.string().emoji();
-z.string().jwt(); // validates format, NOT signature
+z.string().jwt(); // validates format, NOT signature. Accepts algorithm as optional options
 z.string().uuid();
 z.string().nanoid();
 z.string().cuid();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -860,7 +860,8 @@ z.string().length(5);
 z.string().email();
 z.string().url();
 z.string().emoji();
-z.string().jwt(); // validates format, NOT signature. Accepts algorithm as optional options
+z.string().jwt(); // validates format, NOT signature
+z.string().jwt({ alg: "HS256" }); // specify algorithm
 z.string().uuid();
 z.string().nanoid();
 z.string().cuid();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -860,6 +860,7 @@ z.string().length(5);
 z.string().email();
 z.string().url();
 z.string().emoji();
+z.string().jwt(); // validates format, NOT signature
 z.string().uuid();
 z.string().nanoid();
 z.string().cuid();

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -92,6 +92,7 @@ export interface ZodInvalidDateIssue extends ZodIssueBase {
 export type StringValidation =
   | "email"
   | "url"
+  | "jwt"
   | "emoji"
   | "uuid"
   | "nanoid"

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -200,6 +200,39 @@ test("base64 validations", () => {
   }
 });
 
+test("jwt token", () => {
+  const jwtSchema = z.string().jwt();
+
+  // Can't split in 3 parts
+  expect(() =>
+    jwtSchema.parse("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+  ).toThrow();
+  // Header not Base64
+  expect(() =>
+    jwtSchema.parse(
+      "headerIsNotBase64Encoded.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE"
+    )
+  ).toThrow();
+  // Has no type in header
+  expect(() =>
+    jwtSchema.parse(
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.GuoUe6tw79bJlbU1HU0ADX0pr0u2kf3r_4OdrDufSfQ"
+    )
+  ).toBeTruthy();
+  // Type is not JWT
+  expect(() =>
+    jwtSchema.parse(
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpUVyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE"
+    )
+  ).toBeTruthy();
+  //Success
+  expect(() =>
+    jwtSchema.parse(
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+  ).toBeTruthy();
+});
+
 test("url validations", () => {
   const url = z.string().url();
   url.parse("http://google.com");

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -223,19 +223,19 @@ test("jwt token", () => {
   expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
   expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
   expect(() =>
-    z.string().jwt({ algorithm: "ES256" }).parse(GOOD_JWT_HS256)
+    z.string().jwt({ alg: "ES256" }).parse(GOOD_JWT_HS256)
   ).toThrow();
   expect(() =>
-    z.string().jwt({ algorithm: "HS256" }).parse(GOOD_JWT_ES256)
+    z.string().jwt({ alg: "HS256" }).parse(GOOD_JWT_ES256)
   ).toThrow();
   //Success
   expect(() => jwtSchema.parse(GOOD_JWT_HS256)).not.toThrow();
   expect(() => jwtSchema.parse(GOOD_JWT_ES256)).not.toThrow();
   expect(() =>
-    z.string().jwt({ algorithm: "HS256" }).parse(GOOD_JWT_HS256)
+    z.string().jwt({ alg: "HS256" }).parse(GOOD_JWT_HS256)
   ).not.toThrow();
   expect(() =>
-    z.string().jwt({ algorithm: "ES256" }).parse(GOOD_JWT_ES256)
+    z.string().jwt({ alg: "ES256" }).parse(GOOD_JWT_ES256)
   ).not.toThrow();
 });
 

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -201,36 +201,42 @@ test("base64 validations", () => {
 });
 
 test("jwt token", () => {
+  const ONE_PART = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+  const NOT_BASE64 =
+    "headerIsNotBase64Encoded.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE";
+  const NO_TYP =
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.GuoUe6tw79bJlbU1HU0ADX0pr0u2kf3r_4OdrDufSfQ";
+  const TYP_NOT_JWT =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpUVyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE";
+
+  const GOOD_JWT_HS256 =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+  const GOOD_JWT_ES256 =
+    "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA";
+
   const jwtSchema = z.string().jwt();
 
-  // Can't split in 3 parts
+  expect(() => jwtSchema.parse(ONE_PART)).toThrow();
+  expect(() => jwtSchema.parse(NOT_BASE64)).toThrow();
+  expect(() => jwtSchema.parse(NO_TYP)).toThrow();
+  expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
+  expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
+  expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
   expect(() =>
-    jwtSchema.parse("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+    z.string().jwt({ algorithm: "ES256" }).parse(GOOD_JWT_HS256)
   ).toThrow();
-  // Header not Base64
   expect(() =>
-    jwtSchema.parse(
-      "headerIsNotBase64Encoded.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE"
-    )
+    z.string().jwt({ algorithm: "HS256" }).parse(GOOD_JWT_ES256)
   ).toThrow();
-  // Has no type in header
-  expect(() =>
-    jwtSchema.parse(
-      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.GuoUe6tw79bJlbU1HU0ADX0pr0u2kf3r_4OdrDufSfQ"
-    )
-  ).toBeTruthy();
-  // Type is not JWT
-  expect(() =>
-    jwtSchema.parse(
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpUVyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE"
-    )
-  ).toBeTruthy();
   //Success
+  expect(() => jwtSchema.parse(GOOD_JWT_HS256)).not.toThrow();
+  expect(() => jwtSchema.parse(GOOD_JWT_ES256)).not.toThrow();
   expect(() =>
-    jwtSchema.parse(
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-    )
-  ).toBeTruthy();
+    z.string().jwt({ algorithm: "HS256" }).parse(GOOD_JWT_HS256)
+  ).not.toThrow();
+  expect(() =>
+    z.string().jwt({ algorithm: "ES256" }).parse(GOOD_JWT_ES256)
+  ).not.toThrow();
 });
 
 test("url validations", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -680,7 +680,7 @@ function isValidJwt(token: string) {
     }
 
     const [header] = tokensParts;
-    const parsedHeader = JSON.parse(Buffer.from(header, "base64").toString());
+    const parsedHeader = JSON.parse(atob(header));
 
     if (!("type" in parsedHeader) || parsedHeader.type !== "JWT") {
       return false;
@@ -786,12 +786,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "emoji") {
-<<<<<<< HEAD
         if (!emojiRegex) {
           emojiRegex = new RegExp(_emojiRegex, "u");
         }
-=======
->>>>>>> 3a0c1f7 (fix(types): remove forgotten console.log)
         if (!emojiRegex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -527,13 +527,26 @@ export abstract class ZodType<
 /////////////////////////////////////////
 /////////////////////////////////////////
 export type IpVersion = "v4" | "v6";
+export type JwtAlgorithm =
+  | "HS256"
+  | "HS384"
+  | "HS512"
+  | "RS256"
+  | "RS384"
+  | "RS512"
+  | "ES256"
+  | "ES384"
+  | "ES512"
+  | "PS256"
+  | "PS384"
+  | "PS512";
 export type ZodStringCheck =
   | { kind: "min"; value: number; message?: string }
   | { kind: "max"; value: number; message?: string }
   | { kind: "length"; value: number; message?: string }
   | { kind: "email"; message?: string }
   | { kind: "url"; message?: string }
-  | { kind: "jwt"; message?: string }
+  | { kind: "jwt"; alg: JwtAlgorithm | null; message?: string }
   | { kind: "emoji"; message?: string }
   | { kind: "uuid"; message?: string }
   | { kind: "nanoid"; message?: string }
@@ -672,7 +685,7 @@ function isValidIP(ip: string, version?: IpVersion) {
   return false;
 }
 
-function isValidJwt(token: string) {
+function isValidJwt(token: string, algorithm?: JwtAlgorithm) {
   try {
     const tokensParts = token.split(".");
     if (tokensParts.length !== 3) {
@@ -682,7 +695,14 @@ function isValidJwt(token: string) {
     const [header] = tokensParts;
     const parsedHeader = JSON.parse(atob(header));
 
-    if (!("type" in parsedHeader) || parsedHeader.type !== "JWT") {
+    if (!("typ" in parsedHeader) || parsedHeader.typ !== "JWT") {
+      return false;
+    }
+
+    if (
+      algorithm &&
+      (!("alg" in parsedHeader) || parsedHeader.alg !== algorithm)
+    ) {
       return false;
     }
 
@@ -776,7 +796,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "jwt") {
-        if (!isValidJwt(input.data)) {
+        if (!isValidJwt(input.data, check.algorithm)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "jwt",
@@ -1018,8 +1038,13 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   url(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "url", ...errorUtil.errToObj(message) });
   }
-  jwt(message?: errorUtil.ErrMessage) {
-    return this._addCheck({ kind: "jwt", ...errorUtil.errToObj(message) });
+
+  jwt(options?: string | { alg?: JwtAlgorithm; message?: string }) {
+    return this._addCheck({
+      kind: "jwt",
+      alg: typeof options === "object" ? options.alg ?? null : null,
+      ...errorUtil.errToObj(options),
+    });
   }
   emoji(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "emoji", ...errorUtil.errToObj(message) });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -105,7 +105,6 @@ const handleResult = <Input, Output>(
       success: false,
       get error() {
         if ((this as any)._error) return (this as any)._error as Error;
-        console.log(ctx);
         const error = new ZodError(ctx.common.issues);
         (this as any)._error = error;
         return (this as any)._error;
@@ -674,7 +673,6 @@ function isValidIP(ip: string, version?: IpVersion) {
 }
 
 function isValidJwt(token: string) {
-  console.log(token);
   try {
     const tokensParts = token.split(".");
     if (tokensParts.length !== 3) {
@@ -778,7 +776,6 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "jwt") {
-        console.log("aquiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii");
         if (!isValidJwt(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
@@ -789,9 +786,12 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "emoji") {
+<<<<<<< HEAD
         if (!emojiRegex) {
           emojiRegex = new RegExp(_emojiRegex, "u");
         }
+=======
+>>>>>>> 3a0c1f7 (fix(types): remove forgotten console.log)
         if (!emojiRegex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -685,7 +685,7 @@ function isValidIP(ip: string, version?: IpVersion) {
   return false;
 }
 
-function isValidJwt(token: string, algorithm?: JwtAlgorithm) {
+function isValidJwt(token: string, algorithm: JwtAlgorithm | null = null) {
   try {
     const tokensParts = token.split(".");
     if (tokensParts.length !== 3) {
@@ -796,7 +796,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "jwt") {
-        if (!isValidJwt(input.data, check.algorithm)) {
+        if (!isValidJwt(input.data, check.alg)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "jwt",

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -92,6 +92,7 @@ export interface ZodInvalidDateIssue extends ZodIssueBase {
 export type StringValidation =
   | "email"
   | "url"
+  | "jwt"
   | "emoji"
   | "uuid"
   | "nanoid"

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -199,6 +199,39 @@ test("base64 validations", () => {
   }
 });
 
+test("jwt token", () => {
+  const jwtSchema = z.string().jwt();
+
+  // Can't split in 3 parts
+  expect(() =>
+    jwtSchema.parse("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+  ).toThrow();
+  // Header not Base64
+  expect(() =>
+    jwtSchema.parse(
+      "headerIsNotBase64Encoded.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE"
+    )
+  ).toThrow();
+  // Has no type in header
+  expect(() =>
+    jwtSchema.parse(
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.GuoUe6tw79bJlbU1HU0ADX0pr0u2kf3r_4OdrDufSfQ"
+    )
+  ).toBeTruthy();
+  // Type is not JWT
+  expect(() =>
+    jwtSchema.parse(
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpUVyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE"
+    )
+  ).toBeTruthy();
+  //Success
+  expect(() =>
+    jwtSchema.parse(
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+  ).toBeTruthy();
+});
+
 test("url validations", () => {
   const url = z.string().url();
   url.parse("http://google.com");

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -200,36 +200,42 @@ test("base64 validations", () => {
 });
 
 test("jwt token", () => {
+  const ONE_PART = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+  const NOT_BASE64 =
+    "headerIsNotBase64Encoded.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE";
+  const NO_TYP =
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.GuoUe6tw79bJlbU1HU0ADX0pr0u2kf3r_4OdrDufSfQ";
+  const TYP_NOT_JWT =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpUVyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE";
+
+  const GOOD_JWT_HS256 =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+  const GOOD_JWT_ES256 =
+    "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA";
+
   const jwtSchema = z.string().jwt();
 
-  // Can't split in 3 parts
+  expect(() => jwtSchema.parse(ONE_PART)).toThrow();
+  expect(() => jwtSchema.parse(NOT_BASE64)).toThrow();
+  expect(() => jwtSchema.parse(NO_TYP)).toThrow();
+  expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
+  expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
+  expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
   expect(() =>
-    jwtSchema.parse("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9")
+    z.string().jwt({ algorithm: "ES256" }).parse(GOOD_JWT_HS256)
   ).toThrow();
-  // Header not Base64
   expect(() =>
-    jwtSchema.parse(
-      "headerIsNotBase64Encoded.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE"
-    )
+    z.string().jwt({ algorithm: "HS256" }).parse(GOOD_JWT_ES256)
   ).toThrow();
-  // Has no type in header
-  expect(() =>
-    jwtSchema.parse(
-      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.GuoUe6tw79bJlbU1HU0ADX0pr0u2kf3r_4OdrDufSfQ"
-    )
-  ).toBeTruthy();
-  // Type is not JWT
-  expect(() =>
-    jwtSchema.parse(
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpUVyJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.RRi1X2IlXd5rZa9Mf_0VUOf-RxOzAhbB4tgViUGamWE"
-    )
-  ).toBeTruthy();
   //Success
+  expect(() => jwtSchema.parse(GOOD_JWT_HS256)).not.toThrow();
+  expect(() => jwtSchema.parse(GOOD_JWT_ES256)).not.toThrow();
   expect(() =>
-    jwtSchema.parse(
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-    )
-  ).toBeTruthy();
+    z.string().jwt({ algorithm: "HS256" }).parse(GOOD_JWT_HS256)
+  ).not.toThrow();
+  expect(() =>
+    z.string().jwt({ algorithm: "ES256" }).parse(GOOD_JWT_ES256)
+  ).not.toThrow();
 });
 
 test("url validations", () => {

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -222,19 +222,19 @@ test("jwt token", () => {
   expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
   expect(() => jwtSchema.parse(TYP_NOT_JWT)).toThrow();
   expect(() =>
-    z.string().jwt({ algorithm: "ES256" }).parse(GOOD_JWT_HS256)
+    z.string().jwt({ alg: "ES256" }).parse(GOOD_JWT_HS256)
   ).toThrow();
   expect(() =>
-    z.string().jwt({ algorithm: "HS256" }).parse(GOOD_JWT_ES256)
+    z.string().jwt({ alg: "HS256" }).parse(GOOD_JWT_ES256)
   ).toThrow();
   //Success
   expect(() => jwtSchema.parse(GOOD_JWT_HS256)).not.toThrow();
   expect(() => jwtSchema.parse(GOOD_JWT_ES256)).not.toThrow();
   expect(() =>
-    z.string().jwt({ algorithm: "HS256" }).parse(GOOD_JWT_HS256)
+    z.string().jwt({ alg: "HS256" }).parse(GOOD_JWT_HS256)
   ).not.toThrow();
   expect(() =>
-    z.string().jwt({ algorithm: "ES256" }).parse(GOOD_JWT_ES256)
+    z.string().jwt({ alg: "ES256" }).parse(GOOD_JWT_ES256)
   ).not.toThrow();
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -680,7 +680,7 @@ function isValidJwt(token: string) {
     }
 
     const [header] = tokensParts;
-    const parsedHeader = JSON.parse(Buffer.from(header, "base64").toString());
+    const parsedHeader = JSON.parse(atob(header));
 
     if (!("type" in parsedHeader) || parsedHeader.type !== "JWT") {
       return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -685,7 +685,7 @@ function isValidIP(ip: string, version?: IpVersion) {
   return false;
 }
 
-function isValidJwt(token: string, algorithm?: JwtAlgorithm) {
+function isValidJwt(token: string, algorithm: JwtAlgorithm | null = null) {
   try {
     const tokensParts = token.split(".");
     if (tokensParts.length !== 3) {
@@ -796,7 +796,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "jwt") {
-        if (!isValidJwt(input.data, check.algorithm)) {
+        if (!isValidJwt(input.data, check.alg)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "jwt",

--- a/src/types.ts
+++ b/src/types.ts
@@ -546,7 +546,7 @@ export type ZodStringCheck =
   | { kind: "length"; value: number; message?: string }
   | { kind: "email"; message?: string }
   | { kind: "url"; message?: string }
-  | { kind: "jwt"; algorithm?: JwtAlgorithm; message?: string }
+  | { kind: "jwt"; alg: JwtAlgorithm | null; message?: string }
   | { kind: "emoji"; message?: string }
   | { kind: "uuid"; message?: string }
   | { kind: "nanoid"; message?: string }
@@ -1038,8 +1038,13 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   url(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "url", ...errorUtil.errToObj(message) });
   }
-  jwt(options?: string | { algorithm?: JwtAlgorithm; message?: string }) {
-    return this._addCheck({ kind: "jwt", ...errorUtil.errToObj(options) });
+
+  jwt(options?: string | { alg?: JwtAlgorithm; message?: string }) {
+    return this._addCheck({
+      kind: "jwt",
+      alg: typeof options === "object" ? options.alg ?? null : null,
+      ...errorUtil.errToObj(options),
+    });
   }
   emoji(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "emoji", ...errorUtil.errToObj(message) });

--- a/src/types.ts
+++ b/src/types.ts
@@ -682,7 +682,7 @@ function isValidJwt(token: string) {
     const [header] = tokensParts;
     const parsedHeader = JSON.parse(atob(header));
 
-    if (!("type" in parsedHeader) || parsedHeader.type !== "JWT") {
+    if (!("typ" in parsedHeader) || parsedHeader.typ !== "JWT") {
       return false;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,7 +105,6 @@ const handleResult = <Input, Output>(
       success: false,
       get error() {
         if ((this as any)._error) return (this as any)._error as Error;
-        console.log(ctx);
         const error = new ZodError(ctx.common.issues);
         (this as any)._error = error;
         return (this as any)._error;
@@ -674,7 +673,6 @@ function isValidIP(ip: string, version?: IpVersion) {
 }
 
 function isValidJwt(token: string) {
-  console.log(token);
   try {
     const tokensParts = token.split(".");
     if (tokensParts.length !== 3) {
@@ -778,7 +776,6 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "jwt") {
-        console.log("aquiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii");
         if (!isValidJwt(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {


### PR DESCRIPTION
Add a `.jwt()` validator in string type.

It expects for a string with 3 parts splited by `.` with the first part being a base64 encoded string that represents a objetc wit a property `type` with value `JWT`.

**It validates just format NOT signature.**

Resolves #2946