### PR TITLE
`.toJSONSchema()` Fix optional behaviour

### DIFF
--- a/packages/core/src/to-json-schema.ts
+++ b/packages/core/src/to-json-schema.ts
@@ -408,8 +408,7 @@ export class JSONSchemaGenerator {
       }
       case "optional": {
         const inner = this.process(def.innerType, params);
-        const json: JSONSchema.BaseSchema = _json as any;
-        json!.oneOf = [inner, { type: "null" }];
+        Object.assign(_json, inner);
         break;
       }
       case "nullable": {
@@ -420,7 +419,6 @@ export class JSONSchemaGenerator {
       case "nonoptional": {
         const inner = this.process(def.innerType, params);
         Object.assign(_json, inner);
-        _json.not = { type: "null" };
         break;
       }
       case "success": {

--- a/packages/zod/tests/json-schema.test.ts
+++ b/packages/zod/tests/json-schema.test.ts
@@ -573,6 +573,7 @@ describe("toJSONSchema", () => {
     const schema = z.object({
       required: z.string(),
       optional: z.string().optional(),
+      nonoptional: z.string().optional().nonoptional(),
     });
 
     const result = toJSONSchema(schema);
@@ -580,15 +581,11 @@ describe("toJSONSchema", () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "properties": {
+          "nonoptional": {
+            "type": "string",
+          },
           "optional": {
-            "oneOf": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "null",
-              },
-            ],
+            "type": "string",
           },
           "required": {
             "type": "string",
@@ -596,6 +593,7 @@ describe("toJSONSchema", () => {
         },
         "required": [
           "required",
+          "nonoptional",
         ],
         "type": "object",
       }


### PR DESCRIPTION
https://github.com/colinhacks/zod/issues/4089

`.optional()` and `.nonoptional()` shouldn't actually change our type as optionality and nullability are different things.

I've changed it to just pipe through our inner type.