### PR TITLE
docs: Remove invalid semicolon in ERROR_HANDLING.md

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -95,7 +95,7 @@ const person = z.object({
   address: z.object({
     line1: z.string(),
     zipCode: z.number().min(10000), // American 5-digit code
-  }).strict(); // do not allow unrecognized keys
+  }).strict() // do not allow unrecognized keys
 });
 ```
 


### PR DESCRIPTION
Fixes invalid syntax that prevents code example from being copy-pasted.