### PR TITLE
fix(union): allow dynamic arrays of literals in types

### DIFF
--- a/deno/lib/__tests__/unions.test.ts
+++ b/deno/lib/__tests__/unions.test.ts
@@ -63,3 +63,16 @@ test("readonly union", async () => {
   union.parse("asdf");
   union.parse(12);
 });
+
+test("return valid over spread array of literals", () => {
+  const cells = ["a1", "a2", "a3", "b1", "b2", "b3"] as const;
+  const union = z.union([...cells.map((cell) => z.literal(cell))]);
+  union.parse("a1");
+});
+
+test("fails parse over spread array of literals for non-existent item", () => {
+  const cells = ["a1", "a2", "a3", "b1", "b2", "b3"] as const;
+  const union = z.union([...cells.map((cell) => z.literal(cell))]);
+  const result = union.safeParse("c1");
+  expect(result.success).toBe(false);
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2851,7 +2851,7 @@ export type AnyZodObject = ZodObject<any, any, any>;
 //////////                    //////////
 ////////////////////////////////////////
 ////////////////////////////////////////
-export type ZodUnionOptions = Readonly<[ZodTypeAny, ...ZodTypeAny[]]>;
+export type ZodUnionOptions = Readonly<[...ZodTypeAny[]]>;
 export interface ZodUnionDef<
   T extends ZodUnionOptions = Readonly<
     [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]
@@ -2971,9 +2971,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
     return this._def.options;
   }
 
-  static create = <
-    T extends Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>
-  >(
+  static create = <T extends Readonly<ZodTypeAny[]>>(
     types: T,
     params?: RawCreateParams
   ): ZodUnion<T> => {

--- a/src/__tests__/unions.test.ts
+++ b/src/__tests__/unions.test.ts
@@ -62,3 +62,16 @@ test("readonly union", async () => {
   union.parse("asdf");
   union.parse(12);
 });
+
+test("return valid over spread array of literals", () => {
+  const cells = ["a1", "a2", "a3", "b1", "b2", "b3"] as const;
+  const union = z.union([...cells.map((cell) => z.literal(cell))]);
+  union.parse("a1");
+});
+
+test("fails parse over spread array of literals for non-existent item", () => {
+  const cells = ["a1", "a2", "a3", "b1", "b2", "b3"] as const;
+  const union = z.union([...cells.map((cell) => z.literal(cell))]);
+  const result = union.safeParse("c1");
+  expect(result.success).toBe(false);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -2851,7 +2851,7 @@ export type AnyZodObject = ZodObject<any, any, any>;
 //////////                    //////////
 ////////////////////////////////////////
 ////////////////////////////////////////
-export type ZodUnionOptions = Readonly<[ZodTypeAny, ...ZodTypeAny[]]>;
+export type ZodUnionOptions = Readonly<[...ZodTypeAny[]]>;
 export interface ZodUnionDef<
   T extends ZodUnionOptions = Readonly<
     [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]
@@ -2971,9 +2971,7 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
     return this._def.options;
   }
 
-  static create = <
-    T extends Readonly<[ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>
-  >(
+  static create = <T extends Readonly<ZodTypeAny[]>>(
     types: T,
     params?: RawCreateParams
   ): ZodUnion<T> => {


### PR DESCRIPTION
Addresses #3383 

## Description

Modifies the types for allowing creating z.union() for dynamic arrays spread by z.literal, I essentially removed the first two readonly ZodTypes in the array.

Note: I also tried creating a conditional return using `T extends [infer First, ...infer Rest] ? ZodUnion<T> : ZodUnion<[]>` as I first atttempt but I could not find success, if there is a better option by adding a conditional type I accept suggestions.

## New behavior

```ts
const cells = ["a1", "a2", "a3", "b1", "b2", "b3"] as const;
z.union([...cells.map((cell) => z.literal(cell))]).parse("a1");
```

