### PR TITLE
TS compilation perf: steal faster extendShape type from tRPC

### DIFF
--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -135,7 +135,17 @@ export namespace objectUtil {
     };
   };
 
-  export type extendShape<A, B> = flatten<Omit<A, keyof B> & B>;
+  export type extendShape<A, B> = A extends any
+    ? B extends any
+      ? {
+          [K in keyof A | keyof B]: K extends keyof B
+            ? B[K]
+            : K extends keyof A
+            ? A[K]
+            : never;
+        }
+      : never
+    : never;
 }
 
 export const ZodParsedType = util.arrayToEnum([

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -135,7 +135,17 @@ export namespace objectUtil {
     };
   };
 
-  export type extendShape<A, B> = flatten<Omit<A, keyof B> & B>;
+  export type extendShape<A, B> = A extends any
+    ? B extends any
+      ? {
+          [K in keyof A | keyof B]: K extends keyof B
+            ? B[K]
+            : K extends keyof A
+            ? A[K]
+            : never;
+        }
+      : never
+    : never;
 }
 
 export const ZodParsedType = util.arrayToEnum([


### PR DESCRIPTION
I have some empirical evidence in a decently sized closed-source project that liberal use of `ZodObject.extend()` seems to degrade TS compilation and intellisense performance quite rapidly. I remembered seeing an equivalent implementation of `extendShape` in tRPC (in that project, called `Overwrite`) that looked simpler. I did some light profiling on it using said closed-source project and here are the results:

```
// Zod@jussisaurio

% npx tsc --noEmit --extendedDiagnostics --incremental false

Files:                        1248
Lines of Library:            39145
Lines of Definitions:       126023
Lines of TypeScript:         40594
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                183660
Symbols:                    290202
Types:                      147133
Instantiations:            2361427
Memory used:               345043K
Assignability cache size:    34109
Identity cache size:          1470
Subtype cache size:            708
Strict subtype cache size:   22394
I/O Read time:               0.04s
Parse time:                  0.38s
ResolveModule time:          0.09s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.01s
Program time:                0.60s
Bind time:                   0.17s
Check time:                  1.73s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  2.49s

// Zod@3.21.1

% npx tsc --noEmit --extendedDiagnostics --incremental false

Files:                        1248
Lines of Library:            39145
Lines of Definitions:       126004
Lines of TypeScript:         40594
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                183556
Symbols:                    286851
Types:                      152232
Instantiations:            7692583
Memory used:               356978K
Assignability cache size:    33682
Identity cache size:          1464
Subtype cache size:            708
Strict subtype cache size:   22394
I/O Read time:               0.04s
Parse time:                  0.39s
ResolveModule time:          0.10s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.01s
Program time:                0.60s
Bind time:                   0.17s
Check time:                  2.80s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  3.57s

// Zod@jussisaurio, run #2

% npx tsc --noEmit --extendedDiagnostics --incremental false

Files:                        1248
Lines of Library:            39145
Lines of Definitions:       126023
Lines of TypeScript:         40594
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                183660
Symbols:                    290202
Types:                      147133
Instantiations:            2361427
Memory used:               345221K
Assignability cache size:    34109
Identity cache size:          1470
Subtype cache size:            708
Strict subtype cache size:   22394
I/O Read time:               0.04s
Parse time:                  0.40s
ResolveModule time:          0.10s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.01s
Program time:                0.63s
Bind time:                   0.17s
Check time:                  1.80s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  2.60s

// Zod@3.21.1, run #2

% npx tsc --noEmit --extendedDiagnostics --incremental false

Files:                        1248
Lines of Library:            39145
Lines of Definitions:       126004
Lines of TypeScript:         40594
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                183556
Symbols:                    286851
Types:                      152232
Instantiations:            7692583
Memory used:               356570K
Assignability cache size:    33682
Identity cache size:          1464
Subtype cache size:            708
Strict subtype cache size:   22394
I/O Read time:               0.04s
Parse time:                  0.40s
ResolveModule time:          0.10s
ResolveTypeReference time:   0.01s
ResolveLibrary time:         0.01s
Program time:                0.63s
Bind time:                   0.16s
Check time:                  2.81s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  3.61s
```

Main thing (apart from faster runtime) is the dramatically lower number of type instantiations.