### PR TITLE
Implement live types

### DIFF
--- a/.configs/tsconfig.base.json
+++ b/.configs/tsconfig.base.json
@@ -27,6 +27,7 @@
     "downlevelIteration": true,
     "isolatedModules": true,
 
-    "pretty": true
+    "pretty": true,
+    "customConditions": ["@zod/source"]
   }
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -32,6 +32,6 @@
     }
   },
   "files": {
-    "ignore": ["lib", "coverage", "dist"]
+    "ignore": ["lib", "coverage", "dist", ".tshy", ".tshy-build"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "lint-staged": {
     "src/*.ts": ["biome format --write", "biome lint --write"],
+    "*.json": ["biome format --write", "biome lint --write"],
     "*.md": ["prettier --ignore-unknown --write"]
   },
   "scripts": {

--- a/packages/effect-plugin/package.json
+++ b/packages/effect-plugin/package.json
@@ -12,6 +12,7 @@
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/commonjs/index.d.ts",
+
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/effect-plugin/package.json
+++ b/packages/effect-plugin/package.json
@@ -12,11 +12,11 @@
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/commonjs/index.d.ts",
-
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@zod/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       },

--- a/packages/effect-plugin/package.json
+++ b/packages/effect-plugin/package.json
@@ -38,7 +38,10 @@
     "exports": {
       "./package.json": "./package.json",
       ".": "./src/index.ts"
-    }
+    },
+    "sourceDialects": [
+      "@zod/source"
+    ]
   },
   "repository": {
     "type": "git",

--- a/packages/effect-plugin/package.json
+++ b/packages/effect-plugin/package.json
@@ -3,19 +3,10 @@
   "type": "module",
   "version": "0.1.0",
   "author": "Colin McDonnell <zod@colinhacks.com>",
-  "files": [
-    "src",
-    "dist"
-  ],
+  "files": ["src", "dist"],
   "funding": "https://github.com/sponsors/colinhacks",
   "homepage": "https://zod.dev",
-  "keywords": [
-    "typescript",
-    "schema",
-    "validation",
-    "type",
-    "inference"
-  ],
+  "keywords": ["typescript", "schema", "validation", "type", "inference"],
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/commonjs/index.js",
@@ -39,9 +30,7 @@
       "./package.json": "./package.json",
       ".": "./src/index.ts"
     },
-    "sourceDialects": [
-      "@zod/source"
-    ]
+    "sourceDialects": ["@zod/source"]
   },
   "repository": {
     "type": "git",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -4,19 +4,10 @@
   "version": "3.23.8",
   "author": "Colin McDonnell <zod@colinhacks.com>",
   "description": "TypeScript-first schema declaration and validation library with static type inference",
-  "files": [
-    "src",
-    "dist"
-  ],
+  "files": ["src", "dist"],
   "funding": "https://github.com/sponsors/colinhacks",
   "homepage": "https://zod.dev",
-  "keywords": [
-    "typescript",
-    "schema",
-    "validation",
-    "type",
-    "inference"
-  ],
+  "keywords": ["typescript", "schema", "validation", "type", "inference"],
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/commonjs/index.js",
@@ -26,6 +17,7 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "@zod/source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       },
@@ -36,6 +28,7 @@
     },
     "./locales/*": {
       "import": {
+        "@zod/source": "./src/locales/*",
         "types": "./dist/esm/locales/*",
         "default": "./dist/esm/locales/*"
       },
@@ -51,9 +44,7 @@
       ".": "./src/index.ts",
       "./locales/*": "./src/locales/*"
     },
-    "sourceDialects": [
-      "@zod/source"
-    ]
+    "sourceDialects": ["@zod/source"]
   },
   "repository": {
     "type": "git",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -50,7 +50,10 @@
       "./package.json": "./package.json",
       ".": "./src/index.ts",
       "./locales/*": "./src/locales/*"
-    }
+    },
+    "sourceDialects": [
+      "@zod/source"
+    ]
   },
   "repository": {
     "type": "git",
@@ -70,5 +73,8 @@
     "test:watch": "pnpm vitest",
     "test": "pnpm vitest run",
     "prepublishOnly": "pnpm test && pnpm run build"
+  },
+  "dependencies": {
+    "effect": "^3.5.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,11 @@ importers:
         specifier: ^3.0.0
         version: link:../zod
 
-  packages/zod: {}
+  packages/zod:
+    dependencies:
+      effect:
+        specifier: ^3.5.6
+        version: 3.5.6
 
 packages:
 

--- a/vitest.root.mts
+++ b/vitest.root.mts
@@ -1,6 +1,9 @@
 import { type UserConfig, defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    conditions: ["@zod/source"],
+  },
   test: {
     watch: false,
     isolate: false,


### PR DESCRIPTION
These changes make it possible to do regular development on Zod without doing any local builds. All tests run against source files, and inter-package imports just work.

- Add `@zod/source` to point to TypeScript source using tshy's `sourceDialects`
- Use `customConditions` in tsconfig.json to tell TypeScript to incorporate `@zod/source` condition into module resolution
- Update `resolve.conditions` in Vitest root config so imports to workspace packages reference source code
