### PR TITLE
fix(docs): Correct typo in Records

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1731,7 +1731,7 @@ IdCache.parse({
 });
 ```
 
-The key schema can be any Zod schema that as assignable to `string | number | symbol`.
+The key schema can be any Zod schema that is assignable to `string | number | symbol`.
 
 ```ts
 const Keys = z.union([z.string(), z.number(), z.symbol()]);


### PR DESCRIPTION
Correct typo in Records "that as" instead of "that is".