### PR TITLE
Add `z.string().boolean()` function to parse a boolean value represented by string logically

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,7 +837,7 @@ ipv6.parse("192.168.1.1"); // fail
 
 ### Logical Boolean Parsing
 
-The `z.string().boolean()` method transform a string value representing a boolean logically.
+The `z.string().boolean()` method transforms a string value representing a boolean logically.
 
 It accepts `"1"`, `"t"`, `"T"`, `"TRUE"`, `"true"`, `"True"` for `true`, `"0"`, `"f"`, `"F"`, `"FALSE"`, `"false"`, `"False"` for `false`.
 

--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ b.parse(undefined); // false
 b.parse(null); // false
 ```
 
-Also you can use `default()` to handle only `undefined` value.
+You can also use `default()` to fallback to a value on the absence of an input.
 
 ```ts
 const b = z.string().boolean().default("0");

--- a/README.md
+++ b/README.md
@@ -841,9 +841,9 @@ The `z.string().boolean()` method transforms a string value representing a boole
 
 It accepts `"1"`, `"t"`, `"T"`, `"TRUE"`, `"true"`, `"True"` for `true`, `"0"`, `"f"`, `"F"`, `"FALSE"`, `"false"`, `"False"` for `false`.
 
-> This function's behavior does not along with Typescript standard `Boolean()` function.
+> This method does not reproduce [`Boolean()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)'s behavior.
 >
-> If you expect the behavior, use [`z.coerce.boolean()`](#coercion-for-primitives) instead.
+> If you expect [`Boolean()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)'s behavior, use [`z.coerce.boolean()`](#coercion-for-primitives) instead.
 
 ```ts
 const b = z.string().boolean();

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - [Strings](#strings)
   - [ISO datetimes](#iso-datetimes)
   - [IP addresses](#ip-addresses)
+  - [Logical Boolean Parsing](#logical-boolean-parsing)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -695,6 +696,8 @@ z.coerce.boolean().parse(undefined); // => false
 z.coerce.boolean().parse(null); // => false
 ```
 
+> If you want to parse a string value to a boolean logically, use [`Logical Boolean Parsing`](#logical-boolean-parsing) instead.
+
 ## Literals
 
 Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
@@ -741,6 +744,7 @@ z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 z.string().trim(); // trim whitespace
 z.string().toLowerCase(); // toLowerCase
 z.string().toUpperCase(); // toUpperCase
+z.string().boolean(); // parse a string value representing a boolean logically.
 ```
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
@@ -829,6 +833,51 @@ ipv4.parse("84d5:51a0:9114:1855:4cfa:f2d7:1f12:7003"); // fail
 
 const ipv6 = z.string().ip({ version: "v6" });
 ipv6.parse("192.168.1.1"); // fail
+```
+
+### Logical Boolean Parsing
+
+The `z.string().boolean()` method transform a string value representing a boolean logically.
+
+It accepts `"1"`, `"t"`, `"T"`, `"TRUE"`, `"true"`, `"True"` for `true`, `"0"`, `"f"`, `"F"`, `"FALSE"`, `"false"`, `"False"` for `false`.
+
+> This function's behavior does not along with Typescript standard `Boolean()` function.
+>
+> If you expect the behavior, use [`z.coerce.boolean()`](#coercion-for-primitives) instead.
+
+```ts
+const b = z.string().boolean();
+
+b.parse("1"); // true
+b.parse("0"); // false
+b.parse("true"); // true
+b.parse("false"); // false
+b.parse("True"); // true
+b.parse("False"); // false
+
+b.parse("other"); // fail
+b.parse(undefined); // fail
+b.parse(null); // fail
+```
+
+You can additionally use the `catch` function, which handle a parsing error as `true` or `false`.
+
+```ts
+const b = z.string().boolean().catch(false);
+
+b.parse("other"); // false
+b.parse(undefined); // false
+b.parse(null); // false
+```
+
+Also you can use `default()` to handle only `undefined` value.
+
+```ts
+const b = z.string().boolean().default("0");
+
+b.parse("other"); // fail
+b.parse(undefined); // false
+b.parse(null); // fail
 ```
 
 ## Numbers

--- a/README.md
+++ b/README.md
@@ -860,7 +860,7 @@ b.parse(undefined); // fail
 b.parse(null); // fail
 ```
 
-You can additionally use the `catch` function, which handle a parsing error as `true` or `false`.
+You can additionally use the `catch` function, which will return `true` or `false` whenever a parsing error occurs.
 
 ```ts
 const b = z.string().boolean().catch(false);

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -837,7 +837,7 @@ ipv6.parse("192.168.1.1"); // fail
 
 ### Logical Boolean Parsing
 
-The `z.string().boolean()` method transform a string value representing a boolean logically.
+The `z.string().boolean()` method transforms a string value representing a boolean logically.
 
 It accepts `"1"`, `"t"`, `"T"`, `"TRUE"`, `"true"`, `"True"` for `true`, `"0"`, `"f"`, `"F"`, `"FALSE"`, `"false"`, `"False"` for `false`.
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -870,7 +870,7 @@ b.parse(undefined); // false
 b.parse(null); // false
 ```
 
-Also you can use `default()` to handle only `undefined` value.
+You can also use `default()` to fallback to a value on the absence of an input.
 
 ```ts
 const b = z.string().boolean().default("0");

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -841,9 +841,9 @@ The `z.string().boolean()` method transforms a string value representing a boole
 
 It accepts `"1"`, `"t"`, `"T"`, `"TRUE"`, `"true"`, `"True"` for `true`, `"0"`, `"f"`, `"F"`, `"FALSE"`, `"false"`, `"False"` for `false`.
 
-> This function's behavior does not along with Typescript standard `Boolean()` function.
+> This method does not reproduce [`Boolean()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)'s behavior.
 >
-> If you expect the behavior, use [`z.coerce.boolean()`](#coercion-for-primitives) instead.
+> If you expect [`Boolean()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)'s behavior, use [`z.coerce.boolean()`](#coercion-for-primitives) instead.
 
 ```ts
 const b = z.string().boolean();

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -71,6 +71,7 @@
 - [Strings](#strings)
   - [ISO datetimes](#iso-datetimes)
   - [IP addresses](#ip-addresses)
+  - [Logical Boolean Parsing](#logical-boolean-parsing)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -695,6 +696,8 @@ z.coerce.boolean().parse(undefined); // => false
 z.coerce.boolean().parse(null); // => false
 ```
 
+> If you want to parse a string value to a boolean logically, use [`Logical Boolean Parsing`](#logical-boolean-parsing) instead.
+
 ## Literals
 
 Literal schemas represent a [literal type](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#literal-types), like `"hello world"` or `5`.
@@ -741,6 +744,7 @@ z.string().ip(); // defaults to IPv4 and IPv6, see below for options
 z.string().trim(); // trim whitespace
 z.string().toLowerCase(); // toLowerCase
 z.string().toUpperCase(); // toUpperCase
+z.string().boolean(); // parse a string value representing a boolean logically.
 ```
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
@@ -829,6 +833,51 @@ ipv4.parse("84d5:51a0:9114:1855:4cfa:f2d7:1f12:7003"); // fail
 
 const ipv6 = z.string().ip({ version: "v6" });
 ipv6.parse("192.168.1.1"); // fail
+```
+
+### Logical Boolean Parsing
+
+The `z.string().boolean()` method transform a string value representing a boolean logically.
+
+It accepts `"1"`, `"t"`, `"T"`, `"TRUE"`, `"true"`, `"True"` for `true`, `"0"`, `"f"`, `"F"`, `"FALSE"`, `"false"`, `"False"` for `false`.
+
+> This function's behavior does not along with Typescript standard `Boolean()` function.
+>
+> If you expect the behavior, use [`z.coerce.boolean()`](#coercion-for-primitives) instead.
+
+```ts
+const b = z.string().boolean();
+
+b.parse("1"); // true
+b.parse("0"); // false
+b.parse("true"); // true
+b.parse("false"); // false
+b.parse("True"); // true
+b.parse("False"); // false
+
+b.parse("other"); // fail
+b.parse(undefined); // fail
+b.parse(null); // fail
+```
+
+You can additionally use the `catch` function, which handle a parsing error as `true` or `false`.
+
+```ts
+const b = z.string().boolean().catch(false);
+
+b.parse("other"); // false
+b.parse(undefined); // false
+b.parse(null); // false
+```
+
+Also you can use `default()` to handle only `undefined` value.
+
+```ts
+const b = z.string().boolean().default("0");
+
+b.parse("other"); // fail
+b.parse(undefined); // false
+b.parse(null); // fail
 ```
 
 ## Numbers

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -860,7 +860,7 @@ b.parse(undefined); // fail
 b.parse(null); // fail
 ```
 
-You can additionally use the `catch` function, which handle a parsing error as `true` or `false`.
+You can additionally use the `catch` function, which will return `true` or `false` whenever a parsing error occurs.
 
 ```ts
 const b = z.string().boolean().catch(false);

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -12,6 +12,7 @@ const includes = z.string().includes("includes");
 const includesFromIndex2 = z.string().includes("includes", { position: 2 });
 const startsWith = z.string().startsWith("startsWith");
 const endsWith = z.string().endsWith("endsWith");
+const boolean = z.string().boolean();
 
 test("passing validations", () => {
   minFive.parse("12345");
@@ -24,6 +25,7 @@ test("passing validations", () => {
   includesFromIndex2.parse("XXXincludesXX");
   startsWith.parse("startsWithX");
   endsWith.parse("XendsWith");
+  boolean.parse("False");
 });
 
 test("failing validations", () => {
@@ -36,6 +38,7 @@ test("failing validations", () => {
   expect(() => includesFromIndex2.parse("XincludesXX")).toThrow();
   expect(() => startsWith.parse("x")).toThrow();
   expect(() => endsWith.parse("x")).toThrow();
+  expect(() => boolean.parse("")).toThrow();
 });
 
 test("email validations", () => {
@@ -509,4 +512,69 @@ test("IP validation", () => {
   expect(
     invalidIPs.every((ip) => ipSchema.safeParse(ip).success === false)
   ).toBe(true);
+});
+
+test("boolean validation", () => {
+  const b = z.string().boolean();
+
+  expect(b.parse("1")).toEqual(true);
+  expect(b.parse("t")).toEqual(true);
+  expect(b.parse("T")).toEqual(true);
+  expect(b.parse("TRUE")).toEqual(true);
+  expect(b.parse("true")).toEqual(true);
+  expect(b.parse("True")).toEqual(true);
+
+  expect(b.parse("0")).toEqual(false);
+  expect(b.parse("f")).toEqual(false);
+  expect(b.parse("F")).toEqual(false);
+  expect(b.parse("FALSE")).toEqual(false);
+  expect(b.parse("false")).toEqual(false);
+  expect(b.parse("False")).toEqual(false);
+
+  expect(() => b.parse("tRue")).toThrow();
+  expect(() => b.parse("faLse")).toThrow();
+  expect(() => b.parse("other")).toThrow();
+  expect(() => b.parse("")).toThrow();
+  expect(() => b.parse(undefined)).toThrow();
+  expect(() => b.parse(null)).toThrow();
+
+  const catchFalse = z.string().boolean().catch(false);
+
+  expect(catchFalse.parse("tRue")).toEqual(false);
+  expect(catchFalse.parse("faLse")).toEqual(false);
+  expect(catchFalse.parse("other")).toEqual(false);
+  expect(catchFalse.parse("")).toEqual(false);
+  expect(catchFalse.parse(undefined)).toEqual(false);
+  expect(catchFalse.parse(null)).toEqual(false);
+
+  const catchTrue = z.string().boolean().catch(true);
+
+  expect(catchTrue.parse("tRue")).toEqual(true);
+  expect(catchTrue.parse("faLse")).toEqual(true);
+  expect(catchTrue.parse("other")).toEqual(true);
+  expect(catchTrue.parse("")).toEqual(true);
+  expect(catchTrue.parse(undefined)).toEqual(true);
+  expect(catchTrue.parse(null)).toEqual(true);
+
+  const defaultFalse = z.string().boolean().default("0");
+
+  expect(() => defaultFalse.parse("tRue")).toThrow();
+  expect(() => defaultFalse.parse("faLse")).toThrow();
+  expect(() => defaultFalse.parse("other")).toThrow();
+  expect(() => defaultFalse.parse("")).toThrow();
+  expect(defaultFalse.parse(undefined)).toEqual(false); // default
+  expect(() => defaultFalse.parse(null)).toThrow();
+
+  const defaultFalseCatchTrue = z.string().boolean().default("0").catch(true);
+
+  expect(defaultFalseCatchTrue.parse("tRue")).toEqual(true);
+  expect(defaultFalseCatchTrue.parse("faLse")).toEqual(true);
+  expect(defaultFalseCatchTrue.parse("other")).toEqual(true);
+  expect(defaultFalseCatchTrue.parse("")).toEqual(true);
+  expect(defaultFalseCatchTrue.parse(undefined)).toEqual(false); // default
+  expect(defaultFalseCatchTrue.parse(null)).toEqual(true);
+
+  const nullable = z.string().boolean().nullable();
+
+  expect(nullable.parse(null)).toEqual(null);
 });

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -11,6 +11,7 @@ const includes = z.string().includes("includes");
 const includesFromIndex2 = z.string().includes("includes", { position: 2 });
 const startsWith = z.string().startsWith("startsWith");
 const endsWith = z.string().endsWith("endsWith");
+const boolean = z.string().boolean();
 
 test("passing validations", () => {
   minFive.parse("12345");
@@ -23,6 +24,7 @@ test("passing validations", () => {
   includesFromIndex2.parse("XXXincludesXX");
   startsWith.parse("startsWithX");
   endsWith.parse("XendsWith");
+  boolean.parse("False");
 });
 
 test("failing validations", () => {
@@ -35,6 +37,7 @@ test("failing validations", () => {
   expect(() => includesFromIndex2.parse("XincludesXX")).toThrow();
   expect(() => startsWith.parse("x")).toThrow();
   expect(() => endsWith.parse("x")).toThrow();
+  expect(() => boolean.parse("")).toThrow();
 });
 
 test("email validations", () => {
@@ -508,4 +511,69 @@ test("IP validation", () => {
   expect(
     invalidIPs.every((ip) => ipSchema.safeParse(ip).success === false)
   ).toBe(true);
+});
+
+test("boolean validation", () => {
+  const b = z.string().boolean();
+
+  expect(b.parse("1")).toEqual(true);
+  expect(b.parse("t")).toEqual(true);
+  expect(b.parse("T")).toEqual(true);
+  expect(b.parse("TRUE")).toEqual(true);
+  expect(b.parse("true")).toEqual(true);
+  expect(b.parse("True")).toEqual(true);
+
+  expect(b.parse("0")).toEqual(false);
+  expect(b.parse("f")).toEqual(false);
+  expect(b.parse("F")).toEqual(false);
+  expect(b.parse("FALSE")).toEqual(false);
+  expect(b.parse("false")).toEqual(false);
+  expect(b.parse("False")).toEqual(false);
+
+  expect(() => b.parse("tRue")).toThrow();
+  expect(() => b.parse("faLse")).toThrow();
+  expect(() => b.parse("other")).toThrow();
+  expect(() => b.parse("")).toThrow();
+  expect(() => b.parse(undefined)).toThrow();
+  expect(() => b.parse(null)).toThrow();
+
+  const catchFalse = z.string().boolean().catch(false);
+
+  expect(catchFalse.parse("tRue")).toEqual(false);
+  expect(catchFalse.parse("faLse")).toEqual(false);
+  expect(catchFalse.parse("other")).toEqual(false);
+  expect(catchFalse.parse("")).toEqual(false);
+  expect(catchFalse.parse(undefined)).toEqual(false);
+  expect(catchFalse.parse(null)).toEqual(false);
+
+  const catchTrue = z.string().boolean().catch(true);
+
+  expect(catchTrue.parse("tRue")).toEqual(true);
+  expect(catchTrue.parse("faLse")).toEqual(true);
+  expect(catchTrue.parse("other")).toEqual(true);
+  expect(catchTrue.parse("")).toEqual(true);
+  expect(catchTrue.parse(undefined)).toEqual(true);
+  expect(catchTrue.parse(null)).toEqual(true);
+
+  const defaultFalse = z.string().boolean().default("0");
+
+  expect(() => defaultFalse.parse("tRue")).toThrow();
+  expect(() => defaultFalse.parse("faLse")).toThrow();
+  expect(() => defaultFalse.parse("other")).toThrow();
+  expect(() => defaultFalse.parse("")).toThrow();
+  expect(defaultFalse.parse(undefined)).toEqual(false); // default
+  expect(() => defaultFalse.parse(null)).toThrow();
+
+  const defaultFalseCatchTrue = z.string().boolean().default("0").catch(true);
+
+  expect(defaultFalseCatchTrue.parse("tRue")).toEqual(true);
+  expect(defaultFalseCatchTrue.parse("faLse")).toEqual(true);
+  expect(defaultFalseCatchTrue.parse("other")).toEqual(true);
+  expect(defaultFalseCatchTrue.parse("")).toEqual(true);
+  expect(defaultFalseCatchTrue.parse(undefined)).toEqual(false); // default
+  expect(defaultFalseCatchTrue.parse(null)).toEqual(true);
+
+  const nullable = z.string().boolean().nullable();
+
+  expect(nullable.parse(null)).toEqual(null);
 });


### PR DESCRIPTION
Close #2985
Close #1630


The `z.string().boolean()` method transforms a string value representing a boolean logically.

Accepts `"1"`, `"t"`, `"T"`, `"TRUE"`, `"true"`, `"True"` for `true`.
Accepts`"0"`, `"f"`, `"F"`, `"FALSE"`, `"false"`, `"False"` for `false`.

I thought which function name to use in the followings, but use the original name for now.

- `z.string().boolean()`
- `z.string().toBoolean()`