### PR TITLE
`recordWithBrandedKeys` should not be `Partial`

### DIFF
--- a/deno/lib/__tests__/record.test.ts
+++ b/deno/lib/__tests__/record.test.ts
@@ -17,6 +17,9 @@ const recordWithLiteralKeys = z.record(
 );
 type recordWithLiteralKeys = z.infer<typeof recordWithLiteralKeys>;
 
+const recordWithBrandedKeys = z.record(z.string().brand("someKey"), z.string());
+type recordWithBrandedKeys = z.infer<typeof recordWithBrandedKeys>;
+
 test("type inference", () => {
   util.assertEqual<booleanRecord, Record<string, boolean>>(true);
 
@@ -28,6 +31,11 @@ test("type inference", () => {
   util.assertEqual<
     recordWithLiteralKeys,
     Partial<Record<"Tuna" | "Salmon", string>>
+  >(true);
+
+  util.assertEqual<
+    recordWithBrandedKeys,
+    Record<string & z.BRAND<"someKey">, string>
   >(true);
 });
 

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3691,7 +3691,7 @@ export type RecordType<K extends string | number | symbol, V> = [
   ? Record<K, V>
   : [symbol] extends [K]
   ? Record<K, V>
-  : [BRAND<string | number | symbol>] extends [K]
+  : [K] extends [BRAND<string | number | symbol>]
   ? Record<K, V>
   : Partial<Record<K, V>>;
 export class ZodRecord<

--- a/src/__tests__/record.test.ts
+++ b/src/__tests__/record.test.ts
@@ -16,6 +16,9 @@ const recordWithLiteralKeys = z.record(
 );
 type recordWithLiteralKeys = z.infer<typeof recordWithLiteralKeys>;
 
+const recordWithBrandedKeys = z.record(z.string().brand("someKey"), z.string());
+type recordWithBrandedKeys = z.infer<typeof recordWithBrandedKeys>;
+
 test("type inference", () => {
   util.assertEqual<booleanRecord, Record<string, boolean>>(true);
 
@@ -27,6 +30,11 @@ test("type inference", () => {
   util.assertEqual<
     recordWithLiteralKeys,
     Partial<Record<"Tuna" | "Salmon", string>>
+  >(true);
+
+  util.assertEqual<
+    recordWithBrandedKeys,
+    Record<string & z.BRAND<"someKey">, string>
   >(true);
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3691,7 +3691,7 @@ export type RecordType<K extends string | number | symbol, V> = [
   ? Record<K, V>
   : [symbol] extends [K]
   ? Record<K, V>
-  : [BRAND<string | number | symbol>] extends [K]
+  : [K] extends [BRAND<string | number | symbol>]
   ? Record<K, V>
   : Partial<Record<K, V>>;
 export class ZodRecord<


### PR DESCRIPTION
I am attempting to fix a regression. Here's a timeline:

1. [This PR](https://github.com/colinhacks/zod/pull/2097) describes an issue and is merged. Note that it primarily adds
```
  : K extends BRAND<string | number | symbol>
  ? Record<K, V>
```

2. For reasons that are unclear to me [this commit](https://github.com/colinhacks/zod/commit/defdab9c163d9a994f927a0644ab4ec172513fcb) reverses the order of the above and uses `[]` syntax, causing a regression:

```
  : [BRAND<string | number | symbol>] extends [K]
  ? Record<K, V>
```

3. My PR switches the order back to 1, keeps the `[]` syntax, and adds a test to prevent regressions:

```
  : [K] extends [BRAND<string | number | symbol>]
  ? Record<K, V>
```