### PR TITLE
fix(types): fix type cache crash

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2421,7 +2421,7 @@ export class ZodObject<
   private _cached: { shape: T; keys: string[] } | null = null;
 
   _getCached(): { shape: T; keys: string[] } {
-    if (this._cached !== null) return this._cached;
+    if (this._cached) return this._cached;
     const shape = this._def.shape();
     const keys = util.objectKeys(shape);
     return (this._cached = { shape, keys });


### PR DESCRIPTION
There's some kind of weird race condition or something where the strict null check fails but then returns an undefined object. 

See https://github.com/firebase/genkit/issues/972 for details on how to reproduce.

```
  name: 'TypeError',
  message: "Cannot destructure property 'shape' of 'this._getCached(...)' as it is undefined.",
  stack: "TypeError: Cannot destructure property 'shape' of 'this._getCached(...)' as it is undefined.\n" +
    '    at ZodObject._parse (/Users/fuego/Documents/development/gemineye-server/node_modules/zod/lib/types.js:1848:17)\n' +
    '    at ZodObject._parseSync (/Users/fuego/Documents/development/gemineye-server/node_modules/zod/lib/types.js:146:29)\n' +
    '    at /Users/fuego/Documents/development/gemineye-server/node_modules/zod/lib/types.js:1711:29\n' +
    '    at Array.map (<anonymous>)\n' +
    '    at ZodArray._parse (/Users/fuego/Documents/development/gemineye-server/node_modules/zod/lib/types.js:1710:38)\n' +
    '    at ZodObject._parse (/Users/fuego/Documents/development/gemineye-server/node_modules/zod/lib/types.js:1864:37)\n' +
    '    at ZodObject._parseSync (/Users/fuego/Documents/development/gemineye-server/node_modules/zod/lib/types.js:146:29)\n' +
    '    at ZodObject.safeParse (/Users/fuego/Documents/development/gemineye-server/node_modules/zod/lib/types.js:176:29)\n' +
    '    at ZodObject.parse (/Users/fuego/Documents/development/gemineye-server/node_modules/zod/lib/types.js:157:29)\n' +
    '    at /Users/fuego/Documents/development/gemineye-server/node_modules/@genkit-ai/flow/lib/flow.js:522:55',
```