### PR TITLE
Allow creation of discriminated unions with a readonly array of options

### DIFF
--- a/deno/lib/__tests__/discriminated-unions.test.ts
+++ b/deno/lib/__tests__/discriminated-unions.test.ts
@@ -308,3 +308,14 @@ test("optional and nullable", () => {
   if (value.key === "b") value.b;
   if (value.key === null) value.b;
 });
+
+test("readonly array of options", () => {
+  const options = [
+    z.object({ type: z.literal("x"), val: z.literal(1) }),
+    z.object({ type: z.literal("y"), val: z.literal(2) }),
+  ] as const;
+
+  expect(
+    z.discriminatedUnion("type", options).parse({ type: "x", val: 1 })
+  ).toEqual({ type: "x", val: 1 });
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3101,7 +3101,7 @@ export type ZodDiscriminatedUnionOption<Discriminator extends string> =
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<string>[] = ZodDiscriminatedUnionOption<string>[]
+  Options extends readonly ZodDiscriminatedUnionOption<string>[] = ZodDiscriminatedUnionOption<string>[]
 > extends ZodTypeDef {
   discriminator: Discriminator;
   options: Options;
@@ -3111,7 +3111,7 @@ export interface ZodDiscriminatedUnionDef<
 
 export class ZodDiscriminatedUnion<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<Discriminator>[]
+  Options extends readonly ZodDiscriminatedUnionOption<Discriminator>[]
 > extends ZodType<
   output<Options[number]>,
   ZodDiscriminatedUnionDef<Discriminator, Options>,
@@ -3181,7 +3181,7 @@ export class ZodDiscriminatedUnion<
    */
   static create<
     Discriminator extends string,
-    Types extends [
+    Types extends readonly [
       ZodDiscriminatedUnionOption<Discriminator>,
       ...ZodDiscriminatedUnionOption<Discriminator>[]
     ]

--- a/src/__tests__/discriminated-unions.test.ts
+++ b/src/__tests__/discriminated-unions.test.ts
@@ -307,3 +307,14 @@ test("optional and nullable", () => {
   if (value.key === "b") value.b;
   if (value.key === null) value.b;
 });
+
+test("readonly array of options", () => {
+  const options = [
+    z.object({ type: z.literal("x"), val: z.literal(1) }),
+    z.object({ type: z.literal("y"), val: z.literal(2) }),
+  ] as const;
+
+  expect(
+    z.discriminatedUnion("type", options).parse({ type: "x", val: 1 })
+  ).toEqual({ type: "x", val: 1 });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -3101,7 +3101,7 @@ export type ZodDiscriminatedUnionOption<Discriminator extends string> =
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<string>[] = ZodDiscriminatedUnionOption<string>[]
+  Options extends readonly ZodDiscriminatedUnionOption<string>[] = ZodDiscriminatedUnionOption<string>[]
 > extends ZodTypeDef {
   discriminator: Discriminator;
   options: Options;
@@ -3111,7 +3111,7 @@ export interface ZodDiscriminatedUnionDef<
 
 export class ZodDiscriminatedUnion<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<Discriminator>[]
+  Options extends readonly ZodDiscriminatedUnionOption<Discriminator>[]
 > extends ZodType<
   output<Options[number]>,
   ZodDiscriminatedUnionDef<Discriminator, Options>,
@@ -3181,7 +3181,7 @@ export class ZodDiscriminatedUnion<
    */
   static create<
     Discriminator extends string,
-    Types extends [
+    Types extends readonly [
       ZodDiscriminatedUnionOption<Discriminator>,
       ...ZodDiscriminatedUnionOption<Discriminator>[]
     ]


### PR DESCRIPTION
If I extract the array of options out of the `z.discriminatedUnion` call, type-checking fails because an array is not assignable to a non-empty tuple:

```ts
const options = [
  z.object({ type: z.literal("x"), val: z.literal(1) }),
  z.object({ type: z.literal("y"), val: z.literal(2) }),
];

const schema = z.discriminatedUnion("type", options);
```

```
TS2345: Argument of type '(ZodObject<{ type: ZodLiteral<"x">; val: ZodLiteral<1>; }, "strip", ZodTypeAny, { type: "x"; val: 1; }, { type: "x"; val: 1; }> | ZodObject<{ type: ZodLiteral<...>; val: ZodLiteral<...>; }, "strip", ZodTypeAny, { ...; }, { ...; }>)[]' is not assignable to parameter of type '[ZodDiscriminatedUnionOption<"type">, ...ZodDiscriminatedUnionOption<"type">[]]'.
  Source provides no match for required element at position 0 in target.
```

However, if I add `as const` to the `options` definition to make it a readonly tuple, now type-checking fails because the options are not mutable:

```
TS2345: Argument of type 'readonly [ZodObject<{ type: ZodLiteral<"x">; val: ZodLiteral<1>; }, "strip", ZodTypeAny, { type: "x"; val: 1; }, { type: "x"; val: 1; }>, ZodObject<{ type: ZodLiteral<...>; val: ZodLiteral<...>; }, "strip", ZodTypeAny, { ...; }, { ...; }>]' is not assignable to parameter of type '[ZodDiscriminatedUnionOption<"type">, ...ZodDiscriminatedUnionOption<"type">[]]'.
  The type 'readonly [ZodObject<{ type: ZodLiteral<"x">; val: ZodLiteral<1>; }, "strip", ZodTypeAny, { type: "x"; val: 1; }, { type: "x"; val: 1; }>, ZodObject<{ type: ZodLiteral<...>; val: ZodLiteral<...>; }, "strip", ZodTypeAny, { ...; }, { ...; }>]' is 'readonly' and cannot be assigned to the mutable type '[ZodDiscriminatedUnionOption<"type">, ...ZodDiscriminatedUnionOption<"type">[]]'.
```

This PR makes it possible to do this with `as const` by making the generic constraint readonly.