### PR TITLE
Fix typo

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -221,7 +221,7 @@ z.ulid();
 z.ipv4();
 z.ipv6();
 z.cidrv4();        // ipv4 CIDR block
-z.cidrv4();        // ipv6 CIDR block
+z.cidrv6();        // ipv6 CIDR block
 z.iso.date();
 z.iso.time();
 z.iso.datetime();


### PR DESCRIPTION
Corrected CIDR block reference in api.mdx from `.cidrv4()` to `.cidrv6()`