### PR TITLE
Fixed missing CIDR suffix in CIDR version example in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,10 +1000,10 @@ You can specify a version with the `version` parameter.
 
 ```ts
 const ipv4Cidr = z.string().cidr({ version: "v4" });
-ipv4Cidr.parse("84d5:51a0:9114:1855:4cfa:f2d7:1f12:7003"); // fail
+ipv4Cidr.parse("84d5:51a0:9114:1855:4cfa:f2d7:1f12:7003/32"); // fail
 
 const ipv6Cidr = z.string().cidr({ version: "v6" });
-ipv6Cidr.parse("192.168.1.1"); // fail
+ipv6Cidr.parse("192.168.1.1/24"); // fail
 ```
 
 <br/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated usage examples to clarify the correct CIDR notation by including subnet masks for both IPv4 and IPv6 validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->