### PR TITLE
docs: add unplugin-environment in powered by zod

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zod-xlsx`](https://github.com/sidwebworks/zod-xlsx): A xlsx based resource validator using Zod schemas.
 - [`znv`](https://github.com/lostfictions/znv): Type-safe environment parsing and validation for Node.js with Zod schemas.
 - [`zod-config`](https://github.com/alexmarqs/zod-config): Load configurations across multiple sources with flexible adapters, ensuring type safety with Zod.
+- [`unplugin-environment`](https://github.com/r17x/js/tree/main/packages/unplugin-environment#readme): A plugin for loading enviroment variables safely with schema validation, simple with virtual module, type-safe with intellisense, and better DX 🔥 🚀 👷. Powered by Zod.
 
 #### Utilities for Zod
 


### PR DESCRIPTION
I make a plugin for loading and parse environment variable into virtual modules and provided type definition and 80% using power of `Zod`. This plugin support with rollup, rolldown, esbuild, webpack, nextjs, vite, astro, and more (based on unjs/unplugin).

Thanks for @colinhacks for make this (`zod`) over-power library. 
