### PR TITLE
Add support for `kubb` as part of the v4 upgrade

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -29,7 +29,14 @@ const formIntegrations: ZodResource[] = [];
 
 const zodToXConverters: ZodResource[] = [];
 
-const xToZodConverters: ZodResource[] = [];
+const xToZodConverters: ZodResource[] = [
+  {
+    name: "kubb",
+    url: "https://github.com/kubb-labs/kubb",
+    description: "The ultimate toolkit for working with APIs.",
+    slug: "kubb-labs/kubb",
+  },
+];
 
 const mockingLibraries: ZodResource[] = [
   {


### PR DESCRIPTION
Hey everyone!

Thanks for opening an issue the other day. I also got a heads-up from @colinhacks about upgrading to Zod v4 over here:
https://github.com/kubb-labs/kubb/issues/1663

Good news—we’ve confirmed that Zod v4 works smoothly with Kubb, everything’s looking good on our end. We’ll keep working on supporting the latest features in Zod v4. This already lets us drop some of our custom TypeScript helpers, thanks to the new `z.interface` 🙌.

Thanks