### PR TITLE
docs: add zod-form-renderer to form integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`sveltekit-superforms`](https://github.com/ciscoheat/sveltekit-superforms): Supercharged form library for SvelteKit with Zod validation.
 - [`mobx-zod-form`](https://github.com/MonoidDev/mobx-zod-form): Data-first form builder based on MobX & Zod.
 - [`@vee-validate/zod`](https://github.com/logaretm/vee-validate/tree/main/packages/zod): Form library for Vue.js with Zod schema validation.
+- [`zod-form-renderer`](https://github.com/thepeaklab/zod-form-renderer): Auto-infer form fields from zod schema and render them with react-hook-form with E2E type safety.
 
 #### Zod to X
 


### PR DESCRIPTION
Hello there,

thank you for this awesome library!

We've built a form renderer utility which generates react-hook-form fields from a zod schema by using type mapping.
It is available as [open source](https://github.com/thepeaklab/zod-form-renderer) and it would be awesome if we could use your "Form integrations" section to promote it.

Thanks and best regards!