### PR TITLE
docs: Remove outdated doc 'avoid coercions that throw uncaught errors'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2748,36 +2748,6 @@ z.string()
 
 The `.pipe()` method returns a `ZodPipeline` instance.
 
-#### You can use `.pipe()` to fix common issues with `z.coerce`.
-
-You can constrain the input to types that work well with your chosen coercion. Then use `.pipe()` to apply the coercion.
-
-without constrained input:
-
-```ts
-const toDate = z.coerce.date();
-
-// works intuitively
-console.log(toDate.safeParse("2023-01-01").success); // true
-
-// might not be what you want
-console.log(toDate.safeParse(null).success); // true
-```
-
-with constrained input:
-
-```ts
-const datelike = z.union([z.number(), z.string(), z.date()]);
-const datelikeToDate = datelike.pipe(z.coerce.date());
-
-// still works intuitively
-console.log(datelikeToDate.safeParse("2023-01-01").success); // true
-
-// more likely what you want
-console.log(datelikeToDate.safeParse(null).success); // false
-```
-
-
 <br/>
 
 ## Guides and concepts

--- a/README.md
+++ b/README.md
@@ -2777,32 +2777,6 @@ console.log(datelikeToDate.safeParse("2023-01-01").success); // true
 console.log(datelikeToDate.safeParse(null).success); // false
 ```
 
-You can also use this technique to avoid coercions that throw uncaught errors.
-
-without constrained input:
-
-```ts
-const toBigInt = z.coerce.bigint();
-
-// works intuitively
-console.log(toBigInt.safeParse("42")); // true
-
-// probably not what you want
-console.log(toBigInt.safeParse(null)); // throws uncaught error
-```
-
-with constrained input:
-
-```ts
-const toNumber = z.number().or(z.string()).pipe(z.coerce.number());
-const toBigInt = z.bigint().or(toNumber).pipe(z.coerce.bigint());
-
-// still works intuitively
-console.log(toBigInt.safeParse("42").success); // true
-
-// error handled by zod, more likely what you want
-console.log(toBigInt.safeParse(null).success); // false
-```
 
 <br/>
 

--- a/deno/lib/README.md
+++ b/deno/lib/README.md
@@ -2748,62 +2748,6 @@ z.string()
 
 The `.pipe()` method returns a `ZodPipeline` instance.
 
-#### You can use `.pipe()` to fix common issues with `z.coerce`.
-
-You can constrain the input to types that work well with your chosen coercion. Then use `.pipe()` to apply the coercion.
-
-without constrained input:
-
-```ts
-const toDate = z.coerce.date();
-
-// works intuitively
-console.log(toDate.safeParse("2023-01-01").success); // true
-
-// might not be what you want
-console.log(toDate.safeParse(null).success); // true
-```
-
-with constrained input:
-
-```ts
-const datelike = z.union([z.number(), z.string(), z.date()]);
-const datelikeToDate = datelike.pipe(z.coerce.date());
-
-// still works intuitively
-console.log(datelikeToDate.safeParse("2023-01-01").success); // true
-
-// more likely what you want
-console.log(datelikeToDate.safeParse(null).success); // false
-```
-
-You can also use this technique to avoid coercions that throw uncaught errors.
-
-without constrained input:
-
-```ts
-const toBigInt = z.coerce.bigint();
-
-// works intuitively
-console.log(toBigInt.safeParse("42")); // true
-
-// probably not what you want
-console.log(toBigInt.safeParse(null)); // throws uncaught error
-```
-
-with constrained input:
-
-```ts
-const toNumber = z.number().or(z.string()).pipe(z.coerce.number());
-const toBigInt = z.bigint().or(toNumber).pipe(z.coerce.bigint());
-
-// still works intuitively
-console.log(toBigInt.safeParse("42").success); // true
-
-// error handled by zod, more likely what you want
-console.log(toBigInt.safeParse(null).success); // false
-```
-
 <br/>
 
 ## Guides and concepts

--- a/playground.ts
+++ b/playground.ts
@@ -1,3 +1,5 @@
 import { z } from "./src";
 
 z;
+
+z.preprocess;


### PR DESCRIPTION
This change https://github.com/colinhacks/zod/pull/3822 adds a try-catch surrounding `BigInt` coercion, as a result `z.coerce.bigint().safeParse(null)` no longer throws an error now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Streamlined the documentation by removing advanced technical examples and details related to error handling in type conversions, simplifying the content for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->