### PR TITLE
Add a fix for the vulnerability in zod literal validation message

### DIFF
--- a/deno/lib/__tests__/error.test.ts
+++ b/deno/lib/__tests__/error.test.ts
@@ -498,9 +498,7 @@ test("literal default error message", () => {
   } catch (err) {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
-    expect(zerr.issues[0].message).toEqual(
-      `Invalid literal value, expected "Tuna"`
-    );
+    expect(zerr.issues[0].message).toEqual(`Invalid literal value`);
   }
 });
 
@@ -510,9 +508,7 @@ test("literal bigint default error message", () => {
   } catch (err) {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
-    expect(zerr.issues[0].message).toEqual(
-      `Invalid literal value, expected "12"`
-    );
+    expect(zerr.issues[0].message).toEqual(`Invalid literal value`);
   }
 });
 

--- a/deno/lib/locales/en.ts
+++ b/deno/lib/locales/en.ts
@@ -12,10 +12,7 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       }
       break;
     case ZodIssueCode.invalid_literal:
-      message = `Invalid literal value, expected ${JSON.stringify(
-        issue.expected,
-        util.jsonStringifyReplacer
-      )}`;
+      message = `Invalid literal value`;
       break;
     case ZodIssueCode.unrecognized_keys:
       message = `Unrecognized key(s) in object: ${util.joinValues(

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -497,9 +497,7 @@ test("literal default error message", () => {
   } catch (err) {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
-    expect(zerr.issues[0].message).toEqual(
-      `Invalid literal value, expected "Tuna"`
-    );
+    expect(zerr.issues[0].message).toEqual(`Invalid literal value`);
   }
 });
 
@@ -509,9 +507,7 @@ test("literal bigint default error message", () => {
   } catch (err) {
     const zerr: z.ZodError = err as any;
     expect(zerr.issues.length).toEqual(1);
-    expect(zerr.issues[0].message).toEqual(
-      `Invalid literal value, expected "12"`
-    );
+    expect(zerr.issues[0].message).toEqual(`Invalid literal value`);
   }
 });
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -12,10 +12,7 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       }
       break;
     case ZodIssueCode.invalid_literal:
-      message = `Invalid literal value, expected ${JSON.stringify(
-        issue.expected,
-        util.jsonStringifyReplacer
-      )}`;
+      message = `Invalid literal value`;
       break;
     case ZodIssueCode.unrecognized_keys:
       message = `Unrecognized key(s) in object: ${util.joinValues(


### PR DESCRIPTION
zod literal validation was giving the actual literal value in the error message as "Invalid literal, expected <value>". This could be proven to be a potential vulnerability that exposes sensitive information.
For example, when literals are used for API token validation in backend, the error message will simply expose the api token in http error response or in the logs.
This could potentially add a vulnerability in users code and may cause breach.
This PR will remove literal value in error message.