### PR TITLE
docs: in v4, `strict()` is not deprecated

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -308,6 +308,18 @@ type schemaInput = z.input<typeof schema>;
 
 These modifier methods on the `ZodObject` class determine how the schema handles unknown keys. In Zod 4, this functionality now exists in top-level functions. This aligns better with Zod's declarative-first philosophy, and puts all object variants on equal footing. 
 
+
+### discourages `.strict()`
+
+> The `.strict()` method is discouraged but not deprecat4ed. It won't be removed. 
+```ts
+// Zod 3
+z.object({ name: z.string() }).strict();
+
+// Zod 4
+z.strictObject({ name: z.string() });
+```
+
 ### deprecates `.passthrough()`
 
 ```ts

--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -308,16 +308,6 @@ type schemaInput = z.input<typeof schema>;
 
 These modifier methods on the `ZodObject` class determine how the schema handles unknown keys. In Zod 4, this functionality now exists in top-level functions. This aligns better with Zod's declarative-first philosophy, and puts all object variants on equal footing. 
 
-### deprecates `.strict()`
-
-```ts
-// Zod 3
-z.object({ name: z.string() }).strict();
-
-// Zod 4
-z.strictObject({ name: z.string() });
-```
-
 ### deprecates `.passthrough()`
 
 ```ts


### PR DESCRIPTION
The following commit removed the deprecated mark from strict():

https://github.com/colinhacks/zod/commit/4d269a2f379914ab5b8be7f7a33e959cf2e2d53d

And this was an omission from the guide, so I fixed it.

https://github.com/colinhacks/zod/pull/4289#issuecomment-2842957366
