### PR TITLE
Fix z.catchall() return type

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2185,13 +2185,11 @@ export type baseObjectInputType<Shape extends ZodRawShape> =
     [k in keyof Shape]: Shape[k]["_input"];
   }>;
 
-export type CatchallOutput<T extends ZodTypeAny> = ZodTypeAny extends T
-  ? unknown
-  : { [k: string]: T["_output"] };
+export type CatchallOutput<T extends ZodTypeAny> =
+  ZodFirstPartySchemaTypes extends T ? unknown : { [k: string]: T["_output"] };
 
-export type CatchallInput<T extends ZodTypeAny> = ZodTypeAny extends T
-  ? unknown
-  : { [k: string]: T["_input"] };
+export type CatchallInput<T extends ZodTypeAny> =
+  ZodFirstPartySchemaTypes extends T ? unknown : { [k: string]: T["_input"] };
 
 export type PassthroughType<T extends UnknownKeysParam> =
   T extends "passthrough" ? { [k: string]: unknown } : unknown;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2185,13 +2185,11 @@ export type baseObjectInputType<Shape extends ZodRawShape> =
     [k in keyof Shape]: Shape[k]["_input"];
   }>;
 
-export type CatchallOutput<T extends ZodTypeAny> = ZodTypeAny extends T
-  ? unknown
-  : { [k: string]: T["_output"] };
+export type CatchallOutput<T extends ZodTypeAny> =
+  ZodFirstPartySchemaTypes extends T ? unknown : { [k: string]: T["_output"] };
 
-export type CatchallInput<T extends ZodTypeAny> = ZodTypeAny extends T
-  ? unknown
-  : { [k: string]: T["_input"] };
+export type CatchallInput<T extends ZodTypeAny> =
+  ZodFirstPartySchemaTypes extends T ? unknown : { [k: string]: T["_input"] };
 
 export type PassthroughType<T extends UnknownKeysParam> =
   T extends "passthrough" ? { [k: string]: unknown } : unknown;


### PR DESCRIPTION
Fixed an issue where `CatchallOutput` returned unknown for classes without additional methods, such as `ZodBoolean`, `ZodUndefined`, and `ZodNull`. This was resolved by replacing `ZodTypeAny` with `ZodFirstPartySchemaTypes`. This change addresses the behavior described in issue #3043