### PR TITLE
only look in `src` for `bun test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "test:watch": "yarn test:ts-jest --watch",
     "test": "yarn test:ts-jest",
     "test:babel": "jest --coverage --config ./configs/babel-jest.config.json",
-    "test:bun": "bun test",
+    "test:bun": "bun test src/",
     "test:vitest": "npx vitest --config ./configs/vitest.config.ts",
     "test:ts-jest": "npx jest --config ./configs/ts-jest.config.json",
     "test:swc": "npx jest --config ./configs/swc-jest.config.json",


### PR DESCRIPTION
Previously, `yarn run test:bun` would fail if we already built for `deno`, since it does not respect the filter in `jest.config.json`, failing with errors like:
```
deno/lib/__tests__/record.test.ts:
error: FileNotFound reading "https://deno.land/x/expect@v0.2.6/mod.ts"
```