### PR TITLE
Add z.string().json(...) helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
   - [Dates](#dates)
   - [Times](#times)
   - [IP addresses](#ip-addresses)
+  - [JSON](#json)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -1019,6 +1020,44 @@ ipv4.parse("84d5:51a0:9114:1855:4cfa:f2d7:1f12:7003"); // fail
 const ipv6 = z.string().ip({ version: "v6" });
 ipv6.parse("192.168.1.1"); // fail
 ```
+
+### JSON
+
+The `z.string().json(...)` method parses strings as JSON, then [pipes](#pipe) the result to another specified schema.
+
+```ts
+const Env = z.object({
+  API_CONFIG: z.string().json(
+    z.object({
+      host: z.string(),
+      port: z.number().min(1000).max(2000),
+    })
+  ),
+  SOME_OTHER_VALUE: z.string(),
+});
+
+const env = Env.parse({
+  API_CONFIG: '{ "host": "example.com", "port": 1234 }',
+  SOME_OTHER_VALUE: "abc123",
+});
+
+env.API_CONFIG.host; // returns parsed value
+```
+
+If invalid JSON is encountered, the syntax error will be wrapped and put into a parse error:
+
+```ts
+const env = Env.safeParse({
+  API_CONFIG: "not valid json!",
+  SOME_OTHER_VALUE: "abc123",
+});
+
+if (!env.success) {
+  console.log(env.error); // ... Unexpected token n in JSON at position 0 ...
+}
+```
+
+This is recommended over using `z.string().transform(s => JSON.parse(s))`, since that will not catch parse errors, even when using `.safeParse`.
 
 ## Numbers
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -75,6 +75,7 @@
   - [Dates](#dates)
   - [Times](#times)
   - [IP addresses](#ip-addresses)
+  - [JSON](#json)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -1019,6 +1020,44 @@ ipv4.parse("84d5:51a0:9114:1855:4cfa:f2d7:1f12:7003"); // fail
 const ipv6 = z.string().ip({ version: "v6" });
 ipv6.parse("192.168.1.1"); // fail
 ```
+
+### JSON
+
+The `z.string().json(...)` method parses strings as JSON, then [pipes](#pipe) the result to another specified schema.
+
+```ts
+const Env = z.object({
+  API_CONFIG: z.string().json(
+    z.object({
+      host: z.string(),
+      port: z.number().min(1000).max(2000),
+    })
+  ),
+  SOME_OTHER_VALUE: z.string(),
+});
+
+const env = Env.parse({
+  API_CONFIG: '{ "host": "example.com", "port": 1234 }',
+  SOME_OTHER_VALUE: "abc123",
+});
+
+env.API_CONFIG.host; // returns parsed value
+```
+
+If invalid JSON is encountered, the syntax error will be wrapped and put into a parse error:
+
+```ts
+const env = Env.safeParse({
+  API_CONFIG: "not valid json!",
+  SOME_OTHER_VALUE: "abc123",
+});
+
+if (!env.success) {
+  console.log(env.error); // ... Unexpected token n in JSON at position 0 ...
+}
+```
+
+This is recommended over using `z.string().transform(s => JSON.parse(s))`, since that will not catch parse errors, even when using `.safeParse`.
 
 ## Numbers
 

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -93,7 +93,11 @@ export interface ZodInvalidDateIssue extends ZodIssueBase {
 export type StringValidation =
   | "email"
   | "url"
+<<<<<<< HEAD
   | "jwt"
+=======
+  | "json"
+>>>>>>> c5a2690 (Add z.string().json(...) helper)
   | "emoji"
   | "uuid"
   | "nanoid"

--- a/deno/lib/__tests__/json.test.ts
+++ b/deno/lib/__tests__/json.test.ts
@@ -4,7 +4,7 @@ const test = Deno.test;
 
 import * as z from "../index.ts";
 
-test("parse string to json", () => {
+test("parse string to json", async () => {
   const Env = z.object({
     myJsonConfig: z.string().json(z.object({ foo: z.number() })),
     someOtherValue: z.string(),
@@ -20,58 +20,50 @@ test("parse string to json", () => {
     someOtherValue: "abc",
   });
 
-  expect(() =>
-    Env.parse({
+  await expect(
+    Env.parseAsync({
       myJsonConfig: '{"foo": "not a number!"}',
       someOtherValue: null,
     })
-  ).toThrow(
-    JSON.stringify(
-      [
-        {
-          code: "invalid_type",
-          expected: "number",
-          received: "string",
-          path: ["myJsonConfig", "foo"],
-          message: "Expected number, received string",
-        },
-        {
-          code: "invalid_type",
-          expected: "string",
-          received: "null",
-          path: ["someOtherValue"],
-          message: "Expected string, received null",
-        },
-      ],
-      null,
-      2
-    )
-  );
+  ).rejects.toMatchObject({
+    issues: [
+      {
+        code: "invalid_type",
+        expected: "string",
+        received: "null",
+        path: ["someOtherValue"],
+        message: "Expected string, received null",
+      },
+      {
+        code: "invalid_type",
+        expected: "number",
+        received: "string",
+        path: ["myJsonConfig", "foo"],
+        message: "Expected number, received string",
+      },
+    ],
+  });
 
-  expect(() =>
-    Env.parse({
+  await expect(
+    Env.parseAsync({
       myJsonConfig: "This is not valid json",
       someOtherValue: null,
     })
-  ).toThrow(
-    JSON.stringify(
-      [
-        {
-          code: "invalid_string",
-          validation: "json",
-          message: "Unexpected token T in JSON at position 0",
-          path: ["myJsonConfig"],
-        },
-        {
-          code: "invalid_type",
-          expected: "string",
-          received: "null",
-          path: ["someOtherValue"],
-          message: "Expected string, received null",
-        },
-      ],
-      null,
-      2
-    )
-  );
+  ).rejects.toMatchObject({
+    issues: [
+      {
+        code: "invalid_type",
+        expected: "string",
+        received: "null",
+        path: ["someOtherValue"],
+        message: "Expected string, received null",
+      },
+      {
+        code: "invalid_string",
+        validation: "json",
+        message: "Unexpected token T in JSON at position 0",
+        path: ["myJsonConfig"],
+      },
+    ],
+  });
 });

--- a/deno/lib/__tests__/json.test.ts
+++ b/deno/lib/__tests__/json.test.ts
@@ -4,6 +4,9 @@ const test = Deno.test;
 
 import * as z from "../index.ts";
 
+// @ts-ignore TS2304
+const isDeno = typeof Deno === "object";
+
 test("parse string to json", async () => {
   const Env = z.object({
     myJsonConfig: z.string().json(z.object({ foo: z.number() })),
@@ -20,50 +23,58 @@ test("parse string to json", async () => {
     someOtherValue: "abc",
   });
 
-  await expect(
-    Env.parseAsync({
-      myJsonConfig: '{"foo": "not a number!"}',
-      someOtherValue: null,
-    })
-  ).rejects.toMatchObject({
-    issues: [
-      {
-        code: "invalid_type",
-        expected: "string",
-        received: "null",
-        path: ["someOtherValue"],
-        message: "Expected string, received null",
-      },
-      {
-        code: "invalid_type",
-        expected: "number",
-        received: "string",
-        path: ["myJsonConfig", "foo"],
-        message: "Expected number, received string",
-      },
-    ],
+  const invalidValues = Env.safeParse({
+    myJsonConfig: '{"foo": "not a number!"}',
+    someOtherValue: null,
+  });
+  expect(JSON.parse(JSON.stringify(invalidValues))).toEqual({
+    success: false,
+    error: {
+      name: "ZodError",
+      issues: [
+        {
+          code: "invalid_type",
+          expected: "number",
+          received: "string",
+          path: ["myJsonConfig", "foo"],
+          message: "Expected number, received string",
+        },
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "null",
+          path: ["someOtherValue"],
+          message: "Expected string, received null",
+        },
+      ],
+    },
   });
 
-  await expect(
-    Env.parseAsync({
-      myJsonConfig: "This is not valid json",
-      someOtherValue: null,
-    })
-  ).rejects.toMatchObject({
-    issues: [
-      {
-        code: "invalid_type",
-        expected: "string",
-        received: "null",
-        path: ["someOtherValue"],
-        message: "Expected string, received null",
-      },
-      {
-        code: "invalid_string",
-        validation: "json",
-        message: "Unexpected token T in JSON at position 0",
-        path: ["myJsonConfig"],
-      },
-    ],
+  const invalidJsonSyntax = Env.safeParse({
+    myJsonConfig: "This is not valid json",
+    someOtherValue: null,
+  });
+  expect(JSON.parse(JSON.stringify(invalidJsonSyntax))).toEqual({
+    success: false,
+    error: {
+      name: "ZodError",
+      issues: [
+        {
+          code: "invalid_string",
+          validation: "json",
+          message: isDeno
+            ? `Unexpected token 'T', "This is no"... is not valid JSON`
+            : "Unexpected token T in JSON at position 0",
+          path: ["myJsonConfig"],
+        },
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "null",
+          path: ["someOtherValue"],
+          message: "Expected string, received null",
+        },
+      ],
+    },
   });
 });

--- a/deno/lib/__tests__/json.test.ts
+++ b/deno/lib/__tests__/json.test.ts
@@ -1,0 +1,77 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+test("parse string to json", () => {
+  const Env = z.object({
+    myJsonConfig: z.string().json(z.object({ foo: z.number() })),
+    someOtherValue: z.string(),
+  });
+
+  expect(
+    Env.parse({
+      myJsonConfig: '{ "foo": 123 }',
+      someOtherValue: "abc",
+    })
+  ).toEqual({
+    myJsonConfig: { foo: 123 },
+    someOtherValue: "abc",
+  });
+
+  expect(() =>
+    Env.parse({
+      myJsonConfig: '{"foo": "not a number!"}',
+      someOtherValue: null,
+    })
+  ).toThrow(
+    JSON.stringify(
+      [
+        {
+          code: "invalid_type",
+          expected: "number",
+          received: "string",
+          path: ["myJsonConfig", "foo"],
+          message: "Expected number, received string",
+        },
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "null",
+          path: ["someOtherValue"],
+          message: "Expected string, received null",
+        },
+      ],
+      null,
+      2
+    )
+  );
+
+  expect(() =>
+    Env.parse({
+      myJsonConfig: "This is not valid json",
+      someOtherValue: null,
+    })
+  ).toThrow(
+    JSON.stringify(
+      [
+        {
+          code: "invalid_string",
+          validation: "json",
+          message: "Unexpected token T in JSON at position 0",
+          path: ["myJsonConfig"],
+        },
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "null",
+          path: ["someOtherValue"],
+          message: "Expected string, received null",
+        },
+      ],
+      null,
+      2
+    )
+  );
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -569,6 +569,7 @@ export type ZodStringCheck =
       precision: number | null;
       message?: string;
     }
+<<<<<<< HEAD
   | {
       kind: "date";
       // withDate: true;
@@ -582,6 +583,10 @@ export type ZodStringCheck =
   | { kind: "duration"; message?: string }
   | { kind: "ip"; version?: IpVersion; message?: string }
   | { kind: "base64"; message?: string };
+=======
+  | { kind: "ip"; version?: IpVersion; message?: string }
+  | { kind: "json"; message?: string };
+>>>>>>> ca9c3e1 (Add overload)
 
 export interface ZodStringDef extends ZodTypeDef {
   checks: ZodStringCheck[];
@@ -1019,12 +1024,23 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
+<<<<<<< HEAD
       } else if (check.kind === "base64") {
         if (!base64Regex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "base64",
             code: ZodIssueCode.invalid_string,
+=======
+      } else if (check.kind === "json") {
+        try {
+          JSON.parse(input.data);
+        } catch (err) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_string,
+            validation: "json",
+>>>>>>> ca9c3e1 (Add overload)
             message: check.message,
           });
           status.dirty();
@@ -1199,19 +1215,27 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     });
   }
 
-  json<T extends ZodTypeAny>(shape: T) {
-    return this.transform((val, ctx) => {
+  json(message?: errorUtil.ErrMessage): this;
+  json<T extends ZodTypeAny>(
+    pipeTo: T
+  ): ZodPipeline<ZodEffects<this, any, input<this>>, T>;
+  json(input?: errorUtil.ErrMessage | ZodTypeAny) {
+    if (!(input instanceof ZodType)) {
+      return this._addCheck({ kind: "json", ...errorUtil.errToObj(input) });
+    }
+    const schema = this.transform((val, ctx) => {
       try {
         return JSON.parse(val);
       } catch (error: unknown) {
         ctx.addIssue({
           code: ZodIssueCode.invalid_string,
           validation: "json",
-          message: (error as Error).message,
+          // message: (error as Error).message,
         });
         return NEVER;
       }
-    }).pipe(shape);
+    });
+    return input ? schema.pipe(input) : schema;
   }
 
   min(minLength: number, message?: errorUtil.ErrMessage) {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1199,6 +1199,21 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     });
   }
 
+  json<T extends ZodTypeAny>(shape: T) {
+    return this.transform((val, ctx) => {
+      try {
+        return JSON.parse(val);
+      } catch (error: unknown) {
+        ctx.addIssue({
+          code: ZodIssueCode.invalid_string,
+          validation: "json",
+          message: (error as Error).message,
+        });
+        return NEVER;
+      }
+    }).pipe(shape);
+  }
+
   min(minLength: number, message?: errorUtil.ErrMessage) {
     return this._addCheck({
       kind: "min",

--- a/playground.ts
+++ b/playground.ts
@@ -1,3 +1,3 @@
 import { z } from "./src/index";
 
-z.string().parse("asdf");
+z;

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -94,6 +94,7 @@ export type StringValidation =
   | "email"
   | "url"
   | "jwt"
+  | "json"
   | "emoji"
   | "uuid"
   | "nanoid"

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -6,6 +6,17 @@ import * as z from "../index";
 // @ts-ignore TS2304
 const isDeno = typeof Deno === "object";
 
+test("overload types", () => {
+  const schema = z.string().json();
+  z.util.assertEqual<typeof schema, z.ZodString>(true);
+  const schema2 = z.string().json(z.number());
+  z.util.assertEqual<
+    typeof schema2,
+    z.ZodPipeline<z.ZodEffects<z.ZodString, any, string>, z.ZodNumber>
+  >(true);
+  const r2 = schema2.parse("12");
+  z.util.assertEqual<number, typeof r2>(true);
+});
 test("parse string to json", async () => {
   const Env = z.object({
     myJsonConfig: z.string().json(z.object({ foo: z.number() })),
@@ -61,9 +72,7 @@ test("parse string to json", async () => {
         {
           code: "invalid_string",
           validation: "json",
-          message: isDeno
-            ? `Unexpected token 'T', "This is no"... is not valid JSON`
-            : "Unexpected token T in JSON at position 0",
+          message: "Invalid json",
           path: ["myJsonConfig"],
         },
         {
@@ -76,4 +85,17 @@ test("parse string to json", async () => {
       ],
     },
   });
+});
+
+test("no argument", () => {
+  const schema = z.string().json();
+  z.util.assertEqual<typeof schema, z.ZodString>(true);
+  z.string().json().parse(`{}`);
+  z.string().json().parse(`null`);
+  z.string().json().parse(`12`);
+  z.string().json().parse(`{ "test": "test"}`);
+  expect(() => z.string().json().parse(`asdf`)).toThrow();
+  expect(() => z.string().json().parse(`{ "test": undefined }`)).toThrow();
+  expect(() => z.string().json().parse(`{ "test": 12n }`)).toThrow();
+  expect(() => z.string().json().parse(`{ test: "test" }`)).toThrow();
 });

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -1,0 +1,76 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+
+test("parse string to json", () => {
+  const Env = z.object({
+    myJsonConfig: z.string().json(z.object({ foo: z.number() })),
+    someOtherValue: z.string(),
+  });
+
+  expect(
+    Env.parse({
+      myJsonConfig: '{ "foo": 123 }',
+      someOtherValue: "abc",
+    })
+  ).toEqual({
+    myJsonConfig: { foo: 123 },
+    someOtherValue: "abc",
+  });
+
+  expect(() =>
+    Env.parse({
+      myJsonConfig: '{"foo": "not a number!"}',
+      someOtherValue: null,
+    })
+  ).toThrow(
+    JSON.stringify(
+      [
+        {
+          code: "invalid_type",
+          expected: "number",
+          received: "string",
+          path: ["myJsonConfig", "foo"],
+          message: "Expected number, received string",
+        },
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "null",
+          path: ["someOtherValue"],
+          message: "Expected string, received null",
+        },
+      ],
+      null,
+      2
+    )
+  );
+
+  expect(() =>
+    Env.parse({
+      myJsonConfig: "This is not valid json",
+      someOtherValue: null,
+    })
+  ).toThrow(
+    JSON.stringify(
+      [
+        {
+          code: "invalid_string",
+          validation: "json",
+          message: "Unexpected token T in JSON at position 0",
+          path: ["myJsonConfig"],
+        },
+        {
+          code: "invalid_type",
+          expected: "string",
+          received: "null",
+          path: ["someOtherValue"],
+          message: "Expected string, received null",
+        },
+      ],
+      null,
+      2
+    )
+  );
+});

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@jest/globals";
 
 import * as z from "../index";
 
-test("parse string to json", () => {
+test("parse string to json", async () => {
   const Env = z.object({
     myJsonConfig: z.string().json(z.object({ foo: z.number() })),
     someOtherValue: z.string(),
@@ -19,58 +19,50 @@ test("parse string to json", () => {
     someOtherValue: "abc",
   });
 
-  expect(() =>
-    Env.parse({
+  await expect(
+    Env.parseAsync({
       myJsonConfig: '{"foo": "not a number!"}',
       someOtherValue: null,
     })
-  ).toThrow(
-    JSON.stringify(
-      [
-        {
-          code: "invalid_type",
-          expected: "number",
-          received: "string",
-          path: ["myJsonConfig", "foo"],
-          message: "Expected number, received string",
-        },
-        {
-          code: "invalid_type",
-          expected: "string",
-          received: "null",
-          path: ["someOtherValue"],
-          message: "Expected string, received null",
-        },
-      ],
-      null,
-      2
-    )
-  );
+  ).rejects.toMatchObject({
+    issues: [
+      {
+        code: "invalid_type",
+        expected: "string",
+        received: "null",
+        path: ["someOtherValue"],
+        message: "Expected string, received null",
+      },
+      {
+        code: "invalid_type",
+        expected: "number",
+        received: "string",
+        path: ["myJsonConfig", "foo"],
+        message: "Expected number, received string",
+      },
+    ],
+  });
 
-  expect(() =>
-    Env.parse({
+  await expect(
+    Env.parseAsync({
       myJsonConfig: "This is not valid json",
       someOtherValue: null,
     })
-  ).toThrow(
-    JSON.stringify(
-      [
-        {
-          code: "invalid_string",
-          validation: "json",
-          message: "Unexpected token T in JSON at position 0",
-          path: ["myJsonConfig"],
-        },
-        {
-          code: "invalid_type",
-          expected: "string",
-          received: "null",
-          path: ["someOtherValue"],
-          message: "Expected string, received null",
-        },
-      ],
-      null,
-      2
-    )
-  );
+  ).rejects.toMatchObject({
+    issues: [
+      {
+        code: "invalid_type",
+        expected: "string",
+        received: "null",
+        path: ["someOtherValue"],
+        message: "Expected string, received null",
+      },
+      {
+        code: "invalid_string",
+        validation: "json",
+        message: "Unexpected token T in JSON at position 0",
+        path: ["myJsonConfig"],
+      },
+    ],
+  });
 });

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,5 +1,4 @@
 import { util } from "../helpers";
-
 import { ZodErrorMap, ZodIssueCode } from "../ZodError";
 
 const errorMap: ZodErrorMap = (issue, _ctx) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -581,7 +581,8 @@ export type ZodStringCheck =
     }
   | { kind: "duration"; message?: string }
   | { kind: "ip"; version?: IpVersion; message?: string }
-  | { kind: "base64"; message?: string };
+  | { kind: "base64"; message?: string }
+  | { kind: "json"; message?: string };
 
 export interface ZodStringDef extends ZodTypeDef {
   checks: ZodStringCheck[];
@@ -1029,6 +1030,18 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
+      } else if (check.kind === "json") {
+        try {
+          JSON.parse(input.data);
+        } catch (err) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            code: ZodIssueCode.invalid_string,
+            validation: "json",
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else {
         util.assertNever(check);
       }
@@ -1199,19 +1212,27 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     });
   }
 
-  json<T extends ZodTypeAny>(shape: T) {
-    return this.transform((val, ctx) => {
+  json(message?: errorUtil.ErrMessage): this;
+  json<T extends ZodTypeAny>(
+    pipeTo: T
+  ): ZodPipeline<ZodEffects<this, any, input<this>>, T>;
+  json(input?: errorUtil.ErrMessage | ZodTypeAny) {
+    if (!(input instanceof ZodType)) {
+      return this._addCheck({ kind: "json", ...errorUtil.errToObj(input) });
+    }
+    const schema = this.transform((val, ctx) => {
       try {
         return JSON.parse(val);
       } catch (error: unknown) {
         ctx.addIssue({
           code: ZodIssueCode.invalid_string,
           validation: "json",
-          message: (error as Error).message,
+          // message: (error as Error).message,
         });
         return NEVER;
       }
-    }).pipe(shape);
+    });
+    return input ? schema.pipe(input) : schema;
   }
 
   min(minLength: number, message?: errorUtil.ErrMessage) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1199,6 +1199,21 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     });
   }
 
+  json<T extends ZodTypeAny>(shape: T) {
+    return this.transform((val, ctx) => {
+      try {
+        return JSON.parse(val);
+      } catch (error: unknown) {
+        ctx.addIssue({
+          code: ZodIssueCode.invalid_string,
+          validation: "json",
+          message: (error as Error).message,
+        });
+        return NEVER;
+      }
+    }).pipe(shape);
+  }
+
   min(minLength: number, message?: errorUtil.ErrMessage) {
     return this._addCheck({
       kind: "min",


### PR DESCRIPTION
Based on https://github.com/colinhacks/zod/issues/3077#issuecomment-1878470503. I started playing around to see how quick it would be to implement, and it ended up being very quick - so opening a PR in hopes the idea is accepted.

Copying from the readme for the `z.string().json(...)` method - the linked issue has more details on the motivation:

### JSON

The `z.string().json(...)` method parses strings as JSON, then pipes the result to another specified schema.

```ts
const Env = z.object({
  API_CONFIG: z.string().json(
    z.object({
      host: z.string(),
      port: z.number().min(1000).max(2000),
    })
  ),
  SOME_OTHER_VALUE: z.string(),
});

const env = Env.parse({
  API_CONFIG: '{ "host": "example.com", "port": 1234 }',
  SOME_OTHER_VALUE: "abc123",
});

env.API_CONFIG.host; // returns parsed value
```

If invalid JSON is encountered, the syntax error will be wrapped and put into a parse error:

```ts
const env = Env.safeParse({
  API_CONFIG: "not valid json!",
  SOME_OTHER_VALUE: "abc123",
});

if (!env.success) {
  console.log(env.error); // ... Unexpected token n in JSON at position 0 ...
}
```

This is recommended over using `z.string().transform(s => JSON.parse(s))`, since that will not catch parse errors, even when using `.safeParse`.