### PR TITLE
Add "zod-config" to ecosystem.tsx (v4 support via pre-release)

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -40,7 +40,14 @@ const mockingLibraries: ZodResource[] = [
   },
 ];
 
-const poweredByZodProjects: ZodResource[] = [];
+const poweredByZodProjects: ZodResource[] = [
+  {
+    name: "zod-config",
+    url: "https://github.com/alexmarqs/zod-config",
+    description: "Load configurations across multiple sources with flexible adapters, ensuring type safety with Zod.",
+    slug:"alexmarqs/zod-config"
+  }
+];
 
 const zodUtilities: ZodResource[] = [];
 

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -45,8 +45,8 @@ const poweredByZodProjects: ZodResource[] = [
     name: "zod-config",
     url: "https://github.com/alexmarqs/zod-config",
     description: "Load configurations across multiple sources with flexible adapters, ensuring type safety with Zod.",
-    slug:"alexmarqs/zod-config"
-  }
+    slug: "alexmarqs/zod-config",
+  },
 ];
 
 const zodUtilities: ZodResource[] = [];


### PR DESCRIPTION
Thanks for Zod 4!

Adding zod-config back to the v4 ecosystem.

[Zod Config](https://github.com/alexmarqs/zod-config) is supporting Zod 4 via [Pre-Release / Release Candidate](https://github.com/alexmarqs/zod-config/releases/tag/v1.0.0-rc.0) (until Zod 4 it's stable).

Install using the rc tag:
```
# Using npm
npm install zod-config@rc

# Using yarn
yarn add zod-config@rc

# Using pnpm
pnpm add zod-config@rc
```