### PR TITLE
Add composable-functions as a library powered by Zod supporting v4

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -31,6 +31,12 @@ const zodToXConverters: ZodResource[] = [];
 
 const xToZodConverters: ZodResource[] = [
   {
+    name: "orval",
+    url: "https://github.com/orval-labs/orval",
+    description: "Generate Zod schemas from OpenAPI schemas",
+    slug: "orval-labs/orval",
+  },
+  {
     name: "kubb",
     url: "https://github.com/kubb-labs/kubb",
     description: "The ultimate toolkit for working with APIs.",

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -54,6 +54,12 @@ const poweredByZodProjects: ZodResource[] = [
     description: "Load configurations across multiple sources with flexible adapters, ensuring type safety with Zod.",
     slug: "alexmarqs/zod-config",
   },
+  {
+    name: "Composable Functions",
+    url: "https://github.com/seasonedcc/composable-functions",
+    description: "Types and functions to make composition easy and safe.",
+    slug: "seasonedcc/composable-functions",
+  },
 ];
 
 const zodUtilities: ZodResource[] = [];

--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -309,8 +309,10 @@ type schemaInput = z.input<typeof schema>;
 
 These modifier methods on the `ZodObject` class determine how the schema handles unknown keys. In Zod 4, this functionality now exists in top-level functions. This aligns better with Zod's declarative-first philosophy, and puts all object variants on equal footing. 
 
-### deprecates `.strict()`
 
+### discourages `.strict()`
+
+> The `.strict()` method is discouraged but not deprecat4ed. It won't be removed. 
 ```ts
 // Zod 3
 z.object({ name: z.string() }).strict();


### PR DESCRIPTION
Hey folks! Thank you for opening the issue seasonedcc/composable-functions#174 the other day!
And congrats for all the work-zod@4 and zod/min have been a pleasure to work with!

As our library supports @standard-schema I already imagined it would work with zod@4 without any changes and I was right:
seasonedcc/composable-functions#176

I hope we get added to the v4 as zod has been a crucial part of the development of Composable Functions.

Cheers and LMK if I should change anything