### PR TITLE
docs: add GQLoom to ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`koa-zod-router`](https://github.com/JakeFenley/koa-zod-router): Create typesafe routes in Koa with I/O validation using Zod.
 - [`zod-sockets`](https://github.com/RobinTail/zod-sockets): Zod-powered Socket.IO microframework with I/O validation and built-in AsyncAPI specs
 - [`oas-tszod-gen`](https://github.com/inkognitro/oas-tszod-gen): Client SDK code generator to convert OpenApi v3 specifications into TS endpoint caller functions with Zod types.
+- [`GQLoom`](https://github.com/modevol-com/gqloom): Weave GraphQL schema and resolvers using Zod.
 
 #### Form integrations
 

--- a/README_KO.md
+++ b/README_KO.md
@@ -491,6 +491,7 @@ Zod를 기반으로 구축되거나 Zod를 기본적으로 지원하는 도구�
 - [`koa-zod-router`](https://github.com/JakeFenley/koa-zod-router): Koa에서 Zod를 사용해 I/O 검증이 포함된 타입 안전한 라우트 생성.
 - [`zod-sockets`](https://github.com/RobinTail/zod-sockets): Zod 기반 Socket.IO 마이크로프레임워크. I/O 검증과 내장 AsyncAPI 스펙 지원.
 - [`oas-tszod-gen`](https://github.com/inkognitro/oas-tszod-gen): OpenAPI v3 스펙을 Zod 타입이 포함된 TS 엔드포인트 호출 함수로 변환하는 클라이언트 SDK 코드 생성기.
+- [`GQLoom`](https://github.com/modevol-com/gqloom): Zod를 사용하여 GraphQL 스키마와 리졸버를 엮습니다.
 
 #### 폼 통합 라이브러리
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -297,6 +297,7 @@ _要在这里看到你的名字 + Twitter + 網站 , 请在[Freelancer](https://
 - [`zod-i18n-map`](https://github.com/aiji42/zod-i18n): 有助于翻译 zod 错误信息。
 - [`mobx-zod-form`](https://github.com/MonoidDev/mobx-zod-form): 以数据为中心的表格构建工具，基于 MobX 和 Zod。
 - [`zodock`](https://github.com/ItMaga/zodock): 基於 Zod 模式生成模擬數據。
+- [`GQLoom`](https://github.com/modevol-com/gqloom): 使用 ZOD 编织 GraphQL Schema 和解析器。
 
 # 安装
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -536,6 +536,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`koa-zod-router`](https://github.com/JakeFenley/koa-zod-router): Create typesafe routes in Koa with I/O validation using Zod.
 - [`zod-sockets`](https://github.com/RobinTail/zod-sockets): Zod-powered Socket.IO microframework with I/O validation and built-in AsyncAPI specs
 - [`oas-tszod-gen`](https://github.com/inkognitro/oas-tszod-gen): Client SDK code generator to convert OpenApi v3 specifications into TS endpoint caller functions with Zod types.
+- [`GQLoom`](https://github.com/modevol-com/gqloom): Weave GraphQL schema and resolvers using Zod.
 
 #### Form integrations
 


### PR DESCRIPTION
I'm very excited to introduce [GQLoom](https://github.com/modevol-com/gqloom) to you, which can weave `Zod` types into [GraphQL](https://graphql.org/) Schema.

GQLoom is a **Code First** GraphQL Schema Loom, used to weave **runtime types** in the TypeScript/JavaScript ecosystem into a GraphQL Schema.

As the most popular runtime validation library, `Zod` is given primary support by `GQLoom`!

With `GQLoom` and `Zod`, you can easily create a GraphQL Schema without writing GraphQL. 

```ts
import { resolver, query, weave } from "@gqloom/core"
import { ZodWeaver } from "@gqloom/zod"
import { z } from "zod"

const helloResolver = resolver({
  hello: query(z.string())
   .input({ name: z.string().nullish() })
   .resolve(({ name }) => `Hello, ${name?? "World"}!`),
})

export const schema = weave(ZodWeaver, helloResolver)
```

The above code will be woven into the following GraphQL Schema:

```graphql
type Query {
  hello(name: String): String!
}
```

GQLoom is also integrated with popular ORM libraries such as [Prisma](https://www.prisma.io/), [MikroORM](https://mikro-orm.io/), and [Drizzle](https://orm.drizzle.team/). You only need to write the database table structure or entity model once, and `GQLoom` will weave them into the GraphQL Schema. `GQLoom` also provides resolver factories, with which you can create a complete GraphQL CRUD interface for database tables with just a few lines of code!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded ecosystem resources by adding a new reference, **GQLoom**, which offers an integration approach for connecting GraphQL schemas and resolvers using Zod. This update is reflected across several language versions of the documentation, providing users with an additional tool to enhance their development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->