### PR TITLE
clarify datetime format is ISO 8601

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);
 z.string().endsWith(string);
-z.string().datetime(); // defaults to UTC, see below for options
+z.string().datetime(); // ISO 8601; default is without UTC offset, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 
 // transformations
@@ -760,7 +760,7 @@ z.string().ip({ message: "Invalid IP address" });
 
 ### ISO datetimes
 
-The `z.string().datetime()` method defaults to UTC validation: no timezone offsets with arbitrary sub-second decimal precision.
+The `z.string().datetime()` method enforces ISO 8601; default is no timezone offsets and arbitrary sub-second decimal precision.
 
 ```ts
 const datetime = z.string().datetime();


### PR DESCRIPTION
Small tweak to clarify docs for `string.datetime()`. current wording is

> "[defaults to UTC validation](https://github.com/colinhacks/zod/blob/1e23990bcdd33d1e81b31e40e77a031fcfd87ce1/README.md?plain=1#L763)"

however, zod actually isn't validating javascript UTC string format (the following will not succeed with `z.string().datetime()`) ❌:
```js
const utcDateTime = new Date().toUTCString(); // Mon, 21 Aug 2023 20:42:52 GMT
```

clarification to show that [it is expecting ISO 8601](https://github.com/colinhacks/zod/blob/1e23990bcdd33d1e81b31e40e77a031fcfd87ce1/deno/lib/types.ts#L581) with no UTC offset. ex ✅:
```js
const isoDateTime = new Date().toISOString(); // 2023-08-21T20:47:22.189Z
```

