### PR TITLE
docs: add info on unqualified local datetime strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,11 +835,10 @@ datetime.parse("2020-01-01T00:00:00.123+02"); // pass (only offset hours)
 datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
 ```
 
-You can allow unqualified (timezone-less) datetimes using the `local: true` flag.
+Allow unqualified (timezone-less) datetimes with the `local` flag.
 
 ```ts
 const schema = z.string().datetime({ local: true });
-
 schema.parse("2020-01-01T00:00:00"); // pass
 ```
 

--- a/README.md
+++ b/README.md
@@ -835,6 +835,14 @@ datetime.parse("2020-01-01T00:00:00.123+02"); // pass (only offset hours)
 datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
 ```
 
+You can allow unqualified (timezone-less) datetimes using the `local: true` flag.
+
+```ts
+const schema = z.string().datetime({ local: true });
+
+schema.parse("2020-01-01T00:00:00"); // pass
+```
+
 You can additionally constrain the allowable `precision`. By default, arbitrary sub-second precision is supported (but optional).
 
 ```ts

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -13,7 +13,7 @@
 <a href="https://twitter.com/colinhacks" rel="nofollow"><img src="https://img.shields.io/badge/created%20by-@colinhacks-4BBAAB.svg" alt="Created by Colin McDonnell"></a>
 <a href="https://opensource.org/licenses/MIT" rel="nofollow"><img src="https://img.shields.io/github/license/colinhacks/zod" alt="License"></a>
 <a href="https://www.npmjs.com/package/zod" rel="nofollow"><img src="https://img.shields.io/npm/dw/zod.svg" alt="npm"></a>
-<a href="https://www.npmjs.com/package/zod" rel="nofollow"><img src="https://img.shields.io/github/stars/colinhacks/zod" alt="stars"></a>
+<a href="https://github.com/colinhacks/zod" rel="nofollow"><img src="https://img.shields.io/github/stars/colinhacks/zod" alt="stars"></a>
 </p>
 
 <div align="center">
@@ -219,7 +219,7 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
       <a href="https://neon.tech">
         <picture height="68px">
           <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/83b4b1b1-a9ab-4ae5-a632-56d282f0c444">
-          <img alt="stainless" height="68px" src="https://github.com/user-attachments/assets/83b4b1b1-a9ab-4ae5-a632-56d282f0c444">
+          <img alt="Neon" height="68px" src="https://github.com/user-attachments/assets/b5799fc8-81ff-4053-a1c3-b29adf85e7a1">
         </picture>
       </a>
       <br  />   
@@ -833,6 +833,13 @@ datetime.parse("2020-01-01T00:00:00.123+02:00"); // pass (millis optional)
 datetime.parse("2020-01-01T00:00:00.123+0200"); // pass (millis optional)
 datetime.parse("2020-01-01T00:00:00.123+02"); // pass (only offset hours)
 datetime.parse("2020-01-01T00:00:00Z"); // pass (Z still supported)
+```
+
+Allow unqualified (timezone-less) datetimes with the `local` flag.
+
+```ts
+const schema = z.string().datetime({ local: true });
+schema.parse("2020-01-01T00:00:00"); // pass
 ```
 
 You can additionally constrain the allowable `precision`. By default, arbitrary sub-second precision is supported (but optional).


### PR DESCRIPTION
This feature was added in [version 3.23.0](https://github.com/colinhacks/zod/releases/tag/v3.23.0).