### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2150,7 +2150,7 @@ const passwordForm = z
     password: z.string(),
     confirm: z.string(),
   })
-  .refine((data) => data.password === data.confirm, {
+  .refine((data) => data.password !== data.confirm, {
     message: "Passwords don't match",
     path: ["confirm"], // path of error
   });


### PR DESCRIPTION
In the customize error path section, we should use `!==` instead of `===` comparison.