### PR TITLE
Made ZodEnum take readonly string array

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4139,7 +4139,7 @@ export class ZodLiteral<T> extends ZodType<T, ZodLiteralDef<T>, T> {
 export type ArrayKeys = keyof any[];
 export type Indices<T> = Exclude<keyof T, ArrayKeys>;
 
-export type EnumValues<T extends string = string> = [T, ...T[]];
+export type EnumValues<T extends string = string> = readonly [T, ...T[]];
 
 export type Values<T extends EnumValues> = {
   [k in T[number]]: k;


### PR DESCRIPTION
# Zod Pull Request

Enables creating dynamic schemas from `as const` object definitions:

```typescript
const question = {
  questionId: "unit_location",
  answers: ["attic", "upstairs", "main_floor", "basement", "garage", "outside", "other"],
} as const;

function questionToZodSchema<
  Q extends string,
  A extends readonly [string, ...string[]],
>(question: QuestionSpec<Q, A>): z.ZodObject<{ [key in Q]: ZodEnum<A> }> {
  return z.object({ [question.questionId]: z.enum(question.answers) }) as any;
}

const schema = leafQuestionToZodSchema(test);
const value = schema.parse({ unit_location: "attic" });
```

## Overview

Thank you for your contribution to our project! Before submitting your pull request, please ensure the following:

- [ ] Your code changes are well-documented.
- [ ] You have tested your changes.
- [ ] You have updated any relevant documentation.
