### PR TITLE
feat: add method to find if the given field is required #3103

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2692,6 +2692,12 @@ export class ZodObject<
     ) as any;
   }
 
+  isKeyRequired(key: string) {
+    const { shape, keys: shapeKeys } = this._getCached();
+    if (!shapeKeys.find((shapeKey) => shapeKey === key)) return false;
+    return !shape[key].isOptional();
+  }
+
   static create = <T extends ZodRawShape>(
     shape: T,
     params?: RawCreateParams

--- a/src/types.ts
+++ b/src/types.ts
@@ -2692,6 +2692,12 @@ export class ZodObject<
     ) as any;
   }
 
+  isKeyRequired(key: string) {
+    const { shape, keys: shapeKeys } = this._getCached();
+    if (!shapeKeys.find((shapeKey) => shapeKey === key)) return false;
+    return !shape[key].isOptional();
+  }
+
   static create = <T extends ZodRawShape>(
     shape: T,
     params?: RawCreateParams


### PR DESCRIPTION
Added the method to check if a given key is required or not.

```ts
const schema = z.object({
  name: z.string()
})

console.log(schema.isKeyRequired("name")) // true
console.log(schema.isKeyRequired("foo")) // false
```