### PR TITLE
v4: Correcting the default numeric range to be inclusive

### DIFF
--- a/packages/core/src/checks.ts
+++ b/packages/core/src/checks.ts
@@ -271,6 +271,7 @@ export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /
       inst._zod.computed.format = def.format;
       inst._zod.computed.minimum = minimum;
       inst._zod.computed.maximum = maximum;
+      inst._zod.computed.inclusive = true;
       if (isInt) inst._zod.computed.pattern = regexes.integer;
     };
 

--- a/packages/zod/tests/json-schema.test.ts
+++ b/packages/zod/tests/json-schema.test.ts
@@ -157,29 +157,29 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.int())).toMatchInlineSnapshot(`
       {
-        "exclusiveMaximum": 9007199254740991,
-        "exclusiveMinimum": -9007199254740991,
+        "maximum": 9007199254740991,
+        "minimum": -9007199254740991,
         "type": "integer",
       }
     `);
     expect(toJSONSchema(z.int32())).toMatchInlineSnapshot(`
       {
-        "exclusiveMaximum": 2147483647,
-        "exclusiveMinimum": -2147483648,
+        "maximum": 2147483647,
+        "minimum": -2147483648,
         "type": "integer",
       }
     `);
     expect(toJSONSchema(z.float32())).toMatchInlineSnapshot(`
       {
-        "exclusiveMaximum": 3.4028234663852886e+38,
-        "exclusiveMinimum": -3.4028234663852886e+38,
+        "maximum": 3.4028234663852886e+38,
+        "minimum": -3.4028234663852886e+38,
         "type": "number",
       }
     `);
     expect(toJSONSchema(z.float64())).toMatchInlineSnapshot(`
       {
-        "exclusiveMaximum": 1.7976931348623157e+308,
-        "exclusiveMinimum": -1.7976931348623157e+308,
+        "maximum": 1.7976931348623157e+308,
+        "minimum": -1.7976931348623157e+308,
         "type": "number",
       }
     `);


### PR DESCRIPTION
The default range (min/max representable numbers) is inclusive, not exclusive.

Addressing the bug I found and previously described in https://github.com/colinhacks/zod/pull/4074#discussion_r2048393003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated numeric type schemas to use inclusive bounds (`maximum` and `minimum`) instead of exclusive bounds in JSON Schema output.

- **Tests**
  - Updated test snapshots to reflect the use of inclusive numeric boundaries in schema conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->