### PR TITLE
Publish Zod to `jsr`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,14 @@ jobs:
         run: |
           echo "Version in package.json has not changed. Skipping."
           exit 0
+      
+      - name: Update jsr.json version
+        if: steps.publish.outputs.type != 'none'
+        uses: jossef/action-set-json-field@v2.2
+        with:
+          file: deno/lib/jsr.json
+          field: version
+          value: ${{ steps.publish.outputs.version }}
 
       - name: Push to Deno
         if: steps.publish.outputs.type != 'none'

--- a/deno/lib/jsr.json
+++ b/deno/lib/jsr.json
@@ -1,0 +1,5 @@
+{
+  "name": "@colinhacks/zod",
+  "version": "3.23.8",
+  "exports": "./mod.ts"
+}


### PR DESCRIPTION
This pull-request adds a `jsr.json` file to `deno/lib` to publish Zod to [JSR](https://jsr.io/).
I also added a simple step to the GitHub release workflow to update the `"version"` specifier using the one from `package.json`.

The only thing I believe that would have to be set-up for automatic releases is [OIDC-based publishing to JSR](https://jsr.io/docs/publishing-packages#publishing-from-github-actions).

I published a sample package to [`jsr:@prgm/zod`](https://jsr.io/@prgm/zod@3.23.8-alpha.1). 

This should close #3300.