### PR TITLE
Fix broken logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.svg" width="200px" align="center" alt="Zod logo" />
+  <img src="https://raw.githubusercontent.com/colinhacks/zod/main/logo.svg" width="200px" align="center" alt="Zod logo" />
   <h1 align="center">Zod</h1>
   <p align="center">
     ✨ <a href="https://zod.dev">https://zod.dev</a> ✨

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.svg" width="200px" align="center" alt="Zod logo" />
+  <img src="../../logo.svg" width="200px" align="center" alt="Zod logo" />
   <h1 align="center">Zod</h1>
   <p align="center">
     ✨ <a href="https://zod.dev">https://zod.dev</a> ✨

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../../logo.svg" width="200px" align="center" alt="Zod logo" />
+  <img src="https://raw.githubusercontent.com/colinhacks/zod/main/logo.svg" width="200px" align="center" alt="Zod logo" />
   <h1 align="center">Zod</h1>
   <p align="center">
     ✨ <a href="https://zod.dev">https://zod.dev</a> ✨

--- a/playground.ts
+++ b/playground.ts
@@ -1,3 +1,10 @@
 import { z } from "./src";
 
 z;
+
+const Schema = z
+  .object({
+    limit: z.number().default(0),
+  })
+  .default({});
+type Schema = z.infer<typeof Schema>;


### PR DESCRIPTION
Although it works on GitHub, I'm not sure the relative path will resolve properly on https://deno.land/x/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to reference an externally hosted image, ensuring the logo displays consistently regardless of the viewer's file structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->