### PR TITLE
fix(docs): wrong comment for object document

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -871,10 +871,10 @@ In `A`, the `name` property can be set `undefined` or it can be omitted from the
 
 ```ts
 const obj: A = { name: undefined }; // ✅
-const obj: A = {} ; // ✅ 
+const obj: A = {} ; // ✅ pass
 
 const obj: B = { name: undefined }; // ✅ 
-const obj: B = {} ; // ❌ compile error, missing required property `name`
+const obj: B = {} ; // ❌ compile error: missing required property `name`
 ```
 
 


### PR DESCRIPTION
It looks like the comments were interchanged. To my understanding, obj: A will pass because the property in the interface A is optional, whereas obj: B will fail because it is not optional.