### PR TITLE
fix wrong type in custom validator function data argument

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4859,8 +4859,8 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
 ////////////////////////////////////////
 ////////////////////////////////////////
 type CustomParams = CustomErrorParams & { fatal?: boolean };
-export const custom = <T>(
-  check?: (data: unknown) => any,
+export const custom = <T, D>(
+  check?: (data: D) => any,
   params: string | CustomParams | ((input: any) => CustomParams) = {},
   /**
    * @deprecated


### PR DESCRIPTION
The data argument of the function passed to custom validator was causing the following issue:

```
Argument of type '(data: ...) => boolean' is not assignable to parameter of type '(data: unknown) => any'.
```

I solved it by using a ``D`` generic:
```ts
custom: <T>(check?: ((data: unknown) => any) ... -> custom: <T, D>(check?: ((data: D) => any) ...
```