### PR TITLE
Add title field to Zod - close #1831

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@
     - [Async transforms](#async-transforms)
   - [`.default`](#default)
   - [`.describe`](#describe)
+  - [`.describeTitle`](#describeTitle)
   - [`.catch`](#catch)
   - [`.optional`](#optional)
   - [`.nullable`](#nullable)
@@ -2346,6 +2347,17 @@ const documentedString = z
   .string()
   .describe("A useful bit of text, if you know what to do with it.");
 documentedString.description; // A useful bit of text…
+```
+
+This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
+
+### `.describeTitle`
+
+Use `.describeTitle()` to add a `title` property to the resulting schema.
+
+```ts
+const documentedString = z.string().describeTitle("Tile In Readable Format");
+documentedString.title; // A useful name for presentation
 ```
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@
     - [Async transforms](#async-transforms)
   - [`.default`](#default)
   - [`.describe`](#describe)
-  - [`.describeTitle`](#describeTitle)
+  - [`.titled`](#titled)
   - [`.catch`](#catch)
   - [`.optional`](#optional)
   - [`.nullable`](#nullable)
@@ -2351,12 +2351,12 @@ documentedString.description; // A useful bit of text…
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
 
-### `.describeTitle`
+### `.titled`
 
-Use `.describeTitle()` to add a `title` property to the resulting schema.
+Use `.titled()` to add a `title` property to the resulting schema.
 
 ```ts
-const documentedString = z.string().describeTitle("Tile In Readable Format");
+const documentedString = z.string().titled("Tile In Readable Format");
 documentedString.title; // A useful name for presentation
 ```
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -141,6 +141,7 @@
     - [Async transforms](#async-transforms)
   - [`.default`](#default)
   - [`.describe`](#describe)
+  - [`.describeTitle`](#describeTitle)
   - [`.catch`](#catch)
   - [`.optional`](#optional)
   - [`.nullable`](#nullable)
@@ -2346,6 +2347,17 @@ const documentedString = z
   .string()
   .describe("A useful bit of text, if you know what to do with it.");
 documentedString.description; // A useful bit of text…
+```
+
+This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
+
+### `.describeTitle`
+
+Use `.describeTitle()` to add a `title` property to the resulting schema.
+
+```ts
+const documentedString = z.string().describeTitle("Tile In Readable Format");
+documentedString.title; // A useful name for presentation
 ```
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -141,7 +141,7 @@
     - [Async transforms](#async-transforms)
   - [`.default`](#default)
   - [`.describe`](#describe)
-  - [`.describeTitle`](#describeTitle)
+  - [`.titled`](#titled)
   - [`.catch`](#catch)
   - [`.optional`](#optional)
   - [`.nullable`](#nullable)
@@ -2351,12 +2351,12 @@ documentedString.description; // A useful bit of text…
 
 This can be useful for documenting a field, for example in a JSON Schema using a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema)).
 
-### `.describeTitle`
+### `.titled`
 
-Use `.describeTitle()` to add a `title` property to the resulting schema.
+Use `.titled()` to add a `title` property to the resulting schema.
 
 ```ts
-const documentedString = z.string().describeTitle("Tile In Readable Format");
+const documentedString = z.string().titled("Tile In Readable Format");
 documentedString.title; // A useful name for presentation
 ```
 

--- a/deno/lib/__tests__/title.test.ts
+++ b/deno/lib/__tests__/title.test.ts
@@ -12,10 +12,10 @@ test("passing `title` to schema should add a title", () => {
   expect(z.boolean({ title }).title).toEqual(title);
 });
 
-test("`.describeTitle` should add a description", () => {
-  expect(z.string().describeTitle(title).title).toEqual(title);
-  expect(z.number().describeTitle(title).title).toEqual(title);
-  expect(z.boolean().describeTitle(title).title).toEqual(title);
+test("`.titled` should add a description", () => {
+  expect(z.string().titled(title).title).toEqual(title);
+  expect(z.number().titled(title).title).toEqual(title);
+  expect(z.boolean().titled(title).title).toEqual(title);
 });
 
 test("title should carry over to chained schemas", () => {

--- a/deno/lib/__tests__/title.test.ts
+++ b/deno/lib/__tests__/title.test.ts
@@ -1,0 +1,28 @@
+// @ts-ignore TS6133
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+const title = "title";
+
+test("passing `title` to schema should add a title", () => {
+  expect(z.string({ title }).title).toEqual(title);
+  expect(z.number({ title }).title).toEqual(title);
+  expect(z.boolean({ title }).title).toEqual(title);
+});
+
+test("`.describeTitle` should add a description", () => {
+  expect(z.string().describeTitle(title).title).toEqual(title);
+  expect(z.number().describeTitle(title).title).toEqual(title);
+  expect(z.boolean().describeTitle(title).title).toEqual(title);
+});
+
+test("title should carry over to chained schemas", () => {
+  const schema = z.string({ title });
+  expect(schema.title).toEqual(title);
+  expect(schema.optional().title).toEqual(title);
+  expect(schema.optional().nullable().default("default").title).toEqual(
+    title
+  );
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -56,6 +56,7 @@ export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
   errorMap?: ZodErrorMap;
   description?: string;
+  title?: string;
 }
 
 class ParseInputLazyPath implements ParseInput {
@@ -120,21 +121,24 @@ export type RawCreateParams =
       required_error?: string;
       message?: string;
       description?: string;
+      title?: string;
     }
   | undefined;
 export type ProcessedCreateParams = {
   errorMap?: ZodErrorMap;
   description?: string;
+  title?: string;
 };
 function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   if (!params) return {};
-  const { errorMap, invalid_type_error, required_error, description } = params;
+  const { errorMap, invalid_type_error, required_error, description, title } =
+    params;
   if (errorMap && (invalid_type_error || required_error)) {
     throw new Error(
       `Can't use "invalid_type_error" or "required_error" in conjunction with custom error map.`
     );
   }
-  if (errorMap) return { errorMap: errorMap, description };
+  if (errorMap) return { errorMap: errorMap, description, title };
   const customMap: ZodErrorMap = (iss, ctx) => {
     const { message } = params;
 
@@ -147,7 +151,7 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
     if (iss.code !== "invalid_type") return { message: ctx.defaultError };
     return { message: message ?? invalid_type_error ?? ctx.defaultError };
   };
-  return { errorMap: customMap, description };
+  return { errorMap: customMap, description, title };
 }
 
 export type SafeParseSuccess<Output> = {
@@ -177,6 +181,10 @@ export abstract class ZodType<
 
   get description() {
     return this._def.description;
+  }
+
+  get title() {
+    return this._def.title;
   }
 
   abstract _parse(input: ParseInput): ParseReturnType<Output>;
@@ -418,6 +426,7 @@ export abstract class ZodType<
     this.default = this.default.bind(this);
     this.catch = this.catch.bind(this);
     this.describe = this.describe.bind(this);
+    this.describeTitle = this.describeTitle.bind(this);
     this.pipe = this.pipe.bind(this);
     this.readonly = this.readonly.bind(this);
     this.isNullable = this.isNullable.bind(this);
@@ -501,6 +510,14 @@ export abstract class ZodType<
     return new This({
       ...this._def,
       description,
+    });
+  }
+
+  describeTitle(title: string): this {
+    const This = (this as any).constructor;
+    return new This({
+      ...this._def,
+      title,
     });
   }
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -426,7 +426,7 @@ export abstract class ZodType<
     this.default = this.default.bind(this);
     this.catch = this.catch.bind(this);
     this.describe = this.describe.bind(this);
-    this.describeTitle = this.describeTitle.bind(this);
+    this.titled = this.titled.bind(this);
     this.pipe = this.pipe.bind(this);
     this.readonly = this.readonly.bind(this);
     this.isNullable = this.isNullable.bind(this);
@@ -513,7 +513,7 @@ export abstract class ZodType<
     });
   }
 
-  describeTitle(title: string): this {
+  titled(title: string): this {
     const This = (this as any).constructor;
     return new This({
       ...this._def,

--- a/src/__tests__/title.test.ts
+++ b/src/__tests__/title.test.ts
@@ -11,10 +11,10 @@ test("passing `title` to schema should add a title", () => {
   expect(z.boolean({ title }).title).toEqual(title);
 });
 
-test("`.describeTitle` should add a description", () => {
-  expect(z.string().describeTitle(title).title).toEqual(title);
-  expect(z.number().describeTitle(title).title).toEqual(title);
-  expect(z.boolean().describeTitle(title).title).toEqual(title);
+test("`.titled` should add a description", () => {
+  expect(z.string().titled(title).title).toEqual(title);
+  expect(z.number().titled(title).title).toEqual(title);
+  expect(z.boolean().titled(title).title).toEqual(title);
 });
 
 test("title should carry over to chained schemas", () => {

--- a/src/__tests__/title.test.ts
+++ b/src/__tests__/title.test.ts
@@ -1,0 +1,27 @@
+// @ts-ignore TS6133
+import { expect, test } from "@jest/globals";
+
+import * as z from "../index";
+
+const title = "title";
+
+test("passing `title` to schema should add a title", () => {
+  expect(z.string({ title }).title).toEqual(title);
+  expect(z.number({ title }).title).toEqual(title);
+  expect(z.boolean({ title }).title).toEqual(title);
+});
+
+test("`.describeTitle` should add a description", () => {
+  expect(z.string().describeTitle(title).title).toEqual(title);
+  expect(z.number().describeTitle(title).title).toEqual(title);
+  expect(z.boolean().describeTitle(title).title).toEqual(title);
+});
+
+test("title should carry over to chained schemas", () => {
+  const schema = z.string({ title });
+  expect(schema.title).toEqual(title);
+  expect(schema.optional().title).toEqual(title);
+  expect(schema.optional().nullable().default("default").title).toEqual(
+    title
+  );
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
 export interface ZodTypeDef {
   errorMap?: ZodErrorMap;
   description?: string;
+  title?: string;
 }
 
 class ParseInputLazyPath implements ParseInput {
@@ -120,21 +121,24 @@ export type RawCreateParams =
       required_error?: string;
       message?: string;
       description?: string;
+      title?: string;
     }
   | undefined;
 export type ProcessedCreateParams = {
   errorMap?: ZodErrorMap;
   description?: string;
+  title?: string;
 };
 function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
   if (!params) return {};
-  const { errorMap, invalid_type_error, required_error, description } = params;
+  const { errorMap, invalid_type_error, required_error, description, title } =
+    params;
   if (errorMap && (invalid_type_error || required_error)) {
     throw new Error(
       `Can't use "invalid_type_error" or "required_error" in conjunction with custom error map.`
     );
   }
-  if (errorMap) return { errorMap: errorMap, description };
+  if (errorMap) return { errorMap: errorMap, description, title };
   const customMap: ZodErrorMap = (iss, ctx) => {
     const { message } = params;
 
@@ -147,7 +151,7 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
     if (iss.code !== "invalid_type") return { message: ctx.defaultError };
     return { message: message ?? invalid_type_error ?? ctx.defaultError };
   };
-  return { errorMap: customMap, description };
+  return { errorMap: customMap, description, title };
 }
 
 export type SafeParseSuccess<Output> = {
@@ -177,6 +181,10 @@ export abstract class ZodType<
 
   get description() {
     return this._def.description;
+  }
+
+  get title() {
+    return this._def.title;
   }
 
   abstract _parse(input: ParseInput): ParseReturnType<Output>;
@@ -418,6 +426,7 @@ export abstract class ZodType<
     this.default = this.default.bind(this);
     this.catch = this.catch.bind(this);
     this.describe = this.describe.bind(this);
+    this.describeTitle = this.describeTitle.bind(this);
     this.pipe = this.pipe.bind(this);
     this.readonly = this.readonly.bind(this);
     this.isNullable = this.isNullable.bind(this);
@@ -501,6 +510,14 @@ export abstract class ZodType<
     return new This({
       ...this._def,
       description,
+    });
+  }
+
+  describeTitle(title: string): this {
+    const This = (this as any).constructor;
+    return new This({
+      ...this._def,
+      title,
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -426,7 +426,7 @@ export abstract class ZodType<
     this.default = this.default.bind(this);
     this.catch = this.catch.bind(this);
     this.describe = this.describe.bind(this);
-    this.describeTitle = this.describeTitle.bind(this);
+    this.titled = this.titled.bind(this);
     this.pipe = this.pipe.bind(this);
     this.readonly = this.readonly.bind(this);
     this.isNullable = this.isNullable.bind(this);
@@ -513,7 +513,7 @@ export abstract class ZodType<
     });
   }
 
-  describeTitle(title: string): this {
+  titled(title: string): this {
     const This = (this as any).constructor;
     return new This({
       ...this._def,


### PR DESCRIPTION
Title is a useful field when presenting or converting to JSON schema. Title is used for a human-readable name of a variable. Very practical when combined with description.

Add optional title field.
Add titled setter method.
Add test suit.
Update docs next to describe for ease of use.