### PR TITLE
Set `qin` property on `ZodOptional`

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -2983,7 +2983,7 @@ export const $ZodOptional: core.$constructor<$ZodOptional> = /*@__PURE__*/ core.
   "$ZodOptional",
   (inst, def) => {
     $ZodType.init(inst, def);
-    // inst._zod.qin = "true";
+    inst._zod.qin = "true";
     inst._zod.qout = "true";
     if (def.innerType._zod.values) inst._zod.values = new Set([...def.innerType._zod.values, undefined]);
     const pattern = (def.innerType as any)._zod.pattern;


### PR DESCRIPTION
Fixes #4152 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of optional schema properties to improve consistency. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->