### PR TITLE
V4(fix): generate json-schema with min/max(0)

### DIFF
--- a/packages/core/src/to-json-schema.ts
+++ b/packages/core/src/to-json-schema.ts
@@ -16,7 +16,7 @@ interface JSONSchemaGeneratorParams {
    * - `"any"` — Unrepresentable types become `{}` */
   unrepresentable?: "throw" | "any";
   /** Arbitrary custom logic that can be used to modify the generated JSON Schema. */
-  override?: (ctx: { zodSchema: schemas.$ZodType; jsonSchema: JSONSchema.BaseSchema; }) => void;
+  override?: (ctx: { zodSchema: schemas.$ZodType; jsonSchema: JSONSchema.BaseSchema }) => void;
   /** Whether to extract the `"input"` or `"output"` type. Relevant to transforms, Error converting schema to JSONz, defaults, coerced primitives, etc.
    * - `"output" — Default. Convert the output schema.
    * - `"input"` — Convert the input schema. */
@@ -45,13 +45,13 @@ interface EmitParams {
    */
   // uri?: (id: string) => string;
   external?:
-  | {
-    registry: $ZodRegistry<{ id?: string | undefined; }>;
-    uri: (id: string) => string;
-    // __shared: boolean;
-    defs: Record<string, JSONSchema.BaseSchema>;
-  }
-  | undefined;
+    | {
+        registry: $ZodRegistry<{ id?: string | undefined }>;
+        uri: (id: string) => string;
+        // __shared: boolean;
+        defs: Record<string, JSONSchema.BaseSchema>;
+      }
+    | undefined;
 }
 
 const formatMap: Partial<Record<checks.$ZodStringFormats, string>> = {
@@ -79,7 +79,7 @@ export class JSONSchemaGenerator {
   metadataRegistry: $ZodRegistry<Record<string, any>>;
   target: "draft-7" | "draft-2020-12";
   unrepresentable: "throw" | "any";
-  override: (ctx: { zodSchema: schemas.$ZodType; jsonSchema: JSONSchema.BaseSchema; }) => void;
+  override: (ctx: { zodSchema: schemas.$ZodType; jsonSchema: JSONSchema.BaseSchema }) => void;
   io: "input" | "output";
 
   counter = 0;
@@ -90,7 +90,7 @@ export class JSONSchemaGenerator {
     this.metadataRegistry = params?.metadata ?? globalRegistry;
     this.target = params?.target ?? "draft-2020-12";
     this.unrepresentable = params?.unrepresentable ?? "throw";
-    this.override = params?.override ?? (() => { });
+    this.override = params?.override ?? (() => {});
     this.io = params?.io ?? "output";
 
     this.seen = new Map();
@@ -573,7 +573,7 @@ export class JSONSchemaGenerator {
     // initialize result with root schema fields
     // Object.assign(result, seen.cached);
 
-    const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string; } => {
+    const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
       // comparing the seen objects because sometimes
       // multiple schemas map to the same seen object.
       // e.g. lazy
@@ -652,8 +652,8 @@ export class JSONSchemaGenerator {
         if (params.cycles === "throw") {
           throw new Error(
             "Cycle detected: " +
-            `#/${seen.cycle?.join("/")}/<root>` +
-            '\n\nSet the `cycles` parameter to `"ref"` to resolve cyclical schemas with defs.'
+              `#/${seen.cycle?.join("/")}/<root>` +
+              '\n\nSet the `cycles` parameter to `"ref"` to resolve cyclical schemas with defs.'
           );
         } else if (params.cycles === "ref") {
           extractToDef(entry);
@@ -724,18 +724,18 @@ function schemaToRef(seen: Seen, ref: string) {
   }
 }
 
-interface ToJSONSchemaParams extends Omit<JSONSchemaGeneratorParams & EmitParams, never> { }
+interface ToJSONSchemaParams extends Omit<JSONSchemaGeneratorParams & EmitParams, never> {}
 interface RegistryToJSONSchemaParams extends Omit<JSONSchemaGeneratorParams & EmitParams, never> {
   uri?: (id: string) => string;
 }
 
 export function toJSONSchema(schema: schemas.$ZodType, _params?: ToJSONSchemaParams): JSONSchema.BaseSchema;
 export function toJSONSchema(
-  registry: $ZodRegistry<{ id?: string | undefined; }>,
+  registry: $ZodRegistry<{ id?: string | undefined }>,
   _params?: RegistryToJSONSchemaParams
-): { schemas: Record<string, JSONSchema.BaseSchema>; };
+): { schemas: Record<string, JSONSchema.BaseSchema> };
 export function toJSONSchema(
-  input: schemas.$ZodType | $ZodRegistry<{ id?: string | undefined; }>,
+  input: schemas.$ZodType | $ZodRegistry<{ id?: string | undefined }>,
   _params?: ToJSONSchemaParams
 ): any {
   if (input instanceof $ZodRegistry) {

--- a/packages/core/src/to-json-schema.ts
+++ b/packages/core/src/to-json-schema.ts
@@ -16,7 +16,7 @@ interface JSONSchemaGeneratorParams {
    * - `"any"` — Unrepresentable types become `{}` */
   unrepresentable?: "throw" | "any";
   /** Arbitrary custom logic that can be used to modify the generated JSON Schema. */
-  override?: (ctx: { zodSchema: schemas.$ZodType; jsonSchema: JSONSchema.BaseSchema }) => void;
+  override?: (ctx: { zodSchema: schemas.$ZodType; jsonSchema: JSONSchema.BaseSchema; }) => void;
   /** Whether to extract the `"input"` or `"output"` type. Relevant to transforms, Error converting schema to JSONz, defaults, coerced primitives, etc.
    * - `"output" — Default. Convert the output schema.
    * - `"input"` — Convert the input schema. */
@@ -45,13 +45,13 @@ interface EmitParams {
    */
   // uri?: (id: string) => string;
   external?:
-    | {
-        registry: $ZodRegistry<{ id?: string | undefined }>;
-        uri: (id: string) => string;
-        // __shared: boolean;
-        defs: Record<string, JSONSchema.BaseSchema>;
-      }
-    | undefined;
+  | {
+    registry: $ZodRegistry<{ id?: string | undefined; }>;
+    uri: (id: string) => string;
+    // __shared: boolean;
+    defs: Record<string, JSONSchema.BaseSchema>;
+  }
+  | undefined;
 }
 
 const formatMap: Partial<Record<checks.$ZodStringFormats, string>> = {
@@ -79,7 +79,7 @@ export class JSONSchemaGenerator {
   metadataRegistry: $ZodRegistry<Record<string, any>>;
   target: "draft-7" | "draft-2020-12";
   unrepresentable: "throw" | "any";
-  override: (ctx: { zodSchema: schemas.$ZodType; jsonSchema: JSONSchema.BaseSchema }) => void;
+  override: (ctx: { zodSchema: schemas.$ZodType; jsonSchema: JSONSchema.BaseSchema; }) => void;
   io: "input" | "output";
 
   counter = 0;
@@ -90,7 +90,7 @@ export class JSONSchemaGenerator {
     this.metadataRegistry = params?.metadata ?? globalRegistry;
     this.target = params?.target ?? "draft-2020-12";
     this.unrepresentable = params?.unrepresentable ?? "throw";
-    this.override = params?.override ?? (() => {});
+    this.override = params?.override ?? (() => { });
     this.io = params?.io ?? "output";
 
     this.seen = new Map();
@@ -198,15 +198,15 @@ export class JSONSchemaGenerator {
           if (format?.includes("int")) json.type = "integer";
           else json.type = "number";
 
-          if (minimum) {
+          if (typeof minimum === "number") {
             if (inclusive) json.minimum = minimum;
             else json.exclusiveMinimum = minimum;
           }
-          if (maximum) {
+          if (typeof maximum === "number") {
             if (inclusive) json.maximum = maximum;
             else json.exclusiveMaximum = maximum;
           }
-          if (multipleOf) json.multipleOf = multipleOf;
+          if (typeof multipleOf === "number") json.multipleOf = multipleOf;
 
           break;
         }
@@ -573,7 +573,7 @@ export class JSONSchemaGenerator {
     // initialize result with root schema fields
     // Object.assign(result, seen.cached);
 
-    const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
+    const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string; } => {
       // comparing the seen objects because sometimes
       // multiple schemas map to the same seen object.
       // e.g. lazy
@@ -652,8 +652,8 @@ export class JSONSchemaGenerator {
         if (params.cycles === "throw") {
           throw new Error(
             "Cycle detected: " +
-              `#/${seen.cycle?.join("/")}/<root>` +
-              '\n\nSet the `cycles` parameter to `"ref"` to resolve cyclical schemas with defs.'
+            `#/${seen.cycle?.join("/")}/<root>` +
+            '\n\nSet the `cycles` parameter to `"ref"` to resolve cyclical schemas with defs.'
           );
         } else if (params.cycles === "ref") {
           extractToDef(entry);
@@ -724,18 +724,18 @@ function schemaToRef(seen: Seen, ref: string) {
   }
 }
 
-interface ToJSONSchemaParams extends Omit<JSONSchemaGeneratorParams & EmitParams, never> {}
+interface ToJSONSchemaParams extends Omit<JSONSchemaGeneratorParams & EmitParams, never> { }
 interface RegistryToJSONSchemaParams extends Omit<JSONSchemaGeneratorParams & EmitParams, never> {
   uri?: (id: string) => string;
 }
 
 export function toJSONSchema(schema: schemas.$ZodType, _params?: ToJSONSchemaParams): JSONSchema.BaseSchema;
 export function toJSONSchema(
-  registry: $ZodRegistry<{ id?: string | undefined }>,
+  registry: $ZodRegistry<{ id?: string | undefined; }>,
   _params?: RegistryToJSONSchemaParams
-): { schemas: Record<string, JSONSchema.BaseSchema> };
+): { schemas: Record<string, JSONSchema.BaseSchema>; };
 export function toJSONSchema(
-  input: schemas.$ZodType | $ZodRegistry<{ id?: string | undefined }>,
+  input: schemas.$ZodType | $ZodRegistry<{ id?: string | undefined; }>,
   _params?: ToJSONSchemaParams
 ): any {
   if (input instanceof $ZodRegistry) {

--- a/packages/core/src/to-json-schema.ts
+++ b/packages/core/src/to-json-schema.ts
@@ -173,8 +173,8 @@ export class JSONSchemaGenerator {
             pattern?: RegExp;
             contentEncoding?: string;
           };
-          if (minimum) json.minLength = minimum;
-          if (maximum) json.maxLength = maximum;
+          if (typeof minimum === "number") json.minLength = minimum;
+          if (typeof maximum === "number") json.maxLength = maximum;
           // custom pattern overrides format
           if (format) {
             json.format = formatMap[format] ?? format;
@@ -265,8 +265,8 @@ export class JSONSchemaGenerator {
             minimum?: number;
             maximum?: number;
           };
-          if (minimum) json.minItems = minimum;
-          if (maximum) json.maxItems = maximum;
+          if (typeof minimum === "number") json.minItems = minimum;
+          if (typeof maximum === "number") json.maxItems = maximum;
           json.type = "array";
           json.items = this.process(def.element, { ...params, path: [...params.path, "items"] });
           break;
@@ -365,8 +365,8 @@ export class JSONSchemaGenerator {
             minimum?: number;
             maximum?: number;
           };
-          if (minimum) json.minItems = minimum;
-          if (maximum) json.maxItems = maximum;
+          if (typeof minimum === "number") json.minItems = minimum;
+          if (typeof maximum === "number") json.maxItems = maximum;
           break;
         }
         case "record": {


### PR DESCRIPTION
This pull request solves the problem of generating a json schema when the minimum/maximum is zero and does not fall into the schema.

```ts
import { z } from 'zod';

const User = z.strictObject({
  gt: z.number().gt(0),
  gte: z.number().gte(0),

  lt: z.number().lt(0),
  lte: z.number().lte(0),

  positive: z.number().positive(),
  negative: z.number().negative(),

  str: z.string().min(0),
  arr: z.array(z.number()).min(0),
});

console.dir(z.toJSONSchema(User), {depth: null});
```