### PR TITLE
fix(v4): retaining `optionality` for transformations

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -3257,7 +3257,7 @@ export const $ZodPipe: core.$constructor<$ZodPipe> = /*@__PURE__*/ core.$constru
   // inst._zod.qin = def.in._zod.qin;
   // inst._zod.qout = def.in._zod.qout;
   inst._zod.values = def.in._zod.values;
-
+  inst._zod.optionality = def.in._zod.optionality;
   inst._zod.parse = (payload, ctx) => {
     const left = def.in._zod.run(payload, ctx);
     if (left instanceof Promise) {

--- a/packages/zod/tests/pipe.test.ts
+++ b/packages/zod/tests/pipe.test.ts
@@ -71,6 +71,9 @@ test("break on fatal errors", () => {
 });
 
 test("retains optionality", () => {
-  const schema = z.string().optional().transform((str) => str?.length);
+  const schema = z
+    .string()
+    .optional()
+    .transform((str) => str?.length);
   expect(schema._zod.optionality).toBe("optional");
-})
+});

--- a/packages/zod/tests/pipe.test.ts
+++ b/packages/zod/tests/pipe.test.ts
@@ -69,3 +69,8 @@ test("break on fatal errors", () => {
     }
   `);
 });
+
+test("retains optionality", () => {
+  const schema = z.string().optional().transform((str) => str?.length);
+  expect(schema._zod.optionality).toBe("optional");
+})


### PR DESCRIPTION
Fixes #4322 


Similar to `$ZodNullable` implementation.