### PR TITLE
Fix: Accept object or string for date string validation error message

### DIFF
--- a/deno/lib/__tests__/string.test.ts
+++ b/deno/lib/__tests__/string.test.ts
@@ -661,6 +661,22 @@ test("datetime parsing", () => {
 test("date", () => {
   const a = z.string().date();
   expect(a.isDate).toEqual(true);
+
+  // Custom error message as string
+  const badDate = "not a date";
+  const customMsg = "I am custom";
+  const strResult = z.string().date(customMsg).safeParse(badDate);
+  expect(strResult.success).toEqual(false);
+  if (!strResult.success) {
+    expect(strResult.error.issues[0].message).toEqual(customMsg);
+  }
+
+  // Custom error message as string within object
+  const objResult = z.string().date({ message: customMsg }).safeParse(badDate);
+  expect(objResult.success).toEqual(false);
+  if (!objResult.success) {
+    expect(objResult.error.issues[0].message).toEqual(customMsg);
+  }
 });
 
 test("date parsing", () => {

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -1180,8 +1180,8 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     });
   }
 
-  date(message?: string) {
-    return this._addCheck({ kind: "date", message });
+  date(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "date", ...errorUtil.errToObj(message) });
   }
 
   time(

--- a/src/__tests__/string.test.ts
+++ b/src/__tests__/string.test.ts
@@ -660,6 +660,22 @@ test("datetime parsing", () => {
 test("date", () => {
   const a = z.string().date();
   expect(a.isDate).toEqual(true);
+
+  // Custom error message as string
+  const badDate = "not a date";
+  const customMsg = "I am custom";
+  const strResult = z.string().date(customMsg).safeParse(badDate);
+  expect(strResult.success).toEqual(false);
+  if (!strResult.success) {
+    expect(strResult.error.issues[0].message).toEqual(customMsg);
+  }
+
+  // Custom error message as string within object
+  const objResult = z.string().date({ message: customMsg }).safeParse(badDate);
+  expect(objResult.success).toEqual(false);
+  if (!objResult.success) {
+    expect(objResult.error.issues[0].message).toEqual(customMsg);
+  }
 });
 
 test("date parsing", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1180,8 +1180,8 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
     });
   }
 
-  date(message?: string) {
-    return this._addCheck({ kind: "date", message });
+  date(message?: errorUtil.ErrMessage) {
+    return this._addCheck({ kind: "date", ...errorUtil.errToObj(message) });
   }
 
   time(


### PR DESCRIPTION
### Overview
This PR corrects an inconsistency present in date string validation. Currently, in the documentation there is this example code in the Strings section:

`z.string().date({ message: "Invalid date string!" });`

However, this does not work as the `string().date` function currently only accepts a string argument for a custom error message (unlike all other ZodString functions). My changes allow a string or a string within an object as an argument.

### Benefits
1. Non-breaking (still accepts string argument, now also accepts object argument).
1. Makes the date function of ZodString consistent with other ZodString functions.
1. Fixes inconsistency with docs.

### Result
```
import { z } from "./src";

const badDate = "not a date";
const customMsg = "I am custom";

// Custom error message as string
const strResult = z.string().date(customMsg).safeParse(badDate);
console.log(strResult.error?.issues[0].message) // prints "I am custom"

// Custom error message as string within object
const objResult = z.string().date({ message: customMsg }).safeParse(badDate);
console.log(objResult.error?.issues[0].message) // prints "I am custom"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced date validation now accepts flexible custom error messages. Users can supply custom messages either in plain text or in a structured format, providing clear and consistent feedback when invalid dates are entered.
  
- **Tests**
	- New test scenarios ensure that invalid date inputs are accurately detected and that the custom error messages appear as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->