### PR TITLE
Error message based on input value

### DIFF
--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -516,31 +516,116 @@ test("literal bigint default error message", () => {
   }
 });
 
-test("custom error message based on input value", () => {
-  const schema = z
-    .string({
-      invalid_type_error: (value) => `Expected a string, received: ${value}`,
-    })
-    .min(2, {
-      message: (value) =>
-        `Expected a string with at least 2 characters, received: ${value}`,
-    });
+test("string custom error message for invalid types", () => {
+  const schema = z.string({
+    invalid_type_error: (value) =>
+      `I was actually expecting a string, but received a ${value}`,
+  });
 
-  const result = schema.safeParse(3);
+  const result1 = schema.safeParse(3);
 
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual(
-      `Expected a string, received: number`
+  expect(result1.success).toEqual(false);
+  if (!result1.success) {
+    expect(result1.error.issues[0].message).toEqual(
+      `I was actually expecting a string, but received a Number`
     );
   }
 
-  const result2 = schema.safeParse("f");
+  const result2 = schema.safeParse(true);
 
   expect(result2.success).toEqual(false);
   if (!result2.success) {
     expect(result2.error.issues[0].message).toEqual(
-      `Expected a string with at least 2 characters, received: 1`
+      `I was actually expecting a string, but received a Boolean`
+    );
+  }
+});
+
+test("string static custom error message for invalid type", () => {
+  const schema = z.string({
+    invalid_type_error: `I was actually expecting a string`,
+  });
+
+  const result1 = schema.safeParse(3);
+
+  expect(result1.success).toEqual(false);
+  if (!result1.success) {
+    expect(result1.error.issues[0].message).toEqual(
+      `I was actually expecting a string`
+    );
+  }
+});
+
+test("string custom error message for invalid min length", () => {
+  const minLength = 10;
+  const stringTested = "tiny text"; // length 9
+
+  const schema = z.string().min(minLength, {
+    message: (value) =>
+      `Expected a string with at least ${minLength} characters, received: ${value}`,
+  });
+
+  const result = schema.safeParse(stringTested);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string with at least 10 characters, received: 9`
+    );
+  }
+});
+
+test("string static custom error message for invalid min length", () => {
+  const minLength = 1;
+  const stringTested = "";
+
+  const schema = z.string().min(minLength, {
+    message: `Expected a string with at least 1 character`,
+  });
+
+  const result = schema.safeParse(stringTested);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string with at least 1 character`
+    );
+  }
+});
+
+test("string custom error message for invalid max length", () => {
+  const maxLength = 7;
+  const stringTested = "big text"; // length 8
+
+  const schema = z.string().max(maxLength, {
+    message: (value) =>
+      `Expected a string with at least ${maxLength} characters, received: ${value}`,
+  });
+
+  const result = schema.safeParse(stringTested);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string with at least 7 characters, received: 8`
+    );
+  }
+});
+
+test("string static custom error message for invalid max length", () => {
+  const maxLength = 2;
+  const stringTested = "foo";
+
+  const schema = z.string().max(maxLength, {
+    message: `Expected a string with maximum of 2 characters`,
+  });
+
+  const result = schema.safeParse(stringTested);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string with maximum of 2 characters`
     );
   }
 });

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -516,6 +516,26 @@ test("literal bigint default error message", () => {
   }
 });
 
+test("custom error message based on input value", () => {
+  const schema = z
+    .string({ invalid_type_error: value => `Expected a string, received: ${value}` })
+    .min(2, { message: value => `Expected a string, received: number ${value}` });
+
+  const result = schema.safeParse(3);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(`Expected a string, received: number`);
+  }
+
+  const result2 = schema.safeParse('f');
+  
+  expect(result2.success).toEqual(false);
+  if (!result2.success) {
+    expect(result2.error.issues[0].message).toEqual(`Expected a string, received: number 1`);
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -518,21 +518,30 @@ test("literal bigint default error message", () => {
 
 test("custom error message based on input value", () => {
   const schema = z
-    .string({ invalid_type_error: value => `Expected a string, received: ${value}` })
-    .min(2, { message: value => `Expected a string, received: number ${value}` });
+    .string({
+      invalid_type_error: (value) => `Expected a string, received: ${value}`,
+    })
+    .min(2, {
+      message: (value) =>
+        `Expected a string with at least 2 characters, received: ${value}`,
+    });
 
   const result = schema.safeParse(3);
 
   expect(result.success).toEqual(false);
   if (!result.success) {
-    expect(result.error.issues[0].message).toEqual(`Expected a string, received: number`);
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string, received: number`
+    );
   }
 
-  const result2 = schema.safeParse('f');
-  
+  const result2 = schema.safeParse("f");
+
   expect(result2.success).toEqual(false);
   if (!result2.success) {
-    expect(result2.error.issues[0].message).toEqual(`Expected a string, received: number 1`);
+    expect(result2.error.issues[0].message).toEqual(
+      `Expected a string with at least 2 characters, received: 1`
+    );
   }
 });
 

--- a/deno/lib/helpers/errorUtil.ts
+++ b/deno/lib/helpers/errorUtil.ts
@@ -4,4 +4,6 @@ export namespace errorUtil {
     typeof message === "string" ? { message } : message || {};
   export const toString = (message?: ErrMessage): string | undefined =>
     typeof message === "string" ? message : message?.message;
+
+  export type ErrMessageCallback = (value: string) => string;
 }

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -517,21 +517,30 @@ test("literal bigint default error message", () => {
 
 test("custom error message based on input value", () => {
   const schema = z
-    .string({ invalid_type_error: value => `Expected a string, received: ${value}` })
-    .min(2, { message: value => `Expected a string, received: number ${value}` });
+    .string({
+      invalid_type_error: (value) => `Expected a string, received: ${value}`,
+    })
+    .min(2, {
+      message: (value) =>
+        `Expected a string with at least 2 characters, received: ${value}`,
+    });
 
   const result = schema.safeParse(3);
 
   expect(result.success).toEqual(false);
   if (!result.success) {
-    expect(result.error.issues[0].message).toEqual(`Expected a string, received: number`);
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string, received: number`
+    );
   }
 
-  const result2 = schema.safeParse('f');
-  
+  const result2 = schema.safeParse("f");
+
   expect(result2.success).toEqual(false);
   if (!result2.success) {
-    expect(result2.error.issues[0].message).toEqual(`Expected a string, received: number 1`);
+    expect(result2.error.issues[0].message).toEqual(
+      `Expected a string with at least 2 characters, received: 1`
+    );
   }
 });
 

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -515,6 +515,26 @@ test("literal bigint default error message", () => {
   }
 });
 
+test("custom error message based on input value", () => {
+  const schema = z
+    .string({ invalid_type_error: value => `Expected a string, received: ${value}` })
+    .min(2, { message: value => `Expected a string, received: number ${value}` });
+
+  const result = schema.safeParse(3);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(`Expected a string, received: number`);
+  }
+
+  const result2 = schema.safeParse('f');
+  
+  expect(result2.success).toEqual(false);
+  if (!result2.success) {
+    expect(result2.error.issues[0].message).toEqual(`Expected a string, received: number 1`);
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -515,31 +515,116 @@ test("literal bigint default error message", () => {
   }
 });
 
-test("custom error message based on input value", () => {
-  const schema = z
-    .string({
-      invalid_type_error: (value) => `Expected a string, received: ${value}`,
-    })
-    .min(2, {
-      message: (value) =>
-        `Expected a string with at least 2 characters, received: ${value}`,
-    });
+test("string custom error message for invalid types", () => {
+  const schema = z.string({
+    invalid_type_error: (value) =>
+      `I was actually expecting a string, but received a ${value}`,
+  });
 
-  const result = schema.safeParse(3);
+  const result1 = schema.safeParse(3);
 
-  expect(result.success).toEqual(false);
-  if (!result.success) {
-    expect(result.error.issues[0].message).toEqual(
-      `Expected a string, received: number`
+  expect(result1.success).toEqual(false);
+  if (!result1.success) {
+    expect(result1.error.issues[0].message).toEqual(
+      `I was actually expecting a string, but received a Number`
     );
   }
 
-  const result2 = schema.safeParse("f");
+  const result2 = schema.safeParse(true);
 
   expect(result2.success).toEqual(false);
   if (!result2.success) {
     expect(result2.error.issues[0].message).toEqual(
-      `Expected a string with at least 2 characters, received: 1`
+      `I was actually expecting a string, but received a Boolean`
+    );
+  }
+});
+
+test("string static custom error message for invalid type", () => {
+  const schema = z.string({
+    invalid_type_error: `I was actually expecting a string`,
+  });
+
+  const result1 = schema.safeParse(3);
+
+  expect(result1.success).toEqual(false);
+  if (!result1.success) {
+    expect(result1.error.issues[0].message).toEqual(
+      `I was actually expecting a string`
+    );
+  }
+});
+
+test("string custom error message for invalid min length", () => {
+  const minLength = 10;
+  const stringTested = "tiny text"; // length 9
+
+  const schema = z.string().min(minLength, {
+    message: (value) =>
+      `Expected a string with at least ${minLength} characters, received: ${value}`,
+  });
+
+  const result = schema.safeParse(stringTested);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string with at least 10 characters, received: 9`
+    );
+  }
+});
+
+test("string static custom error message for invalid min length", () => {
+  const minLength = 1;
+  const stringTested = "";
+
+  const schema = z.string().min(minLength, {
+    message: `Expected a string with at least 1 character`,
+  });
+
+  const result = schema.safeParse(stringTested);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string with at least 1 character`
+    );
+  }
+});
+
+test("string custom error message for invalid max length", () => {
+  const maxLength = 7;
+  const stringTested = "big text"; // length 8
+
+  const schema = z.string().max(maxLength, {
+    message: (value) =>
+      `Expected a string with at least ${maxLength} characters, received: ${value}`,
+  });
+
+  const result = schema.safeParse(stringTested);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string with at least 7 characters, received: 8`
+    );
+  }
+});
+
+test("string static custom error message for invalid max length", () => {
+  const maxLength = 2;
+  const stringTested = "foo";
+
+  const schema = z.string().max(maxLength, {
+    message: `Expected a string with maximum of 2 characters`,
+  });
+
+  const result = schema.safeParse(stringTested);
+
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual(
+      `Expected a string with maximum of 2 characters`
     );
   }
 });

--- a/src/helpers/errorUtil.ts
+++ b/src/helpers/errorUtil.ts
@@ -4,4 +4,6 @@ export namespace errorUtil {
     typeof message === "string" ? { message } : message || {};
   export const toString = (message?: ErrMessage): string | undefined =>
     typeof message === "string" ? message : message?.message;
+
+  export type ErrMessageCallback = (value: string) => string;
 }


### PR DESCRIPTION
Issue: #3048

Generate error message based on the input value
```ts
z
  .string({ invalid_type_error: value => 'Expected a string, received: ' + String(value) })
  .min(2, { message: value => 'Expected a string with at least 2 characters, received: ' + String(value) })
```