### PR TITLE
Add typed variant of parse, parseAsync, safeParse, and safeParseAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@
   - [`.parseAsync`](#parseasync)
   - [`.safeParse`](#safeparse)
   - [`.safeParseAsync`](#safeparseasync)
+  - [`.typedParse`](#typedparse)
+  - [`.typedSafeParse`](#typedsafeparse)
+  - [`.typedParseAsync`](#typedparseasync)
+  - [`.typedSafeParseAsync`](#typedsafeparseasync)
   - [`.refine`](#refine)
     - [Arguments](#arguments)
     - [Customize error path](#customize-error-path)
@@ -2055,6 +2059,27 @@ For convenience, this has been aliased to `.spa`:
 ```ts
 await stringSchema.spa("billie");
 ```
+
+### `.typedParse`
+
+A typed version of `.parse` that type-checks the input
+
+```ts
+await stringSchema.typedParse("typed"); // No problem.
+await stringSchema.typedParse(12); // Argument of type 'number' is not assignable to parameter of type 'string'.
+```
+
+### `.typedSafeParse`
+
+A typed version of `.safeParse` that type-checks the input
+
+### `.typedParseAsync`
+
+A typed version of `.parseAsync` that type-checks the input
+
+### `.typedSafeParseAsync`
+
+A typed version of `.safeParseAsync` that type-checks the input
 
 ### `.refine`
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -124,6 +124,10 @@
   - [`.parseAsync`](#parseasync)
   - [`.safeParse`](#safeparse)
   - [`.safeParseAsync`](#safeparseasync)
+  - [`.typedParse`](#typedparse)
+  - [`.typedSafeParse`](#typedsafeparse)
+  - [`.typedParseAsync`](#typedparseasync)
+  - [`.typedSafeParseAsync`](#typedsafeparseasync)
   - [`.refine`](#refine)
     - [Arguments](#arguments)
     - [Customize error path](#customize-error-path)
@@ -2055,6 +2059,27 @@ For convenience, this has been aliased to `.spa`:
 ```ts
 await stringSchema.spa("billie");
 ```
+
+### `.typedParse`
+
+A typed version of `.parse` that type-checks the input
+
+```ts
+await stringSchema.typedParse("typed"); // No problem.
+await stringSchema.typedParse(12); // Argument of type 'number' is not assignable to parameter of type 'string'.
+```
+
+### `.typedSafeParse`
+
+A typed version of `.safeParse` that type-checks the input
+
+### `.typedParseAsync`
+
+A typed version of `.parseAsync` that type-checks the input
+
+### `.typedSafeParseAsync`
+
+A typed version of `.safeParseAsync` that type-checks the input
 
 ### `.refine`
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -262,6 +262,17 @@ export abstract class ZodType<
     return handleResult(ctx, result);
   }
 
+  typedParse(data: Input, params?: Partial<ParseParams>): Output {
+    return this.parse(data, params);
+  }
+
+  typedSafeParse(
+    data: Input,
+    params?: Partial<ParseParams>
+  ): SafeParseReturnType<Input, Output> {
+    return this.safeParse(data, params);
+  }
+
   async parseAsync(
     data: unknown,
     params?: Partial<ParseParams>
@@ -293,6 +304,20 @@ export abstract class ZodType<
       ? maybeAsyncResult
       : Promise.resolve(maybeAsyncResult));
     return handleResult(ctx, result);
+  }
+
+  async typedParseAsync(
+    data: Input,
+    params?: Partial<ParseParams>
+  ): Promise<Output> {
+    return this.parseAsync(data, params);
+  }
+
+  async typedSafeParseAsync(
+    data: Input,
+    params?: Partial<ParseParams>
+  ): Promise<SafeParseReturnType<Input, Output>> {
+    return this.safeParseAsync(data, params);
   }
 
   /** Alias of safeParseAsync */
@@ -402,6 +427,10 @@ export abstract class ZodType<
     this.safeParse = this.safeParse.bind(this);
     this.parseAsync = this.parseAsync.bind(this);
     this.safeParseAsync = this.safeParseAsync.bind(this);
+    this.typedParse = this.typedParse.bind(this);
+    this.typedParseAsync = this.typedParseAsync.bind(this);
+    this.typedSafeParse = this.typedSafeParse.bind(this);
+    this.typedSafeParseAsync = this.typedSafeParseAsync.bind(this);
     this.spa = this.spa.bind(this);
     this.refine = this.refine.bind(this);
     this.refinement = this.refinement.bind(this);

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,6 +262,17 @@ export abstract class ZodType<
     return handleResult(ctx, result);
   }
 
+  typedParse(data: Input, params?: Partial<ParseParams>): Output {
+    return this.parse(data, params);
+  }
+
+  typedSafeParse(
+    data: Input,
+    params?: Partial<ParseParams>
+  ): SafeParseReturnType<Input, Output> {
+    return this.safeParse(data, params);
+  }
+
   async parseAsync(
     data: unknown,
     params?: Partial<ParseParams>
@@ -293,6 +304,20 @@ export abstract class ZodType<
       ? maybeAsyncResult
       : Promise.resolve(maybeAsyncResult));
     return handleResult(ctx, result);
+  }
+
+  async typedParseAsync(
+    data: Input,
+    params?: Partial<ParseParams>
+  ): Promise<Output> {
+    return this.parseAsync(data, params);
+  }
+
+  async typedSafeParseAsync(
+    data: Input,
+    params?: Partial<ParseParams>
+  ): Promise<SafeParseReturnType<Input, Output>> {
+    return this.safeParseAsync(data, params);
   }
 
   /** Alias of safeParseAsync */
@@ -402,6 +427,10 @@ export abstract class ZodType<
     this.safeParse = this.safeParse.bind(this);
     this.parseAsync = this.parseAsync.bind(this);
     this.safeParseAsync = this.safeParseAsync.bind(this);
+    this.typedParse = this.typedParse.bind(this);
+    this.typedParseAsync = this.typedParseAsync.bind(this);
+    this.typedSafeParse = this.typedSafeParse.bind(this);
+    this.typedSafeParseAsync = this.typedSafeParseAsync.bind(this);
     this.spa = this.spa.bind(this);
     this.refine = this.refine.bind(this);
     this.refinement = this.refinement.bind(this);


### PR DESCRIPTION
Closes #1748. I didn't add any tests since this is build time and not run time, and it's just a wrapper around the existing methods, but if there are some tests you would find useful just let me know and I'll add 'em!