### PR TITLE
Improve the performance of z.nativeEnum

### DIFF
--- a/deno/lib/benchmarks/primitives.ts
+++ b/deno/lib/benchmarks/primitives.ts
@@ -55,6 +55,38 @@ longEnumSuite
     console.log(`long z.enum: ${e.target}`);
   });
 
+const nativeEnumSuite = new Benchmark.Suite("z.nativeEnum");
+const nativeEnumSchema = z.nativeEnum(enumSchema.Values);
+
+nativeEnumSuite
+  .add("valid", () => {
+    nativeEnumSchema.parse("a");
+  })
+  .add("invalid", () => {
+    try {
+      nativeEnumSchema.parse("x");
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`z.nativeEnum: ${e.target}`);
+  });
+
+const longNativeEnumSuite = new Benchmark.Suite("long z.nativeEnum");
+const longNativeEnumSchema = z.nativeEnum(longEnumSchema.Values);
+
+longNativeEnumSuite
+  .add("valid", () => {
+    longNativeEnumSchema.parse("five");
+  })
+  .add("invalid", () => {
+    try {
+      longNativeEnumSchema.parse("invalid");
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`long z.nativeEnum: ${e.target}`);
+  });
+
 const undefinedSuite = new Benchmark.Suite("z.undefined");
 const undefinedSchema = z.undefined();
 
@@ -164,6 +196,8 @@ export default {
   suites: [
     enumSuite,
     longEnumSuite,
+    nativeEnumSuite,
+    longNativeEnumSuite,
     undefinedSuite,
     literalSuite,
     numberSuite,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4461,14 +4461,13 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
 > {
   #cache: Set<T[keyof T]> | undefined;
   _parse(input: ParseInput): ParseReturnType<T[keyof T]> {
-    const nativeEnumValues = util.getValidEnumValues(this._def.values);
-
     const ctx = this._getOrReturnCtx(input);
+    
     if (
       ctx.parsedType !== ZodParsedType.string &&
       ctx.parsedType !== ZodParsedType.number
     ) {
-      const expectedValues = util.objectValues(nativeEnumValues);
+      const expectedValues = util.getValidEnumValues(this._def.values)
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,
@@ -4482,7 +4481,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     }
 
     if (!this.#cache.has(input.data)) {
-      const expectedValues = util.objectValues(nativeEnumValues);
+      const expectedValues = util.getValidEnumValues(this._def.values)
 
       addIssueToContext(ctx, {
         received: ctx.data,

--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -4462,12 +4462,12 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
   #cache: Set<T[keyof T]> | undefined;
   _parse(input: ParseInput): ParseReturnType<T[keyof T]> {
     const ctx = this._getOrReturnCtx(input);
-    
+
     if (
       ctx.parsedType !== ZodParsedType.string &&
       ctx.parsedType !== ZodParsedType.number
     ) {
-      const expectedValues = util.getValidEnumValues(this._def.values)
+      const expectedValues = util.getValidEnumValues(this._def.values);
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,
@@ -4481,7 +4481,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     }
 
     if (!this.#cache.has(input.data)) {
-      const expectedValues = util.getValidEnumValues(this._def.values)
+      const expectedValues = util.getValidEnumValues(this._def.values);
 
       addIssueToContext(ctx, {
         received: ctx.data,

--- a/src/benchmarks/primitives.ts
+++ b/src/benchmarks/primitives.ts
@@ -55,6 +55,38 @@ longEnumSuite
     console.log(`long z.enum: ${e.target}`);
   });
 
+const nativeEnumSuite = new Benchmark.Suite("z.nativeEnum");
+const nativeEnumSchema = z.nativeEnum(enumSchema.Values);
+
+nativeEnumSuite
+  .add("valid", () => {
+    nativeEnumSchema.parse("a");
+  })
+  .add("invalid", () => {
+    try {
+      nativeEnumSchema.parse("x");
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`z.nativeEnum: ${e.target}`);
+  });
+
+const longNativeEnumSuite = new Benchmark.Suite("long z.nativeEnum");
+const longNativeEnumSchema = z.nativeEnum(longEnumSchema.Values);
+
+longNativeEnumSuite
+  .add("valid", () => {
+    longNativeEnumSchema.parse("five");
+  })
+  .add("invalid", () => {
+    try {
+      longNativeEnumSchema.parse("invalid");
+    } catch (e) {}
+  })
+  .on("cycle", (e: Benchmark.Event) => {
+    console.log(`long z.nativeEnum: ${e.target}`);
+  });
+
 const undefinedSuite = new Benchmark.Suite("z.undefined");
 const undefinedSchema = z.undefined();
 
@@ -164,6 +196,8 @@ export default {
   suites: [
     enumSuite,
     longEnumSuite,
+    nativeEnumSuite,
+    longNativeEnumSuite,
     undefinedSuite,
     literalSuite,
     numberSuite,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4461,14 +4461,13 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
 > {
   #cache: Set<T[keyof T]> | undefined;
   _parse(input: ParseInput): ParseReturnType<T[keyof T]> {
-    const nativeEnumValues = util.getValidEnumValues(this._def.values);
-
     const ctx = this._getOrReturnCtx(input);
+
     if (
       ctx.parsedType !== ZodParsedType.string &&
       ctx.parsedType !== ZodParsedType.number
     ) {
-      const expectedValues = util.objectValues(nativeEnumValues);
+      const expectedValues = util.getValidEnumValues(this._def.values);
       addIssueToContext(ctx, {
         expected: util.joinValues(expectedValues) as "string",
         received: ctx.parsedType,
@@ -4482,7 +4481,7 @@ export class ZodNativeEnum<T extends EnumLike> extends ZodType<
     }
 
     if (!this.#cache.has(input.data)) {
-      const expectedValues = util.objectValues(nativeEnumValues);
+      const expectedValues = util.getValidEnumValues(this._def.values);
 
       addIssueToContext(ctx, {
         received: ctx.data,


### PR DESCRIPTION
The previous implementation converted the enum into an array of values on each parse call, even though the array was never used in the happy path.

This was especially problematic on large enums, since the work done was proportional to the size of the enum.

I also removed an extra call to `util.objectValues` on the failure path, since it seemed to be superfluous (`util.getValidEnumValues` already calls it).

**Before:**

    z.nativeEnum: valid x 4,376,561 ops/sec ±0.65% (95 runs sampled)
    z.nativeEnum: invalid x 139,663 ops/sec ±6.37% (91 runs sampled)
    long z.nativeEnum: valid x 1,197,450 ops/sec ±0.25% (97 runs sampled)
    long z.nativeEnum: invalid x 116,181 ops/sec ±0.46% (96 runs sampled)

**After:**

    z.nativeEnum: valid x 10,978,553 ops/sec ±0.41% (98 runs sampled)
    z.nativeEnum: invalid x 143,931 ops/sec ±5.40% (93 runs sampled)
    long z.nativeEnum: valid x 9,783,582 ops/sec ±0.38% (99 runs sampled)
    long z.nativeEnum: invalid x 122,292 ops/sec ±0.48% (99 runs sampled

With an enum containing 500 members, the difference is about 2000 times larger.

**Before:**

    really long z.nativeEnum: valid x 4,583 ops/sec ±12.75% (86 runs sampled)
    really long z.nativeEnum: invalid x 4,197 ops/sec ±2.06% (91 runs sampled)

**After:**

    really long z.nativeEnum: valid x 9,444,581 ops/sec ±0.29% (99 runs sampled)
    really long z.nativeEnum: invalid x 4,570 ops/sec ±0.89% (95 runs sampled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new benchmark suites to measure performance of native enum schema parsing, including tests for both short and long enums with valid and invalid inputs.

- **Refactor**
  - Improved internal handling of enum value retrieval for schema parsing, resulting in more direct value checks without caching in local variables. No changes to public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->