### PR TITLE
feature: create schema field isRequired() method

### DIFF
--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -451,3 +451,12 @@ test("passthrough index signature", () => {
   type b = z.infer<typeof b>;
   util.assertEqual<{ a: string } & { [k: string]: unknown }, b>(true);
 });
+
+test("isRequired() returns true for required fields and false for optional fields", () => {
+  const schema = z.object({
+    a: z.string(),
+    b: z.string().optional(),
+  });
+  expect(schema.shape.a.isRequired()).toEqual(true);
+  expect(schema.shape.b.isRequired()).toEqual(false);
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -408,6 +408,7 @@ export abstract class ZodType<
     this.readonly = this.readonly.bind(this);
     this.isNullable = this.isNullable.bind(this);
     this.isOptional = this.isOptional.bind(this);
+    this.isRequired = this.isRequired.bind(this);
   }
 
   optional(): ZodOptional<this> {
@@ -499,6 +500,9 @@ export abstract class ZodType<
 
   isOptional(): boolean {
     return this.safeParse(undefined).success;
+  }
+  isRequired(): boolean {
+    return !this.isOptional();
   }
   isNullable(): boolean {
     return this.safeParse(null).success;

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -450,3 +450,12 @@ test("passthrough index signature", () => {
   type b = z.infer<typeof b>;
   util.assertEqual<{ a: string } & { [k: string]: unknown }, b>(true);
 });
+
+test("isRequired() returns true for required fields and false for optional fields", () => {
+  const schema = z.object({
+    a: z.string(),
+    b: z.string().optional(),
+  });
+  expect(schema.shape.a.isRequired()).toEqual(true);
+  expect(schema.shape.b.isRequired()).toEqual(false);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -408,6 +408,7 @@ export abstract class ZodType<
     this.readonly = this.readonly.bind(this);
     this.isNullable = this.isNullable.bind(this);
     this.isOptional = this.isOptional.bind(this);
+    this.isRequired = this.isRequired.bind(this);
   }
 
   optional(): ZodOptional<this> {
@@ -499,6 +500,9 @@ export abstract class ZodType<
 
   isOptional(): boolean {
     return this.safeParse(undefined).success;
+  }
+  isRequired(): boolean {
+    return !this.isOptional();
   }
   isNullable(): boolean {
     return this.safeParse(null).success;


### PR DESCRIPTION
Resolves #3103

Now it is possible to check whether a given field is required or not using `schema.shape.fieldName.isRequired()`