### PR TITLE
feature: add attribute message to enum validatiion

### DIFF
--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -59,19 +59,27 @@ test("extract/exclude", () => {
   util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });
 
-test('error map in extract/exclude', () => {
+test("error map in extract/exclude", () => {
   const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
-  const FoodEnum = z.enum(foods, { errorMap: () => ({ message: "This is not food!" }) });
+  const FoodEnum = z.enum(foods, {
+    errorMap: () => ({ message: "This is not food!" }),
+  });
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const foodsError = FoodEnum.safeParse("Cucumbers");
   const italianError = ItalianEnum.safeParse("Tacos");
   if (!foodsError.success && !italianError.success) {
-    expect(foodsError.error.issues[0].message).toEqual(italianError.error.issues[0].message);
+    expect(foodsError.error.issues[0].message).toEqual(
+      italianError.error.issues[0].message
+    );
   }
 
-  const UnhealthyEnum = FoodEnum.exclude(["Salad"], { errorMap: () => ({ message: "This is not healthy food!" }) });
+  const UnhealthyEnum = FoodEnum.exclude(["Salad"], {
+    errorMap: () => ({ message: "This is not healthy food!" }),
+  });
   const unhealthyError = UnhealthyEnum.safeParse("Salad");
   if (!unhealthyError.success) {
-    expect(unhealthyError.error.issues[0].message).toEqual("This is not healthy food!");
+    expect(unhealthyError.error.issues[0].message).toEqual(
+      "This is not healthy food!"
+    );
   }
 });

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -548,7 +548,7 @@ test("enum with message returns the custom error message", () => {
     );
   }
 });
-  
+
 test("when the message is falsy, it is used as is provided", () => {
   const schema = z.string().max(1, { message: "" });
   const result = schema.safeParse("asdf");

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -516,6 +516,39 @@ test("literal bigint default error message", () => {
   }
 });
 
+test("enum with message returns the custom error message", () => {
+  const schema = z.enum(["apple", "banana"], {
+    message: "the value provided is invalid",
+  });
+
+  const result1 = schema.safeParse("berries");
+  expect(result1.success).toEqual(false);
+  if (!result1.success) {
+    expect(result1.error.issues[0].message).toEqual(
+      "the value provided is invalid"
+    );
+  }
+
+  const result2 = schema.safeParse(undefined);
+  expect(result2.success).toEqual(false);
+  if (!result2.success) {
+    expect(result2.error.issues[0].message).toEqual(
+      "the value provided is invalid"
+    );
+  }
+
+  const result3 = schema.safeParse("banana");
+  expect(result3.success).toEqual(true);
+
+  const result4 = schema.safeParse(null);
+  expect(result4.success).toEqual(false);
+  if (!result4.success) {
+    expect(result4.error.issues[0].message).toEqual(
+      "the value provided is invalid"
+    );
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -118,6 +118,7 @@ export type RawCreateParams =
       errorMap?: ZodErrorMap;
       invalid_type_error?: string;
       required_error?: string;
+      message?: string;
       description?: string;
     }
   | undefined;
@@ -135,11 +136,16 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   }
   if (errorMap) return { errorMap: errorMap, description };
   const customMap: ZodErrorMap = (iss, ctx) => {
-    if (iss.code !== "invalid_type") return { message: ctx.defaultError };
-    if (typeof ctx.data === "undefined") {
-      return { message: required_error ?? ctx.defaultError };
+    const { message } = params;
+
+    if (iss.code === "invalid_enum_value") {
+      return { message: message ?? ctx.defaultError };
     }
-    return { message: invalid_type_error ?? ctx.defaultError };
+    if (typeof ctx.data === "undefined") {
+      return { message: message ?? required_error ?? ctx.defaultError };
+    }
+    if (iss.code !== "invalid_type") return { message: ctx.defaultError };
+    return { message: message ?? invalid_type_error ?? ctx.defaultError };
   };
   return { errorMap: customMap, description };
 }

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -58,19 +58,27 @@ test("extract/exclude", () => {
   util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });
 
-test('error map in extract/exclude', () => {
+test("error map in extract/exclude", () => {
   const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
-  const FoodEnum = z.enum(foods, { errorMap: () => ({ message: "This is not food!" }) });
+  const FoodEnum = z.enum(foods, {
+    errorMap: () => ({ message: "This is not food!" }),
+  });
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
   const foodsError = FoodEnum.safeParse("Cucumbers");
   const italianError = ItalianEnum.safeParse("Tacos");
   if (!foodsError.success && !italianError.success) {
-    expect(foodsError.error.issues[0].message).toEqual(italianError.error.issues[0].message);
+    expect(foodsError.error.issues[0].message).toEqual(
+      italianError.error.issues[0].message
+    );
   }
 
-  const UnhealthyEnum = FoodEnum.exclude(["Salad"], { errorMap: () => ({ message: "This is not healthy food!" }) });
+  const UnhealthyEnum = FoodEnum.exclude(["Salad"], {
+    errorMap: () => ({ message: "This is not healthy food!" }),
+  });
   const unhealthyError = UnhealthyEnum.safeParse("Salad");
   if (!unhealthyError.success) {
-    expect(unhealthyError.error.issues[0].message).toEqual("This is not healthy food!");
+    expect(unhealthyError.error.issues[0].message).toEqual(
+      "This is not healthy food!"
+    );
   }
 });

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -515,6 +515,39 @@ test("literal bigint default error message", () => {
   }
 });
 
+test("enum with message returns the custom error message", () => {
+  const schema = z.enum(["apple", "banana"], {
+    message: "the value provided is invalid",
+  });
+
+  const result1 = schema.safeParse("berries");
+  expect(result1.success).toEqual(false);
+  if (!result1.success) {
+    expect(result1.error.issues[0].message).toEqual(
+      "the value provided is invalid"
+    );
+  }
+
+  const result2 = schema.safeParse(undefined);
+  expect(result2.success).toEqual(false);
+  if (!result2.success) {
+    expect(result2.error.issues[0].message).toEqual(
+      "the value provided is invalid"
+    );
+  }
+
+  const result3 = schema.safeParse("banana");
+  expect(result3.success).toEqual(true);
+
+  const result4 = schema.safeParse(null);
+  expect(result4.success).toEqual(false);
+  if (!result4.success) {
+    expect(result4.error.issues[0].message).toEqual(
+      "the value provided is invalid"
+    );
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,7 @@ export type RawCreateParams =
       errorMap?: ZodErrorMap;
       invalid_type_error?: string;
       required_error?: string;
+      message?: string;
       description?: string;
     }
   | undefined;
@@ -135,11 +136,16 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   }
   if (errorMap) return { errorMap: errorMap, description };
   const customMap: ZodErrorMap = (iss, ctx) => {
-    if (iss.code !== "invalid_type") return { message: ctx.defaultError };
-    if (typeof ctx.data === "undefined") {
-      return { message: required_error ?? ctx.defaultError };
+    const { message } = params;
+
+    if (iss.code === "invalid_enum_value") {
+      return { message: message ?? ctx.defaultError };
     }
-    return { message: invalid_type_error ?? ctx.defaultError };
+    if (typeof ctx.data === "undefined") {
+      return { message: message ?? required_error ?? ctx.defaultError };
+    }
+    if (iss.code !== "invalid_type") return { message: ctx.defaultError };
+    return { message: message ?? invalid_type_error ?? ctx.defaultError };
   };
   return { errorMap: customMap, description };
 }


### PR DESCRIPTION
Resolves #3146

Make it possible to call enum validation with a custom message using `message` attribute:

```ts
  z.enum(['aaa', 'bbb', 'ccc'], { message: 'custom error message' });
```