### PR TITLE
fix: dirty union bug

### DIFF
--- a/src/__tests__/unions.test.ts
+++ b/src/__tests__/unions.test.ts
@@ -62,3 +62,23 @@ test("readonly union", async () => {
   union.parse("asdf");
   union.parse(12);
 });
+
+test("union of strict objects", async () => {
+  // ensure bug in 3.23.8 is fixed, where "dirty" parse failures would mean reporting the first error, rather than a proper `invalid_union` with `unionErrors`.
+  // Demo of bug: https://stackblitz.com/edit/stackblitz-starters-swdj3e?file=index.test.js&startScript=test
+  const union = z.union([
+    z.object({ x: z.number() }).strict(), //
+    z.object({ y: z.number() }).strict(),
+  ]);
+  expect(union.safeParse({ x: 1, y: 1 })).toMatchObject({
+    success: false,
+    error: {
+      issues: [
+        {
+          code: "invalid_union",
+          unionErrors: [expect.any(z.ZodError), expect.any(z.ZodError)],
+        },
+      ],
+    },
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -2987,8 +2987,6 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
         })
       ).then(handleResults);
     } else {
-      let dirty: undefined | { result: DIRTY<any>; ctx: ParseContext } =
-        undefined;
       const issues: ZodIssue[][] = [];
       for (const option of options) {
         const childCtx: ParseContext = {
@@ -3007,18 +3005,11 @@ export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
 
         if (result.status === "valid") {
           return result;
-        } else if (result.status === "dirty" && !dirty) {
-          dirty = { result, ctx: childCtx };
         }
 
         if (childCtx.common.issues.length) {
           issues.push(childCtx.common.issues);
         }
-      }
-
-      if (dirty) {
-        ctx.common.issues.push(...dirty.ctx.common.issues);
-        return dirty.result;
       }
 
       const unionErrors = issues.map((issues) => new ZodError(issues));


### PR DESCRIPTION
bug repro: https://stackblitz.com/edit/stackblitz-starters-swdj3e?file=index.test.js&startScript=test

Basically, zod v3 wrongly reports a "normal" error rather than a union error for a union of strict objects (and presumably other unions that set status=dirty:

```ts
import { test, expect } from 'vitest';
import { z } from 'zod';

test('hmm', () => {
  const union = z.union([
    z.object({ x: z.number() }).strict(),
    z.object({ y: z.number() }).strict(),
  ]);

  expect(union.safeParse({ x: 1, y: 1 })).toMatchInlineSnapshot(`
    {
      "error": [ZodError: [
      {
        "code": "unrecognized_keys",
        "keys": [
          "y"
        ],
        "path": [],
        "message": "Unrecognized key(s) in object: 'y'"
      }
    ]],
      "success": false,
    }
  `);
  expect(union.safeParse({ x: 1, y: 1 })).toMatchObject({
    success: false,
    error: {
      issues: [
        {
          code: 'invalid_union',
          unionErrors: [expect.any(z.ZodError), expect.any(z.ZodError)],
        },
      ],
    },
  });
});
```

Note: this does not repro in v4. I'm not sure if there's anything going into zod v3 still but opening this against main in hopes that it can get fixed in v3.