### PR TITLE
correction in documentation

### DIFF
--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -22,7 +22,7 @@ const mySchema = z.nullable(z.optional(z.string()));
 </Tab>
 <Tab value="zod">
 ```ts
-import * as z from "@zod/mini";
+import { z } from "zod";
 
 const mySchema = z.string().optional().nullable();
 ```


### PR DESCRIPTION
A zod code sample is importing from @zod/mini, this change only updates the import line to match the library it should be coming from.