### PR TITLE
fix #3907: allow custom error message on invalid_date issue code

### DIFF
--- a/deno/lib/__tests__/date.test.ts
+++ b/deno/lib/__tests__/date.test.ts
@@ -33,3 +33,16 @@ test("min max getters", () => {
     beforeBenchmarkDate
   );
 });
+
+test("custom error message on invalid_date", () => {
+  const invalidDate = new Date("I am not a date");
+  const customMsg = "I am custom";
+  const dateWithMsg = z.date({ message: customMsg });
+  try {
+    dateWithMsg.parse(invalidDate);
+  } catch (error) {
+    const issue = (error as z.ZodError).issues[0];
+    expect(issue.code).toBe("invalid_date");
+    expect(issue.message).toBe(customMsg);
+  }
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -145,7 +145,8 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
     if (typeof ctx.data === "undefined") {
       return { message: message ?? required_error ?? ctx.defaultError };
     }
-    if (iss.code !== "invalid_type") return { message: ctx.defaultError };
+    if (iss.code !== "invalid_type" && iss.code !== "invalid_date")
+      return { message: ctx.defaultError };
     return { message: message ?? invalid_type_error ?? ctx.defaultError };
   };
   return { errorMap: customMap, description };

--- a/src/__tests__/date.test.ts
+++ b/src/__tests__/date.test.ts
@@ -32,3 +32,16 @@ test("min max getters", () => {
     beforeBenchmarkDate
   );
 });
+
+test("custom error message on invalid_date", () => {
+  const invalidDate = new Date("I am not a date");
+  const customMsg = "I am custom";
+  const dateWithMsg = z.date({ message: customMsg });
+  try {
+    dateWithMsg.parse(invalidDate);
+  } catch (error) {
+    const issue = (error as z.ZodError).issues[0];
+    expect(issue.code).toBe("invalid_date");
+    expect(issue.message).toBe(customMsg);
+  }
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,7 +145,8 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
     if (typeof ctx.data === "undefined") {
       return { message: message ?? required_error ?? ctx.defaultError };
     }
-    if (iss.code !== "invalid_type") return { message: ctx.defaultError };
+    if (iss.code !== "invalid_type" && iss.code !== "invalid_date")
+      return { message: ctx.defaultError };
     return { message: message ?? invalid_type_error ?? ctx.defaultError };
   };
   return { errorMap: customMap, description };


### PR DESCRIPTION
### Overview
This PR adds support for custom error messages when the issue code is `"invalid_date"`. 

### Why is this change non-breaking?
- The behavior remains unchanged for all existing validation cases.
- `"invalid_date"` validation now allows custom error messages.
- If no custom message is provided, the default `"Invalid date"` message is still used.

### Example Usage
The following code now correctly applies a custom error message:

```typescript
const invalidDate = new Date("I am not a date");
const customMsg = "I am custom";
const dateWithMsg = z.date({ message: customMsg });
dateWithMsg.parse(invalidDate); // Throws ZodError with "I am custom"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new test cases to verify that when an invalid date input is provided, a custom error message is properly displayed.
  
- **Bug Fixes**
  - Enhanced error handling to uniformly process invalid date inputs, ensuring consistent error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->