### PR TITLE
Adding support for `.example()` to document schema examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
     - [Async transforms](#async-transforms)
   - [`.default`](#default)
   - [`.describe`](#describe)
+  - [`.example`](#example)
   - [`.catch`](#catch)
   - [`.optional`](#optional)
   - [`.nullable`](#nullable)
@@ -2322,6 +2323,28 @@ documentedString.description; // A useful bit of text…
 ```
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
+
+### `.example`
+
+Use `.example()` to add an `examples` property to the resulting schema.
+
+```ts
+const documentedString = z.string().url().example("https://example.com");
+documentedString.examples; // ["https://example.com"]
+```
+
+Subsequent calls of `.example()` will add more examples to your schema.
+
+```ts
+const documentedString = z
+  .string()
+  .url()
+  .example("https://example.com")
+  .example("https://example.local");
+documentedString.examples; // ["https://example.com", "https://example.local"]
+```
+
+Like with `.describe()` this can be useful for documenting field examples, such as when using a JSON Schema library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
 
 ### `.catch`
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -139,6 +139,7 @@
     - [Async transforms](#async-transforms)
   - [`.default`](#default)
   - [`.describe`](#describe)
+  - [`.example`](#example)
   - [`.catch`](#catch)
   - [`.optional`](#optional)
   - [`.nullable`](#nullable)
@@ -2322,6 +2323,31 @@ documentedString.description; // A useful bit of text…
 ```
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
+
+### `.example`
+
+Use `.example()` to add an `examples` property to the resulting schema.
+
+```ts
+const documentedString = z
+  .string()
+  .url()
+  .example("https://example.com");
+documentedString.examples; // ["https://example.com"]
+```
+
+Subsequent calls of `.example()` will add more examples to your schema.
+
+```ts
+const documentedString = z
+  .string()
+  .url()
+  .example("https://example.com")
+  .example("https://example.local");
+documentedString.examples; // ["https://example.com", "https://example.local"]
+```
+
+Like with `.describe()` this can be useful for documenting field examples, such as when using a JSON Schema library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
 
 ### `.catch`
 

--- a/deno/lib/__tests__/example.test.ts
+++ b/deno/lib/__tests__/example.test.ts
@@ -1,0 +1,35 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+const example = "an example";
+const examples = [example, 1234];
+
+test("passing `examples` to schema should add an example", () => {
+  expect(z.string({ examples }).examples).toEqual(examples);
+  expect(z.number({ examples }).examples).toEqual(examples);
+  expect(z.boolean({ examples }).examples).toEqual(examples);
+});
+
+test("`.example` should add an example", () => {
+  expect(z.string().example(example).examples).toEqual([example]);
+  expect(z.number().example(example).examples).toEqual([example]);
+  expect(z.boolean().example(example).examples).toEqual([example]);
+});
+
+test("`.example` should be able to be chained", () => {
+  expect(z.string().example(example).example(1234).examples).toEqual(examples);
+  expect(z.number().example(example).example(1234).examples).toEqual(examples);
+  expect(z.boolean().example(example).example(1234).examples).toEqual(examples);
+});
+
+test("examples should carry over to chained schemas", () => {
+  const schema = z.string({ examples });
+  expect(schema.examples).toEqual(examples);
+  expect(schema.optional().examples).toEqual(examples);
+  expect(schema.optional().nullable().default("default").examples).toEqual(
+    examples
+  );
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -22,7 +22,12 @@ import {
 } from "./helpers/parseUtil.ts";
 import { partialUtil } from "./helpers/partialUtil.ts";
 import { Primitive } from "./helpers/typeAliases.ts";
-import { getParsedType, objectUtil, util, ZodParsedType } from "./helpers/util.ts";
+import {
+  getParsedType,
+  objectUtil,
+  util,
+  ZodParsedType,
+} from "./helpers/util.ts";
 import {
   IssueData,
   StringValidation,
@@ -56,6 +61,7 @@ export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
   errorMap?: ZodErrorMap;
   description?: string;
+  examples?: any[];
 }
 
 class ParseInputLazyPath implements ParseInput {
@@ -120,21 +126,29 @@ export type RawCreateParams =
       required_error?: string;
       message?: string;
       description?: string;
+      examples?: any[];
     }
   | undefined;
 export type ProcessedCreateParams = {
   errorMap?: ZodErrorMap;
   description?: string;
+  examples?: any[];
 };
 function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   if (!params) return {};
-  const { errorMap, invalid_type_error, required_error, description } = params;
+  const {
+    errorMap,
+    invalid_type_error,
+    required_error,
+    description,
+    examples,
+  } = params;
   if (errorMap && (invalid_type_error || required_error)) {
     throw new Error(
       `Can't use "invalid_type_error" or "required_error" in conjunction with custom error map.`
     );
   }
-  if (errorMap) return { errorMap: errorMap, description };
+  if (errorMap) return { errorMap: errorMap, description, examples };
   const customMap: ZodErrorMap = (iss, ctx) => {
     const { message } = params;
 
@@ -147,7 +161,7 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
     if (iss.code !== "invalid_type") return { message: ctx.defaultError };
     return { message: message ?? invalid_type_error ?? ctx.defaultError };
   };
-  return { errorMap: customMap, description };
+  return { errorMap: customMap, description, examples };
 }
 
 export type SafeParseSuccess<Output> = {
@@ -177,6 +191,10 @@ export abstract class ZodType<
 
   get description() {
     return this._def.description;
+  }
+
+  get examples() {
+    return this._def.examples;
   }
 
   abstract _parse(input: ParseInput): ParseReturnType<Output>;
@@ -418,6 +436,7 @@ export abstract class ZodType<
     this.default = this.default.bind(this);
     this.catch = this.catch.bind(this);
     this.describe = this.describe.bind(this);
+    this.example = this.example.bind(this);
     this.pipe = this.pipe.bind(this);
     this.readonly = this.readonly.bind(this);
     this.isNullable = this.isNullable.bind(this);
@@ -501,6 +520,14 @@ export abstract class ZodType<
     return new This({
       ...this._def,
       description,
+    });
+  }
+
+  example(example: any): this {
+    const This = (this as any).constructor;
+    return new This({
+      ...this._def,
+      examples: [...(this._def.examples || []), example],
     });
   }
 

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -1,0 +1,34 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+
+const example = "an example";
+const examples = [example, 1234];
+
+test("passing `examples` to schema should add an example", () => {
+  expect(z.string({ examples }).examples).toEqual(examples);
+  expect(z.number({ examples }).examples).toEqual(examples);
+  expect(z.boolean({ examples }).examples).toEqual(examples);
+});
+
+test("`.example` should add an example", () => {
+  expect(z.string().example(example).examples).toEqual([example]);
+  expect(z.number().example(example).examples).toEqual([example]);
+  expect(z.boolean().example(example).examples).toEqual([example]);
+});
+
+test("`.example` should be able to be chained", () => {
+  expect(z.string().example(example).example(1234).examples).toEqual(examples);
+  expect(z.number().example(example).example(1234).examples).toEqual(examples);
+  expect(z.boolean().example(example).example(1234).examples).toEqual(examples);
+});
+
+test("examples should carry over to chained schemas", () => {
+  const schema = z.string({ examples });
+  expect(schema.examples).toEqual(examples);
+  expect(schema.optional().examples).toEqual(examples);
+  expect(schema.optional().nullable().default("default").examples).toEqual(
+    examples
+  );
+});


### PR DESCRIPTION
I've added a new `.example()` method that, like `.describe()`, will allow consumers to document example values and representations of their schemas.

```ts
const documentedString = z
  .string()
  .url()
  .example("https://example.com")
  .example("https://example.local");

documentedString.examples; // ["https://example.com", "https://example.local"]
```

Like the JSON Schema [`examples`](https://json-schema.org/draft/2020-12/json-schema-validation#name-examples) array this currently has no type or shape restrictions. It may at some point be nice to restrict content being supplied to `.example()` to match the schema type (eg. only strings can be supplied on `z.string()`) but I've not (yet) done that here.

This work is being done to resolve https://github.com/colinhacks/zod/discussions/2266, and should, with a followup change to `zod-to-json-schema`[^1], allow Zod consumers to document schema examples within their generated JSON Schema representations.

[^1]: I plan on submitting a change to support `examples` to `zod-to-json-schema` after this work is in.