### PR TITLE
Add mandatory code: ZodeIssueCode to ZodIssueBase type.

### DIFF
--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -37,6 +37,7 @@ export const ZodIssueCode = util.arrayToEnum([
 export type ZodIssueCode = keyof typeof ZodIssueCode;
 
 export type ZodIssueBase = {
+  code: ZodIssueCode;
   path: (string | number)[];
   message?: string;
 };


### PR DESCRIPTION
Minor change. Just makes it easier to tell that all ZodIssue instances are actually going to have a code value.