### PR TITLE
add custom error message on nativeEnum validation

### DIFF
--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -59,19 +59,27 @@ test("extract/exclude", () => {
   util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });
 
-test('error map in extract/exclude', () => {
+test("error map in extract/exclude", () => {
   const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
-  const FoodEnum = z.enum(foods, { errorMap: () => ({ message: "This is not food!" }) });
+  const FoodEnum = z.enum(foods, {
+    errorMap: () => ({ message: "This is not food!" }),
+  });
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const foodsError = FoodEnum.safeParse("Cucumbers");
   const italianError = ItalianEnum.safeParse("Tacos");
   if (!foodsError.success && !italianError.success) {
-    expect(foodsError.error.issues[0].message).toEqual(italianError.error.issues[0].message);
+    expect(foodsError.error.issues[0].message).toEqual(
+      italianError.error.issues[0].message
+    );
   }
 
-  const UnhealthyEnum = FoodEnum.exclude(["Salad"], { errorMap: () => ({ message: "This is not healthy food!" }) });
+  const UnhealthyEnum = FoodEnum.exclude(["Salad"], {
+    errorMap: () => ({ message: "This is not healthy food!" }),
+  });
   const unhealthyError = UnhealthyEnum.safeParse("Salad");
   if (!unhealthyError.success) {
-    expect(unhealthyError.error.issues[0].message).toEqual("This is not healthy food!");
+    expect(unhealthyError.error.issues[0].message).toEqual(
+      "This is not healthy food!"
+    );
   }
 });

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -531,12 +531,12 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
     PROCESSED = "PROCESSED",
   }
 
-  const OrderStatusValidatorViaNativeEnum = z.nativeEnum(OrderStatusEnum, {
-    invalid_enum_value: "the enum provided is invalid",
+  const schema = z.nativeEnum(OrderStatusEnum, {
+    invalid_type_error: "the enum provided is invalid",
     required_error: "status is required",
   });
 
-  const result1 = OrderStatusValidatorViaNativeEnum.safeParse("UNPROCESSEED");
+  const result1 = schema.safeParse("UNPROCESSEED");
   expect(result1.success).toEqual(false);
   if (!result1.success) {
     expect(result1.error.issues[0].message).toEqual(
@@ -544,15 +544,13 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
     );
   }
 
-  const result2 = OrderStatusValidatorViaNativeEnum.safeParse(undefined);
+  const result2 = schema.safeParse(undefined);
   expect(result2.success).toEqual(false);
   if (!result2.success) {
     expect(result2.error.issues[0].message).toEqual("status is required");
   }
 
-  const result3 = OrderStatusValidatorViaNativeEnum.safeParse(
-    OrderStatusEnum.NEW
-  );
+  const result3 = schema.safeParse(OrderStatusEnum.NEW);
   expect(result3.success).toEqual(true);
 });
 

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -525,6 +525,37 @@ test("when the message is falsy, it is used as is provided", () => {
   }
 });
 
+test("nativeEnum with invalid_type_error returns custom error message", () => {
+  enum OrderStatusEnum {
+    NEW = "NEW",
+    PROCESSED = "PROCESSED",
+  }
+
+  const OrderStatusValidatorViaNativeEnum = z.nativeEnum(OrderStatusEnum, {
+    invalid_enum_value: "the enum provided is invalid",
+    required_error: "status is required",
+  });
+
+  const result1 = OrderStatusValidatorViaNativeEnum.safeParse("UNPROCESSEED");
+  expect(result1.success).toEqual(false);
+  if (!result1.success) {
+    expect(result1.error.issues[0].message).toEqual(
+      "the enum provided is invalid"
+    );
+  }
+
+  const result2 = OrderStatusValidatorViaNativeEnum.safeParse(undefined);
+  expect(result2.success).toEqual(false);
+  if (!result2.success) {
+    expect(result2.error.issues[0].message).toEqual("status is required");
+  }
+
+  const result3 = OrderStatusValidatorViaNativeEnum.safeParse(
+    OrderStatusEnum.NEW
+  );
+  expect(result3.success).toEqual(true);
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -532,7 +532,7 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
   }
 
   const schema = z.nativeEnum(OrderStatusEnum, {
-    invalid_type_error: "the enum provided is invalid",
+    invalid_type_error: "the value provided is invalid",
     required_error: "status is required",
   });
 
@@ -540,7 +540,7 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
   expect(result1.success).toEqual(false);
   if (!result1.success) {
     expect(result1.error.issues[0].message).toEqual(
-      "the enum provided is invalid"
+      "the value provided is invalid"
     );
   }
 
@@ -552,6 +552,14 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
 
   const result3 = schema.safeParse(OrderStatusEnum.NEW);
   expect(result3.success).toEqual(true);
+
+  const result4 = schema.safeParse(null);
+  expect(result4.success).toEqual(false);
+  if (!result4.success) {
+    expect(result4.error.issues[0].message).toEqual(
+      "the value provided is invalid"
+    );
+  }
 });
 
 // test("dont short circuit on continuable errors", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -635,11 +635,15 @@ export class ZodString extends ZodType<string, ZodStringDef> {
 
     if (parsedType !== ZodParsedType.string) {
       const ctx = this._getOrReturnCtx(input);
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_type,
-        expected: ZodParsedType.string,
-        received: ctx.parsedType,
-      });
+      addIssueToContext(
+        ctx,
+        {
+          code: ZodIssueCode.invalid_type,
+          expected: ZodParsedType.string,
+          received: ctx.parsedType,
+        }
+        //
+      );
       return INVALID;
     }
 
@@ -4108,7 +4112,6 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       ctx.parsedType !== ZodParsedType.number
     ) {
       const expectedValues = util.objectValues(nativeEnumValues);
-
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -635,15 +635,11 @@ export class ZodString extends ZodType<string, ZodStringDef> {
 
     if (parsedType !== ZodParsedType.string) {
       const ctx = this._getOrReturnCtx(input);
-      addIssueToContext(
-        ctx,
-        {
-          code: ZodIssueCode.invalid_type,
-          expected: ZodParsedType.string,
-          received: ctx.parsedType,
-        }
-        //
-      );
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.string,
+        received: ctx.parsedType,
+      });
       return INVALID;
     }
 
@@ -4095,7 +4091,6 @@ export interface ZodNativeEnumDef<T extends EnumLike = EnumLike>
   extends ZodTypeDef {
   values: T;
   typeName: ZodFirstPartyTypeKind.ZodNativeEnum;
-  message?: string | undefined;
 }
 
 export type EnumLike = { [k: string]: string | number; [nu: number]: string };
@@ -4113,26 +4108,22 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       ctx.parsedType !== ZodParsedType.number
     ) {
       const expectedValues = util.objectValues(nativeEnumValues);
-      const message = this._def.message;
 
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,
         code: ZodIssueCode.invalid_type,
-        message: message,
       });
       return INVALID;
     }
 
     if (nativeEnumValues.indexOf(input.data) === -1) {
       const expectedValues = util.objectValues(nativeEnumValues);
-      const message = this._def.message;
 
       addIssueToContext(ctx, {
         received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
         options: expectedValues,
-        message: message,
       });
       return INVALID;
     }

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -58,19 +58,27 @@ test("extract/exclude", () => {
   util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });
 
-test('error map in extract/exclude', () => {
+test("error map in extract/exclude", () => {
   const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
-  const FoodEnum = z.enum(foods, { errorMap: () => ({ message: "This is not food!" }) });
+  const FoodEnum = z.enum(foods, {
+    errorMap: () => ({ message: "This is not food!" }),
+  });
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const foodsError = FoodEnum.safeParse("Cucumbers");
   const italianError = ItalianEnum.safeParse("Tacos");
   if (!foodsError.success && !italianError.success) {
-    expect(foodsError.error.issues[0].message).toEqual(italianError.error.issues[0].message);
+    expect(foodsError.error.issues[0].message).toEqual(
+      italianError.error.issues[0].message
+    );
   }
 
-  const UnhealthyEnum = FoodEnum.exclude(["Salad"], { errorMap: () => ({ message: "This is not healthy food!" }) });
+  const UnhealthyEnum = FoodEnum.exclude(["Salad"], {
+    errorMap: () => ({ message: "This is not healthy food!" }),
+  });
   const unhealthyError = UnhealthyEnum.safeParse("Salad");
   if (!unhealthyError.success) {
-    expect(unhealthyError.error.issues[0].message).toEqual("This is not healthy food!");
+    expect(unhealthyError.error.issues[0].message).toEqual(
+      "This is not healthy food!"
+    );
   }
 });

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -524,6 +524,37 @@ test("when the message is falsy, it is used as is provided", () => {
   }
 });
 
+test("nativeEnum with invalid_type_error returns custom error message", () => {
+  enum OrderStatusEnum {
+    NEW = "NEW",
+    PROCESSED = "PROCESSED",
+  }
+
+  const OrderStatusValidatorViaNativeEnum = z.nativeEnum(OrderStatusEnum, {
+    invalid_enum_value: "the enum provided is invalid",
+    required_error: "status is required",
+  });
+
+  const result1 = OrderStatusValidatorViaNativeEnum.safeParse("UNPROCESSEED");
+  expect(result1.success).toEqual(false);
+  if (!result1.success) {
+    expect(result1.error.issues[0].message).toEqual(
+      "the enum provided is invalid"
+    );
+  }
+
+  const result2 = OrderStatusValidatorViaNativeEnum.safeParse(undefined);
+  expect(result2.success).toEqual(false);
+  if (!result2.success) {
+    expect(result2.error.issues[0].message).toEqual("status is required");
+  }
+
+  const result3 = OrderStatusValidatorViaNativeEnum.safeParse(
+    OrderStatusEnum.NEW
+  );
+  expect(result3.success).toEqual(true);
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -531,7 +531,7 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
   }
 
   const schema = z.nativeEnum(OrderStatusEnum, {
-    invalid_type_error: "the enum provided is invalid",
+    invalid_type_error: "the value provided is invalid",
     required_error: "status is required",
   });
 
@@ -539,7 +539,7 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
   expect(result1.success).toEqual(false);
   if (!result1.success) {
     expect(result1.error.issues[0].message).toEqual(
-      "the enum provided is invalid"
+      "the value provided is invalid"
     );
   }
 
@@ -551,6 +551,14 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
 
   const result3 = schema.safeParse(OrderStatusEnum.NEW);
   expect(result3.success).toEqual(true);
+
+  const result4 = schema.safeParse(null);
+  expect(result4.success).toEqual(false);
+  if (!result4.success) {
+    expect(result4.error.issues[0].message).toEqual(
+      "the value provided is invalid"
+    );
+  }
 });
 
 // test("dont short circuit on continuable errors", () => {

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -530,12 +530,12 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
     PROCESSED = "PROCESSED",
   }
 
-  const OrderStatusValidatorViaNativeEnum = z.nativeEnum(OrderStatusEnum, {
-    invalid_enum_value: "the enum provided is invalid",
+  const schema = z.nativeEnum(OrderStatusEnum, {
+    invalid_type_error: "the enum provided is invalid",
     required_error: "status is required",
   });
 
-  const result1 = OrderStatusValidatorViaNativeEnum.safeParse("UNPROCESSEED");
+  const result1 = schema.safeParse("UNPROCESSEED");
   expect(result1.success).toEqual(false);
   if (!result1.success) {
     expect(result1.error.issues[0].message).toEqual(
@@ -543,15 +543,13 @@ test("nativeEnum with invalid_type_error returns custom error message", () => {
     );
   }
 
-  const result2 = OrderStatusValidatorViaNativeEnum.safeParse(undefined);
+  const result2 = schema.safeParse(undefined);
   expect(result2.success).toEqual(false);
   if (!result2.success) {
     expect(result2.error.issues[0].message).toEqual("status is required");
   }
 
-  const result3 = OrderStatusValidatorViaNativeEnum.safeParse(
-    OrderStatusEnum.NEW
-  );
+  const result3 = schema.safeParse(OrderStatusEnum.NEW);
   expect(result3.success).toEqual(true);
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -635,11 +635,15 @@ export class ZodString extends ZodType<string, ZodStringDef> {
 
     if (parsedType !== ZodParsedType.string) {
       const ctx = this._getOrReturnCtx(input);
-      addIssueToContext(ctx, {
-        code: ZodIssueCode.invalid_type,
-        expected: ZodParsedType.string,
-        received: ctx.parsedType,
-      });
+      addIssueToContext(
+        ctx,
+        {
+          code: ZodIssueCode.invalid_type,
+          expected: ZodParsedType.string,
+          received: ctx.parsedType,
+        }
+        //
+      );
       return INVALID;
     }
 
@@ -4108,7 +4112,6 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       ctx.parsedType !== ZodParsedType.number
     ) {
       const expectedValues = util.objectValues(nativeEnumValues);
-
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,

--- a/src/types.ts
+++ b/src/types.ts
@@ -635,15 +635,11 @@ export class ZodString extends ZodType<string, ZodStringDef> {
 
     if (parsedType !== ZodParsedType.string) {
       const ctx = this._getOrReturnCtx(input);
-      addIssueToContext(
-        ctx,
-        {
-          code: ZodIssueCode.invalid_type,
-          expected: ZodParsedType.string,
-          received: ctx.parsedType,
-        }
-        //
-      );
+      addIssueToContext(ctx, {
+        code: ZodIssueCode.invalid_type,
+        expected: ZodParsedType.string,
+        received: ctx.parsedType,
+      });
       return INVALID;
     }
 
@@ -4095,7 +4091,6 @@ export interface ZodNativeEnumDef<T extends EnumLike = EnumLike>
   extends ZodTypeDef {
   values: T;
   typeName: ZodFirstPartyTypeKind.ZodNativeEnum;
-  message?: string | undefined;
 }
 
 export type EnumLike = { [k: string]: string | number; [nu: number]: string };
@@ -4113,26 +4108,22 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
       ctx.parsedType !== ZodParsedType.number
     ) {
       const expectedValues = util.objectValues(nativeEnumValues);
-      const message = this._def.message;
 
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,
         code: ZodIssueCode.invalid_type,
-        message: message,
       });
       return INVALID;
     }
 
     if (nativeEnumValues.indexOf(input.data) === -1) {
       const expectedValues = util.objectValues(nativeEnumValues);
-      const message = this._def.message;
 
       addIssueToContext(ctx, {
         received: ctx.data,
         code: ZodIssueCode.invalid_enum_value,
         options: expectedValues,
-        message: message,
       });
       return INVALID;
     }


### PR DESCRIPTION
Resolves #2919

Return `invalid_type_error` on nativeEnum validations instead of  `Invalid enum value` when the attribute is set.

```ts
const schema = z.nativeEnum({ MY_ENUM: "MY_ENUM" }, {
  invalid_type_error: "the value provided is invalid",
})

console.log("result", schema.parse("AAA"));
// returns error "the value provided is invalid"
```