### PR TITLE
Wrap preprocess with try-catch to provide better information on error

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -18,6 +18,7 @@ export type typeToFlattenedError<T, U = string> = {
 export const ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
+  "preprocess_error",
   "custom",
   "invalid_union",
   "invalid_union_discriminator",
@@ -86,6 +87,11 @@ export interface ZodInvalidReturnTypeIssue extends ZodIssueBase {
 
 export interface ZodInvalidDateIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_date;
+}
+
+export interface ZodPreprocessIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.preprocess_error;
+  originalError: any;
 }
 
 export type StringValidation =
@@ -160,6 +166,7 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidIntersectionTypesIssue
   | ZodNotMultipleOfIssue
   | ZodNotFiniteIssue
+  | ZodPreprocessIssue
   | ZodCustomIssue;
 
 export type ZodIssue = ZodIssueOptionalMessage & {

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -205,6 +205,31 @@ test("preprocess", () => {
   util.assertEqual<(typeof schema)["_input"], unknown>(true);
 });
 
+test('preprocess with unexpected error', () => {
+  const schema = z.object({
+    user: z.object({
+      name: z.preprocess((data) => {
+        throw new Error('unexpected error: ' + data);
+      }, z.string())
+    })
+  });
+  expect(() => schema.parse({ user: { name: "asdf"}})).toThrow(
+    JSON.stringify(
+      [
+        {
+          code: "preprocess_error",
+          originalError: { },
+          path: ['user', 'name'],
+          message: "Preprocess error: unexpected error: asdf",
+        },
+      ],
+      null,
+      2
+    )
+
+  );
+});
+
 test("async preprocess", async () => {
   const schema = z.preprocess(async (data) => [data], z.string().array());
 

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -140,6 +140,9 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.not_finite:
       message = "Number must be finite";
       break;
+    case ZodIssueCode.preprocess_error:
+      message = "Preprocess error: " + issue.originalError.message;
+      break;
     default:
       message = _ctx.defaultError;
       util.assertNever(issue);

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -18,6 +18,7 @@ export type typeToFlattenedError<T, U = string> = {
 export const ZodIssueCode = util.arrayToEnum([
   "invalid_type",
   "invalid_literal",
+  "preprocess_error",
   "custom",
   "invalid_union",
   "invalid_union_discriminator",
@@ -86,6 +87,11 @@ export interface ZodInvalidReturnTypeIssue extends ZodIssueBase {
 
 export interface ZodInvalidDateIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_date;
+}
+
+export interface ZodPreprocessIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.preprocess_error;
+  originalError: any;
 }
 
 export type StringValidation =
@@ -160,6 +166,7 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidIntersectionTypesIssue
   | ZodNotMultipleOfIssue
   | ZodNotFiniteIssue
+  | ZodPreprocessIssue
   | ZodCustomIssue;
 
 export type ZodIssue = ZodIssueOptionalMessage & {

--- a/src/__tests__/transformer.test.ts
+++ b/src/__tests__/transformer.test.ts
@@ -204,6 +204,31 @@ test("preprocess", () => {
   util.assertEqual<(typeof schema)["_input"], unknown>(true);
 });
 
+test('preprocess with unexpected error', () => {
+  const schema = z.object({
+    user: z.object({
+      name: z.preprocess((data) => {
+        throw new Error('unexpected error: ' + data);
+      }, z.string())
+    })
+  });
+  expect(() => schema.parse({ user: { name: "asdf"}})).toThrow(
+    JSON.stringify(
+      [
+        {
+          code: "preprocess_error",
+          originalError: { },
+          path: ['user', 'name'],
+          message: "Preprocess error: unexpected error: asdf",
+        },
+      ],
+      null,
+      2
+    )
+
+  );
+});
+
 test("async preprocess", async () => {
   const schema = z.preprocess(async (data) => [data], z.string().array());
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -140,6 +140,9 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.not_finite:
       message = "Number must be finite";
       break;
+    case ZodIssueCode.preprocess_error:
+      message = "Preprocess error: " + issue.originalError.message;
+      break;
     default:
       message = _ctx.defaultError;
       util.assertNever(issue);


### PR DESCRIPTION
Before this fix, any errors during preprocess would result in an error that doesn't provide a lot of debug information. For example, the path where the error happened was not provided by Zod.
This change will make sure that even errors during preprocess are translated to ZodError with useful metadata about the error.

Solves issue #2724