### PR TITLE
docs: add `orval` to "X to Zod" ecosystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`quicktype`](https://app.quicktype.io/): Convert JSON objects and JSON schemas into Zod schemas.
 - [`@sanity-typed/zod`](https://github.com/saiichihashimoto/sanity-typed/tree/main/packages/zod): Generate Zod Schemas from [Sanity Schemas](https://www.sanity.io/docs/schema-types).
 - [`java-to-zod`](https://github.com/ivangreene/java-to-zod): Convert POJOs to Zod schemas
+- [`Orval`](https://github.com/anymaniax/orval): Generate Zod schemas from OpenAPI schemas
 
 #### Mocking
 


### PR DESCRIPTION
First of all, thank you for creating and maintaining the library. I like this.

`Orval` can automatically generate `zod` schema from `OpenAPI`

https://orval.dev/guides/zod

I am currently maintaining this library and would like to recommend it, so I added it to the ecosystem in `README` . If you like this PR, please incorporate it.