### PR TITLE
#4238 Fix extended interfaces causing optional keys to break types

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1804,9 +1804,12 @@ export type $InferInterfaceOutput<
     ? object
     : util.Flatten<
         {
-          -readonly [k in Params["optional"]]?: T[k]["_zod"]["output"];
+          // Use CleanKeys on the optional parameter keys
+          -readonly [k in util.CleanKeys<Params["optional"]>]?: T[k]["_zod"]["output"];
         } & {
-          -readonly [k in Exclude<keyof T, Params["optional"]>]: T[k]["_zod"]["output"];
+          // Use CleanKeys on the required keys.
+          // Apply CleanKeys to keyof T *before* excluding the cleaned optional keys.
+          -readonly [k in util.CleanKeys<Exclude<util.CleanKeys<keyof T>, Params["optional"]>>]: T[k]["_zod"]["output"];
         } & Params["extra"]
       >;
 
@@ -1819,9 +1822,13 @@ export type $InferInterfaceInput<
     ? Record<string, unknown>
     : util.Flatten<
         {
-          -readonly [k in Params["optional"] | Params["defaulted"]]?: T[k]["_zod"]["input"];
+          // Use CleanKeys on optional/defaulted keys
+          -readonly [k in util.CleanKeys<Params["optional"] | Params["defaulted"]>]?: T[k]["_zod"]["input"];
         } & {
-          -readonly [k in Exclude<keyof T, Params["optional"] | Params["defaulted"]>]: T[k]["_zod"]["input"];
+          // Use CleanKeys on required keys
+          -readonly [k in util.CleanKeys<
+            Exclude<keyof T, Params["optional"] | Params["defaulted"]>
+          >]: T[k]["_zod"]["input"];
         } & Params["extra"]
       >;
 

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -580,12 +580,14 @@ export type MergeInterfaceParams<
   B extends schemas.$ZodInterface,
   // BKeys extends PropertyKey,
 > = Identity<{
+  // Optional keys from A, excluding any keys present in B's shape, unioned with B's optional keys
   optional: Exclude<A["_zod"]["optional"], keyof B["_zod"]["def"]["shape"]> | B["_zod"]["optional"];
   defaulted: Exclude<A["_zod"]["defaulted"], keyof B["_zod"]["def"]["shape"]> | B["_zod"]["defaulted"];
   extra: A["_zod"]["extra"];
 }>;
 
 export type ExtendInterfaceParams<A extends schemas.$ZodInterface, Shape extends schemas.$ZodLooseShape> = Identity<{
+  // Optional keys from A, excluding any cleaned keys present in the extending Shape, unioned with the Shape's optional keys
   optional: Exclude<A["_zod"]["optional"], CleanKeys<keyof Shape>> | OptionalInterfaceKeys<keyof Shape>;
   defaulted: Exclude<A["_zod"]["defaulted"], CleanKeys<keyof Shape>> | DefaultedInterfaceKeys<keyof Shape>;
   extra: A["_zod"]["extra"];

--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -1119,7 +1119,7 @@ export interface ZodInterface<
   extend<U extends ZodInterface>(int: U): MergeInterfaces<this, U>;
   extend<U extends core.$ZodLooseShape>(
     shape: U
-  ): MergeInterfaces<this, ZodInterface<U, util.InitInterfaceParams<U, {}>>>;
+  ): MergeInterfaces<this, ZodInterface<util.CleanInterfaceShape<U>, util.InitInterfaceParams<U, {}>>>;
 
   /** @deprecated Use `A.extend(B)` */
   merge<U extends ZodInterface>(incoming: U): MergeInterfaces<this, U>;

--- a/packages/zod/tests/interface-optional-keys.test.ts
+++ b/packages/zod/tests/interface-optional-keys.test.ts
@@ -71,10 +71,7 @@ test("ZodInterface extended optional keys inference - type inference bug", () =>
 
   // Check for property names in the inferred type
   type HasExtendedProp = HasProperty<ExtendedType, "optionalExtendedProp">;
-  type HasExtendedPropWithQuestion = HasProperty<
-    ExtendedType,
-    "optionalExtendedProp?"
-  >;
+  type HasExtendedPropWithQuestion = HasProperty<ExtendedType, "optionalExtendedProp?">;
 
   // This verifies the "optionalExtendedProp" property exists (which is correct)
   expectTypeOf<HasExtendedProp>().toEqualTypeOf<true>();
@@ -121,10 +118,7 @@ test("ZodInterface complex extended/discriminated union optional keys inference 
   });
 
   // Discriminated Union Schema
-  const GenericDiscriminatedSchema = z.discriminatedUnion("kind", [
-    ExtendedSchemaA,
-    ExtendedSchemaB,
-  ]);
+  const GenericDiscriminatedSchema = z.discriminatedUnion("kind", [ExtendedSchemaA, ExtendedSchemaB]);
 
   // Infer types
   type DiscriminatedType = z.infer<typeof GenericDiscriminatedSchema>;
@@ -184,7 +178,5 @@ test("ZodInterface complex extended/discriminated union optional keys inference 
 
   expect(GenericDiscriminatedSchema.parse(exampleA)).toEqual(exampleA);
   expect(GenericDiscriminatedSchema.parse(exampleB)).toEqual(exampleB);
-  expect(GenericDiscriminatedSchema.parse(exampleBaseOptional)).toEqual(
-    exampleBaseOptional
-  );
+  expect(GenericDiscriminatedSchema.parse(exampleBaseOptional)).toEqual(exampleBaseOptional);
 });

--- a/packages/zod/tests/interface-optional-keys.test.ts
+++ b/packages/zod/tests/interface-optional-keys.test.ts
@@ -1,0 +1,89 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as z from "zod";
+
+/**
+ * This test file specifically demonstrates the bug in ZodInterface's type
+ * inference with optional keys in extended interfaces.
+ *
+ * The bug occurs when extending an interface that has optional keys (with a "?" suffix)
+ * The extended interface does not correctly maintain the optionality in the TypeScript
+ * type inference.
+ */
+test("ZodInterface extended optional keys inference - runtime works correctly", () => {
+  // Base interface with an optional key
+  const base = z.interface({
+    "defaultValue?": z.number(),
+  });
+
+  // Extended interface with another optional key
+  const extended = base.extend({
+    "alias?": z.string(),
+  });
+
+  // Runtime verification - these all work correctly
+  const withBothFields = { defaultValue: 123, alias: "test" };
+  expect(extended.parse(withBothFields)).toEqual(withBothFields);
+
+  // Empty object is valid (both fields optional)
+  expect(extended.parse({})).toEqual({});
+
+  // Only defaultValue is valid
+  expect(extended.parse({ defaultValue: 456 })).toEqual({ defaultValue: 456 });
+
+  // Only alias is valid
+  expect(extended.parse({ alias: "test-only" })).toEqual({
+    alias: "test-only",
+  });
+
+  // Verify object property names in the parsed result
+  const parsed = extended.parse(withBothFields);
+  expect("alias?" in parsed).toBe(false); // "alias?" is not a property
+  expect("alias" in parsed).toBe(true); // "alias" is a property (without the ?)
+});
+
+/**
+ * This test demonstrates the TYPE INFERENCE bug.
+ *
+ * The test uses a utility type to check for the presence of keys in the inferred type.
+ * The bug is that the key name may include the question mark in the inferred type.
+ */
+test("ZodInterface extended optional keys inference - type inference bug", () => {
+  // Base interface with an optional key
+  const base = z.interface({
+    "defaultValue?": z.number(),
+  });
+
+  // Extended interface with another optional key
+  const extended = base.extend({
+    "alias?": z.string(),
+  });
+
+  // Utility type to check for property names in a type
+  type HasProperty<T, K extends string> = K extends keyof T ? true : false;
+
+  // Infer the type from our schemas
+  type ExtendedType = z.infer<typeof extended>;
+
+  // Check for property names in the inferred type
+  type HasAlias = HasProperty<ExtendedType, "alias">;
+  type HasAliasWithQuestion = HasProperty<ExtendedType, "alias?">;
+
+  // This verifies the "alias" property exists (which is correct)
+  expectTypeOf<HasAlias>().toEqualTypeOf<true>();
+
+  // The following assertion would fail because of the bug:
+  // When the bug is fixed, this assertion should pass
+  expectTypeOf<HasAliasWithQuestion>().toEqualTypeOf<false>();
+
+  // The bug causes the type to be something like:
+  // {
+  //   defaultValue?: number | undefined;
+  //   "alias?": string;
+  //   alias?: unknown;
+  // }
+  // Instead of the expected:
+  // {
+  //   defaultValue?: number | undefined;
+  //   alias?: string | undefined;
+  // }
+});

--- a/packages/zod/tests/interface-optional-keys.test.ts
+++ b/packages/zod/tests/interface-optional-keys.test.ts
@@ -21,14 +21,19 @@ test("ZodInterface extended optional keys inference - runtime works correctly", 
   });
 
   // Runtime verification - these all work correctly
-  const withBothFields = { optionalBaseProp: 123, optionalExtendedProp: "test" };
+  const withBothFields = {
+    optionalBaseProp: 123,
+    optionalExtendedProp: "test",
+  };
   expect(ExtendedSchema.parse(withBothFields)).toEqual(withBothFields);
 
   // Empty object is valid (both fields optional)
   expect(ExtendedSchema.parse({})).toEqual({});
 
   // Only optionalBaseProp is valid
-  expect(ExtendedSchema.parse({ optionalBaseProp: 456 })).toEqual({ optionalBaseProp: 456 });
+  expect(ExtendedSchema.parse({ optionalBaseProp: 456 })).toEqual({
+    optionalBaseProp: 456,
+  });
 
   // Only optionalExtendedProp is valid
   expect(ExtendedSchema.parse({ optionalExtendedProp: "test-only" })).toEqual({
@@ -66,7 +71,10 @@ test("ZodInterface extended optional keys inference - type inference bug", () =>
 
   // Check for property names in the inferred type
   type HasExtendedProp = HasProperty<ExtendedType, "optionalExtendedProp">;
-  type HasExtendedPropWithQuestion = HasProperty<ExtendedType, "optionalExtendedProp?">;
+  type HasExtendedPropWithQuestion = HasProperty<
+    ExtendedType,
+    "optionalExtendedProp?"
+  >;
 
   // This verifies the "optionalExtendedProp" property exists (which is correct)
   expectTypeOf<HasExtendedProp>().toEqualTypeOf<true>();
@@ -161,10 +169,22 @@ test("ZodInterface complex extended/discriminated union optional keys inference 
 
   // Runtime check example (optional)
   const exampleA: TypeA = { id: "1", kind: "A", propA: "hello" };
-  const exampleB: TypeB = { id: "2", kind: "B", propB: true, optionalB: new Date() };
-  const exampleBaseOptional: TypeA = { id: "3", kind: "A", propA: "world", baseOptional: true };
+  const exampleB: TypeB = {
+    id: "2",
+    kind: "B",
+    propB: true,
+    optionalB: new Date(),
+  };
+  const exampleBaseOptional: TypeA = {
+    id: "3",
+    kind: "A",
+    propA: "world",
+    baseOptional: true,
+  };
 
   expect(GenericDiscriminatedSchema.parse(exampleA)).toEqual(exampleA);
   expect(GenericDiscriminatedSchema.parse(exampleB)).toEqual(exampleB);
-  expect(GenericDiscriminatedSchema.parse(exampleBaseOptional)).toEqual(exampleBaseOptional);
+  expect(GenericDiscriminatedSchema.parse(exampleBaseOptional)).toEqual(
+    exampleBaseOptional
+  );
 });


### PR DESCRIPTION
#4238 

Use util.CleanInterfaceShape when merging interfaces to stop extended interfaces with optional keys causing a duplicate key. Included optional tests to show it is fixed