### PR TITLE
Export jsdoc with `@deprecated` when building

### DIFF
--- a/configs/tsconfig.cjs.json
+++ b/configs/tsconfig.cjs.json
@@ -5,8 +5,7 @@
     "outDir": "../lib",
     "declaration": true,
     "declarationMap": false,
-    "sourceMap": false,
-    "removeComments": true
+    "sourceMap": false
   },
   "exclude": ["../src/**/__tests__", "../playground.ts"]
 }

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -721,7 +721,7 @@ z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);
 z.string().endsWith(string);
-z.string().datetime(); // defaults to UTC, see below for options
+z.string().datetime(); // ISO 8601; default is without UTC offset, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 
 // transformations
@@ -760,7 +760,7 @@ z.string().ip({ message: "Invalid IP address" });
 
 ### ISO datetimes
 
-The `z.string().datetime()` method defaults to UTC validation: no timezone offsets with arbitrary sub-second decimal precision.
+The `z.string().datetime()` method enforces ISO 8601; default is no timezone offsets and arbitrary sub-second decimal precision.
 
 ```ts
 const datetime = z.string().datetime();
@@ -2825,10 +2825,9 @@ This more declarative API makes schema definitions vastly more concise.
 
 [https://github.com/pelotom/runtypes](https://github.com/pelotom/runtypes)
 
-Good type inference support. They DO support readonly types, which Zod does not.
+Good type inference support.
 
 - Supports "pattern matching": computed properties that distribute over unions
-- Supports readonly types
 - Missing object methods: (deepPartial, merge)
 - Missing nonempty arrays with proper typing (`[T, ...T[]]`)
 - Missing promise schemas

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -849,16 +849,17 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     return { status: status.value, value: input.data };
   }
 
-  protected _regex = (
+  protected _regex(
     regex: RegExp,
     validation: StringValidation,
     message?: errorUtil.ErrMessage
-  ) =>
-    this.refinement((data) => regex.test(data), {
+  ) {
+    return this.refinement((data) => regex.test(data), {
       validation,
       code: ZodIssueCode.invalid_string,
       ...errorUtil.errToObj(message),
     });
+  }
 
   _addCheck(check: ZodStringCheck) {
     return new ZodString({
@@ -980,26 +981,30 @@ export class ZodString extends ZodType<string, ZodStringDef> {
    * @deprecated Use z.string().min(1) instead.
    * @see {@link ZodString.min}
    */
-  nonempty = (message?: errorUtil.ErrMessage) =>
-    this.min(1, errorUtil.errToObj(message));
+  nonempty(message?: errorUtil.ErrMessage) {
+    return this.min(1, errorUtil.errToObj(message));
+  }
 
-  trim = () =>
-    new ZodString({
+  trim() {
+    return new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "trim" }],
     });
+  }
 
-  toLowerCase = () =>
-    new ZodString({
+  toLowerCase() {
+    return new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "toLowerCase" }],
     });
+  }
 
-  toUpperCase = () =>
-    new ZodString({
+  toUpperCase() {
+    return new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "toUpperCase" }],
     });
+  }
 
   get isDatetime() {
     return !!this._def.checks.find((ch) => ch.kind === "datetime");

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4858,7 +4858,7 @@ type CustomParams = CustomErrorParams & { fatal?: boolean };
 export const custom = <T>(
   check?: (data: unknown) => any,
   params: string | CustomParams | ((input: any) => CustomParams) = {},
-  /*
+  /**
    * @deprecated
    *
    * Pass `fatal` into the params object instead:

--- a/src/types.ts
+++ b/src/types.ts
@@ -849,16 +849,17 @@ export class ZodString extends ZodType<string, ZodStringDef> {
     return { status: status.value, value: input.data };
   }
 
-  protected _regex = (
+  protected _regex(
     regex: RegExp,
     validation: StringValidation,
     message?: errorUtil.ErrMessage
-  ) =>
-    this.refinement((data) => regex.test(data), {
+  ) {
+    return this.refinement((data) => regex.test(data), {
       validation,
       code: ZodIssueCode.invalid_string,
       ...errorUtil.errToObj(message),
     });
+  }
 
   _addCheck(check: ZodStringCheck) {
     return new ZodString({
@@ -980,26 +981,30 @@ export class ZodString extends ZodType<string, ZodStringDef> {
    * @deprecated Use z.string().min(1) instead.
    * @see {@link ZodString.min}
    */
-  nonempty = (message?: errorUtil.ErrMessage) =>
-    this.min(1, errorUtil.errToObj(message));
+  nonempty(message?: errorUtil.ErrMessage) {
+    return this.min(1, errorUtil.errToObj(message));
+  }
 
-  trim = () =>
-    new ZodString({
+  trim() {
+    return new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "trim" }],
     });
+  }
 
-  toLowerCase = () =>
-    new ZodString({
+  toLowerCase() {
+    return new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "toLowerCase" }],
     });
+  }
 
-  toUpperCase = () =>
-    new ZodString({
+  toUpperCase() {
+    return new ZodString({
       ...this._def,
       checks: [...this._def.checks, { kind: "toUpperCase" }],
     });
+  }
 
   get isDatetime() {
     return !!this._def.checks.find((ch) => ch.kind === "datetime");

--- a/src/types.ts
+++ b/src/types.ts
@@ -4858,7 +4858,7 @@ type CustomParams = CustomErrorParams & { fatal?: boolean };
 export const custom = <T>(
   check?: (data: unknown) => any,
   params: string | CustomParams | ((input: any) => CustomParams) = {},
-  /*
+  /**
    * @deprecated
    *
    * Pass `fatal` into the params object instead:


### PR DESCRIPTION
I didn't know for a long time that `z.string().nonempty()` was deprecated.

- JSdoc was deleted in `build:cjs`, so prevented it.
- JSdoc was output in the constructor when arrow functions were used in the class, so prevented it.
- Fixed comment not in JSdoc format.

## before
<img width="511" alt="スクリーンショット 2023-09-07 11 44 55" src="https://github.com/colinhacks/zod/assets/8909592/5bdcfc26-d3f8-487f-b068-feee609c4fa7">

## after
with strike
<img width="473" alt="スクリーンショット 2023-09-07 11 46 12" src="https://github.com/colinhacks/zod/assets/8909592/7ed331ab-d37f-47a9-997e-eb5d92242e33">
