### PR TITLE
v4: `.toJSONSchema`: Enforce spec-based optional logic (`required`) and simplify `additionalProperties` for strict objects

### DIFF
--- a/packages/core/src/to-json-schema.ts
+++ b/packages/core/src/to-json-schema.ts
@@ -289,6 +289,11 @@ export class JSONSchemaGenerator {
             ...params,
             path: [...params.path, "additionalProperties"],
           });
+
+          // if "additionalProperties" is `{"not": {}}`, then it should be `false`
+          if (JSON.stringify(json.additionalProperties) === '{"not":{}}') {
+            json.additionalProperties = false;
+          }
         }
 
         break;
@@ -410,21 +415,12 @@ export class JSONSchemaGenerator {
         }
         break;
       }
-      case "optional": {
-        const inner = this.process(def.innerType, params);
-        const json: JSONSchema.BaseSchema = _json as any;
-        json!.oneOf = [inner, { type: "null" }];
-        break;
-      }
-      case "nullable": {
-        const inner = this.process(def.innerType, params);
-        _json.oneOf = [inner, { type: "null" }];
-        break;
-      }
+      case "optional":
+      case "nullable":
       case "nonoptional": {
+        // merge with inner, should be handled by `required`
         const inner = this.process(def.innerType, params);
         Object.assign(_json, inner);
-        _json.not = { type: "null" };
         break;
       }
       case "success": {

--- a/packages/zod/tests/json-schema.test.ts
+++ b/packages/zod/tests/json-schema.test.ts
@@ -505,9 +505,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(a)).toMatchInlineSnapshot(`
       {
-        "additionalProperties": {
-          "not": {},
-        },
+        "additionalProperties": false,
         "properties": {
           "age": {
             "type": "number",
@@ -579,16 +577,37 @@ describe("toJSONSchema", () => {
       {
         "properties": {
           "optional": {
-            "oneOf": [
-              {
-                "type": "string",
-              },
-              {
-                "type": "null",
-              },
-            ],
+            "type": "string",
           },
           "required": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "required",
+        ],
+        "type": "object",
+      }
+    `);
+  });
+
+  it("optional fields - object with options", () => {
+    const schema = z.object({
+      required: z.string().min(1),
+      optional: z.string().max(10).optional(),
+    });
+
+    const result = toJSONSchema(schema);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "optional": {
+            "maxLength": 10,
+            "type": "string",
+          },
+          "required": {
+            "minLength": 1,
             "type": "string",
           },
         },
@@ -672,9 +691,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(a)).toMatchInlineSnapshot(`
       {
-        "additionalProperties": {
-          "not": {},
-        },
+        "additionalProperties": false,
         "properties": {
           "age": {
             "type": "number",


### PR DESCRIPTION
Addresses https://github.com/colinhacks/zod/issues/4123 by changing the following:
* skipping `optional`, `nullable` and `nonoptional` and rely on the `required` property instead to prevent union (`oneOf`) types
  * there is an admittedly ambiguous definition at [10.3.2.1](https://json-schema.org/draft/2020-12/json-schema-core#section-10.3.2.1), but it also says that properties that exist must validate against its schema. Since JSON Schema is environment independent, they didn't cover the JS aspect of it
  * while using the `required` property should be the preferred way, technically, using an array of types would also be allowed, e.g. `{ "type": ["string", "null"] }` [7.6.1](https://json-schema.org/draft/2020-12/json-schema-core#section-7.6.1)
  
* checking `object`'s `additionalProperties` for `never` behavior and applies `false` instead of `{ "not": {} }`
  * see [4.3.2](https://json-schema.org/draft/2020-12/json-schema-core#name-boolean-json-schemas) *"Using the boolean values ensures that the intent is clear to both human readers and implementations."*
