### PR TITLE
Restrict .pick()/.omit() mask type to only known properties

### DIFF
--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -16,6 +16,7 @@ export namespace util {
   export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
   export type MakePartial<T, K extends keyof T> = Omit<T, K> &
     Partial<Pick<T, K>>;
+  export type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
 
   export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
     items: U

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2574,7 +2574,7 @@ export class ZodObject<
     }) as any;
   }
 
-  pick<Mask extends { [k in keyof T]?: true }>(
+  pick<Mask extends util.Exactly<{ [k in keyof T]?: true }, Mask>>(
     mask: Mask
   ): ZodObject<Pick<T, Extract<keyof T, keyof Mask>>, UnknownKeys, Catchall> {
     const shape: any = {};
@@ -2591,7 +2591,7 @@ export class ZodObject<
     }) as any;
   }
 
-  omit<Mask extends { [k in keyof T]?: true }>(
+  omit<Mask extends util.Exactly<{ [k in keyof T]?: true }, Mask>>(
     mask: Mask
   ): ZodObject<Omit<T, keyof Mask>, UnknownKeys, Catchall> {
     const shape: any = {};

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -16,6 +16,7 @@ export namespace util {
   export type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
   export type MakePartial<T, K extends keyof T> = Omit<T, K> &
     Partial<Pick<T, K>>;
+  export type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
 
   export const arrayToEnum = <T extends string, U extends [T, ...T[]]>(
     items: U

--- a/src/types.ts
+++ b/src/types.ts
@@ -2574,7 +2574,7 @@ export class ZodObject<
     }) as any;
   }
 
-  pick<Mask extends { [k in keyof T]?: true }>(
+  pick<Mask extends util.Exactly<{ [k in keyof T]?: true }, Mask>>(
     mask: Mask
   ): ZodObject<Pick<T, Extract<keyof T, keyof Mask>>, UnknownKeys, Catchall> {
     const shape: any = {};
@@ -2591,7 +2591,7 @@ export class ZodObject<
     }) as any;
   }
 
-  omit<Mask extends { [k in keyof T]?: true }>(
+  omit<Mask extends util.Exactly<{ [k in keyof T]?: true }, Mask>>(
     mask: Mask
   ): ZodObject<Omit<T, keyof Mask>, UnknownKeys, Catchall> {
     const shape: any = {};


### PR DESCRIPTION
### Current

Both the methods .pick and .omit accept properties that don't exist in the schema.
``` 
const schema = z.object({
  existedProperty: z.string(),
});

const pick = schema.pick({
  existedProperty: true,
  NOT_existed_property: true, // there is no TypeScript error
});
```

### Fixed

Both the methods .pick and .omit now only accept known properties.
``` 
const schema = z.object({
  existedProperty: z.string(),
});

const pick = schema.pick({
  existedProperty: true,
  NOT_existed_property: true, // there is a TypeScript error
});
```

resolves https://github.com/colinhacks/zod/issues/895