### PR TITLE
Schema in object being inferred differently

### DIFF
--- a/deno/lib/__tests__/unions.test.ts
+++ b/deno/lib/__tests__/unions.test.ts
@@ -63,3 +63,11 @@ test("readonly union", async () => {
   union.parse("asdf");
   union.parse(12);
 });
+
+test("nested no undefined", () => {
+  const inner = z.string().or(z.array(z.string()));
+  const outer = z.object({ inner });
+  type outerSchema = z.infer<typeof outer>;
+  z.util.assertEqual<outerSchema, { inner: string | string[] }>(true);
+  expect(outer.safeParse({ inner: undefined }).success).toEqual(false);
+});

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -100,9 +100,9 @@ export namespace objectUtil {
     [k in Exclude<keyof U, keyof V>]: U[k];
   } & V;
 
-  // type optionalKeys<T extends object> = {
-  //   [k in keyof T]: undefined extends T[k] ? k : never;
-  // }[keyof T];
+  type optionalKeys<T extends object> = {
+    [k in keyof T]: undefined extends T[k] ? k : never;
+  }[keyof T];
 
   type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
@@ -110,11 +110,13 @@ export namespace objectUtil {
 
   // type alkjsdf = addQuestionMarks<{ a: any }>;
 
+  // only add question marks if there are optional keys
+  // need to check explicitly for this to work
   export type addQuestionMarks<
     T extends object,
     R extends keyof T = requiredKeys<T>
     // O extends keyof T = optionalKeys<T>
-  > = Pick<Required<T>, R> & Partial<T>;
+  > = Pick<Required<T>, R> & (optionalKeys<T> extends never ? T : Partial<T>);
   //  = { [k in O]?: T[k] } & { [k in R]: T[k] };
 
   export type identity<T> = T;

--- a/src/__tests__/unions.test.ts
+++ b/src/__tests__/unions.test.ts
@@ -62,3 +62,11 @@ test("readonly union", async () => {
   union.parse("asdf");
   union.parse(12);
 });
+
+test("nested no undefined", () => {
+  const inner = z.string().or(z.array(z.string()));
+  const outer = z.object({ inner });
+  type outerSchema = z.infer<typeof outer>;
+  z.util.assertEqual<outerSchema, { inner: string | string[] }>(true);
+  expect(outer.safeParse({ inner: undefined }).success).toEqual(false);
+});

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -100,9 +100,9 @@ export namespace objectUtil {
     [k in Exclude<keyof U, keyof V>]: U[k];
   } & V;
 
-  // type optionalKeys<T extends object> = {
-  //   [k in keyof T]: undefined extends T[k] ? k : never;
-  // }[keyof T];
+  type optionalKeys<T extends object> = {
+    [k in keyof T]: undefined extends T[k] ? k : never;
+  }[keyof T];
 
   type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
@@ -110,11 +110,13 @@ export namespace objectUtil {
 
   // type alkjsdf = addQuestionMarks<{ a: any }>;
 
+  // only add question marks if there are optional keys
+  // need to check explicitly for this to work
   export type addQuestionMarks<
     T extends object,
     R extends keyof T = requiredKeys<T>
     // O extends keyof T = optionalKeys<T>
-  > = Pick<Required<T>, R> & Partial<T>;
+  > = Pick<Required<T>, R> & (optionalKeys<T> extends never ? T : Partial<T>);
   //  = { [k in O]?: T[k] } & { [k in R]: T[k] };
 
   export type identity<T> = T;


### PR DESCRIPTION
fixes: https://github.com/colinhacks/zod/issues/2654

Done by explicitly checking if there are any optional keys in the object and then adding to `addQuestionMarks` type in `utils`