### PR TITLE
Fix improper function definition in migration guide

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -594,7 +594,7 @@ class ZodType<Output = unknown, Input = unknown> {
 The second generic `Def` has been entirely removed. Instead the base class now only tracks `Output` and `Input`. While previously the `Input` value defaulted to `Output`, it now defaults to `unknown`. This allows generic functions involving `z.ZodType` to behave more intuitively in many cases.
 
 ```ts
-const inferSchema<T extends z.ZodType>(schema: T): T {
+function inferSchema<T extends z.ZodType>(schema: T): T {
   return schema;
 };
 


### PR DESCRIPTION
I noticed a function definition improperly using `const` in place of `function` when working through the migration guide.