### PR TITLE
Add `.extend` to Zod enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,6 +1167,15 @@ You can also retrieve the list of options as a tuple with the `.options` propert
 FishEnum.options; // ["Salmon", "Tuna", "Trout"];
 ```
 
+** `.extend()` **
+
+You can create supersets of a Zod enum with the `.extend` method.
+
+```ts
+const SalmonAndTrout = z.enum(["Salmon", "Trout"]);
+const FishEnum = SalmonAndTrout.extend(["Tuna"]);
+```
+
 **`.exclude/.extract()`**
 
 You can create subsets of a Zod enum with the `.exclude` and `.extract` methods.

--- a/src/__tests__/enum.test.ts
+++ b/src/__tests__/enum.test.ts
@@ -41,6 +41,17 @@ test("error params", () => {
   }
 });
 
+test("extends", () => {
+  const italianFoods = ["Pasta", "Pizza"] as const;
+  const ItalianEnum = z.enum(italianFoods);
+  const FoodEnum = ItalianEnum.extend(["Tacos", "Burgers"]);
+
+  util.assertEqual<
+    z.infer<typeof FoodEnum>,
+    "Pasta" | "Pizza" | "Tacos" | "Burgers"
+  >(true);
+});
+
 test("extract/exclude", () => {
   const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
   const FoodEnum = z.enum(foods);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4407,6 +4407,16 @@ export class ZodEnum<T extends [string, ...string[]]> extends ZodType<
     return enumValues as any;
   }
 
+  extend<const ToExtend extends readonly [string, ...string[]]>(
+    values: ToExtend,
+    newDef: RawCreateParams = this._def
+  ): ZodEnum<[...T, ...Writeable<ToExtend>]> {
+    return ZodEnum.create([...this._def.values, ...values], {
+      ...this._def,
+      ...newDef,
+    }) as any;
+  }
+
   extract<ToExtract extends readonly [T[number], ...T[number][]]>(
     values: ToExtract,
     newDef: RawCreateParams = this._def


### PR DESCRIPTION
- Add `.extend` method to Enum class in Zod to allow extending enums with additional values

---

Essentially, adds functionality equivalent to the following.

```ts
const SalmonAndTrout = z.enum(["Salmon", "Trout"]);
const FishEnum = z.enum([...SalmonAndTrout.options, "Tuna"]);

const SalmonAndTrout = z.enum(["Salmon", "Trout"]);
const FishEnum = SalmonAndTrout.extend(["Tuna"]);
```

I think it would be useful to have alongside `.extract` and `.exclude`. The behavior is also equivalent to `z.object`'s `.extend`. I couldn't find any issues on this or similar, hence the PR. Let me know what you think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to extend existing enum definitions with additional values, enhancing flexibility in creating comprehensive enum types.

- **Tests**
  - Added test cases to ensure the new enum extension functionality operates correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->