### PR TITLE
update makeIssue to support the force parameter returned from setErrorMap and allow Custom Message Translations

### DIFF
--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -17,18 +17,24 @@ export const makeIssue = (params: {
   };
 
   let errorMessage = "";
+  // track intention of using error map result even when there is an error message defined at schema level
+  let force = false; 
+  
   const maps = errorMaps
     .filter((m) => !!m)
     .slice()
     .reverse() as ZodErrorMap[];
   for (const map of maps) {
-    errorMessage = map(fullIssue, { data, defaultError: errorMessage }).message;
+    const result = map(fullIssue, { data, defaultError: errorMessage });
+    errorMessage = result.message;
+    force = !force ? !!result.force : force; // only update it once if found
   }
 
+  // if force is enabled, give priority to errorMessage returned from error map
   return {
     ...issueData,
     path: fullPath,
-    message: issueData.message || errorMessage,
+    message: force ? errorMessage || issueData.message :  issueData.message || errorMessage,
   };
 };
 


### PR DESCRIPTION
Now you can define error messages at the schema level (like a translation key), and use setErrorMap like this to lookup the translation.

Returning force: true will prevent this message of being overwritten by the schema message. This allow to create and return more custom translations for messages.

// Translation logic ex.
// error.message is the one defined at schema level; that now you can use it as the translation key

Usage:
```
z.setErrorMap((error, ctx) => {
  const message = getTranslatedMessageForKey(error.message);
  return { message, force: true };
});
```