### PR TITLE
fix (v4): check for null prototype in parsedType function

### DIFF
--- a/packages/core/src/locales/en.ts
+++ b/packages/core/src/locales/en.ts
@@ -33,10 +33,10 @@ export const parsedType = (data: any): string => {
         return "object";
       }
       if (prototype !== Object.prototype) {
-        if (!data.constructor) {
-          return "object";
+        if (data.constructor) {
+          return data.constructor.name;
         }
-        return data.constructor.name;
+        return "object";
       }
     }
   }

--- a/packages/core/src/locales/en.ts
+++ b/packages/core/src/locales/en.ts
@@ -33,6 +33,9 @@ export const parsedType = (data: any): string => {
         return "object";
       }
       if (prototype !== Object.prototype) {
+        if (!data.constructor) {
+          return "object";
+        }
         return data.constructor.name;
       }
     }

--- a/packages/core/src/locales/en.ts
+++ b/packages/core/src/locales/en.ts
@@ -27,7 +27,12 @@ export const parsedType = (data: any): string => {
       if (data === null) {
         return "null";
       }
-      if (Object.getPrototypeOf(data) !== Object.prototype) {
+
+      const prototype = Object.getPrototypeOf(data);
+      if (prototype === null) {
+        return "object";
+      }
+      if (prototype !== Object.prototype) {
         return data.constructor.name;
       }
     }

--- a/packages/core/src/locales/en.ts
+++ b/packages/core/src/locales/en.ts
@@ -28,15 +28,8 @@ export const parsedType = (data: any): string => {
         return "null";
       }
 
-      const prototype = Object.getPrototypeOf(data);
-      if (prototype === null) {
-        return "object";
-      }
-      if (prototype !== Object.prototype) {
-        if (data.constructor) {
-          return data.constructor.name;
-        }
-        return "object";
+      if (Object.getPrototypeOf(data) !== Object.prototype && data.constructor) {
+        return data.constructor.name;
       }
     }
   }

--- a/packages/core/tests/locales/en.test.ts
+++ b/packages/core/tests/locales/en.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+import { parsedType } from "../../src/locales/en.js";
+
+test("parsedType", () => {
+  expect(parsedType("string")).toBe("string");
+  expect(parsedType(1)).toBe("number");
+  expect(parsedType(true)).toBe("boolean");
+  expect(parsedType(null)).toBe("null");
+  expect(parsedType(undefined)).toBe("undefined");
+  expect(parsedType([])).toBe("array");
+  expect(parsedType({})).toBe("object");
+  expect(parsedType(new Date())).toBe("Date");
+  expect(parsedType(new Map())).toBe("Map");
+  expect(parsedType(new Set())).toBe("Set");
+  expect(parsedType(new Error())).toBe("Error");
+
+  const nullPrototype = Object.create(null);
+  expect(parsedType(nullPrototype)).toBe("object");
+});

--- a/packages/core/tests/locales/en.test.ts
+++ b/packages/core/tests/locales/en.test.ts
@@ -16,4 +16,7 @@ test("parsedType", () => {
 
   const nullPrototype = Object.create(null);
   expect(parsedType(nullPrototype)).toBe("object");
+
+  const doubleNullPrototype = Object.create(Object.create(null));
+  expect(parsedType(doubleNullPrototype)).toBe("object");
 });

--- a/packages/mini/tests/object.test.ts
+++ b/packages/mini/tests/object.test.ts
@@ -28,6 +28,12 @@ test("z.object", () => {
   // "test?" is required in ZodObject
   expect(() => z.parse(a, { name: "john", age: "30" })).toThrow();
   expect(() => z.parse(a, "hello")).toThrow();
+
+  // null prototype
+  const schema = z.object({ a: z.string() });
+  const obj = Object.create(null);
+  obj.a = "foo";
+  expect(schema.parse(obj)).toEqual({ a: "foo" });
 });
 
 test("z.strictObject", () => {

--- a/packages/zod/tests/object.test.ts
+++ b/packages/zod/tests/object.test.ts
@@ -440,3 +440,10 @@ test("assignability", () => {
   z.interface({ "a?": z.string() }) satisfies z.ZodInterface;
   z.interface({ "?a": z.string() }) satisfies z.ZodInterface;
 });
+
+test("null prototype", () => {
+  const schema = z.object({ a: z.string() });
+  const obj = Object.create(null);
+  obj.a = "foo";
+  expect(schema.parse(obj)).toEqual({ a: "foo" });
+});


### PR DESCRIPTION
When passing a Object.create(null) object (a " null -prototype object") the parseType function errors because it cannot read the name from the constructor.

Fastify test suite uses these null prototype objects for some reason.