### PR TITLE
docs: fixed missing comment in migration guide

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -495,7 +495,7 @@ z.ZodString.create(); // ❌
 You no longer need to specify a discriminator key (though you still can if you wish; it is ignored).
 
 ```ts
-in Zod 4:
+// in Zod 4:
 const myUnion = z.discriminatedUnion([
   z.object({ type: z.literal("a"), a: z.string() }),
   z.object({ type: z.literal("b"), b: z.number() }),


### PR DESCRIPTION
I found a missing comment in the migration guide and fixed it.