### PR TITLE
fix: add types exports declaration for ./locales/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
 			"import": "./lib/index.mjs"
 		},
 		"./package.json": "./package.json",
-		"./locales/*": "./lib/locales/*"
+		"./locales/*": {
+			"types": "./lib/locales/*.d.ts",
+			"require": "./lib/locales/*.js"
+		}
 	},
 	"bugs": {
 		"url": "https://github.com/colinhacks/zod/issues"


### PR DESCRIPTION
Fixes #2698 #1461

This change fixes an issue that prevented Zod from being build and served through the Skypack CDN. Namely, Skypack was unable to resolve the declaration file `lib/locales/en.d.ts` because it was not exposed by the `package.json#exports` declaration.

I was able to verify this fix by publishing this branch to NPM ([link](https://www.npmjs.com/package/@disintegrator/zod)) and comparing the result of the following in a Chrome console:

```
const z = await import ('https://cdn.skypack.dev/zod')
const zfixed = await import ('https://cdn.skypack.dev/@disintegrator/zod')
```

There was also a hint from other issues that Zod v3.18.x worked through Skypack but 3.19.0 did not. The latter is where the malformed exports declaration for `./locales/*` was introduced.