### PR TITLE
Fixed type Inference with `custom` and `instanceof` in `catchall`

### DIFF
--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -193,6 +193,16 @@ test("test catchall parsing", async () => {
   expect(result2.success).toEqual(false);
 });
 
+test("catchall instanceof", async () => {
+  const date = new Date();
+  const schema = z.object({ name: z.string() }).catchall(z.instanceof(Date));
+  type Schema = z.infer<typeof schema>;
+  util.assertEqual<Schema, { name: string } & { [k: string]: Date }>(true);
+
+  const result = schema.parse({ name: "Foo", date });
+  expect(result).toEqual({ name: "Foo", date });
+});
+
 test("test nonexistent keys", async () => {
   const Schema = z.union([
     z.object({ a: z.string() }),

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -203,6 +203,21 @@ test("catchall instanceof", async () => {
   expect(result).toEqual({ name: "Foo", date });
 });
 
+test("catchall custom", async () => {
+  const schema = z
+    .object({ name: z.string() })
+    .catchall(z.custom<number>((x) => typeof x === "number"));
+  type Schema = z.infer<typeof schema>;
+  util.assertEqual<Schema, { name: string } & { [k: string]: number }>(true);
+
+  const result = schema.parse({ name: "Foo", asdf: 1234 });
+  expect(result).toEqual({ name: "Foo", asdf: 1234 });
+
+  const schema2 = z.object({ name: z.string() }).catchall(z.custom());
+  type Schema2 = z.infer<typeof schema2>;
+  util.assertEqual<Schema2, { name: string } & { [k: string]: unknown }>(true);
+});
+
 test("test nonexistent keys", async () => {
   const Schema = z.union([
     z.object({ a: z.string() }),

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -5090,7 +5090,7 @@ export function custom<T>(
    *
    */
   fatal?: boolean
-): ZodType<T, ZodTypeDef, T> {
+): T extends undefined ? ZodAny : ZodEffects<ZodAny, T, T> {
   if (check)
     return ZodAny.create().superRefine((data, ctx) => {
       if (!check(data)) {
@@ -5104,8 +5104,8 @@ export function custom<T>(
         const p2 = typeof p === "string" ? { message: p } : p;
         ctx.addIssue({ code: "custom", ...p2, fatal: _fatal });
       }
-    });
-  return ZodAny.create();
+    }) as any;
+  return ZodAny.create() as any;
 }
 
 export { ZodType as Schema, ZodType as ZodSchema };

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -195,11 +195,38 @@ test("test catchall parsing", async () => {
 test("catchall instanceof", async () => {
   const date = new Date();
   const schema = z.object({ name: z.string() }).catchall(z.instanceof(Date));
+
   type Schema = z.infer<typeof schema>;
   util.assertEqual<Schema, { name: string } & { [k: string]: Date }>(true);
 
   const result = schema.parse({ name: "Foo", date });
   expect(result).toEqual({ name: "Foo", date });
+});
+
+test("catchall custom", async () => {
+  const schema = z
+    .object({ name: z.string() })
+    .catchall(z.custom<number>((x) => typeof x === "number"));
+  type Schema = z.infer<typeof schema>;
+  util.assertEqual<Schema, { name: string } & { [k: string]: number }>(true);
+
+  const result = schema.parse({ name: "Foo", asdf: 1234 });
+  expect(result).toEqual({ name: "Foo", asdf: 1234 });
+});
+
+test("catchall custom", async () => {
+  const date = new Date();
+  const schema = z.object({ name: z.string() }).catchall(z.instanceof(Date));
+
+  type Schema = z.infer<typeof schema>;
+  util.assertEqual<Schema, { name: string } & { [k: string]: Date }>(true);
+
+  const result = schema.parse({ name: "Foo", date });
+  expect(result).toEqual({ name: "Foo", date });
+
+  const schema2 = z.object({ name: z.string() }).catchall(z.custom());
+  type Schema2 = z.infer<typeof schema2>;
+  util.assertEqual<Schema2, { name: string } & { [k: string]: unknown }>(true);
 });
 
 test("test nonexistent keys", async () => {

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -192,6 +192,16 @@ test("test catchall parsing", async () => {
   expect(result2.success).toEqual(false);
 });
 
+test("catchall instanceof", async () => {
+  const date = new Date();
+  const schema = z.object({ name: z.string() }).catchall(z.instanceof(Date));
+  type Schema = z.infer<typeof schema>;
+  util.assertEqual<Schema, { name: string } & { [k: string]: Date }>(true);
+
+  const result = schema.parse({ name: "Foo", date });
+  expect(result).toEqual({ name: "Foo", date });
+});
+
 test("test nonexistent keys", async () => {
   const Schema = z.union([
     z.object({ a: z.string() }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -5090,7 +5090,7 @@ export function custom<T>(
    *
    */
   fatal?: boolean
-): ZodType<T, ZodTypeDef, T> {
+): T extends undefined ? ZodAny : ZodEffects<ZodAny, T, T> {
   if (check)
     return ZodAny.create().superRefine((data, ctx) => {
       if (!check(data)) {
@@ -5104,8 +5104,8 @@ export function custom<T>(
         const p2 = typeof p === "string" ? { message: p } : p;
         ctx.addIssue({ code: "custom", ...p2, fatal: _fatal });
       }
-    });
-  return ZodAny.create();
+    }) as any;
+  return ZodAny.create() as any;
 }
 
 export { ZodType as Schema, ZodType as ZodSchema };


### PR DESCRIPTION
Hello!

I noticed that when using `custom` or `instanceof` with `catchall`, the type inference using `infer` does not work.
I have fixed it and added tests.

# Before
```typescript
const schema = z.object({ name: z.string() }).catchall(z.instanceof(Date));

// { name: string }
type Schema = z.infer<typeof schema>;
```

# After
```typescript
const schema = z.object({ name: z.string() }).catchall(z.instanceof(Date));

// { name: string } & { [k: string]: Date };
type Schema = z.infer<typeof schema>;
```