### PR TITLE
Optimize `extendShape`

### DIFF
--- a/deno/lib/helpers/util.ts
+++ b/deno/lib/helpers/util.ts
@@ -97,9 +97,13 @@ export namespace util {
 }
 
 export namespace objectUtil {
-  export type MergeShapes<U, V> = {
-    [k in Exclude<keyof U, keyof V>]: U[k];
-  } & V;
+  export type MergeShapes<U, V> =
+    // fast path when there is no keys overlap
+    keyof U & keyof V extends never
+      ? U & V
+      : {
+          [k in Exclude<keyof U, keyof V>]: U[k];
+        } & V;
 
   type optionalKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? k : never;
@@ -131,11 +135,15 @@ export namespace objectUtil {
     };
   };
 
-  export type extendShape<A extends object, B extends object> = {
-    [K in keyof A as K extends keyof B ? never : K]: A[K];
-  } & {
-    [K in keyof B]: B[K];
-  };
+  export type extendShape<A extends object, B extends object> =
+    // fast path when there is no keys overlap
+    keyof A & keyof B extends never
+      ? A & B
+      : {
+          [K in keyof A as K extends keyof B ? never : K]: A[K];
+        } & {
+          [K in keyof B]: B[K];
+        };
 }
 
 export const ZodParsedType = util.arrayToEnum([

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -97,9 +97,13 @@ export namespace util {
 }
 
 export namespace objectUtil {
-  export type MergeShapes<U, V> = {
-    [k in Exclude<keyof U, keyof V>]: U[k];
-  } & V;
+  export type MergeShapes<U, V> =
+    // fast path when there is no keys overlap
+    keyof U & keyof V extends never
+      ? U & V
+      : {
+          [k in Exclude<keyof U, keyof V>]: U[k];
+        } & V;
 
   type optionalKeys<T extends object> = {
     [k in keyof T]: undefined extends T[k] ? k : never;
@@ -131,11 +135,15 @@ export namespace objectUtil {
     };
   };
 
-  export type extendShape<A extends object, B extends object> = {
-    [K in keyof A as K extends keyof B ? never : K]: A[K];
-  } & {
-    [K in keyof B]: B[K];
-  };
+  export type extendShape<A extends object, B extends object> =
+    // fast path when there is no keys overlap
+    keyof A & keyof B extends never
+      ? A & B
+      : {
+          [K in keyof A as K extends keyof B ? never : K]: A[K];
+        } & {
+          [K in keyof B]: B[K];
+        };
 }
 
 export const ZodParsedType = util.arrayToEnum([


### PR DESCRIPTION
It has been proposed [here](https://github.com/microsoft/TypeScript/pull/61505#issuecomment-2800012653) and, in fact, it cuts [`AnswerOverflow/apps/dashboard`](https://github.com/AnswerOverflow/AnswerOverflow/tree/1ab687793a598789a0c86b4ca5f17ee6f3a256aa/apps/dashboard)'s instantiations from 13672403 to 3538464 (74% reduction) and check time from 6.5s to 4s (38% reduction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of type-level merging for object shapes, resulting in faster and more direct merging when object keys do not overlap. This change affects only type definitions and does not impact runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->