### PR TITLE
Add default types to createZodEnum

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3970,11 +3970,11 @@ export type FilterEnum<Values, ToExclude> = Values extends []
 
 export type typecast<A, T> = A extends T ? A : never;
 
-function createZodEnum<U extends string, T extends Readonly<[U, ...U[]]>>(
+function createZodEnum<U extends string, T extends Readonly<[U, ...U[]]>=Readonly<[U, ...U[]]>>(
   values: T,
   params?: RawCreateParams
 ): ZodEnum<Writeable<T>>;
-function createZodEnum<U extends string, T extends [U, ...U[]]>(
+function createZodEnum<U extends string, T extends [U, ...U[]]=[U, ...U[]]>(
   values: T,
   params?: RawCreateParams
 ): ZodEnum<T>;


### PR DESCRIPTION
Fixes https://github.com/colinhacks/zod/issues/2691

When defining a zod enum from an existing union type, currently it is necessary to define it as such:
```
// Assuming AUnionType was defined somewhere as
type AUnionType = 1 | 2 | 3 | 4;

// If we want to provide explicit type to it, we have to define it like
z.enum<AUnionType, [AUnionType, AUnionType, AUnionType, AUnionType]>([1, 2, 3, 4]);
```

However, the explicit typing seems redundant. This commit just adds default types to enums, so now we can do:
```
z.enum<AUnionType>([1, 2, 3, 4]);
```

Same as before, we can provide explicit type when needed.