### PR TITLE
.catchall() method should accept undefined

### DIFF
--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -1082,7 +1082,7 @@ export interface ZodInterface<
 
   keyof(): ZodEnum<util.ToEnum<util.InterfaceKeys<string & keyof Shape>>>;
   catchall<T extends core.$ZodType>(
-    schema: T
+    schema?: T
   ): ZodInterface<
     Shape,
     {
@@ -1259,7 +1259,7 @@ export interface ZodObject<
   shape: Shape;
 
   keyof(): ZodEnum<util.ToEnum<keyof Shape & string>>;
-  catchall<T extends core.$ZodType>(schema: T): ZodObject<Shape, Record<string, T["_zod"]["output"]>>;
+  catchall<T extends core.$ZodType>(schema?: T): ZodObject<Shape, Record<string, T["_zod"]["output"]>>;
 
   /** @deprecated Use `z.looseObject()` or `.loose()` instead. */
   passthrough(): ZodObject<Shape, Record<string, unknown>>;

--- a/packages/zod/tests/interface.test.ts
+++ b/packages/zod/tests/interface.test.ts
@@ -136,7 +136,7 @@ test("make schema strip with catchall", () => {
   const data = { points: 2314, unknown: "asdf" };
   const result = schema.safeParse(data);
   expect(result.data).toEqual({ points: 2314 });
-})
+});
 
 test("extend overrides existing", async () => {
   const a = z.interface({ a: z.string() });

--- a/packages/zod/tests/interface.test.ts
+++ b/packages/zod/tests/interface.test.ts
@@ -131,6 +131,13 @@ test("only run catchall on unknown keys", () => {
   });
 });
 
+test("make schema strip with catchall", () => {
+  const schema = z.strictInterface({ points: z.number() }).catchall();
+  const data = { points: 2314, unknown: "asdf" };
+  const result = schema.safeParse(data);
+  expect(result.data).toEqual({ points: 2314 });
+})
+
 test("extend overrides existing", async () => {
   const a = z.interface({ a: z.string() });
   const b = z.interface({ a: z.number() });

--- a/packages/zod/tests/object.test.ts
+++ b/packages/zod/tests/object.test.ts
@@ -165,7 +165,7 @@ test("catchall overrides strict", () => {
 test("make schema strip with catchall", () => {
   const val = z.strictObject({ points: z.number() }).catchall().parse(data);
   expect(val).toEqual({ points: 2314 });
-})
+});
 
 test("optional keys are unset", async () => {
   const SNamedEntity = z.object({

--- a/packages/zod/tests/object.test.ts
+++ b/packages/zod/tests/object.test.ts
@@ -162,6 +162,11 @@ test("catchall overrides strict", () => {
   });
 });
 
+test("make schema strip with catchall", () => {
+  const val = z.strictObject({ points: z.number() }).catchall().parse(data);
+  expect(val).toEqual({ points: 2314 });
+})
+
 test("optional keys are unset", async () => {
   const SNamedEntity = z.object({
     id: z.string(),


### PR DESCRIPTION
The .strip() method has been deprecated. Currently, loose/strict object schema cannot be made strip (default) afterwards.

```ts
const schema = z.looseObject( ... )

const stripSchema = schema.strip() // deprecated
const stripSchema2 = schema.catchall() // set strip (default); Expected 1 arguments, but got 0.ts(2554)
```

.catchall() method accepts undefined, which can be used in replacement of the .strip() method

```ts
schema.catchall()            // = .strip()
schema.catchall(z.never())   // = .strict()
schema.catchall(z.unknown()) // = .loose()
```