### PR TITLE
refactor: remove recursion from schema utilities to prevent call stack overflows

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -3415,55 +3415,89 @@ function mergeValues(
   a: any,
   b: any
 ): { valid: true; data: any } | { valid: false } {
-  const aType = getParsedType(a);
-  const bType = getParsedType(b);
+  const root = { _data: undefined as any };
 
-  if (a === b) {
-    return { valid: true, data: a };
-  } else if (aType === ZodParsedType.object && bType === ZodParsedType.object) {
-    const bKeys = util.objectKeys(b);
-    const sharedKeys = util
-      .objectKeys(a)
-      .filter((key) => bKeys.indexOf(key) !== -1);
+  let valid = true;
 
-    const newObj: any = { ...a, ...b };
-    for (const key of sharedKeys) {
-      const sharedValue = mergeValues(a[key], b[key]);
-      if (!sharedValue.valid) {
-        return { valid: false };
+  const stack: Array<{
+    a: any;
+    b: any;
+    parent: any;
+    key: string | number;
+  }> = [
+    { a, b, parent: root, key: "_data" },
+  ];
+
+  while (stack.length > 0 && valid) {
+    const { a, b, parent, key } = stack.pop()!;
+    const aType = getParsedType(a);
+    const bType = getParsedType(b);
+
+    if (a === b) {
+      parent[key] = a;
+      continue;
+    }
+
+    if (aType === ZodParsedType.object && bType === ZodParsedType.object) {
+      const bKeys = util.objectKeys(b);
+      const sharedKeys = util
+        .objectKeys(a)
+        .filter((k) => bKeys.indexOf(k) !== -1);
+
+      const newObj = { ...a, ...b };
+      parent[key] = newObj;
+
+      for (const sharedKey of sharedKeys) {
+        stack.push({
+          a: a[sharedKey],
+          b: b[sharedKey],
+          parent: newObj,
+          key: sharedKey,
+        });
       }
-      newObj[key] = sharedValue.data;
+
+      continue;
     }
 
-    return { valid: true, data: newObj };
-  } else if (aType === ZodParsedType.array && bType === ZodParsedType.array) {
-    if (a.length !== b.length) {
-      return { valid: false };
-    }
-
-    const newArray: unknown[] = [];
-    for (let index = 0; index < a.length; index++) {
-      const itemA = a[index];
-      const itemB = b[index];
-      const sharedValue = mergeValues(itemA, itemB);
-
-      if (!sharedValue.valid) {
-        return { valid: false };
+    if (aType === ZodParsedType.array && bType === ZodParsedType.array) {
+      if (a.length !== b.length) {
+        valid = false;
+        break;
       }
 
-      newArray.push(sharedValue.data);
+      const newArray: unknown[] = [];
+      parent[key] = newArray;
+
+      for (let i = 0; i < a.length; i++) {
+        newArray[i] = undefined;
+
+        stack.push({
+          a: a[i],
+          b: b[i],
+          parent: newArray,
+          key: i,
+        });
+      }
+      continue;
     }
 
-    return { valid: true, data: newArray };
-  } else if (
-    aType === ZodParsedType.date &&
-    bType === ZodParsedType.date &&
-    +a === +b
-  ) {
-    return { valid: true, data: a };
-  } else {
+    if (
+      aType === ZodParsedType.date &&
+      bType === ZodParsedType.date &&
+      +a === +b
+    ) {
+      parent[key] = a;
+      continue;
+    }
+
+    valid = false;
+  }
+
+  if (!valid) {
     return { valid: false };
   }
+
+  return { valid: true, data: root._data };
 }
 
 export class ZodIntersection<

--- a/src/types.ts
+++ b/src/types.ts
@@ -3415,55 +3415,89 @@ function mergeValues(
   a: any,
   b: any
 ): { valid: true; data: any } | { valid: false } {
-  const aType = getParsedType(a);
-  const bType = getParsedType(b);
+  const root = { _data: undefined as any };
 
-  if (a === b) {
-    return { valid: true, data: a };
-  } else if (aType === ZodParsedType.object && bType === ZodParsedType.object) {
-    const bKeys = util.objectKeys(b);
-    const sharedKeys = util
-      .objectKeys(a)
-      .filter((key) => bKeys.indexOf(key) !== -1);
+  let valid = true;
 
-    const newObj: any = { ...a, ...b };
-    for (const key of sharedKeys) {
-      const sharedValue = mergeValues(a[key], b[key]);
-      if (!sharedValue.valid) {
-        return { valid: false };
+  const stack: Array<{
+    a: any;
+    b: any;
+    parent: any;
+    key: string | number;
+  }> = [
+    { a, b, parent: root, key: "_data" },
+  ];
+
+  while (stack.length > 0 && valid) {
+    const { a, b, parent, key } = stack.pop()!;
+    const aType = getParsedType(a);
+    const bType = getParsedType(b);
+
+    if (a === b) {
+      parent[key] = a;
+      continue;
+    }
+
+    if (aType === ZodParsedType.object && bType === ZodParsedType.object) {
+      const bKeys = util.objectKeys(b);
+      const sharedKeys = util
+        .objectKeys(a)
+        .filter((k) => bKeys.indexOf(k) !== -1);
+
+      const newObj = { ...a, ...b };
+      parent[key] = newObj;
+
+      for (const sharedKey of sharedKeys) {
+        stack.push({
+          a: a[sharedKey],
+          b: b[sharedKey],
+          parent: newObj,
+          key: sharedKey,
+        });
       }
-      newObj[key] = sharedValue.data;
+
+      continue;
     }
 
-    return { valid: true, data: newObj };
-  } else if (aType === ZodParsedType.array && bType === ZodParsedType.array) {
-    if (a.length !== b.length) {
-      return { valid: false };
-    }
-
-    const newArray: unknown[] = [];
-    for (let index = 0; index < a.length; index++) {
-      const itemA = a[index];
-      const itemB = b[index];
-      const sharedValue = mergeValues(itemA, itemB);
-
-      if (!sharedValue.valid) {
-        return { valid: false };
+    if (aType === ZodParsedType.array && bType === ZodParsedType.array) {
+      if (a.length !== b.length) {
+        valid = false;
+        break;
       }
 
-      newArray.push(sharedValue.data);
+      const newArray: unknown[] = [];
+      parent[key] = newArray;
+
+      for (let i = 0; i < a.length; i++) {
+        newArray[i] = undefined;
+
+        stack.push({
+          a: a[i],
+          b: b[i],
+          parent: newArray,
+          key: i,
+        });
+      }
+      continue;
     }
 
-    return { valid: true, data: newArray };
-  } else if (
-    aType === ZodParsedType.date &&
-    bType === ZodParsedType.date &&
-    +a === +b
-  ) {
-    return { valid: true, data: a };
-  } else {
+    if (
+      aType === ZodParsedType.date &&
+      bType === ZodParsedType.date &&
+      +a === +b
+    ) {
+      parent[key] = a;
+      continue;
+    }
+
+    valid = false;
+  }
+
+  if (!valid) {
     return { valid: false };
   }
+
+  return { valid: true, data: root._data };
 }
 
 export class ZodIntersection<


### PR DESCRIPTION
This PR rewrites `getDiscriminator`, `processError`, and `mergeValues` to use a stack-based iterative approach to deeply nested errors/discriminators, in order to avoid infinite recursion (which could result in a stack overflow, resulting in a crash of the interpreter).

Note: `deepPartialify` also suffers from this issue, but I'm unsure how to approach fixing it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal error handling and data processing for more reliable error reporting.
  - Streamlined merging and extraction of values, enhancing overall stability and maintainability.
  
These updates enhance system robustness and performance, ensuring a smoother and more dependable experience for end-users while preserving backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->