### PR TITLE
`.toJSONSchema()`: Prefer `const` over `enum` for single literal

### DIFF
--- a/packages/core/src/to-json-schema.ts
+++ b/packages/core/src/to-json-schema.ts
@@ -391,7 +391,11 @@ export class JSONSchemaGenerator {
           if (val === undefined) throw new Error("Literal `undefined` cannot be represented in JSON Schema");
           if (typeof val === "bigint") throw new Error("BigInt literals cannot be represented in JSON Schema");
         }
-        json.enum = def.values as any;
+        if (def.values.length === 1) {
+          json.const = def.values[0] as any;
+        } else {
+          json.enum = def.values as any;
+        }
         break;
       }
       case "file": {

--- a/packages/zod/tests/json-schema.test.ts
+++ b/packages/zod/tests/json-schema.test.ts
@@ -438,9 +438,7 @@ describe("toJSONSchema", () => {
     const a = z.literal("hello");
     expect(toJSONSchema(a)).toMatchInlineSnapshot(`
       {
-        "enum": [
-          "hello",
-        ],
+        "const": "hello",
       }
     `);
 


### PR DESCRIPTION
https://json-schema.org/understanding-json-schema/reference/const

