### PR TITLE
[3439] Add default value to createZodEnum generic

### DIFF
--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -18,6 +18,16 @@ test("infer enum", () => {
   util.assertEqual<MyEnum, "Red" | "Green" | "Blue">(true);
 });
 
+test("typed enum input", () => {
+  type MyEnumInputs = "Red" | "Green";
+  const MyEnum = z.enum<MyEnumInputs>(["Red", "Green"]);
+  type MyEnum = z.infer<typeof MyEnum>;
+  util.assertEqual<MyEnum, "Red" | "Green">(true);
+
+  // @ts-expect-error TS2345
+  z.enum<MyEnumInputs>(["Red", "Green", "Blue"]);
+});
+
 test("get options", () => {
   expect(z.enum(["tuna", "trout"]).options).toEqual(["tuna", "trout"]);
 });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4163,11 +4163,11 @@ export type FilterEnum<Values, ToExclude> = Values extends []
 
 export type typecast<A, T> = A extends T ? A : never;
 
-function createZodEnum<U extends string, T extends Readonly<[U, ...U[]]>>(
-  values: T,
-  params?: RawCreateParams
-): ZodEnum<Writeable<T>>;
-function createZodEnum<U extends string, T extends [U, ...U[]]>(
+function createZodEnum<
+  U extends string,
+  T extends Readonly<[U, ...U[]]> = Readonly<[U, ...U[]]>
+>(values: T, params?: RawCreateParams): ZodEnum<Writeable<T>>;
+function createZodEnum<U extends string, T extends [U, ...U[]] = [U, ...U[]]>(
   values: T,
   params?: RawCreateParams
 ): ZodEnum<T>;

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -17,6 +17,16 @@ test("infer enum", () => {
   util.assertEqual<MyEnum, "Red" | "Green" | "Blue">(true);
 });
 
+test("typed enum input", () => {
+  type MyEnumInputs = "Red" | "Green";
+  const MyEnum = z.enum<MyEnumInputs>(["Red", "Green"]);
+  type MyEnum = z.infer<typeof MyEnum>;
+  util.assertEqual<MyEnum, "Red" | "Green">(true);
+
+  // @ts-expect-error TS2345
+  z.enum<MyEnumInputs>(["Red", "Green", "Blue"]);
+});
+
 test("get options", () => {
   expect(z.enum(["tuna", "trout"]).options).toEqual(["tuna", "trout"]);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -4163,11 +4163,11 @@ export type FilterEnum<Values, ToExclude> = Values extends []
 
 export type typecast<A, T> = A extends T ? A : never;
 
-function createZodEnum<U extends string, T extends Readonly<[U, ...U[]]>>(
-  values: T,
-  params?: RawCreateParams
-): ZodEnum<Writeable<T>>;
-function createZodEnum<U extends string, T extends [U, ...U[]]>(
+function createZodEnum<
+  U extends string,
+  T extends Readonly<[U, ...U[]]> = Readonly<[U, ...U[]]>
+>(values: T, params?: RawCreateParams): ZodEnum<Writeable<T>>;
+function createZodEnum<U extends string, T extends [U, ...U[]] = [U, ...U[]]>(
   values: T,
   params?: RawCreateParams
 ): ZodEnum<T>;


### PR DESCRIPTION
Fix for #3439

If you have existing string union types, enum requires both generics to be defined in order to type guard against the input. Example:

```ts
import { z } from 'zod';

type TColors = 'Red' | 'Green' | 'Blue';

// Type error
z.enum<TColors>(["Red", "Green", "Blue"]);

// Success
z.enum<TColors, [TColors, ...TColors[]]>(["Red", "Green", "Blue"]);
```

This PR adds a default value to the `createZodEnum` generic for the list parameter