### PR TITLE
Avoid stackoverflows and memory issues in zod while processing large strings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -935,7 +935,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "base64") {
-        if (!base64Regex.test(input.data)) {
+        if(!processInChunks(input.data, 2048, 4, (chunk)=>base64Regex(chunk))) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "base64",

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ import {
   ParseReturnType,
   ParseStatus,
   SyncParseReturnType,
+  processInChunks,
 } from "./helpers/parseUtil";
 import { partialUtil } from "./helpers/partialUtil";
 import { Primitive } from "./helpers/typeAliases";


### PR DESCRIPTION
This commit will:

* Add a generalized helper for chunkProcessing in parseUtil
* Utilize it for base64 string verification

NOTES: there are sure to be other cases when handling large strings that can benefit from this, but i think maintainers should decide where and when.