### PR TITLE
docs: introduce ".nonstrict" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,6 +1336,10 @@ person.parse({
 // => throws ZodError
 ```
 
+### `.nonstrict`
+
+You can use the `.nonstrict` method to _preserve_ unrecognized keys.
+
 ### `.strip`
 
 You can use the `.strip` method to reset an object schema to the default behavior (stripping unrecognized keys).

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1336,6 +1336,10 @@ person.parse({
 // => throws ZodError
 ```
 
+### `.nonstrict`
+
+You can use the `.nonstrict` method to _preserve_ unrecognized keys.
+
 ### `.strip`
 
 You can use the `.strip` method to reset an object schema to the default behavior (stripping unrecognized keys).


### PR DESCRIPTION
`z.object(...).nonstrict(...)` is available since [v1.0.11](https://github.com/colinhacks/zod/blob/master/CHANGELOG.md#zod1011) but not documented.

I found `.nonstrict` is helpful when I define type loosely and improve in incremental steps.  