### PR TITLE
Added FullProduct.dev to 'Powered by Zod' in Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`unplugin-environment`](https://github.com/r17x/js/tree/main/packages/unplugin-environment#readme): A plugin for loading enviroment variables safely with schema validation, simple with virtual module, type-safe with intellisense, and better DX 🔥 🚀 👷. Powered by Zod.
 - [`zod-struct`](https://codeberg.org/reesericci/zod-struct): Create runtime-checked structs with Zod.
 - [`zod-csv`](https://github.com/bartoszgolebiowski/zod-csv): Validation helpers for zod for parsing CSV data.
+- [`fullproduct.dev`](https://fullproduct.dev?v=z3): Universal Expo + Next.js App Starter. Uses Zod schemas as the 'Single Sources of Truth' to keep things like generated MDX docs / graphql / db models / forms and fetcher functions in sync.
 
 #### Utilities for Zod
 

--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`unplugin-environment`](https://github.com/r17x/js/tree/main/packages/unplugin-environment#readme): A plugin for loading enviroment variables safely with schema validation, simple with virtual module, type-safe with intellisense, and better DX 🔥 🚀 👷. Powered by Zod.
 - [`zod-struct`](https://codeberg.org/reesericci/zod-struct): Create runtime-checked structs with Zod.
 - [`zod-csv`](https://github.com/bartoszgolebiowski/zod-csv): Validation helpers for zod for parsing CSV data.
-- [`fullproduct.dev`](https://fullproduct.dev?v=z3): Universal Expo + Next.js App Starter that uses Zod schemas as the single source of truth to keep generated MDX docs, GraphQL, database models, forms, and fetcher functions in sync.
+- [`fullproduct.dev`](https://fullproduct.dev?identity=freelancers&v=z3): Universal Expo + Next.js App Starter that uses Zod schemas as the single source of truth to keep generated MDX docs, GraphQL, database models, forms, and fetcher functions in sync.
 
 #### Utilities for Zod
 

--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`unplugin-environment`](https://github.com/r17x/js/tree/main/packages/unplugin-environment#readme): A plugin for loading enviroment variables safely with schema validation, simple with virtual module, type-safe with intellisense, and better DX 🔥 🚀 👷. Powered by Zod.
 - [`zod-struct`](https://codeberg.org/reesericci/zod-struct): Create runtime-checked structs with Zod.
 - [`zod-csv`](https://github.com/bartoszgolebiowski/zod-csv): Validation helpers for zod for parsing CSV data.
-- [`fullproduct.dev`](https://fullproduct.dev?v=z3): Universal Expo + Next.js App Starter. Uses Zod schemas as the 'Single Sources of Truth' to keep things like generated MDX docs / graphql / db models / forms and fetcher functions in sync.
+- [`fullproduct.dev`](https://fullproduct.dev?v=z3): Universal Expo + Next.js App Starter that uses Zod schemas as the single source of truth to keep generated MDX docs, GraphQL, database models, forms, and fetcher functions in sync.
 
 #### Utilities for Zod
 


### PR DESCRIPTION
Lists the Zod based [fullproduct.dev](https://fullproduct.dev)'s Universal Starter at the end of the V3 docs Ecosystem section.

### What it is:

- Universal Starterkit (Expo + Next) with a unique _"schemas as single sources of truth"_ system built into it.

### What it does:

- Expand Zod V3 schemas with a powerful metadata and introspection API (to be updated for V4's own metadata API)
- Transform zod component prop schemas to Interactive MDX docs in e.g. Storybook or Nextra
- Scaffold out an auto-generated graphql schema (+ queries) from your back-end resolvers Zod input and output schemas
- Plugins to create DB models from Zod schemas to e.g. Mongoose Models
- `useFormState()` hook to further keep things in sync

### Supporting links + articles with more details:

- [DEV - Zod and the Joy of Single Sources of Truth](https://dev.to/codinsonn/the-joy-of-single-sources-of-truth-277o)
- [Building the right Abstractions with Zod - Tip 3/6 to 'Maximize Efficiency'](https://fullproduct.dev/blog/maximize-efficiency-building-universal-apps?v=z3pr)
- [Open-Source demo of the `GREEN stack starter` to test it all in](https://github.com/Aetherspace/green-stack-starter-demo)

### Other / sidenotes

If the description needs to be shorter, let me know and I'll shorten it

> CC: @colinhacks  if you ever need another `.ai` file turned into `.svg`, feel free to send it and I'll gladly help again 🙌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Added a new resource: "fullproduct.dev," a Universal Expo + Next.js App Starter, to the "Powered by Zod" section, emphasizing its use of Zod schemas for synchronization across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->