### PR TITLE
feat: enhance discriminated union error reporting

### DIFF
--- a/src/__tests__/discriminated-unions.test.ts
+++ b/src/__tests__/discriminated-unions.test.ts
@@ -94,8 +94,10 @@ test("invalid discriminator value", () => {
       {
         code: z.ZodIssueCode.invalid_union_discriminator,
         options: ["a", "b"],
-        message: "Invalid discriminator value. Expected 'a' | 'b'",
+        message:
+          "Invalid discriminator value. Expected 'a' | 'b', received 'x'",
         path: ["type"],
+        received: "x",
       },
     ]);
   }
@@ -114,7 +116,7 @@ test("valid discriminator value, invalid data", () => {
         code: z.ZodIssueCode.invalid_type,
         expected: z.ZodParsedType.string,
         message: "Required",
-        path: ["a"],
+        path: [{ discriminator: "type", value: "a" }, "a"],
         received: z.ZodParsedType.undefined,
       },
     ]);
@@ -189,7 +191,7 @@ test("async - invalid", async () => {
         code: "invalid_type",
         expected: "string",
         received: "number",
-        path: ["a"],
+        path: [{ discriminator: "type", value: "a" }, "a"],
         message: "Expected string, received number",
       },
     ]);

--- a/src/helpers/parseUtil.ts
+++ b/src/helpers/parseUtil.ts
@@ -5,7 +5,7 @@ import type { ZodParsedType } from "./util";
 
 export const makeIssue = (params: {
   data: any;
-  path: (string | number)[];
+  path: ParsePath;
   errorMaps: ZodErrorMap[];
   issueData: IssueData;
 }): ZodIssue => {
@@ -41,12 +41,15 @@ export const makeIssue = (params: {
 };
 
 export type ParseParams = {
-  path: (string | number)[];
+  path: ParsePath;
   errorMap: ZodErrorMap;
   async: boolean;
 };
 
-export type ParsePathComponent = string | number;
+export type ParsePathComponent =
+  | string
+  | number
+  | { discriminator: string; value: string };
 export type ParsePath = ParsePathComponent[];
 export const EMPTY_PATH: ParsePath = [];
 
@@ -65,7 +68,7 @@ export interface ParseContext {
 
 export type ParseInput = {
   data: any;
-  path: (string | number)[];
+  path: ParsePath;
   parent: ParseContext;
 };
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -29,7 +29,7 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
     case ZodIssueCode.invalid_union_discriminator:
       message = `Invalid discriminator value. Expected ${util.joinValues(
         issue.options
-      )}`;
+      )}, received '${issue.received}'`;
       break;
     case ZodIssueCode.invalid_enum_value:
       message = `Invalid enum value. Expected ${util.joinValues(

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,7 @@ import {
 
 export interface RefinementCtx {
   addIssue: (arg: IssueData) => void;
-  path: (string | number)[];
+  path: ParsePath;
 }
 export type ZodRawShape = { [k: string]: ZodTypeAny };
 export type ZodTypeAny = ZodType<any, any, any>;
@@ -3138,22 +3138,20 @@ export class ZodDiscriminatedUnion<
         code: ZodIssueCode.invalid_union_discriminator,
         options: Array.from(this.optionsMap.keys()),
         path: [discriminator],
+        received: discriminatorValue,
       });
       return INVALID;
     }
 
+    const optionCtx = {
+      data: ctx.data,
+      path: [...ctx.path, { discriminator, value: discriminatorValue }],
+      parent: ctx,
+    };
     if (ctx.common.async) {
-      return option._parseAsync({
-        data: ctx.data,
-        path: ctx.path,
-        parent: ctx,
-      }) as any;
+      return option._parseAsync(optionCtx) as any;
     } else {
-      return option._parseSync({
-        data: ctx.data,
-        path: ctx.path,
-        parent: ctx,
-      }) as any;
+      return option._parseSync(optionCtx) as any;
     }
   }
 


### PR DESCRIPTION
## Motivation

When working with discriminated unions, it's crucial to have clear and informative error messages when validation fails. The current implementation lacks some important details that can help developers quickly identify and fix issues.

## Changes

1. Added the `received` value to the error message:
   This allows developers to see exactly what value was provided for the discriminator, making it easier to debug issues where the wrong value is being sent.

2. Modified the error path:
   The new path includes information about the union option, providing more context about where in the schema structure the error occurred.

3. Updated relevant tests:
   The test suite has been updated to reflect these changes and ensure that the new error format is working as expected.

4. Fixed type errors:
   All type-related issues have been addressed to maintain type safety and consistency.