### PR TITLE
fix(v4): Change name of catch schema

### DIFF
--- a/packages/mini/src/schemas.ts
+++ b/packages/mini/src/schemas.ts
@@ -1472,7 +1472,7 @@ export const ZodMiniCatch: core.$constructor<ZodMiniCatch> = /*@__PURE__*/ core.
   }
 );
 
-function _catch<T extends SomeType>(
+export function _catch<T extends SomeType>(
   innerType: T,
   catchValue: core.output<T> | ((ctx: core.$ZodCatchCtx) => core.output<T>),
   params?: core.$ZodCatchParams
@@ -1486,7 +1486,6 @@ function _catch<T extends SomeType>(
     ...util.normalizeParams(params),
   }) as ZodMiniCatch<T>;
 }
-export { _catch as catch };
 
 // ZodMiniNaN
 export interface ZodMiniNaN extends ZodMiniType {

--- a/packages/mini/tests/index.test.ts
+++ b/packages/mini/tests/index.test.ts
@@ -604,17 +604,17 @@ test("z.default", () => {
 });
 
 test("z.catch", () => {
-  const a = z.catch(z.string(), "default");
+  const a = z._catch(z.string(), "default");
   type a = z.output<typeof a>;
   expectTypeOf<a>().toEqualTypeOf<string>();
   expect(z.parse(a, "hello")).toEqual("hello");
   expect(z.parse(a, 123)).toEqual("default");
 
-  const b = z.catch(z.string(), () => "default");
+  const b = z._catch(z.string(), () => "default");
   expect(z.parse(b, "hello")).toEqual("hello");
   expect(z.parse(b, 123)).toEqual("default");
 
-  const c = z.catch(z.string(), (ctx) => {
+  const c = z._catch(z.string(), (ctx) => {
     return `${ctx.error.issues.length}issues`;
   });
   expect(z.parse(c, 1234)).toEqual("1issues");


### PR DESCRIPTION
## Overview

`catch` is a reserved word, so if you try to use it as shown below, an error will occur. Therefore, we added an underscore to it, just like `default`.

![image](https://github.com/user-attachments/assets/dc51fccf-98d7-4767-8f41-c86ee6277644)
