### PR TITLE
Add z.looseObject

### DIFF
--- a/src/__tests__/object.test.ts
+++ b/src/__tests__/object.test.ts
@@ -317,6 +317,18 @@ test("strictcreate", async () => {
   expect(asyncResult.success).toEqual(false);
 });
 
+test("looseObject", async () => {
+  const looseObj = z.looseObject({
+    name: z.string(),
+  });
+
+  const syncResult = looseObj.safeParse({ name: "asdf", unexpected: 13 });
+  expect(syncResult.success).toEqual(true);
+
+  const asyncResult = await looseObj.spa({ name: "asdf", unexpected: 13 });
+  expect(asyncResult.success).toEqual(true);
+});
+
 test("object with refine", async () => {
   const schema = z
     .object({

--- a/src/types.ts
+++ b/src/types.ts
@@ -3052,6 +3052,19 @@ export class ZodObject<
     }) as any;
   };
 
+  static looseCreate = <T extends ZodRawShape>(
+    shape: T,
+    params?: RawCreateParams
+  ): ZodObject<T, "passthrough"> => {
+    return new ZodObject({
+      shape: () => shape,
+      unknownKeys: "passthrough",
+      catchall: ZodNever.create(),
+      typeName: ZodFirstPartyTypeKind.ZodObject,
+      ...processCreateParams(params),
+    }) as any;
+  };
+
   static lazycreate = <T extends ZodRawShape>(
     shape: () => T,
     params?: RawCreateParams
@@ -5394,6 +5407,7 @@ const voidType = ZodVoid.create;
 const arrayType = ZodArray.create;
 const objectType = ZodObject.create;
 const strictObjectType = ZodObject.strictCreate;
+const looseObjectType = ZodObject.looseCreate;
 const unionType = ZodUnion.create;
 const discriminatedUnionType = ZodDiscriminatedUnion.create;
 const intersectionType = ZodIntersection.create;
@@ -5464,6 +5478,7 @@ export {
   recordType as record,
   setType as set,
   strictObjectType as strictObject,
+  looseObjectType as looseObject,
   stringType as string,
   symbolType as symbol,
   effectsType as transformer,


### PR DESCRIPTION
Since `z.strictObject` exist, it should be available a `z.looseObject`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new schema creation function that allows objects to accept unknown keys without validation errors.
- **Tests**
  - Added tests to confirm that objects created with the new schema function correctly allow extra properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->