### PR TITLE
feat: added support for hostname method in z.string() #3589

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ z.string().cuid2();
 z.string().ulid();
 z.string().regex(regex);
 z.string().includes(string);
+z.string().hostname();
 z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().datetime(); // ISO 8601; by default only `Z` timezone allowed
@@ -774,6 +775,7 @@ z.string().url({ message: "Invalid url" });
 z.string().emoji({ message: "Contains non-emoji characters" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().includes("tuna", { message: "Must include tuna" });
+z.string().hostname({ message: "Must provide a valid hostname" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
 z.string().datetime({ message: "Invalid datetime string! Must be UTC." });

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -483,6 +483,7 @@ z.string().ulid();
 z.string().duration();
 z.string().regex(regex);
 z.string().includes(string);
+z.string().hostname();
 z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().datetime(); // ISO 8601；默认值为无 UTC 偏移，选项见下文
@@ -516,6 +517,7 @@ z.string().url({ message: "Invalid url" });
 z.string().emoji({ message: "Contains non-emoji characters" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().includes("tuna", { message: "Must include tuna" });
+z.string().hostname({ message: "Must provide a valid hostname" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
 z.string().datetime({ message: "Invalid datetime string! Must be UTC." });

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -252,7 +252,7 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
     <td align="center">
       <p></p>
       <p>
-      <a href="https://speakeasyapi.dev/?utm_source=zod+docs">
+      <a href="https://speakeasy.com/?utm_source=zod+docs">
         <picture height="40px">
           <source media="(prefers-color-scheme: dark)" srcset="https://github.com/colinhacks/zod/assets/3084745/b1d86601-c7fb-483c-9927-5dc24ce8b737">
           <img alt="speakeasy" height="40px" src="https://github.com/colinhacks/zod/assets/3084745/647524a4-22bb-4199-be70-404207a5a2b5">
@@ -261,7 +261,7 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
       <br  />   
       SDKs & Terraform providers for your API
       <br/>
-      <a href="https://speakeasyapi.dev/?utm_source=zod+docs" style="text-decoration:none;">speakeasyapi.dev</a>
+      <a href="https://speakeasy.com/?utm_source=zod+docs" style="text-decoration:none;">speakeasy.com</a>
       </p>
       <p></p>
     </td>
@@ -490,6 +490,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zod-prisma`](https://github.com/CarterGrimmeisen/zod-prisma): Generate Zod schemas from your Prisma schema.
 - [`Supervillain`](https://github.com/Southclaws/supervillain): Generate Zod schemas from your Go structs.
 - [`prisma-zod-generator`](https://github.com/omar-dulaimi/prisma-zod-generator): Emit Zod schemas from your Prisma schema.
+- [`drizzle-zod`](https://orm.drizzle.team/docs/zod): Emit Zod schemas from your Drizzle schema.
 - [`prisma-trpc-generator`](https://github.com/omar-dulaimi/prisma-trpc-generator): Emit fully implemented tRPC routers and their validation schemas using Zod.
 - [`zod-prisma-types`](https://github.com/chrishoermann/zod-prisma-types) Create Zod types from your Prisma models.
 - [`quicktype`](https://app.quicktype.io/): Convert JSON objects and JSON schemas into Zod schemas.
@@ -734,6 +735,7 @@ z.string().cuid2();
 z.string().ulid();
 z.string().regex(regex);
 z.string().includes(string);
+z.string().hostname();
 z.string().startsWith(string);
 z.string().endsWith(string);
 z.string().datetime(); // ISO 8601; by default only `Z` timezone allowed
@@ -773,6 +775,7 @@ z.string().url({ message: "Invalid url" });
 z.string().emoji({ message: "Contains non-emoji characters" });
 z.string().uuid({ message: "Invalid UUID" });
 z.string().includes("tuna", { message: "Must include tuna" });
+z.string().hostname({ message: "Must provide a valid hostname" });
 z.string().startsWith("https://", { message: "Must provide secure URL" });
 z.string().endsWith(".com", { message: "Only .com domains allowed" });
 z.string().datetime({ message: "Invalid datetime string! Must be UTC." });

--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -106,6 +106,7 @@ export type StringValidation =
   | "base64"
   | { includes: string; position?: number }
   | { startsWith: string }
+  | { hostname: string }
   | { endsWith: string };
 
 export interface ZodInvalidStringIssue extends ZodIssueBase {

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -12,6 +12,7 @@ const includes = z.string().includes("includes");
 const includesFromIndex2 = z.string().includes("includes", { position: 2 });
 const startsWith = z.string().startsWith("startsWith");
 const endsWith = z.string().endsWith("endsWith");
+const hostname = z.string().hostname();
 
 test("passing validations", () => {
   minFive.parse("12345");
@@ -24,6 +25,12 @@ test("passing validations", () => {
   includesFromIndex2.parse("XXXincludesXX");
   startsWith.parse("startsWithX");
   endsWith.parse("XendsWith");
+  hostname.parse("developer.mozilla.org");
+  hostname.parse("hello.world.example.com");
+  hostname.parse("www.google.com");
+  hostname.parse("[2001:db8::ff00:42:8329]");
+  hostname.parse("192.168.1.1");
+  hostname.parse("xn--d1acj3b");
 });
 
 test("failing validations", () => {
@@ -36,6 +43,13 @@ test("failing validations", () => {
   expect(() => includesFromIndex2.parse("XincludesXX")).toThrow();
   expect(() => startsWith.parse("x")).toThrow();
   expect(() => endsWith.parse("x")).toThrow();
+  expect(() => hostname.parse("ht!tp://invalid.com")).toThrow();
+  expect(() => hostname.parse("xn--d1acj3b..com")).toThrow();
+  expect(() => hostname.parse("ex@mple.com")).toThrow();
+  expect(() => hostname.parse("[2001:db8::zzzz]")).toThrow();
+  expect(() => hostname.parse("exa mple.com")).toThrow();
+  expect(() => hostname.parse("-example.com")).toThrow();
+  expect(() => hostname.parse("example..com")).toThrow();
 });
 
 test("email validations", () => {

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -30,7 +30,8 @@ test("passing validations", () => {
   hostname.parse("www.google.com");
   hostname.parse("[2001:db8::ff00:42:8329]");
   hostname.parse("192.168.1.1");
-  hostname.parse("xn--d1acj3b");
+  hostname.parse("xn--d1acj3b.com");
+  hostname.parse("xn--d1acj3b.org");
 });
 
 test("failing validations", () => {
@@ -44,6 +45,7 @@ test("failing validations", () => {
   expect(() => startsWith.parse("x")).toThrow();
   expect(() => endsWith.parse("x")).toThrow();
   expect(() => hostname.parse("ht!tp://invalid.com")).toThrow();
+  expect(() => hostname.parse("xn--d1acj3b")).toThrow();
   expect(() => hostname.parse("xn--d1acj3b..com")).toThrow();
   expect(() => hostname.parse("ex@mple.com")).toThrow();
   expect(() => hostname.parse("[2001:db8::zzzz]")).toThrow();

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -55,6 +55,8 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
           }
         } else if ("startsWith" in issue.validation) {
           message = `Invalid input: must start with "${issue.validation.startsWith}"`;
+        } else if ("hostname" in issue.validation) {
+          message = `Invalid input: must be a valid hostname`;
         } else if ("endsWith" in issue.validation) {
           message = `Invalid input: must end with "${issue.validation.endsWith}"`;
         } else {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -859,7 +859,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
       } else if (check.kind === "hostname") {
         const domainNameRegex =
           /^(?!-)(?!.*--)(?!.*\.\.)(?!.*\.$)[a-zA-Z0-9-]{1,63}(?<!-)(\.[a-zA-Z0-9-]{1,63})*$/;
-        const punycodeRegex = /^xn--[a-zA-Z0-9-]{1,63}$/;
+        const punycodeRegex = /^xn--[a-zA-Z0-9-]{1,63}\.[a-zA-Z]{2,}$/; // Ensure TLD after punycode
         const ipv4Regex =
           /^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)$/;
         const ipv6Regex = /^\[[0-9a-fA-F:]+\]$/;
@@ -868,7 +868,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           domainNameRegex.test(input.data) ||
           ipv4Regex.test(input.data) ||
           ipv6Regex.test(input.data) ||
-          punycodeRegex.test(input.data);
+          punycodeRegex.test(input.data); // Apply punycodeRegex here
 
         if (!isValid) {
           ctx = this._getOrReturnCtx(input, ctx);

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -106,6 +106,7 @@ export type StringValidation =
   | "base64"
   | { includes: string; position?: number }
   | { startsWith: string }
+  | { hostname: string }
   | { endsWith: string };
 
 export interface ZodInvalidStringIssue extends ZodIssueBase {

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -29,7 +29,8 @@ test("passing validations", () => {
   hostname.parse("www.google.com");
   hostname.parse("[2001:db8::ff00:42:8329]");
   hostname.parse("192.168.1.1");
-  hostname.parse("xn--d1acj3b");
+  hostname.parse("xn--d1acj3b.com");
+  hostname.parse("xn--d1acj3b.org");
 });
 
 test("failing validations", () => {
@@ -43,6 +44,7 @@ test("failing validations", () => {
   expect(() => startsWith.parse("x")).toThrow();
   expect(() => endsWith.parse("x")).toThrow();
   expect(() => hostname.parse("ht!tp://invalid.com")).toThrow();
+  expect(() => hostname.parse("xn--d1acj3b")).toThrow();
   expect(() => hostname.parse("xn--d1acj3b..com")).toThrow();
   expect(() => hostname.parse("ex@mple.com")).toThrow();
   expect(() => hostname.parse("[2001:db8::zzzz]")).toThrow();

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -11,6 +11,7 @@ const includes = z.string().includes("includes");
 const includesFromIndex2 = z.string().includes("includes", { position: 2 });
 const startsWith = z.string().startsWith("startsWith");
 const endsWith = z.string().endsWith("endsWith");
+const hostname = z.string().hostname();
 
 test("passing validations", () => {
   minFive.parse("12345");
@@ -23,6 +24,12 @@ test("passing validations", () => {
   includesFromIndex2.parse("XXXincludesXX");
   startsWith.parse("startsWithX");
   endsWith.parse("XendsWith");
+  hostname.parse("developer.mozilla.org");
+  hostname.parse("hello.world.example.com");
+  hostname.parse("www.google.com");
+  hostname.parse("[2001:db8::ff00:42:8329]");
+  hostname.parse("192.168.1.1");
+  hostname.parse("xn--d1acj3b");
 });
 
 test("failing validations", () => {
@@ -35,6 +42,13 @@ test("failing validations", () => {
   expect(() => includesFromIndex2.parse("XincludesXX")).toThrow();
   expect(() => startsWith.parse("x")).toThrow();
   expect(() => endsWith.parse("x")).toThrow();
+  expect(() => hostname.parse("ht!tp://invalid.com")).toThrow();
+  expect(() => hostname.parse("xn--d1acj3b..com")).toThrow();
+  expect(() => hostname.parse("ex@mple.com")).toThrow();
+  expect(() => hostname.parse("[2001:db8::zzzz]")).toThrow();
+  expect(() => hostname.parse("exa mple.com")).toThrow();
+  expect(() => hostname.parse("-example.com")).toThrow();
+  expect(() => hostname.parse("example..com")).toThrow();
 });
 
 test("email validations", () => {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -55,6 +55,8 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
           }
         } else if ("startsWith" in issue.validation) {
           message = `Invalid input: must start with "${issue.validation.startsWith}"`;
+        } else if ("hostname" in issue.validation) {
+          message = `Invalid input: must be a valid hostname`;
         } else if ("endsWith" in issue.validation) {
           message = `Invalid input: must end with "${issue.validation.endsWith}"`;
         } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -859,7 +859,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
       } else if (check.kind === "hostname") {
         const domainNameRegex =
           /^(?!-)(?!.*--)(?!.*\.\.)(?!.*\.$)[a-zA-Z0-9-]{1,63}(?<!-)(\.[a-zA-Z0-9-]{1,63})*$/;
-        const punycodeRegex = /^xn--[a-zA-Z0-9-]{1,63}$/;
+        const punycodeRegex = /^xn--[a-zA-Z0-9-]{1,63}\.[a-zA-Z]{2,}$/; // Ensure TLD after punycode
         const ipv4Regex =
           /^(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[0-1]?[0-9][0-9]?)$/;
         const ipv6Regex = /^\[[0-9a-fA-F:]+\]$/;
@@ -868,7 +868,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           domainNameRegex.test(input.data) ||
           ipv4Regex.test(input.data) ||
           ipv6Regex.test(input.data) ||
-          punycodeRegex.test(input.data);
+          punycodeRegex.test(input.data); // Apply punycodeRegex here
 
         if (!isValid) {
           ctx = this._getOrReturnCtx(input, ctx);


### PR DESCRIPTION
Added support for the hostname method in z.string() for enhanced string validation. This feature introduces a dedicated method to validate domain names, including Punycode, as well as IPv4 and IPv6 addresses(in square brackets). The new validation method ensures that valid hostnames meet the appropriate criteria and excludes invalid patterns.

This implementation was done for ticket #3589.

Changes:

Implemented the hostname method to validate:
Domain names, including those encoded in Punycode.
IPv4 addresses.
IPv6 addresses enclosed in square brackets.
Updated regex patterns to accurately handle valid and invalid hostname cases.
Added comprehensive test cases to ensure robustness and correctness of the new validation method.
Updated documentation to include details about the hostname method and usage examples.