### PR TITLE
feat: strict branding with opt-out

### DIFF
--- a/deno/lib/__tests__/branded.test.ts
+++ b/deno/lib/__tests__/branded.test.ts
@@ -47,8 +47,8 @@ test("branded types", () => {
     true
   );
 
-  // keeping brands out of input types
-  const age = z.number().brand<"age">();
+  // keeping brands out of input types in non-strict mode
+  const age = z.number().brand<"age", false>();
 
   type Age = z.infer<typeof age>;
   type AgeInput = z.input<typeof age>;
@@ -59,4 +59,10 @@ test("branded types", () => {
 
   // @ts-expect-error
   doStuff({ name: "hello there!" });
+
+  // (default) strict mode - should be branded
+  const height = z.number().brand("metricHeight");
+
+  type Height = z.input<typeof height>;
+  util.assertEqual<number & z.BRAND<"metricHeight">, Height>(true);
 });

--- a/deno/lib/helpers/parseUtil.ts
+++ b/deno/lib/helpers/parseUtil.ts
@@ -112,9 +112,11 @@ export class ParseStatus {
   ): Promise<SyncParseReturnType<any>> {
     const syncPairs: ObjectPair[] = [];
     for (const pair of pairs) {
+      const key = await pair.key;
+      const value = await pair.value;
       syncPairs.push({
-        key: await pair.key,
-        value: await pair.value,
+        key,
+        value,
       });
     }
     return ParseStatus.mergeObjectSync(status, syncPairs);

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -466,8 +466,16 @@ export abstract class ZodType<
     }) as any;
   }
 
-  brand<B extends string | number | symbol>(brand?: B): ZodBranded<this, B>;
-  brand<B extends string | number | symbol>(): ZodBranded<this, B> {
+  brand<B extends string | number | symbol, S extends boolean = true>(
+    brand?: B,
+    opts?: {
+      strict: S;
+    }
+  ): ZodBranded<this, B, S>;
+  brand<
+    B extends string | number | symbol,
+    S extends boolean = true
+  >(): ZodBranded<this, B, S> {
     return new ZodBranded({
       typeName: ZodFirstPartyTypeKind.ZodBranded,
       type: this,
@@ -2357,9 +2365,10 @@ export class ZodObject<
           const syncPairs: any[] = [];
           for (const pair of pairs) {
             const key = await pair.key;
+            const value = await pair.value;
             syncPairs.push({
               key,
-              value: await pair.value,
+              value,
               alwaysSet: pair.alwaysSet,
             });
           }
@@ -4726,8 +4735,13 @@ export type BRAND<T extends string | number | symbol> = {
 
 export class ZodBranded<
   T extends ZodTypeAny,
-  B extends string | number | symbol
-> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, T["_input"]> {
+  B extends string | number | symbol,
+  S extends boolean
+> extends ZodType<
+  T["_output"] & BRAND<B>,
+  ZodBrandedDef<T>,
+  S extends true ? T["_input"] & BRAND<B> : T["_input"]
+> {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;
@@ -4999,7 +5013,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodDefault<any>
   | ZodCatch<any>
   | ZodPromise<any>
-  | ZodBranded<any, any>
+  | ZodBranded<any, any, any>
   | ZodPipeline<any, any>
   | ZodReadonly<any>
   | ZodSymbol;

--- a/src/__tests__/branded.test.ts
+++ b/src/__tests__/branded.test.ts
@@ -46,8 +46,8 @@ test("branded types", () => {
     true
   );
 
-  // keeping brands out of input types
-  const age = z.number().brand<"age">();
+  // keeping brands out of input types in non-strict mode
+  const age = z.number().brand<"age", false>();
 
   type Age = z.infer<typeof age>;
   type AgeInput = z.input<typeof age>;
@@ -58,4 +58,10 @@ test("branded types", () => {
 
   // @ts-expect-error
   doStuff({ name: "hello there!" });
+
+  // (default) strict mode - should be branded
+  const height = z.number().brand("metricHeight");
+
+  type Height = z.input<typeof height>;
+  util.assertEqual<number & z.BRAND<"metricHeight">, Height>(true);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -466,8 +466,16 @@ export abstract class ZodType<
     }) as any;
   }
 
-  brand<B extends string | number | symbol>(brand?: B): ZodBranded<this, B>;
-  brand<B extends string | number | symbol>(): ZodBranded<this, B> {
+  brand<B extends string | number | symbol, S extends boolean = true>(
+    brand?: B,
+    opts?: {
+      strict: S;
+    }
+  ): ZodBranded<this, B, S>;
+  brand<
+    B extends string | number | symbol,
+    S extends boolean = true
+  >(): ZodBranded<this, B, S> {
     return new ZodBranded({
       typeName: ZodFirstPartyTypeKind.ZodBranded,
       type: this,
@@ -4727,8 +4735,13 @@ export type BRAND<T extends string | number | symbol> = {
 
 export class ZodBranded<
   T extends ZodTypeAny,
-  B extends string | number | symbol
-> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, T["_input"]> {
+  B extends string | number | symbol,
+  S extends boolean
+> extends ZodType<
+  T["_output"] & BRAND<B>,
+  ZodBrandedDef<T>,
+  S extends true ? T["_input"] & BRAND<B> : T["_input"]
+> {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;
@@ -5000,7 +5013,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodDefault<any>
   | ZodCatch<any>
   | ZodPromise<any>
-  | ZodBranded<any, any>
+  | ZodBranded<any, any, any>
   | ZodPipeline<any, any>
   | ZodReadonly<any>
   | ZodSymbol;


### PR DESCRIPTION
when branding, it's useful to retain the branding on `_input` so you have to explicitly pass a branded value when using the schema

this reverts #1492 but with the option of opting out of branded behavior

I can make it a non-breaking change if that's preferred, so it default to non-strict mode


cc @Xetera 