### PR TITLE
fix: adds ` | never` to `objectOutputType` as a signal to the LSP tha…

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2330,11 +2330,13 @@ export type objectOutputType<
   Shape extends ZodRawShape,
   Catchall extends ZodTypeAny,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam
-> = objectUtil.flatten<
-  objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>
-> &
-  CatchallOutput<Catchall> &
-  PassthroughType<UnknownKeys>;
+> =
+  | never
+  | (objectUtil.flatten<
+      objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>
+    > &
+      CatchallOutput<Catchall> &
+      PassthroughType<UnknownKeys>);
 
 export type baseObjectOutputType<Shape extends ZodRawShape> = {
   [k in keyof Shape]: Shape[k]["_output"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -2330,11 +2330,13 @@ export type objectOutputType<
   Shape extends ZodRawShape,
   Catchall extends ZodTypeAny,
   UnknownKeys extends UnknownKeysParam = UnknownKeysParam
-> = objectUtil.flatten<
-  objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>
-> &
-  CatchallOutput<Catchall> &
-  PassthroughType<UnknownKeys>;
+> =
+  | never
+  | (objectUtil.flatten<
+      objectUtil.addQuestionMarks<baseObjectOutputType<Shape>>
+    > &
+      CatchallOutput<Catchall> &
+      PassthroughType<UnknownKeys>);
 
 export type baseObjectOutputType<Shape extends ZodRawShape> = {
   [k in keyof Shape]: Shape[k]["_output"];


### PR DESCRIPTION
This small PR updates the type of `objectOutputType` to fully evaluate the type.

This only seems to occur with `catchall` schemas, and only sometimes.

**Before:**

<img width="617" alt="Screenshot 2024-06-17 at 12 12 45 PM" src="https://github.com/colinhacks/zod/assets/15133992/76e530ea-7046-4d16-bc3a-9d5a452e7e2c">

You can see in the screenshot that the output type includes the type constructor that created it (`objectOutputType`).

The fix for this when it occurs is to unify the result that `objectOutputType` returns with `never`.

The union of any type with the bottom (`never`) is the first type (` | never` is an identity operation), so this is a no-op in every context except for the LSP, which interprets a union as a signal that it needs to evaluate the node.

**After:**

<img width="617" alt="Screenshot 2024-06-17 at 12 14 26 PM" src="https://github.com/colinhacks/zod/assets/15133992/ab211ebf-d1d2-4bf7-9a78-770346687513">
