### PR TITLE
Improve `addQuestionMarks`, fix #2184

### DIFF
--- a/deno/lib/__tests__/generics.test.ts
+++ b/deno/lib/__tests__/generics.test.ts
@@ -34,9 +34,7 @@ test("assignability", () => {
       [key]: valueSchema,
     });
     const parsed = schema.parse(data);
-    type aldsjkf = z.infer<z.ZodObject<{ [k in K]: VS }>>;
     const inferred: z.infer<z.ZodObject<{ [k in K]: VS }>> = parsed;
-    // this line errors in 3.21.2
     return inferred;
   };
   createSchemaAndParse("foo", z.string(), { foo: "" });

--- a/deno/lib/__tests__/generics.test.ts
+++ b/deno/lib/__tests__/generics.test.ts
@@ -23,3 +23,21 @@ test("generics", () => {
   const result = stripOuter(z.object({ a: z.string() }), { a: "asdf" });
   util.assertEqual<typeof result, Promise<{ a: string }>>(true);
 });
+
+test("assignability", () => {
+  const createSchemaAndParse = <K extends string, VS extends z.ZodString>(
+    key: K,
+    valueSchema: VS,
+    data: unknown
+  ) => {
+    const schema = z.object({
+      [key]: valueSchema,
+    });
+    const parsed = schema.parse(data);
+    type aldsjkf = z.infer<z.ZodObject<{ [k in K]: VS }>>;
+    const inferred: z.infer<z.ZodObject<{ [k in K]: VS }>> = parsed;
+    // this line errors in 3.21.2
+    return inferred;
+  };
+  createSchemaAndParse("foo", z.string(), { foo: "" });
+});

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -451,3 +451,23 @@ test("passthrough index signature", () => {
   type b = z.infer<typeof b>;
   util.assertEqual<{ a: string } & { [k: string]: unknown }, b>(true);
 });
+
+test("xor", () => {
+  type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+  type XOR<T, U> = T extends object
+    ? U extends object
+      ? (Without<T, U> & U) | (Without<U, T> & T)
+      : U
+    : T;
+
+  type A = { name: string; a: number };
+  type B = { name: string; b: number };
+  type C = XOR<A, B>;
+  type Outer = { data: C };
+  const Outer: z.ZodType<Outer> = z.object({
+    data: z.union([
+      z.object({ name: z.string(), a: z.number() }),
+      z.object({ name: z.string(), b: z.number() }),
+    ]),
+  });
+});

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -111,7 +111,7 @@ export namespace objectUtil {
   export type addQuestionMarks<
     T extends object,
     R extends keyof T = requiredKeys<T>
-  > = Pick<Required<T>, R> & Partial<T>;
+  > = Pick<Required<T>, R> & Omit<Partial<T>, R> & { [k in keyof T]?: unknown };
 
   export type identity<T> = T;
   export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -100,9 +100,9 @@ export namespace objectUtil {
     [k in Exclude<keyof U, keyof V>]: U[k];
   } & V;
 
-  // type optionalKeys<T extends object> = {
-  //   [k in keyof T]: undefined extends T[k] ? k : never;
-  // }[keyof T];
+  type optionalKeys<T extends object> = {
+    [k in keyof T]: undefined extends T[k] ? k : never;
+  }[keyof T];
 
   type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
@@ -110,8 +110,9 @@ export namespace objectUtil {
 
   export type addQuestionMarks<
     T extends object,
-    R extends keyof T = requiredKeys<T>
-  > = Pick<Required<T>, R> & Omit<Partial<T>, R> & { [k in keyof T]?: unknown };
+    R extends keyof T = requiredKeys<T>,
+    O extends keyof T = optionalKeys<T>
+  > = Pick<T, R> & Partial<Pick<T, O>> & { [k in keyof T]?: unknown };
 
   export type identity<T> = T;
   export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -108,6 +108,10 @@ export namespace objectUtil {
     [k in keyof T]: undefined extends T[k] ? never : k;
   }[keyof T];
 
+  // export type addQuestionMarks<
+  //   T extends object,
+  //   R extends keyof T = requiredKeys<T>
+  // > = Pick<Required<T>, R> & Partial<T>;
   export type addQuestionMarks<
     T extends object,
     R extends keyof T = requiredKeys<T>,

--- a/playground.ts
+++ b/playground.ts
@@ -1,6 +1,3 @@
-import { z, ZodNativeEnum } from "./src";
+import { z } from "./src";
 
 z;
-
-const A = z.object({}).catchall(z.string());
-type A = z.infer<typeof A>;

--- a/playground.ts
+++ b/playground.ts
@@ -1,3 +1,7 @@
 import { z } from "./src";
 
 z;
+
+const schema = z.object({ name: z.string() }).catchall(z.string());
+
+type schema = z.input<typeof schema>;

--- a/playground.ts
+++ b/playground.ts
@@ -1,7 +1,3 @@
 import { z } from "./src";
 
 z;
-
-const schema = z.object({ name: z.string() }).catchall(z.string());
-
-type schema = z.input<typeof schema>;

--- a/src/__tests__/generics.test.ts
+++ b/src/__tests__/generics.test.ts
@@ -33,9 +33,7 @@ test("assignability", () => {
       [key]: valueSchema,
     });
     const parsed = schema.parse(data);
-    type aldsjkf = z.infer<z.ZodObject<{ [k in K]: VS }>>;
     const inferred: z.infer<z.ZodObject<{ [k in K]: VS }>> = parsed;
-    // this line errors in 3.21.2
     return inferred;
   };
   createSchemaAndParse("foo", z.string(), { foo: "" });

--- a/src/__tests__/generics.test.ts
+++ b/src/__tests__/generics.test.ts
@@ -22,3 +22,21 @@ test("generics", () => {
   const result = stripOuter(z.object({ a: z.string() }), { a: "asdf" });
   util.assertEqual<typeof result, Promise<{ a: string }>>(true);
 });
+
+test("assignability", () => {
+  const createSchemaAndParse = <K extends string, VS extends z.ZodString>(
+    key: K,
+    valueSchema: VS,
+    data: unknown
+  ) => {
+    const schema = z.object({
+      [key]: valueSchema,
+    });
+    const parsed = schema.parse(data);
+    type aldsjkf = z.infer<z.ZodObject<{ [k in K]: VS }>>;
+    const inferred: z.infer<z.ZodObject<{ [k in K]: VS }>> = parsed;
+    // this line errors in 3.21.2
+    return inferred;
+  };
+  createSchemaAndParse("foo", z.string(), { foo: "" });
+});

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -450,3 +450,23 @@ test("passthrough index signature", () => {
   type b = z.infer<typeof b>;
   util.assertEqual<{ a: string } & { [k: string]: unknown }, b>(true);
 });
+
+test("xor", () => {
+  type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
+  type XOR<T, U> = T extends object
+    ? U extends object
+      ? (Without<T, U> & U) | (Without<U, T> & T)
+      : U
+    : T;
+
+  type A = { name: string; a: number };
+  type B = { name: string; b: number };
+  type C = XOR<A, B>;
+  type Outer = { data: C };
+  const Outer: z.ZodType<Outer> = z.object({
+    data: z.union([
+      z.object({ name: z.string(), a: z.number() }),
+      z.object({ name: z.string(), b: z.number() }),
+    ]),
+  });
+});

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -111,7 +111,7 @@ export namespace objectUtil {
   export type addQuestionMarks<
     T extends object,
     R extends keyof T = requiredKeys<T>
-  > = Pick<Required<T>, R> & Partial<T>;
+  > = Pick<Required<T>, R> & Omit<Partial<T>, R> & { [k in keyof T]?: unknown };
 
   export type identity<T> = T;
   export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -100,9 +100,9 @@ export namespace objectUtil {
     [k in Exclude<keyof U, keyof V>]: U[k];
   } & V;
 
-  // type optionalKeys<T extends object> = {
-  //   [k in keyof T]: undefined extends T[k] ? k : never;
-  // }[keyof T];
+  type optionalKeys<T extends object> = {
+    [k in keyof T]: undefined extends T[k] ? k : never;
+  }[keyof T];
 
   type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
@@ -110,8 +110,9 @@ export namespace objectUtil {
 
   export type addQuestionMarks<
     T extends object,
-    R extends keyof T = requiredKeys<T>
-  > = Pick<Required<T>, R> & Omit<Partial<T>, R> & { [k in keyof T]?: unknown };
+    R extends keyof T = requiredKeys<T>,
+    O extends keyof T = optionalKeys<T>
+  > = Pick<T, R> & Partial<Pick<T, O>> & { [k in keyof T]?: unknown };
 
   export type identity<T> = T;
   export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -108,6 +108,10 @@ export namespace objectUtil {
     [k in keyof T]: undefined extends T[k] ? never : k;
   }[keyof T];
 
+  // export type addQuestionMarks<
+  //   T extends object,
+  //   R extends keyof T = requiredKeys<T>
+  // > = Pick<Required<T>, R> & Partial<T>;
   export type addQuestionMarks<
     T extends object,
     R extends keyof T = requiredKeys<T>,


### PR DESCRIPTION
Okay, this is a long time coming. Getting the inferred types to work as expected in generic contexts is quite annoying (see `generics.test.ts` for examples). Some changes I made to that effect seem to interact unhappily with the very specific case described in #2184 - a `ZodObject` schema, with a key corresponding to a union, being cast to `ZodType`.

The change now makes all my tests happy, including assignability in generic contexts and the newly added XOR test.

I'm going to ship this in the next minor since I haven't found a scenario where this breaks or even changes the inferred type signature in non-generic contexts. In generic contexts, it seems to strictly improve assignability characteristics without a big performance hit in the compiler.

cc @chrishoermann