### PR TITLE
add never props to safe parse return types

### DIFF
--- a/deno/lib/__tests__/safeparse.test.ts
+++ b/deno/lib/__tests__/safeparse.test.ts
@@ -8,13 +8,13 @@ const stringSchema = z.string();
 test("safeparse fail", () => {
   const safe = stringSchema.safeParse(12);
   expect(safe.success).toEqual(false);
-  expect((safe as any).error).toBeInstanceOf(z.ZodError);
+  expect(safe.error).toBeInstanceOf(z.ZodError);
 });
 
 test("safeparse pass", () => {
   const safe = stringSchema.safeParse("12");
   expect(safe.success).toEqual(true);
-  expect((safe as any).data).toEqual("12");
+  expect(safe.data).toEqual("12");
 });
 
 test("safeparse unexpected error", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -144,8 +144,16 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   return { errorMap: customMap, description };
 }
 
-export type SafeParseSuccess<Output> = { success: true; data: Output };
-export type SafeParseError<Input> = { success: false; error: ZodError<Input> };
+export type SafeParseSuccess<Output> = {
+  success: true;
+  data: Output;
+  error?: never;
+};
+export type SafeParseError<Input> = {
+  success: false;
+  error: ZodError<Input>;
+  data?: never;
+};
 
 export type SafeParseReturnType<Input, Output> =
   | SafeParseSuccess<Output>

--- a/src/__tests__/safeparse.test.ts
+++ b/src/__tests__/safeparse.test.ts
@@ -7,13 +7,13 @@ const stringSchema = z.string();
 test("safeparse fail", () => {
   const safe = stringSchema.safeParse(12);
   expect(safe.success).toEqual(false);
-  expect((safe as any).error).toBeInstanceOf(z.ZodError);
+  expect(safe.error).toBeInstanceOf(z.ZodError);
 });
 
 test("safeparse pass", () => {
   const safe = stringSchema.safeParse("12");
   expect(safe.success).toEqual(true);
-  expect((safe as any).data).toEqual("12");
+  expect(safe.data).toEqual("12");
 });
 
 test("safeparse unexpected error", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,8 +144,16 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   return { errorMap: customMap, description };
 }
 
-export type SafeParseSuccess<Output> = { success: true; data: Output };
-export type SafeParseError<Input> = { success: false; error: ZodError<Input> };
+export type SafeParseSuccess<Output> = {
+  success: true;
+  data: Output;
+  error?: never;
+};
+export type SafeParseError<Input> = {
+  success: false;
+  error: ZodError<Input>;
+  data?: never;
+};
 
 export type SafeParseReturnType<Input, Output> =
   | SafeParseSuccess<Output>


### PR DESCRIPTION
Possible improvement to safe parse return types as discussed in #3266.

The `?: never` properties added to the type involve no runtime overhead and support all existing patterns. However, as seen in the tests they avoid casting or intermediate variables when we attempt to access properties on the union `SafeParseReturnType`, since now both branches have the property we attempt to access. When accessing `SafeParseReturnType['data']`, we get `Output | undefined`, which is accurate to the runtime behavior. If we are in a context where we've already checked `success`, we get just `Output` as expected.