### PR TITLE
v4: add GQLoom to ecosystem

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -17,6 +17,12 @@ const apiLibraries: ZodResource[] = [
     description: "Build end-to-end typesafe APIs without GraphQL.",
     slug: "trpc/trpc",
   },
+  {
+    name: "GQLoom",
+    url: "https://gqloom.dev/",
+    description: "Weave GraphQL schema and resolvers using Zod.",
+    slug: "modevol-com/gqloom",
+  },
 ];
 
 const formIntegrations: ZodResource[] = [];


### PR DESCRIPTION
Thank you for your excellent work on Zod v4!

[GQLoom](https://github.com/modevol-com/gqloom) now fully supports Zod v4 and has been released in the [next version](https://github.com/modevol-com/gqloom/pull/41).

Install using the `next` tag:

```bash
# Using npm
npm install zod@next @gqloom/zod@next

# Using yarn
yarn add zod@next @gqloom/zod@next

# Using pnpm
pnpm add zod@next @gqloom/zod@next
```

I really love Zod v4, especially the `register` feature, which enables GQLoom to define GraphQL-specific metadata directly on Zod:

```ts
const Orange = z
  .object({
    name: z.string(),
    color: z.string(),
    prize: z.number(),
  })
  .register(asObjectType, { name: "Orange", interfaces: [Fruit] })
```
