### PR TITLE
Keep tabs unmounted

### DIFF
--- a/packages/docs/app/(doc)/[[...slug]]/page.tsx
+++ b/packages/docs/app/(doc)/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import { Callout } from "fumadocs-ui/components/callout";
 import defaultMdxComponents, { createRelativeLink } from "fumadocs-ui/mdx";
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
+import { Tabs } from "@/components/tabs";
 
 export const revalidate = 86400;
 
@@ -36,6 +37,7 @@ export default async function Page(props: {
             a: createRelativeLink(source, page),
             // you can add other MDX components here
             blockquote: Callout,
+            Tabs,
           }}
         />
       </DocsBody>

--- a/packages/docs/components/accordion.tsx
+++ b/packages/docs/components/accordion.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
+import { forwardRef, type ComponentPropsWithoutRef, useState, useEffect } from 'react';
+
+export const Accordion = forwardRef<
+  HTMLDivElement,
+  Omit<ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>, 'value'> & {
+    title: string;
+  }
+>(({ title, className, children, ...props }, ref) => {
+  return (
+    <AccordionPrimitive.Item
+      ref={ref}
+      value={title}
+      className={`group/accordion relative scroll-m-20 ${className ?? ''}`}
+      {...props}
+    >
+      <AccordionPrimitive.Header className="not-prose flex flex-row items-center font-medium text-fd-foreground">
+        <AccordionPrimitive.Trigger className="flex flex-1 items-center gap-2 p-4 text-start focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring">
+          <ChevronRight className="-ms-1 size-4 shrink-0 text-fd-muted-foreground transition-transform duration-200 group-data-[state=open]/accordion:rotate-90" />
+          {title}
+        </AccordionPrimitive.Trigger>
+      </AccordionPrimitive.Header>
+      <AccordionPrimitive.Content
+        forceMount
+        className="overflow-hidden [--height:auto] max-h-[--height] data-[state=closed]:hidden data-[state=closed]:animate-[collapse-out_200ms_cubic-bezier(0.3,0.0,0.8,0.15)] data-[state=open]:animate-[collapse-in_250ms_cubic-bezier(0.05,0.7,0.1,1.0)]"
+      >
+        <div className="p-4 pt-0 prose-no-margin">{children}</div>
+      </AccordionPrimitive.Content>
+    </AccordionPrimitive.Item>
+  );
+});
+
+Accordion.displayName = 'Accordion';

--- a/packages/docs/components/tabs.tsx
+++ b/packages/docs/components/tabs.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Tab, type TabsProps, Primitive } from 'fumadocs-ui/components/tabs';
+import React from 'react';
+
+interface ChildProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+const Tabs = ({ children, ...rest }: TabsProps) => {
+  const validChildren = React.Children.toArray(children)
+    .filter(React.isValidElement)
+    .filter((child: any) => child.props.title);
+
+  if (validChildren.length === 0) {
+    console.warn('Tabs expects at least one valid Tab child, but none were found.');
+    return null;
+  }
+
+  const tabs = validChildren.map(child => {
+    const { title } = child.props as ChildProps;
+    return title;
+  });
+
+  return (
+    <Primitive.Tabs items={tabs} className="border-none rounded-none px-0" defaultValue={tabs[0]} {...rest}>
+      <Primitive.TabsList className="px-0 bg-transparent border-b gap-6">
+        {validChildren.map((child, i) => {
+          const { title } = child.props as ChildProps;
+          return (
+            <Primitive.TabsTrigger
+              key={i}
+              value={title}
+              className="font-medium data-[state=active]:shadow-[inset_0_-1px_0_0_currentColor,_0_1px_0_0_currentColor]"
+            >
+              {title}
+            </Primitive.TabsTrigger>
+          );
+        })}
+      </Primitive.TabsList>
+      {validChildren.map((child, i) => {
+        const { title, children: childContent, ...props } = child.props as ChildProps;
+
+        return (
+          <Primitive.TabsContent
+            forceMount
+            key={title}
+            value={title}
+            className="px-0 data-[state=inactive]:hidden"
+            {...props}
+          >
+            {childContent}
+          </Primitive.TabsContent>
+        );
+      })}
+    </Primitive.Tabs>
+  );
+};
+
+export { Tabs, Tab };


### PR DESCRIPTION
This PR replaces Fumadocs Tabs with tabs that never unmount, so tab content can be easily ingested