### PR TITLE
Add docs for coercing nullish values

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,16 +671,19 @@ Zod now provides a more convenient way to coerce primitive values.
 const schema = z.coerce.string();
 schema.parse("tuna"); // => "tuna"
 schema.parse(12); // => "12"
-schema.parse(true); // => "true"
 ```
 
-During the parsing step, the input is passed through the `String()` function, which is a JavaScript built-in for coercing data into strings. Note that the returned schema is a `ZodString` instance so you can use all string methods.
+During the parsing step, the input is passed through the `String()` function, which is a JavaScript built-in for coercing data into strings.
+
+The returned schema is a normal `ZodString` instance so you can use all string methods.
 
 ```ts
 z.coerce.string().email().min(5);
 ```
 
-All primitive types support coercion.
+**How coercion works**
+
+All primitive types support coercion. Zod coerces all inputs using the built-in constructors: `String(input)`, `Number(input)`, `new Date(input)`, etc.
 
 ```ts
 z.coerce.string(); // String(input)
@@ -690,23 +693,19 @@ z.coerce.bigint(); // BigInt(input)
 z.coerce.date(); // new Date(input)
 ```
 
-**Coercing nullish values**
-
-Some types allow coercing nullish values. The results may be unexpected.
-You can [use `.pipe()` to handle these cases](#you-can-use-pipe-to-fix-common-issues-with-zcoerce).
+Note that some behavior may not be what you expect.
 
 ```ts
-z.coerce.string().parse(null); // => null
-z.coerce.string().parse(undefined); // => undefined
-z.coerce.number().parse(null); // => 0
-z.coerce.boolean().parse(null); // => false
-z.coerce.boolean().parse(undefined); // => false
-z.coerce.date().parse(null); // => 1970-01-01T00:00:00.000Z
+schema.parse(true); // => "true"
+schema.parse(undefined); // => "undefined"
+schema.parse(null); // => "null"
 ```
+
+For more control over coercion logic, consider using [`z.preprocess`](#preprocess) or [`z.pipe()`](#pipe).
 
 **Boolean coercion**
 
-Zod's boolean coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.
+Zod's coerces values coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.
 
 ```ts
 z.coerce.boolean().parse("tuna"); // => true

--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ For more control over coercion logic, consider using [`z.preprocess`](#preproces
 
 **Boolean coercion**
 
-Zod's coerces values coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.
+Zod's approach to coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.
 
 ```ts
 z.coerce.boolean().parse("tuna"); // => true

--- a/README.md
+++ b/README.md
@@ -690,6 +690,20 @@ z.coerce.bigint(); // BigInt(input)
 z.coerce.date(); // new Date(input)
 ```
 
+**Coercing nullish values**
+
+Some types allow coercing nullish values. The results may be unexpected.
+You can [use `.pipe()` to handle these cases](#you-can-use-pipe-to-fix-common-issues-with-zcoerce).
+
+```ts
+z.coerce.string().parse(null); // => null
+z.coerce.string().parse(undefined); // => undefined
+z.coerce.number().parse(null); // => 0
+z.coerce.boolean().parse(null); // => false
+z.coerce.boolean().parse(undefined); // => false
+z.coerce.date().parse(null); // => 1970-01-01T00:00:00.000Z
+```
+
 **Boolean coercion**
 
 Zod's boolean coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -671,16 +671,19 @@ Zod now provides a more convenient way to coerce primitive values.
 const schema = z.coerce.string();
 schema.parse("tuna"); // => "tuna"
 schema.parse(12); // => "12"
-schema.parse(true); // => "true"
 ```
 
-During the parsing step, the input is passed through the `String()` function, which is a JavaScript built-in for coercing data into strings. Note that the returned schema is a `ZodString` instance so you can use all string methods.
+During the parsing step, the input is passed through the `String()` function, which is a JavaScript built-in for coercing data into strings.
+
+The returned schema is a normal `ZodString` instance so you can use all string methods.
 
 ```ts
 z.coerce.string().email().min(5);
 ```
 
-All primitive types support coercion.
+**How coercion works**
+
+All primitive types support coercion. Zod coerces all inputs using the built-in constructors: `String(input)`, `Number(input)`, `new Date(input)`, etc.
 
 ```ts
 z.coerce.string(); // String(input)
@@ -690,23 +693,19 @@ z.coerce.bigint(); // BigInt(input)
 z.coerce.date(); // new Date(input)
 ```
 
-**Coercing nullish values**
-
-Some types allow coercing nullish values. The results may be unexpected.
-You can [use `.pipe()` to handle these cases](#you-can-use-pipe-to-fix-common-issues-with-zcoerce).
+Note that some behavior may not be what you expect.
 
 ```ts
-z.coerce.string().parse(null); // => null
-z.coerce.string().parse(undefined); // => undefined
-z.coerce.number().parse(null); // => 0
-z.coerce.boolean().parse(null); // => false
-z.coerce.boolean().parse(undefined); // => false
-z.coerce.date().parse(null); // => 1970-01-01T00:00:00.000Z
+schema.parse(true); // => "true"
+schema.parse(undefined); // => "undefined"
+schema.parse(null); // => "null"
 ```
+
+For more control over coercion logic, consider using [`z.preprocess`](#preprocess) or [`z.pipe()`](#pipe).
 
 **Boolean coercion**
 
-Zod's boolean coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.
+Zod's coerces values coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.
 
 ```ts
 z.coerce.boolean().parse("tuna"); // => true

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -705,7 +705,7 @@ For more control over coercion logic, consider using [`z.preprocess`](#preproces
 
 **Boolean coercion**
 
-Zod's coerces values coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.
+Zod's approach to coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.
 
 ```ts
 z.coerce.boolean().parse("tuna"); // => true

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -690,6 +690,20 @@ z.coerce.bigint(); // BigInt(input)
 z.coerce.date(); // new Date(input)
 ```
 
+**Coercing nullish values**
+
+Some types allow coercing nullish values. The results may be unexpected.
+You can [use `.pipe()` to handle these cases](#you-can-use-pipe-to-fix-common-issues-with-zcoerce).
+
+```ts
+z.coerce.string().parse(null); // => null
+z.coerce.string().parse(undefined); // => undefined
+z.coerce.number().parse(null); // => 0
+z.coerce.boolean().parse(null); // => false
+z.coerce.boolean().parse(undefined); // => false
+z.coerce.date().parse(null); // => 1970-01-01T00:00:00.000Z
+```
+
 **Boolean coercion**
 
 Zod's boolean coercion is very simple! It passes the value into the `Boolean(value)` function, that's it. Any truthy value will resolve to `true`, any falsy value will resolve to `false`.

--- a/playground.ts
+++ b/playground.ts
@@ -1,32 +1,3 @@
 import { z } from "./src";
-import * as mod from "node:module";
-z;
 
-// @ts-ignore
-// const arg = await import("./index");
-// arg;
-// require.resolve(arg);
-
-load: {
-}
-interface A<T> {
-  name: T;
-  children: any;
-  render(): ReadableStream | string;
-}
-function Hyper<T>(arg: T) {
-  return function () {} as any as {
-    prototype: A<T>;
-    new (): A<T>;
-  };
-}
-
-export default class extends Hyper({ name: 1234 }) {
-  render() {
-    // this.name.name;
-    return `asdf ${this.children} asdf`;
-  }
-}
-
-const a = new Arg();
-a.name;
+console.log(z.coerce.string().safeParse(null));


### PR DESCRIPTION
While the `pipe()` documentation contains a section on how to fix issues with nullish values in `coerce()`. The `coerce()` documentation does not mention that there are issues. This was a pitfall for us. Thus, I'd like to have the nullish value edge cases covered in the `coerce()` section.

Unfortunately, I do not have the language skills to update the Chinese documentation accordingly.