### PR TITLE
(docs) email() validation disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,7 @@ Zod includes a handful of string-specific validations.
 z.string().max(5);
 z.string().min(5);
 z.string().length(5);
-z.string().email();
+z.string().email(); // note that there are various different definitions of what constitutes a valid email address depending on the environment and use case; this is just a reasonable default
 z.string().url();
 z.string().emoji();
 z.string().uuid();


### PR DESCRIPTION
This PR makes @colinhacks stance https://github.com/colinhacks/zod/pull/2157 on email validation explicit in docs. 

I've seen several validator libraries that have this disclaimer. 

https://valibot.dev/api/email/

https://github.com/ianstormtaylor/superstruct?tab=readme-ov-file#why

https://github.com/effect-ts/effect/tree/main/packages/schema#email

https://github.com/jquense/yup?tab=readme-ov-file#stringemailmessage-string--function-schema

The disclaimer wording is stolen (in a shortened form) from effect/schema