### PR TITLE
fixed Readme typo in NaNs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ You can customize certain error messages when creating a nan schema.
 ```ts
 const isNaN = z.nan({
   required_error: "isNaN is required",
-  invalid_type_error: "isNaN must be a number",
+  invalid_type_error: "isNaN must be 'not a number'",
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ You can customize certain error messages when creating a nan schema.
 ```ts
 const isNaN = z.nan({
   required_error: "isNaN is required",
-  invalid_type_error: "isNaN must be not a number",
+  invalid_type_error: "isNaN must be a number",
 });
 ```
 


### PR DESCRIPTION
- ### was reading through docs and saw the typo in this example.

    - see the "invalid_type_error" key-value pair below

![Screenshot 2024-01-24 at 11 54 53](https://github.com/colinhacks/zod/assets/116172031/cf3ab886-66c7-4892-9d6e-97beff0c0516)

- changed to :
     - ### "isNaN must be 'not a number'"