### PR TITLE
fix(transform): abort further processing when inner value is invalid

### DIFF
--- a/deno/lib/__tests__/refine.test.ts
+++ b/deno/lib/__tests__/refine.test.ts
@@ -305,3 +305,19 @@ test("fatal superRefine", () => {
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 });
+
+test("superRefine after skipped transform", () => {
+  const schema = z
+    .string()
+    .regex(/^\d+$/)
+    .transform((val) => Number(val))
+    .superRefine((val) => {
+      if (typeof val !== "number") {
+        throw new Error("Called without transform");
+      }
+    });
+
+  const result = schema.safeParse("");
+
+  expect(result.success).toEqual(false);
+});

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4724,7 +4724,7 @@ export class ZodEffects<
           parent: ctx,
         });
 
-        if (!isValid(base)) return base;
+        if (!isValid(base)) return INVALID;
 
         const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
@@ -4738,7 +4738,7 @@ export class ZodEffects<
         return this._def.schema
           ._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx })
           .then((base) => {
-            if (!isValid(base)) return base;
+            if (!isValid(base)) return INVALID;
 
             return Promise.resolve(effect.transform(base.value, checkCtx)).then(
               (result) => ({ status: status.value, value: result })

--- a/src/__tests__/refine.test.ts
+++ b/src/__tests__/refine.test.ts
@@ -304,3 +304,19 @@ test("fatal superRefine", () => {
   expect(result.success).toEqual(false);
   if (!result.success) expect(result.error.issues.length).toEqual(1);
 });
+
+test("superRefine after skipped transform", () => {
+  const schema = z
+    .string()
+    .regex(/^\d+$/)
+    .transform((val) => Number(val))
+    .superRefine((val) => {
+      if (typeof val !== "number") {
+        throw new Error("Called without transform");
+      }
+    });
+
+  const result = schema.safeParse("");
+
+  expect(result.success).toEqual(false);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -4724,7 +4724,7 @@ export class ZodEffects<
           parent: ctx,
         });
 
-        if (!isValid(base)) return base;
+        if (!isValid(base)) return INVALID;
 
         const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
@@ -4738,7 +4738,7 @@ export class ZodEffects<
         return this._def.schema
           ._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx })
           .then((base) => {
-            if (!isValid(base)) return base;
+            if (!isValid(base)) return INVALID;
 
             return Promise.resolve(effect.transform(base.value, checkCtx)).then(
               (result) => ({ status: status.value, value: result })


### PR DESCRIPTION
Previously when an inner value was invalid, transforms would not run, but subsequent refinements would still run with the non-transformed value, which in most cases would violate the typings.

This fix returns `INVALID` from the transform in case of a failed inner validation and stop outer refinements from running with the wrong types.

Closes #2243
Closes #2192
Closes #2113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a new test to verify behavior when a validation transform is skipped and an additional refinement is applied.
- **Bug Fixes**
	- Improved handling of invalid parse results during schema transformations to ensure consistent error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->