### PR TITLE
Bugfix: Enum.extract/exclude should not remove error mapping

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -518,7 +518,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`tRPC`](https://github.com/trpc/trpc): Build end-to-end typesafe APIs without GraphQL.
 - [`@anatine/zod-nestjs`](https://github.com/anatine/zod-plugins/tree/main/packages/zod-nestjs): Helper methods for using Zod in a NestJS project.
 - [`zod-endpoints`](https://github.com/flock-community/zod-endpoints): Contract-first strictly typed endpoints with Zod. OpenAPI compatible.
--  [`zhttp`](https://github.com/evertdespiegeleer/zhttp): An OpenAPI compatible, strictly typed http library with Zod input and response validation.
+- [`zhttp`](https://github.com/evertdespiegeleer/zhttp): An OpenAPI compatible, strictly typed http library with Zod input and response validation.
 - [`domain-functions`](https://github.com/SeasonedSoftware/domain-functions/): Decouple your business logic from your framework using composable functions. With first-class type inference from end to end powered by Zod schemas.
 - [`@zodios/core`](https://github.com/ecyrbe/zodios): A typescript API client with runtime and compile time validation backed by axios and zod.
 - [`express-zod-api`](https://github.com/RobinTail/express-zod-api): Build Express-based APIs with I/O schema validation and custom middlewares.
@@ -584,8 +584,10 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`freerstore`](https://github.com/JacobWeisenburger/freerstore): Firestore cost optimizer.
 - [`slonik`](https://github.com/gajus/slonik/tree/gajus/add-zod-validation-backwards-compatible#runtime-validation-and-static-type-inference): Node.js Postgres client with strong Zod integration.
 - [`soly`](https://github.com/mdbetancourt/soly): Create CLI applications with zod.
+- [`pastel`](https://github.com/vadimdemedes/pastel): Create CLI applications with react, zod, and ink.
 - [`zod-xlsx`](https://github.com/sidwebworks/zod-xlsx): A xlsx based resource validator using Zod schemas.
 - [`znv`](https://github.com/lostfictions/znv): Type-safe environment parsing and validation for Node.js with Zod schemas.
+- [`zod-config`](https://github.com/alexmarqs/zod-config): Load configurations across multiple sources with flexible adapters, ensuring type safety with Zod.
 
 #### Utilities for Zod
 
@@ -963,7 +965,7 @@ You can customize certain error messages when creating a nan schema.
 ```ts
 const isNaN = z.nan({
   required_error: "isNaN is required",
-  invalid_type_error: "isNaN must be not a number",
+  invalid_type_error: "isNaN must be 'not a number'",
 });
 ```
 

--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -58,3 +58,20 @@ test("extract/exclude", () => {
   util.assertEqual<typeof EmptyFoodEnum, z.ZodEnum<[]>>(true);
   util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });
+
+test('error map in extract/exclude', () => {
+  const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
+  const FoodEnum = z.enum(foods, { errorMap: () => ({ message: "This is not food!" }) });
+  const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
+  const foodsError = FoodEnum.safeParse("Cucumbers");
+  const italianError = ItalianEnum.safeParse("Tacos");
+  if (!foodsError.success && !italianError.success) {
+    expect(foodsError.error.issues[0].message).toEqual(italianError.error.issues[0].message);
+  }
+
+  const UnhealthyEnum = FoodEnum.exclude(["Salad"], { errorMap: () => ({ message: "This is not healthy food!" }) });
+  const unhealthyError = UnhealthyEnum.safeParse("Salad");
+  if (!unhealthyError.success) {
+    expect(unhealthyError.error.issues[0].message).toEqual("This is not healthy food!");
+  }
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4057,13 +4057,15 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
   }
 
   extract<ToExtract extends readonly [T[number], ...T[number][]]>(
-    values: ToExtract
+    values: ToExtract,
+    newDef: RawCreateParams = this._def
   ): ZodEnum<Writeable<ToExtract>> {
-    return ZodEnum.create(values) as any;
+    return ZodEnum.create(values, newDef) as any;
   }
 
   exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
-    values: ToExclude
+    values: ToExclude,
+    newDef: RawCreateParams = this._def
   ): ZodEnum<
     typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
   > {
@@ -4071,7 +4073,8 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
       this.options.filter((opt) => !values.includes(opt)) as FilterEnum<
         T,
         ToExclude[number]
-      >
+      >,
+      newDef
     ) as any;
   }
 

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -57,3 +57,20 @@ test("extract/exclude", () => {
   util.assertEqual<typeof EmptyFoodEnum, z.ZodEnum<[]>>(true);
   util.assertEqual<z.infer<typeof EmptyFoodEnum>, never>(true);
 });
+
+test('error map in extract/exclude', () => {
+  const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
+  const FoodEnum = z.enum(foods, { errorMap: () => ({ message: "This is not food!" }) });
+  const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
+  const foodsError = FoodEnum.safeParse("Cucumbers");
+  const italianError = ItalianEnum.safeParse("Tacos");
+  if (!foodsError.success && !italianError.success) {
+    expect(foodsError.error.issues[0].message).toEqual(italianError.error.issues[0].message);
+  }
+
+  const UnhealthyEnum = FoodEnum.exclude(["Salad"], { errorMap: () => ({ message: "This is not healthy food!" }) });
+  const unhealthyError = UnhealthyEnum.safeParse("Salad");
+  if (!unhealthyError.success) {
+    expect(unhealthyError.error.issues[0].message).toEqual("This is not healthy food!");
+  }
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -4057,13 +4057,15 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
   }
 
   extract<ToExtract extends readonly [T[number], ...T[number][]]>(
-    values: ToExtract
+    values: ToExtract,
+    newDef: RawCreateParams = this._def
   ): ZodEnum<Writeable<ToExtract>> {
-    return ZodEnum.create(values) as any;
+    return ZodEnum.create(values, newDef) as any;
   }
 
   exclude<ToExclude extends readonly [T[number], ...T[number][]]>(
-    values: ToExclude
+    values: ToExclude,
+    newDef: RawCreateParams = this._def
   ): ZodEnum<
     typecast<Writeable<FilterEnum<T, ToExclude[number]>>, [string, ...string[]]>
   > {
@@ -4071,7 +4073,8 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
       this.options.filter((opt) => !values.includes(opt)) as FilterEnum<
         T,
         ToExclude[number]
-      >
+      >,
+      newDef
     ) as any;
   }
 


### PR DESCRIPTION
When calling .extract/exclude we should retain the original RawCreateParams passed to the enum definition. We also allow passing new RawCreateParams if that's necessary. This solves issue #3225.