### PR TITLE
Improve performance with inline typecheck for string parsing

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -775,9 +775,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     if (this._def.coerce) {
       input.data = String(input.data);
     }
-    const parsedType = this._getType(input);
 
-    if (parsedType !== ZodParsedType.string) {
+    // Inline typecheck for performance
+    if (typeof input.data !== "string") {
       const ctx = this._getOrReturnCtx(input);
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_type,

--- a/src/types.ts
+++ b/src/types.ts
@@ -775,9 +775,9 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     if (this._def.coerce) {
       input.data = String(input.data);
     }
-    const parsedType = this._getType(input);
 
-    if (parsedType !== ZodParsedType.string) {
+    // Inline typecheck for performance
+    if (typeof input.data !== "string") {
       const ctx = this._getOrReturnCtx(input);
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_type,


### PR DESCRIPTION
This small change improves the benchmarked speed of string parsing by up to ~70% and realworld by ~20%.

## Benchmark
These were run on my Macbook Pro M3.

Before the change:
```
realworld: valid x 8,305 ops/sec ±1.33% (97 runs sampled)

z.string: empty string x 13,717,506 ops/sec ±0.52% (95 runs sampled)
z.string: short string x 13,772,114 ops/sec ±0.97% (96 runs sampled)
z.string: long string x 13,713,146 ops/sec ±1.06% (97 runs sampled)
z.string: optional string x 10,406,774 ops/sec ±0.44% (95 runs sampled)
z.string: nullable string x 8,216,808 ops/sec ±0.73% (95 runs sampled)
z.string: nullable (null) string x 12,463,414 ops/sec ±0.50% (97 runs sampled)
z.string: invalid: null x 181,548 ops/sec ±1.22% (93 runs sampled)
z.string: manual parser: long x 224,317,422 ops/sec ±6.58% (79 runs sampled)
```

After the change:
```
realworld: valid x 9,900 ops/sec ±1.89% (96 runs sampled)

z.string: empty string x 23,594,188 ops/sec ±1.29% (94 runs sampled)
z.string: short string x 24,173,253 ops/sec ±0.82% (98 runs sampled)
z.string: long string x 24,042,133 ops/sec ±1.05% (95 runs sampled)
z.string: optional string x 13,433,944 ops/sec ±1.04% (95 runs sampled)
z.string: nullable string x 9,788,757 ops/sec ±1.66% (95 runs sampled)
z.string: nullable (null) string x 12,800,957 ops/sec ±2.00% (91 runs sampled)
z.string: invalid: null x 178,741 ops/sec ±1.65% (93 runs sampled)
z.string: manual parser: long x 229,858,255 ops/sec ±4.72% (80 runs sampled)
```


## Explanation
In the parse function for ZodString, we are calling `getParsedType` ([utils.ts](https://github.com/colinhacks/zod/blob/19c6d2e2c497b2d2498cc3f9db142965617e7c2c/src/helpers/util.ts#L166-L220)) through a layer of indirection (`this._getType` -> `getParsedType`) in order to determine whether the data type is *not* a string. Since we don't actually need the full range of responses from getParsedType, we can simplify the logic by performing this negative typecheck inline.

The same is true for most other parse methods (we perform a `!= type` check which can be moved inline), although making this change for strings is the simplest and probably the largest impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined string input validation by replacing an indirect evaluation step with a direct type check. This update reduces unnecessary processing, resulting in improved performance while maintaining consistent error handling for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->