### PR TITLE
fix: tree shake named exports

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -1,6 +1,7 @@
 import type { TypeOf, ZodType } from "./index.ts";
+import { util } from "./helpers/index.ts";
 import { Primitive } from "./helpers/typeAliases.ts";
-import { util, ZodParsedType } from "./helpers/util.ts";
+import { ZodParsedType } from "./helpers/util.ts";
 
 type allKeys<T> = T extends any ? keyof T : never;
 

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -276,10 +276,10 @@ export class ZodError<T = any> extends Error {
     return fieldErrors;
   }
 
-  static create = (issues: ZodIssue[]) => {
+  static create(issues: ZodIssue[]) {
     const error = new ZodError(issues);
     return error;
-  };
+  }
 
   static assert(value: unknown): asserts value is ZodError {
     if (!(value instanceof ZodError)) {

--- a/deno/lib/__tests__/all-errors.test.ts
+++ b/deno/lib/__tests__/all-errors.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 const Test = z.object({

--- a/deno/lib/__tests__/anyunknown.test.ts
+++ b/deno/lib/__tests__/anyunknown.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("check any inference", () => {

--- a/deno/lib/__tests__/array.test.ts
+++ b/deno/lib/__tests__/array.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 const minTwo = z.string().array().min(2);

--- a/deno/lib/__tests__/base.test.ts
+++ b/deno/lib/__tests__/base.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("type guard", () => {

--- a/deno/lib/__tests__/branded.test.ts
+++ b/deno/lib/__tests__/branded.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("branded types", () => {

--- a/deno/lib/__tests__/catch.test.ts
+++ b/deno/lib/__tests__/catch.test.ts
@@ -3,7 +3,7 @@ import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
 import { z } from "../index.ts";
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 
 test("basic catch", () => {
   expect(z.string().catch("default").parse(undefined)).toBe("default");

--- a/deno/lib/__tests__/default.test.ts
+++ b/deno/lib/__tests__/default.test.ts
@@ -3,7 +3,7 @@ import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
 import { z } from "../index.ts";
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 
 test("basic defaults", () => {
   expect(z.string().default("default").parse(undefined)).toBe("default");

--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("create enum", () => {

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -2,7 +2,6 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { ZodParsedType } from "../helpers/util.ts";
 import * as z from "../index.ts";
 import { ZodError, ZodIssueCode } from "../ZodError.ts";
 
@@ -10,8 +9,8 @@ test("error creation", () => {
   const err1 = ZodError.create([]);
   err1.addIssue({
     code: ZodIssueCode.invalid_type,
-    expected: ZodParsedType.object,
-    received: ZodParsedType.string,
+    expected: z.ZodParsedType.object,
+    received: z.ZodParsedType.string,
     path: [],
     message: "",
     fatal: true,

--- a/deno/lib/__tests__/firstparty.test.ts
+++ b/deno/lib/__tests__/firstparty.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("first party switch", () => {

--- a/deno/lib/__tests__/firstpartyschematypes.test.ts
+++ b/deno/lib/__tests__/firstpartyschematypes.test.ts
@@ -3,7 +3,7 @@ import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
 import { ZodFirstPartySchemaTypes, ZodFirstPartyTypeKind } from "../index.ts";
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 
 test("Identify missing [ZodFirstPartySchemaTypes]", () => {
   type ZodFirstPartySchemaForType<T extends ZodFirstPartyTypeKind> =

--- a/deno/lib/__tests__/function.test.ts
+++ b/deno/lib/__tests__/function.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 const args1 = z.tuple([z.string()]);

--- a/deno/lib/__tests__/generics.test.ts
+++ b/deno/lib/__tests__/generics.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("generics", () => {

--- a/deno/lib/__tests__/instanceof.test.ts
+++ b/deno/lib/__tests__/instanceof.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("instanceof", async () => {

--- a/deno/lib/__tests__/map.test.ts
+++ b/deno/lib/__tests__/map.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 import { ZodIssueCode } from "../index.ts";
 

--- a/deno/lib/__tests__/nativeEnum.test.ts
+++ b/deno/lib/__tests__/nativeEnum.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("nativeEnum test with consts", () => {

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 const Test = z.object({

--- a/deno/lib/__tests__/partials.test.ts
+++ b/deno/lib/__tests__/partials.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 import { ZodNullable, ZodOptional } from "../index.ts";
 

--- a/deno/lib/__tests__/pickomit.test.ts
+++ b/deno/lib/__tests__/pickomit.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 const fish = z.object({

--- a/deno/lib/__tests__/preprocess.test.ts
+++ b/deno/lib/__tests__/preprocess.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 test("preprocess", () => {

--- a/deno/lib/__tests__/primitive.test.ts
+++ b/deno/lib/__tests__/primitive.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 import { Mocker } from "./Mocker.ts";
 

--- a/deno/lib/__tests__/promise.test.ts
+++ b/deno/lib/__tests__/promise.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 const promSchema = z.promise(

--- a/deno/lib/__tests__/readonly.test.ts
+++ b/deno/lib/__tests__/readonly.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 enum testEnum {

--- a/deno/lib/__tests__/record.test.ts
+++ b/deno/lib/__tests__/record.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 const booleanRecord = z.record(z.boolean());

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 import { ZodIssueCode } from "../ZodError.ts";
 

--- a/deno/lib/__tests__/set.test.ts
+++ b/deno/lib/__tests__/set.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 import { ZodIssueCode } from "../index.ts";
 

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 
 const stringToNumber = z.string().transform((arg) => parseFloat(arg));

--- a/deno/lib/__tests__/tuple.test.ts
+++ b/deno/lib/__tests__/tuple.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 import { ZodError } from "../ZodError.ts";
 

--- a/deno/lib/__tests__/void.test.ts
+++ b/deno/lib/__tests__/void.test.ts
@@ -2,7 +2,7 @@
 import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 const test = Deno.test;
 
-import { util } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
 import * as z from "../index.ts";
 test("void", () => {
   const v = z.void();

--- a/deno/lib/coerce.ts
+++ b/deno/lib/coerce.ts
@@ -1,0 +1,23 @@
+import { ZodBigInt, ZodBoolean, ZodDate, ZodNumber, ZodString } from "./types.ts";
+
+const coerceString = ((arg) =>
+  ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"];
+const coerceNumber = ((arg) =>
+  ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"];
+const coerceBoolean = ((arg) =>
+  ZodBoolean.create({
+    ...arg,
+    coerce: true,
+  })) as (typeof ZodBoolean)["create"];
+const coerceBigint = ((arg) =>
+  ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"];
+const coerceDate = ((arg) =>
+  ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"];
+
+export {
+  coerceBigint as bigint,
+  coerceBoolean as boolean,
+  coerceDate as date,
+  coerceNumber as number,
+  coerceString as string,
+};

--- a/deno/lib/external.ts
+++ b/deno/lib/external.ts
@@ -1,6 +1,6 @@
 export * from "./errors.ts";
+export * from "./helpers/index.ts";
 export * from "./helpers/parseUtil.ts";
 export * from "./helpers/typeAliases.ts";
-export * from "./helpers/util.ts";
 export * from "./types.ts";
 export * from "./ZodError.ts";

--- a/deno/lib/helpers/enumUtil.ts
+++ b/deno/lib/helpers/enumUtil.ts
@@ -1,19 +1,17 @@
-export namespace enumUtil {
-  type UnionToIntersectionFn<T> = (
-    T extends unknown ? (k: () => T) => void : never
-  ) extends (k: infer Intersection) => void
-    ? Intersection
-    : never;
+type UnionToIntersectionFn<T> = (
+  T extends unknown ? (k: () => T) => void : never
+) extends (k: infer Intersection) => void
+  ? Intersection
+  : never;
 
-  type GetUnionLast<T> = UnionToIntersectionFn<T> extends () => infer Last
-    ? Last
-    : never;
+type GetUnionLast<T> = UnionToIntersectionFn<T> extends () => infer Last
+  ? Last
+  : never;
 
-  type UnionToTuple<T, Tuple extends unknown[] = []> = [T] extends [never]
-    ? Tuple
-    : UnionToTuple<Exclude<T, GetUnionLast<T>>, [GetUnionLast<T>, ...Tuple]>;
+type UnionToTuple<T, Tuple extends unknown[] = []> = [T] extends [never]
+  ? Tuple
+  : UnionToTuple<Exclude<T, GetUnionLast<T>>, [GetUnionLast<T>, ...Tuple]>;
 
-  type CastToStringTuple<T> = T extends [string, ...string[]] ? T : never;
+type CastToStringTuple<T> = T extends [string, ...string[]] ? T : never;
 
-  export type UnionToTupleString<T> = CastToStringTuple<UnionToTuple<T>>;
-}
+export type UnionToTupleString<T> = CastToStringTuple<UnionToTuple<T>>;

--- a/deno/lib/helpers/errorUtil.ts
+++ b/deno/lib/helpers/errorUtil.ts
@@ -1,7 +1,5 @@
-export namespace errorUtil {
-  export type ErrMessage = string | { message?: string };
-  export const errToObj = (message?: ErrMessage) =>
-    typeof message === "string" ? { message } : message || {};
-  export const toString = (message?: ErrMessage): string | undefined =>
-    typeof message === "string" ? message : message?.message;
-}
+export type ErrMessage = string | { message?: string };
+export const errToObj = (message?: ErrMessage) =>
+  typeof message === "string" ? { message } : message || {};
+export const toString = (message?: ErrMessage): string | undefined =>
+  typeof message === "string" ? message : message?.message;

--- a/deno/lib/helpers/index.ts
+++ b/deno/lib/helpers/index.ts
@@ -1,0 +1,5 @@
+export * as enumUtil from "./enumUtil.ts";
+export * as errorUtil from "./errorUtil.ts";
+export * as objectUtil from "./objectUtil.ts";
+export * as partialUtil from "./partialUtil.ts";
+export * as util from "./util.ts";

--- a/deno/lib/helpers/objectUtil.ts
+++ b/deno/lib/helpers/objectUtil.ts
@@ -1,0 +1,40 @@
+export type MergeShapes<U, V> = {
+  [k in Exclude<keyof U, keyof V>]: U[k];
+} & V;
+
+// type optionalKeys<T extends object> = {
+//   [k in keyof T]: undefined extends T[k] ? k : never;
+// }[keyof T];
+
+type requiredKeys<T extends object> = {
+  [k in keyof T]: undefined extends T[k] ? never : k;
+}[keyof T];
+
+// type alkjsdf = addQuestionMarks<{ a: any }>;
+
+export type addQuestionMarks<
+  T extends object,
+  R extends keyof T = requiredKeys<T>
+  // O extends keyof T = optionalKeys<T>
+> = Pick<Required<T>, R> & Partial<T>;
+//  = { [k in O]?: T[k] } & { [k in R]: T[k] };
+
+export type identity<T> = T;
+export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;
+
+export type noNeverKeys<T> = {
+  [k in keyof T]: [T[k]] extends [never] ? never : k;
+}[keyof T];
+
+export type noNever<T> = identity<{
+  [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
+}>;
+
+export const mergeShapes = <U, T>(first: U, second: T): T & U => {
+  return {
+    ...first,
+    ...second, // second overwrites first
+  };
+};
+
+export type extendShape<A, B> = flatten<Omit<A, keyof B> & B>;

--- a/deno/lib/helpers/objectUtil.ts
+++ b/deno/lib/helpers/objectUtil.ts
@@ -1,23 +1,14 @@
-export type MergeShapes<U, V> = {
-  [k in Exclude<keyof U, keyof V>]: U[k];
-} & V;
-
-// type optionalKeys<T extends object> = {
-//   [k in keyof T]: undefined extends T[k] ? k : never;
-// }[keyof T];
-
-type requiredKeys<T extends object> = {
+export type optionalKeys<T extends object> = {
+  [k in keyof T]: undefined extends T[k] ? k : never;
+}[keyof T];
+export type requiredKeys<T extends object> = {
   [k in keyof T]: undefined extends T[k] ? never : k;
 }[keyof T];
-
-// type alkjsdf = addQuestionMarks<{ a: any }>;
-
-export type addQuestionMarks<
-  T extends object,
-  R extends keyof T = requiredKeys<T>
-  // O extends keyof T = optionalKeys<T>
-> = Pick<Required<T>, R> & Partial<T>;
-//  = { [k in O]?: T[k] } & { [k in R]: T[k] };
+export type addQuestionMarks<T extends object, _O = any> = {
+  [K in requiredKeys<T>]: T[K];
+} & {
+  [K in optionalKeys<T>]?: T[K];
+} & { [k in keyof T]?: unknown };
 
 export type identity<T> = T;
 export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;
@@ -37,4 +28,10 @@ export const mergeShapes = <U, T>(first: U, second: T): T & U => {
   };
 };
 
-export type extendShape<A, B> = flatten<Omit<A, keyof B> & B>;
+export type extendShape<A extends object, B extends object> = {
+  [K in keyof A | keyof B]: K extends keyof B
+    ? B[K]
+    : K extends keyof A
+    ? A[K]
+    : never;
+};

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -1,7 +1,7 @@
 import { getErrorMap } from "../errors.ts";
 import defaultErrorMap from "../locales/en.ts";
 import type { IssueData, ZodErrorMap, ZodIssue } from "../ZodError.ts";
-import type { ZodParsedType } from "./util.ts";
+import type { ZodParsedType } from "../index.ts";
 
 export const makeIssue = (params: {
   data: any;

--- a/deno/lib/helpers/partialUtil.ts
+++ b/deno/lib/helpers/partialUtil.ts
@@ -9,70 +9,67 @@ import type {
   ZodTypeAny,
 } from "../index.ts";
 
-export namespace partialUtil {
-  // export type DeepPartial<T extends AnyZodObject> = T extends AnyZodObject
-  //   ? ZodObject<
-  //       { [k in keyof T["_shape"]]: InternalDeepPartial<T["_shape"][k]> },
-  //       T["_unknownKeys"],
-  //       T["_catchall"]
-  //     >
-  //   : T extends ZodArray<infer Type, infer Card>
-  //   ? ZodArray<InternalDeepPartial<Type>, Card>
-  //   : ZodOptional<T>;
+// export type DeepPartial<T extends AnyZodObject> = T extends AnyZodObject
+//   ? ZodObject<
+//       { [k in keyof T["_shape"]]: InternalDeepPartial<T["_shape"][k]> },
+//       T["_unknownKeys"],
+//       T["_catchall"]
+//     >
+//   : T extends ZodArray<infer Type, infer Card>
+//   ? ZodArray<InternalDeepPartial<Type>, Card>
+//   : ZodOptional<T>;
 
-  // {
-  //   // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
-  //   // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;
-  //   object: T extends AnyZodObject
-  //     ? ZodObject<
-  //         { [k in keyof T["_shape"]]: DeepPartial<T["_shape"][k]> },
-  //         T["_unknownKeys"],
-  //         T["_catchall"]
-  //       >
-  //     : never;
-  //   rest: ReturnType<T["optional"]>; // ZodOptional<T>;
-  // }[T extends AnyZodObject
-  //   ? "object" // T extends ZodOptional<any> // ? 'optional' // :
-  //   : "rest"];
+// {
+//   // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
+//   // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;
+//   object: T extends AnyZodObject
+//     ? ZodObject<
+//         { [k in keyof T["_shape"]]: DeepPartial<T["_shape"][k]> },
+//         T["_unknownKeys"],
+//         T["_catchall"]
+//       >
+//     : never;
+//   rest: ReturnType<T["optional"]>; // ZodOptional<T>;
+// }[T extends AnyZodObject
+//   ? "object" // T extends ZodOptional<any> // ? 'optional' // :
+//   : "rest"];
 
-  export type DeepPartial<T extends ZodTypeAny> =
-    T extends ZodObject<ZodRawShape>
-      ? ZodObject<
-          { [k in keyof T["shape"]]: ZodOptional<DeepPartial<T["shape"][k]>> },
-          T["_def"]["unknownKeys"],
-          T["_def"]["catchall"]
-        >
-      : T extends ZodArray<infer Type, infer Card>
-      ? ZodArray<DeepPartial<Type>, Card>
-      : T extends ZodOptional<infer Type>
-      ? ZodOptional<DeepPartial<Type>>
-      : T extends ZodNullable<infer Type>
-      ? ZodNullable<DeepPartial<Type>>
-      : T extends ZodTuple<infer Items>
-      ? {
-          [k in keyof Items]: Items[k] extends ZodTypeAny
-            ? DeepPartial<Items[k]>
-            : never;
-        } extends infer PI
-        ? PI extends ZodTupleItems
-          ? ZodTuple<PI>
-          : never
-        : never
-      : T;
-  //  {
-  //     // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
-  //     // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;
-  //     object: T extends ZodObject<infer Shape, infer Params, infer Catchall>
-  //       ? ZodOptional<
-  //           ZodObject<
-  //             { [k in keyof Shape]: DeepPartial<Shape[k]> },
-  //             Params,
-  //             Catchall
-  //           >
-  //         >
-  //       : never;
-  //     rest: ReturnType<T["optional"]>;
-  //   }[T extends ZodObject<any>
-  //     ? "object" // T extends ZodOptional<any> // ? 'optional' // :
-  //     : "rest"];
-}
+export type DeepPartial<T extends ZodTypeAny> = T extends ZodObject<ZodRawShape>
+  ? ZodObject<
+      { [k in keyof T["shape"]]: ZodOptional<DeepPartial<T["shape"][k]>> },
+      T["_def"]["unknownKeys"],
+      T["_def"]["catchall"]
+    >
+  : T extends ZodArray<infer Type, infer Card>
+  ? ZodArray<DeepPartial<Type>, Card>
+  : T extends ZodOptional<infer Type>
+  ? ZodOptional<DeepPartial<Type>>
+  : T extends ZodNullable<infer Type>
+  ? ZodNullable<DeepPartial<Type>>
+  : T extends ZodTuple<infer Items>
+  ? {
+      [k in keyof Items]: Items[k] extends ZodTypeAny
+        ? DeepPartial<Items[k]>
+        : never;
+    } extends infer PI
+    ? PI extends ZodTupleItems
+      ? ZodTuple<PI>
+      : never
+    : never
+  : T;
+//  {
+//     // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
+//     // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;
+//     object: T extends ZodObject<infer Shape, infer Params, infer Catchall>
+//       ? ZodOptional<
+//           ZodObject<
+//             { [k in keyof Shape]: DeepPartial<Shape[k]> },
+//             Params,
+//             Catchall
+//           >
+//         >
+//       : never;
+//     rest: ReturnType<T["optional"]>;
+//   }[T extends ZodObject<any>
+//     ? "object" // T extends ZodOptional<any> // ? 'optional' // :
+//     : "rest"];

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -1,6 +1,6 @@
-import { objectUtil } from "./index.ts";
+// import { objectUtil } from ".";
 
-type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
+export type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
   V
 >() => V extends U ? 1 : 2
   ? true
@@ -17,6 +17,7 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
 export type MakePartial<T, K extends keyof T> = Omit<T, K> &
   Partial<Pick<T, K>>;
+export type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
 
 export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
   items: U
@@ -28,13 +29,6 @@ export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
   return obj as any;
 };
 
-<<<<<<< HEAD
-  export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-  export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
-  export type MakePartial<T, K extends keyof T> = Omit<T, K> &
-    Partial<Pick<T, K>>;
-  export type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
-=======
 export const getValidEnumValues = (obj: any) => {
   const validKeys = objectKeys(obj).filter(
     (k: any) => typeof obj[obj[k]] !== "number"
@@ -45,7 +39,6 @@ export const getValidEnumValues = (obj: any) => {
   }
   return objectValues(filtered);
 };
->>>>>>> 19fbb9a (fix: make util tree shakeable)
 
 export const objectValues = (obj: any) => {
   return objectKeys(obj).map(function (e) {
@@ -73,8 +66,8 @@ export const find = <T>(arr: T[], checker: (arg: T) => any): T | undefined => {
   return undefined;
 };
 
-export type identity<T> = objectUtil.identity<T>;
-export type flatten<T> = objectUtil.flatten<T>;
+// export type identity<T> = objectUtil.identity<T>;
+// export type flatten<T> = objectUtil.flatten<T>;
 
 export type noUndefined<T> = T extends undefined ? never : T;
 
@@ -100,50 +93,7 @@ export const jsonStringifyReplacer = (_: string, value: any): any => {
   return value;
 };
 
-<<<<<<< HEAD
-  type optionalKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? k : never;
-  }[keyof T];
-  type requiredKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? never : k;
-  }[keyof T];
-  export type addQuestionMarks<T extends object, _O = any> = {
-    [K in requiredKeys<T>]: T[K];
-  } & {
-    [K in optionalKeys<T>]?: T[K];
-  } & { [k in keyof T]?: unknown };
-
-  export type identity<T> = T;
-  export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;
-
-  export type noNeverKeys<T> = {
-    [k in keyof T]: [T[k]] extends [never] ? never : k;
-  }[keyof T];
-
-  export type noNever<T> = identity<{
-    [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
-  }>;
-
-  export const mergeShapes = <U, T>(first: U, second: T): T & U => {
-    return {
-      ...first,
-      ...second, // second overwrites first
-    };
-  };
-
-  export type extendShape<A extends object, B extends object> = {
-    [K in keyof A | keyof B]: K extends keyof B
-      ? B[K]
-      : K extends keyof A
-      ? A[K]
-      : never;
-  };
-}
-
-export const ZodParsedType = util.arrayToEnum([
-=======
 export const ZodParsedType = arrayToEnum([
->>>>>>> 19fbb9a (fix: make util tree shakeable)
   "string",
   "nan",
   "number",

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -1,106 +1,106 @@
-export namespace util {
-  type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
-    V
-  >() => V extends U ? 1 : 2
-    ? true
-    : false;
+import { objectUtil } from "./index.ts";
 
-  export type isAny<T> = 0 extends 1 & T ? true : false;
-  export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
-  export function assertIs<T>(_arg: T): void {}
-  export function assertNever(_x: never): never {
-    throw new Error();
+type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
+  V
+>() => V extends U ? 1 : 2
+  ? true
+  : false;
+
+export type isAny<T> = 0 extends 1 & T ? true : false;
+export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
+export function assertIs<T>(_arg: T): void {}
+export function assertNever(_x: never): never {
+  throw new Error();
+}
+
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
+export type MakePartial<T, K extends keyof T> = Omit<T, K> &
+  Partial<Pick<T, K>>;
+
+export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
+  items: U
+): { [k in U[number]]: k } => {
+  const obj: any = {};
+  for (const item of items) {
+    obj[item] = item;
   }
+  return obj as any;
+};
 
+<<<<<<< HEAD
   export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
   export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
   export type MakePartial<T, K extends keyof T> = Omit<T, K> &
     Partial<Pick<T, K>>;
   export type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
-
-  export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
-    items: U
-  ): { [k in U[number]]: k } => {
-    const obj: any = {};
-    for (const item of items) {
-      obj[item] = item;
-    }
-    return obj as any;
-  };
-
-  export const getValidEnumValues = (obj: any) => {
-    const validKeys = objectKeys(obj).filter(
-      (k: any) => typeof obj[obj[k]] !== "number"
-    );
-    const filtered: any = {};
-    for (const k of validKeys) {
-      filtered[k] = obj[k];
-    }
-    return objectValues(filtered);
-  };
-
-  export const objectValues = (obj: any) => {
-    return objectKeys(obj).map(function (e) {
-      return obj[e];
-    });
-  };
-
-  export const objectKeys: ObjectConstructor["keys"] =
-    typeof Object.keys === "function" // eslint-disable-line ban/ban
-      ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
-      : (object: any) => {
-          const keys = [];
-          for (const key in object) {
-            if (Object.prototype.hasOwnProperty.call(object, key)) {
-              keys.push(key);
-            }
-          }
-          return keys;
-        };
-
-  export const find = <T>(
-    arr: T[],
-    checker: (arg: T) => any
-  ): T | undefined => {
-    for (const item of arr) {
-      if (checker(item)) return item;
-    }
-    return undefined;
-  };
-
-  export type identity<T> = objectUtil.identity<T>;
-  export type flatten<T> = objectUtil.flatten<T>;
-
-  export type noUndefined<T> = T extends undefined ? never : T;
-
-  export const isInteger: NumberConstructor["isInteger"] =
-    typeof Number.isInteger === "function"
-      ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
-      : (val) =>
-          typeof val === "number" && isFinite(val) && Math.floor(val) === val;
-
-  export function joinValues<T extends any[]>(
-    array: T,
-    separator = " | "
-  ): string {
-    return array
-      .map((val) => (typeof val === "string" ? `'${val}'` : val))
-      .join(separator);
+=======
+export const getValidEnumValues = (obj: any) => {
+  const validKeys = objectKeys(obj).filter(
+    (k: any) => typeof obj[obj[k]] !== "number"
+  );
+  const filtered: any = {};
+  for (const k of validKeys) {
+    filtered[k] = obj[k];
   }
+  return objectValues(filtered);
+};
+>>>>>>> 19fbb9a (fix: make util tree shakeable)
 
-  export const jsonStringifyReplacer = (_: string, value: any): any => {
-    if (typeof value === "bigint") {
-      return value.toString();
-    }
-    return value;
-  };
+export const objectValues = (obj: any) => {
+  return objectKeys(obj).map(function (e) {
+    return obj[e];
+  });
+};
+
+export const objectKeys: ObjectConstructor["keys"] =
+  typeof Object.keys === "function" // eslint-disable-line ban/ban
+    ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
+    : (object: any) => {
+        const keys = [];
+        for (const key in object) {
+          if (Object.prototype.hasOwnProperty.call(object, key)) {
+            keys.push(key);
+          }
+        }
+        return keys;
+      };
+
+export const find = <T>(arr: T[], checker: (arg: T) => any): T | undefined => {
+  for (const item of arr) {
+    if (checker(item)) return item;
+  }
+  return undefined;
+};
+
+export type identity<T> = objectUtil.identity<T>;
+export type flatten<T> = objectUtil.flatten<T>;
+
+export type noUndefined<T> = T extends undefined ? never : T;
+
+export const isInteger: NumberConstructor["isInteger"] =
+  typeof Number.isInteger === "function"
+    ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
+    : (val) =>
+        typeof val === "number" && isFinite(val) && Math.floor(val) === val;
+
+export function joinValues<T extends any[]>(
+  array: T,
+  separator = " | "
+): string {
+  return array
+    .map((val) => (typeof val === "string" ? `'${val}'` : val))
+    .join(separator);
 }
 
-export namespace objectUtil {
-  export type MergeShapes<U, V> = {
-    [k in Exclude<keyof U, keyof V>]: U[k];
-  } & V;
+export const jsonStringifyReplacer = (_: string, value: any): any => {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return value;
+};
 
+<<<<<<< HEAD
   type optionalKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? k : never;
   }[keyof T];
@@ -141,6 +141,9 @@ export namespace objectUtil {
 }
 
 export const ZodParsedType = util.arrayToEnum([
+=======
+export const ZodParsedType = arrayToEnum([
+>>>>>>> 19fbb9a (fix: make util tree shakeable)
   "string",
   "nan",
   "number",

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -1,4 +1,5 @@
-import { util, ZodParsedType } from "../helpers/util.ts";
+import { util } from "../helpers/index.ts";
+import { ZodParsedType } from "../helpers/util.ts";
 import { ZodErrorMap, ZodIssueCode } from "../ZodError.ts";
 
 const errorMap: ZodErrorMap = (issue, _ctx) => {

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -1,12 +1,12 @@
 import { util } from "../helpers/index.ts";
-import { ZodParsedType } from "../helpers/util.ts";
+
 import { ZodErrorMap, ZodIssueCode } from "../ZodError.ts";
 
 const errorMap: ZodErrorMap = (issue, _ctx) => {
   let message: string;
   switch (issue.code) {
     case ZodIssueCode.invalid_type:
-      if (issue.received === ZodParsedType.undefined) {
+      if (issue.received === util.ZodParsedType.undefined) {
         message = "Required";
       } else {
         message = `Expected ${issue.expected}, received ${issue.received}`;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1,6 +1,5 @@
 import { defaultErrorMap, getErrorMap } from "./errors.ts";
-import { enumUtil } from "./helpers/enumUtil.ts";
-import { errorUtil } from "./helpers/errorUtil.ts";
+import { enumUtil, errorUtil, objectUtil, partialUtil, util } from "./helpers/index.ts";
 import {
   addIssueToContext,
   AsyncParseReturnType,
@@ -20,9 +19,8 @@ import {
   ParseStatus,
   SyncParseReturnType,
 } from "./helpers/parseUtil.ts";
-import { partialUtil } from "./helpers/partialUtil.ts";
 import { Primitive } from "./helpers/typeAliases.ts";
-import { getParsedType, objectUtil, util, ZodParsedType } from "./helpers/util.ts";
+import { getParsedType, ZodParsedType } from "./helpers/util.ts";
 import {
   IssueData,
   StringValidation,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -31,6 +31,8 @@ import {
   ZodIssueCode,
 } from "./ZodError.ts";
 
+export { ZodParsedType } from "./helpers/util.ts";
+
 ///////////////////////////////////////
 ///////////////////////////////////////
 //////////                   //////////
@@ -3007,7 +3009,7 @@ export class ZodObject<
     ZodTypeAny,
     objectOutputType<T, ZodTypeAny, "strip">,
     objectInputType<T, ZodTypeAny, "strip">
-  > => {
+  > {
     return new ZodObject({
       shape: () => shape,
       unknownKeys: "strip",
@@ -5187,7 +5189,7 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
       typeName: ZodFirstPartyTypeKind.ZodReadonly,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 
   unwrap() {
     return this._def.innerType;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -5396,21 +5396,7 @@ const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
 
-export const coerce = {
-  string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
-  number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
-  boolean: ((arg) =>
-    ZodBoolean.create({
-      ...arg,
-      coerce: true,
-    })) as (typeof ZodBoolean)["create"],
-  bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
-  date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
-};
+export * as coerce from "./coerce.ts";
 
 export {
   anyType as any,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -5332,6 +5332,10 @@ const instanceOfType = <T extends typeof Class>(
   }
 ) => custom<InstanceType<T>>((data) => data instanceof cls, params);
 
+//////////////////////////////////////////////////////
+// MUST be aliased using wrapper functions.         //
+// See: https://github.com/colinhacks/zod/pull/2850 //
+//////////////////////////////////////////////////////
 const stringType: typeof ZodString.create = (...args) =>
   ZodString.create(...args);
 const numberType: typeof ZodNumber.create = (...args) =>

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1330,14 +1330,14 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     return max;
   }
 
-  static create = (params?: RawCreateParams & { coerce?: true }): ZodString => {
+  static create(params?: RawCreateParams & { coerce?: true }): ZodString {
     return new ZodString({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodString,
       coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 /////////////////////////////////////////
@@ -1460,16 +1460,14 @@ export class ZodNumber extends ZodType<number, ZodNumberDef, number> {
     return { status: status.value, value: input.data };
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodNumber => {
+  static create(params?: RawCreateParams & { coerce?: boolean }): ZodNumber {
     return new ZodNumber({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodNumber,
       coerce: params?.coerce || false,
       ...processCreateParams(params),
     });
-  };
+  }
 
   gte(value: number, message?: errorUtil.ErrMessage) {
     return this.setLimit("min", value, true, errorUtil.toString(message));
@@ -1723,16 +1721,14 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef, bigint> {
     return { status: status.value, value: input.data };
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodBigInt => {
+  static create(params?: RawCreateParams & { coerce?: boolean }): ZodBigInt {
     return new ZodBigInt({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodBigInt,
       coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     });
-  };
+  }
 
   gte(value: bigint, message?: errorUtil.ErrMessage) {
     return this.setLimit("min", value, true, errorUtil.toString(message));
@@ -1875,15 +1871,13 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef, boolean> {
     return OK(input.data);
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodBoolean => {
+  static create(params?: RawCreateParams & { coerce?: boolean }): ZodBoolean {
     return new ZodBoolean({
       typeName: ZodFirstPartyTypeKind.ZodBoolean,
       coerce: params?.coerce || false,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////
@@ -2013,16 +2007,14 @@ export class ZodDate extends ZodType<Date, ZodDateDef, Date> {
     return max != null ? new Date(max) : null;
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodDate => {
+  static create(params?: RawCreateParams & { coerce?: boolean }): ZodDate {
     return new ZodDate({
       checks: [],
       coerce: params?.coerce || false,
       typeName: ZodFirstPartyTypeKind.ZodDate,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////////
@@ -2052,12 +2044,12 @@ export class ZodSymbol extends ZodType<symbol, ZodSymbolDef, symbol> {
     return OK(input.data);
   }
 
-  static create = (params?: RawCreateParams): ZodSymbol => {
+  static create(params?: RawCreateParams): ZodSymbol {
     return new ZodSymbol({
       typeName: ZodFirstPartyTypeKind.ZodSymbol,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////////
@@ -2091,12 +2083,12 @@ export class ZodUndefined extends ZodType<
   }
   params?: RawCreateParams;
 
-  static create = (params?: RawCreateParams): ZodUndefined => {
+  static create(params?: RawCreateParams): ZodUndefined {
     return new ZodUndefined({
       typeName: ZodFirstPartyTypeKind.ZodUndefined,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////
@@ -2124,12 +2116,12 @@ export class ZodNull extends ZodType<null, ZodNullDef, null> {
     }
     return OK(input.data);
   }
-  static create = (params?: RawCreateParams): ZodNull => {
+  static create(params?: RawCreateParams): ZodNull {
     return new ZodNull({
       typeName: ZodFirstPartyTypeKind.ZodNull,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////
@@ -2149,12 +2141,12 @@ export class ZodAny extends ZodType<any, ZodAnyDef, any> {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     return OK(input.data);
   }
-  static create = (params?: RawCreateParams): ZodAny => {
+  static create(params?: RawCreateParams): ZodAny {
     return new ZodAny({
       typeName: ZodFirstPartyTypeKind.ZodAny,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -2175,12 +2167,12 @@ export class ZodUnknown extends ZodType<unknown, ZodUnknownDef, unknown> {
     return OK(input.data);
   }
 
-  static create = (params?: RawCreateParams): ZodUnknown => {
+  static create(params?: RawCreateParams): ZodUnknown {
     return new ZodUnknown({
       typeName: ZodFirstPartyTypeKind.ZodUnknown,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////
@@ -2204,12 +2196,12 @@ export class ZodNever extends ZodType<never, ZodNeverDef, never> {
     });
     return INVALID;
   }
-  static create = (params?: RawCreateParams): ZodNever => {
+  static create(params?: RawCreateParams): ZodNever {
     return new ZodNever({
       typeName: ZodFirstPartyTypeKind.ZodNever,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////
@@ -2238,12 +2230,12 @@ export class ZodVoid extends ZodType<void, ZodVoidDef, void> {
     return OK(input.data);
   }
 
-  static create = (params?: RawCreateParams): ZodVoid => {
+  static create(params?: RawCreateParams): ZodVoid {
     return new ZodVoid({
       typeName: ZodFirstPartyTypeKind.ZodVoid,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////
@@ -2426,10 +2418,11 @@ export class ZodArray<
     }) as any;
   }
 
-  static create = <T extends ZodTypeAny>(
+  
+  static create<T extends ZodTypeAny>(
     schema: T,
     params?: RawCreateParams
-  ): ZodArray<T> => {
+  ): ZodArray<T> {
     return new ZodArray({
       type: schema,
       minLength: null,
@@ -2439,7 +2432,7 @@ export class ZodArray<
       typeName: ZodFirstPartyTypeKind.ZodArray,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 export type ZodNonEmptyArray<T extends ZodTypeAny> = ZodArray<T, "atleastone">;
@@ -3002,12 +2995,12 @@ export class ZodObject<
   }
 
   keyof(): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
-    return createZodEnum(
+    return ZodEnum.create(
       util.objectKeys(this.shape) as [string, ...string[]]
     ) as any;
   }
 
-  static create = <T extends ZodRawShape>(
+  static create<T extends ZodRawShape>(
     shape: T,
     params?: RawCreateParams
   ): ZodObject<
@@ -3024,12 +3017,12 @@ export class ZodObject<
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 
-  static strictCreate = <T extends ZodRawShape>(
+  static strictCreate<T extends ZodRawShape>(
     shape: T,
     params?: RawCreateParams
-  ): ZodObject<T, "strict"> => {
+  ): ZodObject<T, "strict"> {
     return new ZodObject({
       shape: () => shape,
       unknownKeys: "strict",
@@ -3037,12 +3030,12 @@ export class ZodObject<
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 
-  static lazycreate = <T extends ZodRawShape>(
+  static lazycreate<T extends ZodRawShape>(
     shape: () => T,
     params?: RawCreateParams
-  ): ZodObject<T, "strip"> => {
+  ): ZodObject<T, "strip"> {
     return new ZodObject({
       shape,
       unknownKeys: "strip",
@@ -3050,7 +3043,7 @@ export class ZodObject<
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 }
 
 export type AnyZodObject = ZodObject<any, any, any>;
@@ -3182,18 +3175,16 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
     return this._def.options;
   }
 
-  static create = <
-    T extends Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>
-  >(
+  static create<T extends Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>>(
     types: T,
     params?: RawCreateParams
-  ): ZodUnion<T> => {
+  ): ZodUnion<T> {
     return new ZodUnion({
       options: types,
       typeName: ZodFirstPartyTypeKind.ZodUnion,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 /////////////////////////////////////////////////////
@@ -3507,18 +3498,18 @@ export class ZodIntersection<
     }
   }
 
-  static create = <T extends ZodTypeAny, U extends ZodTypeAny>(
+  static create<T extends ZodTypeAny, U extends ZodTypeAny>(
     left: T,
     right: U,
     params?: RawCreateParams
-  ): ZodIntersection<T, U> => {
+  ): ZodIntersection<T, U> {
     return new ZodIntersection({
       left: left,
       right: right,
       typeName: ZodFirstPartyTypeKind.ZodIntersection,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////
@@ -3637,10 +3628,10 @@ export class ZodTuple<
     });
   }
 
-  static create = <T extends [ZodTypeAny, ...ZodTypeAny[]] | []>(
+  static create<T extends [ZodTypeAny, ...ZodTypeAny[]] | []>(
     schemas: T,
     params?: RawCreateParams
-  ): ZodTuple<T, null> => {
+  ): ZodTuple<T, null> {
     if (!Array.isArray(schemas)) {
       throw new Error("You must pass an array of schemas to z.tuple([ ... ])");
     }
@@ -3650,7 +3641,7 @@ export class ZodTuple<
       rest: null,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 /////////////////////////////////////////
@@ -3855,21 +3846,21 @@ export class ZodMap<
       return { status: status.value, value: finalMap };
     }
   }
-  static create = <
+  static create<
     Key extends ZodTypeAny = ZodTypeAny,
     Value extends ZodTypeAny = ZodTypeAny
   >(
     keyType: Key,
     valueType: Value,
     params?: RawCreateParams
-  ): ZodMap<Key, Value> => {
+  ): ZodMap<Key, Value> {
     return new ZodMap({
       valueType,
       keyType,
       typeName: ZodFirstPartyTypeKind.ZodMap,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////
@@ -3978,10 +3969,10 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this.min(1, message) as any;
   }
 
-  static create = <Value extends ZodTypeAny = ZodTypeAny>(
+  static create<Value extends ZodTypeAny = ZodTypeAny>(
     valueType: Value,
     params?: RawCreateParams
-  ): ZodSet<Value> => {
+  ): ZodSet<Value> {
     return new ZodSet({
       valueType,
       minSize: null,
@@ -3989,7 +3980,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
       typeName: ZodFirstPartyTypeKind.ZodSet,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////////
@@ -4222,16 +4213,16 @@ export class ZodLazy<T extends ZodTypeAny> extends ZodType<
     return lazySchema._parse({ data: ctx.data, path: ctx.path, parent: ctx });
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     getter: () => T,
     params?: RawCreateParams
-  ): ZodLazy<T> => {
+  ): ZodLazy<T> {
     return new ZodLazy({
       getter: getter,
       typeName: ZodFirstPartyTypeKind.ZodLazy,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -4264,16 +4255,16 @@ export class ZodLiteral<T> extends ZodType<T, ZodLiteralDef<T>, T> {
     return this._def.value;
   }
 
-  static create = <T extends Primitive>(
+  static create<T extends Primitive>(
     value: T,
     params?: RawCreateParams
-  ): ZodLiteral<T> => {
+  ): ZodLiteral<T> {
     return new ZodLiteral({
       value: value,
       typeName: ZodFirstPartyTypeKind.ZodLiteral,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////
@@ -4309,25 +4300,6 @@ export type FilterEnum<Values, ToExclude> = Values extends []
   : never;
 
 export type typecast<A, T> = A extends T ? A : never;
-
-function createZodEnum<U extends string, T extends Readonly<[U, ...U[]]>>(
-  values: T,
-  params?: RawCreateParams
-): ZodEnum<Writeable<T>>;
-function createZodEnum<U extends string, T extends [U, ...U[]]>(
-  values: T,
-  params?: RawCreateParams
-): ZodEnum<T>;
-function createZodEnum(
-  values: [string, ...string[]],
-  params?: RawCreateParams
-) {
-  return new ZodEnum({
-    values,
-    typeName: ZodFirstPartyTypeKind.ZodEnum,
-    ...processCreateParams(params),
-  });
-}
 
 export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
   T[number],
@@ -4422,7 +4394,21 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
     ) as any;
   }
 
-  static create = createZodEnum;
+  static create<U extends string, T extends Readonly<[U, ...U[]]>>(
+    values: T,
+    params?: RawCreateParams
+  ): ZodEnum<Writeable<T>>;
+  static create<U extends string, T extends [U, ...U[]]>(
+    values: T,
+    params?: RawCreateParams
+  ): ZodEnum<T>;
+  static create(values: [string, ...string[]], params?: RawCreateParams) {
+    return new ZodEnum({
+      values,
+      typeName: ZodFirstPartyTypeKind.ZodEnum,
+      ...processCreateParams(params),
+    });
+  }
 }
 
 /////////////////////////////////////////////
@@ -4484,16 +4470,16 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     return this._def.values;
   }
 
-  static create = <T extends EnumLike>(
+  static create<T extends EnumLike>(
     values: T,
     params?: RawCreateParams
-  ): ZodNativeEnum<T> => {
+  ): ZodNativeEnum<T> {
     return new ZodNativeEnum({
       values: values,
       typeName: ZodFirstPartyTypeKind.ZodNativeEnum,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -4547,16 +4533,16 @@ export class ZodPromise<T extends ZodTypeAny> extends ZodType<
     );
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     schema: T,
     params?: RawCreateParams
-  ): ZodPromise<T> => {
+  ): ZodPromise<T> {
     return new ZodPromise({
       type: schema,
       typeName: ZodFirstPartyTypeKind.ZodPromise,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////////
@@ -4737,31 +4723,31 @@ export class ZodEffects<
     util.assertNever(effect);
   }
 
-  static create = <I extends ZodTypeAny>(
+  static create<I extends ZodTypeAny>(
     schema: I,
     effect: Effect<I["_output"]>,
     params?: RawCreateParams
-  ): ZodEffects<I, I["_output"]> => {
+  ): ZodEffects<I, I["_output"]> {
     return new ZodEffects({
       schema,
       typeName: ZodFirstPartyTypeKind.ZodEffects,
       effect,
       ...processCreateParams(params),
     });
-  };
+  }
 
-  static createWithPreprocess = <I extends ZodTypeAny>(
+  static createWithPreprocess<I extends ZodTypeAny>(
     preprocess: (arg: unknown, ctx: RefinementCtx) => unknown,
     schema: I,
     params?: RawCreateParams
-  ): ZodEffects<I, I["_output"], unknown> => {
+  ): ZodEffects<I, I["_output"], unknown> {
     return new ZodEffects({
       schema,
       effect: { type: "preprocess", transform: preprocess },
       typeName: ZodFirstPartyTypeKind.ZodEffects,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 export { ZodEffects as ZodTransformer };
@@ -4798,16 +4784,16 @@ export class ZodOptional<T extends ZodTypeAny> extends ZodType<
     return this._def.innerType;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params?: RawCreateParams
-  ): ZodOptional<T> => {
+  ): ZodOptional<T> {
     return new ZodOptional({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodOptional,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 }
 
 ///////////////////////////////////////////
@@ -4842,16 +4828,16 @@ export class ZodNullable<T extends ZodTypeAny> extends ZodType<
     return this._def.innerType;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params?: RawCreateParams
-  ): ZodNullable<T> => {
+  ): ZodNullable<T> {
     return new ZodNullable({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodNullable,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 }
 
 ////////////////////////////////////////////
@@ -4890,12 +4876,12 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
     return this._def.innerType;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params: RawCreateParams & {
       default: T["_input"] | (() => util.noUndefined<T["_input"]>);
     }
-  ): ZodDefault<T> => {
+  ): ZodDefault<T> {
     return new ZodDefault({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodDefault,
@@ -4905,7 +4891,7 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
           : () => params.default as any,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -4982,12 +4968,12 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
     return this._def.innerType;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params: RawCreateParams & {
       catch: T["_output"] | (() => T["_output"]);
     }
-  ): ZodCatch<T> => {
+  ): ZodCatch<T> {
     return new ZodCatch({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodCatch,
@@ -4995,7 +4981,7 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
         typeof params.catch === "function" ? params.catch : () => params.catch,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 /////////////////////////////////////////
@@ -5026,12 +5012,12 @@ export class ZodNaN extends ZodType<number, ZodNaNDef, number> {
     return { status: "valid", value: input.data };
   }
 
-  static create = (params?: RawCreateParams): ZodNaN => {
+  static create(params?: RawCreateParams): ZodNaN {
     return new ZodNaN({
       typeName: ZodFirstPartyTypeKind.ZodNaN,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -5194,10 +5180,10 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
     return result;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params?: RawCreateParams
-  ): ZodReadonly<T> => {
+  ): ZodReadonly<T> {
     return new ZodReadonly({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodReadonly,
@@ -5252,8 +5238,10 @@ export function custom<T>(
 
 export { ZodType as Schema, ZodType as ZodSchema };
 
+const lateObject: typeof ZodObject.lazycreate = (...args: [any]) =>
+  ZodObject.lazycreate(...args);
 export const late = {
-  object: ZodObject.lazycreate,
+  object: lateObject,
 };
 
 export enum ZodFirstPartyTypeKind {
@@ -5344,40 +5332,62 @@ const instanceOfType = <T extends typeof Class>(
   }
 ) => custom<InstanceType<T>>((data) => data instanceof cls, params);
 
-const stringType = ZodString.create;
-const numberType = ZodNumber.create;
-const nanType = ZodNaN.create;
-const bigIntType = ZodBigInt.create;
-const booleanType = ZodBoolean.create;
-const dateType = ZodDate.create;
-const symbolType = ZodSymbol.create;
-const undefinedType = ZodUndefined.create;
-const nullType = ZodNull.create;
-const anyType = ZodAny.create;
-const unknownType = ZodUnknown.create;
-const neverType = ZodNever.create;
-const voidType = ZodVoid.create;
-const arrayType = ZodArray.create;
-const objectType = ZodObject.create;
-const strictObjectType = ZodObject.strictCreate;
-const unionType = ZodUnion.create;
-const discriminatedUnionType = ZodDiscriminatedUnion.create;
-const intersectionType = ZodIntersection.create;
-const tupleType = ZodTuple.create;
-const recordType = ZodRecord.create;
-const mapType = ZodMap.create;
-const setType = ZodSet.create;
-const functionType = ZodFunction.create;
-const lazyType = ZodLazy.create;
-const literalType = ZodLiteral.create;
-const enumType = ZodEnum.create;
-const nativeEnumType = ZodNativeEnum.create;
-const promiseType = ZodPromise.create;
-const effectsType = ZodEffects.create;
-const optionalType = ZodOptional.create;
-const nullableType = ZodNullable.create;
-const preprocessType = ZodEffects.createWithPreprocess;
-const pipelineType = ZodPipeline.create;
+const stringType: typeof ZodString.create = (...args) =>
+  ZodString.create(...args);
+const numberType: typeof ZodNumber.create = (...args) =>
+  ZodNumber.create(...args);
+const nanType: typeof ZodNaN.create = (...args) => ZodNaN.create(...args);
+const bigIntType: typeof ZodBigInt.create = (...args) =>
+  ZodBigInt.create(...args);
+const booleanType: typeof ZodBoolean.create = (...args) =>
+  ZodBoolean.create(...args);
+const dateType: typeof ZodDate.create = (...args) => ZodDate.create(...args);
+const symbolType: typeof ZodSymbol.create = (...args) =>
+  ZodSymbol.create(...args);
+const undefinedType: typeof ZodUndefined.create = (...args) =>
+  ZodUndefined.create(...args);
+const nullType: typeof ZodNull.create = (...args) => ZodNull.create(...args);
+const anyType: typeof ZodAny.create = (...args) => ZodAny.create(...args);
+const unknownType: typeof ZodUnknown.create = (...args) =>
+  ZodUnknown.create(...args);
+const neverType: typeof ZodNever.create = (...args) => ZodNever.create(...args);
+const voidType: typeof ZodVoid.create = (...args) => ZodVoid.create(...args);
+const arrayType: typeof ZodArray.create = (...args) => ZodArray.create(...args);
+const objectType: typeof ZodObject.create = (...args) =>
+  ZodObject.create(...args);
+const strictObjectType: typeof ZodObject.strictCreate = (...args) =>
+  ZodObject.strictCreate(...args);
+const unionType: typeof ZodUnion.create = (...args) => ZodUnion.create(...args);
+const discriminatedUnionType: typeof ZodDiscriminatedUnion.create = (...args) =>
+  ZodDiscriminatedUnion.create(...args);
+const intersectionType: typeof ZodIntersection.create = (...args) =>
+  ZodIntersection.create(...args);
+const tupleType: typeof ZodTuple.create = (...args) => ZodTuple.create(...args);
+const recordType: typeof ZodRecord.create = (...args: [any]) =>
+  ZodRecord.create(...args);
+const mapType: typeof ZodMap.create = (...args) => ZodMap.create(...args);
+const setType: typeof ZodSet.create = (...args) => ZodSet.create(...args);
+const functionType: typeof ZodFunction.create = (...args: [any?]) =>
+  ZodFunction.create(...args);
+const lazyType: typeof ZodLazy.create = (...args) => ZodLazy.create(...args);
+const literalType: typeof ZodLiteral.create = (...args) =>
+  ZodLiteral.create(...args);
+const enumType: typeof ZodEnum.create = (...args: [any]) =>
+  ZodEnum.create(...args);
+const nativeEnumType: typeof ZodNativeEnum.create = (...args) =>
+  ZodNativeEnum.create(...args);
+const promiseType: typeof ZodPromise.create = (...args) =>
+  ZodPromise.create(...args);
+const effectsType: typeof ZodEffects.create = (...args) =>
+  ZodEffects.create(...args);
+const optionalType: typeof ZodOptional.create = (...args) =>
+  ZodOptional.create(...args);
+const nullableType: typeof ZodNullable.create = (...args) =>
+  ZodNullable.create(...args);
+const preprocessType: typeof ZodEffects.createWithPreprocess = (...args) =>
+  ZodEffects.createWithPreprocess(...args);
+const pipelineType: typeof ZodPipeline.create = (...args) =>
+  ZodPipeline.create(...args);
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();

--- a/playground.ts
+++ b/playground.ts
@@ -1,3 +1,3 @@
-import { z } from "./src";
+import { z } from "./src/index";
 
-z;
+z.string().parse("asdf");

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -1,6 +1,7 @@
 import type { TypeOf, ZodType } from ".";
+import { util } from "./helpers";
 import { Primitive } from "./helpers/typeAliases";
-import { util, ZodParsedType } from "./helpers/util";
+import { ZodParsedType } from "./helpers/util";
 
 type allKeys<T> = T extends any ? keyof T : never;
 

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -276,10 +276,10 @@ export class ZodError<T = any> extends Error {
     return fieldErrors;
   }
 
-  static create = (issues: ZodIssue[]) => {
+  static create(issues: ZodIssue[]) {
     const error = new ZodError(issues);
     return error;
-  };
+  }
 
   static assert(value: unknown): asserts value is ZodError {
     if (!(value instanceof ZodError)) {

--- a/src/__tests__/all-errors.test.ts
+++ b/src/__tests__/all-errors.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 const Test = z.object({

--- a/src/__tests__/anyunknown.test.ts
+++ b/src/__tests__/anyunknown.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("check any inference", () => {

--- a/src/__tests__/array.test.ts
+++ b/src/__tests__/array.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 const minTwo = z.string().array().min(2);

--- a/src/__tests__/base.test.ts
+++ b/src/__tests__/base.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("type guard", () => {

--- a/src/__tests__/branded.test.ts
+++ b/src/__tests__/branded.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
-import { expect, test } from "@jest/globals";
+import { test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("branded types", () => {

--- a/src/__tests__/catch.test.ts
+++ b/src/__tests__/catch.test.ts
@@ -2,7 +2,7 @@
 import { expect, test } from "@jest/globals";
 
 import { z } from "..";
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 
 test("basic catch", () => {
   expect(z.string().catch("default").parse(undefined)).toBe("default");

--- a/src/__tests__/default.test.ts
+++ b/src/__tests__/default.test.ts
@@ -2,7 +2,7 @@
 import { expect, test } from "@jest/globals";
 
 import { z } from "..";
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 
 test("basic defaults", () => {
   expect(z.string().default("default").parse(undefined)).toBe("default");

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("create enum", () => {

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -1,7 +1,6 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { ZodParsedType } from "../helpers/util";
 import * as z from "../index";
 import { ZodError, ZodIssueCode } from "../ZodError";
 
@@ -9,8 +8,8 @@ test("error creation", () => {
   const err1 = ZodError.create([]);
   err1.addIssue({
     code: ZodIssueCode.invalid_type,
-    expected: ZodParsedType.object,
-    received: ZodParsedType.string,
+    expected: z.ZodParsedType.object,
+    received: z.ZodParsedType.string,
     path: [],
     message: "",
     fatal: true,

--- a/src/__tests__/firstparty.test.ts
+++ b/src/__tests__/firstparty.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("first party switch", () => {

--- a/src/__tests__/firstpartyschematypes.test.ts
+++ b/src/__tests__/firstpartyschematypes.test.ts
@@ -2,7 +2,7 @@
 import { test } from "@jest/globals";
 
 import { ZodFirstPartySchemaTypes, ZodFirstPartyTypeKind } from "..";
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 
 test("Identify missing [ZodFirstPartySchemaTypes]", () => {
   type ZodFirstPartySchemaForType<T extends ZodFirstPartyTypeKind> =

--- a/src/__tests__/function.test.ts
+++ b/src/__tests__/function.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 const args1 = z.tuple([z.string()]);

--- a/src/__tests__/generics.test.ts
+++ b/src/__tests__/generics.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
-import { expect, test } from "@jest/globals";
+import { test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("generics", () => {

--- a/src/__tests__/instanceof.test.ts
+++ b/src/__tests__/instanceof.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("instanceof", async () => {

--- a/src/__tests__/map.test.ts
+++ b/src/__tests__/map.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 import { ZodIssueCode } from "../index";
 

--- a/src/__tests__/nativeEnum.test.ts
+++ b/src/__tests__/nativeEnum.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("nativeEnum test with consts", () => {

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 const Test = z.object({

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 import { ZodNullable, ZodOptional } from "../index";
 

--- a/src/__tests__/pickomit.test.ts
+++ b/src/__tests__/pickomit.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 const fish = z.object({

--- a/src/__tests__/preprocess.test.ts
+++ b/src/__tests__/preprocess.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 test("preprocess", () => {

--- a/src/__tests__/primitive.test.ts
+++ b/src/__tests__/primitive.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 import { Mocker } from "./Mocker";
 

--- a/src/__tests__/promise.test.ts
+++ b/src/__tests__/promise.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 const promSchema = z.promise(

--- a/src/__tests__/readonly.test.ts
+++ b/src/__tests__/readonly.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 enum testEnum {

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 const booleanRecord = z.record(z.boolean());

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 import { ZodIssueCode } from "../ZodError";
 

--- a/src/__tests__/set.test.ts
+++ b/src/__tests__/set.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 import { ZodIssueCode } from "../index";
 

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 
 const stringToNumber = z.string().transform((arg) => parseFloat(arg));

--- a/src/__tests__/tuple.test.ts
+++ b/src/__tests__/tuple.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 import { ZodError } from "../ZodError";
 

--- a/src/__tests__/void.test.ts
+++ b/src/__tests__/void.test.ts
@@ -1,7 +1,7 @@
 // @ts-ignore TS6133
 import { expect, test } from "@jest/globals";
 
-import { util } from "../helpers/util";
+import { util } from "../helpers";
 import * as z from "../index";
 test("void", () => {
   const v = z.void();

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -1,0 +1,23 @@
+import { ZodBigInt, ZodBoolean, ZodDate, ZodNumber, ZodString } from "./types";
+
+const coerceString = ((arg) =>
+  ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"];
+const coerceNumber = ((arg) =>
+  ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"];
+const coerceBoolean = ((arg) =>
+  ZodBoolean.create({
+    ...arg,
+    coerce: true,
+  })) as (typeof ZodBoolean)["create"];
+const coerceBigint = ((arg) =>
+  ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"];
+const coerceDate = ((arg) =>
+  ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"];
+
+export {
+  coerceBigint as bigint,
+  coerceBoolean as boolean,
+  coerceDate as date,
+  coerceNumber as number,
+  coerceString as string,
+};

--- a/src/external.ts
+++ b/src/external.ts
@@ -1,6 +1,6 @@
 export * from "./errors";
+export * from "./helpers/index";
 export * from "./helpers/parseUtil";
 export * from "./helpers/typeAliases";
-export * from "./helpers/util";
 export * from "./types";
 export * from "./ZodError";

--- a/src/helpers/enumUtil.ts
+++ b/src/helpers/enumUtil.ts
@@ -1,19 +1,17 @@
-export namespace enumUtil {
-  type UnionToIntersectionFn<T> = (
-    T extends unknown ? (k: () => T) => void : never
-  ) extends (k: infer Intersection) => void
-    ? Intersection
-    : never;
+type UnionToIntersectionFn<T> = (
+  T extends unknown ? (k: () => T) => void : never
+) extends (k: infer Intersection) => void
+  ? Intersection
+  : never;
 
-  type GetUnionLast<T> = UnionToIntersectionFn<T> extends () => infer Last
-    ? Last
-    : never;
+type GetUnionLast<T> = UnionToIntersectionFn<T> extends () => infer Last
+  ? Last
+  : never;
 
-  type UnionToTuple<T, Tuple extends unknown[] = []> = [T] extends [never]
-    ? Tuple
-    : UnionToTuple<Exclude<T, GetUnionLast<T>>, [GetUnionLast<T>, ...Tuple]>;
+type UnionToTuple<T, Tuple extends unknown[] = []> = [T] extends [never]
+  ? Tuple
+  : UnionToTuple<Exclude<T, GetUnionLast<T>>, [GetUnionLast<T>, ...Tuple]>;
 
-  type CastToStringTuple<T> = T extends [string, ...string[]] ? T : never;
+type CastToStringTuple<T> = T extends [string, ...string[]] ? T : never;
 
-  export type UnionToTupleString<T> = CastToStringTuple<UnionToTuple<T>>;
-}
+export type UnionToTupleString<T> = CastToStringTuple<UnionToTuple<T>>;

--- a/src/helpers/errorUtil.ts
+++ b/src/helpers/errorUtil.ts
@@ -1,7 +1,5 @@
-export namespace errorUtil {
-  export type ErrMessage = string | { message?: string };
-  export const errToObj = (message?: ErrMessage) =>
-    typeof message === "string" ? { message } : message || {};
-  export const toString = (message?: ErrMessage): string | undefined =>
-    typeof message === "string" ? message : message?.message;
-}
+export type ErrMessage = string | { message?: string };
+export const errToObj = (message?: ErrMessage) =>
+  typeof message === "string" ? { message } : message || {};
+export const toString = (message?: ErrMessage): string | undefined =>
+  typeof message === "string" ? message : message?.message;

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,5 @@
+export * as enumUtil from "./enumUtil";
+export * as errorUtil from "./errorUtil";
+export * as objectUtil from "./objectUtil";
+export * as partialUtil from "./partialUtil";
+export * as util from "./util";

--- a/src/helpers/objectUtil.ts
+++ b/src/helpers/objectUtil.ts
@@ -1,0 +1,37 @@
+export type optionalKeys<T extends object> = {
+  [k in keyof T]: undefined extends T[k] ? k : never;
+}[keyof T];
+export type requiredKeys<T extends object> = {
+  [k in keyof T]: undefined extends T[k] ? never : k;
+}[keyof T];
+export type addQuestionMarks<T extends object, _O = any> = {
+  [K in requiredKeys<T>]: T[K];
+} & {
+  [K in optionalKeys<T>]?: T[K];
+} & { [k in keyof T]?: unknown };
+
+export type identity<T> = T;
+export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;
+
+export type noNeverKeys<T> = {
+  [k in keyof T]: [T[k]] extends [never] ? never : k;
+}[keyof T];
+
+export type noNever<T> = identity<{
+  [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
+}>;
+
+export const mergeShapes = <U, T>(first: U, second: T): T & U => {
+  return {
+    ...first,
+    ...second, // second overwrites first
+  };
+};
+
+export type extendShape<A extends object, B extends object> = {
+  [K in keyof A | keyof B]: K extends keyof B
+    ? B[K]
+    : K extends keyof A
+    ? A[K]
+    : never;
+};

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -1,7 +1,7 @@
 import { getErrorMap } from "../errors";
 import defaultErrorMap from "../locales/en";
 import type { IssueData, ZodErrorMap, ZodIssue } from "../ZodError";
-import type { ZodParsedType } from "./util";
+import type { ZodParsedType } from "..";
 
 export const makeIssue = (params: {
   data: any;

--- a/src/helpers/partialUtil.ts
+++ b/src/helpers/partialUtil.ts
@@ -9,70 +9,67 @@ import type {
   ZodTypeAny,
 } from "../index";
 
-export namespace partialUtil {
-  // export type DeepPartial<T extends AnyZodObject> = T extends AnyZodObject
-  //   ? ZodObject<
-  //       { [k in keyof T["_shape"]]: InternalDeepPartial<T["_shape"][k]> },
-  //       T["_unknownKeys"],
-  //       T["_catchall"]
-  //     >
-  //   : T extends ZodArray<infer Type, infer Card>
-  //   ? ZodArray<InternalDeepPartial<Type>, Card>
-  //   : ZodOptional<T>;
+// export type DeepPartial<T extends AnyZodObject> = T extends AnyZodObject
+//   ? ZodObject<
+//       { [k in keyof T["_shape"]]: InternalDeepPartial<T["_shape"][k]> },
+//       T["_unknownKeys"],
+//       T["_catchall"]
+//     >
+//   : T extends ZodArray<infer Type, infer Card>
+//   ? ZodArray<InternalDeepPartial<Type>, Card>
+//   : ZodOptional<T>;
 
-  // {
-  //   // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
-  //   // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;
-  //   object: T extends AnyZodObject
-  //     ? ZodObject<
-  //         { [k in keyof T["_shape"]]: DeepPartial<T["_shape"][k]> },
-  //         T["_unknownKeys"],
-  //         T["_catchall"]
-  //       >
-  //     : never;
-  //   rest: ReturnType<T["optional"]>; // ZodOptional<T>;
-  // }[T extends AnyZodObject
-  //   ? "object" // T extends ZodOptional<any> // ? 'optional' // :
-  //   : "rest"];
+// {
+//   // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
+//   // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;
+//   object: T extends AnyZodObject
+//     ? ZodObject<
+//         { [k in keyof T["_shape"]]: DeepPartial<T["_shape"][k]> },
+//         T["_unknownKeys"],
+//         T["_catchall"]
+//       >
+//     : never;
+//   rest: ReturnType<T["optional"]>; // ZodOptional<T>;
+// }[T extends AnyZodObject
+//   ? "object" // T extends ZodOptional<any> // ? 'optional' // :
+//   : "rest"];
 
-  export type DeepPartial<T extends ZodTypeAny> =
-    T extends ZodObject<ZodRawShape>
-      ? ZodObject<
-          { [k in keyof T["shape"]]: ZodOptional<DeepPartial<T["shape"][k]>> },
-          T["_def"]["unknownKeys"],
-          T["_def"]["catchall"]
-        >
-      : T extends ZodArray<infer Type, infer Card>
-      ? ZodArray<DeepPartial<Type>, Card>
-      : T extends ZodOptional<infer Type>
-      ? ZodOptional<DeepPartial<Type>>
-      : T extends ZodNullable<infer Type>
-      ? ZodNullable<DeepPartial<Type>>
-      : T extends ZodTuple<infer Items>
-      ? {
-          [k in keyof Items]: Items[k] extends ZodTypeAny
-            ? DeepPartial<Items[k]>
-            : never;
-        } extends infer PI
-        ? PI extends ZodTupleItems
-          ? ZodTuple<PI>
-          : never
-        : never
-      : T;
-  //  {
-  //     // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
-  //     // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;
-  //     object: T extends ZodObject<infer Shape, infer Params, infer Catchall>
-  //       ? ZodOptional<
-  //           ZodObject<
-  //             { [k in keyof Shape]: DeepPartial<Shape[k]> },
-  //             Params,
-  //             Catchall
-  //           >
-  //         >
-  //       : never;
-  //     rest: ReturnType<T["optional"]>;
-  //   }[T extends ZodObject<any>
-  //     ? "object" // T extends ZodOptional<any> // ? 'optional' // :
-  //     : "rest"];
-}
+export type DeepPartial<T extends ZodTypeAny> = T extends ZodObject<ZodRawShape>
+  ? ZodObject<
+      { [k in keyof T["shape"]]: ZodOptional<DeepPartial<T["shape"][k]>> },
+      T["_def"]["unknownKeys"],
+      T["_def"]["catchall"]
+    >
+  : T extends ZodArray<infer Type, infer Card>
+  ? ZodArray<DeepPartial<Type>, Card>
+  : T extends ZodOptional<infer Type>
+  ? ZodOptional<DeepPartial<Type>>
+  : T extends ZodNullable<infer Type>
+  ? ZodNullable<DeepPartial<Type>>
+  : T extends ZodTuple<infer Items>
+  ? {
+      [k in keyof Items]: Items[k] extends ZodTypeAny
+        ? DeepPartial<Items[k]>
+        : never;
+    } extends infer PI
+    ? PI extends ZodTupleItems
+      ? ZodTuple<PI>
+      : never
+    : never
+  : T;
+//  {
+//     // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
+//     // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;
+//     object: T extends ZodObject<infer Shape, infer Params, infer Catchall>
+//       ? ZodOptional<
+//           ZodObject<
+//             { [k in keyof Shape]: DeepPartial<Shape[k]> },
+//             Params,
+//             Catchall
+//           >
+//         >
+//       : never;
+//     rest: ReturnType<T["optional"]>;
+//   }[T extends ZodObject<any>
+//     ? "object" // T extends ZodOptional<any> // ? 'optional' // :
+//     : "rest"];

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,6 +1,6 @@
-import { objectUtil } from ".";
+// import { objectUtil } from ".";
 
-type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
+export type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
   V
 >() => V extends U ? 1 : 2
   ? true
@@ -66,8 +66,8 @@ export const find = <T>(arr: T[], checker: (arg: T) => any): T | undefined => {
   return undefined;
 };
 
-export type identity<T> = objectUtil.identity<T>;
-export type flatten<T> = objectUtil.flatten<T>;
+// export type identity<T> = objectUtil.identity<T>;
+// export type flatten<T> = objectUtil.flatten<T>;
 
 export type noUndefined<T> = T extends undefined ? never : T;
 

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,146 +1,99 @@
-export namespace util {
-  type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
-    V
-  >() => V extends U ? 1 : 2
-    ? true
-    : false;
+import { objectUtil } from ".";
 
-  export type isAny<T> = 0 extends 1 & T ? true : false;
-  export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
-  export function assertIs<T>(_arg: T): void {}
-  export function assertNever(_x: never): never {
-    throw new Error();
+type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
+  V
+>() => V extends U ? 1 : 2
+  ? true
+  : false;
+
+export type isAny<T> = 0 extends 1 & T ? true : false;
+export const assertEqual = <A, B>(val: AssertEqual<A, B>) => val;
+export function assertIs<T>(_arg: T): void {}
+export function assertNever(_x: never): never {
+  throw new Error();
+}
+
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
+export type MakePartial<T, K extends keyof T> = Omit<T, K> &
+  Partial<Pick<T, K>>;
+export type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
+
+export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
+  items: U
+): { [k in U[number]]: k } => {
+  const obj: any = {};
+  for (const item of items) {
+    obj[item] = item;
   }
+  return obj as any;
+};
 
-  export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-  export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
-  export type MakePartial<T, K extends keyof T> = Omit<T, K> &
-    Partial<Pick<T, K>>;
-  export type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
+export const getValidEnumValues = (obj: any) => {
+  const validKeys = objectKeys(obj).filter(
+    (k: any) => typeof obj[obj[k]] !== "number"
+  );
+  const filtered: any = {};
+  for (const k of validKeys) {
+    filtered[k] = obj[k];
+  }
+  return objectValues(filtered);
+};
 
-  export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
-    items: U
-  ): { [k in U[number]]: k } => {
-    const obj: any = {};
-    for (const item of items) {
-      obj[item] = item;
-    }
-    return obj as any;
-  };
+export const objectValues = (obj: any) => {
+  return objectKeys(obj).map(function (e) {
+    return obj[e];
+  });
+};
 
-  export const getValidEnumValues = (obj: any) => {
-    const validKeys = objectKeys(obj).filter(
-      (k: any) => typeof obj[obj[k]] !== "number"
-    );
-    const filtered: any = {};
-    for (const k of validKeys) {
-      filtered[k] = obj[k];
-    }
-    return objectValues(filtered);
-  };
-
-  export const objectValues = (obj: any) => {
-    return objectKeys(obj).map(function (e) {
-      return obj[e];
-    });
-  };
-
-  export const objectKeys: ObjectConstructor["keys"] =
-    typeof Object.keys === "function" // eslint-disable-line ban/ban
-      ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
-      : (object: any) => {
-          const keys = [];
-          for (const key in object) {
-            if (Object.prototype.hasOwnProperty.call(object, key)) {
-              keys.push(key);
-            }
+export const objectKeys: ObjectConstructor["keys"] =
+  typeof Object.keys === "function" // eslint-disable-line ban/ban
+    ? (obj: any) => Object.keys(obj) // eslint-disable-line ban/ban
+    : (object: any) => {
+        const keys = [];
+        for (const key in object) {
+          if (Object.prototype.hasOwnProperty.call(object, key)) {
+            keys.push(key);
           }
-          return keys;
-        };
+        }
+        return keys;
+      };
 
-  export const find = <T>(
-    arr: T[],
-    checker: (arg: T) => any
-  ): T | undefined => {
-    for (const item of arr) {
-      if (checker(item)) return item;
-    }
-    return undefined;
-  };
-
-  export type identity<T> = objectUtil.identity<T>;
-  export type flatten<T> = objectUtil.flatten<T>;
-
-  export type noUndefined<T> = T extends undefined ? never : T;
-
-  export const isInteger: NumberConstructor["isInteger"] =
-    typeof Number.isInteger === "function"
-      ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
-      : (val) =>
-          typeof val === "number" && isFinite(val) && Math.floor(val) === val;
-
-  export function joinValues<T extends any[]>(
-    array: T,
-    separator = " | "
-  ): string {
-    return array
-      .map((val) => (typeof val === "string" ? `'${val}'` : val))
-      .join(separator);
+export const find = <T>(arr: T[], checker: (arg: T) => any): T | undefined => {
+  for (const item of arr) {
+    if (checker(item)) return item;
   }
+  return undefined;
+};
 
-  export const jsonStringifyReplacer = (_: string, value: any): any => {
-    if (typeof value === "bigint") {
-      return value.toString();
-    }
-    return value;
-  };
+export type identity<T> = objectUtil.identity<T>;
+export type flatten<T> = objectUtil.flatten<T>;
+
+export type noUndefined<T> = T extends undefined ? never : T;
+
+export const isInteger: NumberConstructor["isInteger"] =
+  typeof Number.isInteger === "function"
+    ? (val) => Number.isInteger(val) // eslint-disable-line ban/ban
+    : (val) =>
+        typeof val === "number" && isFinite(val) && Math.floor(val) === val;
+
+export function joinValues<T extends any[]>(
+  array: T,
+  separator = " | "
+): string {
+  return array
+    .map((val) => (typeof val === "string" ? `'${val}'` : val))
+    .join(separator);
 }
 
-export namespace objectUtil {
-  export type MergeShapes<U, V> = {
-    [k in Exclude<keyof U, keyof V>]: U[k];
-  } & V;
+export const jsonStringifyReplacer = (_: string, value: any): any => {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return value;
+};
 
-  type optionalKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? k : never;
-  }[keyof T];
-  type requiredKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? never : k;
-  }[keyof T];
-  export type addQuestionMarks<T extends object, _O = any> = {
-    [K in requiredKeys<T>]: T[K];
-  } & {
-    [K in optionalKeys<T>]?: T[K];
-  } & { [k in keyof T]?: unknown };
-
-  export type identity<T> = T;
-  export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;
-
-  export type noNeverKeys<T> = {
-    [k in keyof T]: [T[k]] extends [never] ? never : k;
-  }[keyof T];
-
-  export type noNever<T> = identity<{
-    [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
-  }>;
-
-  export const mergeShapes = <U, T>(first: U, second: T): T & U => {
-    return {
-      ...first,
-      ...second, // second overwrites first
-    };
-  };
-
-  export type extendShape<A extends object, B extends object> = {
-    [K in keyof A | keyof B]: K extends keyof B
-      ? B[K]
-      : K extends keyof A
-      ? A[K]
-      : never;
-  };
-}
-
-export const ZodParsedType = util.arrayToEnum([
+export const ZodParsedType = arrayToEnum([
   "string",
   "nan",
   "number",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,4 +1,5 @@
-import { util, ZodParsedType } from "../helpers/util";
+import { util } from "../helpers";
+import { ZodParsedType } from "../helpers/util";
 import { ZodErrorMap, ZodIssueCode } from "../ZodError";
 
 const errorMap: ZodErrorMap = (issue, _ctx) => {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,12 +1,12 @@
 import { util } from "../helpers";
-import { ZodParsedType } from "../helpers/util";
+
 import { ZodErrorMap, ZodIssueCode } from "../ZodError";
 
 const errorMap: ZodErrorMap = (issue, _ctx) => {
   let message: string;
   switch (issue.code) {
     case ZodIssueCode.invalid_type:
-      if (issue.received === ZodParsedType.undefined) {
+      if (issue.received === util.ZodParsedType.undefined) {
         message = "Required";
       } else {
         message = `Expected ${issue.expected}, received ${issue.received}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 import { defaultErrorMap, getErrorMap } from "./errors";
-import { enumUtil } from "./helpers/enumUtil";
-import { errorUtil } from "./helpers/errorUtil";
+import { enumUtil, errorUtil, objectUtil, partialUtil, util } from "./helpers";
 import {
   addIssueToContext,
   AsyncParseReturnType,
@@ -20,9 +19,8 @@ import {
   ParseStatus,
   SyncParseReturnType,
 } from "./helpers/parseUtil";
-import { partialUtil } from "./helpers/partialUtil";
 import { Primitive } from "./helpers/typeAliases";
-import { getParsedType, objectUtil, util, ZodParsedType } from "./helpers/util";
+import { getParsedType, ZodParsedType } from "./helpers/util";
 import {
   IssueData,
   StringValidation,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5332,6 +5332,10 @@ const instanceOfType = <T extends typeof Class>(
   }
 ) => custom<InstanceType<T>>((data) => data instanceof cls, params);
 
+//////////////////////////////////////////////////////
+// MUST be aliased using wrapper functions.         //
+// See: https://github.com/colinhacks/zod/pull/2850 //
+//////////////////////////////////////////////////////
 const stringType: typeof ZodString.create = (...args) =>
   ZodString.create(...args);
 const numberType: typeof ZodNumber.create = (...args) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1330,14 +1330,14 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     return max;
   }
 
-  static create = (params?: RawCreateParams & { coerce?: true }): ZodString => {
+  static create(params?: RawCreateParams & { coerce?: true }): ZodString {
     return new ZodString({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodString,
       coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 /////////////////////////////////////////
@@ -1460,16 +1460,14 @@ export class ZodNumber extends ZodType<number, ZodNumberDef, number> {
     return { status: status.value, value: input.data };
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodNumber => {
+  static create(params?: RawCreateParams & { coerce?: boolean }): ZodNumber {
     return new ZodNumber({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodNumber,
       coerce: params?.coerce || false,
       ...processCreateParams(params),
     });
-  };
+  }
 
   gte(value: number, message?: errorUtil.ErrMessage) {
     return this.setLimit("min", value, true, errorUtil.toString(message));
@@ -1723,16 +1721,14 @@ export class ZodBigInt extends ZodType<bigint, ZodBigIntDef, bigint> {
     return { status: status.value, value: input.data };
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodBigInt => {
+  static create(params?: RawCreateParams & { coerce?: boolean }): ZodBigInt {
     return new ZodBigInt({
       checks: [],
       typeName: ZodFirstPartyTypeKind.ZodBigInt,
       coerce: params?.coerce ?? false,
       ...processCreateParams(params),
     });
-  };
+  }
 
   gte(value: bigint, message?: errorUtil.ErrMessage) {
     return this.setLimit("min", value, true, errorUtil.toString(message));
@@ -1875,15 +1871,13 @@ export class ZodBoolean extends ZodType<boolean, ZodBooleanDef, boolean> {
     return OK(input.data);
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodBoolean => {
+  static create(params?: RawCreateParams & { coerce?: boolean }): ZodBoolean {
     return new ZodBoolean({
       typeName: ZodFirstPartyTypeKind.ZodBoolean,
       coerce: params?.coerce || false,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////
@@ -2013,16 +2007,14 @@ export class ZodDate extends ZodType<Date, ZodDateDef, Date> {
     return max != null ? new Date(max) : null;
   }
 
-  static create = (
-    params?: RawCreateParams & { coerce?: boolean }
-  ): ZodDate => {
+  static create(params?: RawCreateParams & { coerce?: boolean }): ZodDate {
     return new ZodDate({
       checks: [],
       coerce: params?.coerce || false,
       typeName: ZodFirstPartyTypeKind.ZodDate,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////////
@@ -2052,12 +2044,12 @@ export class ZodSymbol extends ZodType<symbol, ZodSymbolDef, symbol> {
     return OK(input.data);
   }
 
-  static create = (params?: RawCreateParams): ZodSymbol => {
+  static create(params?: RawCreateParams): ZodSymbol {
     return new ZodSymbol({
       typeName: ZodFirstPartyTypeKind.ZodSymbol,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////////
@@ -2091,12 +2083,12 @@ export class ZodUndefined extends ZodType<
   }
   params?: RawCreateParams;
 
-  static create = (params?: RawCreateParams): ZodUndefined => {
+  static create(params?: RawCreateParams): ZodUndefined {
     return new ZodUndefined({
       typeName: ZodFirstPartyTypeKind.ZodUndefined,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////
@@ -2124,12 +2116,12 @@ export class ZodNull extends ZodType<null, ZodNullDef, null> {
     }
     return OK(input.data);
   }
-  static create = (params?: RawCreateParams): ZodNull => {
+  static create(params?: RawCreateParams): ZodNull {
     return new ZodNull({
       typeName: ZodFirstPartyTypeKind.ZodNull,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////
@@ -2149,12 +2141,12 @@ export class ZodAny extends ZodType<any, ZodAnyDef, any> {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     return OK(input.data);
   }
-  static create = (params?: RawCreateParams): ZodAny => {
+  static create(params?: RawCreateParams): ZodAny {
     return new ZodAny({
       typeName: ZodFirstPartyTypeKind.ZodAny,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -2175,12 +2167,12 @@ export class ZodUnknown extends ZodType<unknown, ZodUnknownDef, unknown> {
     return OK(input.data);
   }
 
-  static create = (params?: RawCreateParams): ZodUnknown => {
+  static create(params?: RawCreateParams): ZodUnknown {
     return new ZodUnknown({
       typeName: ZodFirstPartyTypeKind.ZodUnknown,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////
@@ -2204,12 +2196,12 @@ export class ZodNever extends ZodType<never, ZodNeverDef, never> {
     });
     return INVALID;
   }
-  static create = (params?: RawCreateParams): ZodNever => {
+  static create(params?: RawCreateParams): ZodNever {
     return new ZodNever({
       typeName: ZodFirstPartyTypeKind.ZodNever,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////
@@ -2238,12 +2230,12 @@ export class ZodVoid extends ZodType<void, ZodVoidDef, void> {
     return OK(input.data);
   }
 
-  static create = (params?: RawCreateParams): ZodVoid => {
+  static create(params?: RawCreateParams): ZodVoid {
     return new ZodVoid({
       typeName: ZodFirstPartyTypeKind.ZodVoid,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////
@@ -2426,10 +2418,11 @@ export class ZodArray<
     }) as any;
   }
 
-  static create = <T extends ZodTypeAny>(
+  
+  static create<T extends ZodTypeAny>(
     schema: T,
     params?: RawCreateParams
-  ): ZodArray<T> => {
+  ): ZodArray<T> {
     return new ZodArray({
       type: schema,
       minLength: null,
@@ -2439,7 +2432,7 @@ export class ZodArray<
       typeName: ZodFirstPartyTypeKind.ZodArray,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 export type ZodNonEmptyArray<T extends ZodTypeAny> = ZodArray<T, "atleastone">;
@@ -3002,12 +2995,12 @@ export class ZodObject<
   }
 
   keyof(): ZodEnum<enumUtil.UnionToTupleString<keyof T>> {
-    return createZodEnum(
+    return ZodEnum.create(
       util.objectKeys(this.shape) as [string, ...string[]]
     ) as any;
   }
 
-  static create = <T extends ZodRawShape>(
+  static create<T extends ZodRawShape>(
     shape: T,
     params?: RawCreateParams
   ): ZodObject<
@@ -3024,12 +3017,12 @@ export class ZodObject<
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 
-  static strictCreate = <T extends ZodRawShape>(
+  static strictCreate<T extends ZodRawShape>(
     shape: T,
     params?: RawCreateParams
-  ): ZodObject<T, "strict"> => {
+  ): ZodObject<T, "strict"> {
     return new ZodObject({
       shape: () => shape,
       unknownKeys: "strict",
@@ -3037,12 +3030,12 @@ export class ZodObject<
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 
-  static lazycreate = <T extends ZodRawShape>(
+  static lazycreate<T extends ZodRawShape>(
     shape: () => T,
     params?: RawCreateParams
-  ): ZodObject<T, "strip"> => {
+  ): ZodObject<T, "strip"> {
     return new ZodObject({
       shape,
       unknownKeys: "strip",
@@ -3050,7 +3043,7 @@ export class ZodObject<
       typeName: ZodFirstPartyTypeKind.ZodObject,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 }
 
 export type AnyZodObject = ZodObject<any, any, any>;
@@ -3182,18 +3175,16 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
     return this._def.options;
   }
 
-  static create = <
-    T extends Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>
-  >(
+  static create<T extends Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>>(
     types: T,
     params?: RawCreateParams
-  ): ZodUnion<T> => {
+  ): ZodUnion<T> {
     return new ZodUnion({
       options: types,
       typeName: ZodFirstPartyTypeKind.ZodUnion,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 /////////////////////////////////////////////////////
@@ -3507,18 +3498,18 @@ export class ZodIntersection<
     }
   }
 
-  static create = <T extends ZodTypeAny, U extends ZodTypeAny>(
+  static create<T extends ZodTypeAny, U extends ZodTypeAny>(
     left: T,
     right: U,
     params?: RawCreateParams
-  ): ZodIntersection<T, U> => {
+  ): ZodIntersection<T, U> {
     return new ZodIntersection({
       left: left,
       right: right,
       typeName: ZodFirstPartyTypeKind.ZodIntersection,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ////////////////////////////////////////
@@ -3637,10 +3628,10 @@ export class ZodTuple<
     });
   }
 
-  static create = <T extends [ZodTypeAny, ...ZodTypeAny[]] | []>(
+  static create<T extends [ZodTypeAny, ...ZodTypeAny[]] | []>(
     schemas: T,
     params?: RawCreateParams
-  ): ZodTuple<T, null> => {
+  ): ZodTuple<T, null> {
     if (!Array.isArray(schemas)) {
       throw new Error("You must pass an array of schemas to z.tuple([ ... ])");
     }
@@ -3650,7 +3641,7 @@ export class ZodTuple<
       rest: null,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 /////////////////////////////////////////
@@ -3855,21 +3846,21 @@ export class ZodMap<
       return { status: status.value, value: finalMap };
     }
   }
-  static create = <
+  static create<
     Key extends ZodTypeAny = ZodTypeAny,
     Value extends ZodTypeAny = ZodTypeAny
   >(
     keyType: Key,
     valueType: Value,
     params?: RawCreateParams
-  ): ZodMap<Key, Value> => {
+  ): ZodMap<Key, Value> {
     return new ZodMap({
       valueType,
       keyType,
       typeName: ZodFirstPartyTypeKind.ZodMap,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////
@@ -3978,10 +3969,10 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
     return this.min(1, message) as any;
   }
 
-  static create = <Value extends ZodTypeAny = ZodTypeAny>(
+  static create<Value extends ZodTypeAny = ZodTypeAny>(
     valueType: Value,
     params?: RawCreateParams
-  ): ZodSet<Value> => {
+  ): ZodSet<Value> {
     return new ZodSet({
       valueType,
       minSize: null,
@@ -3989,7 +3980,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
       typeName: ZodFirstPartyTypeKind.ZodSet,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////////
@@ -4222,16 +4213,16 @@ export class ZodLazy<T extends ZodTypeAny> extends ZodType<
     return lazySchema._parse({ data: ctx.data, path: ctx.path, parent: ctx });
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     getter: () => T,
     params?: RawCreateParams
-  ): ZodLazy<T> => {
+  ): ZodLazy<T> {
     return new ZodLazy({
       getter: getter,
       typeName: ZodFirstPartyTypeKind.ZodLazy,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -4264,16 +4255,16 @@ export class ZodLiteral<T> extends ZodType<T, ZodLiteralDef<T>, T> {
     return this._def.value;
   }
 
-  static create = <T extends Primitive>(
+  static create<T extends Primitive>(
     value: T,
     params?: RawCreateParams
-  ): ZodLiteral<T> => {
+  ): ZodLiteral<T> {
     return new ZodLiteral({
       value: value,
       typeName: ZodFirstPartyTypeKind.ZodLiteral,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 ///////////////////////////////////////
@@ -4309,25 +4300,6 @@ export type FilterEnum<Values, ToExclude> = Values extends []
   : never;
 
 export type typecast<A, T> = A extends T ? A : never;
-
-function createZodEnum<U extends string, T extends Readonly<[U, ...U[]]>>(
-  values: T,
-  params?: RawCreateParams
-): ZodEnum<Writeable<T>>;
-function createZodEnum<U extends string, T extends [U, ...U[]]>(
-  values: T,
-  params?: RawCreateParams
-): ZodEnum<T>;
-function createZodEnum(
-  values: [string, ...string[]],
-  params?: RawCreateParams
-) {
-  return new ZodEnum({
-    values,
-    typeName: ZodFirstPartyTypeKind.ZodEnum,
-    ...processCreateParams(params),
-  });
-}
 
 export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
   T[number],
@@ -4422,7 +4394,21 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
     ) as any;
   }
 
-  static create = createZodEnum;
+  static create<U extends string, T extends Readonly<[U, ...U[]]>>(
+    values: T,
+    params?: RawCreateParams
+  ): ZodEnum<Writeable<T>>;
+  static create<U extends string, T extends [U, ...U[]]>(
+    values: T,
+    params?: RawCreateParams
+  ): ZodEnum<T>;
+  static create(values: [string, ...string[]], params?: RawCreateParams) {
+    return new ZodEnum({
+      values,
+      typeName: ZodFirstPartyTypeKind.ZodEnum,
+      ...processCreateParams(params),
+    });
+  }
 }
 
 /////////////////////////////////////////////
@@ -4484,16 +4470,16 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     return this._def.values;
   }
 
-  static create = <T extends EnumLike>(
+  static create<T extends EnumLike>(
     values: T,
     params?: RawCreateParams
-  ): ZodNativeEnum<T> => {
+  ): ZodNativeEnum<T> {
     return new ZodNativeEnum({
       values: values,
       typeName: ZodFirstPartyTypeKind.ZodNativeEnum,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -4547,16 +4533,16 @@ export class ZodPromise<T extends ZodTypeAny> extends ZodType<
     );
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     schema: T,
     params?: RawCreateParams
-  ): ZodPromise<T> => {
+  ): ZodPromise<T> {
     return new ZodPromise({
       type: schema,
       typeName: ZodFirstPartyTypeKind.ZodPromise,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////////
@@ -4737,31 +4723,31 @@ export class ZodEffects<
     util.assertNever(effect);
   }
 
-  static create = <I extends ZodTypeAny>(
+  static create<I extends ZodTypeAny>(
     schema: I,
     effect: Effect<I["_output"]>,
     params?: RawCreateParams
-  ): ZodEffects<I, I["_output"]> => {
+  ): ZodEffects<I, I["_output"]> {
     return new ZodEffects({
       schema,
       typeName: ZodFirstPartyTypeKind.ZodEffects,
       effect,
       ...processCreateParams(params),
     });
-  };
+  }
 
-  static createWithPreprocess = <I extends ZodTypeAny>(
+  static createWithPreprocess<I extends ZodTypeAny>(
     preprocess: (arg: unknown, ctx: RefinementCtx) => unknown,
     schema: I,
     params?: RawCreateParams
-  ): ZodEffects<I, I["_output"], unknown> => {
+  ): ZodEffects<I, I["_output"], unknown> {
     return new ZodEffects({
       schema,
       effect: { type: "preprocess", transform: preprocess },
       typeName: ZodFirstPartyTypeKind.ZodEffects,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 export { ZodEffects as ZodTransformer };
@@ -4798,16 +4784,16 @@ export class ZodOptional<T extends ZodTypeAny> extends ZodType<
     return this._def.innerType;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params?: RawCreateParams
-  ): ZodOptional<T> => {
+  ): ZodOptional<T> {
     return new ZodOptional({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodOptional,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 }
 
 ///////////////////////////////////////////
@@ -4842,16 +4828,16 @@ export class ZodNullable<T extends ZodTypeAny> extends ZodType<
     return this._def.innerType;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params?: RawCreateParams
-  ): ZodNullable<T> => {
+  ): ZodNullable<T> {
     return new ZodNullable({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodNullable,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 }
 
 ////////////////////////////////////////////
@@ -4890,12 +4876,12 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
     return this._def.innerType;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params: RawCreateParams & {
       default: T["_input"] | (() => util.noUndefined<T["_input"]>);
     }
-  ): ZodDefault<T> => {
+  ): ZodDefault<T> {
     return new ZodDefault({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodDefault,
@@ -4905,7 +4891,7 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
           : () => params.default as any,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -4982,12 +4968,12 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
     return this._def.innerType;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params: RawCreateParams & {
       catch: T["_output"] | (() => T["_output"]);
     }
-  ): ZodCatch<T> => {
+  ): ZodCatch<T> {
     return new ZodCatch({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodCatch,
@@ -4995,7 +4981,7 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
         typeof params.catch === "function" ? params.catch : () => params.catch,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 /////////////////////////////////////////
@@ -5026,12 +5012,12 @@ export class ZodNaN extends ZodType<number, ZodNaNDef, number> {
     return { status: "valid", value: input.data };
   }
 
-  static create = (params?: RawCreateParams): ZodNaN => {
+  static create(params?: RawCreateParams): ZodNaN {
     return new ZodNaN({
       typeName: ZodFirstPartyTypeKind.ZodNaN,
       ...processCreateParams(params),
     });
-  };
+  }
 }
 
 //////////////////////////////////////////
@@ -5194,10 +5180,10 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
     return result;
   }
 
-  static create = <T extends ZodTypeAny>(
+  static create<T extends ZodTypeAny>(
     type: T,
     params?: RawCreateParams
-  ): ZodReadonly<T> => {
+  ): ZodReadonly<T> {
     return new ZodReadonly({
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodReadonly,
@@ -5252,8 +5238,10 @@ export function custom<T>(
 
 export { ZodType as Schema, ZodType as ZodSchema };
 
+const lateObject: typeof ZodObject.lazycreate = (...args: [any]) =>
+  ZodObject.lazycreate(...args);
 export const late = {
-  object: ZodObject.lazycreate,
+  object: lateObject,
 };
 
 export enum ZodFirstPartyTypeKind {
@@ -5344,40 +5332,62 @@ const instanceOfType = <T extends typeof Class>(
   }
 ) => custom<InstanceType<T>>((data) => data instanceof cls, params);
 
-const stringType = ZodString.create;
-const numberType = ZodNumber.create;
-const nanType = ZodNaN.create;
-const bigIntType = ZodBigInt.create;
-const booleanType = ZodBoolean.create;
-const dateType = ZodDate.create;
-const symbolType = ZodSymbol.create;
-const undefinedType = ZodUndefined.create;
-const nullType = ZodNull.create;
-const anyType = ZodAny.create;
-const unknownType = ZodUnknown.create;
-const neverType = ZodNever.create;
-const voidType = ZodVoid.create;
-const arrayType = ZodArray.create;
-const objectType = ZodObject.create;
-const strictObjectType = ZodObject.strictCreate;
-const unionType = ZodUnion.create;
-const discriminatedUnionType = ZodDiscriminatedUnion.create;
-const intersectionType = ZodIntersection.create;
-const tupleType = ZodTuple.create;
-const recordType = ZodRecord.create;
-const mapType = ZodMap.create;
-const setType = ZodSet.create;
-const functionType = ZodFunction.create;
-const lazyType = ZodLazy.create;
-const literalType = ZodLiteral.create;
-const enumType = ZodEnum.create;
-const nativeEnumType = ZodNativeEnum.create;
-const promiseType = ZodPromise.create;
-const effectsType = ZodEffects.create;
-const optionalType = ZodOptional.create;
-const nullableType = ZodNullable.create;
-const preprocessType = ZodEffects.createWithPreprocess;
-const pipelineType = ZodPipeline.create;
+const stringType: typeof ZodString.create = (...args) =>
+  ZodString.create(...args);
+const numberType: typeof ZodNumber.create = (...args) =>
+  ZodNumber.create(...args);
+const nanType: typeof ZodNaN.create = (...args) => ZodNaN.create(...args);
+const bigIntType: typeof ZodBigInt.create = (...args) =>
+  ZodBigInt.create(...args);
+const booleanType: typeof ZodBoolean.create = (...args) =>
+  ZodBoolean.create(...args);
+const dateType: typeof ZodDate.create = (...args) => ZodDate.create(...args);
+const symbolType: typeof ZodSymbol.create = (...args) =>
+  ZodSymbol.create(...args);
+const undefinedType: typeof ZodUndefined.create = (...args) =>
+  ZodUndefined.create(...args);
+const nullType: typeof ZodNull.create = (...args) => ZodNull.create(...args);
+const anyType: typeof ZodAny.create = (...args) => ZodAny.create(...args);
+const unknownType: typeof ZodUnknown.create = (...args) =>
+  ZodUnknown.create(...args);
+const neverType: typeof ZodNever.create = (...args) => ZodNever.create(...args);
+const voidType: typeof ZodVoid.create = (...args) => ZodVoid.create(...args);
+const arrayType: typeof ZodArray.create = (...args) => ZodArray.create(...args);
+const objectType: typeof ZodObject.create = (...args) =>
+  ZodObject.create(...args);
+const strictObjectType: typeof ZodObject.strictCreate = (...args) =>
+  ZodObject.strictCreate(...args);
+const unionType: typeof ZodUnion.create = (...args) => ZodUnion.create(...args);
+const discriminatedUnionType: typeof ZodDiscriminatedUnion.create = (...args) =>
+  ZodDiscriminatedUnion.create(...args);
+const intersectionType: typeof ZodIntersection.create = (...args) =>
+  ZodIntersection.create(...args);
+const tupleType: typeof ZodTuple.create = (...args) => ZodTuple.create(...args);
+const recordType: typeof ZodRecord.create = (...args: [any]) =>
+  ZodRecord.create(...args);
+const mapType: typeof ZodMap.create = (...args) => ZodMap.create(...args);
+const setType: typeof ZodSet.create = (...args) => ZodSet.create(...args);
+const functionType: typeof ZodFunction.create = (...args: [any?]) =>
+  ZodFunction.create(...args);
+const lazyType: typeof ZodLazy.create = (...args) => ZodLazy.create(...args);
+const literalType: typeof ZodLiteral.create = (...args) =>
+  ZodLiteral.create(...args);
+const enumType: typeof ZodEnum.create = (...args: [any]) =>
+  ZodEnum.create(...args);
+const nativeEnumType: typeof ZodNativeEnum.create = (...args) =>
+  ZodNativeEnum.create(...args);
+const promiseType: typeof ZodPromise.create = (...args) =>
+  ZodPromise.create(...args);
+const effectsType: typeof ZodEffects.create = (...args) =>
+  ZodEffects.create(...args);
+const optionalType: typeof ZodOptional.create = (...args) =>
+  ZodOptional.create(...args);
+const nullableType: typeof ZodNullable.create = (...args) =>
+  ZodNullable.create(...args);
+const preprocessType: typeof ZodEffects.createWithPreprocess = (...args) =>
+  ZodEffects.createWithPreprocess(...args);
+const pipelineType: typeof ZodPipeline.create = (...args) =>
+  ZodPipeline.create(...args);
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ import {
   ZodIssueCode,
 } from "./ZodError";
 
+export { ZodParsedType } from "./helpers/util";
+
 ///////////////////////////////////////
 ///////////////////////////////////////
 //////////                   //////////
@@ -3007,7 +3009,7 @@ export class ZodObject<
     ZodTypeAny,
     objectOutputType<T, ZodTypeAny, "strip">,
     objectInputType<T, ZodTypeAny, "strip">
-  > => {
+  > {
     return new ZodObject({
       shape: () => shape,
       unknownKeys: "strip",
@@ -5187,7 +5189,7 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
       typeName: ZodFirstPartyTypeKind.ZodReadonly,
       ...processCreateParams(params),
     }) as any;
-  };
+  }
 
   unwrap() {
     return this._def.innerType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5396,21 +5396,7 @@ const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
 
-export const coerce = {
-  string: ((arg) =>
-    ZodString.create({ ...arg, coerce: true })) as (typeof ZodString)["create"],
-  number: ((arg) =>
-    ZodNumber.create({ ...arg, coerce: true })) as (typeof ZodNumber)["create"],
-  boolean: ((arg) =>
-    ZodBoolean.create({
-      ...arg,
-      coerce: true,
-    })) as (typeof ZodBoolean)["create"],
-  bigint: ((arg) =>
-    ZodBigInt.create({ ...arg, coerce: true })) as (typeof ZodBigInt)["create"],
-  date: ((arg) =>
-    ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
-};
+export * as coerce from "./coerce";
 
 export {
   anyType as any,


### PR DESCRIPTION
This PR allows vite/esbuild to tree shake unused exports if user imports schemas using named exports:
```ts
import { number } from 'zod';
```
Before this PR, vite will bundle the whole library regardless what schemas you use. Now, it will bundle only what is needed. E.g., if you import only `number`, vite will not include `string` in the final bundle.

__NOTE__: Compiling ESM with `tsc` would also treeshake `import { z } from 'zod'`. This is not included in this PR but I believe this would be highly desirable.

Closes #2596.

## How this is fixed
- For some reason, `static create = (...) => { ... }` is not treeshakeable by vite/esbuild, but `static create(...) { ... }` is.
- Using `const numberType = ZodNumber.create` is not treeshakeable but `const numberType = (...args) => ZodNumber.create(...args)` is.
- Extracted `coerce` to a separate file and used named export for each schema instead of `export const coerce`.
- Removed `export namespace` exports because the code that is generated by typescript is not treeshakeable.

## To further improve tree shaking
- **breaking change**: consider removing convenience methods from `ZodType`. Even with this PR merged, a single `number()` produces a 1600 line file. It includes `ZodArray` because of `.array()`, `ZodOptional` because of `.optional()`, etc.
  - Removing all convenience methods from `ZodType` still produces 900 lines of code in final bundle (vs 1600 lines with convenience methods). Most of that code (600 lines) is related to `ZodError`

