### PR TITLE
v4: Reusing `Number.MAX_VALUE` for `float64` range

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -631,7 +631,7 @@ export const NUMBER_FORMAT_RANGES: Record<checks.$ZodNumberFormats, [number, num
   int32: [-2147483648, 2147483647],
   uint32: [0, 4294967295],
   float32: [-3.4028234663852886e38, 3.4028234663852886e38],
-  float64: [-1.7976931348623157e308, 1.7976931348623157e308],
+  float64: [-Number.MAX_VALUE, Number.MAX_VALUE],
 };
 
 export const BIGINT_FORMAT_RANGES: Record<checks.$ZodBigIntFormats, [bigint, bigint]> = {


### PR DESCRIPTION
there is a const for that
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE

Extracted from [suggestion](https://github.com/colinhacks/zod/pull/4074#discussion_r2048370314) by request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the internal handling of number format ranges for improved consistency with JavaScript standards. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->