### PR TITLE
fix: wrong typing

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4859,8 +4859,8 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
 ////////////////////////////////////////
 ////////////////////////////////////////
 type CustomParams = CustomErrorParams & { fatal?: boolean };
-export const custom = <T>(
-  check?: (data: unknown) => any,
+export const custom = <T, P>(
+  check?: (data: P) => any,
   params: string | CustomParams | ((input: any) => CustomParams) = {},
   /**
    * @deprecated


### PR DESCRIPTION
The type of the check argument function must be a generic, otherwise the type you use for your own custom function would need to be unknown, and that's what is currently happening:

```ts
function customValidator(value: string) {
 ...
}

z.custom(customValidator) 
// this throws an error saying that the customValidator function `value` argument must be of type unknown.
```

After inserting the generic, everything works fine!