### PR TITLE
 Fix for `multipleOf` issue with 7 decimal places 

### DIFF
--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -427,6 +427,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`@sanity-typed/zod`](https://github.com/saiichihashimoto/sanity-typed/tree/main/packages/zod): Generate Zod Schemas from [Sanity Schemas](https://www.sanity.io/docs/schema-types).
 - [`java-to-zod`](https://github.com/ivangreene/java-to-zod): Convert POJOs to Zod schemas
 - [`Orval`](https://github.com/anymaniax/orval): Generate Zod schemas from OpenAPI schemas
+- [`Kubb`](https://github.com/kubb-labs/kubb): Generate SDKs and Zod schemas from your OpenAPI schemas
 
 #### Mocking
 

--- a/deno/lib/__tests__/multipleOf.test.ts
+++ b/deno/lib/__tests__/multipleOf.test.ts
@@ -1,0 +1,56 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+
+describe('z.number().multipleOf() behavior', () => {
+  const numbers = {
+    number3: 5.123,
+    number6: 5.123456,
+    number7: 5.1234567,
+    number8: 5.12345678,
+  };
+
+  const schemas = {
+    schema6: z.number().multipleOf(0.000001),
+    schema7: z.number().multipleOf(0.0000001),
+  };
+
+  describe('schema6 tests', () => {
+    test('should not throw for number3', () => {
+      expect(() => schemas.schema6.parse(numbers.number3)).not.toThrow();
+    });
+
+    test('should not throw for number6', () => {
+      expect(() => schemas.schema6.parse(numbers.number6)).not.toThrow();
+    });
+
+    test('should throw for number7', () => {
+      expect(() => schemas.schema6.parse(numbers.number7)).toThrow();
+    });
+
+    test('should throw for number8', () => {
+      expect(() => schemas.schema6.parse(numbers.number8)).toThrow();
+    });
+  });
+
+  describe('schema7 tests', () => {
+    test('should not throw for number3', () => {
+      expect(() => schemas.schema7.parse(numbers.number3)).not.toThrow();
+    });
+
+    test('should not throw for number6', () => {
+      expect(() => schemas.schema7.parse(numbers.number6)).not.toThrow();
+    });
+
+    test('should not throw for number7', () => {
+      expect(() => schemas.schema7.parse(numbers.number7)).not.toThrow();
+    });
+
+    test('should throw for number8', () => {
+      expect(() => schemas.schema7.parse(numbers.number8)).toThrow();
+    });
+  });
+});

--- a/deno/lib/__tests__/multipleOf.test.ts
+++ b/deno/lib/__tests__/multipleOf.test.ts
@@ -18,7 +18,6 @@ describe('z.number().multipleOf() behavior', () => {
     schema7: z.number().multipleOf(0.0000001),
   };
 
-  describe('schema6 tests', () => {
     test('should not throw for number3', () => {
       expect(() => schemas.schema6.parse(numbers.number3)).not.toThrow();
     });
@@ -34,9 +33,7 @@ describe('z.number().multipleOf() behavior', () => {
     test('should throw for number8', () => {
       expect(() => schemas.schema6.parse(numbers.number8)).toThrow();
     });
-  });
 
-  describe('schema7 tests', () => {
     test('should not throw for number3', () => {
       expect(() => schemas.schema7.parse(numbers.number3)).not.toThrow();
     });
@@ -52,5 +49,4 @@ describe('z.number().multipleOf() behavior', () => {
     test('should throw for number8', () => {
       expect(() => schemas.schema7.parse(numbers.number8)).toThrow();
     });
-  });
 });

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1249,8 +1249,9 @@ export type ZodNumberCheck =
 function floatSafeRemainder(val: number, step: number) {
   const valDecCount = (val.toString().split(".")[1] || "").length;
   let stepDecCount = (step.toString().split(".")[1] || "").length;
-  if (stepDecCount === 0 && /\d?e-\d?/.test(step.toString())) {
-    const match = step.toString().match(/\d?e-(\d?)/);
+  const stepString = step.toString();
+  if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
+    const match = stepString.match(/\d?e-(\d?)/);
     if (match && match[1]) {
       stepDecCount = parseInt(match[1]);
     }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1248,7 +1248,13 @@ export type ZodNumberCheck =
 // https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript/31711034#31711034
 function floatSafeRemainder(val: number, step: number) {
   const valDecCount = (val.toString().split(".")[1] || "").length;
-  const stepDecCount = (step.toString().split(".")[1] || "").length;
+  let stepDecCount = (step.toString().split(".")[1] || "").length;
+  if (stepDecCount === 0 && /\d?e-\d?/.test(step.toString())) {
+    const match = step.toString().match(/\d?e-(\d?)/);
+    if (match && match[1]) {
+      stepDecCount = parseInt(match[1]);
+    }
+  }
   const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
   const valInt = parseInt(val.toFixed(decCount).replace(".", ""));
   const stepInt = parseInt(step.toFixed(decCount).replace(".", ""));

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1248,8 +1248,8 @@ export type ZodNumberCheck =
 // https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript/31711034#31711034
 function floatSafeRemainder(val: number, step: number) {
   const valDecCount = (val.toString().split(".")[1] || "").length;
-  let stepDecCount = (step.toString().split(".")[1] || "").length;
   const stepString = step.toString();
+  let stepDecCount = (stepString.split(".")[1] || "").length;
   if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
     const match = stepString.match(/\d?e-(\d?)/);
     if (match && match[1]) {

--- a/src/__tests__/multipleOf.test.ts
+++ b/src/__tests__/multipleOf.test.ts
@@ -1,0 +1,55 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+
+
+describe('z.number().multipleOf() behavior', () => {
+  const numbers = {
+    number3: 5.123,
+    number6: 5.123456,
+    number7: 5.1234567,
+    number8: 5.12345678,
+  };
+
+  const schemas = {
+    schema6: z.number().multipleOf(0.000001),
+    schema7: z.number().multipleOf(0.0000001),
+  };
+
+  describe('schema6 tests', () => {
+    test('should not throw for number3', () => {
+      expect(() => schemas.schema6.parse(numbers.number3)).not.toThrow();
+    });
+
+    test('should not throw for number6', () => {
+      expect(() => schemas.schema6.parse(numbers.number6)).not.toThrow();
+    });
+
+    test('should throw for number7', () => {
+      expect(() => schemas.schema6.parse(numbers.number7)).toThrow();
+    });
+
+    test('should throw for number8', () => {
+      expect(() => schemas.schema6.parse(numbers.number8)).toThrow();
+    });
+  });
+
+  describe('schema7 tests', () => {
+    test('should not throw for number3', () => {
+      expect(() => schemas.schema7.parse(numbers.number3)).not.toThrow();
+    });
+
+    test('should not throw for number6', () => {
+      expect(() => schemas.schema7.parse(numbers.number6)).not.toThrow();
+    });
+
+    test('should not throw for number7', () => {
+      expect(() => schemas.schema7.parse(numbers.number7)).not.toThrow();
+    });
+
+    test('should throw for number8', () => {
+      expect(() => schemas.schema7.parse(numbers.number8)).toThrow();
+    });
+  });
+});

--- a/src/__tests__/multipleOf.test.ts
+++ b/src/__tests__/multipleOf.test.ts
@@ -17,7 +17,6 @@ describe('z.number().multipleOf() behavior', () => {
     schema7: z.number().multipleOf(0.0000001),
   };
 
-  describe('schema6 tests', () => {
     test('should not throw for number3', () => {
       expect(() => schemas.schema6.parse(numbers.number3)).not.toThrow();
     });
@@ -33,9 +32,7 @@ describe('z.number().multipleOf() behavior', () => {
     test('should throw for number8', () => {
       expect(() => schemas.schema6.parse(numbers.number8)).toThrow();
     });
-  });
 
-  describe('schema7 tests', () => {
     test('should not throw for number3', () => {
       expect(() => schemas.schema7.parse(numbers.number3)).not.toThrow();
     });
@@ -51,5 +48,4 @@ describe('z.number().multipleOf() behavior', () => {
     test('should throw for number8', () => {
       expect(() => schemas.schema7.parse(numbers.number8)).toThrow();
     });
-  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1249,8 +1249,9 @@ export type ZodNumberCheck =
 function floatSafeRemainder(val: number, step: number) {
   const valDecCount = (val.toString().split(".")[1] || "").length;
   let stepDecCount = (step.toString().split(".")[1] || "").length;
-  if (stepDecCount === 0 && /\d?e-\d?/.test(step.toString())) {
-    const match = step.toString().match(/\d?e-(\d?)/);
+  const stepString = step.toString();
+  if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
+    const match = stepString.match(/\d?e-(\d?)/);
     if (match && match[1]) {
       stepDecCount = parseInt(match[1]);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1248,7 +1248,13 @@ export type ZodNumberCheck =
 // https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript/31711034#31711034
 function floatSafeRemainder(val: number, step: number) {
   const valDecCount = (val.toString().split(".")[1] || "").length;
-  const stepDecCount = (step.toString().split(".")[1] || "").length;
+  let stepDecCount = (step.toString().split(".")[1] || "").length;
+  if (stepDecCount === 0 && /\d?e-\d?/.test(step.toString())) {
+    const match = step.toString().match(/\d?e-(\d?)/);
+    if (match && match[1]) {
+      stepDecCount = parseInt(match[1]);
+    }
+  }
   const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
   const valInt = parseInt(val.toFixed(decCount).replace(".", ""));
   const stepInt = parseInt(step.toFixed(decCount).replace(".", ""));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1248,8 +1248,8 @@ export type ZodNumberCheck =
 // https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript/31711034#31711034
 function floatSafeRemainder(val: number, step: number) {
   const valDecCount = (val.toString().split(".")[1] || "").length;
-  let stepDecCount = (step.toString().split(".")[1] || "").length;
   const stepString = step.toString();
+  let stepDecCount = (stepString.split(".")[1] || "").length;
   if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
     const match = stepString.match(/\d?e-(\d?)/);
     if (match && match[1]) {


### PR DESCRIPTION
This pull request addresses the issue  [#3486](https://github.com/colinhacks/zod/issues/3486#event-12839437351) where `multipleOf()` was behaving incorrectly when dealing with numbers having 7 or more decimal places.

Changes:

- Modified the `stepDecCount` variable declaration from `const` to `let` to allow its value to be updated later in the code.
- Added a conditional check to test if the step value is in scientific notation (e.g., 1e-7). If it is, the code extracts the exponent part and uses it to update `stepDecCount`.
- This change ensures that `stepDecCount` correctly reflects the number of decimal places in `step`, **even when `step` is in scientific notation.**
- This fix should resolve the issue and make `multipleOf()` function as expected for numbers with 7 or more decimal places.

