### PR TITLE
Add comment to message getter noting that it returns JSON

### DIFF
--- a/deno/lib/ZodError.ts
+++ b/deno/lib/ZodError.ts
@@ -283,6 +283,10 @@ export class ZodError<T = any> extends Error {
   override toString() {
     return this.message;
   }
+
+  /**
+   * message returns the .issues field as a pretty-printed JSON string, NOT necessarily a human-readable message.
+   */
   override get message() {
     return JSON.stringify(this.issues, util.jsonStringifyReplacer, 2);
   }

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -283,6 +283,10 @@ export class ZodError<T = any> extends Error {
   override toString() {
     return this.message;
   }
+
+  /**
+   * message returns the .issues field as a pretty-printed JSON string, NOT necessarily a human-readable message.
+   */
   override get message() {
     return JSON.stringify(this.issues, util.jsonStringifyReplacer, 2);
   }


### PR DESCRIPTION
Per #2883, there seems to be quite a bit of confusion around the meaning of the `ZodError.message` field (which returns JSON instead of a simple human-readable error message, as one might expect given the name).

Unsure how intentional the current behavior is or if the field is meant to be used at all (I don't see it directly in docs (https://zod.dev/?id=error-handling, https://zod.dev/ERROR_HANDLING), but at the very least an explanatory comment would be helpful and wouldn't be a breaking change.