### PR TITLE
Remove createParams cascade from .array()

### DIFF
--- a/deno/lib/__tests__/description.test.ts
+++ b/deno/lib/__tests__/description.test.ts
@@ -26,3 +26,11 @@ test("description should carry over to chained schemas", () => {
     description
   );
 });
+
+test("description should not carry over to chained array schema", () => {
+  const schema = z.string().describe(description)
+
+  expect(schema.description).toEqual(description);
+  expect(schema.array().description).toEqual(undefined);
+  expect(z.array(schema).description).toEqual(undefined);
+})

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -434,7 +434,7 @@ export abstract class ZodType<
     return this.nullable().optional();
   }
   array(): ZodArray<this> {
-    return ZodArray.create(this, this._def);
+    return ZodArray.create(this);
   }
   promise(): ZodPromise<this> {
     return ZodPromise.create(this, this._def);

--- a/src/__tests__/description.test.ts
+++ b/src/__tests__/description.test.ts
@@ -25,3 +25,11 @@ test("description should carry over to chained schemas", () => {
     description
   );
 });
+
+test("description should not carry over to chained array schema", () => {
+  const schema = z.string().describe(description)
+
+  expect(schema.description).toEqual(description);
+  expect(schema.array().description).toEqual(undefined);
+  expect(z.array(schema).description).toEqual(undefined);
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -434,7 +434,7 @@ export abstract class ZodType<
     return this.nullable().optional();
   }
   array(): ZodArray<this> {
-    return ZodArray.create(this, this._def);
+    return ZodArray.create(this);
   }
   promise(): ZodPromise<this> {
     return ZodPromise.create(this, this._def);


### PR DESCRIPTION
See [this issue](https://github.com/colinhacks/zod/issues/3529) for more context.

Basically, the description for a type was getting unexpectedly duplicated when using `.array()`. For example:
```typescript
z.string().describe("a description").array()

// ^ was functionally the same as v

z.array(
  z.string().describe("a description")
).describe("a description")
```

The issue was not present for `z.array()`
```typescript
z.array(z.string().describe("a description")) // works as expected
```

This unexpected behavior was introduced in a fix trying to ensure that something like `z.string().describe("a description").optional()` persisted the description after being wrapped by `ZodOptional`.

While this behavior makes sense for types like `ZodOptional` or `ZodNullable`, `ZodArray` is a completely separate type.

Other types that do this cascading `createParams`:
- `optional`
- `nullable`
- `promise`
- `or`
- `and`
- `transform`
- `default`
- `brand`
- `catch`

I think the logic makes sense for all of these (maybe `or` and `and` are also exceptions? not sure)

Added a test for this as well :)