### PR TITLE
Correct conditions for error in docs

### DIFF
--- a/packages/docs/content/error-formatting.mdx
+++ b/packages/docs/content/error-formatting.mdx
@@ -10,7 +10,7 @@ Zod emphasizes _completeness_ and _correctness_ in its error reporting. In many 
 Consider this simple object schema.
 
 ```ts
-const schema = z.object({
+const schema = z.strictObject({
   username: z.string(),
   favoriteNumbers: z.array(z.number()),
 });
@@ -22,6 +22,7 @@ Attempting to parse this invalid data results in an error containing two issues.
 const result = schema.safeParse({
   username: 1234,
   favoriteNumbers: [1234, "4567"],
+  extraKey: 1234,
 });
 
 result.error!.issues;


### PR DESCRIPTION
- Make schema a strict object
- Add extra key to induce error described later

____
## Issue this solves
Quoting https://github.com/colinhacks/zod/issues/4213#issuecomment-2841705047 directly:

I've noticed something about the `treeifyError()` function in v4 related to the documentation:

In the documentation example, the errors array contains values:

```json5
{
  errors: [ 'Unrecognized key: "extraKey"' ],
  // ...
}
```
However, in the original issue's example code, the errors arrays are empty, and I've observed the same behavior in my own testing:

```json5
{
  "errors": [],
  "properties": {
    "coworkers": {
      "errors": [],
      // ...
    }
  }
}
```
This inconsistency between documentation and actual behavior makes it harder to understand how to properly use and interpret the results of `treeifyError()`. Could we get clarification on when `errors` arrays contain values versus when they're empty? It's possible I'm using it incorrectly, but some guidance on the expected behavior would be helpful.