### PR TITLE
Make depcruise pass

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -118,8 +118,7 @@ module.exports = {
         "from.pathNot re of the not-to-dev-dep rule in the dependency-cruiser configuration",
       from: {
         path: "^(src)",
-        pathNot:
-          "\\.(spec|test)\\.(js|mjs|cjs|ts|ls|coffee|litcoffee|coffee\\.md)$",
+        pathNot: ["^src/__tests__/", "^src/benchmarks/"],
       },
       to: {
         dependencyTypes: ["npm-dev"],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
+    "@jest/globals": "^29.4.3",
     "@rollup/plugin-typescript": "^8.2.0",
     "@swc/core": "^1.3.66",
     "@swc/jest": "^0.2.26",


### PR DESCRIPTION
Previously the sanity checks in `yarn run depcruise` would fail for two reasons:

1. Benchmark scripts were mistakenly not marked as development-only and were using development dependencies
2. Test code was referencing the `@jest/globals` package, which was an implicit requirement (via `jest`)

Now this script should pass