### PR TITLE
Update benchmark instructions to include switching to the v4 branch

### DIFF
--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -37,6 +37,7 @@ You can run these benchmarks yourself in the Zod repo:
 ```sh 
 $ git clone git@github.com:colinhacks/zod.git
 $ cd zod
+$ git switch v4
 $ pnpm install
 ```
 


### PR DESCRIPTION
Added `git switch v4` to the benchmark instructions, as the `bench` command doesn’t work unless you're on the `v4` branch.