### PR TITLE
chore: removed deprecated .nonstrict() and replace with .passthrough()

### DIFF
--- a/deno/lib/__tests__/complex.test.ts
+++ b/deno/lib/__tests__/complex.test.ts
@@ -15,7 +15,7 @@ test("parse", () => {
     sumMinLength: [12, 15, 16, 98, 24, 63],
     intersection: {},
     enum: "one",
-    nonstrict: { points: 1234 },
+    passthrough: { points: 1234 },
     numProm: Promise.resolve(12),
     lenfun: (x: string) => x.length,
   });

--- a/deno/lib/__tests__/crazySchema.ts
+++ b/deno/lib/__tests__/crazySchema.ts
@@ -25,7 +25,7 @@ export const crazySchema = z.object({
     z.object({ p1: z.number().optional() })
   ),
   enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
-  nonstrict: z.object({ points: z.number() }).nonstrict(),
+  passthrough: z.object({ points: z.number() }).passthrough(),
   numProm: z.promise(z.number()),
   lenfun: z.function(z.tuple([z.string()]), z.boolean()),
 });

--- a/deno/lib/__tests__/deepmasking.test.ts
+++ b/deno/lib/__tests__/deepmasking.test.ts
@@ -21,7 +21,7 @@ test("test", () => {
 //     name: z.string(),
 //     color: z.string(),
 //   })
-//   .nonstrict();
+//   .passthrough();
 
 // test('object pick type', () => {
 //   const modNonStrictFish = nonStrict.omit({ name: true });

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -91,7 +91,7 @@ test("unknownkeys override", () => {
     .strict()
     .passthrough()
     .strip()
-    .nonstrict()
+    .passthrough()
     .parse(data);
 
   expect(val).toEqual(data);

--- a/deno/lib/__tests__/parser.test.ts
+++ b/deno/lib/__tests__/parser.test.ts
@@ -15,7 +15,7 @@ test("parse strict object with unknown keys", () => {
 
 test("parse nonstrict object with unknown keys", () => {
   z.object({ name: z.string() })
-    .nonstrict()
+    .passthrough()
     .parse({ name: "bill", unknownKey: 12 });
 });
 

--- a/deno/lib/__tests__/recursive.test.ts
+++ b/deno/lib/__tests__/recursive.test.ts
@@ -136,11 +136,11 @@ test("recursion involving union type", () => {
 //             .object({
 //               val: z.number(),
 //             })
-//             .nonstrict(),
+//             .passthrough(),
 //         })
-//         .nonstrict(),
+//         .passthrough(),
 //     })
-//     .nonstrict();
+//     .passthrough();
 
 //   const fragment = FragmentOnA.parse(a);
 //   fragment;

--- a/src/__tests__/complex.test.ts
+++ b/src/__tests__/complex.test.ts
@@ -14,7 +14,7 @@ test("parse", () => {
     sumMinLength: [12, 15, 16, 98, 24, 63],
     intersection: {},
     enum: "one",
-    nonstrict: { points: 1234 },
+    passthrough: { points: 1234 },
     numProm: Promise.resolve(12),
     lenfun: (x: string) => x.length,
   });

--- a/src/__tests__/crazySchema.ts
+++ b/src/__tests__/crazySchema.ts
@@ -25,7 +25,7 @@ export const crazySchema = z.object({
     z.object({ p1: z.number().optional() })
   ),
   enum: z.intersection(z.enum(["zero", "one"]), z.enum(["one", "two"])),
-  nonstrict: z.object({ points: z.number() }).nonstrict(),
+  passthrough: z.object({ points: z.number() }).passthrough(),
   numProm: z.promise(z.number()),
   lenfun: z.function(z.tuple([z.string()]), z.boolean()),
 });

--- a/src/__tests__/deepmasking.test.ts
+++ b/src/__tests__/deepmasking.test.ts
@@ -20,7 +20,7 @@ test("test", () => {
 //     name: z.string(),
 //     color: z.string(),
 //   })
-//   .nonstrict();
+//   .passthrough();
 
 // test('object pick type', () => {
 //   const modNonStrictFish = nonStrict.omit({ name: true });

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -90,7 +90,7 @@ test("unknownkeys override", () => {
     .strict()
     .passthrough()
     .strip()
-    .nonstrict()
+    .passthrough()
     .parse(data);
 
   expect(val).toEqual(data);

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -14,7 +14,7 @@ test("parse strict object with unknown keys", () => {
 
 test("parse nonstrict object with unknown keys", () => {
   z.object({ name: z.string() })
-    .nonstrict()
+    .passthrough()
     .parse({ name: "bill", unknownKey: 12 });
 });
 

--- a/src/__tests__/recursive.test.ts
+++ b/src/__tests__/recursive.test.ts
@@ -135,11 +135,11 @@ test("recursion involving union type", () => {
 //             .object({
 //               val: z.number(),
 //             })
-//             .nonstrict(),
+//             .passthrough(),
 //         })
-//         .nonstrict(),
+//         .passthrough(),
 //     })
-//     .nonstrict();
+//     .passthrough();
 
 //   const fragment = FragmentOnA.parse(a);
 //   fragment;


### PR DESCRIPTION
This PR resolves #3522 by removing all usage of `.nonstrict()` and replacing it with `.passthrough()`