### PR TITLE
Refactor `Extend` to preserve declaration links

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -70,6 +70,7 @@
       ".next",
       "packages/bench",
       "packages/treeshake",
+      "packages/tsc",
       ".source"
     ]
   }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -70,7 +70,6 @@
       ".next",
       "packages/bench",
       "packages/treeshake",
-      "packages/tsc",
       ".source"
     ]
   }

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -124,19 +124,16 @@ export type NoNeverKeys<T> = {
 export type NoNever<T> = Identity<{
   [k in NoNeverKeys<T>]: k extends keyof T ? T[k] : never;
 }>;
-export type ExtendShape<A extends object, B extends object> = Identity<
+export type ExtendShape<A extends object, B extends object> = Flatten<
   // fast path when there is no keys overlap
-  keyof A & keyof B extends never
-    ? A & B
-    : {
-        [K in keyof A as K extends keyof B ? never : K]: A[K];
-      } & {
-        [K in keyof B]: B[K];
-      }
+  keyof A & keyof B extends never ? A & B
+  : {
+      [K in keyof A as K extends keyof B ? never : K]: A[K];
+    } & {
+      [K in keyof B]: B[K];
+    }
 >;
-export type ExtendObject<A extends schemas.$ZodLooseShape, B extends schemas.$ZodLooseShape> = Flatten<
-  ExtendShape<A, B>
->;
+export type ExtendObject<A extends schemas.$ZodLooseShape, B extends schemas.$ZodLooseShape> = ExtendShape<A, B>;
 export type TupleItems = ReadonlyArray<schemas.$ZodType>;
 export type AnyFunc = (...args: any[]) => any;
 export type IsProp<T, K extends keyof T> = T[K] extends AnyFunc ? never : K;

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -588,7 +588,7 @@ export type ExtendInterfaceParams<A extends schemas.$ZodInterface, Shape extends
   defaulted: Exclude<A["_zod"]["defaulted"], CleanKeys<keyof Shape>> | DefaultedInterfaceKeys<keyof Shape>;
   extra: A["_zod"]["extra"];
 }>;
-export type ExtendInterfaceShape<A extends schemas.$ZodLooseShape, B extends schemas.$ZodLooseShape> = ExtendShape<
+export type ExtendInterfaceShape<A extends schemas.$ZodLooseShape, B extends schemas.$ZodLooseShape> = Extend<
   A,
   CleanInterfaceShape<B>
 >;

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -124,9 +124,16 @@ export type NoNeverKeys<T> = {
 export type NoNever<T> = Identity<{
   [k in NoNeverKeys<T>]: k extends keyof T ? T[k] : never;
 }>;
-export type ExtendShape<A extends object, B extends object> = Identity<{
-  [K in keyof A | keyof B]: K extends keyof B ? B[K] : K extends keyof A ? A[K] : never;
-}>;
+export type ExtendShape<A extends object, B extends object> = Identity<
+  // fast path when there is no keys overlap
+  keyof A & keyof B extends never
+    ? A & B
+    : {
+        [K in keyof A as K extends keyof B ? never : K]: A[K];
+      } & {
+        [K in keyof B]: B[K];
+      }
+>;
 export type ExtendObject<A extends schemas.$ZodLooseShape, B extends schemas.$ZodLooseShape> = Flatten<
   ExtendShape<A, B>
 >;

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -117,23 +117,25 @@ export type SomeObject = Record<PropertyKey, any>;
 export type Identity<T> = T;
 export type Flatten<T> = Identity<{ [k in keyof T]: T[k] }>;
 export type Mapped<T> = { [k in keyof T]: T[k] };
-export type Overwrite<T extends SomeObject, U extends SomeObject> = Omit<T, keyof U> & U;
+
 export type NoNeverKeys<T> = {
   [k in keyof T]: [T[k]] extends [never] ? never : k;
 }[keyof T];
 export type NoNever<T> = Identity<{
   [k in NoNeverKeys<T>]: k extends keyof T ? T[k] : never;
 }>;
-export type ExtendShape<A extends object, B extends object> = Flatten<
+export type Extend<A extends SomeObject, B extends SomeObject> = Flatten<
   // fast path when there is no keys overlap
-  keyof A & keyof B extends never ? A & B
-  : {
-      [K in keyof A as K extends keyof B ? never : K]: A[K];
-    } & {
-      [K in keyof B]: B[K];
-    }
+  keyof A & keyof B extends never
+    ? A & B
+    : {
+        [K in keyof A as K extends keyof B ? never : K]: A[K];
+      } & {
+        [K in keyof B]: B[K];
+      }
 >;
-export type ExtendObject<A extends schemas.$ZodLooseShape, B extends schemas.$ZodLooseShape> = ExtendShape<A, B>;
+// export type Overwrite<A extends SomeObject, B extends SomeObject> = Extend<A, B>;
+// export type Extend<A extends schemas.$ZodLooseShape, B extends schemas.$ZodLooseShape> = Extend<A, B>;
 export type TupleItems = ReadonlyArray<schemas.$ZodType>;
 export type AnyFunc = (...args: any[]) => any;
 export type IsProp<T, K extends keyof T> = T[K] extends AnyFunc ? never : K;

--- a/packages/mini/src/schemas.ts
+++ b/packages/mini/src/schemas.ts
@@ -859,15 +859,12 @@ export function looseObject<T extends core.$ZodShape>(
 export function extend<T extends ZodMiniInterface, U extends ZodMiniInterface>(
   a: T,
   b: U
-): ZodMiniInterface<
-  util.ExtendShape<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
-  util.MergeInterfaceParams<T, U>
->;
+): ZodMiniInterface<util.Extend<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>, util.MergeInterfaceParams<T, U>>;
 export function extend<T extends ZodMiniObject, U extends ZodMiniObject>(
   a: T,
   b: U
 ): ZodMiniObject<
-  util.ExtendObject<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
+  util.Extend<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
   U["_zod"]["extra"] & T["_zod"]["extra"]
 >;
 
@@ -878,7 +875,7 @@ export function extend<T extends ZodMiniInterface, U extends core.$ZodLooseShape
 export function extend<T extends ZodMiniObject, U extends core.$ZodLooseShape>(
   a: T,
   b: U
-): ZodMiniObject<util.ExtendObject<T["_zod"]["def"]["shape"], U>, T["_zod"]["extra"]>;
+): ZodMiniObject<util.Extend<T["_zod"]["def"]["shape"], U>, T["_zod"]["extra"]>;
 export function extend(schema: ZodMiniObjectLike, shape: any): ZodMiniObjectLike {
   // console.log({ schema, shape });
   if (shape instanceof core.$ZodType) return util.mergeObjectLike(schema, shape as any);
@@ -894,14 +891,14 @@ export function merge<T extends ZodMiniObjectLike, U extends core.$ZodLooseShape
   shape: U
 ): T["_zod"]["def"]["type"] extends "interface"
   ? ZodMiniInterface<
-      util.ExtendShape<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
+      util.Extend<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
       {
         extra: T["_zod"]["extra"] & U["_zod"]["extra"];
         optional: Exclude<T["_zod"]["optional"], keyof U["_zod"]["def"]["shape"]> | U["_zod"]["optional"];
         defaulted: Exclude<T["_zod"]["defaulted"], keyof U["_zod"]["def"]["shape"]> | U["_zod"]["defaulted"];
       }
     >
-  : ZodMiniObject<util.ExtendObject<T["_zod"]["def"]["shape"], U>, T["_zod"]["extra"]>;
+  : ZodMiniObject<util.Extend<T["_zod"]["def"]["shape"], U>, T["_zod"]["extra"]>;
 export function merge(a: ZodMiniObjectLike, b: ZodMiniObjectLike): ZodMiniObjectLike {
   return util.mergeObjectLike(a, b);
 }
@@ -980,7 +977,7 @@ export function partial<
   mask: M
 ): T["_zod"]["def"]["type"] extends "interface"
   ? ZodMiniInterface<
-      util.ExtendShape<
+      util.Extend<
         T["_zod"]["def"]["shape"],
         {
           [k in keyof M & keyof T["_zod"]["def"]["shape"]]: ZodMiniOptional<T["_zod"]["def"]["shape"][k]>;
@@ -1018,7 +1015,7 @@ export function required<
   schema: T,
   mask: M
 ): ZodMiniObject<
-  util.ExtendShape<
+  util.Extend<
     T["_zod"]["def"]["shape"],
     {
       [k in keyof M & keyof T["_zod"]["def"]["shape"]]: ZodMiniNonOptional<T["_zod"]["def"]["shape"][k]>;
@@ -1044,7 +1041,7 @@ export function required<
   schema: T,
   mask: M
 ): ZodMiniInterface<
-  util.ExtendShape<
+  util.Extend<
     T["_zod"]["def"]["shape"],
     {
       [k in keyof M & keyof T["_zod"]["def"]["shape"]]: ZodMiniNonOptional<T["_zod"]["def"]["shape"][k]>;

--- a/packages/tsc/bench/lots-of-objects.ts
+++ b/packages/tsc/bench/lots-of-objects.ts
@@ -1,7 +1,7 @@
 import { execa } from "execa";
 
 const $ = execa({ stdout: "inherit", stderr: "inherit" });
-import { ARKTYPE, ZOD, ZOD3, generate } from "../generate.js";
+import * as gen from "../generate.js";
 
 const SHARED = {
   numSchemas: 500,
@@ -11,8 +11,8 @@ const SHARED = {
 console.log("╔════════════════╗");
 console.log("║     Zod v3     ║");
 console.log("╚════════════════╝");
-await generate({
-  ...ZOD3,
+await gen.generate({
+  ...gen.ZOD3,
   schemaType: "z.object",
   ...SHARED,
 });
@@ -22,8 +22,8 @@ await $`pnpm run build:bench`;
 console.log("╔════════════════╗");
 console.log("║     Zod v4     ║");
 console.log("╚════════════════╝");
-await generate({
-  ...ZOD,
+await gen.generate({
+  ...gen.ZOD,
   schemaType: "z.object",
   ...SHARED,
 });
@@ -33,8 +33,8 @@ await $`pnpm run build:bench`;
 // console.log("╔═════════════════╗");
 // console.log("║     ArkType     ║");
 // console.log("╚═════════════════╝");
-// await generate({
-//   ...ARKTYPE,
+// await gen.generate({
+// gen.  ...ARKTYPE,
 //   ...SHARED
 // });
 

--- a/packages/tsc/bench/object-with-extend.ts
+++ b/packages/tsc/bench/object-with-extend.ts
@@ -1,13 +1,13 @@
 import { execa } from "execa";
 
 const $ = execa({ stdout: "inherit", stderr: "inherit" });
-import { ZOD, ZOD3, generate } from "../generate.js";
+import * as gen from "../generate.js";
 
 console.log("╔════════════════╗");
 console.log("║     Zod v3     ║");
 console.log("╚════════════════╝");
-await generate({
-  ...ZOD3,
+await gen.generate({
+  ...gen.ZOD3,
   schemaType: "z.object",
   numSchemas: 1,
   numExtends: 1,
@@ -21,8 +21,8 @@ await $`pnpm run build:bench`;
 console.log("╔════════════════╗");
 console.log("║     Zod v4     ║");
 console.log("╚════════════════╝");
-await generate({
-  ...ZOD,
+await gen.generate({
+  ...gen.ZOD,
   schemaType: "z.object",
   numSchemas: 1,
   numExtends: 1,

--- a/packages/tsc/bench/omit-extend.ts
+++ b/packages/tsc/bench/omit-extend.ts
@@ -1,19 +1,16 @@
 import { execa } from "execa";
 
 const $ = execa({ stdout: "inherit", stderr: "inherit" });
-import { ZOD, ZOD3, generate } from "../generate.js";
+import * as gen from "../generate.js";
 
 console.log("╔═════════════════════╗");
 console.log("║     Zod v3.24.2     ║");
 console.log("╚═════════════════════╝");
-await generate({
-  ...ZOD,
-
-  numSchemas: 0,
-  numKeys: 0,
-
+await gen.generateExtendChain({
+  ...gen.ZOD,
+  numSchemas: 14,
+  numKeys: 6,
   imports: ["import * as z from 'zod3-24-2'"],
-  custom: body(),
 });
 
 await $`pnpm run build:bench`;
@@ -21,135 +18,35 @@ await $`pnpm run build:bench`;
 console.log("╔═════════════════════╗");
 console.log("║     Zod v3.24.3     ║");
 console.log("╚═════════════════════╝");
-await generate({
-  ...ZOD,
-
-  numSchemas: 0,
-  numKeys: 0,
-
+await gen.generateExtendChain({
+  ...gen.ZOD,
+  numSchemas: 14,
+  numKeys: 6,
   imports: ["import * as z from 'zod3-24-3'"],
-  custom: body(),
 });
 
 await $`pnpm run build:bench`;
 
-console.log("╔════════════════╗");
-console.log("║     Zod v4     ║");
-console.log("╚════════════════╝");
-await generate({
-  ...ZOD,
-  schemaType: "z.interface",
-  numSchemas: 0,
-  numKeys: 0,
+console.log("╔══════════════════════╗");
+console.log("║     Zod v4 (pre)     ║");
+console.log("╚══════════════════════╝");
+await gen.generateExtendChain({
+  ...gen.ZOD,
+  numSchemas: 14,
+  numKeys: 6,
+  imports: ["import * as z from 'zod4'"],
+});
 
+await $`pnpm run build:bench`;
+
+console.log("╔═══════════════════════╗");
+console.log("║     Zod v4 (curr)     ║");
+console.log("╚═══════════════════════╝");
+await gen.generateExtendChain({
+  ...gen.ZOD,
+  numSchemas: 14,
+  numKeys: 6,
   imports: ["import * as z from 'zod'"],
-  custom: body(),
 });
 
 await $`pnpm run build:bench`;
-
-export function body() {
-  return `
-export const a = z.object({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-
-export const b = a.omit({
-  a: true,
-  b: true,
-  c: true,
-});
-
-export const c = b.extend({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-
-export const d = c.omit({
-  a: true,
-  b: true,
-  c: true,
-});
-
-export const e = d.extend({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-
-export const f = e.omit({
-  a: true,
-  b: true,
-  c: true,
-});
-
-export const g = f.extend({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-
-export const h = g.omit({
-  a: true,
-  b: true,
-  c: true,
-});
-
-export const i = h.extend({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-
-export const j = i.omit({
-  a: true,
-  b: true,
-  c: true,
-});
-
-export const k = j.extend({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-
-export const l = k.omit({
-  a: true,
-  b: true,
-  c: true,
-});
-
-export const m = l.extend({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-
-export const n = m.omit({
-  a: true,
-  b: true,
-  c: true,
-});
-
-export const o = n.extend({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-
-export const p = o.omit({
-  a: true,
-  b: true,
-  c: true,
-});
-
-export const q = p.extend({
-  a: z.string(),
-  b: z.string(),
-  c: z.string(),
-});
-`;
-}

--- a/packages/tsc/bench/string.ts
+++ b/packages/tsc/bench/string.ts
@@ -1,13 +1,13 @@
 import { execa } from "execa";
 
 const $ = execa({ stdout: "inherit", stderr: "inherit" });
-import { ARKTYPE, ZOD, ZOD3, generate } from "../generate.js";
+import * as gen from "../generate.js";
 
 console.log("╔════════════════╗");
 console.log("║     Zod v3     ║");
 console.log("╚════════════════╝");
-await generate({
-  ...ZOD3,
+await gen.generate({
+  ...gen.ZOD3,
   numSchemas: 0,
   numKeys: 0,
   custom: `
@@ -21,8 +21,8 @@ await $`pnpm run build:bench`;
 console.log("╔════════════════╗");
 console.log("║     Zod v4     ║");
 console.log("╚════════════════╝");
-await generate({
-  ...ZOD,
+await gen.generate({
+  ...gen.ZOD,
   numSchemas: 0,
   numKeys: 0,
   custom: `

--- a/packages/tsc/bench/strongly-connected.ts
+++ b/packages/tsc/bench/strongly-connected.ts
@@ -1,13 +1,13 @@
 import { execa } from "execa";
 
 const $ = execa({ stdout: "inherit", stderr: "inherit" });
-import { ARKTYPE, ZOD, ZOD3, generate } from "../generate.js";
+import * as gen from "../generate.js";
 
 console.log("╔════════════════╗");
 console.log("║     Zod v4     ║");
 console.log("╚════════════════╝");
-await generate({
-  ...ZOD,
+await gen.generate({
+  ...gen.ZOD,
   schemaType: "z.interface",
   numSchemas: 500,
   numKeys: 3,

--- a/packages/tsc/bisect.ts
+++ b/packages/tsc/bisect.ts
@@ -1,5 +1,5 @@
 import { $ } from "execa";
-import { ARKTYPE, VALIBOT, ZOD, ZOD3, generate } from "./generate.js";
+import * as gen from "./generate.js";
 
 // detect control c and process.exit()
 process.on("SIGINT", () => {
@@ -39,13 +39,18 @@ let CURR = MIN;
 // regular interface: 33328
 // shape interface: 43472
 
-while (!MAX || MAX - MIN > 10) {
-  generate({
-    ...ZOD,
-    schemaType: "z.interface",
+while (!MAX || MAX - MIN > 2) {
+  // generate({
+  //   ...ZOD,
+  //   schemaType: "z.interface",
+  //   numSchemas: CURR,
+  //   numKeys: 3,
+  //   numRefs: 1,
+  // });
+  gen.generateExtendChain({
+    ...gen.ZOD,
     numSchemas: CURR,
-    numKeys: 3,
-    numRefs: 1,
+    numKeys: 6,
   });
 
   console.log(`Attempting tsc compilation...`);

--- a/packages/tsc/extend.ts
+++ b/packages/tsc/extend.ts
@@ -1,46 +1,46 @@
-import { z } from "zod";
+// import { z } from "zod";
 
-const Type1 = z.object({});
-let test1: z.infer<typeof Type1>;
+// const Type1 = z.object({});
+// let test1: z.infer<typeof Type1>;
 
-const Type2 = Type1.extend({});
-let test2: z.infer<typeof Type2>;
+// const Type2 = Type1.extend({});
+// let test2: z.infer<typeof Type2>;
 
-const Type3 = Type2.extend({});
-let test3: z.infer<typeof Type3>;
+// const Type3 = Type2.extend({});
+// let test3: z.infer<typeof Type3>;
 
-const Type4 = Type3.extend({});
-let test4: z.infer<typeof Type4>;
+// const Type4 = Type3.extend({});
+// let test4: z.infer<typeof Type4>;
 
-const Type5 = Type4.extend({});
-let test5: z.infer<typeof Type5>;
+// const Type5 = Type4.extend({});
+// let test5: z.infer<typeof Type5>;
 
-const Type6 = Type5.extend({});
-let test6: z.infer<typeof Type6>;
+// const Type6 = Type5.extend({});
+// let test6: z.infer<typeof Type6>;
 
-const Type7 = Type6.extend({});
-let test7: z.infer<typeof Type7>;
+// const Type7 = Type6.extend({});
+// let test7: z.infer<typeof Type7>;
 
-const Type8 = Type7.extend({});
-let test8: z.infer<typeof Type8>;
+// const Type8 = Type7.extend({});
+// let test8: z.infer<typeof Type8>;
 
-const Type9 = Type8.extend({});
-let test9: z.infer<typeof Type9>;
+// const Type9 = Type8.extend({});
+// let test9: z.infer<typeof Type9>;
 
-const Type10 = Type9.extend({});
-let test10: z.infer<typeof Type10>;
+// const Type10 = Type9.extend({});
+// let test10: z.infer<typeof Type10>;
 
-const Type11 = Type10.extend({});
-let test11: z.infer<typeof Type11>;
+// const Type11 = Type10.extend({});
+// let test11: z.infer<typeof Type11>;
 
-const Type12 = Type11.extend({});
-let test12: z.infer<typeof Type12>;
+// const Type12 = Type11.extend({});
+// let test12: z.infer<typeof Type12>;
 
-const Type13 = Type12.extend({});
-let test13: z.infer<typeof Type13>;
+// const Type13 = Type12.extend({});
+// let test13: z.infer<typeof Type13>;
 
-const Type14 = Type13.extend({});
-let test14: z.infer<typeof Type14>;
+// const Type14 = Type13.extend({});
+// let test14: z.infer<typeof Type14>;
 
-const Type15 = Type14.extend({});
-let test15: z.infer<typeof Type15>;
+// const Type15 = Type14.extend({});
+// let test15: z.infer<typeof Type15>;

--- a/packages/tsc/generate.ts
+++ b/packages/tsc/generate.ts
@@ -24,26 +24,31 @@ export const ARKTYPE = {
   valueTypes: [`"string"`],
 };
 
-generate({
-  // ...ZOD3,
+generateExtendChain({
   ...ZOD,
-  schemaType: "z.interface",
-  // ...ARKTYPE,
-  // ...ZOD3,
-  numSchemas: 1000,
-  numKeys: 10,
-  numRefs: 3,
-
-  // numSchemas: 1000,
-  // methods: [""],
-  // numKeys: 5,
-  // numRefs: 0,
-  // numOmits: 10,
-  // numPicks: 10,
-  // numExtends: 10,
+  numSchemas: 40,
+  numKeys: 6,
 });
+// generate({
+//   // ...ZOD3,
+//   ...ZOD,
+//   schemaType: "z.interface",
+//   // ...ARKTYPE,
+//   // ...ZOD3,
+//   numSchemas: 1000,
+//   numKeys: 10,
+//   numRefs: 3,
 
-interface GenerateParams {
+//   // numSchemas: 1000,
+//   // methods: [""],
+//   // numKeys: 5,
+//   // numRefs: 0,
+//   // numOmits: 10,
+//   // numPicks: 10,
+//   // numExtends: 10,
+// });
+
+interface GenerateObjectsParams {
   // path?: string;
   imports: string[];
   schemaType: "z.object" | "z.interface" | "arktype" | "valibot";
@@ -58,7 +63,7 @@ interface GenerateParams {
   custom?: string;
 }
 // Step 4: Write the generated schemas to a file
-export function generate(params: GenerateParams) {
+export function generate(params: GenerateObjectsParams) {
   const {
     imports,
     schemaType,
@@ -67,7 +72,7 @@ export function generate(params: GenerateParams) {
     numOmits = 0,
     numPicks = 0,
     numExtends = 0,
-    methods = [""],
+
     custom = "",
   } = params;
   const path = "src/index.ts";
@@ -193,6 +198,135 @@ export function generate(params: GenerateParams) {
   writeFileSync(path, file.join("\n"), { flag: "w" });
 }
 
+interface GenerateExtendChainParams {
+  // path?: string;
+  imports: string[];
+  schemaType: "z.object" | "z.interface" | "arktype" | "valibot";
+  valueTypes: string[];
+  methods?: string[];
+  numSchemas: number;
+  numKeys: number;
+  // numRefs?: number;
+  numOmits?: number;
+  numPicks?: number;
+  numExtends?: number;
+  custom?: string;
+}
+export function generateExtendChain(params: GenerateExtendChainParams) {
+  const {
+    imports,
+    schemaType,
+    numSchemas,
+
+    // numRefs = 0,
+    // numOmits = 0,
+    // numPicks = 0,
+    // numExtends = 0,
+    // methods = [""],
+    // custom = "",
+  } = params;
+
+  // let counter = 0;
+
+  const path = "src/index.ts";
+  // console.log(params);
+  let file: string[] = [];
+  // const file: string[] = params.imports;
+  file = file.concat(imports);
+  const initialName = randomStr(17);
+  // const generated: Array<string> = [...names];
+
+  console.log(`Generating ${numSchemas} chained calls to .extend() w/ ${params.numKeys} keys...`);
+  if (schemaType === "arktype") {
+    file.push(`export const ${initialName}_0 = type({`);
+  } else if (schemaType === "valibot") {
+    // throw new Error("Not supported yet.")
+    file.push(`export const ${initialName}_0 = v.object({`);
+  } else {
+    file.push(`export const ${initialName}_0 = ${schemaType}({`);
+  }
+
+  // fields
+  let fields = generateFields(params);
+  for (const { key, schema } of fields) {
+    file.push(`  ${key}: ${schema},`);
+  }
+
+  file.push("});");
+
+  // while(let counter = 0; counter < numSchemas; counter++) {
+
+  // }
+  // let counter = 0;
+  let mode: "omit" | "extend" = "omit";
+
+  for (let counter = 1; counter < numSchemas; counter++) {
+    file.push(``);
+    const prevName = `${initialName}_${counter - 1}`;
+    const newName = `${initialName}_${counter}`;
+    if (mode === "omit") {
+      // omit three keys from `fields`
+      const omitFields = fields.slice(0, 3); //.filter(() => Math.random() > 0.5);
+
+      if (schemaType === "arktype") {
+        file.push(
+          `export const ${newName} = ${prevName}.omit(${omitFields.map((field) => `"${field.key}"`).join(",")});`
+        );
+        // continue
+      } else if (schemaType === "valibot") {
+        file.push(
+          `export const ${newName} = v.omit(${prevName}, [${omitFields.map((field) => `"${field.key}"`).join(",")} ]);`
+        );
+      } else {
+        file.push(`export const ${newName} = ${prevName}.omit({`);
+        for (const field of omitFields) {
+          file.push(`  "${field.key}": true,`);
+        }
+        file.push(`});`);
+      }
+
+      fields = fields.slice(3);
+      mode = "extend";
+    } else if (mode === "extend") {
+      // extend three keys to `fields`
+      const newFields = generateFields({ ...params, numKeys: 3 });
+      if (schemaType === "arktype") {
+        file.push(`export const ${newName} = type({ "...": ${prevName},`);
+        for (const field of newFields) {
+          file.push(`  "${field.key}": ${field.schema},`);
+        }
+        file.push(`});`);
+        file.push(`export type ${newName} = typeof ${newName}.out;`);
+      } else if (schemaType === "valibot") {
+        file.push(`export const ${newName} = v.object({ ...${prevName}.entries,`);
+        for (const field of newFields) {
+          file.push(`  "${field.key}": ${field.schema},`);
+        }
+        file.push(`});`);
+      } else {
+        // super slow
+        file.push(`export const ${newName} = ${prevName}.extend({`);
+
+        // even slower somehow
+        // file.push(`export const ${newName} = z.extend(${prevName}, {`);
+
+        // much faster...spread
+        // file.push(`export const ${newName} = ${schemaType}({`);
+        // file.push(`  ...${prevName}.shape,`);
+        for (const field of newFields) {
+          file.push(`  "${field.key}": ${field.schema},`);
+        }
+        file.push(`});`);
+        file.push(`export type ${newName} = z.infer<typeof ${newName}>;`);
+      }
+      fields = fields.concat(newFields);
+      mode = "omit";
+    }
+  }
+
+  writeFileSync(path, file.join("\n"), { flag: "w" });
+}
+
 // Step 2: Generate a random string for keys and variable names
 function randomStr(length: number) {
   const charset = "abcdefghijklmnopqrstuvwxyz";
@@ -206,7 +340,7 @@ function randomStr(length: number) {
 
 // Step 3: Generate a random Zod schema
 function generateFields(
-  params: Pick<GenerateParams, "numKeys" | "valueTypes" | "methods">
+  params: Pick<GenerateObjectsParams, "numKeys" | "valueTypes" | "methods">
 ): { key: string; schema: string }[] {
   //Math.floor(Math.random() * 30) + 1; // 1-30 keys
   const { methods = [""] } = params;

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -14,6 +14,7 @@
     "@zod/core": "workspace:*",
     "zod3-24-2": "npm:zod@3.24.2",
     "zod3-24-3": "npm:zod@3.24.3",
+    "zod4": "npm:zod@4.0.0-beta.20250415T232143",
     "zod3": "npm:zod@^3.0.0",
     "@zod/mini": "workspace:*",
     "execa": "^9.5.2"
@@ -26,6 +27,7 @@
     "build:bench": "tsc -p tsconfig.bench.json",
     "lint": "tslint -c tslint.json src/**/*.ts",
     "prepublish": "npm run build",
-    "bench": "tsx ./bench/index.ts"
+    "bench": "tsx ./bench/index.ts",
+    "bisect": "tsx bisect.ts"
   }
 }

--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -1035,7 +1035,7 @@ type ZodInterfacePartial<
   T extends ZodInterface,
   Keys extends keyof T["_zod"]["def"]["shape"] = keyof T["_zod"]["def"]["shape"],
 > = ZodInterface<
-  util.ExtendShape<
+  util.Extend<
     T["_zod"]["def"]["shape"],
     {
       [k in Keys]: ZodOptional<T["_zod"]["def"]["shape"][k]>;
@@ -1052,7 +1052,7 @@ type ZodInterfaceRequired<
   T extends ZodInterface,
   Keys extends keyof T["_zod"]["def"]["shape"] = keyof T["_zod"]["def"]["shape"],
 > = ZodInterface<
-  util.ExtendShape<
+  util.Extend<
     T["_zod"]["def"]["shape"],
     {
       [k in Keys]: ZodNonOptional<T["_zod"]["def"]["shape"][k]>;
@@ -1066,7 +1066,7 @@ type ZodInterfaceRequired<
 >;
 
 export type MergeInterfaces<A extends ZodInterface, B extends ZodInterface> = ZodInterface<
-  util.ExtendShape<A["_zod"]["def"]["shape"], B["_zod"]["def"]["shape"]>,
+  util.Extend<A["_zod"]["def"]["shape"], B["_zod"]["def"]["shape"]>,
   util.MergeInterfaceParams<A, B>
 >;
 
@@ -1270,11 +1270,11 @@ export interface ZodObject<
   /** @deprecated This is the default behavior. This method call is likely unnecessary. */
   strip(): ZodObject<Shape, {}>;
 
-  extend<const U extends ZodObject>(schema: U): ZodObject<util.ExtendShape<Shape, U["_zod"]["def"]["shape"]>, Extra>;
+  extend<const U extends ZodObject>(schema: U): ZodObject<util.Extend<Shape, U["_zod"]["def"]["shape"]>, Extra>;
   extend<U extends core.$ZodShape>(
     shape: U
   ): ZodObject<
-    util.ExtendShape<Shape, U>,
+    util.Extend<Shape, U>,
     Extra // & B['_zod']["extra"]
   >;
 
@@ -1282,7 +1282,7 @@ export interface ZodObject<
   /** @deprecated Use `A.extend(B)` */
   merge<U extends ZodObject<any, any>>(
     other: U
-  ): ZodObject<util.Flatten<util.Overwrite<Shape, U["_zod"]["def"]["shape"]>>, Extra>;
+  ): ZodObject<util.Flatten<util.Extend<Shape, U["_zod"]["def"]["shape"]>>, Extra>;
 
   pick<M extends util.Exactly<util.Mask<string & keyof Shape>, M>>(
     mask: M
@@ -1396,15 +1396,12 @@ export function looseObject<T extends core.$ZodShape>(
 export function extend<T extends ZodInterface, U extends ZodInterface>(
   a: T,
   b: U
-): ZodInterface<
-  util.ExtendShape<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
-  util.MergeInterfaceParams<T, U>
->;
+): ZodInterface<util.Extend<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>, util.MergeInterfaceParams<T, U>>;
 export function extend<T extends ZodObject, U extends ZodObject>(
   a: T,
   b: U
 ): ZodObject<
-  util.ExtendObject<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
+  util.Extend<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
   U["_zod"]["extra"] & T["_zod"]["extra"]
 >;
 export function extend<T extends ZodObjectLike, U extends core.$ZodLooseShape>(
@@ -1412,7 +1409,7 @@ export function extend<T extends ZodObjectLike, U extends core.$ZodLooseShape>(
   shape: U
 ): T extends ZodInterface<infer TShape, infer TParams>
   ? ZodInterface<util.ExtendInterfaceShape<TShape, U>, util.ExtendInterfaceParams<ZodInterface<TShape, TParams>, U>>
-  : ZodObject<util.ExtendObject<T["_zod"]["def"]["shape"], U>, T["_zod"]["extra"]>;
+  : ZodObject<util.Extend<T["_zod"]["def"]["shape"], U>, T["_zod"]["extra"]>;
 export function extend(schema: ZodObjectLike, shape: core.$ZodShape): ZodObjectLike {
   if (shape instanceof core.$ZodType) return util.mergeObjectLike(schema, shape as any);
   if (schema instanceof ZodInterface) {
@@ -1428,14 +1425,14 @@ export function merge<T extends ZodObjectLike, U extends core.$ZodLooseShape>(
 ): T["_zod"]["def"]["type"] extends "interface"
   ? // T extends ZodInterface
     ZodInterface<
-      util.ExtendShape<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
+      util.Extend<T["_zod"]["def"]["shape"], U["_zod"]["def"]["shape"]>,
       {
         extra: T["_zod"]["extra"] & U["_zod"]["extra"];
         optional: Exclude<T["_zod"]["optional"], keyof U["_zod"]["def"]["shape"]> | U["_zod"]["optional"];
         defaulted: Exclude<T["_zod"]["defaulted"], keyof U["_zod"]["def"]["shape"]> | U["_zod"]["defaulted"];
       }
     >
-  : ZodObject<util.ExtendObject<T["_zod"]["def"]["shape"], U>, T["_zod"]["extra"]>;
+  : ZodObject<util.Extend<T["_zod"]["def"]["shape"], U>, T["_zod"]["extra"]>;
 export function merge(a: ZodObjectLike, b: ZodObjectLike): ZodObjectLike {
   return util.mergeObjectLike(a, b);
 }
@@ -1509,7 +1506,7 @@ export function partial<T extends ZodObjectLike, M extends util.Exactly<util.Mas
   mask: M
 ): T["_zod"]["def"]["type"] extends "interface"
   ? ZodInterface<
-      util.ExtendShape<
+      util.Extend<
         T["_zod"]["def"]["shape"],
         {
           [k in keyof M & keyof T["_zod"]["def"]["shape"]]: ZodOptional<T["_zod"]["def"]["shape"][k]>;
@@ -1547,7 +1544,7 @@ export function required<
   schema: T,
   mask: M
 ): ZodObject<
-  util.ExtendShape<
+  util.Extend<
     T["_zod"]["def"]["shape"],
     {
       [k in keyof M & keyof T["_zod"]["def"]["shape"]]: ZodNonOptional<T["_zod"]["def"]["shape"][k]>;
@@ -1573,7 +1570,7 @@ export function required<
   schema: T,
   mask: M
 ): ZodInterface<
-  util.ExtendShape<
+  util.Extend<
     T["_zod"]["def"]["shape"],
     {
       [k in keyof M & keyof T["_zod"]["def"]["shape"]]: ZodNonOptional<T["_zod"]["def"]["shape"][k]>;

--- a/play.ts
+++ b/play.ts
@@ -1,11 +1,19 @@
-import * as zm from "@zod/mini";
-import * as z from "zod";
+import * as z from "./packages/tsc/node_modules/zod4/dist/esm/index.js";
 
-zm._default;
+export const a = z.object({
+  a: z.string(),
+  b: z.string(),
+  c: z.string(),
+});
 
-z.config(z.locales.es());
+export const b = a.omit({
+  a: true,
+  b: true,
+  c: true,
+});
 
-const result = z.string().safeParse(123);
-
-result.error!.issues[0].message;
-// => Entrada inválida: se esperaba string, recibido número
+export const c = b.extend({
+  a: z.string(),
+  b: z.string(),
+  c: z.string(),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,9 @@ importers:
       zod3-24-3:
         specifier: npm:zod@3.24.3
         version: zod@3.24.3
+      zod4:
+        specifier: npm:zod@4.0.0-beta.20250415T232143
+        version: zod@4.0.0-beta.20250415T232143
 
   packages/zod:
     dependencies:
@@ -2440,6 +2443,9 @@ packages:
 
   '@zag-js/types@1.8.2':
     resolution: {integrity: sha512-J+94HhFAPOBchNdGcmvqjB8nbQFgKHcqGoPl5vNTKlcoibN0yFjn4XFZoQU6uCf8sPhNg6NUNTkluR5YjybyJA==}
+
+  '@zod/core@0.5.1':
+    resolution: {integrity: sha512-Iqa3r1weIYaG1pjR+vNhfmaQ+5YtdQEp839R7bil0CC30cwiExXuBI5AAEjZMMS2CzGcBlAWca+0+vxzUmdJ6Q==}
 
   '@zxing/text-encoding@0.9.0':
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
@@ -5256,6 +5262,9 @@ packages:
   zod@3.24.3:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
 
+  zod@4.0.0-beta.20250415T232143:
+    resolution: {integrity: sha512-qy5jcyX/4Vt003S9II2NxTeAU31CQ71wJxk54stbrU+dhF+RcZL6xMwj8vGBbRVJi26pjCbTe2BldpK75nzlDw==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -7237,6 +7246,8 @@ snapshots:
   '@zag-js/types@1.8.2':
     dependencies:
       csstype: 3.1.3
+
+  '@zod/core@0.5.1': {}
 
   '@zxing/text-encoding@0.9.0':
     optional: true
@@ -10676,5 +10687,9 @@ snapshots:
   zod@3.24.2: {}
 
   zod@3.24.3: {}
+
+  zod@4.0.0-beta.20250415T232143:
+    dependencies:
+      '@zod/core': 0.5.1
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
This targets v4 and it's basically the same change as in https://github.com/colinhacks/zod/pull/4150 (but that targets v3).

The proposed version is better because it preserves declaration links and that helps in-IDE navigation. To get proper declaration links you need to iterate over a single "modifier object" and `[P in keyof T | keyof U]` breaks that (it sources keys from 2 objects, so the compiler can't decide from which one the declaration, and modifiers, should be picked from). See this [TS playground](https://www.typescriptlang.org/play/?ssl=3&ssc=23&pln=3&pc=47#code/C4TwDgpgBAthBOBzCBGAPAFQDRQKoD4oBeKAeRgEthMcBrCEAewDMoMoAyKep1gzvAG4AUKEiwEyAEw08hEjxZsBivlAgAPYBAB2AEwDOUHRABuCKAH5lXXFABcZStWzcGS9l1VyBuEWOg4JAgAZll+EgBvKABtAAUoCh03XmUAHxSlXABdRwTNbX0jbztrXHjshzZ4lXdWDEqAXxFRcGgAMUZGYihI4SgBqGYuxwNgeCTEYUbhVvEAIQBDeB6+wagAI2XHHQBXGA2EadmAehOoRG7gbr0IAGMAG2XF4ApGZO0xgznoeAgDXYPYAoHpBZDoTqMHBLeD4GIAIi28HhlTOUEYtB+UD+AKBUlBkggMkh0OWcMRyxRUDRGKxOMBwBCBOCYRJUBh5KRVLROkYkCAA)