### PR TITLE
RFC: New error map API

### DIFF
--- a/.configs/tsconfig.test.json
+++ b/.configs/tsconfig.test.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": ".",
     "strict": true,
     "isolatedDeclarations": false
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test:watch": "pnpm vitest",
     "test": "pnpm vitest run",
     "prepublishOnly": "pnpm run test && pnpm run build",
-    "play": "tsx --watch playground.ts ",
+    "play": "tsx --watch playground.ts",
     "bench": "pnpm run build:cjs && tsx benchmarks/index.ts",
     "prepare": "husky install",
     "publish:jsr": "jsr publish --dry-run"

--- a/packages/zod/src/ZodError.ts
+++ b/packages/zod/src/ZodError.ts
@@ -413,15 +413,3 @@ export class ZodTemplateLiteralUnsupportedCheckError extends Error {
     this.name = "ZodTemplateLiteralUnsupportedCheckError";
   }
 }
-
-export type ZodNewErrorMap = (
-  issue: ZodIssueOptionalMessage,
-  ctx: {
-    /** @deprecated */
-    defaultError: string;
-    data: any;
-  }
-) => { message: string } | string | undefined;
-const errm: ZodNewErrorMap = (iss, ctx) => {
-  if (iss.code === "invalid_type") return "Sup";
-};

--- a/packages/zod/src/ZodError.ts
+++ b/packages/zod/src/ZodError.ts
@@ -413,3 +413,15 @@ export class ZodTemplateLiteralUnsupportedCheckError extends Error {
     this.name = "ZodTemplateLiteralUnsupportedCheckError";
   }
 }
+
+export type ZodNewErrorMap = (
+  issue: ZodIssueOptionalMessage,
+  ctx: {
+    /** @deprecated */
+    defaultError: string;
+    data: any;
+  }
+) => { message: string } | string | undefined;
+const errm: ZodNewErrorMap = (iss, ctx) => {
+  if (iss.code === "invalid_type") return "Sup";
+};

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,6 +1,4 @@
-My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth! 🤙 —Colin
-
-<!-- [![clerk logo](https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f)](https://go.clerk.com/DHliRIG) -->
+My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth.
 
 <a href="https://go.clerk.com/DHliRIG">
   <img src="https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f" alt="clerk logo" height="100" />

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -256,6 +256,8 @@ The `error` key will also support an even simpler string-based syntax. The passe
 z.string({ error: "Invalid input" });
 ```
 
+A new `"required"` issue code will be added. This code will be used whenever the input to a non-optional schema is `undefined`.
+
 Currently, all refinement methods support error customization via the `message` key.
 
 ```ts

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -21,7 +21,7 @@ const errorMap: ZodErrorMap = (issue, ctx) => {
 };
 ```
 
-## The fix
+### The fix
 
 Allow returning a string directly.
 
@@ -73,7 +73,7 @@ These keys are snake-case for the sake of visual consistency with Zod's issue co
 
 ### Footguns
 
-The `invalid_type_error` will only be applied to issues with code `invalid_type`. This makes sense, but it has also confused users who think their custom message will be applied more broadly.
+The `invalid_type_error` will only be applied to issues with code `invalid_type`. This makes sense, but it also has understandably confused users who think their custom message will be applied more broadly.
 
 A particularly unfortunate example is this:
 
@@ -83,7 +83,7 @@ z.enum(["red", "white", "blue"], { invalid_type_error: "Invalid color" });
 
 The custom message `invalid_type_error` is only applied to issues with code `invalid_type`. If the input is, say `"green"`, the resulting issue code is `invalid_enum_value`. As such the `invalid_type_error` message will not be applied. This is confusing.
 
-## The fix(es)
+### The fix(es)
 
 Zod will support an object-based syntactic sugar API on the `error` key. This customizing the error message for all issue codes. This also siloes the snake case keys into their own object, so they aren't alongside camelCase keys.
 
@@ -117,7 +117,7 @@ While `invalid_type` is a Zod issue code, `required` is not. If you pass `undefi
 
 To users with knowledge of Zod's issue codes, the existence of `required_error` can be confusing because it doesn't correspond to an issue code.
 
-## The fix
+### The fix
 
 Zod will add a new issue code `"required"` issue code. This issue code will be used any time a value of `undefined` is passed into a non-optional schema.
 
@@ -167,7 +167,7 @@ The idea was to simplify the error map type signature by always requiring a retu
 
 But this "bottom up" approach occurs an unnecessary performance penalty. All error maps must be run for each new issue.
 
-## The fix
+### The fix
 
 Switch over to a "top-down" resolution strategy. To accommodate this, error maps should allow returning `undefined/void` to signal that the issue should be passed down to the next map in the chain.
 
@@ -195,7 +195,7 @@ Zod has had a long-standing policy of hiding input data from issues for security
 
 This obviates the need for `ctx.data`, since the same information will be available on `issue.input`.
 
-## The fix
+### The fix
 
 Deprecate `ctx` entirely.
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,5 +1,9 @@
 This document proposes a new error map API for Zod 4.
 
+My full-time work on Zod 4, including the design & implementation of this proposal, is supported by my friends at [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth 🫶
+
+[![clerk logo](https://avatars.githubusercontent.com/u/49538330?s=200&v=4)](https://go.clerk.com/DHliRIG)
+
 # Issue #1: Bottom-up execution
 
 Zod's current approach to error maps is a little backwards. For starters, Zod generates error messages by passing a `message`-less version of the issue into a pipeline of error maps. In order of increasing precedence, the error maps are:
@@ -135,11 +139,11 @@ The custom message will only be applied if the input data is a non-string. If an
 
 ## The fix(es)
 
-Zod will add a special `"required"` issue code. This is pragmatic. Trying to consolidate all type errors under `invalid_type` for the sake of elegance isn't pragmatic here. Some special treatment for `undefined` is inevitable in JavaScript.
+Zod will add a special `"required"` issue code. Trying to consolidate all type errors under `invalid_type` for the sake of elegance isn't pragmatic here. Some special treatment for `undefined` is inevitable in JavaScript.
 
 > A `"required"` issue code is also an important part of Zod's new approach to key optionality in objects (`exactOptionalPropertyTypes`)—RFC forthcoming.
 
-Zod will support an object-based syntactic sugar API on the `error` key. This customizing the error message for all issue codes.
+Zod will support an object-based syntactic sugar API on the `error` key. This customizing the error message for all issue codes. This also siloes the snake case keys into their own object, so they aren't alongside camelCase keys.
 
 ```ts
 const emailSchema = z.string({

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,6 +1,10 @@
 My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth! 🤙
 
-[![clerk logo](https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f)](https://go.clerk.com/DHliRIG)
+<!-- [![clerk logo](https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f)](https://go.clerk.com/DHliRIG) -->
+
+<a href="https://go.clerk.com/DHliRIG">
+  <img src="https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f" alt="clerk logo" height="100" />
+</a>
 
 ---
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -6,9 +6,11 @@ My full-time work on Zod 4, including the design & implementation of this propos
 
 ---
 
+# Error maps in Zod 4
+
 This document proposes a new error map API for Zod 4.
 
-# Issue 1: Verbosity
+## Issue 1: Verbosity
 
 The current API is verbose. To override the error message for a particular issue code:
 
@@ -41,7 +43,7 @@ This will be supported alongside the more verbose `{message: string}` syntax.
 +  ) => { message: string } | string;
 ```
 
-# Issue 2: Confusing sugar
+## Issue 2: Confusing sugar
 
 Due to the verbosity of the current API, it was onerous for users to customize error messages for a specific schema.
 
@@ -102,7 +104,7 @@ Zod can limit the keys to the issue codes that are actually throwable by the sch
 
 The `invalid_type_error` and `required_error` fields will be deprecated.
 
-# Issue 3: "Required" errors
+## Issue 3: "Required" errors
 
 There is an additional inconsistency in the current `invalid_type_error` and `required_error` API.
 
@@ -136,7 +138,7 @@ This also solves the inconsistency between Zod's error customization API and the
 
 > A `"required"` issue code will also be an important part of Zod's new approach to key optionality in objects (`exactOptionalPropertyTypes`)—RFC forthcoming. This code will be used when a key that's required by a `ZodObject` shape isn't specified in the input.
 
-# Issue 4: Bottom-up execution
+## Issue 4: Bottom-up execution
 
 Zod's current approach to resolving error maps is a little backwards.
 
@@ -182,7 +184,7 @@ Switch over to a "top-down" resolution strategy. To accommodate this, error maps
 
 For compatibility `ctx.defaultError` can be set to some unique internal string value like `"{{zod_default_error}}"`. When Zod sees this value, it will know to proceed to the next error map in the chain.
 
-# Issue 5: Unnecessary `ctx`
+## Issue 5: Unnecessary `ctx`
 
 With `ctx.defaultError` becoming irrelevant, the only remaining key on `ctx` is `ctx.data`.
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -172,12 +172,14 @@ z.string({
 
 # Issue 5: Bottom-up execution
 
-Zod's current approach to error maps is a little backwards. For starters, Zod generates error messages by passing a `message`-less version of the issue into a pipeline of error maps. In order of increasing precedence, the error maps are:
+Zod's current approach to resolving error maps is a little backwards.
+
+Zod generates error messages by passing a `message`-less version of the issue (`ZodIssueOptionalMessage`) into a pipeline of error maps. In order of increasing precedence, the error maps are:
 
 1. contextual error map (passed into `.parse(<data>, {errorMap: myErrorMap})`)
 2. schema-specific error map (`z.string({ errorMap: myErrorMap })`)
 
-- `invalid_type_error` and `required_error` also creates a schema-specific error map internally
+   - `invalid_type_error` and `required_error` also creates a schema-specific error map internally
 
 3. `overrideErrorMap` (settable with `z.setErrorMap()`)
 4. `defaultErrorMap` (the standard English error map in `locales/en.ts`)

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,7 +1,7 @@
 My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth.
 
 <a href="https://go.clerk.com/DHliRIG">
-  <img src="https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f" alt="clerk logo" height="100" />
+  <img src="https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f" alt="clerk logo" height="80" />
 </a>
 
 ---

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -162,7 +162,7 @@ const errorMap: ZodErrorMap = (issue, ctx) => {
 
 The idea was to simplify the error map type signature by always requiring a return type of `{message: string}`. It would also encourage exhaustiveness checking by forcing the developer to explicitly return `{ message: ctx.defaultError }` if they want to defer to lower-priority error maps.
 
-But this "bottom up" approach occurs an unnecessary performance penalty. All error maps must be run for each new issue.
+But ultimately I don't think either of those reasons are particularly compelling, and is arguably more confusing than the alternative. This "bottom up" approach also incurs an unnecessary performance penalty since all error maps must be run for each new issue.
 
 ### The fix
 
@@ -172,7 +172,7 @@ Switch over to a "top-down" resolution strategy. To accommodate this, error maps
   export type ZodErrorMap = (
     issue: ZodIssueOptionalMessage,
     ctx: {
-      /** @deprecated */
++     /** @deprecated */
       defaultError: string;
       data: any
     }

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,4 +1,4 @@
-My full-time work on Zod 4, including the design & implementation of this proposal, is supported by my friends at [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth 🫶 — Colin
+My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth! 🤙
 
 [![clerk logo](https://avatars.githubusercontent.com/u/49538330?s=200&v=4)](https://go.clerk.com/DHliRIG)
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,6 +1,6 @@
 My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth! 🤙
 
-[![clerk logo](https://avatars.githubusercontent.com/u/49538330?s=200&v=4)](https://go.clerk.com/DHliRIG)
+[![clerk logo](https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f)](https://go.clerk.com/DHliRIG)
 
 ---
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,0 +1,224 @@
+# Error maps
+
+This document proposes a new error map API for Zod 4.
+
+## Issue #1: Bottom-up execution
+
+Zod's current approach to error maps is a little backwards. For starters, Zod generates error messages by passing a `message`-less version of the issue into a pipeline of error maps. In order of increasing precedence, the error maps are:
+
+1. contextual error map (passed into `.parse(<data>, {errorMap: myErrorMap})`)
+2. schema-specific error map (`z.string({ errorMap: myErrorMap })`)
+
+- `invalid_type_error` and `required_error` also creates a schema-specific error map internally
+
+3. `overrideErrorMap` (settable with `z.setErrorMap()`)
+4. `defaultErrorMap` (the standard English error map in `locales/en.ts`)
+
+The reasonable thing to do would be to pass the issue into the #1 and see if it returns a message. If it does, that message will be used; otherwise, proceed to the next map in the chain.
+
+For some reason Zod does this "bottom-up". It first gets a message from the lowest-priority map first, then passes that into the higher-priority maps as `ctx.defaultError`.
+
+```ts
+const errorMap: ZodErrorMap = (issue, ctx) => {
+  if (issue instanceof ZodInvalidLiteralIssue) {
+    return { message: "Invalid literal!" };
+  }
+  return { message: ctx.defaultError };
+};
+```
+
+The idea was to simplify the error map type signature by always requiring a return type of `{message: string}`. It would also encourage exhaustiveness checking by forcing the developer to explicitly return `{ message: ctx.defaultError }` if they want to defer to lower-priority error maps.
+
+```ts
+export type ZodErrorMap = (
+  issue: ZodIssueOptionalMessage,
+  ctx: { defaultError: string; data: any }
+) => { message: string };
+
+export type ZodIssueOptionalMessage =
+  | ZodInvalidTypeIssue
+  | ZodInvalidLiteralIssue
+  // ...
+  | ZodCustomIssue;
+```
+
+But this "bottom up" approach occurs an unnecessary performance penalty. All error maps must be run for each new issue.
+
+### The fix
+
+Switch over to a "top-down" resolution strategy. To accommodate this, error maps should allow returning `undefined/void` to signal that the issue should be passed down to the next map in the chain.
+
+```diff
+  export type ZodErrorMap = (
+    issue: ZodIssueOptionalMessage,
+    ctx: { defaultError: string; data: any }
+-  ) => { message: string };
++  ) => undefined | { message: string };
+```
+
+## Issue #2: Verbosity
+
+The current API is verbose. To override the error message for a particular issue code:
+
+```ts
+const errorMap: ZodErrorMap = (issue, ctx) => {
+  if (issue instanceof ZodInvalidLiteralIssue) {
+    return { message: "Invalid literal!" };
+  }
+  return { message: ctx.defaultError };
+};
+```
+
+### The fix
+
+Allow returning a string directly.
+
+```ts
+const errorMap: ZodErrorMap = (issue, ctx) => {
+  if (issue instanceof ZodInvalidLiteralIssue) return "Invalid literal!";
+};
+```
+
+This will be supported alongside the more verbose `{message: string}` syntax.
+
+```diff
+  export type ZodErrorMap = (
+    issue: ZodIssueOptionalMessage,
+    ctx: { defaultError: string; data: any }
++  ) => undefined | { message: string };
++  ) => undefined | message | { message: string };
+```
+
+## Issue #4: Inconsistency
+
+Due to the verbosity of the current API, it was onerous for users to customize error messages for a specific schema.
+
+```ts
+const emailSchema = z.string({
+  errorMap: (iss, ctx) => {
+    if (iss.code === "invalid_type") {
+      return { message: "Email must be a string" };
+    }
+    return { message: ctx.defaultError };
+  },
+});
+```
+
+To address this, Zod added some syntactic sugar: `invalid_type_error` and `required_error`.
+
+```ts
+const emailSchema = z.string({
+  invalid_type_error: "Email must be a string",
+  required_error: "Field cannot be left blank",
+});
+```
+
+This has been useful for a lot of people, but it's quite inelegant in the context of Zod's broader error reporting system.
+
+### Snake case
+
+It's snake-case for the sake of visual consistency with Zod's issue code (e.g. `"invalid_type"`). But it's not consistent with the rest of Zod's API.
+
+### Inconsistency with issue codes
+
+While `invalid_type` is a known issue code, `required` is not. There's no special issue type for when a required field is missing...it's just an `invalid_type` error like any other. To users with knowledge of Zod's issue codes, the existence of `required_error` can be confusing.
+
+### Footguns
+
+The `invalid_type_error` will only be applied to issues with code `invalid_type`. This makes sense, but it has also confused users who think their custom message will be applied more broadly.
+
+A particularly unfortunate example is this:
+
+```ts
+z.enum(["red", "white", "blue"], { invalid_type_error: "Invalid color" });
+```
+
+The custom message will only be applied if the input data is a non-string. If an invalid color ("green") is passed in, the resulting issue code is `invalid_enum_value`. As such the `invalid_type_error` message will not be applied. This is confusing. There's currently no easy one-liner for customizing the message for invalid enum values.
+
+### The fix(es)
+
+Zod will add a special `"required"` issue code. This is pragmatic. Trying to consolidate all type errors under `invalid_type` for the sake of elegance isn't pragmatic here. Some special treatment for `undefined` is inevitable in JavaScript.
+
+> A `"required"` issue code is also an important part of Zod's new approach to key optionality in objects (`exactOptionalPropertyTypes`)—RFC forthcoming.
+
+Zod will support an object-based syntactic sugar API on the `error` key. This customizing the error message for all issue codes.
+
+```ts
+const emailSchema = z.string({
+  error: {
+    invalid_type: "Email must be a string",
+    required: "Field cannot be blank",
+  },
+});
+```
+
+> As indicated in the previous example, Zod will add a special-cased issue code `"required"` for the case where `undefined` is passed as input into a non-optional schema.
+
+Zod can limit the keys to the issue codes that are actually throwable by the schema. For instance, `ZodString` can only produce `invalid_type` and `required` errors. This will be enforced by TypeScript.
+
+Technically, a `ZodString` schema can produce `invalid_string`, `too_small`, and `too_big` errors too, but these error messages should be customized in the method that introduces the constraint (e.g. `.uuid()`, `.min()`, etc).
+
+Here's the enum example using the new API:
+
+```ts
+z.enum(["red", "white", "blue"], {
+  error: {
+    invalid_type: "Must be a string",
+    invalid_enum_value: "Invalid color",
+  },
+});
+```
+
+## Final proposal
+
+The type signature for ZodErrorMap will be changed to allow returning `undefined`. This will signal to Zod that the error map is kicking the can down to the next map in the chain.
+
+```ts
+export type ZodErrorMap = (
+  issue: ZodIssueOptionalMessage,
+  ctx: {
+    /** @deprecated */
+    defaultError: string;
+    data: any;
+  }
+) => { message: string } | string | undefined;
+```
+
+A custom error map can be passed into a schema via the `error` key.
+
+> Currently error maps are passed as `errorMap`. This will be deprecated but supported for backwards compatibility.
+
+```ts
+z.string({
+  error: (issue, ctx) => {
+    if (issue.code === "invalid_type") return "Email must be a string";
+  },
+});
+```
+
+This key will also support an object-based syntactic sugar:
+
+```ts
+z.string({
+  error: {
+    invalid_type: "Email must be a string",
+    required: "Field cannot be blank",
+  },
+});
+```
+
+An even simpler string-based syntax will also be supported. This will be applied for all issue codes.
+
+```ts
+z.string({ error: "Invalid input" });
+```
+
+> For consistency, all refinement methods will also be updated to support `error` in addition to the current `message` key:
+>
+> ```ts
+> // current
+> z.string().min(5, { message: "Too short" });
+>
+> // new
+> z.string().min(5, { error: "Too short" });
+> ```

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -143,10 +143,7 @@ Zod's current approach to resolving error maps is a little backwards.
 Zod generates error messages by passing a `message`-less version of the issue (`ZodIssueOptionalMessage`) into a pipeline of error maps. In order of increasing precedence, the error maps are:
 
 1. contextual error map (passed into `.parse(<data>, {errorMap: myErrorMap})`)
-2. schema-specific error map (`z.string({ errorMap: myErrorMap })`)
-
-   - using `invalid_type_error` and `required_error` also creates a schema-specific error map internally
-
+2. schema-specific error map (`z.string({ errorMap: myErrorMap })` or `invalid_type_error`, etc)
 3. `overrideErrorMap` (settable with `z.setErrorMap()`)
 4. `defaultErrorMap` (the standard English error map in `locales/en.ts`)
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,4 +1,4 @@
-My full-time work on Zod 4, including the design & implementation of this proposal, is supported by my friends at [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth 🫶
+My full-time work on Zod 4, including the design & implementation of this proposal, is supported by my friends at [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth 🫶 — Colin
 
 [![clerk logo](https://avatars.githubusercontent.com/u/49538330?s=200&v=4)](https://go.clerk.com/DHliRIG)
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -39,11 +39,11 @@ This will be supported alongside the more verbose `{message: string}` syntax.
   export type ZodErrorMap = (
     issue: ZodIssueOptionalMessage,
     ctx: { defaultError: string; data: any }
-+  ) => { message: string };
+-  ) => { message: string };
 +  ) => { message: string } | string;
 ```
 
-# Issue 1: Inconsistency
+# Issue 2: Inconsistency
 
 Due to the verbosity of the current API, it was onerous for users to customize error messages for a specific schema.
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,8 +1,10 @@
-This document proposes a new error map API for Zod 4.
-
 My full-time work on Zod 4, including the design & implementation of this proposal, is supported by my friends at [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth 🫶
 
 [![clerk logo](https://avatars.githubusercontent.com/u/49538330?s=200&v=4)](https://go.clerk.com/DHliRIG)
+
+---
+
+This document proposes a new error map API for Zod 4.
 
 # Issue #1: Bottom-up execution
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -41,7 +41,7 @@ This will be supported alongside the more verbose `{message: string}` syntax.
 +  ) => { message: string } | string;
 ```
 
-# Issue 2: Inconsistency
+# Issue 2: Confusing sugar
 
 Due to the verbosity of the current API, it was onerous for users to customize error messages for a specific schema.
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -6,11 +6,11 @@ My full-time work on Zod 4, including the design & implementation of this propos
 
 ---
 
-# Error maps in Zod 4
+## Error maps in Zod 4
 
-This document proposes a new error map API for Zod 4.
+This document proposes a new error map API for Zod 4. It breaks down 5 issues with the current API and proposes changes incrementally. The final proposal is re-iterated at the bottom of the document under "Final proposal".
 
-## Issue 1: Verbosity
+# Issue 1: Verbosity
 
 The current API is verbose. To override the error message for a particular issue code:
 
@@ -43,7 +43,7 @@ This will be supported alongside the more verbose `{message: string}` syntax.
 +  ) => { message: string } | string;
 ```
 
-## Issue 2: Confusing sugar
+# Issue 2: Confusing sugar
 
 Due to the verbosity of the current API, it was onerous for users to customize error messages for a specific schema.
 
@@ -104,7 +104,7 @@ Zod can limit the keys to the issue codes that are actually throwable by the sch
 
 The `invalid_type_error` and `required_error` fields will be deprecated.
 
-## Issue 3: "Required" errors
+# Issue 3: "Required" errors
 
 There is an additional inconsistency in the current `invalid_type_error` and `required_error` API.
 
@@ -138,7 +138,7 @@ This also solves the inconsistency between Zod's error customization API and the
 
 > A `"required"` issue code will also be an important part of Zod's new approach to key optionality in objects (`exactOptionalPropertyTypes`)—RFC forthcoming. This code will be used when a key that's required by a `ZodObject` shape isn't specified in the input.
 
-## Issue 4: Bottom-up execution
+# Issue 4: Bottom-up execution
 
 Zod's current approach to resolving error maps is a little backwards.
 
@@ -184,7 +184,7 @@ Switch over to a "top-down" resolution strategy. To accommodate this, error maps
 
 For compatibility `ctx.defaultError` can be set to some unique internal string value like `"{{zod_default_error}}"`. When Zod sees this value, it will know to proceed to the next error map in the chain.
 
-## Issue 5: Unnecessary `ctx`
+# Issue 5: Unnecessary `ctx`
 
 With `ctx.defaultError` becoming irrelevant, the only remaining key on `ctx` is `ctx.data`.
 

--- a/rfcs/v4-error-maps.md
+++ b/rfcs/v4-error-maps.md
@@ -1,4 +1,4 @@
-My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth! 🤙
+My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Friends don't let friends roll their own auth! 🤙 —Colin
 
 <!-- [![clerk logo](https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f)](https://go.clerk.com/DHliRIG) -->
 


### PR DESCRIPTION
# RFC: Error maps

General comments can go below. Leave specific comments in the "Files changed" interface.

View the formatted RFC here: https://github.com/colinhacks/zod/blob/v4-rfc-error-maps/rfcs/v4-error-maps.md

```diff
  export type ZodErrorMap = (
    issue: ZodIssueOptionalMessage,  // includes `input` field to replace `ctx.data`
+   /** @deprecated */
    ctx: { defaultError: string; data: any }
- ) => { message: string };
+ ) => { message: string } | string | undefined;
```

---

My full-time work on Zod 4, including the design & implementation of this proposal, is supported by [Clerk](https://go.clerk.com/DHliRIG). Don't roll your own auth. 🫶

<a href="https://go.clerk.com/DHliRIG">
  <img src="https://github.com/colinhacks/zod/assets/3084745/22a4a523-5845-4ac7-b5be-02fbf436409f" alt="clerk logo" height="50" />
</a>
