### PR TITLE
fix: .partial() produced "undefined" in props #635

### DIFF
--- a/configs/tsconfig.base.json
+++ b/configs/tsconfig.base.json
@@ -13,6 +13,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
     "downlevelIteration": true,
     "isolatedModules": true
   },

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -38,7 +38,7 @@ export type ZodIssueCode = keyof typeof ZodIssueCode;
 
 export type ZodIssueBase = {
   path: (string | number)[];
-  message?: string;
+  message?: string | undefined;
 };
 
 export interface ZodInvalidTypeIssue extends ZodIssueBase {
@@ -99,7 +99,7 @@ export type StringValidation =
   | "ulid"
   | "datetime"
   | "ip"
-  | { includes: string; position?: number }
+  | { includes: string; position?: number | undefined }
   | { startsWith: string }
   | { endsWith: string };
 
@@ -164,7 +164,7 @@ export type ZodIssueOptionalMessage =
 
 export type ZodIssue = ZodIssueOptionalMessage & {
   fatal?: boolean;
-  message: string;
+  message: string | undefined;
 };
 
 export const quotelessJson = (obj: any) => {

--- a/deno/lib/__tests__/all-errors.test.ts
+++ b/deno/lib/__tests__/all-errors.test.ts
@@ -133,7 +133,7 @@ test("all errors", () => {
       },
     });
 
-    expect(error.flatten((iss) => iss.message.toUpperCase())).toEqual({
+    expect(error.flatten((iss) => iss.message?.toUpperCase())).toEqual({
       formErrors: [],
       fieldErrors: {
         a: ["EXPECTED STRING, RECEIVED NULL"],
@@ -166,7 +166,7 @@ test("all errors", () => {
       },
     });
     // Test mapping
-    expect(error.flatten((i: z.ZodIssue) => i.message.length)).toEqual({
+    expect(error.flatten((i: z.ZodIssue) => i.message?.length)).toEqual({
       formErrors: [],
       fieldErrors: {
         a: ["Expected string, received null".length],

--- a/deno/lib/__tests__/partials.test.ts
+++ b/deno/lib/__tests__/partials.test.ts
@@ -7,7 +7,7 @@ import * as z from "../index.ts";
 import { ZodNullable, ZodOptional } from "../index.ts";
 
 const nested = z.object({
-  name: z.string(),
+  name: z.string().optional(),
   age: z.number(),
   outer: z.object({
     inner: z.string(),
@@ -19,9 +19,9 @@ test("shallow inference", () => {
   const shallow = nested.partial();
   type shallow = z.infer<typeof shallow>;
   type correct = {
-    name?: string | undefined;
-    age?: number | undefined;
-    outer?: { inner: string } | undefined;
+    name?: string;
+    age?: number;
+    outer?: { inner: string };
     array?: { asdf: string }[];
   };
   util.assertEqual<shallow, correct>(true);

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -33,9 +33,9 @@ export const makeIssue = (params: {
 };
 
 export type ParseParams = {
-  path: (string | number)[];
-  errorMap: ZodErrorMap;
-  async: boolean;
+  path?: (string | number)[];
+  errorMap: ZodErrorMap | undefined;
+  async: boolean | undefined;
 };
 
 export type ParsePathComponent = string | number;
@@ -45,11 +45,11 @@ export const EMPTY_PATH: ParsePath = [];
 export interface ParseContext {
   readonly common: {
     readonly issues: ZodIssue[];
-    readonly contextualErrorMap?: ZodErrorMap;
+    readonly contextualErrorMap?: ZodErrorMap | undefined;
     readonly async: boolean;
   };
   readonly path: ParsePath;
-  readonly schemaErrorMap?: ZodErrorMap;
+  readonly schemaErrorMap?: ZodErrorMap | undefined;
   readonly parent: ParseContext | null;
   readonly data: any;
   readonly parsedType: ZodParsedType;

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -109,12 +109,21 @@ export namespace objectUtil {
   }[keyof T];
 
   // type alkjsdf = addQuestionMarks<{ a: any }>;
+  type ExcludeUndefined<T extends object> = {
+    [k in keyof T]: Exclude<T[k], undefined>
+  }
 
   export type addQuestionMarks<
     T extends object,
     R extends keyof T = requiredKeys<T>
     // O extends keyof T = optionalKeys<T>
   > = Pick<Required<T>, R> & Partial<T>;
+
+  export type addQuestionMarksWithoutUndefined<
+    T extends object,
+    R extends keyof T = requiredKeys<T>
+    // O extends keyof T = optionalKeys<T>
+  > = ExcludeUndefined<addQuestionMarks<T,R>>;
   //  = { [k in O]?: T[k] } & { [k in R]: T[k] };
 
   export type identity<T> = T;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -45,6 +45,7 @@ export type RefinementCtx = {
   addIssue: (arg: IssueData) => void;
   path: (string | number)[];
 };
+
 export type ZodRawShape = { [k: string]: ZodTypeAny };
 export type ZodTypeAny = ZodType<any, any, any>;
 export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
@@ -55,7 +56,7 @@ export type { TypeOf as infer };
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
   errorMap?: ZodErrorMap;
-  description?: string;
+  description?: string | undefined;
 }
 
 class ParseInputLazyPath implements ParseInput {
@@ -116,14 +117,14 @@ const handleResult = <Input, Output>(
 export type RawCreateParams =
   | {
       errorMap?: ZodErrorMap;
-      invalid_type_error?: string;
-      required_error?: string;
-      description?: string;
+      invalid_type_error?: string | undefined;
+      required_error?: string | undefined;
+      description?: string | undefined;
     }
   | undefined;
 export type ProcessedCreateParams = {
   errorMap?: ZodErrorMap;
-  description?: string;
+  description?: string | undefined;
 };
 function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   if (!params) return {};
@@ -286,15 +287,27 @@ export abstract class ZodType<
 
   refine<RefinedOutput extends Output>(
     check: (arg: Output) => arg is RefinedOutput,
-    message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
+    message?:
+      | string
+      | CustomErrorParams
+      | ((arg: Output) => CustomErrorParams)
+      | undefined
   ): ZodEffects<this, RefinedOutput, Input>;
   refine(
     check: (arg: Output) => unknown | Promise<unknown>,
-    message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
+    message?:
+      | string
+      | CustomErrorParams
+      | ((arg: Output) => CustomErrorParams)
+      | undefined
   ): ZodEffects<this, Output, Input>;
   refine(
     check: (arg: Output) => unknown,
-    message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
+    message?:
+      | string
+      | CustomErrorParams
+      | ((arg: Output) => CustomErrorParams)
+      | undefined
   ): ZodEffects<this, Output, Input> {
     const getIssueProperties = (val: Output) => {
       if (typeof message === "string" || typeof message === "undefined") {
@@ -522,7 +535,12 @@ export type ZodStringCheck =
   | { kind: "emoji"; message?: string }
   | { kind: "uuid"; message?: string }
   | { kind: "cuid"; message?: string }
-  | { kind: "includes"; value: string; position?: number; message?: string }
+  | {
+      kind: "includes";
+      value: string;
+      position?: number | undefined;
+      message?: string;
+    }
   | { kind: "cuid2"; message?: string }
   | { kind: "ulid"; message?: string }
   | { kind: "startsWith"; value: string; message?: string }
@@ -1067,11 +1085,21 @@ export class ZodString extends ZodType<string, ZodStringDef> {
 /////////////////////////////////////////
 /////////////////////////////////////////
 export type ZodNumberCheck =
-  | { kind: "min"; value: number; inclusive: boolean; message?: string }
-  | { kind: "max"; value: number; inclusive: boolean; message?: string }
-  | { kind: "int"; message?: string }
-  | { kind: "multipleOf"; value: number; message?: string }
-  | { kind: "finite"; message?: string };
+  | {
+      kind: "min";
+      value: number;
+      inclusive: boolean;
+      message?: string | undefined;
+    }
+  | {
+      kind: "max";
+      value: number;
+      inclusive: boolean;
+      message?: string | undefined;
+    }
+  | { kind: "int"; message?: string | undefined }
+  | { kind: "multipleOf"; value: number; message?: string | undefined }
+  | { kind: "finite"; message?: string | undefined };
 
 // https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript/31711034#31711034
 function floatSafeRemainder(val: number, step: number) {
@@ -1364,9 +1392,19 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
 /////////////////////////////////////////
 /////////////////////////////////////////
 export type ZodBigIntCheck =
-  | { kind: "min"; value: bigint; inclusive: boolean; message?: string }
-  | { kind: "max"; value: bigint; inclusive: boolean; message?: string }
-  | { kind: "multipleOf"; value: bigint; message?: string };
+  | {
+      kind: "min";
+      value: bigint;
+      inclusive: boolean;
+      message?: string | undefined;
+    }
+  | {
+      kind: "max";
+      value: bigint;
+      inclusive: boolean;
+      message?: string | undefined;
+    }
+  | { kind: "multipleOf"; value: bigint; message?: string | undefined };
 
 export interface ZodBigIntDef extends ZodTypeDef {
   checks: ZodBigIntCheck[];
@@ -1613,8 +1651,8 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
 ///////////////////////////////////////
 ///////////////////////////////////////
 export type ZodDateCheck =
-  | { kind: "min"; value: number; message?: string }
-  | { kind: "max"; value: number; message?: string };
+  | { kind: "min"; value: number; message?: string | undefined }
+  | { kind: "max"; value: number; message?: string | undefined };
 export interface ZodDateDef extends ZodTypeDef {
   checks: ZodDateCheck[];
   coerce: boolean;
@@ -1972,9 +2010,9 @@ export interface ZodArrayDef<T extends ZodTypeAny = ZodTypeAny>
   extends ZodTypeDef {
   type: T;
   typeName: ZodFirstPartyTypeKind.ZodArray;
-  exactLength: { value: number; message?: string } | null;
-  minLength: { value: number; message?: string } | null;
-  maxLength: { value: number; message?: string } | null;
+  exactLength: { value: number; message?: string | undefined } | null;
+  minLength: { value: number; message?: string | undefined } | null;
+  maxLength: { value: number; message?: string | undefined } | null;
 }
 
 export type ArrayCardinality = "many" | "atleastone";
@@ -2155,7 +2193,7 @@ export type objectOutputType<
   Catchall extends ZodTypeAny,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam
 > = objectUtil.flatten<
-  objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>
+  objectUtil.addQuestionMarksWithoutUndefined<baseObjectOutputType<Shape>>
 > &
   CatchallOutput<Catchall> &
   PassthroughType<UnknownKeys>;
@@ -3543,8 +3581,8 @@ export interface ZodSetDef<Value extends ZodTypeAny = ZodTypeAny>
   extends ZodTypeDef {
   valueType: Value;
   typeName: ZodFirstPartyTypeKind.ZodSet;
-  minSize: { value: number; message?: string } | null;
-  maxSize: { value: number; message?: string } | null;
+  minSize: { value: number; message?: string | undefined } | null;
+  maxSize: { value: number; message?: string | undefined } | null;
 }
 
 export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -38,7 +38,7 @@ export type ZodIssueCode = keyof typeof ZodIssueCode;
 
 export type ZodIssueBase = {
   path: (string | number)[];
-  message?: string;
+  message?: string | undefined;
 };
 
 export interface ZodInvalidTypeIssue extends ZodIssueBase {
@@ -99,7 +99,7 @@ export type StringValidation =
   | "ulid"
   | "datetime"
   | "ip"
-  | { includes: string; position?: number }
+  | { includes: string; position?: number | undefined }
   | { startsWith: string }
   | { endsWith: string };
 
@@ -164,7 +164,7 @@ export type ZodIssueOptionalMessage =
 
 export type ZodIssue = ZodIssueOptionalMessage & {
   fatal?: boolean;
-  message: string;
+  message: string | undefined;
 };
 
 export const quotelessJson = (obj: any) => {

--- a/src/__tests__/all-errors.test.ts
+++ b/src/__tests__/all-errors.test.ts
@@ -132,7 +132,7 @@ test("all errors", () => {
       },
     });
 
-    expect(error.flatten((iss) => iss.message.toUpperCase())).toEqual({
+    expect(error.flatten((iss) => iss.message?.toUpperCase())).toEqual({
       formErrors: [],
       fieldErrors: {
         a: ["EXPECTED STRING, RECEIVED NULL"],
@@ -165,7 +165,7 @@ test("all errors", () => {
       },
     });
     // Test mapping
-    expect(error.flatten((i: z.ZodIssue) => i.message.length)).toEqual({
+    expect(error.flatten((i: z.ZodIssue) => i.message?.length)).toEqual({
       formErrors: [],
       fieldErrors: {
         a: ["Expected string, received null".length],

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -6,7 +6,7 @@ import * as z from "../index";
 import { ZodNullable, ZodOptional } from "../index";
 
 const nested = z.object({
-  name: z.string(),
+  name: z.string().optional(),
   age: z.number(),
   outer: z.object({
     inner: z.string(),
@@ -18,9 +18,9 @@ test("shallow inference", () => {
   const shallow = nested.partial();
   type shallow = z.infer<typeof shallow>;
   type correct = {
-    name?: string | undefined;
-    age?: number | undefined;
-    outer?: { inner: string } | undefined;
+    name?: string;
+    age?: number;
+    outer?: { inner: string };
     array?: { asdf: string }[];
   };
   util.assertEqual<shallow, correct>(true);

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -33,9 +33,9 @@ export const makeIssue = (params: {
 };
 
 export type ParseParams = {
-  path: (string | number)[];
-  errorMap: ZodErrorMap;
-  async: boolean;
+  path?: (string | number)[];
+  errorMap: ZodErrorMap | undefined;
+  async: boolean | undefined;
 };
 
 export type ParsePathComponent = string | number;
@@ -45,11 +45,11 @@ export const EMPTY_PATH: ParsePath = [];
 export interface ParseContext {
   readonly common: {
     readonly issues: ZodIssue[];
-    readonly contextualErrorMap?: ZodErrorMap;
+    readonly contextualErrorMap?: ZodErrorMap | undefined;
     readonly async: boolean;
   };
   readonly path: ParsePath;
-  readonly schemaErrorMap?: ZodErrorMap;
+  readonly schemaErrorMap?: ZodErrorMap | undefined;
   readonly parent: ParseContext | null;
   readonly data: any;
   readonly parsedType: ZodParsedType;

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -109,12 +109,21 @@ export namespace objectUtil {
   }[keyof T];
 
   // type alkjsdf = addQuestionMarks<{ a: any }>;
+  type ExcludeUndefined<T extends object> = {
+    [k in keyof T]: Exclude<T[k], undefined>
+  }
 
   export type addQuestionMarks<
     T extends object,
     R extends keyof T = requiredKeys<T>
     // O extends keyof T = optionalKeys<T>
   > = Pick<Required<T>, R> & Partial<T>;
+
+  export type addQuestionMarksWithoutUndefined<
+    T extends object,
+    R extends keyof T = requiredKeys<T>
+    // O extends keyof T = optionalKeys<T>
+  > = ExcludeUndefined<addQuestionMarks<T,R>>;
   //  = { [k in O]?: T[k] } & { [k in R]: T[k] };
 
   export type identity<T> = T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type RefinementCtx = {
   addIssue: (arg: IssueData) => void;
   path: (string | number)[];
 };
+
 export type ZodRawShape = { [k: string]: ZodTypeAny };
 export type ZodTypeAny = ZodType<any, any, any>;
 export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
@@ -55,7 +56,7 @@ export type { TypeOf as infer };
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
   errorMap?: ZodErrorMap;
-  description?: string;
+  description?: string | undefined;
 }
 
 class ParseInputLazyPath implements ParseInput {
@@ -116,14 +117,14 @@ const handleResult = <Input, Output>(
 export type RawCreateParams =
   | {
       errorMap?: ZodErrorMap;
-      invalid_type_error?: string;
-      required_error?: string;
-      description?: string;
+      invalid_type_error?: string | undefined;
+      required_error?: string | undefined;
+      description?: string | undefined;
     }
   | undefined;
 export type ProcessedCreateParams = {
   errorMap?: ZodErrorMap;
-  description?: string;
+  description?: string | undefined;
 };
 function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   if (!params) return {};
@@ -286,15 +287,27 @@ export abstract class ZodType<
 
   refine<RefinedOutput extends Output>(
     check: (arg: Output) => arg is RefinedOutput,
-    message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
+    message?:
+      | string
+      | CustomErrorParams
+      | ((arg: Output) => CustomErrorParams)
+      | undefined
   ): ZodEffects<this, RefinedOutput, Input>;
   refine(
     check: (arg: Output) => unknown | Promise<unknown>,
-    message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
+    message?:
+      | string
+      | CustomErrorParams
+      | ((arg: Output) => CustomErrorParams)
+      | undefined
   ): ZodEffects<this, Output, Input>;
   refine(
     check: (arg: Output) => unknown,
-    message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)
+    message?:
+      | string
+      | CustomErrorParams
+      | ((arg: Output) => CustomErrorParams)
+      | undefined
   ): ZodEffects<this, Output, Input> {
     const getIssueProperties = (val: Output) => {
       if (typeof message === "string" || typeof message === "undefined") {
@@ -522,7 +535,12 @@ export type ZodStringCheck =
   | { kind: "emoji"; message?: string }
   | { kind: "uuid"; message?: string }
   | { kind: "cuid"; message?: string }
-  | { kind: "includes"; value: string; position?: number; message?: string }
+  | {
+      kind: "includes";
+      value: string;
+      position?: number | undefined;
+      message?: string;
+    }
   | { kind: "cuid2"; message?: string }
   | { kind: "ulid"; message?: string }
   | { kind: "startsWith"; value: string; message?: string }
@@ -1067,11 +1085,21 @@ export class ZodString extends ZodType<string, ZodStringDef> {
 /////////////////////////////////////////
 /////////////////////////////////////////
 export type ZodNumberCheck =
-  | { kind: "min"; value: number; inclusive: boolean; message?: string }
-  | { kind: "max"; value: number; inclusive: boolean; message?: string }
-  | { kind: "int"; message?: string }
-  | { kind: "multipleOf"; value: number; message?: string }
-  | { kind: "finite"; message?: string };
+  | {
+      kind: "min";
+      value: number;
+      inclusive: boolean;
+      message?: string | undefined;
+    }
+  | {
+      kind: "max";
+      value: number;
+      inclusive: boolean;
+      message?: string | undefined;
+    }
+  | { kind: "int"; message?: string | undefined }
+  | { kind: "multipleOf"; value: number; message?: string | undefined }
+  | { kind: "finite"; message?: string | undefined };
 
 // https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript/31711034#31711034
 function floatSafeRemainder(val: number, step: number) {
@@ -1364,9 +1392,19 @@ export class ZodNumber extends ZodType<number, ZodNumberDef> {
 /////////////////////////////////////////
 /////////////////////////////////////////
 export type ZodBigIntCheck =
-  | { kind: "min"; value: bigint; inclusive: boolean; message?: string }
-  | { kind: "max"; value: bigint; inclusive: boolean; message?: string }
-  | { kind: "multipleOf"; value: bigint; message?: string };
+  | {
+      kind: "min";
+      value: bigint;
+      inclusive: boolean;
+      message?: string | undefined;
+    }
+  | {
+      kind: "max";
+      value: bigint;
+      inclusive: boolean;
+      message?: string | undefined;
+    }
+  | { kind: "multipleOf"; value: bigint; message?: string | undefined };
 
 export interface ZodBigIntDef extends ZodTypeDef {
   checks: ZodBigIntCheck[];
@@ -1613,8 +1651,8 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef> {
 ///////////////////////////////////////
 ///////////////////////////////////////
 export type ZodDateCheck =
-  | { kind: "min"; value: number; message?: string }
-  | { kind: "max"; value: number; message?: string };
+  | { kind: "min"; value: number; message?: string | undefined }
+  | { kind: "max"; value: number; message?: string | undefined };
 export interface ZodDateDef extends ZodTypeDef {
   checks: ZodDateCheck[];
   coerce: boolean;
@@ -1972,9 +2010,9 @@ export interface ZodArrayDef<T extends ZodTypeAny = ZodTypeAny>
   extends ZodTypeDef {
   type: T;
   typeName: ZodFirstPartyTypeKind.ZodArray;
-  exactLength: { value: number; message?: string } | null;
-  minLength: { value: number; message?: string } | null;
-  maxLength: { value: number; message?: string } | null;
+  exactLength: { value: number; message?: string | undefined } | null;
+  minLength: { value: number; message?: string | undefined } | null;
+  maxLength: { value: number; message?: string | undefined } | null;
 }
 
 export type ArrayCardinality = "many" | "atleastone";
@@ -2155,7 +2193,7 @@ export type objectOutputType<
   Catchall extends ZodTypeAny,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam
 > = objectUtil.flatten<
-  objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>
+  objectUtil.addQuestionMarksWithoutUndefined<baseObjectOutputType<Shape>>
 > &
   CatchallOutput<Catchall> &
   PassthroughType<UnknownKeys>;
@@ -3543,8 +3581,8 @@ export interface ZodSetDef<Value extends ZodTypeAny = ZodTypeAny>
   extends ZodTypeDef {
   valueType: Value;
   typeName: ZodFirstPartyTypeKind.ZodSet;
-  minSize: { value: number; message?: string } | null;
-  maxSize: { value: number; message?: string } | null;
+  minSize: { value: number; message?: string | undefined } | null;
+  maxSize: { value: number; message?: string | undefined } | null;
 }
 
 export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<


### PR DESCRIPTION
⚠️  There may have been a  breaking change in PR, I don't know.
Fixes #635
All tests passed except `all-errors`, now a message can have undefined type and it should be checked by ? (question mark, before referring to it)

This patch can be installed for testing by adding the following lines to `package.json`.
```json
"zod": "npm:@bazuka5801/zod@3.22.2"
```