### PR TITLE
Support for all types of discriminators in `z.discriminatedUnion`

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -21,6 +21,7 @@ export const ZodIssueCode = util.arrayToEnum([
   "custom",
   "invalid_union",
   "invalid_union_discriminator",
+  "ambiguous_union_discriminator",
   "invalid_enum_value",
   "unrecognized_keys",
   "invalid_arguments",
@@ -66,6 +67,14 @@ export interface ZodInvalidUnionIssue extends ZodIssueBase {
 export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_union_discriminator;
   options: Primitive[];
+  otherOptions: number;
+  received: unknown;
+}
+
+export interface ZodAmbiguousUnionDiscriminatorIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.ambiguous_union_discriminator;
+  received: unknown;
+  optionsMatched: number;
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
@@ -155,6 +164,7 @@ export type ZodIssueOptionalMessage =
   | ZodUnrecognizedKeysIssue
   | ZodInvalidUnionIssue
   | ZodInvalidUnionDiscriminatorIssue
+  | ZodAmbiguousUnionDiscriminatorIssue
   | ZodInvalidEnumValueIssue
   | ZodInvalidArgumentsIssue
   | ZodInvalidReturnTypeIssue

--- a/deno/lib/__tests__/discriminated-unions.test.ts
+++ b/deno/lib/__tests__/discriminated-unions.test.ts
@@ -95,8 +95,10 @@ test("invalid discriminator value", () => {
       {
         code: z.ZodIssueCode.invalid_union_discriminator,
         options: ["a", "b"],
-        message: "Invalid discriminator value. Expected 'a' | 'b'",
+        message: "Invalid discriminator value \"x\". Expected 'a' | 'b'",
+        otherOptions: 0,
         path: ["type"],
+        received: "x",
       },
     ]);
   }
@@ -117,6 +119,70 @@ test("valid discriminator value, invalid data", () => {
         message: "Required",
         path: ["a"],
         received: z.ZodParsedType.undefined,
+      },
+    ]);
+  }
+});
+
+test("valid - non-literal discriminator", () => {
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a"), val: z.string() }),
+    z.object({ type: z.number(), val: z.number() }),
+  ]);
+
+  expect(schema.parse({ type: "a", val: "abc" })).toEqual({
+    type: "a",
+    val: "abc",
+  });
+  expect(schema.parse({ type: 1, val: 2 })).toEqual({ type: 1, val: 2 });
+});
+
+test("invalid - ambiguous non-literal discriminator", () => {
+  try {
+    z.discriminatedUnion("type", [
+      z.object({
+        type: z.literal("a"),
+        a: z.string(),
+      }),
+      z.object({
+        type: z.string().refine((val) => val === "a"),
+        b: z.string(),
+      }),
+    ]).parse({ type: "a", a: "abc" });
+    throw new Error();
+  } catch (e: any) {
+    expect(JSON.parse(e.message)).toEqual([
+      {
+        code: z.ZodIssueCode.ambiguous_union_discriminator,
+        message: 'Ambiguous discriminator value: "a" matched 2 options',
+        optionsMatched: 2,
+        path: ["type"],
+        received: "a",
+      },
+    ]);
+  }
+});
+
+test("invalid value for non-literal discriminator", () => {
+  try {
+    z.discriminatedUnion("type", [
+      z.object({ type: z.literal("a"), a: z.string() }),
+      z.object({
+        type: z.string().refine((val) => val === "b"),
+        b: z.string(),
+      }),
+    ]).parse({ type: "x", a: "abc" });
+    throw new Error();
+  } catch (e: any) {
+    expect(JSON.parse(e.message)).toEqual([
+      {
+        code: z.ZodIssueCode.invalid_union_discriminator,
+        options: ["a"],
+        message:
+          "Invalid discriminator value \"x\". Expected 'a' (+ 1 other option(s))",
+        otherOptions: 1,
+        path: ["type"],
+        received: "x",
       },
     ]);
   }
@@ -195,6 +261,26 @@ test("async - invalid", async () => {
       },
     ]);
   }
+});
+
+test("async - valid non-literal discriminator", async () => {
+  expect(
+    await z
+      .discriminatedUnion("type", [
+        z.object({
+          type: z.string().refine(async (val) => val === "a"),
+          a: z
+            .string()
+            .refine(async () => true)
+            .transform(async (val) => Number(val)),
+        }),
+        z.object({
+          type: z.literal("b"),
+          b: z.string(),
+        }),
+      ])
+      .parseAsync({ type: "a", a: "1" })
+  ).toEqual({ type: "a", a: 1 });
 });
 
 test("valid - literals with .default or .preprocess", () => {

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -27,9 +27,19 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       message = `Invalid input`;
       break;
     case ZodIssueCode.invalid_union_discriminator:
-      message = `Invalid discriminator value. Expected ${util.joinValues(
-        issue.options
-      )}`;
+      message = `Invalid discriminator value ${JSON.stringify(
+        issue.received
+      )}. Expected ${util.joinValues(issue.options)}${
+        issue.otherOptions > 0
+          ? ` (+ ${issue.otherOptions} other option(s))`
+          : ""
+      }`;
+      break;
+    case ZodIssueCode.ambiguous_union_discriminator:
+      message = `Ambiguous discriminator value: ${JSON.stringify(
+        issue.received,
+        util.jsonStringifyReplacer
+      )} matched ${issue.optionsMatched} options`;
       break;
     case ZodIssueCode.invalid_enum_value:
       message = `Invalid enum value. Expected ${util.joinValues(

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -21,6 +21,7 @@ export const ZodIssueCode = util.arrayToEnum([
   "custom",
   "invalid_union",
   "invalid_union_discriminator",
+  "ambiguous_union_discriminator",
   "invalid_enum_value",
   "unrecognized_keys",
   "invalid_arguments",
@@ -66,6 +67,14 @@ export interface ZodInvalidUnionIssue extends ZodIssueBase {
 export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_union_discriminator;
   options: Primitive[];
+  otherOptions: number;
+  received: unknown;
+}
+
+export interface ZodAmbiguousUnionDiscriminatorIssue extends ZodIssueBase {
+  code: typeof ZodIssueCode.ambiguous_union_discriminator;
+  received: unknown;
+  optionsMatched: number;
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {
@@ -155,6 +164,7 @@ export type ZodIssueOptionalMessage =
   | ZodUnrecognizedKeysIssue
   | ZodInvalidUnionIssue
   | ZodInvalidUnionDiscriminatorIssue
+  | ZodAmbiguousUnionDiscriminatorIssue
   | ZodInvalidEnumValueIssue
   | ZodInvalidArgumentsIssue
   | ZodInvalidReturnTypeIssue

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -27,9 +27,19 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       message = `Invalid input`;
       break;
     case ZodIssueCode.invalid_union_discriminator:
-      message = `Invalid discriminator value. Expected ${util.joinValues(
-        issue.options
-      )}`;
+      message = `Invalid discriminator value ${JSON.stringify(
+        issue.received
+      )}. Expected ${util.joinValues(issue.options)}${
+        issue.otherOptions > 0
+          ? ` (+ ${issue.otherOptions} other option(s))`
+          : ""
+      }`;
+      break;
+    case ZodIssueCode.ambiguous_union_discriminator:
+      message = `Ambiguous discriminator value: ${JSON.stringify(
+        issue.received,
+        util.jsonStringifyReplacer
+      )} matched ${issue.optionsMatched} options`;
       break;
     case ZodIssueCode.invalid_enum_value:
       message = `Invalid enum value. Expected ${util.joinValues(


### PR DESCRIPTION
Currently in discriminated unions, the discriminator key must be one of a limited number of literal types (see [`getDiscriminator`](https://github.com/colinhacks/zod/blob/4641f434f3bb3dab1bb8cb07f44dd2693c72e35e/src/types.ts#L3060C1-L3091C3)).

This change allows *any* Zod type to be used for the discriminator key

This resolves the following issue:
* #1075

and also covers other use-cases, e.g. to allow an "anything else" case, where the final discriminator key accepts any value other than the known enum values from the other cases:
* #3654 

Async parsing is supported (and covered by a unit test), with validation of the keys happening in parallel.

At parsing time, if the object being parsed matches more than one discriminator key, the object is considered invalid (previously this could always be checked at type-construction time).

## Performance

There is only a performance hit if some of the discriminator keys are not one of the literal types already recognized (in which case all unrecognized keys must be checked one by one). Existing use-cases will have the same performance as before.
