### PR TITLE
test: add back no printable characters test since is valid test

### DIFF
--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -71,9 +71,9 @@ test("email validations", () => {
   ];
   const invalidEmails = [
     // no "printable characters"
-    // `user%example.com@example.org`,
-    // `mailhost!username@example.org`,
-    // `test/test@test.com`,
+    `user%example.com@example.org`,
+    `mailhost!username@example.org`,
+    `test/test@test.com`,
 
     // double @
     `francois@@etu.inp-n7.fr`,

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -70,9 +70,9 @@ test("email validations", () => {
   ];
   const invalidEmails = [
     // no "printable characters"
-    // `user%example.com@example.org`,
-    // `mailhost!username@example.org`,
-    // `test/test@test.com`,
+    `user%example.com@example.org`,
+    `mailhost!username@example.org`,
+    `test/test@test.com`,
 
     // double @
     `francois@@etu.inp-n7.fr`,


### PR DESCRIPTION
Re-enables the previously commented-out test for non-printable characters. The test remains valid and ensures proper handling of such cases. (unless this behaviour is not intended)  No changes were made to the test logic, only reactivating it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced email validation by activating additional invalid cases.
  - Expanded tests to verify correct handling of identifier formats (e.g., unique string IDs).
  - Updated validations for date, time, datetime, regex, and duration to ensure proper rejection of invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->