### PR TITLE
Allow undefined values in record, similar to object.

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -868,11 +868,8 @@ z.string().nanoid();
 z.string().cuid();
 z.string().cuid2();
 z.string().ulid();
-<<<<<<< HEAD
 z.string().xid();
-=======
 z.string().ksuid();
->>>>>>> eca2545 (feat: add support for KSUIDs)
 z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -105,11 +105,8 @@ export type StringValidation =
   | "cuid"
   | "cuid2"
   | "ulid"
-<<<<<<< HEAD
   | "xid"
-=======
   | "ksuid"
->>>>>>> eca2545 (feat: add support for KSUIDs)
   | "datetime"
   | "date"
   | "time"

--- a/deno/lib/__tests__/record.test.ts
+++ b/deno/lib/__tests__/record.test.ts
@@ -179,3 +179,14 @@ test("dont parse undefined values", () => {
     foo: undefined,
   });
 });
+
+test("allow undefined values", () => {
+  const schema = z.record(z.string(), z.undefined());
+  expect(
+    util.objectKeys(
+      schema.parse({
+        _test: undefined,
+      })
+    )
+  ).toEqual(["_test"]);
+});

--- a/deno/lib/__tests__/record.test.ts
+++ b/deno/lib/__tests__/record.test.ts
@@ -172,7 +172,7 @@ test("is not vulnerable to prototype pollution", async () => {
   }
 });
 
-test("dont parse undefined values", () => {
+test("dont remove undefined values", () => {
   const result1 = z.record(z.any()).parse({ foo: undefined });
 
   expect(result1).toEqual({
@@ -196,7 +196,7 @@ test("allow undefined values async", async () => {
   const schemaAsync = z.record(z.string().optional()).refine(async () => true);
 
   expect(
-    Object.keys(
+    util.objectKeys(
       await schemaAsync.parseAsync({
         _test: undefined,
       })

--- a/deno/lib/__tests__/record.test.ts
+++ b/deno/lib/__tests__/record.test.ts
@@ -182,9 +182,22 @@ test("dont parse undefined values", () => {
 
 test("allow undefined values", () => {
   const schema = z.record(z.string(), z.undefined());
+
   expect(
     util.objectKeys(
       schema.parse({
+        _test: undefined,
+      })
+    )
+  ).toEqual(["_test"]);
+});
+
+test("allow undefined values async", async () => {
+  const schemaAsync = z.record(z.string().optional()).refine(async () => true);
+
+  expect(
+    Object.keys(
+      await schemaAsync.parseAsync({
         _test: undefined,
       })
     )

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -412,7 +412,6 @@ test("ulid", () => {
   }
 });
 
-<<<<<<< HEAD
 test("xid", () => {
   const xid = z.string().xid();
   xid.parse("9m4e2mr0ui3e8a215n4g");
@@ -420,7 +419,9 @@ test("xid", () => {
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("Invalid xid");
-=======
+  }
+});
+
 test("ksuid", () => {
   const ksuid = z.string().ksuid();
   ksuid.parse("0o0t9hkGxgFLtd3lmJ4TSTeY0Vb");
@@ -430,7 +431,6 @@ test("ksuid", () => {
   expect(ksuid.safeParse(tooLong).success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("Invalid ksuid");
->>>>>>> eca2545 (feat: add support for KSUIDs)
   }
 });
 
@@ -473,11 +473,8 @@ test("checks getters", () => {
   expect(z.string().email().isNANOID).toEqual(false);
   expect(z.string().email().isIP).toEqual(false);
   expect(z.string().email().isULID).toEqual(false);
-<<<<<<< HEAD
   expect(z.string().email().isXID).toEqual(false);
-=======
   expect(z.string().email().isKSUID).toEqual(false);
->>>>>>> eca2545 (feat: add support for KSUIDs)
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
@@ -487,11 +484,8 @@ test("checks getters", () => {
   expect(z.string().url().isNANOID).toEqual(false);
   expect(z.string().url().isIP).toEqual(false);
   expect(z.string().url().isULID).toEqual(false);
-<<<<<<< HEAD
   expect(z.string().url().isXID).toEqual(false);
-=======
   expect(z.string().url().isKSUID).toEqual(false);
->>>>>>> eca2545 (feat: add support for KSUIDs)
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
@@ -501,11 +495,8 @@ test("checks getters", () => {
   expect(z.string().cuid().isNANOID).toEqual(false);
   expect(z.string().cuid().isIP).toEqual(false);
   expect(z.string().cuid().isULID).toEqual(false);
-<<<<<<< HEAD
   expect(z.string().cuid().isXID).toEqual(false);
-=======
   expect(z.string().cuid().isKSUID).toEqual(false);
->>>>>>> eca2545 (feat: add support for KSUIDs)
 
   expect(z.string().cuid2().isEmail).toEqual(false);
   expect(z.string().cuid2().isURL).toEqual(false);
@@ -515,11 +506,8 @@ test("checks getters", () => {
   expect(z.string().cuid2().isNANOID).toEqual(false);
   expect(z.string().cuid2().isIP).toEqual(false);
   expect(z.string().cuid2().isULID).toEqual(false);
-<<<<<<< HEAD
   expect(z.string().cuid2().isXID).toEqual(false);
-=======
   expect(z.string().cuid2().isKSUID).toEqual(false);
->>>>>>> eca2545 (feat: add support for KSUIDs)
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
@@ -529,7 +517,6 @@ test("checks getters", () => {
   expect(z.string().uuid().isNANOID).toEqual(false);
   expect(z.string().uuid().isIP).toEqual(false);
   expect(z.string().uuid().isULID).toEqual(false);
-<<<<<<< HEAD
   expect(z.string().uuid().isXID).toEqual(false);
 
   expect(z.string().nanoid().isEmail).toEqual(false);
@@ -540,9 +527,7 @@ test("checks getters", () => {
   expect(z.string().nanoid().isNANOID).toEqual(true);
   expect(z.string().nanoid().isIP).toEqual(false);
   expect(z.string().nanoid().isULID).toEqual(false);
-=======
   expect(z.string().uuid().isKSUID).toEqual(false);
->>>>>>> eca2545 (feat: add support for KSUIDs)
 
   expect(z.string().ip().isEmail).toEqual(false);
   expect(z.string().ip().isURL).toEqual(false);
@@ -552,11 +537,8 @@ test("checks getters", () => {
   expect(z.string().ip().isNANOID).toEqual(false);
   expect(z.string().ip().isIP).toEqual(true);
   expect(z.string().ip().isULID).toEqual(false);
-<<<<<<< HEAD
   expect(z.string().ip().isXID).toEqual(false);
-=======
   expect(z.string().ip().isKSUID).toEqual(false);
->>>>>>> eca2545 (feat: add support for KSUIDs)
 
   expect(z.string().ulid().isEmail).toEqual(false);
   expect(z.string().ulid().isURL).toEqual(false);
@@ -566,7 +548,6 @@ test("checks getters", () => {
   expect(z.string().ulid().isNANOID).toEqual(false);
   expect(z.string().ulid().isIP).toEqual(false);
   expect(z.string().ulid().isULID).toEqual(true);
-<<<<<<< HEAD
   expect(z.string().ulid().isXID).toEqual(false);
 
   expect(z.string().xid().isEmail).toEqual(false);
@@ -577,7 +558,6 @@ test("checks getters", () => {
   expect(z.string().xid().isIP).toEqual(false);
   expect(z.string().xid().isULID).toEqual(false);
   expect(z.string().xid().isXID).toEqual(true);
-=======
   expect(z.string().ulid().isKSUID).toEqual(false);
 
   expect(z.string().ksuid().isEmail).toEqual(false);
@@ -588,7 +568,6 @@ test("checks getters", () => {
   expect(z.string().ksuid().isIP).toEqual(false);
   expect(z.string().ksuid().isULID).toEqual(false);
   expect(z.string().ksuid().isKSUID).toEqual(true);
->>>>>>> eca2545 (feat: add support for KSUIDs)
 });
 
 test("min max getters", () => {

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -91,6 +91,7 @@ export function addIssueToContext(
 export type ObjectPair = {
   key: SyncParseReturnType<any>;
   value: SyncParseReturnType<any>;
+  alwaysSet?: boolean;
 };
 export class ParseStatus {
   value: "aborted" | "dirty" | "valid" = "valid";
@@ -117,15 +118,25 @@ export class ParseStatus {
 
   static async mergeObjectAsync(
     status: ParseStatus,
-    pairs: { key: ParseReturnType<any>; value: ParseReturnType<any> }[]
+    pairs: {
+      key: ParseReturnType<any>;
+      value: ParseReturnType<any>;
+      alwaysSet?: boolean;
+    }[]
   ): Promise<SyncParseReturnType<any>> {
     const syncPairs: ObjectPair[] = [];
     for (const pair of pairs) {
       const key = await pair.key;
       const value = await pair.value;
       syncPairs.push({
+<<<<<<< HEAD
         key,
         value,
+=======
+        key: await pair.key,
+        value: await pair.value,
+        alwaysSet: pair.alwaysSet
+>>>>>>> 497e77d (Update `mergeObjectAsync` to support `alwaysSet` like `mergeObjectSync`)
       });
     }
     return ParseStatus.mergeObjectSync(status, syncPairs);

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -144,11 +144,7 @@ export class ParseStatus {
 
   static mergeObjectSync(
     status: ParseStatus,
-    pairs: {
-      key: SyncParseReturnType<any>;
-      value: SyncParseReturnType<any>;
-      alwaysSet?: boolean;
-    }[]
+    pairs: ObjectPair[]
   ): SyncParseReturnType {
     const finalObject: any = {};
     for (const pair of pairs) {

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -129,14 +129,9 @@ export class ParseStatus {
       const key = await pair.key;
       const value = await pair.value;
       syncPairs.push({
-<<<<<<< HEAD
         key,
         value,
-=======
-        key: await pair.key,
-        value: await pair.value,
-        alwaysSet: pair.alwaysSet
->>>>>>> 497e77d (Update `mergeObjectAsync` to support `alwaysSet` like `mergeObjectSync`)
+        alwaysSet: pair.alwaysSet,
       });
     }
     return ParseStatus.mergeObjectSync(status, syncPairs);

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -1,7 +1,7 @@
+import type { ZodParsedType } from "../index.ts";
 import { getErrorMap } from "../errors.ts";
 import defaultErrorMap from "../locales/en.ts";
 import type { IssueData, ZodErrorMap, ZodIssue } from "../ZodError.ts";
-import type { ZodParsedType } from "../index.ts";
 
 export const makeIssue = (params: {
   data: any;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -555,11 +555,8 @@ export type ZodStringCheck =
   | { kind: "includes"; value: string; position?: number; message?: string }
   | { kind: "cuid2"; message?: string }
   | { kind: "ulid"; message?: string }
-<<<<<<< HEAD
   | { kind: "xid"; message?: string }
-=======
   | { kind: "ksuid"; message?: string }
->>>>>>> eca2545 (feat: add support for KSUIDs)
   | { kind: "startsWith"; value: string; message?: string }
   | { kind: "endsWith"; value: string; message?: string }
   | { kind: "regex"; regex: RegExp; message?: string }
@@ -597,11 +594,8 @@ export interface ZodStringDef extends ZodTypeDef {
 const cuidRegex = /^c[^\s-]{8,}$/i;
 const cuid2Regex = /^[0-9a-z]+$/;
 const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
-<<<<<<< HEAD
 const xidRegex = /^[0-9a-v]{20}$/i;
-=======
 const ksuidRegex = /^[A-Za-z0-9]{27}$/;
->>>>>>> eca2545 (feat: add support for KSUIDs)
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // const uuidRegex =
@@ -902,19 +896,21 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
-<<<<<<< HEAD
       } else if (check.kind === "xid") {
         if (!xidRegex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "xid",
-=======
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "ksuid") {
         if (!ksuidRegex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "ksuid",
->>>>>>> eca2545 (feat: add support for KSUIDs)
             code: ZodIssueCode.invalid_string,
             message: check.message,
           });
@@ -1123,16 +1119,14 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   ulid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "ulid", ...errorUtil.errToObj(message) });
   }
-<<<<<<< HEAD
   base64(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "base64", ...errorUtil.errToObj(message) });
   }
   xid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "xid", ...errorUtil.errToObj(message) });
-=======
+  }
   ksuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "ksuid", ...errorUtil.errToObj(message) });
->>>>>>> eca2545 (feat: add support for KSUIDs)
   }
 
   ip(options?: string | { version?: "v4" | "v6"; message?: string }) {
@@ -1357,13 +1351,11 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   get isULID() {
     return !!this._def.checks.find((ch) => ch.kind === "ulid");
   }
-<<<<<<< HEAD
   get isXID() {
     return !!this._def.checks.find((ch) => ch.kind === "xid");
-=======
+  }
   get isKSUID() {
     return !!this._def.checks.find((ch) => ch.kind === "ksuid");
->>>>>>> eca2545 (feat: add support for KSUIDs)
   }
   get isIP() {
     return !!this._def.checks.find((ch) => ch.kind === "ip");
@@ -3761,7 +3753,7 @@ export class ZodRecord<
     const pairs: {
       key: ParseReturnType<any>;
       value: ParseReturnType<any>;
-      alwaysSet: boolean;
+      alwaysSet?: boolean;
     }[] = [];
 
     const keyType = this._def.keyType;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3765,7 +3765,7 @@ export class ZodRecord<
         value: valueType._parse(
           new ParseInputLazyPath(ctx, ctx.data[key], ctx.path, key)
         ),
-        alwaysSet: key in ctx.data,
+        alwaysSet: true,
       });
     }
 

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -178,3 +178,14 @@ test("dont parse undefined values", () => {
     foo: undefined,
   });
 });
+
+test("allow undefined values", () => {
+  const schema = z.record(z.string(), z.undefined());
+  expect(
+    util.objectKeys(
+      schema.parse({
+        _test: undefined,
+      })
+    )
+  ).toEqual(["_test"]);
+});

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -181,9 +181,22 @@ test("dont parse undefined values", () => {
 
 test("allow undefined values", () => {
   const schema = z.record(z.string(), z.undefined());
+
   expect(
     util.objectKeys(
       schema.parse({
+        _test: undefined,
+      })
+    )
+  ).toEqual(["_test"]);
+});
+
+test("allow undefined values async", async () => {
+  const schemaAsync = z.record(z.string().optional()).refine(async () => true);
+
+  expect(
+    Object.keys(
+      await schemaAsync.parseAsync({
         _test: undefined,
       })
     )

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -171,7 +171,7 @@ test("is not vulnerable to prototype pollution", async () => {
   }
 });
 
-test("dont parse undefined values", () => {
+test("dont remove undefined values", () => {
   const result1 = z.record(z.any()).parse({ foo: undefined });
 
   expect(result1).toEqual({
@@ -195,7 +195,7 @@ test("allow undefined values async", async () => {
   const schemaAsync = z.record(z.string().optional()).refine(async () => true);
 
   expect(
-    Object.keys(
+    util.objectKeys(
       await schemaAsync.parseAsync({
         _test: undefined,
       })

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -91,6 +91,7 @@ export function addIssueToContext(
 export type ObjectPair = {
   key: SyncParseReturnType<any>;
   value: SyncParseReturnType<any>;
+  alwaysSet?: boolean;
 };
 export class ParseStatus {
   value: "aborted" | "dirty" | "valid" = "valid";
@@ -117,7 +118,11 @@ export class ParseStatus {
 
   static async mergeObjectAsync(
     status: ParseStatus,
-    pairs: { key: ParseReturnType<any>; value: ParseReturnType<any> }[]
+    pairs: {
+      key: ParseReturnType<any>;
+      value: ParseReturnType<any>;
+      alwaysSet?: boolean;
+    }[]
   ): Promise<SyncParseReturnType<any>> {
     const syncPairs: ObjectPair[] = [];
     for (const pair of pairs) {
@@ -126,6 +131,7 @@ export class ParseStatus {
       syncPairs.push({
         key,
         value,
+        alwaysSet: pair.alwaysSet,
       });
     }
     return ParseStatus.mergeObjectSync(status, syncPairs);

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -139,11 +139,7 @@ export class ParseStatus {
 
   static mergeObjectSync(
     status: ParseStatus,
-    pairs: {
-      key: SyncParseReturnType<any>;
-      value: SyncParseReturnType<any>;
-      alwaysSet?: boolean;
-    }[]
+    pairs: ObjectPair[]
   ): SyncParseReturnType {
     const finalObject: any = {};
     for (const pair of pairs) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3753,7 +3753,7 @@ export class ZodRecord<
     const pairs: {
       key: ParseReturnType<any>;
       value: ParseReturnType<any>;
-      alwaysSet: boolean;
+      alwaysSet?: boolean;
     }[] = [];
 
     const keyType = this._def.keyType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3765,7 +3765,7 @@ export class ZodRecord<
         value: valueType._parse(
           new ParseInputLazyPath(ctx, ctx.data[key], ctx.path, key)
         ),
-        alwaysSet: key in ctx.data,
+        alwaysSet: true,
       });
     }
 


### PR DESCRIPTION
`ZodRecord` and `ZodObject` `_parse` methods are dealing differently with undefined values which seems inconsistent.
Problem described further in this issue: #2762 .
I added the same logic to the `_parse` method in `ZodRecord` as implemented  in `ZodObject`.

closes #2762 