### PR TITLE
Simplifying installation guide now that Deno supports installing from npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@
     - [Utilities for Zod](#utilities-for-zod)
 - [Installation](#installation)
   - [Requirements](#requirements)
-  - [From `npm` (Node/Bun)](#from-npm-nodebun)
-  - [From `deno.land/x` (Deno)](#from-denolandx-deno)
+  - [From `npm`](#from-npm)
 - [Basic usage](#basic-usage)
 - [Primitives](#primitives)
 - [Coercion for primitives](#coercion-for-primitives)
@@ -592,10 +591,11 @@ There are a growing number of tools that are built atop or support Zod natively!
   }
   ```
 
-### From `npm` (Node/Bun)
+### From `npm`
 
 ```sh
 npm install zod       # npm
+deno add npm:zod      # deno
 yarn add zod          # yarn
 bun add zod           # bun
 pnpm add zod          # pnpm
@@ -605,24 +605,12 @@ Zod also publishes a canary version on every commit. To install the canary:
 
 ```sh
 npm install zod@canary       # npm
+deno add npm:zod@canary      # deno
 yarn add zod@canary          # yarn
 bun add zod@canary           # bun
 pnpm add zod@canary          # pnpm
 ```
 
-### From `deno.land/x` (Deno)
-
-Unlike Node, Deno relies on direct URL imports instead of a package manager like NPM. Zod is available on [deno.land/x](https://deno.land/x). The latest version can be imported like so:
-
-```ts
-import { z } from "https://deno.land/x/zod/mod.ts";
-```
-
-You can also specify a particular version:
-
-```ts
-import { z } from "https://deno.land/x/zod@v3.16.1/mod.ts";
-```
 
 > The rest of this README assumes you are using npm and importing directly from the `"zod"` package.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -316,28 +316,16 @@ _要在这里看到你的名字 + Twitter + 網站 , 请在[Freelancer](https://
 }
 ```
 
-### 从`npm`(Node/Bun)安装
+### 从`npm` 安装
 
 ```sh
 npm install zod
+deno add npm:zod      # deno
 yarn add zod          # yarn
 bun add zod           # bun
 pnpm add zod          # pnpm
 ```
 
-### 从`deno.land/x` (Deno)安装
-
-和 Node 不同，Deno 依靠一个直接的 URL 导入而非像 npm 这样的包管理器。可以这样导入最新版本的 Zod:
-
-```ts
-import { z } from "https://deno.land/x/zod/mod.ts";
-```
-
-你也可以指定一个具体的版本：
-
-```ts
-import { z } from "https://deno.land/x/zod@v3.16.1/mod.ts";
-```
 
 > README 的剩余部分假定你是直接通过 npm 安装的`zod`包。
 


### PR DESCRIPTION
Since Deno now supports installing directly from npm, no differentiation is required between npm/bun and deno. We can streamline the install guide.

This PR updates the readme to:
- remove the dedicated section on importing from deno.land as this is no longer required (in English and Simplified Chinese files)
- add `deno add` example (in English and Simplified Chinese files)
- add `deno add` example for canary

This update has been tested against the provided basic usage examples to validate that it works as expected.
