### PR TITLE
Add E.164 format validation for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,20 @@ if (!env.success) {
 
 This is recommended over using `z.string().transform(s => JSON.parse(s))`, since that will not catch parse errors, even when using `.safeParse`.
 
+### E.164 telephone numbers
+
+The z.string().e164() method can be used to validate international telephone numbers.
+
+```ts
+const e164Number = z.string().e164();
+
+e164Number.parse("+1555555"); // pass
+e164Number.parse("+155555555555555"); // pass
+
+e164Number.parse("555555555"); // fail
+e164Number.parse("+1 1555555"); // fail
+```
+
 ## Numbers
 
 You can customize certain error messages when creating a number schema.

--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ z.string().date(); // ISO date format (YYYY-MM-DD)
 z.string().time(); // ISO time format (HH:mm:ss[.SSSSSS])
 z.string().duration(); // ISO 8601 duration
 z.string().base64();
+z.string().e164(); // E.164 number format
 ```
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -652,6 +652,7 @@ z.string().date(); // ISO date format (YYYY-MM-DD)
 z.string().time(); // ISO time format (HH:mm:ss[.SSSSSS])
 z.string().duration(); // ISO 8601 duration
 z.string().base64();
+z.string().e164(); // E.164 number format
 ```
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -788,7 +788,6 @@ const ipv6 = z.string().ip({ version: "v6" });
 ipv6.parse("192.168.1.1"); // fail
 ```
 
-<<<<<<< HEAD
 ### JSON
 
 The `z.string().json(...)` method parses strings as JSON, then [pipes](#pipe) the result to another specified schema.
@@ -827,7 +826,6 @@ if (!env.success) {
 
 This is recommended over using `z.string().transform(s => JSON.parse(s))`, since that will not catch parse errors, even when using `.safeParse`.
 
-=======
 ### E.164 telephone numbers
 
 The z.string().e164() method can be used to validate international telephone numbers.
@@ -842,7 +840,6 @@ e164Number.parse("555555555"); // fail
 e164Number.parse("+1 1555555"); // fail
 ```
 
->>>>>>> cc17c188 (added documentation)
 ## Numbers
 
 You can customize certain error messages when creating a number schema.

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -788,6 +788,7 @@ const ipv6 = z.string().ip({ version: "v6" });
 ipv6.parse("192.168.1.1"); // fail
 ```
 
+<<<<<<< HEAD
 ### JSON
 
 The `z.string().json(...)` method parses strings as JSON, then [pipes](#pipe) the result to another specified schema.
@@ -826,6 +827,22 @@ if (!env.success) {
 
 This is recommended over using `z.string().transform(s => JSON.parse(s))`, since that will not catch parse errors, even when using `.safeParse`.
 
+=======
+### E.164 telephone numbers
+
+The z.string().e164() method can be used to validate international telephone numbers.
+
+```ts
+const e164Number = z.string().e164();
+
+e164Number.parse("+1555555"); // pass
+e164Number.parse("+155555555555555"); // pass
+
+e164Number.parse("555555555"); // fail
+e164Number.parse("+1 1555555"); // fail
+```
+
+>>>>>>> cc17c188 (added documentation)
 ## Numbers
 
 You can customize certain error messages when creating a number schema.

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -113,6 +113,7 @@ export type StringValidation =
   | "duration"
   | "ip"
   | "base64"
+  | "e164"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -906,3 +906,40 @@ test("IP validation", () => {
     invalidIPs.every((ip) => ipSchema.safeParse(ip).success === false)
   ).toBe(true);
 });
+
+test("E.164 validation", () => {
+  const e164Number = z.string().e164();
+  expect(e164Number.safeParse("+1555555").success).toBe(true);
+
+  const validE164Numbers = [
+    "+1555555", // min-length (7 + 1)
+    "+15555555",
+    "+155555555",
+    "+1555555555",
+    "+15555555555",
+    "+155555555555",
+    "+1555555555555",
+    "+15555555555555",
+    "+155555555555555",
+    "+105555555555555",
+    "+100555555555555", // max-length (15 + 1)
+  ];
+
+  const invalidE164Numbers = [
+    "", // empty
+    "+", // only plus sign
+    "-", // wrong sign
+    "555555555", // missing plus sign
+    "+1 555 555 555", // space after plus sign
+    "+1555 555 555", // space after plus sign
+    "+1555 555 555", // space between numbers
+    "+1555+555", // multiple plus signs
+    "+1555555555555555", // too long
+    "+115abc55", // non numeric characters in number part
+  ];
+
+  expect(validE164Numbers.every((number) => e164Number.safeParse(number).success)).toBe(true);
+  expect(
+    invalidE164Numbers.every((number) => e164Number.safeParse(number).success === false)
+  ).toBe(true);
+});

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -912,7 +912,7 @@ test("E.164 validation", () => {
   expect(e164Number.safeParse("+1555555").success).toBe(true);
 
   const validE164Numbers = [
-    "+1555555", // min-length (7 + 1)
+    "+1555555", // min-length (7 digits + '+')
     "+15555555",
     "+155555555",
     "+1555555555",
@@ -922,20 +922,21 @@ test("E.164 validation", () => {
     "+15555555555555",
     "+155555555555555",
     "+105555555555555",
-    "+100555555555555", // max-length (15 + 1)
+    "+100555555555555", // max-length (15 digits + '+')
   ];
 
   const invalidE164Numbers = [
     "", // empty
     "+", // only plus sign
     "-", // wrong sign
+    " 555555555", // starts with space
     "555555555", // missing plus sign
     "+1 555 555 555", // space after plus sign
-    "+1555 555 555", // space after plus sign
     "+1555 555 555", // space between numbers
     "+1555+555", // multiple plus signs
     "+1555555555555555", // too long
     "+115abc55", // non numeric characters in number part
+    "+1555555 ", // space after number
   ];
 
   expect(validE164Numbers.every((number) => e164Number.safeParse(number).success)).toBe(true);

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -551,7 +551,11 @@ export type ZodStringCheck =
   | { kind: "duration"; message?: string }
   | { kind: "ip"; version?: IpVersion; message?: string }
   | { kind: "base64"; message?: string }
+<<<<<<< HEAD
   | { kind: "json"; message?: string };
+=======
+  | { kind: "e164"; message?: string };
+>>>>>>> 84694186 (Added e164 validation)
 
 export interface ZodStringDef extends ZodTypeDef {
   checks: ZodStringCheck[];
@@ -618,9 +622,14 @@ const ipv6Regex =
 const base64Regex =
   /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 
+<<<<<<< HEAD
 // based on https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
 const hostnameRegex =
   /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
+=======
+// https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3 (regex from there allows spaces)
+const e164Regex = /^\+(?:[0-9]){6,14}[0-9]$/;
+>>>>>>> 84694186 (Added e164 validation)
 
 // simple
 // const dateRegexSource = `\\d{4}-\\d{2}-\\d{2}`;
@@ -1035,6 +1044,16 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
             message: check.message,
           });
         }
+      } else if (check.kind === "e164") {
+        if (!e164Regex.test(input.data)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "e164",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else {
         util.assertNever(check);
       }
@@ -1120,6 +1139,10 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
 
   ip(options?: string | { version?: "v4" | "v6"; message?: string }) {
     return this._addCheck({ kind: "ip", ...errorUtil.errToObj(options) });
+  }
+
+  e164(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "e164", ...errorUtil.errToObj(message) });
   }
 
   datetime(
@@ -1352,6 +1375,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   get isBase64() {
     return !!this._def.checks.find((ch) => ch.kind === "base64");
+  }
+  get isE164() {
+    return !!this._def.checks.find((ch) => ch.kind === "e164");
   }
 
   get minLength() {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -623,11 +623,15 @@ const base64Regex =
   /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 // based on https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
 const hostnameRegex =
   /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
 =======
 // https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3 (regex from there allows spaces)
+=======
+// https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3 (regex sans spaces)
+>>>>>>> 0c908749 (cleanup and missing files)
 const e164Regex = /^\+(?:[0-9]){6,14}[0-9]$/;
 >>>>>>> 84694186 (Added e164 validation)
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -551,11 +551,8 @@ export type ZodStringCheck =
   | { kind: "duration"; message?: string }
   | { kind: "ip"; version?: IpVersion; message?: string }
   | { kind: "base64"; message?: string }
-<<<<<<< HEAD
   | { kind: "json"; message?: string };
-=======
   | { kind: "e164"; message?: string };
->>>>>>> 84694186 (Added e164 validation)
 
 export interface ZodStringDef extends ZodTypeDef {
   checks: ZodStringCheck[];
@@ -614,26 +611,19 @@ let emojiRegex: RegExp;
 // faster, simpler, safer
 const ipv4Regex =
   /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/;
-
 const ipv6Regex =
   /^(([a-f0-9]{1,4}:){7}|::([a-f0-9]{1,4}:){0,6}|([a-f0-9]{1,4}:){1}:([a-f0-9]{1,4}:){0,5}|([a-f0-9]{1,4}:){2}:([a-f0-9]{1,4}:){0,4}|([a-f0-9]{1,4}:){3}:([a-f0-9]{1,4}:){0,3}|([a-f0-9]{1,4}:){4}:([a-f0-9]{1,4}:){0,2}|([a-f0-9]{1,4}:){5}:([a-f0-9]{1,4}:){0,1})([a-f0-9]{1,4}|(((25[0-5])|(2[0-4][0-9])|(1[0-9]{2})|([0-9]{1,2}))\.){3}((25[0-5])|(2[0-4][0-9])|(1[0-9]{2})|([0-9]{1,2})))$/;
 
 // https://stackoverflow.com/questions/7860392/determine-if-string-is-in-base64-using-javascript
 const base64Regex =
   /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
-
-<<<<<<< HEAD
-<<<<<<< HEAD
 // based on https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
+
 const hostnameRegex =
   /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
-=======
-// https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3 (regex from there allows spaces)
-=======
+
 // https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3 (regex sans spaces)
->>>>>>> 0c908749 (cleanup and missing files)
 const e164Regex = /^\+(?:[0-9]){6,14}[0-9]$/;
->>>>>>> 84694186 (Added e164 validation)
 
 // simple
 // const dateRegexSource = `\\d{4}-\\d{2}-\\d{2}`;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -551,7 +551,7 @@ export type ZodStringCheck =
   | { kind: "duration"; message?: string }
   | { kind: "ip"; version?: IpVersion; message?: string }
   | { kind: "base64"; message?: string }
-  | { kind: "json"; message?: string };
+  | { kind: "json"; message?: string }
   | { kind: "e164"; message?: string };
 
 export interface ZodStringDef extends ZodTypeDef {
@@ -1039,14 +1039,14 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
         }
       } else if (check.kind === "e164") {
-        if (!e164Regex.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext(ctx, {
+        if (!e164Regex.test(input)) {
+          issues = issues || [];
+          issues.push({
+            input,
             validation: "e164",
             code: ZodIssueCode.invalid_string,
             message: check.message,
           });
-          status.dirty();
         }
       } else {
         util.assertNever(check);

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -113,6 +113,7 @@ export type StringValidation =
   | "duration"
   | "ip"
   | "base64"
+  | "e164"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -911,7 +911,7 @@ test("E.164 validation", () => {
   expect(e164Number.safeParse("+1555555").success).toBe(true);
 
   const validE164Numbers = [
-    "+1555555", // min-length (7 + 1)
+    "+1555555", // min-length (7 digits + '+')
     "+15555555",
     "+155555555",
     "+1555555555",
@@ -921,20 +921,21 @@ test("E.164 validation", () => {
     "+15555555555555",
     "+155555555555555",
     "+105555555555555",
-    "+100555555555555", // max-length (15 + 1)
+    "+100555555555555", // max-length (15 digits + '+')
   ];
 
   const invalidE164Numbers = [
     "", // empty
     "+", // only plus sign
     "-", // wrong sign
+    " 555555555", // starts with space
     "555555555", // missing plus sign
     "+1 555 555 555", // space after plus sign
-    "+1555 555 555", // space after plus sign
     "+1555 555 555", // space between numbers
     "+1555+555", // multiple plus signs
     "+1555555555555555", // too long
     "+115abc55", // non numeric characters in number part
+    "+1555555 ", // space after number
   ];
 
   expect(validE164Numbers.every((number) => e164Number.safeParse(number).success)).toBe(true);

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -905,3 +905,40 @@ test("IP validation", () => {
     invalidIPs.every((ip) => ipSchema.safeParse(ip).success === false)
   ).toBe(true);
 });
+
+test("E.164 validation", () => {
+  const e164Number = z.string().e164();
+  expect(e164Number.safeParse("+1555555").success).toBe(true);
+
+  const validE164Numbers = [
+    "+1555555", // min-length (7 + 1)
+    "+15555555",
+    "+155555555",
+    "+1555555555",
+    "+15555555555",
+    "+155555555555",
+    "+1555555555555",
+    "+15555555555555",
+    "+155555555555555",
+    "+105555555555555",
+    "+100555555555555", // max-length (15 + 1)
+  ];
+
+  const invalidE164Numbers = [
+    "", // empty
+    "+", // only plus sign
+    "-", // wrong sign
+    "555555555", // missing plus sign
+    "+1 555 555 555", // space after plus sign
+    "+1555 555 555", // space after plus sign
+    "+1555 555 555", // space between numbers
+    "+1555+555", // multiple plus signs
+    "+1555555555555555", // too long
+    "+115abc55", // non numeric characters in number part
+  ];
+
+  expect(validE164Numbers.every((number) => e164Number.safeParse(number).success)).toBe(true);
+  expect(
+    invalidE164Numbers.every((number) => e164Number.safeParse(number).success === false)
+  ).toBe(true);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1039,14 +1039,14 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
         }
       } else if (check.kind === "e164") {
-        if (!e164Regex.test(input.data)) {
-          ctx = this._getOrReturnCtx(input, ctx);
-          addIssueToContext(ctx, {
+        if (!e164Regex.test(input)) {
+          issues = issues || [];
+          issues.push({
+            input,
             validation: "e164",
             code: ZodIssueCode.invalid_string,
             message: check.message,
           });
-          status.dirty();
         }
       } else {
         util.assertNever(check);

--- a/src/types.ts
+++ b/src/types.ts
@@ -611,18 +611,18 @@ let emojiRegex: RegExp;
 // faster, simpler, safer
 const ipv4Regex =
   /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$/;
-
 const ipv6Regex =
   /^(([a-f0-9]{1,4}:){7}|::([a-f0-9]{1,4}:){0,6}|([a-f0-9]{1,4}:){1}:([a-f0-9]{1,4}:){0,5}|([a-f0-9]{1,4}:){2}:([a-f0-9]{1,4}:){0,4}|([a-f0-9]{1,4}:){3}:([a-f0-9]{1,4}:){0,3}|([a-f0-9]{1,4}:){4}:([a-f0-9]{1,4}:){0,2}|([a-f0-9]{1,4}:){5}:([a-f0-9]{1,4}:){0,1})([a-f0-9]{1,4}|(((25[0-5])|(2[0-4][0-9])|(1[0-9]{2})|([0-9]{1,2}))\.){3}((25[0-5])|(2[0-4][0-9])|(1[0-9]{2})|([0-9]{1,2})))$/;
 
 // https://stackoverflow.com/questions/7860392/determine-if-string-is-in-base64-using-javascript
 const base64Regex =
   /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
-
 // based on https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
+
 const hostnameRegex =
   /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)+([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/;
-// https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3 (regex from there allows spaces)
+
+// https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3 (regex sans spaces)
 const e164Regex = /^\+(?:[0-9]){6,14}[0-9]$/;
 
 // simple


### PR DESCRIPTION
Hello, following the previous [discussion](https://github.com/colinhacks/zod/issues/3378), I added validation for the E.164 format on strings using a modified regex from this [article](https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3).  I removed support for spaces as those don't seem to be [permitted](https://gotrunk.com/blog/the-e-164-format-what-is-it-and-how-to-use-it-correctly/#:~:text=How%20to%20dial%20an%20E.164%20phone%20number%20correctly). The validation could be further enhanced by prohibiting `0` as the first value since country codes start with `1`.

There is an alternative regular expression from the [Twilio docs](https://www.twilio.com/docs/glossary/what-e164#regex-matching-for-e164) for E.164 numbers. This regular expression permits very short E.164 numbers. It could be used in tandem with the existing string validations like `min` and `max`. This would give users the option to adapt the number length further, which seems to be necessary in some instances, according to this [stack overflow post](https://stackoverflow.com/questions/14894899/what-is-the-minimum-length-of-a-valid-international-phone-number).

Cheers

Thank you for your contribution to our project! Before submitting your pull request, please ensure the following:

- [x] Your code changes are well-documented.
- [x] You have tested your changes.
- [x] You have updated any relevant documentation.
