### PR TITLE
Input contravariance

### DIFF
--- a/deno/lib/__tests__/all-errors.test.ts
+++ b/deno/lib/__tests__/all-errors.test.ts
@@ -60,7 +60,7 @@ test("form errors type inference", () => {
 });
 
 test(".flatten() type assertion", () => {
-  const parsed = Test.safeParse({}) as z.SafeParseError<void>;
+  const parsed = z.safeParse(Test, {}) as z.SafeParseError<void>;
   const validFlattenedErrors: TestFlattenedErrors = parsed.error.flatten(
     () => ({ message: "", code: 0 })
   );
@@ -82,7 +82,7 @@ test(".flatten() type assertion", () => {
 });
 
 test(".formErrors type assertion", () => {
-  const parsed = Test.safeParse({}) as z.SafeParseError<void>;
+  const parsed = z.safeParse(Test, {}) as z.SafeParseError<void>;
   const validFormErrors: TestFormErrors = parsed.error.formErrors;
   // @ts-expect-error should fail assertion between `TestFlattenedErrors` and `.formErrors`.
   const invalidFlattenedErrors: TestFlattenedErrors = parsed.error.formErrors;

--- a/deno/lib/__tests__/array.test.ts
+++ b/deno/lib/__tests__/array.test.ts
@@ -56,7 +56,7 @@ test("continue parsing despite array size error", () => {
     people: z.string().array().min(2),
   });
 
-  const result = schema.safeParse({
+  const result = z.safeParse(schema, {
     people: [123],
   });
   expect(result.success).toEqual(false);

--- a/deno/lib/__tests__/async-parsing.test.ts
+++ b/deno/lib/__tests__/async-parsing.test.ts
@@ -11,11 +11,11 @@ test("string async parse", async () => {
   const goodData = "XXX";
   const badData = 12;
 
-  const goodResult = await stringSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(stringSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await stringSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(stringSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -26,11 +26,11 @@ test("number async parse", async () => {
   const goodData = 1234.2353;
   const badData = "1234";
 
-  const goodResult = await numberSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(numberSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await numberSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(numberSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -41,11 +41,11 @@ test("bigInt async parse", async () => {
   const goodData = BigInt(145);
   const badData = 134;
 
-  const goodResult = await bigIntSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(bigIntSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await bigIntSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(bigIntSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -56,11 +56,11 @@ test("boolean async parse", async () => {
   const goodData = true;
   const badData = 1;
 
-  const goodResult = await booleanSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(booleanSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await booleanSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(booleanSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -71,11 +71,11 @@ test("date async parse", async () => {
   const goodData = new Date();
   const badData = new Date().toISOString();
 
-  const goodResult = await dateSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(dateSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await dateSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(dateSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -86,11 +86,11 @@ test("undefined async parse", async () => {
   const goodData = undefined;
   const badData = "XXX";
 
-  const goodResult = await undefinedSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(undefinedSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(undefined);
 
-  const badResult = await undefinedSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(undefinedSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -101,11 +101,11 @@ test("null async parse", async () => {
   const goodData = null;
   const badData = undefined;
 
-  const goodResult = await nullSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(nullSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await nullSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(nullSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -116,11 +116,11 @@ test("any async parse", async () => {
   const goodData = [{}];
   // const badData = 'XXX';
 
-  const goodResult = await anySchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(anySchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  // const badResult = await anySchema.safeParseAsync(badData);
+  // const badResult = await z.safeParseAsync(anySchema, badData);
   // expect(badResult.success).toBe(false);
   // if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -131,11 +131,11 @@ test("unknown async parse", async () => {
   const goodData = ["asdf", 124, () => {}];
   // const badData = 'XXX';
 
-  const goodResult = await unknownSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(unknownSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  // const badResult = await unknownSchema.safeParseAsync(badData);
+  // const badResult = await z.safeParseAsync(unknownSchema, badData);
   // expect(badResult.success).toBe(false);
   // if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -146,11 +146,11 @@ test("void async parse", async () => {
   const goodData = undefined;
   const badData = 0;
 
-  const goodResult = await voidSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(voidSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await voidSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(voidSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -161,11 +161,11 @@ test("array async parse", async () => {
   const goodData = ["XXX"];
   const badData = "XXX";
 
-  const goodResult = await arraySchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(arraySchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await arraySchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(arraySchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -176,11 +176,11 @@ test("object async parse", async () => {
   const goodData = { string: "XXX" };
   const badData = { string: 12 };
 
-  const goodResult = await objectSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(objectSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await objectSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(objectSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -191,11 +191,11 @@ test("union async parse", async () => {
   const goodData = undefined;
   const badData = null;
 
-  const goodResult = await unionSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(unionSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await unionSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(unionSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -206,11 +206,11 @@ test("record async parse", async () => {
   const goodData = { adsf: {}, asdf: {} };
   const badData = [{}];
 
-  const goodResult = await recordSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(recordSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await recordSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(recordSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -221,11 +221,11 @@ test("function async parse", async () => {
   const goodData = () => {};
   const badData = "XXX";
 
-  const goodResult = await functionSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(functionSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(typeof goodResult.data).toEqual("function");
 
-  const badResult = await functionSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(functionSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -236,11 +236,11 @@ test("literal async parse", async () => {
   const goodData = "asdf";
   const badData = "asdff";
 
-  const goodResult = await literalSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(literalSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await literalSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(literalSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -251,11 +251,11 @@ test("enum async parse", async () => {
   const goodData = "whale";
   const badData = "leopard";
 
-  const goodResult = await enumSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(enumSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await enumSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(enumSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -270,11 +270,11 @@ test("nativeEnum async parse", async () => {
   const goodData = nativeEnumTest.asdf;
   const badData = "asdf";
 
-  const goodResult = await nativeEnumSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(nativeEnumSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await nativeEnumSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(nativeEnumSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -284,7 +284,7 @@ const promiseSchema = z.promise(z.number());
 test("promise async parse good", async () => {
   const goodData = Promise.resolve(123);
 
-  const goodResult = await promiseSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(promiseSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) {
     expect(goodResult.data).toBeInstanceOf(Promise);
@@ -299,7 +299,7 @@ test("promise async parse good", async () => {
 
 test("promise async parse bad", async () => {
   const badData = Promise.resolve("XXX");
-  const badResult = await promiseSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(promiseSchema, badData);
   expect(badResult.success).toBe(true);
   if (badResult.success) {
     await expect(badResult.data).rejects.toBeInstanceOf(z.ZodError);
@@ -315,8 +315,8 @@ test("async validation non-empty strings", async () => {
   });
 
   const testval = { hello: "", foo: "" };
-  const result1 = base.safeParse(testval);
-  const result2 = base.safeParseAsync(testval);
+  const result1 = z.safeParse(base, testval);
+  const result2 = z.safeParseAsync(base, testval);
 
   const r1 = result1;
   await result2.then((r2) => {
@@ -332,8 +332,8 @@ test("async validation multiple errors 1", async () => {
   });
 
   const testval = { hello: 3, foo: "hello" };
-  const result1 = base.safeParse(testval);
-  const result2 = base.safeParseAsync(testval);
+  const result1 = z.safeParse(base, testval);
+  const result2 = z.safeParseAsync(base, testval);
 
   const r1 = result1;
   await result2.then((r2) => {
@@ -352,8 +352,8 @@ test("async validation multiple errors 2", async () => {
     });
 
   const testval = { hello: 3, foo: { bar: 4 } };
-  const result1 = base().safeParse(testval);
-  const result2 = base(true).safeParseAsync(testval);
+  const result1 = z.safeParse(base(), testval);
+  const result2 = z.safeParseAsync(base(true), testval);
 
   const r1 = result1;
   await result2.then((r2) => {
@@ -379,7 +379,7 @@ test("ensure early async failure prevents follow-up refinement checks", async ()
   });
 
   const testval = { hello: "bye", foo: 3 };
-  const result = await base.safeParseAsync(testval);
+  const result = await z.safeParseAsync(base, testval);
   if (result.success === false) {
     expect(result.error.issues.length).toBe(1);
     expect(count).toBe(1);

--- a/deno/lib/__tests__/base.test.ts
+++ b/deno/lib/__tests__/base.test.ts
@@ -14,7 +14,7 @@ test("type guard", () => {
   type t1 = z.input<typeof s1>;
 
   const data = { stringToNumber: "asdf" };
-  const parsed = s1.safeParse(data);
+  const parsed = z.safeParse(s1, data);
   if (parsed.success) {
     util.assertEqual<typeof data, t1>(true);
   }
@@ -25,6 +25,10 @@ test("test this binding", () => {
     return predicate("hello");
   };
 
-  expect(callback((value) => z.string().safeParse(value).success)).toBe(true); // true
-  expect(callback((value) => z.string().safeParse(value).success)).toBe(true); // true
+  expect(callback((value) => z.safeParse(z.string(), value).success)).toBe(
+    true
+  ); // true
+  expect(callback((value) => z.safeParse(z.string(), value).success)).toBe(
+    true
+  ); // true
 });

--- a/deno/lib/__tests__/catch.test.ts
+++ b/deno/lib/__tests__/catch.test.ts
@@ -6,7 +6,7 @@ import { z } from "../index.ts";
 import { util } from "../helpers/util.ts";
 
 test("basic catch", () => {
-  expect(z.string().catch("default").parse(undefined)).toBe("default");
+  expect(z.catch_(z.string(), "default").parse(undefined)).toBe("default");
 });
 
 test("catch fn does not run when parsing succeeds", () => {
@@ -15,30 +15,30 @@ test("catch fn does not run when parsing succeeds", () => {
     isCalled = true;
     return "asdf";
   };
-  expect(z.string().catch(cb).parse("test")).toBe("test");
+  expect(z.catch_(z.string(), cb).parse("test")).toBe("test");
   expect(isCalled).toEqual(false);
 });
 
 test("basic catch async", async () => {
-  const result = await z.string().catch("default").parseAsync(1243);
+  const result = await z.catch_(z.string(), "default").parseAsync(1243);
   expect(result).toBe("default");
 });
 
 test("catch replace wrong types", () => {
-  expect(z.string().catch("default").parse(true)).toBe("default");
-  expect(z.string().catch("default").parse(true)).toBe("default");
-  expect(z.string().catch("default").parse(15)).toBe("default");
-  expect(z.string().catch("default").parse([])).toBe("default");
-  expect(z.string().catch("default").parse(new Map())).toBe("default");
-  expect(z.string().catch("default").parse(new Set())).toBe("default");
-  expect(z.string().catch("default").parse({})).toBe("default");
+  expect(z.catch_(z.string(), "default").parse(true)).toBe("default");
+  expect(z.catch_(z.string(), "default").parse(true)).toBe("default");
+  expect(z.catch_(z.string(), "default").parse(15)).toBe("default");
+  expect(z.catch_(z.string(), "default").parse([])).toBe("default");
+  expect(z.catch_(z.string(), "default").parse(new Map())).toBe("default");
+  expect(z.catch_(z.string(), "default").parse(new Set())).toBe("default");
+  expect(z.catch_(z.string(), "default").parse({})).toBe("default");
 });
 
 test("catch with transform", () => {
-  const stringWithDefault = z
-    .string()
-    .transform((val) => val.toUpperCase())
-    .catch("default");
+  const stringWithDefault = z.catch_(
+    z.string().transform((val) => val.toUpperCase()),
+    "default"
+  );
   expect(stringWithDefault.parse(undefined)).toBe("default");
   expect(stringWithDefault.parse(15)).toBe("default");
   expect(stringWithDefault).toBeInstanceOf(z.ZodCatch);
@@ -54,7 +54,7 @@ test("catch with transform", () => {
 });
 
 test("catch on existing optional", () => {
-  const stringWithDefault = z.string().optional().catch("asdf");
+  const stringWithDefault = z.catch_(z.string().optional(), "asdf");
   expect(stringWithDefault.parse(undefined)).toBe(undefined);
   expect(stringWithDefault.parse(15)).toBe("asdf");
   expect(stringWithDefault).toBeInstanceOf(z.ZodCatch);
@@ -70,7 +70,7 @@ test("catch on existing optional", () => {
 });
 
 test("optional on catch", () => {
-  const stringWithDefault = z.string().catch("asdf").optional();
+  const stringWithDefault = z.catch_(z.string(), "asdf").optional();
 
   type inp = z.input<typeof stringWithDefault>;
   util.assertEqual<inp, unknown>(true);
@@ -79,15 +79,19 @@ test("optional on catch", () => {
 });
 
 test("complex chain example", () => {
-  const complex = z
-    .string()
-    .catch("asdf")
-    .transform((val) => val + "!")
-    .transform((val) => val.toUpperCase())
-    .catch("qwer")
-    .removeCatch()
-    .optional()
-    .catch("asdfasdf");
+  const complex = z.catch_(
+    z
+      .catch_(
+        z
+          .catch_(z.string(), "asdf")
+          .transform((val) => val + "!")
+          .transform((val) => val.toUpperCase()),
+        "qwer"
+      )
+      .removeCatch()
+      .optional(),
+    "asdfasdf"
+  );
 
   expect(complex.parse("qwer")).toBe("QWER!");
   expect(complex.parse(15)).toBe("ASDF!");
@@ -95,15 +99,15 @@ test("complex chain example", () => {
 });
 
 test("removeCatch", () => {
-  const stringWithRemovedDefault = z.string().catch("asdf").removeCatch();
+  const stringWithRemovedDefault = z.catch_(z.string(), "asdf").removeCatch();
 
   type out = z.output<typeof stringWithRemovedDefault>;
   util.assertEqual<out, string>(true);
 });
 
 test("nested", () => {
-  const inner = z.string().catch("asdf");
-  const outer = z.object({ inner }).catch({
+  const inner = z.catch_(z.string(), "asdf");
+  const outer = z.catch_(z.object({ inner }), {
     inner: "asdf",
   });
   type input = z.input<typeof outer>;
@@ -116,7 +120,7 @@ test("nested", () => {
 });
 
 test("chained catch", () => {
-  const stringWithDefault = z.string().catch("inner").catch("outer");
+  const stringWithDefault = z.catch_(z.catch_(z.string(), "inner"), "outer");
   const result = stringWithDefault.parse(undefined);
   expect(result).toEqual("inner");
   const resultDiff = stringWithDefault.parse(5);
@@ -136,7 +140,7 @@ test("native enum", () => {
   }
 
   const schema = z.object({
-    fruit: z.nativeEnum(Fruits).catch(Fruits.apple),
+    fruit: z.catch_(z.nativeEnum(Fruits), Fruits.apple),
   });
 
   expect(schema.parse({})).toEqual({ fruit: Fruits.apple });
@@ -145,7 +149,7 @@ test("native enum", () => {
 
 test("enum", () => {
   const schema = z.object({
-    fruit: z.enum(["apple", "orange"]).catch("apple"),
+    fruit: z.catch_(z.enum(["apple", "orange"]), "apple"),
   });
 
   expect(schema.parse({})).toEqual({ fruit: "apple" });
@@ -159,11 +163,11 @@ test("reported issues with nested usage", () => {
     obj: z.object({
       sub: z.object({
         lit: z.literal("a"),
-        subCatch: z.number().catch(23),
+        subCatch: z.catch_(z.number(), 23),
       }),
-      midCatch: z.number().catch(42),
+      midCatch: z.catch_(z.number(), 42),
     }),
-    number: z.number().catch(0),
+    number: z.catch_(z.number(), 0),
     bool: z.boolean(),
   });
 
@@ -195,14 +199,14 @@ test("catch error", () => {
 
   const schema = z.object({
     age: z.number(),
-    name: z.string().catch((ctx) => {
+    name: z.catch_(z.string(), (ctx) => {
       catchError = ctx.error;
 
       return "John Doe";
     }),
   });
 
-  const result = schema.safeParse({
+  const result = z.safeParse(schema, {
     age: null,
     name: null,
   });
@@ -221,7 +225,7 @@ test("catch error", () => {
 });
 
 test("ctx.input", () => {
-  const schema = z.string().catch((ctx) => {
+  const schema = z.catch_(z.string(), (ctx) => {
     return String(ctx.input);
   });
 

--- a/deno/lib/__tests__/custom.test.ts
+++ b/deno/lib/__tests__/custom.test.ts
@@ -12,7 +12,7 @@ test("passing validations", () => {
 
 test("string params", () => {
   const example1 = z.custom<number>((x) => typeof x !== "number", "customerr");
-  const result = example1.safeParse(1234);
+  const result = z.safeParse(example1, 1234);
   expect(result.success).toEqual(false);
   // @ts-ignore
   expect(JSON.stringify(result.error).includes("customerr")).toEqual(true);

--- a/deno/lib/__tests__/enum.test.ts
+++ b/deno/lib/__tests__/enum.test.ts
@@ -33,9 +33,10 @@ test("readonly enum", () => {
 });
 
 test("error params", () => {
-  const result = z
-    .enum(["test"], { required_error: "REQUIRED" })
-    .safeParse(undefined);
+  const result = z.safeParse(
+    z.enum(["test"], { required_error: "REQUIRED" }),
+    undefined
+  );
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("REQUIRED");
@@ -65,8 +66,8 @@ test("error map in extract/exclude", () => {
     errorMap: () => ({ message: "This is not food!" }),
   });
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
-  const foodsError = FoodEnum.safeParse("Cucumbers");
-  const italianError = ItalianEnum.safeParse("Tacos");
+  const foodsError = z.safeParse(FoodEnum, "Cucumbers");
+  const italianError = z.safeParse(ItalianEnum, "Tacos");
   if (!foodsError.success && !italianError.success) {
     expect(foodsError.error.issues[0].message).toEqual(
       italianError.error.issues[0].message
@@ -76,7 +77,7 @@ test("error map in extract/exclude", () => {
   const UnhealthyEnum = FoodEnum.exclude(["Salad"], {
     errorMap: () => ({ message: "This is not healthy food!" }),
   });
-  const unhealthyError = UnhealthyEnum.safeParse("Salad");
+  const unhealthyError = z.safeParse(UnhealthyEnum, "Salad");
   if (!unhealthyError.success) {
     expect(unhealthyError.error.issues[0].message).toEqual(
       "This is not healthy food!"

--- a/deno/lib/__tests__/generics.test.ts
+++ b/deno/lib/__tests__/generics.test.ts
@@ -48,5 +48,5 @@ test("nested no undefined", () => {
   const outer = z.object({ inner });
   type outerSchema = z.infer<typeof outer>;
   z.util.assertEqual<outerSchema, { inner: string | string[] }>(true);
-  expect(outer.safeParse({ inner: undefined }).success).toEqual(false);
+  expect(z.safeParse(outer, { inner: undefined }).success).toEqual(false);
 });

--- a/deno/lib/__tests__/instanceof.test.ts
+++ b/deno/lib/__tests__/instanceof.test.ts
@@ -37,6 +37,6 @@ test("instanceof", async () => {
 
 test("instanceof fatal", () => {
   const schema = z.instanceof(Date).refine((d) => d.toString());
-  const res = schema.safeParse(null);
+  const res = z.safeParse(schema, null);
   expect(res.success).toBe(false);
 });

--- a/deno/lib/__tests__/intersection.test.ts
+++ b/deno/lib/__tests__/intersection.test.ts
@@ -78,7 +78,7 @@ test("invalid intersection types", async () => {
     z.number().transform((x) => x + 1)
   );
 
-  const syncResult = numberIntersection.safeParse(1234);
+  const syncResult = z.safeParse(numberIntersection, 1234);
   expect(syncResult.success).toEqual(false);
   if (!syncResult.success) {
     expect(syncResult.error.issues[0].code).toEqual(
@@ -86,7 +86,7 @@ test("invalid intersection types", async () => {
     );
   }
 
-  const asyncResult = await numberIntersection.spa(1234);
+  const asyncResult = await z.spa(numberIntersection, 1234);
   expect(asyncResult.success).toEqual(false);
   if (!asyncResult.success) {
     expect(asyncResult.error.issues[0].code).toEqual(
@@ -103,7 +103,7 @@ test("invalid array merge", async () => {
       .array()
       .transform((val) => [...val, "asdf"])
   );
-  const syncResult = stringArrInt.safeParse(["asdf", "qwer"]);
+  const syncResult = z.safeParse(stringArrInt, ["asdf", "qwer"]);
   expect(syncResult.success).toEqual(false);
   if (!syncResult.success) {
     expect(syncResult.error.issues[0].code).toEqual(
@@ -111,7 +111,7 @@ test("invalid array merge", async () => {
     );
   }
 
-  const asyncResult = await stringArrInt.spa(["asdf", "qwer"]);
+  const asyncResult = await z.spa(stringArrInt, ["asdf", "qwer"]);
   expect(asyncResult.success).toEqual(false);
   if (!asyncResult.success) {
     expect(asyncResult.error.issues[0].code).toEqual(

--- a/deno/lib/__tests__/literal.test.ts
+++ b/deno/lib/__tests__/literal.test.ts
@@ -27,7 +27,7 @@ test("failing validations", () => {
 
 test("invalid_literal should have `received` field with data", () => {
   const data = "shark";
-  const result = literalTuna.safeParse(data);
+  const result = z.safeParse(literalTuna, data);
   if (!result.success) {
     const issue = result.error.issues[0];
     if (issue.code === "invalid_literal") {

--- a/deno/lib/__tests__/map.test.ts
+++ b/deno/lib/__tests__/map.test.ts
@@ -14,7 +14,8 @@ test("type inference", () => {
 });
 
 test("valid parse", () => {
-  const result = stringMap.safeParse(
+  const result = z.safeParse(
+    stringMap,
     new Map([
       ["first", "foo"],
       ["second", "bar"],
@@ -30,7 +31,8 @@ test("valid parse", () => {
 });
 
 test("valid parse async", async () => {
-  const result = await stringMap.spa(
+  const result = await z.spa(
+    stringMap,
     new Map([
       ["first", "foo"],
       ["second", "bar"],
@@ -46,7 +48,7 @@ test("valid parse async", async () => {
 });
 
 test("throws when a Set is given", () => {
-  const result = stringMap.safeParse(new Set([]));
+  const result = z.safeParse(stringMap, new Set([]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(1);
@@ -55,7 +57,7 @@ test("throws when a Set is given", () => {
 });
 
 test("throws when the given map has invalid key and invalid input", () => {
-  const result = stringMap.safeParse(new Map([[42, Symbol()]]));
+  const result = z.safeParse(stringMap, new Map([[42, Symbol()]]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(2);
@@ -67,16 +69,17 @@ test("throws when the given map has invalid key and invalid input", () => {
 });
 
 test("throws when the given map has multiple invalid entries", () => {
-  // const result = stringMap.safeParse(new Map([[42, Symbol()]]));
+  // const result = z.safeParse(stringMap, new Map([[42, Symbol()]]));
 
-  const result = stringMap.safeParse(
+  const result = z.safeParse(
+    stringMap,
     new Map([
       [1, "foo"],
       ["bar", 2],
     ] as [any, any][]) as Map<any, any>
   );
 
-  // const result = stringMap.safeParse(new Map([[42, Symbol()]]));
+  // const result = z.safeParse(stringMap, new Map([[42, Symbol()]]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(2);
@@ -94,7 +97,8 @@ test("dirty", async () => {
     }),
     z.string()
   );
-  const result = await map.spa(
+  const result = await z.spa(
+    map,
     new Map([
       ["first", "foo"],
       ["second", "bar"],

--- a/deno/lib/__tests__/object.test.ts
+++ b/deno/lib/__tests__/object.test.ts
@@ -110,7 +110,7 @@ test("strip unknown", () => {
 });
 
 test("strict", () => {
-  const val = z.object({ points: z.number() }).strict().safeParse(data);
+  const val = z.safeParse(z.object({ points: z.number() }).strict(), data);
 
   expect(val.success).toEqual(false);
 });
@@ -185,10 +185,10 @@ test("test catchall parsing", async () => {
 
   expect(result).toEqual({ name: "Foo", validExtraKey: 61 });
 
-  const result2 = z
-    .object({ name: z.string() })
-    .catchall(z.number())
-    .safeParse({ name: "Foo", validExtraKey: 61, invalid: "asdf" });
+  const result2 = z.safeParse(
+    z.object({ name: z.string() }).catchall(z.number()),
+    { name: "Foo", validExtraKey: 61, invalid: "asdf" }
+  );
 
   expect(result2.success).toEqual(false);
 });
@@ -199,7 +199,7 @@ test("test nonexistent keys", async () => {
     z.object({ b: z.number() }),
   ]);
   const obj = { a: "A" };
-  const result = await Schema.spa(obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
+  const result = await z.spa(Schema, obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
   expect(result.success).toBe(true);
 });
 
@@ -214,7 +214,7 @@ test("test async union", async () => {
   ]);
 
   const obj = { ty: "A" };
-  const result = await Schema2.spa(obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
+  const result = await z.spa(Schema2, obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
   expect(result.success).toEqual(true);
 });
 
@@ -311,10 +311,10 @@ test("strictcreate", async () => {
     name: z.string(),
   });
 
-  const syncResult = strictObj.safeParse({ name: "asdf", unexpected: 13 });
+  const syncResult = z.safeParse(strictObj, { name: "asdf", unexpected: 13 });
   expect(syncResult.success).toEqual(false);
 
-  const asyncResult = await strictObj.spa({ name: "asdf", unexpected: 13 });
+  const asyncResult = await z.spa(strictObj, { name: "asdf", unexpected: 13 });
   expect(asyncResult.success).toEqual(false);
 });
 

--- a/deno/lib/__tests__/partials.test.ts
+++ b/deno/lib/__tests__/partials.test.ts
@@ -249,5 +249,5 @@ test("deeppartial array", () => {
   schema.parse({});
 
   // should be false, but is true
-  expect(schema.safeParse({ array: [] }).success).toBe(false);
+  expect(z.safeParse(schema, { array: [] }).success).toBe(false);
 });

--- a/deno/lib/__tests__/pipeline.test.ts
+++ b/deno/lib/__tests__/pipeline.test.ts
@@ -23,8 +23,8 @@ test("break if dirty", () => {
     .refine((c) => c === "1234")
     .transform(async (val) => Number(val))
     .pipe(z.number().refine((v) => v < 100));
-  const r1: any = schema.safeParse("12345");
+  const r1: any = z.safeParse(schema, "12345");
   expect(r1.error.issues.length).toBe(1);
-  const r2: any = schema.safeParse("3");
+  const r2: any = z.safeParse(schema, "3");
   expect(r2.error.issues.length).toBe(1);
 });

--- a/deno/lib/__tests__/preprocess.test.ts
+++ b/deno/lib/__tests__/preprocess.test.ts
@@ -10,7 +10,7 @@ test("preprocess", () => {
 
   const value = schema.parse("asdf");
   expect(value).toEqual(["asdf"]);
-  util.assertEqual<(typeof schema)["_input"], unknown>(true);
+  util.assertEqual<z.input<typeof schema>, unknown>(true);
 });
 
 test("async preprocess", async () => {
@@ -100,15 +100,16 @@ test("async preprocess ctx.addIssue with parse", async () => {
 });
 
 test("preprocess ctx.addIssue with parseAsync", async () => {
-  const result = await z
-    .preprocess(async (data, ctx) => {
+  const result = await z.safeParseAsync(
+    z.preprocess(async (data, ctx) => {
       ctx.addIssue({
         code: "custom",
         message: `${data} is not one of our allowed strings`,
       });
       return data;
-    }, z.string())
-    .safeParseAsync("asdf");
+    }, z.string()),
+    "asdf"
+  );
 
   expect(JSON.parse(JSON.stringify(result))).toEqual({
     success: false,
@@ -136,7 +137,7 @@ test("z.NEVER in preprocess", () => {
 
   type foo = z.infer<typeof foo>;
   util.assertEqual<foo, number>(true);
-  const arg = foo.safeParse(undefined);
+  const arg = z.safeParse(foo, undefined);
   if (!arg.success) {
     expect(arg.error.issues[0].message).toEqual("bad");
   }
@@ -146,7 +147,7 @@ test("preprocess as the second property of object", () => {
     nonEmptyStr: z.string().min(1),
     positiveNum: z.preprocess((v) => Number(v), z.number().positive()),
   });
-  const result = schema.safeParse({
+  const result = z.safeParse(schema, {
     nonEmptyStr: "",
     positiveNum: "",
   });

--- a/deno/lib/__tests__/record.test.ts
+++ b/deno/lib/__tests__/record.test.ts
@@ -156,7 +156,7 @@ test("is not vulnerable to prototype pollution", async () => {
   const obj1 = rec.parse(data);
   expect(obj1.a).toBeUndefined();
 
-  const obj2 = rec.safeParse(data);
+  const obj2 = z.safeParse(rec, data);
   expect(obj2.success).toBe(true);
   if (obj2.success) {
     expect(obj2.data.a).toBeUndefined();
@@ -165,7 +165,7 @@ test("is not vulnerable to prototype pollution", async () => {
   const obj3 = await rec.parseAsync(data);
   expect(obj3.a).toBeUndefined();
 
-  const obj4 = await rec.safeParseAsync(data);
+  const obj4 = await z.safeParseAsync(rec, data);
   expect(obj4.success).toBe(true);
   if (obj4.success) {
     expect(obj4.data.a).toBeUndefined();

--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -85,13 +85,15 @@ test("refinement Promise", async () => {
 });
 
 test("custom path", async () => {
-  const result = await z
-    .object({
-      password: z.string(),
-      confirm: z.string(),
-    })
-    .refine((data) => data.confirm === data.password, { path: ["confirm"] })
-    .spa({ password: "asdf", confirm: "qewr" });
+  const result = await z.spa(
+    z
+      .object({
+        password: z.string(),
+        confirm: z.string(),
+      })
+      .refine((data) => data.confirm === data.password, { path: ["confirm"] }),
+    { password: "asdf", confirm: "qewr" }
+  );
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].path).toEqual(["confirm"]);
@@ -115,8 +117,8 @@ test("use path in refinement context", async () => {
     foo: noNested,
   });
 
-  const t1 = await noNested.spa("asdf");
-  const t2 = await data.spa({ foo: "asdf" });
+  const t1 = await z.spa(noNested, "asdf");
+  const t2 = await z.spa(data, { foo: "asdf" });
 
   expect(t1.success).toBe(true);
   expect(t2.success).toBe(false);
@@ -148,7 +150,7 @@ test("superRefine", () => {
     }
   });
 
-  const result = Strings.safeParse(["asfd", "asfd", "asfd", "asfd"]);
+  const result = z.safeParse(Strings, ["asfd", "asfd", "asfd", "asfd"]);
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(2);
@@ -177,7 +179,12 @@ test("superRefine async", async () => {
     }
   });
 
-  const result = await Strings.safeParseAsync(["asfd", "asfd", "asfd", "asfd"]);
+  const result = await z.safeParseAsync(Strings, [
+    "asfd",
+    "asfd",
+    "asfd",
+    "asfd",
+  ]);
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(2);
@@ -208,8 +215,8 @@ test("superRefine - type narrowing", () => {
 
   util.assertEqual<z.infer<typeof schema>, NarrowType>(true);
 
-  expect(schema.safeParse({ type: "test", age: 0 }).success).toEqual(true);
-  expect(schema.safeParse(null).success).toEqual(false);
+  expect(z.safeParse(schema, { type: "test", age: 0 }).success).toEqual(true);
+  expect(z.safeParse(schema, null).success).toEqual(false);
 });
 
 test("chained mixed refining types", () => {
@@ -264,14 +271,14 @@ test("chained refinements", () => {
       path: ["size"],
       message: "size greater than 7",
     });
-  const r1 = objectSchema.safeParse({
+  const r1 = z.safeParse(objectSchema, {
     length: 4,
     size: 9,
   });
   expect(r1.success).toEqual(false);
   if (!r1.success) expect(r1.error.issues.length).toEqual(1);
 
-  const r2 = objectSchema.safeParse({
+  const r2 = z.safeParse(objectSchema, {
     length: 4,
     size: 3,
   });
@@ -300,7 +307,7 @@ test("fatal superRefine", () => {
       }
     });
 
-  const result = Strings.safeParse("");
+  const result = z.safeParse(Strings, "");
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);

--- a/deno/lib/__tests__/safeparse.test.ts
+++ b/deno/lib/__tests__/safeparse.test.ts
@@ -6,23 +6,24 @@ import * as z from "../index.ts";
 const stringSchema = z.string();
 
 test("safeparse fail", () => {
-  const safe = stringSchema.safeParse(12);
+  const safe = z.safeParse(stringSchema, 12);
   expect(safe.success).toEqual(false);
   expect(safe.error).toBeInstanceOf(z.ZodError);
 });
 
 test("safeparse pass", () => {
-  const safe = stringSchema.safeParse("12");
+  const safe = z.safeParse(stringSchema, "12");
   expect(safe.success).toEqual(true);
   expect(safe.data).toEqual("12");
 });
 
 test("safeparse unexpected error", () => {
   expect(() =>
-    stringSchema
-      .refine((data) => {
+    z.safeParse(
+      stringSchema.refine((data) => {
         throw new Error(data);
-      })
-      .safeParse("12")
+      }),
+      "12"
+    )
   ).toThrow();
 });

--- a/deno/lib/__tests__/set.test.ts
+++ b/deno/lib/__tests__/set.test.ts
@@ -20,7 +20,7 @@ test("type inference", () => {
 });
 
 test("valid parse", () => {
-  const result = stringSet.safeParse(new Set(["first", "second"]));
+  const result = z.safeParse(stringSet, new Set(["first", "second"]));
   expect(result.success).toEqual(true);
   if (result.success) {
     expect(result.data.has("first")).toEqual(true);
@@ -40,7 +40,7 @@ test("valid parse", () => {
 });
 
 test("valid parse async", async () => {
-  const result = await stringSet.spa(new Set(["first", "second"]));
+  const result = await z.spa(stringSet, new Set(["first", "second"]));
   expect(result.success).toEqual(true);
   if (result.success) {
     expect(result.data.has("first")).toEqual(true);
@@ -48,7 +48,10 @@ test("valid parse async", async () => {
     expect(result.data.has("third")).toEqual(false);
   }
 
-  const asyncResult = await stringSet.safeParse(new Set(["first", "second"]));
+  const asyncResult = await z.safeParse(
+    stringSet,
+    new Set(["first", "second"])
+  );
   expect(asyncResult.success).toEqual(true);
   if (asyncResult.success) {
     expect(asyncResult.data.has("first")).toEqual(true);
@@ -76,7 +79,7 @@ test("valid parse: size-related methods", () => {
 });
 
 test("failing when parsing empty set in nonempty ", () => {
-  const result = nonEmpty.safeParse(new Set());
+  const result = z.safeParse(nonEmpty, new Set());
   expect(result.success).toEqual(false);
 
   if (result.success === false) {
@@ -86,7 +89,7 @@ test("failing when parsing empty set in nonempty ", () => {
 });
 
 test("failing when set is smaller than min() ", () => {
-  const result = minTwo.safeParse(new Set(["just_one"]));
+  const result = z.safeParse(minTwo, new Set(["just_one"]));
   expect(result.success).toEqual(false);
 
   if (result.success === false) {
@@ -96,7 +99,7 @@ test("failing when set is smaller than min() ", () => {
 });
 
 test("failing when set is bigger than max() ", () => {
-  const result = maxTwo.safeParse(new Set(["one", "two", "three"]));
+  const result = z.safeParse(maxTwo, new Set(["one", "two", "three"]));
   expect(result.success).toEqual(false);
 
   if (result.success === false) {
@@ -106,12 +109,12 @@ test("failing when set is bigger than max() ", () => {
 });
 
 test("doesn’t throw when an empty set is given", () => {
-  const result = stringSet.safeParse(new Set([]));
+  const result = z.safeParse(stringSet, new Set([]));
   expect(result.success).toEqual(true);
 });
 
 test("throws when a Map is given", () => {
-  const result = stringSet.safeParse(new Map([]));
+  const result = z.safeParse(stringSet, new Map([]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(1);
@@ -120,7 +123,7 @@ test("throws when a Map is given", () => {
 });
 
 test("throws when the given set has invalid input", () => {
-  const result = stringSet.safeParse(new Set([Symbol()]));
+  const result = z.safeParse(stringSet, new Set([Symbol()]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(1);
@@ -130,7 +133,7 @@ test("throws when the given set has invalid input", () => {
 });
 
 test("throws when the given set has multiple invalid entries", () => {
-  const result = stringSet.safeParse(new Set([1, 2] as any[]) as Set<any>);
+  const result = z.safeParse(stringSet, new Set([1, 2] as any[]) as Set<any>);
 
   expect(result.success).toEqual(false);
   if (result.success === false) {

--- a/deno/lib/__tests__/transformer.test.ts
+++ b/deno/lib/__tests__/transformer.test.ts
@@ -45,9 +45,8 @@ test("transform ctx.addIssue with parse", () => {
 test("transform ctx.addIssue with parseAsync", async () => {
   const strs = ["foo", "bar"];
 
-  const result = await z
-    .string()
-    .transform(async (data, ctx) => {
+  const result = await z.safeParseAsync(
+    z.string().transform(async (data, ctx) => {
       const i = strs.indexOf(data);
       if (i === -1) {
         ctx.addIssue({
@@ -56,8 +55,9 @@ test("transform ctx.addIssue with parseAsync", async () => {
         });
       }
       return data.length;
-    })
-    .safeParseAsync("asdf");
+    }),
+    "asdf"
+  );
 
   expect(JSON.parse(JSON.stringify(result))).toEqual({
     success: false,
@@ -87,7 +87,7 @@ test("z.NEVER in transform", () => {
     });
   type foo = z.infer<typeof foo>;
   util.assertEqual<foo, number>(true);
-  const arg = foo.safeParse(undefined);
+  const arg = z.safeParse(foo, undefined);
   if (!arg.success) {
     expect(arg.error.issues[0].message).toEqual("bad");
   }
@@ -202,13 +202,13 @@ test("short circuit on dirty", () => {
     .string()
     .refine(() => false)
     .transform((val) => val.toUpperCase());
-  const result = schema.safeParse("asdf");
+  const result = z.safeParse(schema, "asdf");
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].code).toEqual(z.ZodIssueCode.custom);
   }
 
-  const result2 = schema.safeParse(1234);
+  const result2 = z.safeParse(schema, 1234);
   expect(result2.success).toEqual(false);
   if (!result2.success) {
     expect(result2.error.issues[0].code).toEqual(z.ZodIssueCode.invalid_type);
@@ -220,13 +220,13 @@ test("async short circuit on dirty", async () => {
     .string()
     .refine(() => false)
     .transform((val) => val.toUpperCase());
-  const result = await schema.spa("asdf");
+  const result = await z.spa(schema, "asdf");
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].code).toEqual(z.ZodIssueCode.custom);
   }
 
-  const result2 = await schema.spa(1234);
+  const result2 = await z.spa(schema, 1234);
   expect(result2.success).toEqual(false);
   if (!result2.success) {
     expect(result2.error.issues[0].code).toEqual(z.ZodIssueCode.invalid_type);

--- a/deno/lib/__tests__/tuple.test.ts
+++ b/deno/lib/__tests__/tuple.test.ts
@@ -46,7 +46,7 @@ test("failed validation", () => {
 });
 
 test("failed async validation", async () => {
-  const res = await testTuple.safeParse(badData);
+  const res = await z.safeParse(testTuple, badData);
   expect(res.success).toEqual(false);
   if (!res.success) {
     expect(res.error.issues.length).toEqual(3);

--- a/deno/lib/__tests__/type.test.ts
+++ b/deno/lib/__tests__/type.test.ts
@@ -1,0 +1,14 @@
+import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+const test = Deno.test;
+
+import * as z from "../index.ts";
+
+test("ZodType is covariant with the output", () => {
+  function f<S extends z.ZodType<string, any, any>>(_: S) {}
+  f(z.literal("a"));
+});
+
+test("ZodType is contravariant with the input", () => {
+  function f<S extends z.ZodType<any, any, "a">>(_: S) {}
+  f(z.string());
+});

--- a/deno/lib/__tests__/unions.test.ts
+++ b/deno/lib/__tests__/unions.test.ts
@@ -9,14 +9,15 @@ test("function parsing", () => {
     z.string().refine(() => false),
     z.number().refine(() => false),
   ]);
-  const result = schema.safeParse("asdf");
+  const result = z.safeParse(schema, "asdf");
   expect(result.success).toEqual(false);
 });
 
 test("union 2", () => {
-  const result = z
-    .union([z.number(), z.string().refine(() => false)])
-    .safeParse("a");
+  const result = z.safeParse(
+    z.union([z.number(), z.string().refine(() => false)]),
+    "a"
+  );
   expect(result.success).toEqual(false);
 });
 
@@ -34,9 +35,10 @@ test("return valid over invalid", () => {
 });
 
 test("return dirty result over aborted", () => {
-  const result = z
-    .union([z.number(), z.string().refine(() => false)])
-    .safeParse("a");
+  const result = z.safeParse(
+    z.union([z.number(), z.string().refine(() => false)]),
+    "a"
+  );
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues).toEqual([

--- a/deno/lib/helpers/partialUtil.ts
+++ b/deno/lib/helpers/partialUtil.ts
@@ -1,9 +1,9 @@
 import type {
+  AnyZodObject,
   ZodArray,
   ZodNullable,
   ZodObject,
   ZodOptional,
-  ZodRawShape,
   ZodTuple,
   ZodTupleItems,
   ZodTypeAny,
@@ -35,30 +35,29 @@ export namespace partialUtil {
   //   ? "object" // T extends ZodOptional<any> // ? 'optional' // :
   //   : "rest"];
 
-  export type DeepPartial<T extends ZodTypeAny> =
-    T extends ZodObject<ZodRawShape>
-      ? ZodObject<
-          { [k in keyof T["shape"]]: ZodOptional<DeepPartial<T["shape"][k]>> },
-          T["_def"]["unknownKeys"],
-          T["_def"]["catchall"]
-        >
-      : T extends ZodArray<infer Type, infer Card>
-      ? ZodArray<DeepPartial<Type>, Card>
-      : T extends ZodOptional<infer Type>
-      ? ZodOptional<DeepPartial<Type>>
-      : T extends ZodNullable<infer Type>
-      ? ZodNullable<DeepPartial<Type>>
-      : T extends ZodTuple<infer Items>
-      ? {
-          [k in keyof Items]: Items[k] extends ZodTypeAny
-            ? DeepPartial<Items[k]>
-            : never;
-        } extends infer PI
-        ? PI extends ZodTupleItems
-          ? ZodTuple<PI>
-          : never
+  export type DeepPartial<T extends ZodTypeAny> = T extends AnyZodObject
+    ? ZodObject<
+        { [k in keyof T["shape"]]: ZodOptional<DeepPartial<T["shape"][k]>> },
+        T["_def"]["unknownKeys"],
+        T["_def"]["catchall"]
+      >
+    : T extends ZodArray<infer Type, infer Card>
+    ? ZodArray<DeepPartial<Type>, Card>
+    : T extends ZodOptional<infer Type>
+    ? ZodOptional<DeepPartial<Type>>
+    : T extends ZodNullable<infer Type>
+    ? ZodNullable<DeepPartial<Type>>
+    : T extends ZodTuple<infer Items>
+    ? {
+        [k in keyof Items]: Items[k] extends ZodTypeAny
+          ? DeepPartial<Items[k]>
+          : never;
+      } extends infer PI
+      ? PI extends ZodTupleItems
+        ? ZodTuple<PI>
         : never
-      : T;
+      : never
+    : T;
   //  {
   //     // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
   //     // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -2839,7 +2839,7 @@ export class ZodObject<
   };
 }
 
-export type AnyZodObject = ZodObject<any, any, any>;
+export type AnyZodObject = ZodObject<any, any, any, any, never>;
 
 ////////////////////////////////////////
 ////////////////////////////////////////
@@ -3347,17 +3347,15 @@ export interface ZodTupleDef<
   typeName: ZodFirstPartyTypeKind.ZodTuple;
 }
 
-export type AnyZodTuple = ZodTuple<
-  [ZodTypeAny, ...ZodTypeAny[]] | [],
-  ZodTypeAny | null
->;
+export type AnyZodTuple = ZodTuple<[] | ZodTupleItems, any, any | never>;
 export class ZodTuple<
   T extends [ZodTypeAny, ...ZodTypeAny[]] | [] = [ZodTypeAny, ...ZodTypeAny[]],
-  Rest extends ZodTypeAny | null = null
+  Rest extends ZodTypeAny | null = null,
+  Input = InputTypeOfTupleWithRest<T, Rest>
 > extends ZodType<
   OutputTypeOfTupleWithRest<T, Rest>,
   ZodTupleDef<T, Rest>,
-  InputTypeOfTupleWithRest<T, Rest>
+  Input
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { status, ctx } = this._processInputParams(input);
@@ -3788,7 +3786,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
 ///////////////////////////////////////////
 ///////////////////////////////////////////
 export interface ZodFunctionDef<
-  Args extends ZodTuple<any, any> = ZodTuple<any, any>,
+  Args extends AnyZodTuple = AnyZodTuple,
   Returns extends ZodTypeAny = ZodTypeAny
 > extends ZodTypeDef {
   args: Args;
@@ -3797,21 +3795,21 @@ export interface ZodFunctionDef<
 }
 
 export type OuterTypeOfFunction<
-  Args extends ZodTuple<any, any>,
+  Args extends AnyZodTuple,
   Returns extends ZodTypeAny
 > = input<Args> extends Array<any>
   ? (...args: input<Args>) => Returns["_output"]
   : never;
 
 export type InnerTypeOfFunction<
-  Args extends ZodTuple<any, any>,
+  Args extends AnyZodTuple,
   Returns extends ZodTypeAny
 > = Args["_output"] extends Array<any>
   ? (...args: Args["_output"]) => input<Returns>
   : never;
 
 export class ZodFunction<
-  Args extends ZodTuple<any, any>,
+  Args extends AnyZodTuple,
   Returns extends ZodTypeAny
 > extends ZodType<
   OuterTypeOfFunction<Args, Returns>,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -5242,24 +5242,15 @@ export async function safeParseAsync<Output, Input>(
 /** Alias of safeParseAsync */
 export const spa = safeParseAsync;
 
-export function catch_<
-  Output,
-  Input,
-  Schema extends ZodType<Output, any, Input>
->(schema: Schema, def: Output): ZodCatch<Schema>;
-export function catch_<
-  Output,
-  Input,
-  Schema extends ZodType<Output, any, Input>
->(
+export function catch_<Schema extends ZodTypeAny>(
   schema: Schema,
-  def: (ctx: { error: ZodError; input: Input }) => Output
+  def: output<Schema>
 ): ZodCatch<Schema>;
-export function catch_<
-  Output,
-  Input,
-  Schema extends ZodType<Output, any, Input>
->(schema: Schema, def: any) {
+export function catch_<Schema extends ZodTypeAny>(
+  schema: Schema,
+  def: (ctx: { error: ZodError; input: input<Schema> }) => output<Schema>
+): ZodCatch<Schema>;
+export function catch_<Schema extends ZodTypeAny>(schema: Schema, def: any) {
   const catchValueFunc = typeof def === "function" ? def : () => def;
 
   return new ZodCatch({

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -46,10 +46,12 @@ export interface RefinementCtx {
   path: (string | number)[];
 }
 export type ZodRawShape = { [k: string]: ZodTypeAny };
-export type ZodTypeAny = ZodType<any, any, any>;
-export type TypeOf<T extends ZodType<any, any, any>> = T["_output"];
-export type input<T extends ZodType<any, any, any>> = T["_input"];
-export type output<T extends ZodType<any, any, any>> = T["_output"];
+export type ZodTypeAny = ZodType<any, any, any> | ZodType<any, any, never>;
+export type TypeOf<T extends ZodTypeAny> = T["_output"];
+export type input<T extends ZodTypeAny> = T extends ZodType<any, any, infer I>
+  ? I
+  : never;
+export type output<T extends ZodTypeAny> = T["_output"];
 export type { TypeOf as infer };
 
 export type CustomErrorParams = Partial<util.Omit<ZodCustomIssue, "code">>;
@@ -168,11 +170,11 @@ export type SafeParseReturnType<Input, Output> =
 export abstract class ZodType<
   Output = any,
   Def extends ZodTypeDef = ZodTypeDef,
-  Input = Output
+  /*in*/ Input = Output
 > {
   readonly _type!: Output;
   readonly _output!: Output;
-  readonly _input!: Input;
+  readonly _input!: (_: Input) => void;
   readonly _def!: Def;
 
   get description() {
@@ -236,67 +238,19 @@ export abstract class ZodType<
   }
 
   parse(data: unknown, params?: Partial<ParseParams>): Output {
-    const result = this.safeParse(data, params);
+    const result = safeParse(this, data, params);
     if (result.success) return result.data;
     throw result.error;
-  }
-
-  safeParse(
-    data: unknown,
-    params?: Partial<ParseParams>
-  ): SafeParseReturnType<Input, Output> {
-    const ctx: ParseContext = {
-      common: {
-        issues: [],
-        async: params?.async ?? false,
-        contextualErrorMap: params?.errorMap,
-      },
-      path: params?.path || [],
-      schemaErrorMap: this._def.errorMap,
-      parent: null,
-      data,
-      parsedType: getParsedType(data),
-    };
-    const result = this._parseSync({ data, path: ctx.path, parent: ctx });
-
-    return handleResult(ctx, result);
   }
 
   async parseAsync(
     data: unknown,
     params?: Partial<ParseParams>
   ): Promise<Output> {
-    const result = await this.safeParseAsync(data, params);
+    const result = await safeParseAsync(this, data, params);
     if (result.success) return result.data;
     throw result.error;
   }
-
-  async safeParseAsync(
-    data: unknown,
-    params?: Partial<ParseParams>
-  ): Promise<SafeParseReturnType<Input, Output>> {
-    const ctx: ParseContext = {
-      common: {
-        issues: [],
-        contextualErrorMap: params?.errorMap,
-        async: true,
-      },
-      path: params?.path || [],
-      schemaErrorMap: this._def.errorMap,
-      parent: null,
-      data,
-      parsedType: getParsedType(data),
-    };
-
-    const maybeAsyncResult = this._parse({ data, path: ctx.path, parent: ctx });
-    const result = await (isAsync(maybeAsyncResult)
-      ? maybeAsyncResult
-      : Promise.resolve(maybeAsyncResult));
-    return handleResult(ctx, result);
-  }
-
-  /** Alias of safeParseAsync */
-  spa = this.safeParseAsync;
 
   refine<RefinedOutput extends Output>(
     check: (arg: Output) => arg is RefinedOutput,
@@ -399,10 +353,7 @@ export abstract class ZodType<
   constructor(def: Def) {
     this._def = def;
     this.parse = this.parse.bind(this);
-    this.safeParse = this.safeParse.bind(this);
     this.parseAsync = this.parseAsync.bind(this);
-    this.safeParseAsync = this.safeParseAsync.bind(this);
-    this.spa = this.spa.bind(this);
     this.refine = this.refine.bind(this);
     this.refinement = this.refinement.bind(this);
     this.superRefine = this.superRefine.bind(this);
@@ -416,7 +367,6 @@ export abstract class ZodType<
     this.transform = this.transform.bind(this);
     this.brand = this.brand.bind(this);
     this.default = this.default.bind(this);
-    this.catch = this.catch.bind(this);
     this.describe = this.describe.bind(this);
     this.pipe = this.pipe.bind(this);
     this.readonly = this.readonly.bind(this);
@@ -450,7 +400,7 @@ export abstract class ZodType<
 
   transform<NewOut>(
     transform: (arg: Output, ctx: RefinementCtx) => NewOut | Promise<NewOut>
-  ): ZodEffects<this, NewOut> {
+  ): ZodEffects<this, NewOut, Input> {
     return new ZodEffects({
       ...processCreateParams(this._def),
       schema: this,
@@ -481,21 +431,6 @@ export abstract class ZodType<
     });
   }
 
-  catch(def: Output): ZodCatch<this>;
-  catch(
-    def: (ctx: { error: ZodError; input: Input }) => Output
-  ): ZodCatch<this>;
-  catch(def: any) {
-    const catchValueFunc = typeof def === "function" ? def : () => def;
-
-    return new ZodCatch({
-      ...processCreateParams(this._def),
-      innerType: this,
-      catchValue: catchValueFunc,
-      typeName: ZodFirstPartyTypeKind.ZodCatch,
-    }) as any;
-  }
-
   describe(description: string): this {
     const This = (this as any).constructor;
     return new This({
@@ -512,10 +447,10 @@ export abstract class ZodType<
   }
 
   isOptional(): boolean {
-    return this.safeParse(undefined).success;
+    return safeParse(this, undefined).success;
   }
   isNullable(): boolean {
-    return this.safeParse(null).success;
+    return safeParse(this, null).success;
   }
 }
 
@@ -2167,9 +2102,7 @@ export class ZodArray<
 > extends ZodType<
   arrayOutputType<T, Cardinality>,
   ZodArrayDef<T>,
-  Cardinality extends "atleastone"
-    ? [T["_input"], ...T["_input"][]]
-    : T["_input"][]
+  Cardinality extends "atleastone" ? [input<T>, ...input<T>[]] : input<T>[]
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { ctx, status } = this._processInputParams(input);
@@ -2349,16 +2282,16 @@ export type objectInputType<
   PassthroughType<UnknownKeys>;
 export type baseObjectInputType<Shape extends ZodRawShape> =
   objectUtil.addQuestionMarks<{
-    [k in keyof Shape]: Shape[k]["_input"];
+    [k in keyof Shape]: input<Shape[k]>;
   }>;
 
-export type CatchallOutput<T extends ZodType> = ZodType extends T
+export type CatchallOutput<T extends ZodTypeAny> = ZodType extends T
   ? unknown
   : { [k: string]: T["_output"] };
 
-export type CatchallInput<T extends ZodType> = ZodType extends T
+export type CatchallInput<T extends ZodTypeAny> = ZodType extends T
   ? unknown
-  : { [k: string]: T["_input"] };
+  : { [k: string]: input<T> };
 
 export type PassthroughType<T extends UnknownKeysParam> =
   T extends "passthrough" ? { [k: string]: unknown } : unknown;
@@ -2619,7 +2552,7 @@ export class ZodObject<
   //   }>,
   //   NewInput extends util.flatten<{
   //     [k in keyof Augmentation | keyof Input]: k extends keyof Augmentation
-  //       ? Augmentation[k]["_input"]
+  //       ? input<Augmentation[k]>
   //       : k extends keyof Input
   //       ? Input[k]
   //       : never;
@@ -2681,7 +2614,7 @@ export class ZodObject<
   //   },
   //   NewInput extends {
   //     [k in keyof Augmentation | keyof Input]: k extends keyof Augmentation
-  //       ? Augmentation[k]["_input"]
+  //       ? input<Augmentation[k]>
   //       : k extends keyof Input
   //       ? Input[k]
   //       : never;
@@ -2928,7 +2861,7 @@ export interface ZodUnionDef<
 export class ZodUnion<T extends ZodUnionOptions> extends ZodType<
   T[number]["_output"],
   ZodUnionDef<T>,
-  T[number]["_input"]
+  input<T[number]>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { ctx } = this._processInputParams(input);
@@ -3092,14 +3025,16 @@ const getDiscriminator = <T extends ZodTypeAny>(type: T): Primitive[] => {
 
 export type ZodDiscriminatedUnionOption<Discriminator extends string> =
   ZodObject<
-    { [key in Discriminator]: ZodTypeAny } & ZodRawShape,
+    { [key in Discriminator]: ZodTypeAny },
     UnknownKeysParam,
-    ZodTypeAny
+    ZodTypeAny,
+    any,
+    never
   >;
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<string>[] = ZodDiscriminatedUnionOption<string>[]
+  Options extends ZodDiscriminatedUnionOption<Discriminator>[] = ZodDiscriminatedUnionOption<Discriminator>[]
 > extends ZodTypeDef {
   discriminator: Discriminator;
   options: Options;
@@ -3220,7 +3155,7 @@ export class ZodDiscriminatedUnion<
       typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion,
       discriminator,
       options,
-      optionsMap,
+      optionsMap: optionsMap as any,
       ...processCreateParams(params),
     });
   }
@@ -3303,7 +3238,7 @@ export class ZodIntersection<
 > extends ZodType<
   T["_output"] & U["_output"],
   ZodIntersectionDef<T, U>,
-  T["_input"] & U["_input"]
+  input<T> & input<U>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { status, ctx } = this._processInputParams(input);
@@ -3384,7 +3319,7 @@ export class ZodIntersection<
 export type ZodTupleItems = [ZodTypeAny, ...ZodTypeAny[]];
 export type AssertArray<T> = T extends any[] ? T : never;
 export type OutputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<{
-  [k in keyof T]: T[k] extends ZodType<any, any, any> ? T[k]["_output"] : never;
+  [k in keyof T]: T[k] extends ZodTypeAny ? T[k]["_output"] : never;
 }>;
 export type OutputTypeOfTupleWithRest<
   T extends ZodTupleItems | [],
@@ -3394,13 +3329,13 @@ export type OutputTypeOfTupleWithRest<
   : OutputTypeOfTuple<T>;
 
 export type InputTypeOfTuple<T extends ZodTupleItems | []> = AssertArray<{
-  [k in keyof T]: T[k] extends ZodType<any, any, any> ? T[k]["_input"] : never;
+  [k in keyof T]: T[k] extends ZodTypeAny ? input<T[k]> : never;
 }>;
 export type InputTypeOfTupleWithRest<
   T extends ZodTupleItems | [],
   Rest extends ZodTypeAny | null = null
 > = Rest extends ZodTypeAny
-  ? [...InputTypeOfTuple<T>, ...Rest["_input"][]]
+  ? [...InputTypeOfTuple<T>, ...input<Rest>[]]
   : InputTypeOfTuple<T>;
 
 export interface ZodTupleDef<
@@ -3540,7 +3475,7 @@ export class ZodRecord<
 > extends ZodType<
   RecordType<Key["_output"], Value["_output"]>,
   ZodRecordDef<Key, Value>,
-  RecordType<Key["_input"], Value["_input"]>
+  RecordType<input<Key>, input<Value>>
 > {
   get keySchema() {
     return this._def.keyType;
@@ -3639,7 +3574,7 @@ export class ZodMap<
 > extends ZodType<
   Map<Key["_output"], Value["_output"]>,
   ZodMapDef<Key, Value>,
-  Map<Key["_input"], Value["_input"]>
+  Map<input<Key>, input<Value>>
 > {
   get keySchema() {
     return this._def.keyType;
@@ -3743,7 +3678,7 @@ export interface ZodSetDef<Value extends ZodTypeAny = ZodTypeAny>
 export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
   Set<Value["_output"]>,
   ZodSetDef<Value>,
-  Set<Value["_input"]>
+  Set<input<Value>>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { status, ctx } = this._processInputParams(input);
@@ -3864,15 +3799,15 @@ export interface ZodFunctionDef<
 export type OuterTypeOfFunction<
   Args extends ZodTuple<any, any>,
   Returns extends ZodTypeAny
-> = Args["_input"] extends Array<any>
-  ? (...args: Args["_input"]) => Returns["_output"]
+> = input<Args> extends Array<any>
+  ? (...args: input<Args>) => Returns["_output"]
   : never;
 
 export type InnerTypeOfFunction<
   Args extends ZodTuple<any, any>,
   Returns extends ZodTypeAny
 > = Args["_output"] extends Array<any>
-  ? (...args: Args["_output"]) => Returns["_input"]
+  ? (...args: Args["_output"]) => input<Returns>
   : never;
 
 export class ZodFunction<
@@ -3961,12 +3896,12 @@ export class ZodFunction<
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const me = this;
       return OK(function (this: any, ...args: any[]) {
-        const parsedArgs = me._def.args.safeParse(args, params);
+        const parsedArgs = safeParse(me._def.args, args, params);
         if (!parsedArgs.success) {
           throw new ZodError([makeArgsIssue(args, parsedArgs.error)]);
         }
         const result = Reflect.apply(fn, this, parsedArgs.data);
-        const parsedReturns = me._def.returns.safeParse(result, params);
+        const parsedReturns = safeParse(me._def.returns, result, params);
         if (!parsedReturns.success) {
           throw new ZodError([makeReturnsIssue(result, parsedReturns.error)]);
         }
@@ -3992,7 +3927,7 @@ export class ZodFunction<
     });
   }
 
-  returns<NewReturnType extends ZodType<any, any, any>>(
+  returns<NewReturnType extends ZodTypeAny>(
     returnType: NewReturnType
   ): ZodFunction<Args, NewReturnType> {
     return new ZodFunction({
@@ -4004,7 +3939,7 @@ export class ZodFunction<
   implement<F extends InnerTypeOfFunction<Args, Returns>>(
     func: F
   ): ReturnType<F> extends Returns["_output"]
-    ? (...args: Args["_input"]) => ReturnType<F>
+    ? (...args: input<Args>) => ReturnType<F>
     : OuterTypeOfFunction<Args, Returns> {
     const validatedFunc = this.parse(func);
     return validatedFunc as any;
@@ -4365,7 +4300,7 @@ export interface ZodPromiseDef<T extends ZodTypeAny = ZodTypeAny>
 export class ZodPromise<T extends ZodTypeAny> extends ZodType<
   Promise<T["_output"]>,
   ZodPromiseDef<T>,
-  Promise<T["_input"]>
+  Promise<input<T>>
 > {
   unwrap() {
     return this._def.type;
@@ -4637,7 +4572,7 @@ export type ZodOptionalType<T extends ZodTypeAny> = ZodOptional<T>;
 export class ZodOptional<T extends ZodTypeAny> extends ZodType<
   T["_output"] | undefined,
   ZodOptionalDef<T>,
-  T["_input"] | undefined
+  input<T> | undefined
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const parsedType = this._getType(input);
@@ -4681,7 +4616,7 @@ export type ZodNullableType<T extends ZodTypeAny> = ZodNullable<T>;
 export class ZodNullable<T extends ZodTypeAny> extends ZodType<
   T["_output"] | null,
   ZodNullableDef<T>,
-  T["_input"] | null
+  input<T> | null
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const parsedType = this._getType(input);
@@ -4717,14 +4652,14 @@ export class ZodNullable<T extends ZodTypeAny> extends ZodType<
 export interface ZodDefaultDef<T extends ZodTypeAny = ZodTypeAny>
   extends ZodTypeDef {
   innerType: T;
-  defaultValue: () => util.noUndefined<T["_input"]>;
+  defaultValue: () => util.noUndefined<input<T>>;
   typeName: ZodFirstPartyTypeKind.ZodDefault;
 }
 
 export class ZodDefault<T extends ZodTypeAny> extends ZodType<
   util.noUndefined<T["_output"]>,
   ZodDefaultDef<T>,
-  T["_input"] | undefined
+  input<T> | undefined
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { ctx } = this._processInputParams(input);
@@ -4746,7 +4681,7 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
   static create = <T extends ZodTypeAny>(
     type: T,
     params: RawCreateParams & {
-      default: T["_input"] | (() => util.noUndefined<T["_input"]>);
+      default: input<T> | (() => util.noUndefined<input<T>>);
     }
   ): ZodDefault<T> => {
     return new ZodDefault({
@@ -4754,7 +4689,7 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
       typeName: ZodFirstPartyTypeKind.ZodDefault,
       defaultValue:
         typeof params.default === "function"
-          ? params.default
+          ? (params.default as any)
           : () => params.default as any,
       ...processCreateParams(params),
     }) as any;
@@ -4771,14 +4706,14 @@ export class ZodDefault<T extends ZodTypeAny> extends ZodType<
 export interface ZodCatchDef<T extends ZodTypeAny = ZodTypeAny>
   extends ZodTypeDef {
   innerType: T;
-  catchValue: (ctx: { error: ZodError; input: unknown }) => T["_input"];
+  catchValue: (ctx: { error: ZodError; input: unknown }) => input<T>;
   typeName: ZodFirstPartyTypeKind.ZodCatch;
 }
 
 export class ZodCatch<T extends ZodTypeAny> extends ZodType<
   T["_output"],
   ZodCatchDef<T>,
-  unknown // any input will pass validation // T["_input"]
+  unknown // any input will pass validation // input<T>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { ctx } = this._processInputParams(input);
@@ -4845,7 +4780,9 @@ export class ZodCatch<T extends ZodTypeAny> extends ZodType<
       innerType: type,
       typeName: ZodFirstPartyTypeKind.ZodCatch,
       catchValue:
-        typeof params.catch === "function" ? params.catch : () => params.catch,
+        typeof params.catch === "function"
+          ? (params.catch as any)
+          : () => params.catch,
       ...processCreateParams(params),
     });
   };
@@ -4908,7 +4845,7 @@ export type BRAND<T extends string | number | symbol> = {
 export class ZodBranded<
   T extends ZodTypeAny,
   B extends string | number | symbol
-> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, T["_input"]> {
+> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, input<T>> {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { ctx } = this._processInputParams(input);
     const data = ctx.data;
@@ -4942,7 +4879,7 @@ export interface ZodPipelineDef<A extends ZodTypeAny, B extends ZodTypeAny>
 export class ZodPipeline<
   A extends ZodTypeAny,
   B extends ZodTypeAny
-> extends ZodType<B["_output"], ZodPipelineDef<A, B>, A["_input"]> {
+> extends ZodType<B["_output"], ZodPipelineDef<A, B>, input<A>> {
   _parse(input: ParseInput): ParseReturnType<any> {
     const { status, ctx } = this._processInputParams(input);
     if (ctx.common.async) {
@@ -5037,7 +4974,7 @@ export interface ZodReadonlyDef<T extends ZodTypeAny = ZodTypeAny>
 export class ZodReadonly<T extends ZodTypeAny> extends ZodType<
   MakeReadonly<T["_output"]>,
   ZodReadonlyDef<T>,
-  MakeReadonly<T["_input"]>
+  MakeReadonly<input<T>>
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const result = this._def.innerType._parse(input);
@@ -5178,7 +5115,7 @@ export type ZodFirstPartySchemaTypes =
   | ZodLazy<any>
   | ZodLiteral<any>
   | ZodEnum<any>
-  | ZodEffects<any, any, any>
+  | ZodEffects<any, any, never>
   | ZodNativeEnum<any>
   | ZodOptional<any>
   | ZodNullable<any>
@@ -5255,6 +5192,83 @@ export const coerce = {
   date: ((arg) =>
     ZodDate.create({ ...arg, coerce: true })) as (typeof ZodDate)["create"],
 };
+
+export function safeParse<Output, Input>(
+  schema: ZodType<Output, any, Input>,
+  data: unknown,
+  params?: Partial<ParseParams>
+): SafeParseReturnType<Input, Output> {
+  const ctx: ParseContext = {
+    common: {
+      issues: [],
+      async: params?.async ?? false,
+      contextualErrorMap: params?.errorMap,
+    },
+    path: params?.path || [],
+    schemaErrorMap: schema._def.errorMap,
+    parent: null,
+    data,
+    parsedType: getParsedType(data),
+  };
+  const result = schema._parseSync({ data, path: ctx.path, parent: ctx });
+
+  return handleResult(ctx, result);
+}
+
+export async function safeParseAsync<Output, Input>(
+  schema: ZodType<Output, any, Input>,
+  data: unknown,
+  params?: Partial<ParseParams>
+): Promise<SafeParseReturnType<Input, Output>> {
+  const ctx: ParseContext = {
+    common: {
+      issues: [],
+      contextualErrorMap: params?.errorMap,
+      async: true,
+    },
+    path: params?.path || [],
+    schemaErrorMap: schema._def.errorMap,
+    parent: null,
+    data,
+    parsedType: getParsedType(data),
+  };
+  const maybeAsyncResult = schema._parse({ data, path: ctx.path, parent: ctx });
+  const result = await (isAsync(maybeAsyncResult)
+    ? maybeAsyncResult
+    : Promise.resolve(maybeAsyncResult));
+  return handleResult(ctx, result);
+}
+
+/** Alias of safeParseAsync */
+export const spa = safeParseAsync;
+
+export function catch_<
+  Output,
+  Input,
+  Schema extends ZodType<Output, any, Input>
+>(schema: Schema, def: Output): ZodCatch<Schema>;
+export function catch_<
+  Output,
+  Input,
+  Schema extends ZodType<Output, any, Input>
+>(
+  schema: Schema,
+  def: (ctx: { error: ZodError; input: Input }) => Output
+): ZodCatch<Schema>;
+export function catch_<
+  Output,
+  Input,
+  Schema extends ZodType<Output, any, Input>
+>(schema: Schema, def: any) {
+  const catchValueFunc = typeof def === "function" ? def : () => def;
+
+  return new ZodCatch({
+    ...processCreateParams(schema._def),
+    innerType: schema,
+    catchValue: catchValueFunc,
+    typeName: ZodFirstPartyTypeKind.ZodCatch,
+  }) as any;
+}
 
 export {
   anyType as any,

--- a/src/__tests__/all-errors.test.ts
+++ b/src/__tests__/all-errors.test.ts
@@ -59,7 +59,7 @@ test("form errors type inference", () => {
 });
 
 test(".flatten() type assertion", () => {
-  const parsed = Test.safeParse({}) as z.SafeParseError<void>;
+  const parsed = z.safeParse(Test, {}) as z.SafeParseError<void>;
   const validFlattenedErrors: TestFlattenedErrors = parsed.error.flatten(
     () => ({ message: "", code: 0 })
   );
@@ -81,7 +81,7 @@ test(".flatten() type assertion", () => {
 });
 
 test(".formErrors type assertion", () => {
-  const parsed = Test.safeParse({}) as z.SafeParseError<void>;
+  const parsed = z.safeParse(Test, {}) as z.SafeParseError<void>;
   const validFormErrors: TestFormErrors = parsed.error.formErrors;
   // @ts-expect-error should fail assertion between `TestFlattenedErrors` and `.formErrors`.
   const invalidFlattenedErrors: TestFlattenedErrors = parsed.error.formErrors;

--- a/src/__tests__/array.test.ts
+++ b/src/__tests__/array.test.ts
@@ -55,7 +55,7 @@ test("continue parsing despite array size error", () => {
     people: z.string().array().min(2),
   });
 
-  const result = schema.safeParse({
+  const result = z.safeParse(schema, {
     people: [123],
   });
   expect(result.success).toEqual(false);

--- a/src/__tests__/async-parsing.test.ts
+++ b/src/__tests__/async-parsing.test.ts
@@ -10,11 +10,11 @@ test("string async parse", async () => {
   const goodData = "XXX";
   const badData = 12;
 
-  const goodResult = await stringSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(stringSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await stringSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(stringSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -25,11 +25,11 @@ test("number async parse", async () => {
   const goodData = 1234.2353;
   const badData = "1234";
 
-  const goodResult = await numberSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(numberSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await numberSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(numberSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -40,11 +40,11 @@ test("bigInt async parse", async () => {
   const goodData = BigInt(145);
   const badData = 134;
 
-  const goodResult = await bigIntSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(bigIntSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await bigIntSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(bigIntSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -55,11 +55,11 @@ test("boolean async parse", async () => {
   const goodData = true;
   const badData = 1;
 
-  const goodResult = await booleanSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(booleanSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await booleanSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(booleanSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -70,11 +70,11 @@ test("date async parse", async () => {
   const goodData = new Date();
   const badData = new Date().toISOString();
 
-  const goodResult = await dateSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(dateSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await dateSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(dateSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -85,11 +85,11 @@ test("undefined async parse", async () => {
   const goodData = undefined;
   const badData = "XXX";
 
-  const goodResult = await undefinedSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(undefinedSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(undefined);
 
-  const badResult = await undefinedSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(undefinedSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -100,11 +100,11 @@ test("null async parse", async () => {
   const goodData = null;
   const badData = undefined;
 
-  const goodResult = await nullSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(nullSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await nullSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(nullSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -115,11 +115,11 @@ test("any async parse", async () => {
   const goodData = [{}];
   // const badData = 'XXX';
 
-  const goodResult = await anySchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(anySchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  // const badResult = await anySchema.safeParseAsync(badData);
+  // const badResult = await z.safeParseAsync(anySchema, badData);
   // expect(badResult.success).toBe(false);
   // if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -130,11 +130,11 @@ test("unknown async parse", async () => {
   const goodData = ["asdf", 124, () => {}];
   // const badData = 'XXX';
 
-  const goodResult = await unknownSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(unknownSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  // const badResult = await unknownSchema.safeParseAsync(badData);
+  // const badResult = await z.safeParseAsync(unknownSchema, badData);
   // expect(badResult.success).toBe(false);
   // if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -145,11 +145,11 @@ test("void async parse", async () => {
   const goodData = undefined;
   const badData = 0;
 
-  const goodResult = await voidSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(voidSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await voidSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(voidSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -160,11 +160,11 @@ test("array async parse", async () => {
   const goodData = ["XXX"];
   const badData = "XXX";
 
-  const goodResult = await arraySchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(arraySchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await arraySchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(arraySchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -175,11 +175,11 @@ test("object async parse", async () => {
   const goodData = { string: "XXX" };
   const badData = { string: 12 };
 
-  const goodResult = await objectSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(objectSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await objectSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(objectSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -190,11 +190,11 @@ test("union async parse", async () => {
   const goodData = undefined;
   const badData = null;
 
-  const goodResult = await unionSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(unionSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await unionSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(unionSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -205,11 +205,11 @@ test("record async parse", async () => {
   const goodData = { adsf: {}, asdf: {} };
   const badData = [{}];
 
-  const goodResult = await recordSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(recordSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await recordSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(recordSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -220,11 +220,11 @@ test("function async parse", async () => {
   const goodData = () => {};
   const badData = "XXX";
 
-  const goodResult = await functionSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(functionSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(typeof goodResult.data).toEqual("function");
 
-  const badResult = await functionSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(functionSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -235,11 +235,11 @@ test("literal async parse", async () => {
   const goodData = "asdf";
   const badData = "asdff";
 
-  const goodResult = await literalSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(literalSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await literalSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(literalSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -250,11 +250,11 @@ test("enum async parse", async () => {
   const goodData = "whale";
   const badData = "leopard";
 
-  const goodResult = await enumSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(enumSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await enumSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(enumSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -269,11 +269,11 @@ test("nativeEnum async parse", async () => {
   const goodData = nativeEnumTest.asdf;
   const badData = "asdf";
 
-  const goodResult = await nativeEnumSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(nativeEnumSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) expect(goodResult.data).toEqual(goodData);
 
-  const badResult = await nativeEnumSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(nativeEnumSchema, badData);
   expect(badResult.success).toBe(false);
   if (!badResult.success) expect(badResult.error).toBeInstanceOf(z.ZodError);
 });
@@ -283,7 +283,7 @@ const promiseSchema = z.promise(z.number());
 test("promise async parse good", async () => {
   const goodData = Promise.resolve(123);
 
-  const goodResult = await promiseSchema.safeParseAsync(goodData);
+  const goodResult = await z.safeParseAsync(promiseSchema, goodData);
   expect(goodResult.success).toBe(true);
   if (goodResult.success) {
     expect(goodResult.data).toBeInstanceOf(Promise);
@@ -298,7 +298,7 @@ test("promise async parse good", async () => {
 
 test("promise async parse bad", async () => {
   const badData = Promise.resolve("XXX");
-  const badResult = await promiseSchema.safeParseAsync(badData);
+  const badResult = await z.safeParseAsync(promiseSchema, badData);
   expect(badResult.success).toBe(true);
   if (badResult.success) {
     await expect(badResult.data).rejects.toBeInstanceOf(z.ZodError);
@@ -314,8 +314,8 @@ test("async validation non-empty strings", async () => {
   });
 
   const testval = { hello: "", foo: "" };
-  const result1 = base.safeParse(testval);
-  const result2 = base.safeParseAsync(testval);
+  const result1 = z.safeParse(base, testval);
+  const result2 = z.safeParseAsync(base, testval);
 
   const r1 = result1;
   await result2.then((r2) => {
@@ -331,8 +331,8 @@ test("async validation multiple errors 1", async () => {
   });
 
   const testval = { hello: 3, foo: "hello" };
-  const result1 = base.safeParse(testval);
-  const result2 = base.safeParseAsync(testval);
+  const result1 = z.safeParse(base, testval);
+  const result2 = z.safeParseAsync(base, testval);
 
   const r1 = result1;
   await result2.then((r2) => {
@@ -351,8 +351,8 @@ test("async validation multiple errors 2", async () => {
     });
 
   const testval = { hello: 3, foo: { bar: 4 } };
-  const result1 = base().safeParse(testval);
-  const result2 = base(true).safeParseAsync(testval);
+  const result1 = z.safeParse(base(), testval);
+  const result2 = z.safeParseAsync(base(true), testval);
 
   const r1 = result1;
   await result2.then((r2) => {
@@ -378,7 +378,7 @@ test("ensure early async failure prevents follow-up refinement checks", async ()
   });
 
   const testval = { hello: "bye", foo: 3 };
-  const result = await base.safeParseAsync(testval);
+  const result = await z.safeParseAsync(base, testval);
   if (result.success === false) {
     expect(result.error.issues.length).toBe(1);
     expect(count).toBe(1);

--- a/src/__tests__/base.test.ts
+++ b/src/__tests__/base.test.ts
@@ -13,7 +13,7 @@ test("type guard", () => {
   type t1 = z.input<typeof s1>;
 
   const data = { stringToNumber: "asdf" };
-  const parsed = s1.safeParse(data);
+  const parsed = z.safeParse(s1, data);
   if (parsed.success) {
     util.assertEqual<typeof data, t1>(true);
   }
@@ -24,6 +24,10 @@ test("test this binding", () => {
     return predicate("hello");
   };
 
-  expect(callback((value) => z.string().safeParse(value).success)).toBe(true); // true
-  expect(callback((value) => z.string().safeParse(value).success)).toBe(true); // true
+  expect(callback((value) => z.safeParse(z.string(), value).success)).toBe(
+    true
+  ); // true
+  expect(callback((value) => z.safeParse(z.string(), value).success)).toBe(
+    true
+  ); // true
 });

--- a/src/__tests__/custom.test.ts
+++ b/src/__tests__/custom.test.ts
@@ -11,7 +11,7 @@ test("passing validations", () => {
 
 test("string params", () => {
   const example1 = z.custom<number>((x) => typeof x !== "number", "customerr");
-  const result = example1.safeParse(1234);
+  const result = z.safeParse(example1, 1234);
   expect(result.success).toEqual(false);
   // @ts-ignore
   expect(JSON.stringify(result.error).includes("customerr")).toEqual(true);

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -32,9 +32,10 @@ test("readonly enum", () => {
 });
 
 test("error params", () => {
-  const result = z
-    .enum(["test"], { required_error: "REQUIRED" })
-    .safeParse(undefined);
+  const result = z.safeParse(
+    z.enum(["test"], { required_error: "REQUIRED" }),
+    undefined
+  );
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("REQUIRED");
@@ -64,8 +65,8 @@ test("error map in extract/exclude", () => {
     errorMap: () => ({ message: "This is not food!" }),
   });
   const ItalianEnum = FoodEnum.extract(["Pasta", "Pizza"]);
-  const foodsError = FoodEnum.safeParse("Cucumbers");
-  const italianError = ItalianEnum.safeParse("Tacos");
+  const foodsError = z.safeParse(FoodEnum, "Cucumbers");
+  const italianError = z.safeParse(ItalianEnum, "Tacos");
   if (!foodsError.success && !italianError.success) {
     expect(foodsError.error.issues[0].message).toEqual(
       italianError.error.issues[0].message
@@ -75,7 +76,7 @@ test("error map in extract/exclude", () => {
   const UnhealthyEnum = FoodEnum.exclude(["Salad"], {
     errorMap: () => ({ message: "This is not healthy food!" }),
   });
-  const unhealthyError = UnhealthyEnum.safeParse("Salad");
+  const unhealthyError = z.safeParse(UnhealthyEnum, "Salad");
   if (!unhealthyError.success) {
     expect(unhealthyError.error.issues[0].message).toEqual(
       "This is not healthy food!"

--- a/src/__tests__/generics.test.ts
+++ b/src/__tests__/generics.test.ts
@@ -47,5 +47,5 @@ test("nested no undefined", () => {
   const outer = z.object({ inner });
   type outerSchema = z.infer<typeof outer>;
   z.util.assertEqual<outerSchema, { inner: string | string[] }>(true);
-  expect(outer.safeParse({ inner: undefined }).success).toEqual(false);
+  expect(z.safeParse(outer, { inner: undefined }).success).toEqual(false);
 });

--- a/src/__tests__/instanceof.test.ts
+++ b/src/__tests__/instanceof.test.ts
@@ -36,6 +36,6 @@ test("instanceof", async () => {
 
 test("instanceof fatal", () => {
   const schema = z.instanceof(Date).refine((d) => d.toString());
-  const res = schema.safeParse(null);
+  const res = z.safeParse(schema, null);
   expect(res.success).toBe(false);
 });

--- a/src/__tests__/intersection.test.ts
+++ b/src/__tests__/intersection.test.ts
@@ -77,7 +77,7 @@ test("invalid intersection types", async () => {
     z.number().transform((x) => x + 1)
   );
 
-  const syncResult = numberIntersection.safeParse(1234);
+  const syncResult = z.safeParse(numberIntersection, 1234);
   expect(syncResult.success).toEqual(false);
   if (!syncResult.success) {
     expect(syncResult.error.issues[0].code).toEqual(
@@ -85,7 +85,7 @@ test("invalid intersection types", async () => {
     );
   }
 
-  const asyncResult = await numberIntersection.spa(1234);
+  const asyncResult = await z.spa(numberIntersection, 1234);
   expect(asyncResult.success).toEqual(false);
   if (!asyncResult.success) {
     expect(asyncResult.error.issues[0].code).toEqual(
@@ -102,7 +102,7 @@ test("invalid array merge", async () => {
       .array()
       .transform((val) => [...val, "asdf"])
   );
-  const syncResult = stringArrInt.safeParse(["asdf", "qwer"]);
+  const syncResult = z.safeParse(stringArrInt, ["asdf", "qwer"]);
   expect(syncResult.success).toEqual(false);
   if (!syncResult.success) {
     expect(syncResult.error.issues[0].code).toEqual(
@@ -110,7 +110,7 @@ test("invalid array merge", async () => {
     );
   }
 
-  const asyncResult = await stringArrInt.spa(["asdf", "qwer"]);
+  const asyncResult = await z.spa(stringArrInt, ["asdf", "qwer"]);
   expect(asyncResult.success).toEqual(false);
   if (!asyncResult.success) {
     expect(asyncResult.error.issues[0].code).toEqual(

--- a/src/__tests__/literal.test.ts
+++ b/src/__tests__/literal.test.ts
@@ -26,7 +26,7 @@ test("failing validations", () => {
 
 test("invalid_literal should have `received` field with data", () => {
   const data = "shark";
-  const result = literalTuna.safeParse(data);
+  const result = z.safeParse(literalTuna, data);
   if (!result.success) {
     const issue = result.error.issues[0];
     if (issue.code === "invalid_literal") {

--- a/src/__tests__/map.test.ts
+++ b/src/__tests__/map.test.ts
@@ -13,7 +13,8 @@ test("type inference", () => {
 });
 
 test("valid parse", () => {
-  const result = stringMap.safeParse(
+  const result = z.safeParse(
+    stringMap,
     new Map([
       ["first", "foo"],
       ["second", "bar"],
@@ -29,7 +30,8 @@ test("valid parse", () => {
 });
 
 test("valid parse async", async () => {
-  const result = await stringMap.spa(
+  const result = await z.spa(
+    stringMap,
     new Map([
       ["first", "foo"],
       ["second", "bar"],
@@ -45,7 +47,7 @@ test("valid parse async", async () => {
 });
 
 test("throws when a Set is given", () => {
-  const result = stringMap.safeParse(new Set([]));
+  const result = z.safeParse(stringMap, new Set([]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(1);
@@ -54,7 +56,7 @@ test("throws when a Set is given", () => {
 });
 
 test("throws when the given map has invalid key and invalid input", () => {
-  const result = stringMap.safeParse(new Map([[42, Symbol()]]));
+  const result = z.safeParse(stringMap, new Map([[42, Symbol()]]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(2);
@@ -66,16 +68,17 @@ test("throws when the given map has invalid key and invalid input", () => {
 });
 
 test("throws when the given map has multiple invalid entries", () => {
-  // const result = stringMap.safeParse(new Map([[42, Symbol()]]));
+  // const result = z.safeParse(stringMap, new Map([[42, Symbol()]]));
 
-  const result = stringMap.safeParse(
+  const result = z.safeParse(
+    stringMap,
     new Map([
       [1, "foo"],
       ["bar", 2],
     ] as [any, any][]) as Map<any, any>
   );
 
-  // const result = stringMap.safeParse(new Map([[42, Symbol()]]));
+  // const result = z.safeParse(stringMap, new Map([[42, Symbol()]]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(2);
@@ -93,7 +96,8 @@ test("dirty", async () => {
     }),
     z.string()
   );
-  const result = await map.spa(
+  const result = await z.spa(
+    map,
     new Map([
       ["first", "foo"],
       ["second", "bar"],

--- a/src/__tests__/object-in-es5-env.test.ts
+++ b/src/__tests__/object-in-es5-env.test.ts
@@ -9,21 +9,21 @@ const RealDate = Date;
 
 test("doesn’t throw when Date is undefined", () => {
   delete (globalThis as any).Date;
-  const result = z.object({}).safeParse({});
+  const result = z.safeParse(z.object({}), {});
   expect(result.success).toEqual(true);
   globalThis.Date = RealDate;
 });
 
 test("doesn’t throw when Set is undefined", () => {
   delete (globalThis as any).Set;
-  const result = z.object({}).safeParse({});
+  const result = z.safeParse(z.object({}), {});
   expect(result.success).toEqual(true);
   globalThis.Set = RealSet;
 });
 
 test("doesn’t throw when Map is undefined", () => {
   delete (globalThis as any).Map;
-  const result = z.object({}).safeParse({});
+  const result = z.safeParse(z.object({}), {});
   expect(result.success).toEqual(true);
   globalThis.Map = RealMap;
 });

--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -109,7 +109,7 @@ test("strip unknown", () => {
 });
 
 test("strict", () => {
-  const val = z.object({ points: z.number() }).strict().safeParse(data);
+  const val = z.safeParse(z.object({ points: z.number() }).strict(), data);
 
   expect(val.success).toEqual(false);
 });
@@ -184,10 +184,10 @@ test("test catchall parsing", async () => {
 
   expect(result).toEqual({ name: "Foo", validExtraKey: 61 });
 
-  const result2 = z
-    .object({ name: z.string() })
-    .catchall(z.number())
-    .safeParse({ name: "Foo", validExtraKey: 61, invalid: "asdf" });
+  const result2 = z.safeParse(
+    z.object({ name: z.string() }).catchall(z.number()),
+    { name: "Foo", validExtraKey: 61, invalid: "asdf" }
+  );
 
   expect(result2.success).toEqual(false);
 });
@@ -198,7 +198,7 @@ test("test nonexistent keys", async () => {
     z.object({ b: z.number() }),
   ]);
   const obj = { a: "A" };
-  const result = await Schema.spa(obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
+  const result = await z.spa(Schema, obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
   expect(result.success).toBe(true);
 });
 
@@ -213,7 +213,7 @@ test("test async union", async () => {
   ]);
 
   const obj = { ty: "A" };
-  const result = await Schema2.spa(obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
+  const result = await z.spa(Schema2, obj); // Works with 1.11.10, breaks with 2.0.0-beta.21
   expect(result.success).toEqual(true);
 });
 
@@ -310,10 +310,10 @@ test("strictcreate", async () => {
     name: z.string(),
   });
 
-  const syncResult = strictObj.safeParse({ name: "asdf", unexpected: 13 });
+  const syncResult = z.safeParse(strictObj, { name: "asdf", unexpected: 13 });
   expect(syncResult.success).toEqual(false);
 
-  const asyncResult = await strictObj.spa({ name: "asdf", unexpected: 13 });
+  const asyncResult = await z.spa(strictObj, { name: "asdf", unexpected: 13 });
   expect(asyncResult.success).toEqual(false);
 });
 

--- a/src/__tests__/partials.test.ts
+++ b/src/__tests__/partials.test.ts
@@ -248,5 +248,5 @@ test("deeppartial array", () => {
   schema.parse({});
 
   // should be false, but is true
-  expect(schema.safeParse({ array: [] }).success).toBe(false);
+  expect(z.safeParse(schema, { array: [] }).success).toBe(false);
 });

--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -22,8 +22,8 @@ test("break if dirty", () => {
     .refine((c) => c === "1234")
     .transform(async (val) => Number(val))
     .pipe(z.number().refine((v) => v < 100));
-  const r1: any = schema.safeParse("12345");
+  const r1: any = z.safeParse(schema, "12345");
   expect(r1.error.issues.length).toBe(1);
-  const r2: any = schema.safeParse("3");
+  const r2: any = z.safeParse(schema, "3");
   expect(r2.error.issues.length).toBe(1);
 });

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -155,7 +155,7 @@ test("is not vulnerable to prototype pollution", async () => {
   const obj1 = rec.parse(data);
   expect(obj1.a).toBeUndefined();
 
-  const obj2 = rec.safeParse(data);
+  const obj2 = z.safeParse(rec, data);
   expect(obj2.success).toBe(true);
   if (obj2.success) {
     expect(obj2.data.a).toBeUndefined();
@@ -164,7 +164,7 @@ test("is not vulnerable to prototype pollution", async () => {
   const obj3 = await rec.parseAsync(data);
   expect(obj3.a).toBeUndefined();
 
-  const obj4 = await rec.safeParseAsync(data);
+  const obj4 = await z.safeParseAsync(rec, data);
   expect(obj4.success).toBe(true);
   if (obj4.success) {
     expect(obj4.data.a).toBeUndefined();

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -84,13 +84,15 @@ test("refinement Promise", async () => {
 });
 
 test("custom path", async () => {
-  const result = await z
-    .object({
-      password: z.string(),
-      confirm: z.string(),
-    })
-    .refine((data) => data.confirm === data.password, { path: ["confirm"] })
-    .spa({ password: "asdf", confirm: "qewr" });
+  const result = await z.spa(
+    z
+      .object({
+        password: z.string(),
+        confirm: z.string(),
+      })
+      .refine((data) => data.confirm === data.password, { path: ["confirm"] }),
+    { password: "asdf", confirm: "qewr" }
+  );
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].path).toEqual(["confirm"]);
@@ -114,8 +116,8 @@ test("use path in refinement context", async () => {
     foo: noNested,
   });
 
-  const t1 = await noNested.spa("asdf");
-  const t2 = await data.spa({ foo: "asdf" });
+  const t1 = await z.spa(noNested, "asdf");
+  const t2 = await z.spa(data, { foo: "asdf" });
 
   expect(t1.success).toBe(true);
   expect(t2.success).toBe(false);
@@ -147,7 +149,7 @@ test("superRefine", () => {
     }
   });
 
-  const result = Strings.safeParse(["asfd", "asfd", "asfd", "asfd"]);
+  const result = z.safeParse(Strings, ["asfd", "asfd", "asfd", "asfd"]);
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(2);
@@ -176,7 +178,12 @@ test("superRefine async", async () => {
     }
   });
 
-  const result = await Strings.safeParseAsync(["asfd", "asfd", "asfd", "asfd"]);
+  const result = await z.safeParseAsync(Strings, [
+    "asfd",
+    "asfd",
+    "asfd",
+    "asfd",
+  ]);
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(2);
@@ -207,8 +214,8 @@ test("superRefine - type narrowing", () => {
 
   util.assertEqual<z.infer<typeof schema>, NarrowType>(true);
 
-  expect(schema.safeParse({ type: "test", age: 0 }).success).toEqual(true);
-  expect(schema.safeParse(null).success).toEqual(false);
+  expect(z.safeParse(schema, { type: "test", age: 0 }).success).toEqual(true);
+  expect(z.safeParse(schema, null).success).toEqual(false);
 });
 
 test("chained mixed refining types", () => {
@@ -263,14 +270,14 @@ test("chained refinements", () => {
       path: ["size"],
       message: "size greater than 7",
     });
-  const r1 = objectSchema.safeParse({
+  const r1 = z.safeParse(objectSchema, {
     length: 4,
     size: 9,
   });
   expect(r1.success).toEqual(false);
   if (!r1.success) expect(r1.error.issues.length).toEqual(1);
 
-  const r2 = objectSchema.safeParse({
+  const r2 = z.safeParse(objectSchema, {
     length: 4,
     size: 3,
   });
@@ -299,7 +306,7 @@ test("fatal superRefine", () => {
       }
     });
 
-  const result = Strings.safeParse("");
+  const result = z.safeParse(Strings, "");
 
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);

--- a/src/__tests__/safeparse.test.ts
+++ b/src/__tests__/safeparse.test.ts
@@ -5,23 +5,24 @@ import * as z from "../index";
 const stringSchema = z.string();
 
 test("safeparse fail", () => {
-  const safe = stringSchema.safeParse(12);
+  const safe = z.safeParse(stringSchema, 12);
   expect(safe.success).toEqual(false);
   expect(safe.error).toBeInstanceOf(z.ZodError);
 });
 
 test("safeparse pass", () => {
-  const safe = stringSchema.safeParse("12");
+  const safe = z.safeParse(stringSchema, "12");
   expect(safe.success).toEqual(true);
   expect(safe.data).toEqual("12");
 });
 
 test("safeparse unexpected error", () => {
   expect(() =>
-    stringSchema
-      .refine((data) => {
+    z.safeParse(
+      stringSchema.refine((data) => {
         throw new Error(data);
-      })
-      .safeParse("12")
+      }),
+      "12"
+    )
   ).toThrow();
 });

--- a/src/__tests__/set.test.ts
+++ b/src/__tests__/set.test.ts
@@ -19,7 +19,7 @@ test("type inference", () => {
 });
 
 test("valid parse", () => {
-  const result = stringSet.safeParse(new Set(["first", "second"]));
+  const result = z.safeParse(stringSet, new Set(["first", "second"]));
   expect(result.success).toEqual(true);
   if (result.success) {
     expect(result.data.has("first")).toEqual(true);
@@ -39,7 +39,7 @@ test("valid parse", () => {
 });
 
 test("valid parse async", async () => {
-  const result = await stringSet.spa(new Set(["first", "second"]));
+  const result = await z.spa(stringSet, new Set(["first", "second"]));
   expect(result.success).toEqual(true);
   if (result.success) {
     expect(result.data.has("first")).toEqual(true);
@@ -47,7 +47,10 @@ test("valid parse async", async () => {
     expect(result.data.has("third")).toEqual(false);
   }
 
-  const asyncResult = await stringSet.safeParse(new Set(["first", "second"]));
+  const asyncResult = await z.safeParse(
+    stringSet,
+    new Set(["first", "second"])
+  );
   expect(asyncResult.success).toEqual(true);
   if (asyncResult.success) {
     expect(asyncResult.data.has("first")).toEqual(true);
@@ -75,7 +78,7 @@ test("valid parse: size-related methods", () => {
 });
 
 test("failing when parsing empty set in nonempty ", () => {
-  const result = nonEmpty.safeParse(new Set());
+  const result = z.safeParse(nonEmpty, new Set());
   expect(result.success).toEqual(false);
 
   if (result.success === false) {
@@ -85,7 +88,7 @@ test("failing when parsing empty set in nonempty ", () => {
 });
 
 test("failing when set is smaller than min() ", () => {
-  const result = minTwo.safeParse(new Set(["just_one"]));
+  const result = z.safeParse(minTwo, new Set(["just_one"]));
   expect(result.success).toEqual(false);
 
   if (result.success === false) {
@@ -95,7 +98,7 @@ test("failing when set is smaller than min() ", () => {
 });
 
 test("failing when set is bigger than max() ", () => {
-  const result = maxTwo.safeParse(new Set(["one", "two", "three"]));
+  const result = z.safeParse(maxTwo, new Set(["one", "two", "three"]));
   expect(result.success).toEqual(false);
 
   if (result.success === false) {
@@ -105,12 +108,12 @@ test("failing when set is bigger than max() ", () => {
 });
 
 test("doesn’t throw when an empty set is given", () => {
-  const result = stringSet.safeParse(new Set([]));
+  const result = z.safeParse(stringSet, new Set([]));
   expect(result.success).toEqual(true);
 });
 
 test("throws when a Map is given", () => {
-  const result = stringSet.safeParse(new Map([]));
+  const result = z.safeParse(stringSet, new Map([]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(1);
@@ -119,7 +122,7 @@ test("throws when a Map is given", () => {
 });
 
 test("throws when the given set has invalid input", () => {
-  const result = stringSet.safeParse(new Set([Symbol()]));
+  const result = z.safeParse(stringSet, new Set([Symbol()]));
   expect(result.success).toEqual(false);
   if (result.success === false) {
     expect(result.error.issues.length).toEqual(1);
@@ -129,7 +132,7 @@ test("throws when the given set has invalid input", () => {
 });
 
 test("throws when the given set has multiple invalid entries", () => {
-  const result = stringSet.safeParse(new Set([1, 2] as any[]) as Set<any>);
+  const result = z.safeParse(stringSet, new Set([1, 2] as any[]) as Set<any>);
 
   expect(result.success).toEqual(false);
   if (result.success === false) {

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -154,12 +154,12 @@ test("email validations", () => {
 
   expect(
     validEmails.every((email) => {
-      return emailSchema.safeParse(email).success;
+      return z.safeParse(emailSchema, email).success;
     })
   ).toBe(true);
   expect(
     invalidEmails.every((email) => {
-      return emailSchema.safeParse(email).success === false;
+      return z.safeParse(emailSchema, email).success === false;
     })
   ).toBe(true);
 });
@@ -179,7 +179,9 @@ test("base64 validations", () => {
   ];
 
   for (const str of validBase64Strings) {
-    expect(str + z.string().base64().safeParse(str).success).toBe(str + "true");
+    expect(str + z.safeParse(z.string().base64(), str).success).toBe(
+      str + "true"
+    );
   }
 
   const invalidBase64Strings = [
@@ -193,7 +195,7 @@ test("base64 validations", () => {
   ];
 
   for (const str of invalidBase64Strings) {
-    expect(str + z.string().base64().safeParse(str).success).toBe(
+    expect(str + z.safeParse(z.string().base64(), str).success).toBe(
       str + "false"
     );
   }
@@ -250,7 +252,7 @@ test("uuid", () => {
   uuid.parse("00000000-0000-0000-0000-000000000000");
   uuid.parse("b3ce60f8-e8b9-40f5-1150-172ede56ff74"); // Variant 0 - RFC 4122: Reserved, NCS backward compatibility
   uuid.parse("92e76bf9-28b3-4730-cd7f-cb6bc51f8c09"); // Variant 2 - RFC 4122: Reserved, Microsoft Corporation backward compatibility
-  const result = uuid.safeParse("9491d710-3185-4e06-bea0-6a2f275345e0X");
+  const result = z.safeParse(uuid, "9491d710-3185-4e06-bea0-6a2f275345e0X");
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("custom error");
@@ -260,7 +262,7 @@ test("uuid", () => {
 test("bad uuid", () => {
   const uuid = z.string().uuid("custom error");
   uuid.parse("9491d710-3185-4e06-bea0-6a2f275345e0");
-  const result = uuid.safeParse("invalid uuid");
+  const result = z.safeParse(uuid, "invalid uuid");
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("custom error");
@@ -273,7 +275,7 @@ test("nanoid", () => {
   nanoid.parse("mIU_4PJWikaU8fMbmkouz");
   nanoid.parse("Hb9ZUtUa2JDm_dD-47EGv");
   nanoid.parse("5Noocgv_8vQ9oPijj4ioQ");
-  const result = nanoid.safeParse("Xq90uDyhddC53KsoASYJGX");
+  const result = z.safeParse(nanoid, "Xq90uDyhddC53KsoASYJGX");
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("custom error");
@@ -283,7 +285,7 @@ test("nanoid", () => {
 test("bad nanoid", () => {
   const nanoid = z.string().nanoid("custom error");
   nanoid.parse("ySh_984wpDUu7IQRrLXAp");
-  const result = nanoid.safeParse("invalid nanoid");
+  const result = z.safeParse(nanoid, "invalid nanoid");
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("custom error");
@@ -293,7 +295,7 @@ test("bad nanoid", () => {
 test("cuid", () => {
   const cuid = z.string().cuid();
   cuid.parse("ckopqwooh000001la8mbi2im9");
-  const result = cuid.safeParse("cifjhdsfhsd-invalid-cuid");
+  const result = z.safeParse(cuid, "cifjhdsfhsd-invalid-cuid");
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("Invalid cuid");
@@ -313,7 +315,7 @@ test("cuid2", () => {
     "tz4a98xxat96iws9zMbrgj3a", // include uppercase
     "tz4a98xxat96iws-zmbrgj3a", // involve symbols
   ];
-  const results = invalidStrings.map((s) => cuid2.safeParse(s));
+  const results = invalidStrings.map((s) => z.safeParse(cuid2, s));
   expect(results.every((r) => !r.success)).toEqual(true);
   if (!results[0].success) {
     expect(results[0].error.issues[0].message).toEqual("Invalid cuid2");
@@ -323,10 +325,10 @@ test("cuid2", () => {
 test("ulid", () => {
   const ulid = z.string().ulid();
   ulid.parse("01ARZ3NDEKTSV4RRFFQ69G5FAV");
-  const result = ulid.safeParse("invalidulid");
+  const result = z.safeParse(ulid, "invalidulid");
   expect(result.success).toEqual(false);
   const tooLong = "01ARZ3NDEKTSV4RRFFQ69G5FAVA";
-  expect(ulid.safeParse(tooLong).success).toEqual(false);
+  expect(z.safeParse(ulid, tooLong).success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("Invalid ulid");
   }
@@ -340,10 +342,10 @@ test("regex", () => {
 });
 
 test("regexp error message", () => {
-  const result = z
+  const result = z.safeParse(z
     .string()
     .regex(/^moo+$/)
-    .safeParse("boooo");
+    ,"boooo")
   if (!result.success) {
     expect(result.error.issues[0].message).toEqual("Invalid");
   } else {
@@ -355,11 +357,11 @@ test("regexp error message", () => {
 
 test("regex lastIndex reset", () => {
   const schema = z.string().regex(/^\d+$/g);
-  expect(schema.safeParse("123").success).toEqual(true);
-  expect(schema.safeParse("123").success).toEqual(true);
-  expect(schema.safeParse("123").success).toEqual(true);
-  expect(schema.safeParse("123").success).toEqual(true);
-  expect(schema.safeParse("123").success).toEqual(true);
+  expect(z.safeParse(schema, "123").success).toEqual(true);
+  expect(z.safeParse(schema, "123").success).toEqual(true);
+  expect(z.safeParse(schema, "123").success).toEqual(true);
+  expect(z.safeParse(schema, "123").success).toEqual(true);
+  expect(z.safeParse(schema, "123").success).toEqual(true);
 });
 
 test("checks getters", () => {
@@ -707,14 +709,14 @@ test("duration", () => {
   ];
 
   for (const val of validDurations) {
-    const result = duration.safeParse(val);
+    const result = z.safeParse(duration, val);
     if (!result.success) {
       throw Error(`Valid duration could not be parsed: ${val}`);
     }
   }
 
   for (const val of invalidDurations) {
-    const result = duration.safeParse(val);
+    const result = z.safeParse(duration, val);
 
     if (result.success) {
       throw Error(`Invalid duration was successful parsed: ${val}`);
@@ -726,7 +728,7 @@ test("duration", () => {
 
 test("IP validation", () => {
   const ip = z.string().ip();
-  expect(ip.safeParse("122.122.122.122").success).toBe(true);
+  expect(z.safeParse(ip, "122.122.122.122").success).toBe(true);
 
   const ipv4 = z.string().ip({ version: "v4" });
   expect(() => ipv4.parse("6097:adfa:6f0b:220d:db08:5021:6191:7990")).toThrow();
@@ -759,8 +761,8 @@ test("IP validation", () => {
   ];
   // no parameters check IPv4 or IPv6
   const ipSchema = z.string().ip();
-  expect(validIPs.every((ip) => ipSchema.safeParse(ip).success)).toBe(true);
+  expect(validIPs.every((ip) => z.safeParse(ipSchema, ip).success)).toBe(true);
   expect(
-    invalidIPs.every((ip) => ipSchema.safeParse(ip).success === false)
+    invalidIPs.every((ip) => z.safeParse(ipSchema, ip).success === false)
   ).toBe(true);
 });

--- a/src/__tests__/tuple.test.ts
+++ b/src/__tests__/tuple.test.ts
@@ -45,7 +45,7 @@ test("failed validation", () => {
 });
 
 test("failed async validation", async () => {
-  const res = await testTuple.safeParse(badData);
+  const res = await z.safeParse(testTuple, badData);
   expect(res.success).toEqual(false);
   if (!res.success) {
     expect(res.error.issues.length).toEqual(3);

--- a/src/__tests__/type.test.ts
+++ b/src/__tests__/type.test.ts
@@ -1,7 +1,6 @@
-import { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
-const test = Deno.test;
+import { test } from "@jest/globals";
 
-import * as z from "../index.ts";
+import * as z from "../index";
 
 test("ZodType is covariant with the output", () => {
   function f<S extends z.ZodType<string, any, any>>(_: S) {}

--- a/src/__tests__/unions.test.ts
+++ b/src/__tests__/unions.test.ts
@@ -8,14 +8,15 @@ test("function parsing", () => {
     z.string().refine(() => false),
     z.number().refine(() => false),
   ]);
-  const result = schema.safeParse("asdf");
+  const result = z.safeParse(schema, "asdf");
   expect(result.success).toEqual(false);
 });
 
 test("union 2", () => {
-  const result = z
-    .union([z.number(), z.string().refine(() => false)])
-    .safeParse("a");
+  const result = z.safeParse(
+    z.union([z.number(), z.string().refine(() => false)]),
+    "a"
+  );
   expect(result.success).toEqual(false);
 });
 
@@ -33,9 +34,10 @@ test("return valid over invalid", () => {
 });
 
 test("return dirty result over aborted", () => {
-  const result = z
-    .union([z.number(), z.string().refine(() => false)])
-    .safeParse("a");
+  const result = z.safeParse(
+    z.union([z.number(), z.string().refine(() => false)]),
+    "a"
+  );
   expect(result.success).toEqual(false);
   if (!result.success) {
     expect(result.error.issues).toEqual([

--- a/src/helpers/partialUtil.ts
+++ b/src/helpers/partialUtil.ts
@@ -1,9 +1,9 @@
 import type {
+  AnyZodObject,
   ZodArray,
   ZodNullable,
   ZodObject,
   ZodOptional,
-  ZodRawShape,
   ZodTuple,
   ZodTupleItems,
   ZodTypeAny,
@@ -35,30 +35,29 @@ export namespace partialUtil {
   //   ? "object" // T extends ZodOptional<any> // ? 'optional' // :
   //   : "rest"];
 
-  export type DeepPartial<T extends ZodTypeAny> =
-    T extends ZodObject<ZodRawShape>
-      ? ZodObject<
-          { [k in keyof T["shape"]]: ZodOptional<DeepPartial<T["shape"][k]>> },
-          T["_def"]["unknownKeys"],
-          T["_def"]["catchall"]
-        >
-      : T extends ZodArray<infer Type, infer Card>
-      ? ZodArray<DeepPartial<Type>, Card>
-      : T extends ZodOptional<infer Type>
-      ? ZodOptional<DeepPartial<Type>>
-      : T extends ZodNullable<infer Type>
-      ? ZodNullable<DeepPartial<Type>>
-      : T extends ZodTuple<infer Items>
-      ? {
-          [k in keyof Items]: Items[k] extends ZodTypeAny
-            ? DeepPartial<Items[k]>
-            : never;
-        } extends infer PI
-        ? PI extends ZodTupleItems
-          ? ZodTuple<PI>
-          : never
+  export type DeepPartial<T extends ZodTypeAny> = T extends AnyZodObject
+    ? ZodObject<
+        { [k in keyof T["shape"]]: ZodOptional<DeepPartial<T["shape"][k]>> },
+        T["_def"]["unknownKeys"],
+        T["_def"]["catchall"]
+      >
+    : T extends ZodArray<infer Type, infer Card>
+    ? ZodArray<DeepPartial<Type>, Card>
+    : T extends ZodOptional<infer Type>
+    ? ZodOptional<DeepPartial<Type>>
+    : T extends ZodNullable<infer Type>
+    ? ZodNullable<DeepPartial<Type>>
+    : T extends ZodTuple<infer Items>
+    ? {
+        [k in keyof Items]: Items[k] extends ZodTypeAny
+          ? DeepPartial<Items[k]>
+          : never;
+      } extends infer PI
+      ? PI extends ZodTupleItems
+        ? ZodTuple<PI>
         : never
-      : T;
+      : never
+    : T;
   //  {
   //     // optional: T extends ZodOptional<ZodTypeAny> ? T : ZodOptional<T>;
   //     // array: T extends ZodArray<infer Type> ? ZodArray<DeepPartial<Type>> : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2839,7 +2839,7 @@ export class ZodObject<
   };
 }
 
-export type AnyZodObject = ZodObject<any, any, any>;
+export type AnyZodObject = ZodObject<any, any, any, any, never>;
 
 ////////////////////////////////////////
 ////////////////////////////////////////
@@ -3347,17 +3347,15 @@ export interface ZodTupleDef<
   typeName: ZodFirstPartyTypeKind.ZodTuple;
 }
 
-export type AnyZodTuple = ZodTuple<
-  [ZodTypeAny, ...ZodTypeAny[]] | [],
-  ZodTypeAny | null
->;
+export type AnyZodTuple = ZodTuple<[] | ZodTupleItems, any, any | never>;
 export class ZodTuple<
   T extends [ZodTypeAny, ...ZodTypeAny[]] | [] = [ZodTypeAny, ...ZodTypeAny[]],
-  Rest extends ZodTypeAny | null = null
+  Rest extends ZodTypeAny | null = null,
+  Input = InputTypeOfTupleWithRest<T, Rest>
 > extends ZodType<
   OutputTypeOfTupleWithRest<T, Rest>,
   ZodTupleDef<T, Rest>,
-  InputTypeOfTupleWithRest<T, Rest>
+  Input
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
     const { status, ctx } = this._processInputParams(input);
@@ -3788,7 +3786,7 @@ export class ZodSet<Value extends ZodTypeAny = ZodTypeAny> extends ZodType<
 ///////////////////////////////////////////
 ///////////////////////////////////////////
 export interface ZodFunctionDef<
-  Args extends ZodTuple<any, any> = ZodTuple<any, any>,
+  Args extends AnyZodTuple = AnyZodTuple,
   Returns extends ZodTypeAny = ZodTypeAny
 > extends ZodTypeDef {
   args: Args;
@@ -3797,21 +3795,21 @@ export interface ZodFunctionDef<
 }
 
 export type OuterTypeOfFunction<
-  Args extends ZodTuple<any, any>,
+  Args extends AnyZodTuple,
   Returns extends ZodTypeAny
 > = input<Args> extends Array<any>
   ? (...args: input<Args>) => Returns["_output"]
   : never;
 
 export type InnerTypeOfFunction<
-  Args extends ZodTuple<any, any>,
+  Args extends AnyZodTuple,
   Returns extends ZodTypeAny
 > = Args["_output"] extends Array<any>
   ? (...args: Args["_output"]) => input<Returns>
   : never;
 
 export class ZodFunction<
-  Args extends ZodTuple<any, any>,
+  Args extends AnyZodTuple,
   Returns extends ZodTypeAny
 > extends ZodType<
   OuterTypeOfFunction<Args, Returns>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5242,24 +5242,15 @@ export async function safeParseAsync<Output, Input>(
 /** Alias of safeParseAsync */
 export const spa = safeParseAsync;
 
-export function catch_<
-  Output,
-  Input,
-  Schema extends ZodType<Output, any, Input>
->(schema: Schema, def: Output): ZodCatch<Schema>;
-export function catch_<
-  Output,
-  Input,
-  Schema extends ZodType<Output, any, Input>
->(
+export function catch_<Schema extends ZodTypeAny>(
   schema: Schema,
-  def: (ctx: { error: ZodError; input: Input }) => Output
+  def: output<Schema>
 ): ZodCatch<Schema>;
-export function catch_<
-  Output,
-  Input,
-  Schema extends ZodType<Output, any, Input>
->(schema: Schema, def: any) {
+export function catch_<Schema extends ZodTypeAny>(
+  schema: Schema,
+  def: (ctx: { error: ZodError; input: input<Schema> }) => output<Schema>
+): ZodCatch<Schema>;
+export function catch_<Schema extends ZodTypeAny>(schema: Schema, def: any) {
   const catchValueFunc = typeof def === "function" ? def : () => def;
 
   return new ZodCatch({

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,11 +170,11 @@ export type SafeParseReturnType<Input, Output> =
 export abstract class ZodType<
   Output = any,
   Def extends ZodTypeDef = ZodTypeDef,
-  in Input = Output
+  /*in*/ Input = Output
 > {
   readonly _type!: Output;
   readonly _output!: Output;
-  _input(_: Input): void {}
+  readonly _input!: (_: Input) => void;
   readonly _def!: Def;
 
   get description() {
@@ -3027,12 +3027,14 @@ export type ZodDiscriminatedUnionOption<Discriminator extends string> =
   ZodObject<
     { [key in Discriminator]: ZodTypeAny },
     UnknownKeysParam,
-    ZodTypeAny
+    ZodTypeAny,
+    any,
+    never
   >;
 
 export interface ZodDiscriminatedUnionDef<
   Discriminator extends string,
-  Options extends ZodDiscriminatedUnionOption<string>[] = ZodDiscriminatedUnionOption<string>[]
+  Options extends ZodDiscriminatedUnionOption<Discriminator>[] = ZodDiscriminatedUnionOption<Discriminator>[]
 > extends ZodTypeDef {
   discriminator: Discriminator;
   options: Options;
@@ -3153,7 +3155,7 @@ export class ZodDiscriminatedUnion<
       typeName: ZodFirstPartyTypeKind.ZodDiscriminatedUnion,
       discriminator,
       options,
-      optionsMap,
+      optionsMap: optionsMap as any,
       ...processCreateParams(params),
     });
   }


### PR DESCRIPTION
Fixes https://github.com/colinhacks/zod/issues/3795.

Breaking changes:
- Turns `safeParse`, `safeParseAsync`, `spa`, and `catch` into independent functions taking schemas as parameters, instead of being methods on `ZodType`.