### PR TITLE
z.date({ coerce: 'iso' })

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,23 @@ console.log(dateSchema.safeParse("0000-00-00").success); // false
 
 For older zod versions, use [`z.preprocess`](#preprocess) like [described in this thread](https://github.com/colinhacks/zod/discussions/879#discussioncomment-2036276).
 
+**ISO 8601 coercion**
+
+If you prefer to only coerce [valid ISO 8601 strings](https://en.wikipedia.org/wiki/ISO_8601), use the `coerce` parameter.
+
+This method is useful when using zod with a tool that uses JSON to serialize/deserialize, since `Date` objects are serialized via `.toISOString()` with `JSON.stringify`.
+
+```ts
+const dateSchema = z.date({ coerce: "iso" });
+
+console.log(dateSchema.safeParse("2023-01-10T00:00:00.000Z").success); // true
+console.log(dateSchema.safeParse(new Date()).success); // true
+
+console.log(dateSchema.safeParse("1/10/23").success); // false
+console.log(dateSchema.safeParse(0).success); // false
+console.log(dateSchema.safeParse(null).success); // false
+```
+
 ## Files (Browser only)
 
 Use z.file() to validate `File` instances.

--- a/README.md
+++ b/README.md
@@ -970,7 +970,7 @@ For older zod versions, use [`z.preprocess`](#preprocess) like [described in thi
 
 If you prefer to only coerce [valid ISO 8601 strings](https://en.wikipedia.org/wiki/ISO_8601), use the `coerce` parameter.
 
-This method is useful when using zod with a tool that uses JSON to serialize/deserialize, since `Date` objects are serialized via `.toISOString()` with `JSON.stringify`.
+This method is useful to avoid accidentally coercing `null` into `1970-01-01`, and also when using zod with a tool that uses JSON to serialize/deserialize (since `Date` objects are serialized via `.toISOString()` with `JSON.stringify`).
 
 ```ts
 const dateSchema = z.date({ coerce: "iso" });

--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -2009,7 +2009,7 @@ export type ZodDateCheck =
   | { kind: "max"; value: number; message?: string };
 export interface ZodDateDef extends ZodTypeDef {
   checks: ZodDateCheck[];
-  coerce: boolean;
+  coerce: boolean | "iso";
   typeName: ZodFirstPartyTypeKind.ZodDate;
 }
 
@@ -2018,7 +2018,12 @@ export class ZodDate extends ZodType<Date, ZodDateDef, Date> {
     input: ParseInput,
     _ctx: ParseContext
   ): ParseReturnType<this["_output"]> {
-    if (this._def.coerce) {
+    if (this._def.coerce === "iso") {
+      const coerced = typeof input === "string" ? new Date(input) : null;
+      if (coerced && coerced.toISOString() === input) {
+        input = coerced;
+      }
+    } else if (this._def.coerce) {
       input = new Date(input);
     }
     const parsedType = this._getType(input);
@@ -2127,7 +2132,7 @@ export class ZodDate extends ZodType<Date, ZodDateDef, Date> {
     return max != null ? new Date(max) : null;
   }
 
-  static create(params?: RawCreateParams & { coerce?: boolean }): ZodDate {
+  static create(params?: RawCreateParams & { coerce?: boolean | "iso" }): ZodDate {
     return new ZodDate({
       checks: [],
       coerce: params?.coerce || false,

--- a/packages/zod/tests/date.test.ts
+++ b/packages/zod/tests/date.test.ts
@@ -7,6 +7,8 @@ const beforeBenchmarkDate = new Date(2022, 10, 4);
 const benchmarkDate = new Date(2022, 10, 5);
 const afterBenchmarkDate = new Date(2022, 10, 6);
 
+const milleniumUTC = new Date("2000-01-01T00:00:00.000Z");
+
 const minCheck = z.date().min(benchmarkDate);
 const maxCheck = z.date().max(benchmarkDate);
 
@@ -31,4 +33,28 @@ test("min max getters", () => {
   expect(maxCheck.max(beforeBenchmarkDate).maxDate).toEqual(
     beforeBenchmarkDate
   );
+});
+
+test("coerce true", () => {
+  const withCoerce = z.date({ coerce: true });
+
+  expect(withCoerce.parse(new Date("2000-01-01T00:00:00.000Z"))).toEqual(milleniumUTC);
+  expect(withCoerce.parse("2000-01-01T00:00:00.000Z")).toEqual(milleniumUTC);
+  expect(withCoerce.parse('1/1/2000 UTC')).toEqual(new Date("2000-01-01T00:00:00.000Z"));
+  expect(withCoerce.parse(milleniumUTC.getTime())).toEqual(milleniumUTC);
+
+  // you'll need to watch out for nulls/0 if you use coerce: true
+  expect(withCoerce.parse(null)).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+  expect(withCoerce.parse(0)).toEqual(new Date("1970-01-01T00:00:00.000Z"));
+});
+
+test("coerce iso", () => {
+  const withCoerce = z.date({ coerce: "iso" });
+
+  expect(withCoerce.parse(new Date("2000-01-01T00:00:00.000Z"))).toEqual(milleniumUTC);
+  expect(withCoerce.parse("2000-01-01T00:00:00.000Z")).toEqual(milleniumUTC);
+
+  expect(() => withCoerce.parse('1/1/2000 UTC')).toThrow(/Expected date, received string/);
+  expect(() => withCoerce.parse(0)).toThrow(/Expected date, received number/);
+  expect(() => withCoerce.parse(null)).toThrow(/Expected date, received null/);
 });


### PR DESCRIPTION
Closes #3643

I got a whole 👍 on that issue and I think it's a good idea so opening a PR. Copy pasting issue body below

---

hi - I find `z.date({ coerce: true })` very useful when using with trpc or another tool that uses JSON to cross an i/o boundary. Because, it forces the client to use a `Date` value - which is then serialized via its `toJSON` method into an ISO string and correctly converted back to a `Date` on the other side. So you get nice `Date` types on either side of the boundary.

But a not-ideal effect of using that trick is that it will also accept values like `null` and `0` which both parse to `1970-01-01T00:00:00.000Z`, so it's a bit dangerous.

So suggestion here is to change `coerce: boolean` to `coerce: boolean | 'iso'`, then update this block: https://github.com/colinhacks/zod/blob/9257ab78eec366c04331a3c2d59deb344a02d9f6/src/types.ts#L1798-L1800

An easy change to that block which should give the right results:

```ts
if (this._def.coerce === 'iso') {
  const coerced = typeof input.data === 'string' ? new Date(input.data) : null;
  if (coerced && coerced.toISOString() === input.data) {
    input.data = coerced;
  }
} else if (this._def.coerce) {
  input.data = new Date(input.data);
}
```

This just makes sure that the ISO string exactly matches the parsed `Date`'s ISO string, but it could also use a regex or some other ISO string validation technique.