### PR TITLE
docs: add API response validation example to basic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,32 @@ type User = z.infer<typeof User>;
 // { username: string }
 ```
 
+Validating an API response:
+
+```ts
+import { z } from "zod";
+
+const userSchema = z.object({
+  id: z.number(),
+  username: z.string(),
+  email: z.string().email(),
+});
+
+type User = z.infer<typeof userSchema>;
+
+async function getUserById(id: number) {
+  const response = await fetch(`/api/users/${id}`);
+  // data is untyped JSON response from the API
+  const data = await response.json();
+
+  // parse and validate the data against the schema to ensure it matches the expected shape
+  const user = userSchema.parse(data);
+
+  // user is now fully typed as { id: number, username: string, email: string }
+  return user;
+}
+```
+
 ## Primitives
 
 ```ts


### PR DESCRIPTION
The Basic Usage section currently shows simple schema validation but doesn't demonstrate one of Zod's most common use cases: validating API responses. Since API validation is often the entry point for developers discovering Zod, adding this example early in the documentation helps readers understand a practical, real-world application.

The example demonstrates:
- Schema definition
- Type inference
- Runtime validation
- Async usage

This addition bridges the gap between the existing primitive examples and more complex use cases, providing a clear path for new users to understand Zod's value proposition.