### PR TITLE
feat: add safeParseOptional to return an optional result

### DIFF
--- a/deno/lib/__tests__/safeparseoptional.test.ts
+++ b/deno/lib/__tests__/safeparseoptional.test.ts
@@ -1,0 +1,27 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+const stringSchema = z.string();
+
+test("safeparseoptional fail", () => {
+  const safe = stringSchema.safeParseOptional(12);
+  expect(safe).toBeUndefined();
+});
+
+test("safeparseoptional pass", () => {
+  const safe = stringSchema.safeParseOptional("12");
+  expect(safe).toEqual("12");
+});
+
+test("safeparseoptional unexpected error", () => {
+  expect(() =>
+    stringSchema
+      // deno-lint-ignore no-explicit-any
+      .refine((data: any) => {
+        throw new Error(data);
+      })
+      .safeParseOptional("12")
+  ).toThrow();
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -281,6 +281,22 @@ export abstract class ZodType<
     return handleResult(ctx, result);
   }
 
+  safeParseOptional(
+    data: unknown,
+    params?: Partial<ParseParams>
+  ): Output | undefined {
+    const result = this.safeParse(data, params);
+    return result.success ? result.data : undefined;
+  }
+
+  async safeParseOptionalAsync(
+    data: unknown,
+    params?: Partial<ParseParams>
+  ): Promise<Output | undefined> {
+    const result = await this.safeParseAsync(data, params);
+    return result.success ? result.data : undefined;
+  }
+
   /** Alias of safeParseAsync */
   spa = this.safeParseAsync;
 

--- a/src/__tests__/safeparseoptional.test.ts
+++ b/src/__tests__/safeparseoptional.test.ts
@@ -1,0 +1,26 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+const stringSchema = z.string();
+
+test("safeparseoptional fail", () => {
+  const safe = stringSchema.safeParseOptional(12);
+  expect(safe).toBeUndefined();
+});
+
+test("safeparseoptional pass", () => {
+  const safe = stringSchema.safeParseOptional("12");
+  expect(safe).toEqual("12");
+});
+
+test("safeparseoptional unexpected error", () => {
+  expect(() =>
+    stringSchema
+      // deno-lint-ignore no-explicit-any
+      .refine((data: any) => {
+        throw new Error(data);
+      })
+      .safeParseOptional("12")
+  ).toThrow();
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,6 +281,22 @@ export abstract class ZodType<
     return handleResult(ctx, result);
   }
 
+  safeParseOptional(
+    data: unknown,
+    params?: Partial<ParseParams>
+  ): Output | undefined {
+    const result = this.safeParse(data, params);
+    return result.success ? result.data : undefined;
+  }
+
+  async safeParseOptionalAsync(
+    data: unknown,
+    params?: Partial<ParseParams>
+  ): Promise<Output | undefined> {
+    const result = await this.safeParseAsync(data, params);
+    return result.success ? result.data : undefined;
+  }
+
   /** Alias of safeParseAsync */
   spa = this.safeParseAsync;
 


### PR DESCRIPTION
`safeParse` is a very useful function to use when validating, however there are often circumstances in which a user might not need access to an error, and would like to use optional chaining on the result. Unfortunately, to do this one would need to narrow the result object based on the success flag.

For example, the following is impossible: 

```ts
const schema = z.object({ name: z.string() });

const getName = (data: unknown) => schema.safeParse(data).data?.name;
                                                        // ^ Property 'data' does not exist on type 'SafeParseReturnType<{ name: string; }, { name: string; }>'.
```

Instead one would need to take a more verbose approach:

```ts
const schema = z.object({ name: z.string() });

const getName = (data: unknown) => {
  const result = schema.safeParse(data);
  return result.success ? result.data.name : undefined;
};
```

Or, cast to any directly [(as is done in the Zod tests)](https://github.com/colinhacks/zod/blob/dc05fd2b17feb706263772b88fa636f0609004f1/src/__tests__/safeparse.test.ts#L16).

I tend to use a tiny util in most projects that runs the above checks. I thought it might be worthwhile opening a very basic PR to add this to Zod in case others might find this useful!

If this approach is agreed, I would be happy to expand documentation to cover this.

(ps. I did have a dig in past PRs to see if anyone has covered this already but couldn't find anything. Apologies if this is duplicated work!)