### PR TITLE
Bugfix: z.record().parse should not filter out undefined values

### DIFF
--- a/deno/lib/__tests__/record.test.ts
+++ b/deno/lib/__tests__/record.test.ts
@@ -171,3 +171,11 @@ test("is not vulnerable to prototype pollution", async () => {
     expect(obj4.data.a).toBeUndefined();
   }
 });
+
+test("dont parse undefined values", () => {
+  const result1 = z.record( z.any() ).parse( { foo: undefined } );
+
+  expect(result1).toEqual({
+    foo: undefined,
+  });
+})

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3380,6 +3380,7 @@ export class ZodRecord<
     const pairs: {
       key: ParseReturnType<any>;
       value: ParseReturnType<any>;
+      alwaysSet: boolean;
     }[] = [];
 
     const keyType = this._def.keyType;
@@ -3391,6 +3392,7 @@ export class ZodRecord<
         value: valueType._parse(
           new ParseInputLazyPath(ctx, ctx.data[key], ctx.path, key)
         ),
+        alwaysSet: key in ctx.data,
       });
     }
 

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -170,3 +170,11 @@ test("is not vulnerable to prototype pollution", async () => {
     expect(obj4.data.a).toBeUndefined();
   }
 });
+
+test("dont parse undefined values", () => {
+  const result1 = z.record( z.any() ).parse( { foo: undefined } );
+
+  expect(result1).toEqual({
+    foo: undefined,
+  });
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -3380,6 +3380,7 @@ export class ZodRecord<
     const pairs: {
       key: ParseReturnType<any>;
       value: ParseReturnType<any>;
+      alwaysSet: boolean;
     }[] = [];
 
     const keyType = this._def.keyType;
@@ -3391,6 +3392,7 @@ export class ZodRecord<
         value: valueType._parse(
           new ParseInputLazyPath(ctx, ctx.data[key], ctx.path, key)
         ),
+        alwaysSet: key in ctx.data,
       });
     }
 


### PR DESCRIPTION
When calling .parse on z.record() we should not filter out undefined values. Add the optional 'alwaysSet' to the z.record pairs before passing them to mergeObject to maintain undefined values.

This solves issue #3197