### PR TITLE
Update type in test for upcoming intersection equality behavior change

### DIFF
--- a/src/__tests__/branded.test.ts
+++ b/src/__tests__/branded.test.ts
@@ -15,7 +15,7 @@ test("branded types", () => {
   type MySchema = z.infer<typeof mySchema>;
   util.assertEqual<
     MySchema,
-    { name: string } & { [z.BRAND]: { superschema: true } }
+    { name: string } & z.BRAND<'superschema'>
   >(true);
 
   const doStuff = (arg: MySchema) => arg;


### PR DESCRIPTION
If https://github.com/microsoft/TypeScript/pull/60726 is merged, then the type `{ name: string } & { [z.BRAND]: { superschema: true } }` will become identical to `{ name: string ; [z.BRAND]: { superschema: true } }`, which is not identical to `{ name: string } & z.BRAND<'superschema'>` because ` z.BRAND<'superschema'>` cannot be "trivially merged" into the object literal type.