### PR TITLE
Fix #3437: extendShape erases JSDoc property documentation

### DIFF
--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -132,11 +132,9 @@ export namespace objectUtil {
   };
 
   export type extendShape<A extends object, B extends object> = {
-    [K in keyof A | keyof B]: K extends keyof B
-      ? B[K]
-      : K extends keyof A
-      ? A[K]
-      : never;
+    [K in keyof A as K extends keyof B ? never : K]: A[K];
+  } & {
+    [K in keyof B]: B[K];
   };
 }
 

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -132,11 +132,9 @@ export namespace objectUtil {
   };
 
   export type extendShape<A extends object, B extends object> = {
-    [K in keyof A | keyof B]: K extends keyof B
-      ? B[K]
-      : K extends keyof A
-      ? A[K]
-      : never;
+    [K in keyof A as K extends keyof B ? never : K]: A[K];
+  } & {
+    [K in keyof B]: B[K];
   };
 }
 


### PR DESCRIPTION
Fixes the issue described [here](https://github.com/colinhacks/zod/issues/3437), at least the minimal repro example provided.

Benchmarking the change using [zod-ts-perftest](https://github.com/jussisaurio/zod-ts-perftest) it increases the number of type instantiations by 8.5%, which may be an acceptable compromise, but ofc not ideal

[More discussion here](https://github.com/colinhacks/zod/pull/2845#issuecomment-2093772277)
