### PR TITLE
Recursive types should use z.input instead of z.infer (e.g. z.output)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1869,7 +1869,7 @@ const baseCategorySchema = z.object({
   name: z.string(),
 });
 
-type Category = z.infer<typeof baseCategorySchema> & {
+type Category = z.input<typeof baseCategorySchema> & {
   subcategories: Category[];
 };
 


### PR DESCRIPTION
If Input != Output, this causes problems, e.g. if a default value is set. The README example technically works, but causes trouble in it's current form.

Repro:

```
let OptionBase = z.object({
    description: z.string().optional(),
    _kind: z.literal('option').default('option'),
})

// change z.infer to z.input to fix
type _Option = z.infer<typeof OptionBase> & {
    type: z.ZodType | _Option
}

let Option: z.ZodType<_Option> = OptionBase.extend({
    type: z.instanceof(z.ZodType).or(z.lazy(() => Option)),
})
```

gives the error:

```
error TS2322: Type 'ZodObject<{ description: ZodOptional<ZodString>; _kind: ZodDefault<ZodLiteral<"option">>; type: ZodUnion<[ZodType<ZodType<unknown, ZodTypeDef, unknown>, ZodTypeDef, ZodType<...>>, ZodLazy<...>]>; }, "strip", ZodTypeAny, { ...; }, { ...; }>' is not assignable to type 'ZodType<_Option, ZodTypeDef, _Option>'.
  Types of property '_input' are incompatible.
    Type '{ type: (_Option | ZodType<unknown, ZodTypeDef, unknown>) & (_Option | ZodType<unknown, ZodTypeDef, unknown> | undefined); description?: string | undefined; _kind?: "option" | undefined; }' is not assignable to type '_Option'.
      Type '{ type: (_Option | ZodType<unknown, ZodTypeDef, unknown>) & (_Option | ZodType<unknown, ZodTypeDef, unknown> | undefined); description?: string | undefined; _kind?: "option" | undefined; }' is not assignable to type '{ _kind: "option"; description?: string | undefined; }'.
        Types of property '_kind' are incompatible.
          Type '"option" | undefined' is not assignable to type '"option"'.
            Type 'undefined' is not assignable to type '"option"'.
```