### PR TITLE
Strict RFC4122 UUID validation and separate guid validation

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -96,6 +96,7 @@ export type StringValidation =
   | "emoji"
   | "uuid"
   | "nanoid"
+  | "guid"
   | "regex"
   | "cuid"
   | "cuid2"

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -307,14 +307,12 @@ test("bad nanoid", () => {
 });
 
 [
-  "9491d710-3185-0e06-bea0-6a2f275345e0",
   "9491d710-3185-1e06-bea0-6a2f275345e0",
   "9491d710-3185-2e06-bea0-6a2f275345e0",
   "9491d710-3185-3e06-bea0-6a2f275345e0",
   "9491d710-3185-4e06-bea0-6a2f275345e0",
   "9491d710-3185-5e06-bea0-6a2f275345e0",
   "9491d710-3185-5e06-aea0-6a2f275345e0",
-  "9491d710-3185-5e06-0ea0-6a2f275345e0",
   "9491d710-3185-5e06-8ea0-6a2f275345e0",
   "9491d710-3185-5e06-9ea0-6a2f275345e0",
   "00000000-0000-0000-0000-000000000000",
@@ -327,6 +325,8 @@ test("bad nanoid", () => {
 );
 
 [
+  "9491d710-3185-0e06-bea0-6a2f275345e0",
+  "9491d710-3185-5e06-0ea0-6a2f275345e0",
   "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
   "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
   "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -283,44 +283,6 @@ test("emoji validations", () => {
   expect(() => emoji.parse("stuff😀")).toThrow();
 });
 
-[
-  "9491d710-3185-0e06-bea0-6a2f275345e0",
-  "9491d710-3185-1e06-bea0-6a2f275345e0",
-  "9491d710-3185-2e06-bea0-6a2f275345e0",
-  "9491d710-3185-3e06-bea0-6a2f275345e0",
-  "9491d710-3185-4e06-bea0-6a2f275345e0",
-  "9491d710-3185-5e06-bea0-6a2f275345e0",
-  "9491d710-3185-5e06-aea0-6a2f275345e0",
-  "9491d710-3185-5e06-0ea0-6a2f275345e0",
-  "9491d710-3185-5e06-8ea0-6a2f275345e0",
-  "9491d710-3185-5e06-9ea0-6a2f275345e0",
-  "00000000-0000-0000-0000-000000000000",
-].forEach((goodUuid) =>
-  test(`uuid: ${goodUuid}`, () => {
-    const uuid = z.string().uuid("custom error");
-    const result = uuid.safeParse(goodUuid);
-    expect(result.success).toEqual(true);
-  })
-);
-
-[
-  "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
-  "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
-  "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
-  "invalid uuid",
-  "9491d710-3185-4e06-bea0-6a2f275345e0X",
-  "ffffffff-ffff-ffff-ffff-ffffffffffff",
-].forEach((badUuid) =>
-  test(`bad uuid: ${badUuid}`, () => {
-    const uuid = z.string().uuid("custom error");
-    const result = uuid.safeParse(badUuid);
-    expect(result.success).toEqual(false);
-    if (!result.success) {
-      expect(result.error.issues[0].message).toEqual("custom error");
-    }
-  })
-);
-
 test("nanoid", () => {
   const nanoid = z.string().nanoid("custom error");
   nanoid.parse("lfNZluvAxMkf7Q8C5H-QS");
@@ -343,6 +305,65 @@ test("bad nanoid", () => {
     expect(result.error.issues[0].message).toEqual("custom error");
   }
 });
+
+test.each([
+  "9491d710-3185-0e06-bea0-6a2f275345e0",
+  "9491d710-3185-1e06-bea0-6a2f275345e0",
+  "9491d710-3185-2e06-bea0-6a2f275345e0",
+  "9491d710-3185-3e06-bea0-6a2f275345e0",
+  "9491d710-3185-4e06-bea0-6a2f275345e0",
+  "9491d710-3185-5e06-bea0-6a2f275345e0",
+  "9491d710-3185-5e06-aea0-6a2f275345e0",
+  "9491d710-3185-5e06-0ea0-6a2f275345e0",
+  "9491d710-3185-5e06-8ea0-6a2f275345e0",
+  "9491d710-3185-5e06-9ea0-6a2f275345e0",
+  "00000000-0000-0000-0000-000000000000",
+])("uuid: %s", (goodUuid: unknown) => {
+  const uuid = z.string().uuid("custom error");
+  const result = uuid.safeParse(goodUuid);
+  expect(result.success).toEqual(true);
+});
+
+test.each([
+  "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
+  "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
+  "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
+  "invalid uuid",
+  "9491d710-3185-4e06-bea0-6a2f275345e0X",
+  "ffffffff-ffff-ffff-ffff-ffffffffffff",
+])("bad uuid: %s", (badUuid: unknown) => {
+  const uuid = z.string().uuid("custom error");
+  const result = uuid.safeParse(badUuid);
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
+test.each([
+  "9491d710-3185-4e06-bea0-6a2f275345e0",
+  "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
+  "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
+  "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
+  "00000000-0000-0000-0000-000000000000",
+  "ffffffff-ffff-ffff-ffff-ffffffffffff",
+])("guid: %s", (goodGuid: unknown) => {
+  const guid = z.string().guid("custom error");
+  const result = guid.safeParse(goodGuid);
+  expect(result.success).toEqual(true);
+});
+
+test.each(["9491d710-3185-4e06-bea0-6a2f275345e0X"])(
+  "bad guid: %s",
+  (badGuid: unknown) => {
+    const guid = z.string().guid("custom error");
+    const result = guid.safeParse(badGuid);
+    expect(result.success).toEqual(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toEqual("custom error");
+    }
+  }
+);
 
 test("cuid", () => {
   const cuid = z.string().cuid();

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -283,29 +283,43 @@ test("emoji validations", () => {
   expect(() => emoji.parse("stuff😀")).toThrow();
 });
 
-test("uuid", () => {
-  const uuid = z.string().uuid("custom error");
-  uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
-  uuid.parse("d89e7b01-7598-ed11-9d7a-0022489382fd"); // new sequential id
-  uuid.parse("00000000-0000-0000-0000-000000000000");
-  uuid.parse("b3ce60f8-e8b9-40f5-1150-172ede56ff74"); // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
-  uuid.parse("92e76bf9-28b3-4730-cd7f-cb6bc51f8c09"); // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
-  const result = uuid.safeParse("9491d710-3185-4e06-bea0-6a2f275345e0X");
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual("custom error");
-  }
-});
+[
+  "9491d710-3185-0e06-bea0-6a2f275345e0",
+  "9491d710-3185-1e06-bea0-6a2f275345e0",
+  "9491d710-3185-2e06-bea0-6a2f275345e0",
+  "9491d710-3185-3e06-bea0-6a2f275345e0",
+  "9491d710-3185-4e06-bea0-6a2f275345e0",
+  "9491d710-3185-5e06-bea0-6a2f275345e0",
+  "9491d710-3185-5e06-aea0-6a2f275345e0",
+  "9491d710-3185-5e06-0ea0-6a2f275345e0",
+  "9491d710-3185-5e06-8ea0-6a2f275345e0",
+  "9491d710-3185-5e06-9ea0-6a2f275345e0",
+  "00000000-0000-0000-0000-000000000000",
+].forEach((goodUuid) =>
+  test(`uuid: ${goodUuid}`, () => {
+    const uuid = z.string().uuid("custom error");
+    const result = uuid.safeParse(goodUuid);
+    expect(result.success).toEqual(true);
+  })
+);
 
-test("bad uuid", () => {
-  const uuid = z.string().uuid("custom error");
-  uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
-  const result = uuid.safeParse("invalid uuid");
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual("custom error");
-  }
-});
+[
+  "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
+  "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
+  "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
+  "invalid uuid",
+  "9491d710-3185-4e06-bea0-6a2f275345e0X",
+  "ffffffff-ffff-ffff-ffff-ffffffffffff",
+].forEach((badUuid) =>
+  test(`bad uuid: ${badUuid}`, () => {
+    const uuid = z.string().uuid("custom error");
+    const result = uuid.safeParse(badUuid);
+    expect(result.success).toEqual(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toEqual("custom error");
+    }
+  })
+);
 
 test("nanoid", () => {
   const nanoid = z.string().nanoid("custom error");

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -306,7 +306,7 @@ test("bad nanoid", () => {
   }
 });
 
-test.each([
+[
   "9491d710-3185-0e06-bea0-6a2f275345e0",
   "9491d710-3185-1e06-bea0-6a2f275345e0",
   "9491d710-3185-2e06-bea0-6a2f275345e0",
@@ -318,51 +318,56 @@ test.each([
   "9491d710-3185-5e06-8ea0-6a2f275345e0",
   "9491d710-3185-5e06-9ea0-6a2f275345e0",
   "00000000-0000-0000-0000-000000000000",
-])("uuid: %s", (goodUuid: unknown) => {
-  const uuid = z.string().uuid("custom error");
-  const result = uuid.safeParse(goodUuid);
-  expect(result.success).toEqual(true);
-});
+].forEach((goodUuid) =>
+  test(`uuid: ${goodUuid}`, () => {
+    const uuid = z.string().uuid("custom error");
+    const result = uuid.safeParse(goodUuid);
+    expect(result.success).toEqual(true);
+  })
+);
 
-test.each([
+[
   "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
   "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
   "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
   "invalid uuid",
   "9491d710-3185-4e06-bea0-6a2f275345e0X",
   "ffffffff-ffff-ffff-ffff-ffffffffffff",
-])("bad uuid: %s", (badUuid: unknown) => {
-  const uuid = z.string().uuid("custom error");
-  const result = uuid.safeParse(badUuid);
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual("custom error");
-  }
-});
+].forEach((badUuid) =>
+  test(`bad uuid: ${badUuid}`, () => {
+    const uuid = z.string().uuid("custom error");
+    const result = uuid.safeParse(badUuid);
+    expect(result.success).toEqual(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toEqual("custom error");
+    }
+  })
+);
 
-test.each([
+[
   "9491d710-3185-4e06-bea0-6a2f275345e0",
   "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
   "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
   "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
   "00000000-0000-0000-0000-000000000000",
   "ffffffff-ffff-ffff-ffff-ffffffffffff",
-])("guid: %s", (goodGuid: unknown) => {
-  const guid = z.string().guid("custom error");
-  const result = guid.safeParse(goodGuid);
-  expect(result.success).toEqual(true);
-});
+].forEach((goodGuid) =>
+  test(`guid: ${goodGuid}`, () => {
+    const guid = z.string().guid("custom error");
+    const result = guid.safeParse(goodGuid);
+    expect(result.success).toEqual(true);
+  })
+);
 
-test.each(["9491d710-3185-4e06-bea0-6a2f275345e0X"])(
-  "bad guid: %s",
-  (badGuid: unknown) => {
+["9491d710-3185-4e06-bea0-6a2f275345e0X"].forEach((badGuid) =>
+  test(`bad guid: ${badGuid}`, () => {
     const guid = z.string().guid("custom error");
     const result = guid.safeParse(badGuid);
     expect(result.success).toEqual(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toEqual("custom error");
     }
-  }
+  })
 );
 
 test("cuid", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1274,8 +1274,13 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   get isUUID() {
     return !!this._def.checks.find((ch) => ch.kind === "uuid");
   }
+<<<<<<< HEAD
   get isNANOID() {
     return !!this._def.checks.find((ch) => ch.kind === "nanoid");
+=======
+  get isGUID() {
+    return !!this._def.checks.find((ch) => ch.kind === "guid");
+>>>>>>> 162be85 (Add isGUID method)
   }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -550,6 +550,7 @@ export type ZodStringCheck =
   | { kind: "emoji"; message?: string }
   | { kind: "uuid"; message?: string }
   | { kind: "nanoid"; message?: string }
+  | { kind: "guid"; message?: string }
   | { kind: "cuid"; message?: string }
   | { kind: "includes"; value: string; position?: number; message?: string }
   | { kind: "cuid2"; message?: string }
@@ -602,6 +603,8 @@ const durationRegex =
 
 const uuidRegex =
   /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-5][0-9a-f]{3}\b-[089ab][0-9a-f]{3}\b-[0-9a-f]{12}$/i;
+const guidRegex =
+  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
@@ -840,6 +843,16 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
+      } else if (check.kind === "guid") {
+        if (!guidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "guid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "cuid") {
         if (!cuidRegex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
@@ -1057,6 +1070,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   nanoid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "nanoid", ...errorUtil.errToObj(message) });
+  }
+  guid(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "guid", ...errorUtil.errToObj(message) });
   }
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -602,9 +602,19 @@ const durationRegex =
   /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
 
 const uuidRegex =
-  /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-5][0-9a-f]{3}\b-[089ab][0-9a-f]{3}\b-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv1Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv2Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-2[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv3Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv4Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv5Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const guidRegex =
-  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}\b-[0-9a-f]{4}-[0-9a-f]{4}\b-[0-9a-f]{12}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -594,12 +594,14 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 const xidRegex = /^[0-9a-v]{20}$/i;
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
-const uuidRegex =
-  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+// const uuidRegex =
+//   /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 const nanoidRegex = /^[a-z0-9_-]{21}$/i;
 const durationRegex =
   /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
 
+const uuidRegex =
+  /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-5][0-9a-f]{3}\b-[089ab][0-9a-f]{3}\b-[0-9a-f]{12}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -602,7 +602,7 @@ const durationRegex =
   /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
 
 const uuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // const uuidv1Regex =
 //   /^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 // const uuidv2Regex =
@@ -614,7 +614,7 @@ const uuidRegex =
 // const uuidv5Regex =
 //   /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const guidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}\b-[0-9a-f]{4}-[0-9a-f]{4}\b-[0-9a-f]{12}$/i;
+  /^([0-9a-f]{8}-[0-9a-f]{4}\b-[0-9a-f]{4}-[0-9a-f]{4}\b-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
@@ -1284,13 +1284,11 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   get isUUID() {
     return !!this._def.checks.find((ch) => ch.kind === "uuid");
   }
-<<<<<<< HEAD
   get isNANOID() {
     return !!this._def.checks.find((ch) => ch.kind === "nanoid");
-=======
+  }
   get isGUID() {
     return !!this._def.checks.find((ch) => ch.kind === "guid");
->>>>>>> 162be85 (Add isGUID method)
   }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -96,6 +96,7 @@ export type StringValidation =
   | "emoji"
   | "uuid"
   | "nanoid"
+  | "guid"
   | "regex"
   | "cuid"
   | "cuid2"

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -282,6 +282,29 @@ test("emoji validations", () => {
   expect(() => emoji.parse("stuff😀")).toThrow();
 });
 
+test("nanoid", () => {
+  const nanoid = z.string().nanoid("custom error");
+  nanoid.parse("lfNZluvAxMkf7Q8C5H-QS");
+  nanoid.parse("mIU_4PJWikaU8fMbmkouz");
+  nanoid.parse("Hb9ZUtUa2JDm_dD-47EGv");
+  nanoid.parse("5Noocgv_8vQ9oPijj4ioQ");
+  const result = nanoid.safeParse("Xq90uDyhddC53KsoASYJGX");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
+test("bad nanoid", () => {
+  const nanoid = z.string().nanoid("custom error");
+  nanoid.parse("ySh_984wpDUu7IQRrLXAp");
+  const result = nanoid.safeParse("invalid nanoid");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("custom error");
+  }
+});
+
 test.each([
   "9491d710-3185-0e06-bea0-6a2f275345e0",
   "9491d710-3185-1e06-bea0-6a2f275345e0",
@@ -316,28 +339,30 @@ test.each([
   }
 });
 
-test("nanoid", () => {
-  const nanoid = z.string().nanoid("custom error");
-  nanoid.parse("lfNZluvAxMkf7Q8C5H-QS");
-  nanoid.parse("mIU_4PJWikaU8fMbmkouz");
-  nanoid.parse("Hb9ZUtUa2JDm_dD-47EGv");
-  nanoid.parse("5Noocgv_8vQ9oPijj4ioQ");
-  const result = nanoid.safeParse("Xq90uDyhddC53KsoASYJGX");
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual("custom error");
-  }
+test.each([
+  "9491d710-3185-4e06-bea0-6a2f275345e0",
+  "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
+  "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
+  "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
+  "00000000-0000-0000-0000-000000000000",
+  "ffffffff-ffff-ffff-ffff-ffffffffffff",
+])("guid: %s", (goodGuid: unknown) => {
+  const guid = z.string().guid("custom error");
+  const result = guid.safeParse(goodGuid);
+  expect(result.success).toEqual(true);
 });
 
-test("bad nanoid", () => {
-  const nanoid = z.string().nanoid("custom error");
-  nanoid.parse("ySh_984wpDUu7IQRrLXAp");
-  const result = nanoid.safeParse("invalid nanoid");
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual("custom error");
+test.each(["9491d710-3185-4e06-bea0-6a2f275345e0X"])(
+  "bad guid: %s",
+  (badGuid: unknown) => {
+    const guid = z.string().guid("custom error");
+    const result = guid.safeParse(badGuid);
+    expect(result.success).toEqual(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toEqual("custom error");
+    }
   }
-});
+);
 
 test("cuid", () => {
   const cuid = z.string().cuid();

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -306,14 +306,12 @@ test("bad nanoid", () => {
 });
 
 [
-  "9491d710-3185-0e06-bea0-6a2f275345e0",
   "9491d710-3185-1e06-bea0-6a2f275345e0",
   "9491d710-3185-2e06-bea0-6a2f275345e0",
   "9491d710-3185-3e06-bea0-6a2f275345e0",
   "9491d710-3185-4e06-bea0-6a2f275345e0",
   "9491d710-3185-5e06-bea0-6a2f275345e0",
   "9491d710-3185-5e06-aea0-6a2f275345e0",
-  "9491d710-3185-5e06-0ea0-6a2f275345e0",
   "9491d710-3185-5e06-8ea0-6a2f275345e0",
   "9491d710-3185-5e06-9ea0-6a2f275345e0",
   "00000000-0000-0000-0000-000000000000",
@@ -326,6 +324,8 @@ test("bad nanoid", () => {
 );
 
 [
+  "9491d710-3185-0e06-bea0-6a2f275345e0",
+  "9491d710-3185-5e06-0ea0-6a2f275345e0",
   "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
   "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
   "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -282,24 +282,34 @@ test("emoji validations", () => {
   expect(() => emoji.parse("stuff😀")).toThrow();
 });
 
-test("uuid", () => {
+test.each([
+  "9491d710-3185-0e06-bea0-6a2f275345e0",
+  "9491d710-3185-1e06-bea0-6a2f275345e0",
+  "9491d710-3185-2e06-bea0-6a2f275345e0",
+  "9491d710-3185-3e06-bea0-6a2f275345e0",
+  "9491d710-3185-4e06-bea0-6a2f275345e0",
+  "9491d710-3185-5e06-bea0-6a2f275345e0",
+  "9491d710-3185-5e06-aea0-6a2f275345e0",
+  "9491d710-3185-5e06-0ea0-6a2f275345e0",
+  "9491d710-3185-5e06-8ea0-6a2f275345e0",
+  "9491d710-3185-5e06-9ea0-6a2f275345e0",
+  "00000000-0000-0000-0000-000000000000",
+])("uuid: %s", (goodUuid: unknown) => {
   const uuid = z.string().uuid("custom error");
-  uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
-  uuid.parse("d89e7b01-7598-ed11-9d7a-0022489382fd"); // new sequential id
-  uuid.parse("00000000-0000-0000-0000-000000000000");
-  uuid.parse("b3ce60f8-e8b9-40f5-1150-172ede56ff74"); // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
-  uuid.parse("92e76bf9-28b3-4730-cd7f-cb6bc51f8c09"); // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
-  const result = uuid.safeParse("9491d710-3185-4e06-bea0-6a2f275345e0X");
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual("custom error");
-  }
+  const result = uuid.safeParse(goodUuid);
+  expect(result.success).toEqual(true);
 });
 
-test("bad uuid", () => {
+test.each([
+  "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
+  "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
+  "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
+  "invalid uuid",
+  "9491d710-3185-4e06-bea0-6a2f275345e0X",
+  "ffffffff-ffff-ffff-ffff-ffffffffffff",
+])("bad uuid: %s", (badUuid: unknown) => {
   const uuid = z.string().uuid("custom error");
-  uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
-  const result = uuid.safeParse("invalid uuid");
+  const result = uuid.safeParse(badUuid);
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("custom error");

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -305,7 +305,7 @@ test("bad nanoid", () => {
   }
 });
 
-test.each([
+[
   "9491d710-3185-0e06-bea0-6a2f275345e0",
   "9491d710-3185-1e06-bea0-6a2f275345e0",
   "9491d710-3185-2e06-bea0-6a2f275345e0",
@@ -317,51 +317,56 @@ test.each([
   "9491d710-3185-5e06-8ea0-6a2f275345e0",
   "9491d710-3185-5e06-9ea0-6a2f275345e0",
   "00000000-0000-0000-0000-000000000000",
-])("uuid: %s", (goodUuid: unknown) => {
-  const uuid = z.string().uuid("custom error");
-  const result = uuid.safeParse(goodUuid);
-  expect(result.success).toEqual(true);
-});
+].forEach((goodUuid) =>
+  test(`uuid: ${goodUuid}`, () => {
+    const uuid = z.string().uuid("custom error");
+    const result = uuid.safeParse(goodUuid);
+    expect(result.success).toEqual(true);
+  })
+);
 
-test.each([
+[
   "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
   "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
   "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
   "invalid uuid",
   "9491d710-3185-4e06-bea0-6a2f275345e0X",
   "ffffffff-ffff-ffff-ffff-ffffffffffff",
-])("bad uuid: %s", (badUuid: unknown) => {
-  const uuid = z.string().uuid("custom error");
-  const result = uuid.safeParse(badUuid);
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual("custom error");
-  }
-});
+].forEach((badUuid) =>
+  test(`bad uuid: ${badUuid}`, () => {
+    const uuid = z.string().uuid("custom error");
+    const result = uuid.safeParse(badUuid);
+    expect(result.success).toEqual(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toEqual("custom error");
+    }
+  })
+);
 
-test.each([
+[
   "9491d710-3185-4e06-bea0-6a2f275345e0",
   "d89e7b01-7598-ed11-9d7a-0022489382fd", // new sequential id
   "b3ce60f8-e8b9-40f5-1150-172ede56ff74", // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
   "92e76bf9-28b3-4730-cd7f-cb6bc51f8c09", // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
   "00000000-0000-0000-0000-000000000000",
   "ffffffff-ffff-ffff-ffff-ffffffffffff",
-])("guid: %s", (goodGuid: unknown) => {
-  const guid = z.string().guid("custom error");
-  const result = guid.safeParse(goodGuid);
-  expect(result.success).toEqual(true);
-});
+].forEach((goodGuid) =>
+  test(`guid: ${goodGuid}`, () => {
+    const guid = z.string().guid("custom error");
+    const result = guid.safeParse(goodGuid);
+    expect(result.success).toEqual(true);
+  })
+);
 
-test.each(["9491d710-3185-4e06-bea0-6a2f275345e0X"])(
-  "bad guid: %s",
-  (badGuid: unknown) => {
+["9491d710-3185-4e06-bea0-6a2f275345e0X"].forEach((badGuid) =>
+  test(`bad guid: ${badGuid}`, () => {
     const guid = z.string().guid("custom error");
     const result = guid.safeParse(badGuid);
     expect(result.success).toEqual(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toEqual("custom error");
     }
-  }
+  })
 );
 
 test("cuid", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1274,8 +1274,13 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   get isUUID() {
     return !!this._def.checks.find((ch) => ch.kind === "uuid");
   }
+<<<<<<< HEAD
   get isNANOID() {
     return !!this._def.checks.find((ch) => ch.kind === "nanoid");
+=======
+  get isGUID() {
+    return !!this._def.checks.find((ch) => ch.kind === "guid");
+>>>>>>> 162be85 (Add isGUID method)
   }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");

--- a/src/types.ts
+++ b/src/types.ts
@@ -550,6 +550,7 @@ export type ZodStringCheck =
   | { kind: "emoji"; message?: string }
   | { kind: "uuid"; message?: string }
   | { kind: "nanoid"; message?: string }
+  | { kind: "guid"; message?: string }
   | { kind: "cuid"; message?: string }
   | { kind: "includes"; value: string; position?: number; message?: string }
   | { kind: "cuid2"; message?: string }
@@ -602,6 +603,8 @@ const durationRegex =
 
 const uuidRegex =
   /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-5][0-9a-f]{3}\b-[089ab][0-9a-f]{3}\b-[0-9a-f]{12}$/i;
+const guidRegex =
+  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
@@ -840,6 +843,16 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
+      } else if (check.kind === "guid") {
+        if (!guidRegex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "guid",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "cuid") {
         if (!cuidRegex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
@@ -1057,6 +1070,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   nanoid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "nanoid", ...errorUtil.errToObj(message) });
+  }
+  guid(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "guid", ...errorUtil.errToObj(message) });
   }
   cuid(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "cuid", ...errorUtil.errToObj(message) });

--- a/src/types.ts
+++ b/src/types.ts
@@ -602,9 +602,19 @@ const durationRegex =
   /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
 
 const uuidRegex =
-  /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-5][0-9a-f]{3}\b-[089ab][0-9a-f]{3}\b-[0-9a-f]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv1Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv2Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-2[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv3Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-3[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv4Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// const uuidv5Regex =
+//   /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const guidRegex =
-  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+  /^[0-9a-f]{8}-[0-9a-f]{4}\b-[0-9a-f]{4}-[0-9a-f]{4}\b-[0-9a-f]{12}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;

--- a/src/types.ts
+++ b/src/types.ts
@@ -594,12 +594,14 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 const xidRegex = /^[0-9a-v]{20}$/i;
 // const uuidRegex =
 //   /^([a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}|00000000-0000-0000-0000-000000000000)$/i;
-const uuidRegex =
-  /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
+// const uuidRegex =
+//   /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 const nanoidRegex = /^[a-z0-9_-]{21}$/i;
 const durationRegex =
   /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
 
+const uuidRegex =
+  /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-5][0-9a-f]{3}\b-[089ab][0-9a-f]{3}\b-[0-9a-f]{12}$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;

--- a/src/types.ts
+++ b/src/types.ts
@@ -602,7 +602,7 @@ const durationRegex =
   /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
 
 const uuidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // const uuidv1Regex =
 //   /^[0-9a-f]{8}-[0-9a-f]{4}-1[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 // const uuidv2Regex =
@@ -614,7 +614,7 @@ const uuidRegex =
 // const uuidv5Regex =
 //   /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const guidRegex =
-  /^[0-9a-f]{8}-[0-9a-f]{4}\b-[0-9a-f]{4}-[0-9a-f]{4}\b-[0-9a-f]{12}$/i;
+  /^([0-9a-f]{8}-[0-9a-f]{4}\b-[0-9a-f]{4}-[0-9a-f]{4}\b-[0-9a-f]{12}|00000000-0000-0000-0000-000000000000)$/i;
 // from https://stackoverflow.com/a/46181/1550155
 // old version: too slow, didn't support unicode
 // const emailRegex = /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/i;
@@ -1284,13 +1284,11 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   get isUUID() {
     return !!this._def.checks.find((ch) => ch.kind === "uuid");
   }
-<<<<<<< HEAD
   get isNANOID() {
     return !!this._def.checks.find((ch) => ch.kind === "nanoid");
-=======
+  }
   get isGUID() {
     return !!this._def.checks.find((ch) => ch.kind === "guid");
->>>>>>> 162be85 (Add isGUID method)
   }
   get isCUID() {
     return !!this._def.checks.find((ch) => ch.kind === "cuid");


### PR DESCRIPTION
I wanted to use Zod to validate UUIDs, but noticed that the current implementation passes also UUIDs that are actually not valid according to the spec [as defined in RFC4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4).

Namely, the existing regex allows for version and variant values that should not be possible for a UUID.

I created this PR as a proposal in order to have UUID validation follow RFC4122 strictly and add a more generic `guid` string validator that allows for non-conforming UUID-like values (utilising the pre-existing regex making migration as simple as updating `string().uuid`s to `string().guid` where necessary). 

In regards to UUID v6+ I would suggest adding a `uuidv6` (or similar explicitly named) validator until the [RFC draft](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-new-formats) gets approved. This is not implemented by this PR.

I updated the tests accordingly and made sure they pass.

I hope this is helpful! (At the very least, I hope to spark some discussion.)

If there is something that I overlooked, please let me know.

Thanks a lot for creating an amazing library!

Related issues I was able to find:
https://github.com/colinhacks/zod/issues/2122
https://github.com/colinhacks/zod/pull/2341
https://github.com/colinhacks/zod/pull/2430