### PR TITLE
fix: bigint coerce crash

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1549,7 +1549,11 @@ export interface ZodBigIntDef extends ZodTypeDef {
 export class ZodBigInt extends ZodType<bigint, ZodBigIntDef, bigint> {
   _parse(input: ParseInput): ParseReturnType<bigint> {
     if (this._def.coerce) {
-      input.data = BigInt(input.data);
+      try {
+        input.data = BigInt(input.data);
+      } catch {
+        input.data = undefined;
+      }
     }
     const parsedType = this._getType(input);
     if (parsedType !== ZodParsedType.bigint) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1549,7 +1549,11 @@ export interface ZodBigIntDef extends ZodTypeDef {
 export class ZodBigInt extends ZodType<bigint, ZodBigIntDef, bigint> {
   _parse(input: ParseInput): ParseReturnType<bigint> {
     if (this._def.coerce) {
-      input.data = BigInt(input.data);
+      try {
+        input.data = BigInt(input.data);
+      } catch {
+        input.data = undefined;
+      }
     }
     const parsedType = this._getType(input);
     if (parsedType !== ZodParsedType.bigint) {


### PR DESCRIPTION
Discovered when parse is executed through `isOptional` check on `ZodBigInt` which adds a `undefined` safeParse execution to look for errors, it crashes when attempting to add `undefined` to BigInt as its an invalid value.

My suggested fix here is to just try catch the instantiation and cast the coerced value to `undefined` if it throws and error. This way all parser checks will fail on invalid values but not crash on internal checks which provides undefined as the input value.

closed #3821