### PR TITLE
fix(ZodDefault): apply default even if inner parse returns undefined

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -27,6 +27,7 @@ export const ZodIssueCode = util.arrayToEnum([
   "invalid_return_type",
   "invalid_date",
   "invalid_string",
+  "failed_default",
   "too_small",
   "too_big",
   "invalid_intersection_types",
@@ -137,6 +138,10 @@ export interface ZodNotFiniteIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.not_finite;
 }
 
+export interface ZodFailedDefaultIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.failed_default;
+}
+
 export interface ZodCustomIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.custom;
   params?: { [k: string]: any };
@@ -160,6 +165,7 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidIntersectionTypesIssue
   | ZodNotMultipleOfIssue
   | ZodNotFiniteIssue
+  | ZodFailedDefaultIssue
   | ZodCustomIssue;
 
 export type ZodIssue = ZodIssueOptionalMessage & {

--- a/deno/lib/__tests__/default.test.ts
+++ b/deno/lib/__tests__/default.test.ts
@@ -27,6 +27,39 @@ test("default with transform", () => {
   util.assertEqual<out, string>(true);
 });
 
+test("default after transform that returns undefined", () => {
+  const schema = z
+    .union([z.literal("").transform(() => undefined), z.string().optional()])
+    .default("default");
+
+  expect(schema.parse(undefined)).toBe("default");
+  expect(schema.parse("foo")).toBe("foo");
+  expect(schema.parse("")).toBe("default");
+
+  type inp = z.input<typeof schema>;
+  util.assertEqual<inp, string | undefined>(true);
+  type out = z.output<typeof schema>;
+  util.assertEqual<out, string>(true);
+});
+
+test("default after async transform that returns undefined", async () => {
+  const schema = z
+    .union([
+      z.literal("").transform(async () => undefined),
+      z.string().optional(),
+    ])
+    .default("default");
+
+  expect(await schema.parseAsync(undefined)).toBe("default");
+  expect(await schema.parseAsync("foo")).toBe("foo");
+  expect(await schema.parseAsync("")).toBe("default");
+
+  type inp = z.input<typeof schema>;
+  util.assertEqual<inp, string | undefined>(true);
+  type out = z.output<typeof schema>;
+  util.assertEqual<out, string>(true);
+});
+
 test("default on existing optional", () => {
   const stringWithDefault = z.string().optional().default("asdf");
   expect(stringWithDefault.parse(undefined)).toBe("asdf");

--- a/deno/lib/__tests__/default.test.ts
+++ b/deno/lib/__tests__/default.test.ts
@@ -29,12 +29,37 @@ test("default with transform", () => {
 
 test("default after transform that returns undefined", () => {
   const schema = z
-    .union([z.literal("").transform(() => undefined), z.string().optional()])
+    .union([
+      z.literal("").transform(() => undefined),
+      z.string().toUpperCase().optional(),
+    ])
     .default("default");
 
-  expect(schema.parse(undefined)).toBe("default");
+  expect(schema.parse(undefined)).toBe("DEFAULT");
+  expect(schema.parse("foo")).toBe("FOO");
+  expect(schema.parse("")).toBe("DEFAULT");
+
+  type inp = z.input<typeof schema>;
+  util.assertEqual<inp, string | undefined>(true);
+  type out = z.output<typeof schema>;
+  util.assertEqual<out, string>(true);
+});
+
+test("default when transform returns undefined on default value", () => {
+  const schema = z
+    .union([
+      z.enum(["", "default"]).transform(() => undefined),
+      z.string().optional(),
+    ])
+    .default("default");
+
+  expect(() => schema.parse(undefined)).toThrow(
+    "default value parsed to undefined"
+  );
   expect(schema.parse("foo")).toBe("foo");
-  expect(schema.parse("")).toBe("default");
+  expect(() => schema.parse("")).toThrowError(
+    "default value parsed to undefined"
+  );
 
   type inp = z.input<typeof schema>;
   util.assertEqual<inp, string | undefined>(true);

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -140,6 +140,9 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.not_finite:
       message = "Number must be finite";
       break;
+    case ZodIssueCode.failed_default:
+      message = "default value parsed to undefined";
+      break;
     default:
       message = _ctx.defaultError;
       util.assertNever(issue);

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4507,10 +4507,9 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
     });
     const checkParsedDefault = (parsed: SyncParseReturnType<any>) => {
       if (parsed.status === "valid" && parsed.value === undefined) {
-        ctx.common.issues.push({
+        addIssueToContext(ctx, {
           code: ZodIssueCode.failed_default,
           path: ctx.path,
-          message: "default value parsed to undefined",
         });
         return INVALID;
       }

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4500,11 +4500,20 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
     if (ctx.parsedType === ZodParsedType.undefined) {
       data = this._def.defaultValue();
     }
-    return this._def.innerType._parse({
+    const parsed = this._def.innerType._parse({
       data,
       path: ctx.path,
       parent: ctx,
     });
+    return "then" in parsed
+      ? parsed.then((parsed) =>
+          parsed.status === "valid" && parsed.value === undefined
+            ? OK(this._def.defaultValue())
+            : parsed
+        )
+      : parsed.status === "valid" && parsed.value === undefined
+      ? OK(this._def.defaultValue())
+      : parsed;
   }
 
   removeDefault() {

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -27,6 +27,7 @@ export const ZodIssueCode = util.arrayToEnum([
   "invalid_return_type",
   "invalid_date",
   "invalid_string",
+  "failed_default",
   "too_small",
   "too_big",
   "invalid_intersection_types",
@@ -137,6 +138,10 @@ export interface ZodNotFiniteIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.not_finite;
 }
 
+export interface ZodFailedDefaultIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.failed_default;
+}
+
 export interface ZodCustomIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.custom;
   params?: { [k: string]: any };
@@ -160,6 +165,7 @@ export type ZodIssueOptionalMessage =
   | ZodInvalidIntersectionTypesIssue
   | ZodNotMultipleOfIssue
   | ZodNotFiniteIssue
+  | ZodFailedDefaultIssue
   | ZodCustomIssue;
 
 export type ZodIssue = ZodIssueOptionalMessage & {

--- a/src/__tests__/default.test.ts
+++ b/src/__tests__/default.test.ts
@@ -26,6 +26,39 @@ test("default with transform", () => {
   util.assertEqual<out, string>(true);
 });
 
+test("default after transform that returns undefined", () => {
+  const schema = z
+    .union([z.literal("").transform(() => undefined), z.string().optional()])
+    .default("default");
+
+  expect(schema.parse(undefined)).toBe("default");
+  expect(schema.parse("foo")).toBe("foo");
+  expect(schema.parse("")).toBe("default");
+
+  type inp = z.input<typeof schema>;
+  util.assertEqual<inp, string | undefined>(true);
+  type out = z.output<typeof schema>;
+  util.assertEqual<out, string>(true);
+});
+
+test("default after async transform that returns undefined", async () => {
+  const schema = z
+    .union([
+      z.literal("").transform(async () => undefined),
+      z.string().optional(),
+    ])
+    .default("default");
+
+  expect(await schema.parseAsync(undefined)).toBe("default");
+  expect(await schema.parseAsync("foo")).toBe("foo");
+  expect(await schema.parseAsync("")).toBe("default");
+
+  type inp = z.input<typeof schema>;
+  util.assertEqual<inp, string | undefined>(true);
+  type out = z.output<typeof schema>;
+  util.assertEqual<out, string>(true);
+});
+
 test("default on existing optional", () => {
   const stringWithDefault = z.string().optional().default("asdf");
   expect(stringWithDefault.parse(undefined)).toBe("asdf");

--- a/src/__tests__/default.test.ts
+++ b/src/__tests__/default.test.ts
@@ -28,12 +28,37 @@ test("default with transform", () => {
 
 test("default after transform that returns undefined", () => {
   const schema = z
-    .union([z.literal("").transform(() => undefined), z.string().optional()])
+    .union([
+      z.literal("").transform(() => undefined),
+      z.string().toUpperCase().optional(),
+    ])
     .default("default");
 
-  expect(schema.parse(undefined)).toBe("default");
+  expect(schema.parse(undefined)).toBe("DEFAULT");
+  expect(schema.parse("foo")).toBe("FOO");
+  expect(schema.parse("")).toBe("DEFAULT");
+
+  type inp = z.input<typeof schema>;
+  util.assertEqual<inp, string | undefined>(true);
+  type out = z.output<typeof schema>;
+  util.assertEqual<out, string>(true);
+});
+
+test("default when transform returns undefined on default value", () => {
+  const schema = z
+    .union([
+      z.enum(["", "default"]).transform(() => undefined),
+      z.string().optional(),
+    ])
+    .default("default");
+
+  expect(() => schema.parse(undefined)).toThrow(
+    "default value parsed to undefined"
+  );
   expect(schema.parse("foo")).toBe("foo");
-  expect(schema.parse("")).toBe("default");
+  expect(() => schema.parse("")).toThrowError(
+    "default value parsed to undefined"
+  );
 
   type inp = z.input<typeof schema>;
   util.assertEqual<inp, string | undefined>(true);

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -140,6 +140,9 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.not_finite:
       message = "Number must be finite";
       break;
+    case ZodIssueCode.failed_default:
+      message = "default value parsed to undefined";
+      break;
     default:
       message = _ctx.defaultError;
       util.assertNever(issue);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4507,10 +4507,9 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
     });
     const checkParsedDefault = (parsed: SyncParseReturnType<any>) => {
       if (parsed.status === "valid" && parsed.value === undefined) {
-        ctx.common.issues.push({
+        addIssueToContext(ctx, {
           code: ZodIssueCode.failed_default,
           path: ctx.path,
-          message: "default value parsed to undefined",
         });
         return INVALID;
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4500,11 +4500,20 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
     if (ctx.parsedType === ZodParsedType.undefined) {
       data = this._def.defaultValue();
     }
-    return this._def.innerType._parse({
+    const parsed = this._def.innerType._parse({
       data,
       path: ctx.path,
       parent: ctx,
     });
+    return "then" in parsed
+      ? parsed.then((parsed) =>
+          parsed.status === "valid" && parsed.value === undefined
+            ? OK(this._def.defaultValue())
+            : parsed
+        )
+      : parsed.status === "valid" && parsed.value === undefined
+      ? OK(this._def.defaultValue())
+      : parsed;
   }
 
   removeDefault() {


### PR DESCRIPTION
fix #3614

Note: I can't see any reasonable way to make
```ts
    z.union([
      z.literal("").transform(async () => undefined),
      z.string().optional(),
    ])
    .default("inner")
    .default("outer")
    .parse("")
```
return `"outer"`, it returns `"inner"`.