### PR TITLE
fix: support unqualified (local) datetime strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ z.string().uuid({ message: "Invalid UUID" });
 z.string().includes("tuna", { message: "Must include tuna" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
-z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
+z.string().datetime({ message: "Invalid datetime string!" });
 z.string().ip({ message: "Invalid IP address" });
 ```
 
@@ -754,6 +754,7 @@ The `z.string().datetime()` method enforces ISO 8601; default is no timezone off
 const datetime = z.string().datetime();
 
 datetime.parse("2020-01-01T00:00:00Z"); // pass
+datetime.parse("2020-01-01T00:00:00"); // pass (unqualified)
 datetime.parse("2020-01-01T00:00:00.123Z"); // pass
 datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
 datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
@@ -777,6 +778,7 @@ You can additionally constrain the allowable `precision`. By default, arbitrary 
 const datetime = z.string().datetime({ precision: 3 });
 
 datetime.parse("2020-01-01T00:00:00.123Z"); // pass
+datetime.parse("2020-01-01T00:00:00.123"); // pass (unqualified still supported)
 datetime.parse("2020-01-01T00:00:00Z"); // fail
 datetime.parse("2020-01-01T00:00:00.123456Z"); // fail
 ```

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);
 z.string().endsWith(string);
-z.string().datetime(); // ISO 8601; default is without UTC offset, see below for options
+z.string().datetime(); // ISO 8601; default is UTC with zero offset, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 
 // transformations
@@ -742,22 +742,22 @@ z.string().uuid({ message: "Invalid UUID" });
 z.string().includes("tuna", { message: "Must include tuna" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
-z.string().datetime({ message: "Invalid datetime string!" });
+z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
 z.string().ip({ message: "Invalid IP address" });
 ```
 
 ### ISO datetimes
 
-The `z.string().datetime()` method enforces ISO 8601; default is no timezone offsets and arbitrary sub-second decimal precision.
+The `z.string().datetime()` method enforces ISO 8601; default is UTC with zero timezone offset and arbitrary sub-second decimal precision.
 
 ```ts
 const datetime = z.string().datetime();
 
 datetime.parse("2020-01-01T00:00:00Z"); // pass
-datetime.parse("2020-01-01T00:00:00"); // pass (unqualified)
 datetime.parse("2020-01-01T00:00:00.123Z"); // pass
 datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
 datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
+datetime.parse("2020-01-01T00:00:00"); // fail (UTC relation required)
 ```
 
 Timezone offsets can be allowed by setting the `offset` option to `true`.
@@ -778,9 +778,18 @@ You can additionally constrain the allowable `precision`. By default, arbitrary 
 const datetime = z.string().datetime({ precision: 3 });
 
 datetime.parse("2020-01-01T00:00:00.123Z"); // pass
-datetime.parse("2020-01-01T00:00:00.123"); // pass (unqualified still supported)
 datetime.parse("2020-01-01T00:00:00Z"); // fail
 datetime.parse("2020-01-01T00:00:00.123456Z"); // fail
+```
+
+Unqualified (no UTC relation) datetimes can be allowed by setting the `unqualified` option to `true`.
+
+```ts
+const datetime = z.string().datetime({ unqualified: true });
+
+datetime.parse("2020-01-01T00:00:00"); // pass
+datetime.parse("2020-01-01T00:00:00.123"); // pass (millis optional)
+datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
 ```
 
 ### IP addresses

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -742,7 +742,7 @@ z.string().uuid({ message: "Invalid UUID" });
 z.string().includes("tuna", { message: "Must include tuna" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
-z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
+z.string().datetime({ message: "Invalid datetime string!" });
 z.string().ip({ message: "Invalid IP address" });
 ```
 
@@ -754,6 +754,7 @@ The `z.string().datetime()` method enforces ISO 8601; default is no timezone off
 const datetime = z.string().datetime();
 
 datetime.parse("2020-01-01T00:00:00Z"); // pass
+datetime.parse("2020-01-01T00:00:00"); // pass (unqualified)
 datetime.parse("2020-01-01T00:00:00.123Z"); // pass
 datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
 datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
@@ -777,6 +778,7 @@ You can additionally constrain the allowable `precision`. By default, arbitrary 
 const datetime = z.string().datetime({ precision: 3 });
 
 datetime.parse("2020-01-01T00:00:00.123Z"); // pass
+datetime.parse("2020-01-01T00:00:00.123"); // pass (unqualified still supported)
 datetime.parse("2020-01-01T00:00:00Z"); // fail
 datetime.parse("2020-01-01T00:00:00.123456Z"); // fail
 ```

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -709,7 +709,7 @@ z.string().regex(regex);
 z.string().includes(string);
 z.string().startsWith(string);
 z.string().endsWith(string);
-z.string().datetime(); // ISO 8601; default is without UTC offset, see below for options
+z.string().datetime(); // ISO 8601; default is UTC with zero offset, see below for options
 z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 
 // transformations
@@ -742,22 +742,22 @@ z.string().uuid({ message: "Invalid UUID" });
 z.string().includes("tuna", { message: "Must include tuna" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
-z.string().datetime({ message: "Invalid datetime string!" });
+z.string().datetime({ message: "Invalid datetime string! Must be UTC." });
 z.string().ip({ message: "Invalid IP address" });
 ```
 
 ### ISO datetimes
 
-The `z.string().datetime()` method enforces ISO 8601; default is no timezone offsets and arbitrary sub-second decimal precision.
+The `z.string().datetime()` method enforces ISO 8601; default is UTC with zero timezone offset and arbitrary sub-second decimal precision.
 
 ```ts
 const datetime = z.string().datetime();
 
 datetime.parse("2020-01-01T00:00:00Z"); // pass
-datetime.parse("2020-01-01T00:00:00"); // pass (unqualified)
 datetime.parse("2020-01-01T00:00:00.123Z"); // pass
 datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
 datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
+datetime.parse("2020-01-01T00:00:00"); // fail (UTC relation required)
 ```
 
 Timezone offsets can be allowed by setting the `offset` option to `true`.
@@ -778,9 +778,18 @@ You can additionally constrain the allowable `precision`. By default, arbitrary 
 const datetime = z.string().datetime({ precision: 3 });
 
 datetime.parse("2020-01-01T00:00:00.123Z"); // pass
-datetime.parse("2020-01-01T00:00:00.123"); // pass (unqualified still supported)
 datetime.parse("2020-01-01T00:00:00Z"); // fail
 datetime.parse("2020-01-01T00:00:00.123456Z"); // fail
+```
+
+Unqualified (no UTC relation) datetimes can be allowed by setting the `unqualified` option to `true`.
+
+```ts
+const datetime = z.string().datetime({ unqualified: true });
+
+datetime.parse("2020-01-01T00:00:00"); // pass
+datetime.parse("2020-01-01T00:00:00.123"); // pass (millis optional)
+datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
 ```
 
 ### IP addresses

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -404,15 +404,10 @@ test("datetime", () => {
 test("datetime parsing", () => {
   const datetime = z.string().datetime();
   datetime.parse("1970-01-01T00:00:00.000Z");
-  datetime.parse("1970-01-01T00:00:00.000");
   datetime.parse("2022-10-13T09:52:31.816Z");
-  datetime.parse("2022-10-13T09:52:31.816");
   datetime.parse("2022-10-13T09:52:31.8162314Z");
-  datetime.parse("2022-10-13T09:52:31.8162314");
   datetime.parse("1970-01-01T00:00:00Z");
-  datetime.parse("1970-01-01T00:00:00");
   datetime.parse("2022-10-13T09:52:31Z");
-  datetime.parse("2022-10-13T09:52:31");
   expect(() => datetime.parse("")).toThrow();
   expect(() => datetime.parse("foo")).toThrow();
   expect(() => datetime.parse("2020-10-14")).toThrow();
@@ -421,9 +416,7 @@ test("datetime parsing", () => {
 
   const datetimeNoMs = z.string().datetime({ precision: 0 });
   datetimeNoMs.parse("1970-01-01T00:00:00Z");
-  datetimeNoMs.parse("1970-01-01T00:00:00");
   datetimeNoMs.parse("2022-10-13T09:52:31Z");
-  datetimeNoMs.parse("2022-10-13T09:52:31");
   expect(() => datetimeNoMs.parse("tuna")).toThrow();
   expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.Z")).toThrow();
@@ -431,9 +424,7 @@ test("datetime parsing", () => {
 
   const datetime3Ms = z.string().datetime({ precision: 3 });
   datetime3Ms.parse("1970-01-01T00:00:00.000Z");
-  datetime3Ms.parse("1970-01-01T00:00:00.000");
   datetime3Ms.parse("2022-10-13T09:52:31.123Z");
-  datetime3Ms.parse("2022-10-13T09:52:31.123");
   expect(() => datetime3Ms.parse("tuna")).toThrow();
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.1Z")).toThrow();
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.12Z")).toThrow();
@@ -476,6 +467,117 @@ test("datetime parsing", () => {
   expect(() => datetimeOffset4Ms.parse("1970-01-01T00:00:00.123Z")).toThrow();
   expect(() =>
     datetimeOffset4Ms.parse("2020-10-14T17:42:29.124+00:00")
+  ).toThrow();
+
+  const datetimeUnqualified = z.string().datetime({ unqualified: true });
+  datetimeUnqualified.parse("1970-01-01T00:00:00.000Z");
+  datetimeUnqualified.parse("1970-01-01T00:00:00.000");
+  datetimeUnqualified.parse("2022-10-13T09:52:31.816Z");
+  datetimeUnqualified.parse("2022-10-13T09:52:31.816");
+  datetimeUnqualified.parse("2022-10-13T09:52:31.8162314Z");
+  datetimeUnqualified.parse("2022-10-13T09:52:31.8162314");
+  datetimeUnqualified.parse("1970-01-01T00:00:00Z");
+  datetimeUnqualified.parse("1970-01-01T00:00:00");
+  datetimeUnqualified.parse("2022-10-13T09:52:31Z");
+  datetimeUnqualified.parse("2022-10-13T09:52:31");
+  expect(() => datetimeOffset.parse("tuna")).toThrow();
+  expect(() => datetimeOffset.parse("2022-10-13T09:52:31.Z")).toThrow();
+
+  const datetimeUnqualifiedNoMs = z
+    .string()
+    .datetime({ unqualified: true, precision: 0 });
+  datetimeUnqualifiedNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeUnqualifiedNoMs.parse("1970-01-01T00:00:00");
+  datetimeUnqualifiedNoMs.parse("2022-10-13T09:52:31Z");
+  datetimeUnqualifiedNoMs.parse("2022-10-13T09:52:31");
+  expect(() => datetimeUnqualifiedNoMs.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeUnqualifiedNoMs.parse("1970-01-01T00:00:00.000Z")
+  ).toThrow();
+  expect(() =>
+    datetimeUnqualifiedNoMs.parse("1970-01-01T00:00:00.Z")
+  ).toThrow();
+  expect(() =>
+    datetimeUnqualifiedNoMs.parse("2022-10-13T09:52:31.816Z")
+  ).toThrow();
+
+  const datetimeUnqualified3Ms = z
+    .string()
+    .datetime({ unqualified: true, precision: 3 });
+  datetimeUnqualified3Ms.parse("1970-01-01T00:00:00.000Z");
+  datetimeUnqualified3Ms.parse("1970-01-01T00:00:00.000");
+  datetimeUnqualified3Ms.parse("2022-10-13T09:52:31.123Z");
+  datetimeUnqualified3Ms.parse("2022-10-13T09:52:31.123");
+  expect(() => datetimeUnqualified3Ms.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeUnqualified3Ms.parse("1970-01-01T00:00:00.1Z")
+  ).toThrow();
+  expect(() =>
+    datetimeUnqualified3Ms.parse("1970-01-01T00:00:00.12Z")
+  ).toThrow();
+  expect(() => datetimeUnqualified3Ms.parse("2022-10-13T09:52:31Z")).toThrow();
+
+  const datetimeOffsetUnqualified = z
+    .string()
+    .datetime({ offset: true, unqualified: true });
+  datetimeOffsetUnqualified.parse("1970-01-01T00:00:00.000Z");
+  datetimeOffsetUnqualified.parse("1970-01-01T00:00:00.000");
+  datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.816234134Z");
+  datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.816234134");
+  datetimeOffsetUnqualified.parse("1970-01-01T00:00:00Z");
+  datetimeOffsetUnqualified.parse("1970-01-01T00:00:00");
+  datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.4Z");
+  datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.4");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29+00:00");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29+03:15");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29+0315");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29+03");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29");
+  expect(() => datetimeOffsetUnqualified.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.Z")
+  ).toThrow();
+
+  const datetimeOffsetUnqualifiedNoMs = z
+    .string()
+    .datetime({ offset: true, unqualified: true, precision: 0 });
+  datetimeOffsetUnqualifiedNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeOffsetUnqualifiedNoMs.parse("1970-01-01T00:00:00");
+  datetimeOffsetUnqualifiedNoMs.parse("2022-10-13T09:52:31Z");
+  datetimeOffsetUnqualifiedNoMs.parse("2022-10-13T09:52:31");
+  datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29+00:00");
+  datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29+0000");
+  datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29+00");
+  datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29");
+  expect(() => datetimeOffsetUnqualifiedNoMs.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualifiedNoMs.parse("1970-01-01T00:00:00.000Z")
+  ).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualifiedNoMs.parse("1970-01-01T00:00:00.Z")
+  ).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualifiedNoMs.parse("2022-10-13T09:52:31.816Z")
+  ).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29.124+00:00")
+  ).toThrow();
+
+  const datetimeOffsetUnqualified4Ms = z
+    .string()
+    .datetime({ offset: true, unqualified: true, precision: 4 });
+  datetimeOffsetUnqualified4Ms.parse("1970-01-01T00:00:00.1234Z");
+  datetimeOffsetUnqualified4Ms.parse("1970-01-01T00:00:00.1234");
+  datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.1234+00:00");
+  datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.1234+0000");
+  datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.1234+00");
+  datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.1234");
+  expect(() => datetimeOffsetUnqualified4Ms.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualified4Ms.parse("1970-01-01T00:00:00.123Z")
+  ).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.124+00:00")
   ).toThrow();
 });
 

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -404,10 +404,15 @@ test("datetime", () => {
 test("datetime parsing", () => {
   const datetime = z.string().datetime();
   datetime.parse("1970-01-01T00:00:00.000Z");
+  datetime.parse("1970-01-01T00:00:00.000");
   datetime.parse("2022-10-13T09:52:31.816Z");
+  datetime.parse("2022-10-13T09:52:31.816");
   datetime.parse("2022-10-13T09:52:31.8162314Z");
+  datetime.parse("2022-10-13T09:52:31.8162314");
   datetime.parse("1970-01-01T00:00:00Z");
+  datetime.parse("1970-01-01T00:00:00");
   datetime.parse("2022-10-13T09:52:31Z");
+  datetime.parse("2022-10-13T09:52:31");
   expect(() => datetime.parse("")).toThrow();
   expect(() => datetime.parse("foo")).toThrow();
   expect(() => datetime.parse("2020-10-14")).toThrow();
@@ -416,7 +421,9 @@ test("datetime parsing", () => {
 
   const datetimeNoMs = z.string().datetime({ precision: 0 });
   datetimeNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeNoMs.parse("1970-01-01T00:00:00");
   datetimeNoMs.parse("2022-10-13T09:52:31Z");
+  datetimeNoMs.parse("2022-10-13T09:52:31");
   expect(() => datetimeNoMs.parse("tuna")).toThrow();
   expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.Z")).toThrow();
@@ -424,7 +431,9 @@ test("datetime parsing", () => {
 
   const datetime3Ms = z.string().datetime({ precision: 3 });
   datetime3Ms.parse("1970-01-01T00:00:00.000Z");
+  datetime3Ms.parse("1970-01-01T00:00:00.000");
   datetime3Ms.parse("2022-10-13T09:52:31.123Z");
+  datetime3Ms.parse("2022-10-13T09:52:31.123");
   expect(() => datetime3Ms.parse("tuna")).toThrow();
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.1Z")).toThrow();
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.12Z")).toThrow();

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -588,7 +588,7 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
       );
     } else {
       return new RegExp(
-        `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{${args.precision}}Z$`
+        `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{${args.precision}}Z?$`
       );
     }
   } else if (args.precision === 0) {
@@ -597,7 +597,7 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
         `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(([+-]\\d{2}(:?\\d{2})?)|Z)$`
       );
     } else {
-      return new RegExp(`^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$`);
+      return new RegExp(`^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?$`);
     }
   } else {
     if (args.offset) {
@@ -606,7 +606,7 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
       );
     } else {
       return new RegExp(
-        `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$`
+        `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z?$`
       );
     }
   }

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -403,15 +403,10 @@ test("datetime", () => {
 test("datetime parsing", () => {
   const datetime = z.string().datetime();
   datetime.parse("1970-01-01T00:00:00.000Z");
-  datetime.parse("1970-01-01T00:00:00.000");
   datetime.parse("2022-10-13T09:52:31.816Z");
-  datetime.parse("2022-10-13T09:52:31.816");
   datetime.parse("2022-10-13T09:52:31.8162314Z");
-  datetime.parse("2022-10-13T09:52:31.8162314");
   datetime.parse("1970-01-01T00:00:00Z");
-  datetime.parse("1970-01-01T00:00:00");
   datetime.parse("2022-10-13T09:52:31Z");
-  datetime.parse("2022-10-13T09:52:31");
   expect(() => datetime.parse("")).toThrow();
   expect(() => datetime.parse("foo")).toThrow();
   expect(() => datetime.parse("2020-10-14")).toThrow();
@@ -420,9 +415,7 @@ test("datetime parsing", () => {
 
   const datetimeNoMs = z.string().datetime({ precision: 0 });
   datetimeNoMs.parse("1970-01-01T00:00:00Z");
-  datetimeNoMs.parse("1970-01-01T00:00:00");
   datetimeNoMs.parse("2022-10-13T09:52:31Z");
-  datetimeNoMs.parse("2022-10-13T09:52:31");
   expect(() => datetimeNoMs.parse("tuna")).toThrow();
   expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.Z")).toThrow();
@@ -430,9 +423,7 @@ test("datetime parsing", () => {
 
   const datetime3Ms = z.string().datetime({ precision: 3 });
   datetime3Ms.parse("1970-01-01T00:00:00.000Z");
-  datetime3Ms.parse("1970-01-01T00:00:00.000");
   datetime3Ms.parse("2022-10-13T09:52:31.123Z");
-  datetime3Ms.parse("2022-10-13T09:52:31.123");
   expect(() => datetime3Ms.parse("tuna")).toThrow();
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.1Z")).toThrow();
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.12Z")).toThrow();
@@ -475,6 +466,117 @@ test("datetime parsing", () => {
   expect(() => datetimeOffset4Ms.parse("1970-01-01T00:00:00.123Z")).toThrow();
   expect(() =>
     datetimeOffset4Ms.parse("2020-10-14T17:42:29.124+00:00")
+  ).toThrow();
+
+  const datetimeUnqualified = z.string().datetime({ unqualified: true });
+  datetimeUnqualified.parse("1970-01-01T00:00:00.000Z");
+  datetimeUnqualified.parse("1970-01-01T00:00:00.000");
+  datetimeUnqualified.parse("2022-10-13T09:52:31.816Z");
+  datetimeUnqualified.parse("2022-10-13T09:52:31.816");
+  datetimeUnqualified.parse("2022-10-13T09:52:31.8162314Z");
+  datetimeUnqualified.parse("2022-10-13T09:52:31.8162314");
+  datetimeUnqualified.parse("1970-01-01T00:00:00Z");
+  datetimeUnqualified.parse("1970-01-01T00:00:00");
+  datetimeUnqualified.parse("2022-10-13T09:52:31Z");
+  datetimeUnqualified.parse("2022-10-13T09:52:31");
+  expect(() => datetimeOffset.parse("tuna")).toThrow();
+  expect(() => datetimeOffset.parse("2022-10-13T09:52:31.Z")).toThrow();
+
+  const datetimeUnqualifiedNoMs = z
+    .string()
+    .datetime({ unqualified: true, precision: 0 });
+  datetimeUnqualifiedNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeUnqualifiedNoMs.parse("1970-01-01T00:00:00");
+  datetimeUnqualifiedNoMs.parse("2022-10-13T09:52:31Z");
+  datetimeUnqualifiedNoMs.parse("2022-10-13T09:52:31");
+  expect(() => datetimeUnqualifiedNoMs.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeUnqualifiedNoMs.parse("1970-01-01T00:00:00.000Z")
+  ).toThrow();
+  expect(() =>
+    datetimeUnqualifiedNoMs.parse("1970-01-01T00:00:00.Z")
+  ).toThrow();
+  expect(() =>
+    datetimeUnqualifiedNoMs.parse("2022-10-13T09:52:31.816Z")
+  ).toThrow();
+
+  const datetimeUnqualified3Ms = z
+    .string()
+    .datetime({ unqualified: true, precision: 3 });
+  datetimeUnqualified3Ms.parse("1970-01-01T00:00:00.000Z");
+  datetimeUnqualified3Ms.parse("1970-01-01T00:00:00.000");
+  datetimeUnqualified3Ms.parse("2022-10-13T09:52:31.123Z");
+  datetimeUnqualified3Ms.parse("2022-10-13T09:52:31.123");
+  expect(() => datetimeUnqualified3Ms.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeUnqualified3Ms.parse("1970-01-01T00:00:00.1Z")
+  ).toThrow();
+  expect(() =>
+    datetimeUnqualified3Ms.parse("1970-01-01T00:00:00.12Z")
+  ).toThrow();
+  expect(() => datetimeUnqualified3Ms.parse("2022-10-13T09:52:31Z")).toThrow();
+
+  const datetimeOffsetUnqualified = z
+    .string()
+    .datetime({ offset: true, unqualified: true });
+  datetimeOffsetUnqualified.parse("1970-01-01T00:00:00.000Z");
+  datetimeOffsetUnqualified.parse("1970-01-01T00:00:00.000");
+  datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.816234134Z");
+  datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.816234134");
+  datetimeOffsetUnqualified.parse("1970-01-01T00:00:00Z");
+  datetimeOffsetUnqualified.parse("1970-01-01T00:00:00");
+  datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.4Z");
+  datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.4");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29+00:00");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29+03:15");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29+0315");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29+03");
+  datetimeOffsetUnqualified.parse("2020-10-14T17:42:29");
+  expect(() => datetimeOffsetUnqualified.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualified.parse("2022-10-13T09:52:31.Z")
+  ).toThrow();
+
+  const datetimeOffsetUnqualifiedNoMs = z
+    .string()
+    .datetime({ offset: true, unqualified: true, precision: 0 });
+  datetimeOffsetUnqualifiedNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeOffsetUnqualifiedNoMs.parse("1970-01-01T00:00:00");
+  datetimeOffsetUnqualifiedNoMs.parse("2022-10-13T09:52:31Z");
+  datetimeOffsetUnqualifiedNoMs.parse("2022-10-13T09:52:31");
+  datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29+00:00");
+  datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29+0000");
+  datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29+00");
+  datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29");
+  expect(() => datetimeOffsetUnqualifiedNoMs.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualifiedNoMs.parse("1970-01-01T00:00:00.000Z")
+  ).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualifiedNoMs.parse("1970-01-01T00:00:00.Z")
+  ).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualifiedNoMs.parse("2022-10-13T09:52:31.816Z")
+  ).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualifiedNoMs.parse("2020-10-14T17:42:29.124+00:00")
+  ).toThrow();
+
+  const datetimeOffsetUnqualified4Ms = z
+    .string()
+    .datetime({ offset: true, unqualified: true, precision: 4 });
+  datetimeOffsetUnqualified4Ms.parse("1970-01-01T00:00:00.1234Z");
+  datetimeOffsetUnqualified4Ms.parse("1970-01-01T00:00:00.1234");
+  datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.1234+00:00");
+  datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.1234+0000");
+  datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.1234+00");
+  datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.1234");
+  expect(() => datetimeOffsetUnqualified4Ms.parse("tuna")).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualified4Ms.parse("1970-01-01T00:00:00.123Z")
+  ).toThrow();
+  expect(() =>
+    datetimeOffsetUnqualified4Ms.parse("2020-10-14T17:42:29.124+00:00")
   ).toThrow();
 });
 

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -403,10 +403,15 @@ test("datetime", () => {
 test("datetime parsing", () => {
   const datetime = z.string().datetime();
   datetime.parse("1970-01-01T00:00:00.000Z");
+  datetime.parse("1970-01-01T00:00:00.000");
   datetime.parse("2022-10-13T09:52:31.816Z");
+  datetime.parse("2022-10-13T09:52:31.816");
   datetime.parse("2022-10-13T09:52:31.8162314Z");
+  datetime.parse("2022-10-13T09:52:31.8162314");
   datetime.parse("1970-01-01T00:00:00Z");
+  datetime.parse("1970-01-01T00:00:00");
   datetime.parse("2022-10-13T09:52:31Z");
+  datetime.parse("2022-10-13T09:52:31");
   expect(() => datetime.parse("")).toThrow();
   expect(() => datetime.parse("foo")).toThrow();
   expect(() => datetime.parse("2020-10-14")).toThrow();
@@ -415,7 +420,9 @@ test("datetime parsing", () => {
 
   const datetimeNoMs = z.string().datetime({ precision: 0 });
   datetimeNoMs.parse("1970-01-01T00:00:00Z");
+  datetimeNoMs.parse("1970-01-01T00:00:00");
   datetimeNoMs.parse("2022-10-13T09:52:31Z");
+  datetimeNoMs.parse("2022-10-13T09:52:31");
   expect(() => datetimeNoMs.parse("tuna")).toThrow();
   expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.000Z")).toThrow();
   expect(() => datetimeNoMs.parse("1970-01-01T00:00:00.Z")).toThrow();
@@ -423,7 +430,9 @@ test("datetime parsing", () => {
 
   const datetime3Ms = z.string().datetime({ precision: 3 });
   datetime3Ms.parse("1970-01-01T00:00:00.000Z");
+  datetime3Ms.parse("1970-01-01T00:00:00.000");
   datetime3Ms.parse("2022-10-13T09:52:31.123Z");
+  datetime3Ms.parse("2022-10-13T09:52:31.123");
   expect(() => datetime3Ms.parse("tuna")).toThrow();
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.1Z")).toThrow();
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.12Z")).toThrow();

--- a/src/types.ts
+++ b/src/types.ts
@@ -588,7 +588,7 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
       );
     } else {
       return new RegExp(
-        `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{${args.precision}}Z$`
+        `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{${args.precision}}Z?$`
       );
     }
   } else if (args.precision === 0) {
@@ -597,7 +597,7 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
         `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(([+-]\\d{2}(:?\\d{2})?)|Z)$`
       );
     } else {
-      return new RegExp(`^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$`);
+      return new RegExp(`^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z?$`);
     }
   } else {
     if (args.offset) {
@@ -606,7 +606,7 @@ const datetimeRegex = (args: { precision: number | null; offset: boolean }) => {
       );
     } else {
       return new RegExp(
-        `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z$`
+        `^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z?$`
       );
     }
   }


### PR DESCRIPTION
FIxes #2385

Adds support for local unqualified date time strings. (the ones that don't end in "Z")

ISO-8601 allows unqualified date time strings, in which case the time is assumed to be in local time rather than UTC. [(See)](https://en.wikipedia.org/wiki/ISO_8601#Local_time_(unqualified)) 

To prevent breaking changes, this is an an additional opt-in option to the existing `string().dateTime()` method.

```
const datetime = z.string().datetime();
datetime.parse("2020-01-01T00:00:00"); // fail, same as before, requires trailing "z"

const datetimeUnqualified = z.string().datetime({ unqualified: true });
datetime.parse("2020-01-01T00:00:00"); // pass
```

I realized shortly after creating this PR that there is a similar effort at #2522. I've taken a slightly different approach in this PR. I am not sure what the etiquette is in terms of duplicate PRs, happy to collaborate and merge efforts with #2522 if that is possible/preferred.