### PR TITLE
fix: make `input` of `.required()` readonly

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4832,7 +4832,7 @@ export interface ZodReadonlyDef<T extends ZodTypeAny = ZodTypeAny>
 export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
   MakeReadonly<T["_output"]>,
   ZodReadonlyDef<T>,
-  T["_input"]
+  MakeReadonly<T["_input"]>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const result = this._def.innerType._parse(input);


### PR DESCRIPTION
More info: https://github.com/trpc/trpc/issues/5538

Unsure if this is a legit fix. I could see this working as designed.

cc @tkdodo @PeterMK85 