### PR TITLE
chore: add `orval` to XtoZod ecosystems in v4

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -23,7 +23,14 @@ const formIntegrations: ZodResource[] = [];
 
 const zodToXConverters: ZodResource[] = [];
 
-const xToZodConverters: ZodResource[] = [];
+const xToZodConverters: ZodResource[] = [
+  {
+    name: "orval",
+    url: "https://github.com/orval-labs/orval",
+    description: "Generate Zod schemas from OpenAPI schemas",
+    slug: "orval-labs/orval",
+  },
+];
 
 const mockingLibraries: ZodResource[] = [];
 


### PR DESCRIPTION
HI everyone, Thank you for creating an issue the other day.
I received an issue from @colinhacks  here with information about upgrading to v4:

https://github.com/orval-labs/orval/issues/2042

I have confirmed that v4 is compatible with orval, so I will continue to set up links as part of the ecosystem after v4 👍 