### PR TITLE
#2718 Updated Custom Schemas documentation example to use type narrowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1879,7 +1879,7 @@ You can create a Zod schema for any TypeScript type by using `z.custom()`. This 
 
 ```ts
 const px = z.custom<`${number}px`>((val) => {
-  return /^\d+px$/.test(val as string);
+  return typeof val === "string" ? /^\d+px$/.test(val) : false;
 });
 
 type px = z.infer<typeof px>; // `${number}px`


### PR DESCRIPTION
Hi,

I'm interested in updating the Custom Schemas example in the documentation. The function type takes in an unknown, so the example casts the value to a string in order to operate on it with a RegExp

```typescript
const px = z.custom<`${number}px`>((val) => {
  return /^\d+px$/.test(val as string);
});
```

I want to propose using Type Narrowing. It's helped me catch errors from validating a non-expected type, and I believe it would help others as well as a good practice with interacting with the unknown type.

```typescript
const px = z.custom<`${number}px`>((val) => {
  return typeof val === "string" ? /^\d+px$/.test(val) : false;
});
```

This is a PR for issue #2718 