### PR TITLE
Add types to `ZodFirstPartySchemaTypes`

### DIFF
--- a/src/__tests__/firstpartyschematypes.test.ts
+++ b/src/__tests__/firstpartyschematypes.test.ts
@@ -1,0 +1,20 @@
+// @ts-ignore TS6133
+import { test } from "@jest/globals";
+import { util } from "../helpers/util";
+
+import { 
+  ZodFirstPartySchemaTypes,
+  ZodFirstPartyTypeKind,
+} from "..";
+
+test("Identify missing [ZodFirstPartySchemaTypes]", () => {
+  type ZodFirstPartySchemaForType<T extends ZodFirstPartyTypeKind> = ZodFirstPartySchemaTypes extends infer Schema
+    ? Schema extends { _def: { typeName: T } }
+      ? Schema
+      : never
+    : never;
+  type ZodMappedTypes = { [key in ZodFirstPartyTypeKind]: ZodFirstPartySchemaForType<key> };
+  type ZodFirstPartySchemaTypesMissingFromUnion = keyof { [key in keyof ZodMappedTypes as ZodMappedTypes[key] extends { _def: never } ? key : never]: unknown };
+
+  util.assertNever({} as ZodFirstPartySchemaTypesMissingFromUnion);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -4972,7 +4972,9 @@ export type ZodFirstPartySchemaTypes =
   | ZodCatch<any>
   | ZodPromise<any>
   | ZodBranded<any, any>
-  | ZodPipeline<any, any>;
+  | ZodPipeline<any, any>
+  | ZodReadonly<any>
+  | ZodSymbol;
 
 // requires TS 4.4+
 abstract class Class {


### PR DESCRIPTION
Fixes #3246

Some first party schema types were missing from the union. This pull-request adds them, along with a test that tries to keep the union and ambient type declaration in sync.