### PR TITLE
Add method to preserve readonly props after call to extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1383,6 +1383,35 @@ person.parse({
 
 Using `.catchall()` obviates `.passthrough()` , `.strip()` , or `.strict()`. All keys are now considered "known".
 
+### `.readonlyProps`
+
+You can use the `.readonlyProps` method to mark all of the properties as readonly. When the `.extend` method is called on the resulting `ZodObject` the readonly decoration of the properties will be preserved.
+
+````ts
+const base = z
+  .object({
+    id: z.string(),
+    version: z.number(),
+  })
+  .readonlyProps();
+type Base = z.infer<base>;
+
+// Base = {
+//   readonly id: string,
+//   readonly version: number,
+// }
+
+const person = base.extend({
+  name: z.string(),
+});
+type Person = z.infer<person>;
+
+// Person = {
+//   readonly id: string,
+//   readonly version: number,
+//   name: string,
+// }
+
 ## Arrays
 
 ```ts
@@ -1390,7 +1419,7 @@ const stringArray = z.array(z.string());
 
 // equivalent
 const stringArray = z.string().array();
-```
+````
 
 Be careful with the `.array()` method. It returns a new `ZodArray` instance. This means the _order_ in which you call methods matters. For instance:
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1383,6 +1383,35 @@ person.parse({
 
 Using `.catchall()` obviates `.passthrough()` , `.strip()` , or `.strict()`. All keys are now considered "known".
 
+### `.readonlyProps`
+
+You can use the `.readonlyProps` method to mark all of the properties as readonly. When the `.extend` method is called on the resulting `ZodObject` the readonly decoration of the properties will be preserved.
+
+````ts
+const base = z
+  .object({
+    id: z.string(),
+    version: z.number(),
+  })
+  .readonlyProps();
+type Base = z.infer<base>;
+
+// Base = {
+//   readonly id: string,
+//   readonly version: number,
+// }
+
+const person = base.extend({
+  name: z.string(),
+});
+type Person = z.infer<person>;
+
+// Person = {
+//   readonly id: string,
+//   readonly version: number,
+//   name: string,
+// }
+
 ## Arrays
 
 ```ts
@@ -1390,7 +1419,7 @@ const stringArray = z.array(z.string());
 
 // equivalent
 const stringArray = z.string().array();
-```
+````
 
 Be careful with the `.array()` method. It returns a new `ZodArray` instance. This means the _order_ in which you call methods matters. For instance:
 

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -1,3 +1,5 @@
+import { ZodRawShape } from '../types.ts';
+
 export namespace util {
   type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
     V
@@ -107,11 +109,23 @@ export namespace objectUtil {
   type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
   }[keyof T];
-  export type addQuestionMarks<T extends object, _O = any> = {
+  export type addInputDecorations<T extends object, _O = any> = {
     [K in requiredKeys<T>]: T[K];
   } & {
     [K in optionalKeys<T>]?: T[K];
   } & { [k in keyof T]?: unknown };
+
+  type ShapeOutput<S extends ZodRawShape> = {
+    [k in keyof S]: S[k]['_output'];
+  };
+  
+  type optionalShapeKeys<S extends ZodRawShape> = {
+    [k in keyof S]: undefined extends S[k]['_output'] ? k : never;
+  }[keyof S];
+
+  export type addOutputDecorations<S extends ZodRawShape, _O = any> = Omit<ShapeOutput<S>, optionalShapeKeys<S>>
+    & Partial<Pick<ShapeOutput<S>, optionalShapeKeys<S>>>
+    & { [k in keyof S]?: unknown };
 
   export type identity<T> = T;
   export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2330,9 +2330,7 @@ export type objectOutputType<
   Shape extends ZodRawShape,
   Catchall extends ZodTypeAny,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam
-> = objectUtil.flatten<
-  objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>
-> &
+> = objectUtil.flatten<objectUtil.addOutputDecorations<Shape>> &
   CatchallOutput<Catchall> &
   PassthroughType<UnknownKeys>;
 
@@ -2348,7 +2346,7 @@ export type objectInputType<
   CatchallInput<Catchall> &
   PassthroughType<UnknownKeys>;
 export type baseObjectInputType<Shape extends ZodRawShape> =
-  objectUtil.addQuestionMarks<{
+  objectUtil.addInputDecorations<{
     [k in keyof Shape]: Shape[k]["_input"];
   }>;
 
@@ -2904,6 +2902,16 @@ export class ZodObject<
       ...processCreateParams(params),
     }) as any;
   };
+
+  readonlyProps(): ZodObject<
+    Readonly<T>,
+    UnknownKeys,
+    Catchall,
+    Readonly<Output>,
+    Readonly<Input>
+  > {
+    return this as any;
+  }
 }
 
 export type AnyZodObject = ZodObject<any, any, any>;

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -1,3 +1,5 @@
+import { ZodRawShape } from '../types';
+
 export namespace util {
   type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <
     V
@@ -107,11 +109,23 @@ export namespace objectUtil {
   type requiredKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? never : k;
   }[keyof T];
-  export type addQuestionMarks<T extends object, _O = any> = {
+  export type addInputDecorations<T extends object, _O = any> = {
     [K in requiredKeys<T>]: T[K];
   } & {
     [K in optionalKeys<T>]?: T[K];
   } & { [k in keyof T]?: unknown };
+
+  type ShapeOutput<S extends ZodRawShape> = {
+    [k in keyof S]: S[k]['_output'];
+  };
+  
+  type optionalShapeKeys<S extends ZodRawShape> = {
+    [k in keyof S]: undefined extends S[k]['_output'] ? k : never;
+  }[keyof S];
+
+  export type addOutputDecorations<S extends ZodRawShape, _O = any> = Omit<ShapeOutput<S>, optionalShapeKeys<S>>
+    & Partial<Pick<ShapeOutput<S>, optionalShapeKeys<S>>>
+    & { [k in keyof S]?: unknown };
 
   export type identity<T> = T;
   export type flatten<T> = identity<{ [k in keyof T]: T[k] }>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2330,9 +2330,7 @@ export type objectOutputType<
   Shape extends ZodRawShape,
   Catchall extends ZodTypeAny,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam
-> = objectUtil.flatten<
-  objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>
-> &
+> = objectUtil.flatten<objectUtil.addOutputDecorations<Shape>> &
   CatchallOutput<Catchall> &
   PassthroughType<UnknownKeys>;
 
@@ -2348,7 +2346,7 @@ export type objectInputType<
   CatchallInput<Catchall> &
   PassthroughType<UnknownKeys>;
 export type baseObjectInputType<Shape extends ZodRawShape> =
-  objectUtil.addQuestionMarks<{
+  objectUtil.addInputDecorations<{
     [k in keyof Shape]: Shape[k]["_input"];
   }>;
 
@@ -2904,6 +2902,16 @@ export class ZodObject<
       ...processCreateParams(params),
     }) as any;
   };
+
+  readonlyProps(): ZodObject<
+    Readonly<T>,
+    UnknownKeys,
+    Catchall,
+    Readonly<Output>,
+    Readonly<Input>
+  > {
+    return this as any;
+  }
 }
 
 export type AnyZodObject = ZodObject<any, any, any>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1279,7 +1279,7 @@
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
-"@jest/globals@^29.7.0":
+"@jest/globals@^29.4.3", "@jest/globals@^29.7.0":
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d"
   integrity sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==


### PR DESCRIPTION
The only way to have object properties marked as `readonly` is to call the `readonly()` method, but this results in a `ZodReadonly` object which cannot be extended via the `extend()` method. The `merge()` method does not preserve the `readonly` markers. The `objectUtil.mergeShapes()` sort of achieves the desired result, however the resulting object is not compatible with `ZodSchema<T>` and thus can't be passed as a parameter to a method that expects `ZodSchema<T>`

This change adds the `readonlyProps()` method to `ZodObject` which results in a projection of the `ZodObject` with all fields marked `readonly`.

Additionally, the handling of the `Output` type parameter was changed so that when using `z.infer` the resulting type to has the `readonly` markers preserved.

The `readonlyProps` method could be extended in the future to allow for a list of properties to be specified which would allow only specific props to be marked `readonly`. However, it's easy enough to use `extend()` that this would be only a convenience.

Many many many alternative approaches were considered, such as overloading the `readonly()` method to return a `ZodReadonlyObject` class which would have an `extend()` method. IMO, this is not a good solution because the semantics of the `readonly()` are to freeze, and render readonly, the value, not the property assignment.

This solution works very well for my usecase where a common base object contains `readonly` properties.