### PR TITLE
feat: Add JWT string validator

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -104,6 +104,7 @@ export type StringValidation =
   | "duration"
   | "ip"
   | "base64"
+  | "jwt"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -200,6 +200,44 @@ test("base64 validations", () => {
   }
 });
 
+test("jwt validations", () => {
+  const jwt = z.string().jwt();
+  const jwtWithAlg = z.string().jwt({ algorithm: "HS256" });
+
+  // Valid JWTs
+  const validHeader = Buffer.from(JSON.stringify({ typ: "JWT", alg: "HS256" })).toString('base64url');
+  const validPayload = Buffer.from("{}").toString('base64url');
+  const validSignature = "signature";
+  const validJWT = `${validHeader}.${validPayload}.${validSignature}`;
+
+  expect(() => jwt.parse(validJWT)).not.toThrow();
+  expect(() => jwtWithAlg.parse(validJWT)).not.toThrow();
+
+  // Invalid format
+  expect(() => jwt.parse("invalid")).toThrow();
+  expect(() => jwt.parse("invalid.invalid")).toThrow();
+  expect(() => jwt.parse("invalid.invalid.invalid")).toThrow();
+
+  // Invalid header
+  const invalidHeader = Buffer.from("{}").toString('base64url');
+  const invalidHeaderJWT = `${invalidHeader}.${validPayload}.${validSignature}`;
+  expect(() => jwt.parse(invalidHeaderJWT)).toThrow();
+
+  // Wrong algorithm
+  const wrongAlgHeader = Buffer.from(JSON.stringify({ typ: "JWT", alg: "RS256" })).toString('base64url');
+  const wrongAlgJWT = `${wrongAlgHeader}.${validPayload}.${validSignature}`;
+  expect(() => jwtWithAlg.parse(wrongAlgJWT)).toThrow();
+
+  // Custom error message
+  const customMsg = "Invalid JWT token";
+  const jwtWithMsg = z.string().jwt({ message: customMsg });
+  try {
+    jwtWithMsg.parse("invalid");
+  } catch (error) {
+    expect((error as z.ZodError).issues[0].message).toBe(customMsg);
+  }
+});
+
 test("url validations", () => {
   const url = z.string().url();
   url.parse("http://google.com");

--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -249,7 +249,7 @@ for (const str of invalidBase64URLStrings) {
 
 test("jwt validations", () => {
   const jwt = z.string().jwt();
-  const jwtWithAlg = z.string().jwt({ algorithm: "HS256" });
+  const jwtWithAlg = z.string().jwt({ alg: "HS256" });
 
   // Valid JWTs
   const validHeader = Buffer.from(JSON.stringify({ typ: "JWT", alg: "HS256" })).toString('base64url');

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -604,7 +604,7 @@ export type ZodStringCheck =
   | { kind: "trim"; message?: string }
   | { kind: "toLowerCase"; message?: string }
   | { kind: "toUpperCase"; message?: string }
-  | { kind: "jwt"; algorithm?: string; message?: string }
+  | { kind: "jwt"; alg?: string; message?: string }
   | {
       kind: "datetime";
       offset: boolean;
@@ -1034,7 +1034,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "jwt") {
-        if (!isValidJWT(input.data, check.algorithm)) {
+        if (!isValidJWT(input.data, check.alg)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "jwt",

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -546,6 +546,7 @@ export type ZodStringCheck =
   | { kind: "trim"; message?: string }
   | { kind: "toLowerCase"; message?: string }
   | { kind: "toUpperCase"; message?: string }
+  | { kind: "jwt"; algorithm?: string; message?: string }
   | {
       kind: "datetime";
       offset: boolean;
@@ -581,6 +582,7 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
 const uuidRegex =
   /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 const nanoidRegex = /^[a-z0-9_-]{21}$/i;
+const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/;
 const durationRegex =
   /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
 
@@ -669,6 +671,25 @@ function isValidIP(ip: string, version?: IpVersion) {
   }
 
   return false;
+}
+
+function isValidJWT(jwt: string, alg?: string): boolean {
+  if (!jwtRegex.test(jwt)) return false;
+  try {
+    const [header] = jwt.split(".");
+    // Convert base64url to base64
+    const base64 = header
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+      .padEnd(header.length + ((4 - (header.length % 4)) % 4), "=");
+    const decoded = JSON.parse(atob(base64));
+    if (typeof decoded !== "object" || decoded === null) return false;
+    if (!decoded.typ || !decoded.alg) return false;
+    if (alg && decoded.alg !== alg) return false;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export class ZodString extends ZodType<string, ZodStringDef, string> {
@@ -933,6 +954,16 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
+      } else if (check.kind === "jwt") {
+        if (!isValidJWT(input.data, check.algorithm)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "jwt",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "base64") {
         if (!base64Regex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
@@ -1000,6 +1031,10 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   base64(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "base64", ...errorUtil.errToObj(message) });
+  }
+
+  jwt(options?: { alg?: string; message?: string }) {
+    return this._addCheck({ kind: "jwt", ...errorUtil.errToObj(options) });
   }
 
   ip(options?: string | { version?: IpVersion; message?: string }) {

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -104,6 +104,7 @@ export type StringValidation =
   | "duration"
   | "ip"
   | "base64"
+  | "jwt"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -248,7 +248,7 @@ for (const str of invalidBase64URLStrings) {
 
 test("jwt validations", () => {
   const jwt = z.string().jwt();
-  const jwtWithAlg = z.string().jwt({ algorithm: "HS256" });
+  const jwtWithAlg = z.string().jwt({ alg: "HS256" });
 
   // Valid JWTs
   const validHeader = Buffer.from(JSON.stringify({ typ: "JWT", alg: "HS256" })).toString('base64url');

--- a/src/types.ts
+++ b/src/types.ts
@@ -604,7 +604,7 @@ export type ZodStringCheck =
   | { kind: "trim"; message?: string }
   | { kind: "toLowerCase"; message?: string }
   | { kind: "toUpperCase"; message?: string }
-  | { kind: "jwt"; algorithm?: string; message?: string }
+  | { kind: "jwt"; alg?: string; message?: string }
   | {
       kind: "datetime";
       offset: boolean;
@@ -1034,7 +1034,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "jwt") {
-        if (!isValidJWT(input.data, check.algorithm)) {
+        if (!isValidJWT(input.data, check.alg)) {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {
             validation: "jwt",

--- a/src/types.ts
+++ b/src/types.ts
@@ -546,6 +546,7 @@ export type ZodStringCheck =
   | { kind: "trim"; message?: string }
   | { kind: "toLowerCase"; message?: string }
   | { kind: "toUpperCase"; message?: string }
+  | { kind: "jwt"; algorithm?: string; message?: string }
   | {
       kind: "datetime";
       offset: boolean;
@@ -581,6 +582,7 @@ const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
 const uuidRegex =
   /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/i;
 const nanoidRegex = /^[a-z0-9_-]{21}$/i;
+const jwtRegex = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$/;
 const durationRegex =
   /^[-+]?P(?!$)(?:(?:[-+]?\d+Y)|(?:[-+]?\d+[.,]\d+Y$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:(?:[-+]?\d+W)|(?:[-+]?\d+[.,]\d+W$))?(?:(?:[-+]?\d+D)|(?:[-+]?\d+[.,]\d+D$))?(?:T(?=[\d+-])(?:(?:[-+]?\d+H)|(?:[-+]?\d+[.,]\d+H$))?(?:(?:[-+]?\d+M)|(?:[-+]?\d+[.,]\d+M$))?(?:[-+]?\d+(?:[.,]\d+)?S)?)??$/;
 
@@ -669,6 +671,25 @@ function isValidIP(ip: string, version?: IpVersion) {
   }
 
   return false;
+}
+
+function isValidJWT(jwt: string, alg?: string): boolean {
+  if (!jwtRegex.test(jwt)) return false;
+  try {
+    const [header] = jwt.split(".");
+    // Convert base64url to base64
+    const base64 = header
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+      .padEnd(header.length + ((4 - (header.length % 4)) % 4), "=");
+    const decoded = JSON.parse(atob(base64));
+    if (typeof decoded !== "object" || decoded === null) return false;
+    if (!decoded.typ || !decoded.alg) return false;
+    if (alg && decoded.alg !== alg) return false;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export class ZodString extends ZodType<string, ZodStringDef, string> {
@@ -933,6 +954,16 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
+      } else if (check.kind === "jwt") {
+        if (!isValidJWT(input.data, check.algorithm)) {
+          ctx = this._getOrReturnCtx(input, ctx);
+          addIssueToContext(ctx, {
+            validation: "jwt",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
       } else if (check.kind === "base64") {
         if (!base64Regex.test(input.data)) {
           ctx = this._getOrReturnCtx(input, ctx);
@@ -1000,6 +1031,10 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   }
   base64(message?: errorUtil.ErrMessage) {
     return this._addCheck({ kind: "base64", ...errorUtil.errToObj(message) });
+  }
+
+  jwt(options?: { alg?: string; message?: string }) {
+    return this._addCheck({ kind: "jwt", ...errorUtil.errToObj(options) });
   }
 
   ip(options?: string | { version?: IpVersion; message?: string }) {


### PR DESCRIPTION
This PR retroactively implements the jwt string format in Zod v3. Resolves #2946 

Supports the following API:

```ts
z.string().jwt() // checks for jwt format
z.string().jwt({ alg?: string }) // with optional algorithm
```

Implements:

- A three-part JWT structure (header.payload.signature), with base64 encoding of all parts and header containing required 'typ' and 'alg' fields.
- Optional algorithm validation when specified
- Implement in both main and Deno versions
- Add comprehensive test coverage

Link to Devin run: https://preview.devin.ai/sessions/51826709fcd3457abc4be25e587c790c