### PR TITLE
v4: fix typo in defining schemas section

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -102,7 +102,7 @@ To allow multiple literal values:
 ```ts
 const colors = z.literal(["red", "green", "blue"]);
 
-colos.parse("green"); // ✅
+colors.parse("green"); // ✅
 colors.parse("yellow"); // ❌
 ```
 


### PR DESCRIPTION
fixed a typo for the constant`colors`