### PR TITLE
fix(v4): use input, not output, for input of `$ZodUnionInternals`

### DIFF
--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -1803,7 +1803,7 @@ export interface $ZodUnionDef<Options extends readonly $ZodType[] = readonly $Zo
 }
 
 export interface $ZodUnionInternals<T extends readonly $ZodType[] = readonly $ZodType[]>
-  extends $ZodTypeInternals<$InferUnionOutput<T[number]>, $InferUnionOutput<T[number]>> {
+  extends $ZodTypeInternals<$InferUnionOutput<T[number]>, $InferUnionInput<T[number]>> {
   def: $ZodUnionDef<T>;
   isst: errors.$ZodIssueInvalidUnion;
   pattern: T[number]["_zod"]["pattern"];


### PR DESCRIPTION
fixes https://github.com/colinhacks/zod/issues/4329

tested with a local patched version so far.
feel free to reject this and fix it a different way, or if I am not following the pr process correctly for zod.