### PR TITLE
fix(locale): show correct prefix instead of [object Object] in AZ and ES language

### DIFF
--- a/packages/core/src/locales/az.ts
+++ b/packages/core/src/locales/az.ts
@@ -91,7 +91,7 @@ const error: errors.$ZodErrorMap = (issue) => {
     }
     case "invalid_format": {
       const _issue = issue as errors.$ZodStringFormatIssues;
-      if (_issue.format === "starts_with") return `Yanlış mətn: "${issue}" ilə başlamalıdır`;
+      if (_issue.format === "starts_with") return `Yanlış mətn: "${_issue.prefix}" ilə başlamalıdır`;
       if (_issue.format === "ends_with") return `Yanlış mətn: "${_issue.suffix}" ilə bitməlidir`;
       if (_issue.format === "includes") return `Yanlış mətn: "${_issue.includes}" daxil olmalıdır`;
       if (_issue.format === "regex") return `Yanlış mətn: ${_issue.pattern} şablonuna uyğun olmalıdır`;

--- a/packages/core/src/locales/es.ts
+++ b/packages/core/src/locales/es.ts
@@ -94,7 +94,7 @@ const error: errors.$ZodErrorMap = (issue) => {
     }
     case "invalid_format": {
       const _issue = issue as errors.$ZodStringFormatIssues;
-      if (_issue.format === "starts_with") return `Cadena inválida: debe comenzar con "${issue}"`;
+      if (_issue.format === "starts_with") return `Cadena inválida: debe comenzar con "${_issue.prefix}"`;
       if (_issue.format === "ends_with") return `Cadena inválida: debe terminar en "${_issue.suffix}"`;
       if (_issue.format === "includes") return `Cadena inválida: debe incluir "${_issue.includes}"`;
       if (_issue.format === "regex") return `Cadena inválida: debe coincidir con el patrón ${_issue.pattern}`;


### PR DESCRIPTION
Fix issue of showing [object Object] in startsWith error for AZ and ES languages

![image](https://github.com/user-attachments/assets/47150b94-fab3-49ae-9308-da1569d0161a)
