### PR TITLE
Propose feature`.defer()` to support lazy parsing

### DIFF
--- a/deno/lib/__tests__/defer.test.ts
+++ b/deno/lib/__tests__/defer.test.ts
@@ -1,0 +1,110 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import { util } from "../helpers/util.ts";
+import * as z from "../index.ts";
+
+test("parse defer primitives", () => {
+  const schema = z.number().defer();
+
+  expect(() => schema.parse("not a number")).not.toThrow();
+  expect(() => schema.parse("not a number")()).toThrow();
+
+  expect(() => schema.parse(42)).not.toThrow();
+  expect(schema.parse(42)()).toEqual(42);
+});
+
+test("defer type inference", () => {
+  const schema = z
+    .object({
+      a: z.string(),
+      b: z.number().nullable(),
+    })
+    .partial();
+  type Schema = z.infer<typeof schema>;
+
+  const deferredSchema = schema.defer();
+
+  type inferred = z.infer<typeof deferredSchema>;
+  util.assertEqual<inferred, () => Schema>(true);
+});
+
+test("parse deferred object props", () => {
+  const schema1 = z.object({
+    a: z.string(),
+    b: z.string().defer(),
+  });
+
+  expect(() => schema1.parse({ a: "foo", b: 1 })).not.toThrow();
+
+  const parsed = schema1.parse({ a: "foo", b: 1 });
+  expect(() => parsed.b()).toThrow();
+
+  expect(schema1.parse({ a: "foo", b: "bar" }).b()).toEqual("bar");
+
+  const schema2 = z
+    .object({
+      a: z.string(),
+      b: z.string(),
+    })
+    .deferProps();
+  const parsed2 = schema2.parse({ a: "foo", b: 1 });
+  expect(parsed2.a()).toEqual("foo");
+  expect(() => parsed2.b()).toThrow();
+});
+
+test("deferProps", () => {
+  const schema = z.object({
+    stringField: z.string(),
+    numberField: z.number(),
+    nullableField: z.string().nullable(),
+    objectField: z.object({
+      a: z.string(),
+      b: z.number(),
+    }),
+  });
+
+  const deferredSchema = schema.deferProps();
+
+  type deferred = z.infer<typeof deferredSchema>;
+  type expectedDeferred = {
+    stringField: () => string;
+    numberField: () => number;
+    nullableField: () => string | null;
+    objectField: () => {
+      a: string;
+      b: number;
+    };
+  };
+  util.assertEqual<deferred, expectedDeferred>(true);
+
+  const deferredSchemaWithMask = schema.deferProps({
+    stringField: true,
+    objectField: true,
+  });
+
+  type deferredWithMask = z.infer<typeof deferredSchemaWithMask>;
+  type expectedDeferredWithMask = {
+    stringField: () => string;
+    numberField: number;
+    nullableField: string | null;
+    objectField: () => {
+      a: string;
+      b: number;
+    };
+  };
+  util.assertEqual<deferredWithMask, expectedDeferredWithMask>(true);
+});
+
+test("usage with effects", () => {
+  const transformSchema = z
+    .string()
+    .transform((value) => value.length)
+    .defer();
+
+  expect(() => transformSchema.parse(32)).not.toThrow();
+  expect(() => transformSchema.parse(32)()).toThrow();
+  expect(() => transformSchema.parse("hello")).not.toThrow();
+  expect(transformSchema.parse("hello")()).toEqual(5);
+});

--- a/deno/lib/__tests__/firstparty.test.ts
+++ b/deno/lib/__tests__/firstparty.test.ts
@@ -82,6 +82,8 @@ test("first party switch", () => {
       break;
     case z.ZodFirstPartyTypeKind.ZodReadonly:
       break;
+    case z.ZodFirstPartyTypeKind.ZodDefer:
+      break;
     default:
       util.assertNever(def);
   }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -510,6 +510,9 @@ export abstract class ZodType<
   readonly(): ZodReadonly<this> {
     return ZodReadonly.create(this);
   }
+  defer(): ZodDefer<this> {
+    return ZodDefer.create(this, this._def) as any;
+  }
 
   isOptional(): boolean {
     return this.safeParse(undefined).success;
@@ -2860,6 +2863,39 @@ export class ZodObject<
     ) as any;
   }
 
+  deferProps(): ZodObject<
+    { [k in keyof T]: ZodDefer<T[k]> },
+    UnknownKeys,
+    Catchall
+  >;
+  deferProps<Mask extends util.Exactly<{ [k in keyof T]?: true }, Mask>>(
+    mask: Mask
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? ZodDefer<T[k]> : T[k];
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  deferProps(mask?: any) {
+    const newShape: any = {};
+
+    util.objectKeys(this.shape).forEach((key) => {
+      const fieldSchema = this.shape[key];
+
+      if (mask && !mask[key]) {
+        newShape[key] = fieldSchema;
+      } else {
+        newShape[key] = fieldSchema.defer();
+      }
+    });
+
+    return new ZodObject({
+      ...this._def,
+      shape: () => newShape,
+    }) as any;
+  }
+
   static create = <T extends ZodRawShape>(
     shape: T,
     params?: RawCreateParams
@@ -5068,6 +5104,46 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
   }
 }
 
+///////////////////////////////////////////
+///////////////////////////////////////////
+//////////                       //////////
+//////////       ZodDefer        //////////
+//////////                       //////////
+///////////////////////////////////////////
+///////////////////////////////////////////
+export interface ZodDeferDef<T extends ZodTypeAny = ZodTypeAny>
+  extends ZodTypeDef {
+  innerType: T;
+  typeName: ZodFirstPartyTypeKind.ZodDefer;
+}
+
+export type ZodDeferType<T extends ZodTypeAny> = ZodDefer<T>;
+
+export class ZodDefer<T extends ZodTypeAny> extends ZodType<
+  () => T["_output"],
+  ZodDeferDef<T>,
+  T["_input"]
+> {
+  _parse(input: ParseInput): ParseReturnType<() => this["_output"]> {
+    return OK(() => this._def.innerType.parse(input.data));
+  }
+
+  eager() {
+    return this._def.innerType;
+  }
+
+  static create = <T extends ZodTypeAny>(
+    type: T,
+    params?: RawCreateParams
+  ): ZodDefer<T> => {
+    return new ZodDefer({
+      innerType: type,
+      typeName: ZodFirstPartyTypeKind.ZodDefer,
+      ...processCreateParams(params),
+    }) as any;
+  };
+}
+
 ////////////////////////////////////////
 ////////////////////////////////////////
 //////////                    //////////
@@ -5151,6 +5227,7 @@ export enum ZodFirstPartyTypeKind {
   ZodBranded = "ZodBranded",
   ZodPipeline = "ZodPipeline",
   ZodReadonly = "ZodReadonly",
+  ZodDefer = "ZodDefer",
 }
 export type ZodFirstPartySchemaTypes =
   | ZodString
@@ -5188,6 +5265,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodBranded<any, any>
   | ZodPipeline<any, any>
   | ZodReadonly<any>
+  | ZodDefer<any>
   | ZodSymbol;
 
 // requires TS 4.4+
@@ -5236,6 +5314,7 @@ const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
 const pipelineType = ZodPipeline.create;
+const deferType = ZodDefer.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -5262,6 +5341,7 @@ export {
   bigIntType as bigint,
   booleanType as boolean,
   dateType as date,
+  deferType as defer,
   discriminatedUnionType as discriminatedUnion,
   effectsType as effect,
   enumType as enum,

--- a/src/__tests__/defer.test.ts
+++ b/src/__tests__/defer.test.ts
@@ -1,0 +1,109 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import { util } from "../helpers/util";
+import * as z from "../index";
+
+test("parse defer primitives", () => {
+  const schema = z.number().defer();
+
+  expect(() => schema.parse("not a number")).not.toThrow();
+  expect(() => schema.parse("not a number")()).toThrow();
+
+  expect(() => schema.parse(42)).not.toThrow();
+  expect(schema.parse(42)()).toEqual(42);
+});
+
+test("defer type inference", () => {
+  const schema = z
+    .object({
+      a: z.string(),
+      b: z.number().nullable(),
+    })
+    .partial();
+  type Schema = z.infer<typeof schema>;
+
+  const deferredSchema = schema.defer();
+
+  type inferred = z.infer<typeof deferredSchema>;
+  util.assertEqual<inferred, () => Schema>(true);
+});
+
+test("parse deferred object props", () => {
+  const schema1 = z.object({
+    a: z.string(),
+    b: z.string().defer(),
+  });
+
+  expect(() => schema1.parse({ a: "foo", b: 1 })).not.toThrow();
+
+  const parsed = schema1.parse({ a: "foo", b: 1 });
+  expect(() => parsed.b()).toThrow();
+
+  expect(schema1.parse({ a: "foo", b: "bar" }).b()).toEqual("bar");
+
+  const schema2 = z
+    .object({
+      a: z.string(),
+      b: z.string(),
+    })
+    .deferProps();
+  const parsed2 = schema2.parse({ a: "foo", b: 1 });
+  expect(parsed2.a()).toEqual("foo");
+  expect(() => parsed2.b()).toThrow();
+});
+
+test("deferProps", () => {
+  const schema = z.object({
+    stringField: z.string(),
+    numberField: z.number(),
+    nullableField: z.string().nullable(),
+    objectField: z.object({
+      a: z.string(),
+      b: z.number(),
+    }),
+  });
+
+  const deferredSchema = schema.deferProps();
+
+  type deferred = z.infer<typeof deferredSchema>;
+  type expectedDeferred = {
+    stringField: () => string;
+    numberField: () => number;
+    nullableField: () => string | null;
+    objectField: () => {
+      a: string;
+      b: number;
+    };
+  };
+  util.assertEqual<deferred, expectedDeferred>(true);
+
+  const deferredSchemaWithMask = schema.deferProps({
+    stringField: true,
+    objectField: true,
+  });
+
+  type deferredWithMask = z.infer<typeof deferredSchemaWithMask>;
+  type expectedDeferredWithMask = {
+    stringField: () => string;
+    numberField: number;
+    nullableField: string | null;
+    objectField: () => {
+      a: string;
+      b: number;
+    };
+  };
+  util.assertEqual<deferredWithMask, expectedDeferredWithMask>(true);
+});
+
+test("usage with effects", () => {
+  const transformSchema = z
+    .string()
+    .transform((value) => value.length)
+    .defer();
+
+  expect(() => transformSchema.parse(32)).not.toThrow();
+  expect(() => transformSchema.parse(32)()).toThrow();
+  expect(() => transformSchema.parse("hello")).not.toThrow();
+  expect(transformSchema.parse("hello")()).toEqual(5);
+});

--- a/src/__tests__/firstparty.test.ts
+++ b/src/__tests__/firstparty.test.ts
@@ -81,6 +81,8 @@ test("first party switch", () => {
       break;
     case z.ZodFirstPartyTypeKind.ZodReadonly:
       break;
+    case z.ZodFirstPartyTypeKind.ZodDefer:
+      break;
     default:
       util.assertNever(def);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -510,6 +510,9 @@ export abstract class ZodType<
   readonly(): ZodReadonly<this> {
     return ZodReadonly.create(this);
   }
+  defer(): ZodDefer<this> {
+    return ZodDefer.create(this, this._def) as any;
+  }
 
   isOptional(): boolean {
     return this.safeParse(undefined).success;
@@ -2860,6 +2863,39 @@ export class ZodObject<
     ) as any;
   }
 
+  deferProps(): ZodObject<
+    { [k in keyof T]: ZodDefer<T[k]> },
+    UnknownKeys,
+    Catchall
+  >;
+  deferProps<Mask extends util.Exactly<{ [k in keyof T]?: true }, Mask>>(
+    mask: Mask
+  ): ZodObject<
+    objectUtil.noNever<{
+      [k in keyof T]: k extends keyof Mask ? ZodDefer<T[k]> : T[k];
+    }>,
+    UnknownKeys,
+    Catchall
+  >;
+  deferProps(mask?: any) {
+    const newShape: any = {};
+
+    util.objectKeys(this.shape).forEach((key) => {
+      const fieldSchema = this.shape[key];
+
+      if (mask && !mask[key]) {
+        newShape[key] = fieldSchema;
+      } else {
+        newShape[key] = fieldSchema.defer();
+      }
+    });
+
+    return new ZodObject({
+      ...this._def,
+      shape: () => newShape,
+    }) as any;
+  }
+
   static create = <T extends ZodRawShape>(
     shape: T,
     params?: RawCreateParams
@@ -5068,6 +5104,46 @@ export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
   }
 }
 
+///////////////////////////////////////////
+///////////////////////////////////////////
+//////////                       //////////
+//////////       ZodDefer        //////////
+//////////                       //////////
+///////////////////////////////////////////
+///////////////////////////////////////////
+export interface ZodDeferDef<T extends ZodTypeAny = ZodTypeAny>
+  extends ZodTypeDef {
+  innerType: T;
+  typeName: ZodFirstPartyTypeKind.ZodDefer;
+}
+
+export type ZodDeferType<T extends ZodTypeAny> = ZodDefer<T>;
+
+export class ZodDefer<T extends ZodTypeAny> extends ZodType<
+  () => T["_output"],
+  ZodDeferDef<T>,
+  T["_input"]
+> {
+  _parse(input: ParseInput): ParseReturnType<() => this["_output"]> {
+    return OK(() => this._def.innerType.parse(input.data));
+  }
+
+  eager() {
+    return this._def.innerType;
+  }
+
+  static create = <T extends ZodTypeAny>(
+    type: T,
+    params?: RawCreateParams
+  ): ZodDefer<T> => {
+    return new ZodDefer({
+      innerType: type,
+      typeName: ZodFirstPartyTypeKind.ZodDefer,
+      ...processCreateParams(params),
+    }) as any;
+  };
+}
+
 ////////////////////////////////////////
 ////////////////////////////////////////
 //////////                    //////////
@@ -5151,6 +5227,7 @@ export enum ZodFirstPartyTypeKind {
   ZodBranded = "ZodBranded",
   ZodPipeline = "ZodPipeline",
   ZodReadonly = "ZodReadonly",
+  ZodDefer = "ZodDefer",
 }
 export type ZodFirstPartySchemaTypes =
   | ZodString
@@ -5188,6 +5265,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodBranded<any, any>
   | ZodPipeline<any, any>
   | ZodReadonly<any>
+  | ZodDefer<any>
   | ZodSymbol;
 
 // requires TS 4.4+
@@ -5236,6 +5314,7 @@ const optionalType = ZodOptional.create;
 const nullableType = ZodNullable.create;
 const preprocessType = ZodEffects.createWithPreprocess;
 const pipelineType = ZodPipeline.create;
+const deferType = ZodDefer.create;
 const ostring = () => stringType().optional();
 const onumber = () => numberType().optional();
 const oboolean = () => booleanType().optional();
@@ -5262,6 +5341,7 @@ export {
   bigIntType as bigint,
   booleanType as boolean,
   dateType as date,
+  deferType as defer,
   discriminatedUnionType as discriminatedUnion,
   effectsType as effect,
   enumType as enum,


### PR DESCRIPTION
I propose a new feature `defer` to support lazy parsing, which is requested on #2060.

I think this feature would have pretty much use cases such as:
- Only parse the needed fields and prevent unused fields breaking the application. 
- Defer parsing of expensive large schemas.
- And more...

## What it does

You can mark a subpart of a schema as 'deferred' using `.defer()`

The parsing of a schema which is marked 'deferred', is skipped during the parsing, and **outputs a function that can be called to parse the input laterwise** where the schema is actually used.

```typescript
const schema = z.object({
  foo: z.string(),
  bar: z.string().defer(),
})

const parsed = schema.parse({ foo: "foo", bar: "bar" });  // bar is not parsed here

parsed.foo
parsed.bar() // bar is parsed here
```

## Interface
```typescript
// standalone
z.defer(z.string());

// method
z.string().defer();

// can be combined with other effects
z.string().transform(val => val.length).defer();
```

## Additional helper methods

Since the realworld usage would require scenarios like 'defer all props of an object', I also propose a helper method `.deferProps()` in `ZodObject`.

(Just like `.partial()` in `.optional()`)

> I don't think `.deferProps()` is the best naming of the functionality. I'm open for suggestions.

```typescript
z.object({
  foo: z.number(),
  bar: z.string(),
}).deferProps();

// same as 
z.object({
  foo: z.number().defer(),
  bar: z.string().defer(),
});
```

As `.partial()` accepts a mask to mark the fields to be optional. `.deferProps()` also does.
```typescript
z.object({ ... }).deferProps({ foo: true })  // defer prop 'foo' only
```

## WIP

The docs and more exhaustive test cases is a work in process. I plan to work on it after discussions about this new feature request.
