### PR TITLE
fix: `strict()` marks as deprecated in v4

### DIFF
--- a/packages/zod/src/schemas.ts
+++ b/packages/zod/src/schemas.ts
@@ -1266,7 +1266,7 @@ export interface ZodObject<
 
   loose(): ZodObject<Shape, Record<string, unknown>>;
 
-  /** The `z.strictObject()` API is preferred. */
+  /** @deprecated Use `z.strictObject()` instead. */
   strict(): ZodObject<Shape, {}>;
 
   /** @deprecated This is the default behavior. This method call is likely unnecessary. */


### PR DESCRIPTION
The following commit removed the deprecated mark from `strict()`:
https://github.com/colinhacks/zod/pull/4074/commits/4d269a2f379914ab5b8be7f7a33e959cf2e2d53d

However, in the migration guide for zod 4, this is deprecated:

https://v4.zod.dev/v4/changelog#deprecates-strict

I marked `strict()` as deprecated to fix this inconsistency.