### PR TITLE
Fixes: Issue#3008  support single value in enum's .exclude & .extract

### DIFF
--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -47,9 +47,13 @@ test("extract/exclude", () => {
   const FoodEnum = z.enum(foods);
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const UnhealthyEnum = FoodEnum.exclude(["Salad"]);
+  const PastaEnum = FoodEnum.extract("Pasta");
+  const notPastaEnum = FoodEnum.exclude("Pasta");
   const EmptyFoodEnum = FoodEnum.exclude(foods);
 
   util.assertEqual<z.infer<typeof ItalianEnum>, "Pasta" | "Pizza">(true);
+  util.assertEqual<z.infer<typeof PastaEnum>, "Pasta">(true);
+  util.assertEqual<z.infer<typeof notPastaEnum>, "Pizza" | "Tacos" | "Burgers" | "Salad">(true);
   util.assertEqual<
     z.infer<typeof UnhealthyEnum>,
     "Pasta" | "Pizza" | "Tacos" | "Burgers"

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4056,25 +4056,29 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
     return enumValues as any;
   }
 
-  extract<ToExtract extends readonly [T[number], ...T[number][]]>(
-    values: ToExtract
-  ): ZodEnum<Writeable<ToExtract>> {
-    return ZodEnum.create(values) as any;
+  extract<ToExtract extends string>(values: ToExtract): ZodEnum<[ToExtract]>;
+  extract<ToExtract extends readonly [T[number], ...T[number][]]>(values: ToExtract): ZodEnum<Writeable<ToExtract>>;
+  extract(values: string | readonly [T[number], ...T[number][]]): ZodEnum<any> {
+    if (typeof values === 'string') {
+      return ZodEnum.create([values as T[number]]) as any;
+    } else {
+    return ZodEnum.create(values as [T[number], ...T[number][]]) as any;
+    }
   }
 
-  exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
-    values: ToExclude
-  ): ZodEnum<
-    typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
-  > {
-    return ZodEnum.create(
-      this.options.filter((opt) => !values.includes(opt)) as FilterEnum<
-        T,
-        ToExclude[number]
-      >
-    ) as any;
+  exclude<ToExclude extends string>(values: ToExclude): ZodEnum<FilterEnum<T, ToExclude>>;
+  exclude<ToExclude extends readonly [T[number], ...T[number][]]>(values: ToExclude): ZodEnum<FilterEnum<T, ToExclude[number]>>;
+  exclude(values: string | readonly [T[number], ...T[number][]]): ZodEnum<any> {
+    if (typeof values === 'string') {
+      return ZodEnum.create(
+        this.options.filter((opt) => opt !== values) as FilterEnum<T, T[number]>
+      ) as any;
+    } else {
+      return ZodEnum.create(
+        this.options.filter((opt) => !values.includes(opt)) as FilterEnum<T, T[number]>
+      ) as any;
+    }
   }
-
   static create = createZodEnum;
 }
 

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -47,10 +47,12 @@ test("extract/exclude", () => {
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const UnhealthyEnum = FoodEnum.exclude(["Salad"]);
   const PastaEnum = FoodEnum.extract("Pasta");
+  const notPastaEnum = FoodEnum.exclude("Pasta");
   const EmptyFoodEnum = FoodEnum.exclude(foods);
 
   util.assertEqual<z.infer<typeof ItalianEnum>, "Pasta" | "Pizza">(true);
   util.assertEqual<z.infer<typeof PastaEnum>, "Pasta">(true);
+  util.assertEqual<z.infer<typeof notPastaEnum>, "Pizza" | "Tacos" | "Burgers" | "Salad">(true);
   util.assertEqual<
     z.infer<typeof UnhealthyEnum>,
     "Pasta" | "Pizza" | "Tacos" | "Burgers"

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -46,9 +46,11 @@ test("extract/exclude", () => {
   const FoodEnum = z.enum(foods);
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const UnhealthyEnum = FoodEnum.exclude(["Salad"]);
+  const PastaEnum = FoodEnum.extract("Pasta");
   const EmptyFoodEnum = FoodEnum.exclude(foods);
 
   util.assertEqual<z.infer<typeof ItalianEnum>, "Pasta" | "Pizza">(true);
+  util.assertEqual<z.infer<typeof PastaEnum>, "Pasta">(true);
   util.assertEqual<
     z.infer<typeof UnhealthyEnum>,
     "Pasta" | "Pizza" | "Tacos" | "Burgers"

--- a/src/types.ts
+++ b/src/types.ts
@@ -4056,10 +4056,14 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
     return enumValues as any;
   }
 
-  extract<ToExtract extends readonly [T[number], ...T[number][]]>(
-    values: ToExtract
-  ): ZodEnum<Writeable<ToExtract>> {
-    return ZodEnum.create(values) as any;
+  extract<ToExtract extends string>(values: ToExtract): ZodEnum<[ToExtract]>;
+  extract<ToExtract extends readonly [T[number], ...T[number][]]>(values: ToExtract): ZodEnum<Writeable<ToExtract>>;
+  extract(values: string | readonly [T[number], ...T[number][]]): ZodEnum<any> {
+    if (typeof values === 'string') {
+      return ZodEnum.create([values as T[number]]) as any;
+    } else {
+      return ZodEnum.create(values as [T[number], ...T[number][]]) as any;
+    }
   }
 
   exclude<ToExclude extends readonly [T[number], ...T[number][]]>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -4066,17 +4066,18 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
     }
   }
 
-  exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
-    values: ToExclude
-  ): ZodEnum<
-    typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
-  > {
-    return ZodEnum.create(
-      this.options.filter((opt) => !values.includes(opt)) as FilterEnum<
-        T,
-        ToExclude[number]
-      >
-    ) as any;
+  exclude<ToExclude extends string>(values: ToExclude): ZodEnum<FilterEnum<T, ToExclude>>;
+  exclude<ToExclude extends readonly [T[number], ...T[number][]]>(values: ToExclude): ZodEnum<FilterEnum<T, ToExclude[number]>>;
+  exclude(values: string | readonly [T[number], ...T[number][]]): ZodEnum<any> {
+    if (typeof values === 'string') {
+      return ZodEnum.create(
+        this.options.filter((opt) => opt !== values) as FilterEnum<T, T[number]>
+      ) as any;
+    } else {
+      return ZodEnum.create(
+        this.options.filter((opt) => !values.includes(opt)) as FilterEnum<T, T[number]>
+      ) as any;
+    }
   }
 
   static create = createZodEnum;


### PR DESCRIPTION
### Description:

This pull request aims to enhance the functionality of the exclude and extract functions within ZodEnum as described in issue #3008  . The proposed changes include:

- **Refactoring the Exclude/Extract Function:**
  - Modified the exclude/extract function to accommodate both single strings and arrays of strings, providing greater flexibility in usage.
  
- **Test Cases for Validation:**
  - Integrated test cases to validate the functionality of refactored cases

> However in javascript those functions were doing fine initially but typescript was throwing some type errors. Now those errors are fixed.


https://github.com/colinhacks/zod/assets/106688422/fb92fe7b-2262-484c-b2d6-5a3bf65482a9



### Testing:
  - All test cases have been successfully passed.

### Additional Notes:

Any feedback or suggestions for further improvements are highly welcome.

---

*Please review and merge at your earliest convenience.*