### PR TITLE
Fixed freezing async ZodReadonly results

### DIFF
--- a/README.md
+++ b/README.md
@@ -2681,7 +2681,7 @@ Note that branded types do not affect the runtime result of `.parse`. It is a st
 This method returns a `ZodReadonly` schema instance that parses the input using the base schema, then calls `Object.freeze()` on the result. The inferred type is also marked as `readonly`.
 
 ```ts
-const schema = z.object({ name: string }).readonly();
+const schema = z.object({ name: z.string() }).readonly();
 type schema = z.infer<typeof schema>;
 // Readonly<{name: string}>
 

--- a/src/__tests__/readonly.test.ts
+++ b/src/__tests__/readonly.test.ts
@@ -202,3 +202,53 @@ test("object freezing", () => {
     )
   ).toBe(true);
 });
+
+test("async object freezing", async () => {
+  expect(
+    Object.isFrozen(await z.array(z.string()).readonly().parseAsync(["a"]))
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      await z.tuple([z.string(), z.number()]).readonly().parseAsync(["a", 1])
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      await z
+        .map(z.string(), z.date())
+        .readonly()
+        .parseAsync(new Map([["a", new Date()]]))
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      await z
+        .set(z.promise(z.string()))
+        .readonly()
+        .parseAsync(new Set([Promise.resolve("a")]))
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      await z.record(z.string()).readonly().parseAsync({ a: "b" })
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      await z.record(z.string(), z.number()).readonly().parseAsync({ a: 1 })
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      await z
+        .object({ a: z.string(), 1: z.number() })
+        .readonly()
+        .parseAsync({ a: "b", 1: 2 })
+    )
+  ).toBe(true);
+  expect(
+    Object.isFrozen(
+      await z.promise(z.string()).readonly().parseAsync(Promise.resolve("a"))
+    )
+  ).toBe(true);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -5041,10 +5041,15 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const result = this._def.innerType._parse(input);
-    if (isValid(result)) {
-      result.value = Object.freeze(result.value);
-    }
-    return result;
+    const freeze = (data: ParseReturnType<this["_output"]>) => {
+      if (isValid(data)) {
+        data.value = Object.freeze(data.value);
+      }
+      return data;
+    };
+    return isAsync(result)
+      ? result.then((data) => freeze(data))
+      : freeze(result);
   }
 
   static create = <T extends ZodTypeAny>(


### PR DESCRIPTION
Hello!

I noticed that the parsed results of `readonly()` schemas are not really readonly after `parseAsync()`
I added tests, then a fix. (and corrected a minor typo in the related docs)

- [x] Your code changes are well-documented.
- [x] You have tested your changes.
- [x] You have updated any relevant documentation.
