### PR TITLE
Add JWT string validator

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -104,6 +104,7 @@ export type StringValidation =
   | "duration"
   | "ip"
   | "base64"
+  | "jwt"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -194,10 +194,36 @@ test("base64 validations", () => {
   ];
 
   for (const str of invalidBase64Strings) {
-    expect(str + z.string().base64().safeParse(str).success).toBe(
-      str + "false"
-    );
+    expect(str + z.string().base64().safeParse(str).success).toBe(str + "false");
   }
+});
+
+test("jwt validations", () => {
+  const jwt = z.string().jwt();
+  const jwtWithAlg = z.string().jwt({ alg: "HS256" });
+
+  // Valid JWTs
+  const validHeader = btoa(JSON.stringify({ typ: "JWT", alg: "HS256" }));
+  const validPayload = btoa(JSON.stringify({ sub: "1234" }));
+  const validSignature = btoa("signature");
+  const validJWT = `${validHeader}.${validPayload}.${validSignature}`;
+
+  expect(jwt.safeParse(validJWT).success).toBe(true);
+  expect(jwtWithAlg.safeParse(validJWT).success).toBe(true);
+
+  // Different algorithm
+  const headerWithDiffAlg = btoa(JSON.stringify({ typ: "JWT", alg: "RS256" }));
+  const jwtWithDiffAlg = `${headerWithDiffAlg}.${validPayload}.${validSignature}`;
+  expect(jwt.safeParse(jwtWithDiffAlg).success).toBe(true);
+  expect(jwtWithAlg.safeParse(jwtWithDiffAlg).success).toBe(false);
+
+  // Invalid cases
+  expect(jwt.safeParse("not.a.jwt").success).toBe(false);
+  expect(jwt.safeParse("not.enough.parts.here").success).toBe(false);
+  expect(jwt.safeParse("invalid!base64.parts.here").success).toBe(false);
+  expect(jwt.safeParse(`${btoa("invalid json")}.${validPayload}.${validSignature}`).success).toBe(false);
+  expect(jwt.safeParse(`${btoa(JSON.stringify({ alg: "HS256" }))}.${validPayload}.${validSignature}`).success).toBe(false);
+  expect(jwt.safeParse(`${btoa(JSON.stringify({ typ: "JWT" }))}.${validPayload}.${validSignature}`).success).toBe(false);
 });
 
 test("url validations", () => {

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -104,6 +104,7 @@ export type StringValidation =
   | "duration"
   | "ip"
   | "base64"
+  | "jwt"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };


### PR DESCRIPTION
This PR retroactively implements the jwt string format in Zod v3. Resolves #2946 

Supports the following API:

```ts
z.string().jwt() // checks for jwt format
z.string().jwt({ alg?: string }) // with optional algorithm
```

Validates:

- Three-part JWT structure (header.payload.signature)
- Base64 encoding of all parts
- Header contains required 'typ' and 'alg' fields
- Optional algorithm validation when specified

Link to Devin run: https://preview.devin.ai/sessions/7aa913c03a7d4ce0b5c8f87d2ce59ec5