### PR TITLE
feat: Add MAC Address validation (#3970)

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,7 +810,7 @@ z.string().date(); // ISO date format (YYYY-MM-DD)
 z.string().time(); // ISO time format (HH:mm:ss[.SSSSSS])
 z.string().duration(); // ISO 8601 duration
 z.string().base64();
-z.string().mac(); //Validate 48-bit MAC  
+z.string().mac(); // Validate 48-bit MAC  
 ```
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
@@ -983,7 +983,7 @@ const mac = z.string().mac();
 mac.parse("00:1A:2B:3C:4D:5E"); // Pass
 mac.parse("98-76-54-32-10-FF"); // Pass
 mac.parse("00:1A:2B:3C:4D:5E:FF"); // Fail
-//Fails if mixed sperator used
+// Fails if mixed separator is used
 mac.parse("00:1A:2B-3C:4D:5E"); // Fail
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@
   - [Dates](#dates)
   - [Times](#times)
   - [IP addresses](#ip-addresses)
-  - [IP ranges](#ip-ranges-cidr)
+  - [IP ranges (CIDR)](#ip-ranges-cidr)
+  - [MAC addresses](#mac-addresses)
 - [Numbers](#numbers)
 - [BigInts](#bigints)
 - [NaNs](#nans)
@@ -106,7 +107,6 @@
 - [Unions](#unions)
 - [Discriminated unions](#discriminated-unions)
 - [Records](#records)
-  - [Record key type](#record-key-type)
 - [Maps](#maps)
 - [Sets](#sets)
 - [Intersections](#intersections)
@@ -154,6 +154,7 @@
 - [Guides and concepts](#guides-and-concepts)
   - [Type inference](#type-inference)
   - [Writing generic functions](#writing-generic-functions)
+    - [Inferring the inferred type](#inferring-the-inferred-type)
     - [Constraining allowable inputs](#constraining-allowable-inputs)
   - [Error handling](#error-handling)
   - [Error formatting](#error-formatting)
@@ -809,6 +810,7 @@ z.string().date(); // ISO date format (YYYY-MM-DD)
 z.string().time(); // ISO time format (HH:mm:ss[.SSSSSS])
 z.string().duration(); // ISO 8601 duration
 z.string().base64();
+z.string().mac(); //Validate 48-bit MAC  
 ```
 
 > Check out [validator.js](https://github.com/validatorjs/validator.js) for a bunch of other useful string validation functions that can be used in conjunction with [Refinements](#refine).
@@ -840,6 +842,7 @@ z.string().date({ message: "Invalid date string!" });
 z.string().time({ message: "Invalid time string!" });
 z.string().ip({ message: "Invalid IP address" });
 z.string().cidr({ message: "Invalid CIDR" });
+z.string().mac({ message: "Invalid MAC address" });
 ```
 
 ### Datetimes
@@ -970,6 +973,18 @@ ipv4Cidr.parse("84d5:51a0:9114:1855:4cfa:f2d7:1f12:7003"); // fail
 
 const ipv6Cidr = z.string().cidr({ version: "v6" });
 ipv6Cidr.parse("192.168.1.1"); // fail
+```
+ ### MAC addresses
+
+Validate standard 48-bit MAC address [IEEE 802](https://en.wikipedia.org/wiki/MAC_address).
+
+```ts
+const mac = z.string().mac();
+mac.parse("00:1A:2B:3C:4D:5E"); // Pass
+mac.parse("98-76-54-32-10-FF"); // Pass
+mac.parse("00:1A:2B:3C:4D:5E:FF"); // Fail
+//Fails if mixed sperator used
+mac.parse("00:1A:2B-3C:4D:5E"); // Fail
 ```
 
 ## Numbers

--- a/src/ZodError.ts
+++ b/src/ZodError.ts
@@ -107,6 +107,7 @@ export type StringValidation =
   | "base64"
   | "jwt"
   | "base64url"
+  | "mac"
   | { includes: string; position?: number }
   | { startsWith: string }
   | { endsWith: string };

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -464,6 +464,7 @@ test("checks getters", () => {
   expect(z.string().email().isIP).toEqual(false);
   expect(z.string().email().isCIDR).toEqual(false);
   expect(z.string().email().isULID).toEqual(false);
+  expect(z.string().email().isMac).toEqual(false);
 
   expect(z.string().url().isEmail).toEqual(false);
   expect(z.string().url().isURL).toEqual(true);
@@ -474,6 +475,7 @@ test("checks getters", () => {
   expect(z.string().url().isIP).toEqual(false);
   expect(z.string().url().isCIDR).toEqual(false);
   expect(z.string().url().isULID).toEqual(false);
+  expect(z.string().url().isMac).toEqual(false);
 
   expect(z.string().cuid().isEmail).toEqual(false);
   expect(z.string().cuid().isURL).toEqual(false);
@@ -484,6 +486,7 @@ test("checks getters", () => {
   expect(z.string().cuid().isIP).toEqual(false);
   expect(z.string().cuid().isCIDR).toEqual(false);
   expect(z.string().cuid().isULID).toEqual(false);
+  expect(z.string().cuid().isMac).toEqual(false);
 
   expect(z.string().cuid2().isEmail).toEqual(false);
   expect(z.string().cuid2().isURL).toEqual(false);
@@ -494,6 +497,7 @@ test("checks getters", () => {
   expect(z.string().cuid2().isIP).toEqual(false);
   expect(z.string().cuid2().isCIDR).toEqual(false);
   expect(z.string().cuid2().isULID).toEqual(false);
+  expect(z.string().cuid2().isMac).toEqual(false);
 
   expect(z.string().uuid().isEmail).toEqual(false);
   expect(z.string().uuid().isURL).toEqual(false);
@@ -504,6 +508,7 @@ test("checks getters", () => {
   expect(z.string().uuid().isIP).toEqual(false);
   expect(z.string().uuid().isCIDR).toEqual(false);
   expect(z.string().uuid().isULID).toEqual(false);
+  expect(z.string().uuid().isMac).toEqual(false);
 
   expect(z.string().nanoid().isEmail).toEqual(false);
   expect(z.string().nanoid().isURL).toEqual(false);
@@ -514,6 +519,7 @@ test("checks getters", () => {
   expect(z.string().nanoid().isIP).toEqual(false);
   expect(z.string().nanoid().isCIDR).toEqual(false);
   expect(z.string().nanoid().isULID).toEqual(false);
+  expect(z.string().nanoid().isMac).toEqual(false);
 
   expect(z.string().ip().isEmail).toEqual(false);
   expect(z.string().ip().isURL).toEqual(false);
@@ -524,6 +530,7 @@ test("checks getters", () => {
   expect(z.string().ip().isIP).toEqual(true);
   expect(z.string().ip().isCIDR).toEqual(false);
   expect(z.string().ip().isULID).toEqual(false);
+  expect(z.string().ip().isMac).toEqual(false);
 
   expect(z.string().cidr().isEmail).toEqual(false);
   expect(z.string().cidr().isURL).toEqual(false);
@@ -534,6 +541,7 @@ test("checks getters", () => {
   expect(z.string().cidr().isIP).toEqual(false);
   expect(z.string().cidr().isCIDR).toEqual(true);
   expect(z.string().cidr().isULID).toEqual(false);
+  expect(z.string().cidr().isMac).toEqual(false);
 
   expect(z.string().ulid().isEmail).toEqual(false);
   expect(z.string().ulid().isURL).toEqual(false);
@@ -543,7 +551,19 @@ test("checks getters", () => {
   expect(z.string().ulid().isNANOID).toEqual(false);
   expect(z.string().ulid().isIP).toEqual(false);
   expect(z.string().ulid().isCIDR).toEqual(false);
+  expect(z.string().ulid().isMac).toEqual(false);
   expect(z.string().ulid().isULID).toEqual(true);
+
+  expect(z.string().mac().isEmail).toEqual(false);
+  expect(z.string().mac().isURL).toEqual(false);
+  expect(z.string().mac().isCUID).toEqual(false);
+  expect(z.string().mac().isCUID2).toEqual(false);
+  expect(z.string().mac().isUUID).toEqual(false);
+  expect(z.string().mac().isNANOID).toEqual(false);
+  expect(z.string().mac().isIP).toEqual(false);
+  expect(z.string().mac().isCIDR).toEqual(false);
+  expect(z.string().mac().isULID).toEqual(false);
+  expect(z.string().mac().isMac).toEqual(true);
 });
 
 test("min max getters", () => {
@@ -917,4 +937,40 @@ test("CIDR validation", () => {
   expect(
     invalidCidrs.every((ip) => cidrSchema.safeParse(ip).success === false)
   ).toBe(true);
+});
+
+test("MAC validation", () => {
+  const mac = z.string().mac();
+  expect(mac.safeParse("00:1A:2B:3C:4D:5E").success).toBe(true);
+  expect(() => mac.parse("00:1A-2B:3C:4D:5E")).toThrow();
+
+  const validMacs = [
+    "00:1A:2B:3C:4D:5E",
+    "FF:FF:FF:FF:FF:FF",
+    "01-23-45-67-89-AB",
+    "A1:B2:C3:D4:E5:F6",
+    "10:20:30:40:50:60",
+    "AA-BB-CC-DD-EE-FF",
+    "0a:1b:2c:3d:4e:5f",
+    "DE-AD-BE-EF-00-01",
+    "12:34:56:78:9A:BC",
+    "98-76-54-32-10-FF"
+  ];
+
+  const invalidMacs = [
+    "00:1A-2B:3C-4D:5E",
+    "001A2B3C4D5E",
+    "00:1A:2B:3C:4D",
+    "00:1A:2B:3C:4D:5E:FF",
+    "00-1A-2B-3C-4D",
+    "00:1A:2B:3C:4D:GZ",
+    "00:1A:2B:3C:4D:5E:GG",
+    "123:45:67:89:AB:CD",
+    "00--1A:2B:3C:4D:5E",
+    "00:1A::2B:3C:4D:5E"
+  ];
+
+  const macSchema = z.string().mac();
+  expect(validMacs.every((mac) => macSchema.safeParse(mac).success)).toBe(true);
+  expect(invalidMacs.every((mac) => macSchema.safeParse(mac).success)).toBe(false);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1087,7 +1087,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           status.dirty();
         }
       } else if (check.kind === "mac") {
-        if(!isValidMac(input.data)) {
+        if (!isValidMac(input.data)) {
           ctx = this._getOrReturnCtx(input,ctx);
           addIssueToContext(ctx, {
             validation: "mac",

--- a/src/types.ts
+++ b/src/types.ts
@@ -625,7 +625,8 @@ export type ZodStringCheck =
   | { kind: "ip"; version?: IpVersion; message?: string }
   | { kind: "cidr"; version?: IpVersion; message?: string }
   | { kind: "base64"; message?: string }
-  | { kind: "base64url"; message?: string };
+  | { kind: "base64url"; message?: string }
+  | { kind: "mac"; message?: string };
 
 export interface ZodStringDef extends ZodTypeDef {
   checks: ZodStringCheck[];
@@ -694,6 +695,11 @@ const base64urlRegex =
 // with leap year validation
 const dateRegexSource = `((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))`;
 const dateRegex = new RegExp(`^${dateRegexSource}$`);
+
+// https://stackoverflow.com/questions/4260467/what-is-a-regular-expression-for-a-mac-address
+// no support for mac without seperators
+// enforces all seperators should be either ':' or '-'
+const macRegex=/^([0-9A-Fa-f]{2}(:)){5}[0-9A-Fa-f]{2}$|^([0-9A-Fa-f]{2}(-)){5}[0-9A-Fa-f]{2}$/;
 
 function timeRegexSource(args: { precision?: number | null }) {
   // let regex = `\\d{2}:\\d{2}:\\d{2}`;
@@ -764,6 +770,14 @@ function isValidCidr(ip: string, version?: IpVersion) {
     return true;
   }
   if ((version === "v6" || !version) && ipv6CidrRegex.test(ip)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isValidMac(mac:string) {
+  if (macRegex.test(mac)){
     return true;
   }
 
@@ -1072,7 +1086,18 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           });
           status.dirty();
         }
-      } else {
+      } else if (check.kind === "mac") {
+        if(!isValidMac(input.data)) {
+          ctx = this._getOrReturnCtx(input,ctx);
+          addIssueToContext(ctx, {
+            validation: "mac",
+            code: ZodIssueCode.invalid_string,
+            message: check.message,
+          });
+          status.dirty();
+        }
+      }
+      else {
         util.assertNever(check);
       }
     }
@@ -1148,6 +1173,10 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
 
   cidr(options?: string | { version?: IpVersion; message?: string }) {
     return this._addCheck({ kind: "cidr", ...errorUtil.errToObj(options) });
+  }
+
+  mac(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "mac", ...errorUtil.errToObj(message) });
   }
 
   datetime(
@@ -1351,6 +1380,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
   get isBase64url() {
     // base64url encoding is a modification of base64 that can safely be used in URLs and filenames
     return !!this._def.checks.find((ch) => ch.kind === "base64url");
+  }
+  get isMac() {
+    return !!this._def.checks.find((ch)=> ch.kind === "mac")
   }
 
   get minLength() {


### PR DESCRIPTION
This PR adds support for validating **MAC addresses** in Zod, addressing issue **#3970**. The validation ensures that input values conform to standard MAC address formats.  

### **Changes Introduced:**  
- Added a new **MAC address validation** method in the schema.  
- Supports both **colon-separated (`XX:XX:XX:XX:XX:XX`)** and **dash-separated (`XX-XX-XX-XX-XX-XX`)** formats.  
- Implemented **unit tests** to verify correct validation behavior.  
- Updated documentation with usage examples.  

### **Testing Done:**  
- Ran `yarn test` to ensure all existing and new tests pass.  
- Validated various correct and incorrect MAC address formats.  

### **Checklist:**  
- [x] Added unit tests.  
- [x] Verified no breaking changes.  
- [x] Updated documentation.  

### **Issue Reference:**  
Closes #3970.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced MAC address validation that ensures proper formatting and consistent separators, highlighting support for standard 48-bit MAC addresses.

- **Documentation**
	- Updated documentation with a dedicated section on MAC address validation, including examples of valid and invalid formats and clarifications for IP ranges.

- **Tests**
	- Added tests to verify accurate MAC address parsing, ensuring that the new validations work reliably without affecting existing string validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->