### PR TITLE
fix: add the formatted type in `ZodFormattedError` type recursion

### DIFF
--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -177,17 +177,17 @@ export const quotelessJson = (obj: any) => {
   return json.replace(/"([^"]+)":/g, "$1:");
 };
 
-type recursiveZodFormattedError<T> = T extends [any, ...any[]]
-  ? { [K in keyof T]?: ZodFormattedError<T[K]> }
+type recursiveZodFormattedError<T, U = string> = T extends [any, ...any[]]
+  ? { [K in keyof T]?: ZodFormattedError<T[K], U> }
   : T extends any[]
-  ? { [k: number]: ZodFormattedError<T[number]> }
+  ? { [k: number]: ZodFormattedError<T[number], U> }
   : T extends object
-  ? { [K in keyof T]?: ZodFormattedError<T[K]> }
+  ? { [K in keyof T]?: ZodFormattedError<T[K], U> }
   : unknown;
 
 export type ZodFormattedError<T, U = string> = {
   _errors: U[];
-} & recursiveZodFormattedError<NonNullable<T>>;
+} & recursiveZodFormattedError<NonNullable<T>, U>;
 
 export type inferFormattedError<
   T extends ZodType<any, any, any>,

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -309,9 +309,16 @@ test("formatting", () => {
   if (!result2.success) {
     type FormattedError = z.inferFormattedError<typeof schema, number>;
     const error: FormattedError = result2.error.format(() => 5);
-    expect(error._errors).toEqual([]);
-    expect(error.inner?._errors).toEqual([]);
-    expect(error.inner?.name?._errors).toEqual([5]);
+
+    type FormattedErrors = number[] | undefined;
+    const schemaErrors: FormattedErrors = error._errors;
+    const innerErrors: FormattedErrors = error.inner?._errors;
+    // @ts-expect-error it should not be the default formatted type
+    const nameErrors: string[] | undefined = error.inner?.name?._errors;
+
+    expect(schemaErrors).toEqual([]);
+    expect(innerErrors).toEqual([]);
+    expect(nameErrors).toEqual([5]);
   }
 });
 


### PR DESCRIPTION
Fixes #3761