### PR TITLE
fix(deno): re-export default from index.ts in mod.ts

### DIFF
--- a/deno/lib/mod.ts
+++ b/deno/lib/mod.ts
@@ -1,1 +1,2 @@
 export * from "./index.ts";
+export { default as default } from "./index.ts";


### PR DESCRIPTION
Noticed that the deno version of zod doesn't export zod as default