### PR TITLE
feature: allow falsy error message

### DIFF
--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -516,6 +516,15 @@ test("literal bigint default error message", () => {
   }
 });
 
+test.only("when the message is falsy, it is used as is provided", () => {
+  const schema = z.string().max(1, { message: "" });
+  const result = schema.safeParse("asdf");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("");
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -28,7 +28,7 @@ export const makeIssue = (params: {
   return {
     ...issueData,
     path: fullPath,
-    message: issueData.message || errorMessage,
+    message: issueData.message ?? errorMessage,
   };
 };
 

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -515,6 +515,15 @@ test("literal bigint default error message", () => {
   }
 });
 
+test.only("when the message is falsy, it is used as is provided", () => {
+  const schema = z.string().max(1, { message: "" });
+  const result = schema.safeParse("asdf");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toEqual("");
+  }
+});
+
 // test("dont short circuit on continuable errors", () => {
 //   const user = z
 //     .object({

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -28,7 +28,7 @@ export const makeIssue = (params: {
   return {
     ...issueData,
     path: fullPath,
-    message: issueData.message || errorMessage,
+    message: issueData.message ?? errorMessage,
   };
 };
 


### PR DESCRIPTION
Resolves #3101

Allows setting falsy error messages on validation.

```ts
  const schema = z.string().max(1, { message: "" }).parse("aaaa")
  // returns error { message: "" }
```