### PR TITLE
Add proper plurals to error messages

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -133,7 +133,7 @@ Here are the errors that will be printed:
     code: "unrecognized_keys",
     keys: ["extra"],
     path: ["address"],
-    message: "Unrecognized key(s) in object: 'extra'",
+    message: "Unrecognized key in object: 'extra'",
   },
   {
     code: "too_small",

--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -130,7 +130,7 @@ test("array minimum", () => {
     const zerr: ZodError = err as any;
     expect(zerr.issues[0].code).toEqual(ZodIssueCode.too_small);
     expect(zerr.issues[0].message).toEqual(
-      `Array must contain at least 3 element(s)`
+      `Array must contain at least 3 elements`
     );
   }
 });

--- a/deno/lib/__tests__/validations.test.ts
+++ b/deno/lib/__tests__/validations.test.ts
@@ -9,7 +9,7 @@ test("array min", async () => {
     await z.array(z.string()).min(4).parseAsync([]);
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "Array must contain at least 4 element(s)"
+      "Array must contain at least 4 elements"
     );
   }
 });
@@ -19,7 +19,7 @@ test("array max", async () => {
     await z.array(z.string()).max(2).parseAsync(["asdf", "asdf", "asdf"]);
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "Array must contain at most 2 element(s)"
+      "Array must contain at most 2 elements"
     );
   }
 });
@@ -29,7 +29,7 @@ test("array length", async () => {
     await z.array(z.string()).length(2).parseAsync(["asdf", "asdf", "asdf"]);
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "Array must contain exactly 2 element(s)"
+      "Array must contain exactly 2 elements"
     );
   }
 
@@ -37,7 +37,7 @@ test("array length", async () => {
     await z.array(z.string()).length(2).parseAsync(["asdf"]);
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "Array must contain exactly 2 element(s)"
+      "Array must contain exactly 2 elements"
     );
   }
 });
@@ -47,7 +47,7 @@ test("string length", async () => {
     await z.string().length(4).parseAsync("asd");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "String must contain exactly 4 character(s)"
+      "String must contain exactly 4 characters"
     );
   }
 
@@ -55,7 +55,7 @@ test("string length", async () => {
     await z.string().length(4).parseAsync("asdaa");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "String must contain exactly 4 character(s)"
+      "String must contain exactly 4 characters"
     );
   }
 });
@@ -65,7 +65,7 @@ test("string min", async () => {
     await z.string().min(4).parseAsync("asd");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "String must contain at least 4 character(s)"
+      "String must contain at least 4 characters"
     );
   }
 });
@@ -75,7 +75,7 @@ test("string max", async () => {
     await z.string().max(4).parseAsync("aasdfsdfsd");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "String must contain at most 4 character(s)"
+      "String must contain at most 4 characters"
     );
   }
 });

--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -88,6 +88,10 @@ export namespace util {
       .join(separator);
   }
 
+  export function pluralize(count: number | bigint, singular: string, plural: string = singular + "s") {
+    return count === 1 ? singular : plural;
+  }
+
   export const jsonStringifyReplacer = (_: string, value: any): any => {
     if (typeof value === "bigint") {
       return value.toString();

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -18,7 +18,7 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       )}`;
       break;
     case ZodIssueCode.unrecognized_keys:
-      message = `Unrecognized key(s) in object: ${util.joinValues(
+      message = `Unrecognized ${util.pluralize(issue.keys.length, "key")} in object: ${util.joinValues(
         issue.keys,
         ", "
       )}`;
@@ -70,11 +70,11 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       if (issue.type === "array")
         message = `Array must contain ${
           issue.exact ? "exactly" : issue.inclusive ? `at least` : `more than`
-        } ${issue.minimum} element(s)`;
+        } ${issue.minimum} ${util.pluralize(issue.minimum, "element")}`;
       else if (issue.type === "string")
         message = `String must contain ${
           issue.exact ? "exactly" : issue.inclusive ? `at least` : `over`
-        } ${issue.minimum} character(s)`;
+        } ${issue.minimum} ${util.pluralize(issue.minimum, "character")}`;
       else if (issue.type === "number")
         message = `Number must be ${
           issue.exact
@@ -97,11 +97,11 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       if (issue.type === "array")
         message = `Array must contain ${
           issue.exact ? `exactly` : issue.inclusive ? `at most` : `less than`
-        } ${issue.maximum} element(s)`;
+        } ${issue.maximum} ${util.pluralize(issue.maximum, "element")}`;
       else if (issue.type === "string")
         message = `String must contain ${
           issue.exact ? `exactly` : issue.inclusive ? `at most` : `under`
-        } ${issue.maximum} character(s)`;
+        } ${issue.maximum} ${util.pluralize(issue.maximum, "character")}`;
       else if (issue.type === "number")
         message = `Number must be ${
           issue.exact

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -129,7 +129,7 @@ test("array minimum", () => {
     const zerr: ZodError = err as any;
     expect(zerr.issues[0].code).toEqual(ZodIssueCode.too_small);
     expect(zerr.issues[0].message).toEqual(
-      `Array must contain at least 3 element(s)`
+      `Array must contain at least 3 elements`
     );
   }
 });

--- a/src/__tests__/validations.test.ts
+++ b/src/__tests__/validations.test.ts
@@ -8,7 +8,7 @@ test("array min", async () => {
     await z.array(z.string()).min(4).parseAsync([]);
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "Array must contain at least 4 element(s)"
+      "Array must contain at least 4 elements"
     );
   }
 });
@@ -18,7 +18,7 @@ test("array max", async () => {
     await z.array(z.string()).max(2).parseAsync(["asdf", "asdf", "asdf"]);
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "Array must contain at most 2 element(s)"
+      "Array must contain at most 2 elements"
     );
   }
 });
@@ -28,7 +28,7 @@ test("array length", async () => {
     await z.array(z.string()).length(2).parseAsync(["asdf", "asdf", "asdf"]);
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "Array must contain exactly 2 element(s)"
+      "Array must contain exactly 2 elements"
     );
   }
 
@@ -36,7 +36,7 @@ test("array length", async () => {
     await z.array(z.string()).length(2).parseAsync(["asdf"]);
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "Array must contain exactly 2 element(s)"
+      "Array must contain exactly 2 elements"
     );
   }
 });
@@ -46,7 +46,7 @@ test("string length", async () => {
     await z.string().length(4).parseAsync("asd");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "String must contain exactly 4 character(s)"
+      "String must contain exactly 4 characters"
     );
   }
 
@@ -54,7 +54,7 @@ test("string length", async () => {
     await z.string().length(4).parseAsync("asdaa");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "String must contain exactly 4 character(s)"
+      "String must contain exactly 4 characters"
     );
   }
 });
@@ -64,7 +64,7 @@ test("string min", async () => {
     await z.string().min(4).parseAsync("asd");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "String must contain at least 4 character(s)"
+      "String must contain at least 4 characters"
     );
   }
 });
@@ -74,7 +74,7 @@ test("string max", async () => {
     await z.string().max(4).parseAsync("aasdfsdfsd");
   } catch (err) {
     expect((err as z.ZodError).issues[0].message).toEqual(
-      "String must contain at most 4 character(s)"
+      "String must contain at most 4 characters"
     );
   }
 });

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -88,6 +88,10 @@ export namespace util {
       .join(separator);
   }
 
+  export function pluralize(count: number | bigint, singular: string, plural: string = singular + "s") {
+    return count === 1 ? singular : plural;
+  }
+
   export const jsonStringifyReplacer = (_: string, value: any): any => {
     if (typeof value === "bigint") {
       return value.toString();

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -18,7 +18,7 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       )}`;
       break;
     case ZodIssueCode.unrecognized_keys:
-      message = `Unrecognized key(s) in object: ${util.joinValues(
+      message = `Unrecognized ${util.pluralize(issue.keys.length, "key")} in object: ${util.joinValues(
         issue.keys,
         ", "
       )}`;
@@ -70,11 +70,11 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       if (issue.type === "array")
         message = `Array must contain ${
           issue.exact ? "exactly" : issue.inclusive ? `at least` : `more than`
-        } ${issue.minimum} element(s)`;
+        } ${issue.minimum} ${util.pluralize(issue.minimum, "element")}`;
       else if (issue.type === "string")
         message = `String must contain ${
           issue.exact ? "exactly" : issue.inclusive ? `at least` : `over`
-        } ${issue.minimum} character(s)`;
+        } ${issue.minimum} ${util.pluralize(issue.minimum, "character")}`;
       else if (issue.type === "number")
         message = `Number must be ${
           issue.exact
@@ -97,11 +97,11 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       if (issue.type === "array")
         message = `Array must contain ${
           issue.exact ? `exactly` : issue.inclusive ? `at most` : `less than`
-        } ${issue.maximum} element(s)`;
+        } ${issue.maximum} ${util.pluralize(issue.maximum, "element")}`;
       else if (issue.type === "string")
         message = `String must contain ${
           issue.exact ? `exactly` : issue.inclusive ? `at most` : `under`
-        } ${issue.maximum} character(s)`;
+        } ${issue.maximum} ${util.pluralize(issue.maximum, "character")}`;
       else if (issue.type === "number")
         message = `Number must be ${
           issue.exact


### PR DESCRIPTION
A bit of low-cost polish to determine if the plural or singular of phrases in error messages should be used. Replaces `(s)`.

Before
```
Must be 5 or fewer character(s) long
Array must contain at most 1 element(s)
Unrecognized key(s) in object: 'extra'
```

After 
```
Must be 5 or fewer characters long
Array must contain at most 1 element
Unrecognized key in object: 'extra'
```

Especially given that these errors or [derivatives](https://github.com/causaly/zod-validation-error/tree/main) of them are often returned by APIs or shown in forms, this small change could make a positive impact on end user UX.