### PR TITLE
[v4 beta] Add `shape` to `$ZodObjectInternals`

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1915,6 +1915,7 @@ export interface $ZodObjectInternals<
 > extends $ZodObjectLikeInternals<$InferObjectOutput<Shape, Extra>, $InferObjectInput<Shape, Extra>> {
   subtype: "object";
   def: $ZodObjectDef<Shape>;
+  shape: Shape;
   extra: Extra;
 }
 


### PR DESCRIPTION
The current definition of the `$ZodObjectInternals` type is not setting `shape`, causing `.partial()` (and likely several other functions) to infer the wrong type. `$ZodInterfaceInternals` is not affected as it sets `shape`.

```ts
import * as z from '@zod/mini'

const object = z.object({ foo: $.string() })
type ObjectType = z.infer<typeof object> // { foo: string }

const partial = z.partial(object)

// Before:
type PartialType = z.infer<typeof partial> // object

// After:
type PartialType = z.infer<typeof partial> // { foo?: string | undefined }
```

This commit sets uses `$ZodInterfaceInternals` as an example and sets `$ZodObjectInternals["shape"]` to the value of the `Shape` generic.


It appears you have _do_ a test that is supposed to catch this issue (`object.test.ts -> z.partial`). However, I lack the requisite knowledge of Zod's internals and test framework to understand why it isn't working.


### Update:
I ran the tests without the change, and everything passes. However, my editor shows the errors:

![Screenshot 2025-05-01 at 10 59 43 AM](https://github.com/user-attachments/assets/7dd71c3b-f972-4dd7-94bf-a2551178f187)

My commit resolves all of the type errors. Perhaps `vitest` is misconfigured?
