### PR TITLE
Add brand to ZodBranded def at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2442,6 +2442,17 @@ type Cat = z.infer<typeof Cat>;
 
 Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
 
+However when using the brand as a parameter the type will include it in the typing at runtime (but not the parse!)
+
+```ts
+const Cat = z.object({ name: z.string() }).brand("Cat"); // Notice brand being a parameter
+type Cat = z.infer<typeof Cat>;
+// {name: string} & {[symbol]: "Cat"}
+
+const isCatType = Cat._def.brand === "Cat"; // true
+const isCat = Cat.parse({ name: "Whiskers" })._def.brand; // Invalid. This is undefined
+```
+
 ### `.readonly`
 
 `.readonly() => ZodReadonly<this>`

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1879,7 +1879,7 @@ You can create a Zod schema for any TypeScript type by using `z.custom()`. This 
 
 ```ts
 const px = z.custom<`${number}px`>((val) => {
-  return /^\d+px$/.test(val as string);
+  return typeof val === "string" ? /^\d+px$/.test(val) : false;
 });
 
 type px = z.infer<typeof px>; // `${number}px`
@@ -2441,6 +2441,17 @@ type Cat = z.infer<typeof Cat>;
 ```
 
 Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
+
+However when using the brand as a parameter the type will include it in the typing at runtime (but not the parse!)
+
+```ts
+const Cat = z.object({ name: z.string() }).brand("Cat"); // Notice brand being a parameter
+type Cat = z.infer<typeof Cat>;
+// {name: string} & {[symbol]: "Cat"}
+
+const isCatType = Cat._def.brand === "Cat"; // true
+const isCat = Cat.parse({ name: "Whiskers" })._def.brand; // Invalid. This is undefined
+```
 
 ### `.readonly`
 

--- a/deno/lib/__tests__/branded.test.ts
+++ b/deno/lib/__tests__/branded.test.ts
@@ -59,4 +59,17 @@ test("branded types", () => {
 
   // @ts-expect-error
   doStuff({ name: "hello there!" });
+
+  // runtime brand
+  const runtimeBranded = z.number().brand("runtime");
+  expect(runtimeBranded.parse(3000)).toEqual(3000);
+  expect(runtimeBranded._def.brand).toEqual("runtime");
+
+  const runtimeBrandedWithSymbol = z.string().brand(MyBrand);
+  expect(runtimeBrandedWithSymbol.parse("hi")).toEqual("hi");
+  expect(runtimeBrandedWithSymbol._def.brand).toEqual(MyBrand);
+
+  const typeBranded = z.string().brand<'myType'>();
+  expect(typeBranded.parse("hi")).toEqual("hi");
+  expect(typeBranded._def.brand).toEqual(undefined);
 });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -458,9 +458,13 @@ export abstract class ZodType<
     }) as any;
   }
 
-  brand<B extends string | number | symbol>(brand?: B): ZodBranded<this, B>;
-  brand<B extends string | number | symbol>(): ZodBranded<this, B> {
+  brand<B extends string | number | symbol>(): ZodBranded<this, B, undefined>;
+  brand<B extends string | number | symbol>(brand: B): ZodBranded<this, B, B>;
+  brand<B extends string | number | symbol>(
+    brand?: B
+  ): ZodBranded<this, B, B | undefined> {
     return new ZodBranded({
+      brand,
       typeName: ZodFirstPartyTypeKind.ZodBranded,
       type: this,
       ...processCreateParams(this._def),
@@ -4678,9 +4682,13 @@ export class ZodNaN extends ZodType<number, ZodNaNDef> {
 //////////////////////////////////////////
 //////////////////////////////////////////
 
-export interface ZodBrandedDef<T extends ZodTypeAny> extends ZodTypeDef {
+export interface ZodBrandedDef<
+  T extends ZodTypeAny,
+  B extends string | number | symbol | undefined
+> extends ZodTypeDef {
   type: T;
   typeName: ZodFirstPartyTypeKind.ZodBranded;
+  brand: B;
 }
 
 export const BRAND: unique symbol = Symbol("zod_brand");
@@ -4690,8 +4698,13 @@ export type BRAND<T extends string | number | symbol> = {
 
 export class ZodBranded<
   T extends ZodTypeAny,
-  B extends string | number | symbol
-> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, T["_input"]> {
+  B extends string | number | symbol,
+  BRuntime extends B | undefined = undefined
+> extends ZodType<
+  T["_output"] & BRAND<B>,
+  ZodBrandedDef<T, BRuntime>,
+  T["_input"]
+> {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;
@@ -4959,7 +4972,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodDefault<any>
   | ZodCatch<any>
   | ZodPromise<any>
-  | ZodBranded<any, any>
+  | ZodBranded<any, any, any>
   | ZodPipeline<any, any>;
 
 // requires TS 4.4+

--- a/src/__tests__/branded.test.ts
+++ b/src/__tests__/branded.test.ts
@@ -58,4 +58,17 @@ test("branded types", () => {
 
   // @ts-expect-error
   doStuff({ name: "hello there!" });
+
+  // runtime brand
+  const runtimeBranded = z.number().brand("runtime");
+  expect(runtimeBranded.parse(3000)).toEqual(3000);
+  expect(runtimeBranded._def.brand).toEqual("runtime");
+
+  const runtimeBrandedWithSymbol = z.string().brand(MyBrand);
+  expect(runtimeBrandedWithSymbol.parse("hi")).toEqual("hi");
+  expect(runtimeBrandedWithSymbol._def.brand).toEqual(MyBrand);
+
+  const typeBranded = z.string().brand<'myType'>();
+  expect(typeBranded.parse("hi")).toEqual("hi");
+  expect(typeBranded._def.brand).toEqual(undefined);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -458,9 +458,13 @@ export abstract class ZodType<
     }) as any;
   }
 
-  brand<B extends string | number | symbol>(brand?: B): ZodBranded<this, B>;
-  brand<B extends string | number | symbol>(): ZodBranded<this, B> {
+  brand<B extends string | number | symbol>(): ZodBranded<this, B, undefined>;
+  brand<B extends string | number | symbol>(brand: B): ZodBranded<this, B, B>;
+  brand<B extends string | number | symbol>(
+    brand?: B
+  ): ZodBranded<this, B, B | undefined> {
     return new ZodBranded({
+      brand,
       typeName: ZodFirstPartyTypeKind.ZodBranded,
       type: this,
       ...processCreateParams(this._def),
@@ -4678,9 +4682,13 @@ export class ZodNaN extends ZodType<number, ZodNaNDef> {
 //////////////////////////////////////////
 //////////////////////////////////////////
 
-export interface ZodBrandedDef<T extends ZodTypeAny> extends ZodTypeDef {
+export interface ZodBrandedDef<
+  T extends ZodTypeAny,
+  B extends string | number | symbol | undefined
+> extends ZodTypeDef {
   type: T;
   typeName: ZodFirstPartyTypeKind.ZodBranded;
+  brand: B;
 }
 
 export const BRAND: unique symbol = Symbol("zod_brand");
@@ -4690,8 +4698,13 @@ export type BRAND<T extends string | number | symbol> = {
 
 export class ZodBranded<
   T extends ZodTypeAny,
-  B extends string | number | symbol
-> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, T["_input"]> {
+  B extends string | number | symbol,
+  BRuntime extends B | undefined = undefined
+> extends ZodType<
+  T["_output"] & BRAND<B>,
+  ZodBrandedDef<T, BRuntime>,
+  T["_input"]
+> {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;
@@ -4959,7 +4972,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodDefault<any>
   | ZodCatch<any>
   | ZodPromise<any>
-  | ZodBranded<any, any>
+  | ZodBranded<any, any, any>
   | ZodPipeline<any, any>;
 
 // requires TS 4.4+


### PR DESCRIPTION
Make brand available at runtime when used as a parameter for .brand()

With this brand() can be used to enable external code to operate on types based on definition.

Typing is left as-is to be backwards-compatible so instead of overriding the BRAND symbol this just puts the brand parameter of the constructor in _def.

Let me know what you think! 🙂