### PR TITLE
fix: ZodObject pick/omit/required/partial strict args keys

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -721,7 +721,7 @@ z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);
 z.string().endsWith(string);
-z.string().datetime(); // defaults to UTC, see below for options
+z.string().datetime(); // ISO 8601; default is without UTC offset, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 
 // transformations
@@ -760,7 +760,7 @@ z.string().ip({ message: "Invalid IP address" });
 
 ### ISO datetimes
 
-The `z.string().datetime()` method defaults to UTC validation: no timezone offsets with arbitrary sub-second decimal precision.
+The `z.string().datetime()` method enforces ISO 8601; default is no timezone offsets and arbitrary sub-second decimal precision.
 
 ```ts
 const datetime = z.string().datetime();
@@ -2825,10 +2825,9 @@ This more declarative API makes schema definitions vastly more concise.
 
 [https://github.com/pelotom/runtypes](https://github.com/pelotom/runtypes)
 
-Good type inference support. They DO support readonly types, which Zod does not.
+Good type inference support.
 
 - Supports "pattern matching": computed properties that distribute over unions
-- Supports readonly types
 - Missing object methods: (deepPartial, merge)
 - Missing nonempty arrays with proper typing (`[T, ...T[]]`)
 - Missing promise schemas

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -451,3 +451,21 @@ test("passthrough index signature", () => {
   type b = z.infer<typeof b>;
   util.assertEqual<{ a: string } & { [k: string]: unknown }, b>(true);
 });
+
+test("error when pick/omit/required/partial with unknown keys", () => {
+  const example = z.object({
+    name: z.string(),
+    age: z.number(),
+    isAdmin: z.boolean(),
+  });
+
+  type BadExample = util.StrictKnownKeys<
+    z.infer<typeof example>,
+    { name: true; asd: true; zxc: false; xcv: "asd" }
+  >;
+
+  util.assertEqual<
+    BadExample,
+    { name: true; asd: never; zxc: never; xcv: never }
+  >(true);
+});

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -12,6 +12,10 @@ export namespace util {
     throw new Error();
   }
 
+  export type StrictKnownKeys<TObj, TKeysObj> = {
+    [k in keyof TKeysObj]: k extends keyof TObj ? TKeysObj[k] : never;
+  };
+
   export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
   export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
   export type MakePartial<T, K extends keyof T> = Omit<T, K> &

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2566,7 +2566,7 @@ export class ZodObject<
   }
 
   pick<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: util.StrictKnownKeys<T, Mask>
   ): ZodObject<Pick<T, Extract<keyof T, keyof Mask>>, UnknownKeys, Catchall> {
     const shape: any = {};
 
@@ -2583,7 +2583,7 @@ export class ZodObject<
   }
 
   omit<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: util.StrictKnownKeys<T, Mask>
   ): ZodObject<Omit<T, keyof Mask>, UnknownKeys, Catchall> {
     const shape: any = {};
 
@@ -2612,7 +2612,7 @@ export class ZodObject<
     Catchall
   >;
   partial<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: util.StrictKnownKeys<T, Mask>
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k];
@@ -2645,7 +2645,7 @@ export class ZodObject<
     Catchall
   >;
   required<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: util.StrictKnownKeys<T, Mask>
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? deoptional<T[k]> : T[k];

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -450,3 +450,21 @@ test("passthrough index signature", () => {
   type b = z.infer<typeof b>;
   util.assertEqual<{ a: string } & { [k: string]: unknown }, b>(true);
 });
+
+test("error when pick/omit/required/partial with unknown keys", () => {
+  const example = z.object({
+    name: z.string(),
+    age: z.number(),
+    isAdmin: z.boolean(),
+  });
+
+  type BadExample = util.StrictKnownKeys<
+    z.infer<typeof example>,
+    { name: true; asd: true; zxc: false; xcv: "asd" }
+  >;
+
+  util.assertEqual<
+    BadExample,
+    { name: true; asd: never; zxc: never; xcv: never }
+  >(true);
+});

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -12,6 +12,10 @@ export namespace util {
     throw new Error();
   }
 
+  export type StrictKnownKeys<TObj, TKeysObj> = {
+    [k in keyof TKeysObj]: k extends keyof TObj ? TKeysObj[k] : never;
+  };
+
   export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
   export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
   export type MakePartial<T, K extends keyof T> = Omit<T, K> &

--- a/src/types.ts
+++ b/src/types.ts
@@ -2566,7 +2566,7 @@ export class ZodObject<
   }
 
   pick<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: util.StrictKnownKeys<T, Mask>
   ): ZodObject<Pick<T, Extract<keyof T, keyof Mask>>, UnknownKeys, Catchall> {
     const shape: any = {};
 
@@ -2583,7 +2583,7 @@ export class ZodObject<
   }
 
   omit<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: util.StrictKnownKeys<T, Mask>
   ): ZodObject<Omit<T, keyof Mask>, UnknownKeys, Catchall> {
     const shape: any = {};
 
@@ -2612,7 +2612,7 @@ export class ZodObject<
     Catchall
   >;
   partial<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: util.StrictKnownKeys<T, Mask>
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? ZodOptional<T[k]> : T[k];
@@ -2645,7 +2645,7 @@ export class ZodObject<
     Catchall
   >;
   required<Mask extends { [k in keyof T]?: true }>(
-    mask: Mask
+    mask: util.StrictKnownKeys<T, Mask>
   ): ZodObject<
     objectUtil.noNever<{
       [k in keyof T]: k extends keyof Mask ? deoptional<T[k]> : T[k];


### PR DESCRIPTION
This PR add the ability to ZodObject pick/omit/required/partial functions to only allow valid object keys, instead of allowing any unkown keys (current behavior).
This fix the following Issues: https://github.com/colinhacks/zod/issues/2607

New behavior:

```ts

import { z } from "./src";

const schema = z.object({
  name: z.string(),
  age: z.number(),
  isAdmin: z.boolean(),
});

schema.pick({
  name: true,
  asd: true, // <-- Now errors because `asd` is not in `schema `
  zxc: "", // <-- Now errors because `zxc` is not in `schema `
  isAdmin: true,
});


schema.omit({
  name: true,
  asd: true, // <-- Now errors because `asd` is not in `schema `
  zxc: "", // <-- Now errors because `zxc` is not in `schema `
  isAdmin: true,
});

schema.partial({
  name: true,
  asd: true, // <-- Now errors because `asd` is not in `schema `
  zxc: "", // <-- Now errors because `zxc` is not in `schema `
  isAdmin: true,
});

schema.required({
  name: true,
  asd: true, // <-- Errors because `asd` is not in `schema `
  zxc: "", // <-- Errors because `zxc` is not in `schema `
  isAdmin: true,
});
```