### PR TITLE
docs: add `zod-sandbox` to README ecosystem links

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 #### Utilities for Zod
 
 - [`zod_utilz`](https://github.com/JacobWeisenburger/zod_utilz): Framework agnostic utilities for Zod.
+- [`zod-sandbox`](https://github.com/nereumelo/zod-sandbox): Controlled environment for testing zod schemas. [Live demo](https://zod-sandbox.vercel.app/).
 
 ## Installation
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -523,6 +523,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 #### Utilities for Zod
 
 - [`zod_utilz`](https://github.com/JacobWeisenburger/zod_utilz): Framework agnostic utilities for Zod.
+- [`zod-sandbox`](https://github.com/nereumelo/zod-sandbox): Controlled environment for testing zod schemas. [Live demo](https://zod-sandbox.vercel.app/).
 
 ## Installation
 


### PR DESCRIPTION
I am developing a sandbox aplication for testing zod schemas: [`zod-sandbox`](https://zod-sandbox.vercel.app/).
It could be useful and I would like to add it to the ecosystem list.