### PR TITLE
Fix params option to work with regex method

### DIFF
--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -323,7 +323,7 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   inst.duration = (params) => inst.check(iso.duration(params as any));
 
   // validations
-  inst.regex = (params) => inst.check(checks.regex(params));
+  inst.regex = (...args) => inst.check(checks.regex(...args));
   inst.includes = (...args) => inst.check(checks.includes(...args));
   inst.startsWith = (params) => inst.check(checks.startsWith(params));
   inst.endsWith = (params) => inst.check(checks.endsWith(params));

--- a/packages/zod/tests/string.test.ts
+++ b/packages/zod/tests/string.test.ts
@@ -581,6 +581,27 @@ test("regexp error message", () => {
   expect(() => z.string().uuid().parse("purr")).toThrow();
 });
 
+test("regexp error custom message", () => {
+  const result = z
+    .string()
+    .regex(/^moo+$/, { message: 'Custom error message' })
+    .safeParse("boooo");
+  expect(result.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_format",
+        "format": "regex",
+        "message": "Custom error message",
+        "origin": "string",
+        "path": [],
+        "pattern": "/^moo+$/",
+      },
+    ]
+  `);
+
+  expect(() => z.string().uuid().parse("purr")).toThrow();
+});
+
 test("regex lastIndex reset", () => {
   const schema = z.string().regex(/^\d+$/g);
   expect(schema.safeParse("123").success).toEqual(true);


### PR DESCRIPTION
## Overview

While checking the operation of v4, I noticed that the second argument option of the regex method does not work.