### PR TITLE
Fix does not work async check logic

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -199,8 +199,7 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
           throw new core.$ZodAsyncError();
         }
         if (asyncResult || _ instanceof Promise) {
-          asyncResult = asyncResult ?? Promise.resolve();
-          asyncResult.then(async () => {
+          asyncResult = (asyncResult ?? Promise.resolve()).then(async () => {
             await _;
             const nextLen = payload.issues.length;
             if (nextLen === currLen) return;

--- a/packages/zod/tests/async-parsing.test.ts
+++ b/packages/zod/tests/async-parsing.test.ts
@@ -331,7 +331,14 @@ test("async validation multiple errors 2", async () => {
     z.object({
       hello: z.string(),
       foo: z.object({
-        bar: z.number().refine(is_async ? async () => false : () => false),
+        bar: z.number().refine(
+          is_async
+            ? async () =>
+                new Promise((resolve) => {
+                  setTimeout(() => resolve(false), 500);
+                })
+            : () => false
+        ),
       }),
     });
 


### PR DESCRIPTION
## Overview

Fixed a bug where asynchronous check logic did not work properly

I discovered that while asynchronous processes that are executed immediately, such as `Promise.resolve`, work properly in `refine` and `check`, if an asynchronous process that takes time to process is passed, all asynchronous processes are not executed.

The cause seems to be that the `check` process chains asynchronous processes, but the chained processes cannot be defined.