### PR TITLE
Remove check for JWT typ header

### DIFF
--- a/deno/lib/types.ts
+++ b/deno/lib/types.ts
@@ -752,7 +752,7 @@ function isValidJWT(jwt: string, alg?: string): boolean {
       .padEnd(header.length + ((4 - (header.length % 4)) % 4), "=");
     const decoded = JSON.parse(atob(base64));
     if (typeof decoded !== "object" || decoded === null) return false;
-    if (!decoded.typ || !decoded.alg) return false;
+    if (!decoded.alg) return false;
     if (alg && decoded.alg !== alg) return false;
     return true;
   } catch {

--- a/src/types.ts
+++ b/src/types.ts
@@ -752,7 +752,7 @@ function isValidJWT(jwt: string, alg?: string): boolean {
       .padEnd(header.length + ((4 - (header.length % 4)) % 4), "=");
     const decoded = JSON.parse(atob(base64));
     if (typeof decoded !== "object" || decoded === null) return false;
-    if (!decoded.typ || !decoded.alg) return false;
+    if (!decoded.alg) return false;
     if (alg && decoded.alg !== alg) return false;
     return true;
   } catch {


### PR DESCRIPTION
Per RFC 7519, JWT implementations are required to ignore the typ header:
- The `typ` header will typically not be used when it is already known that the object is a JWT.
- This parameter is ignored by JWT implementations.
- Use of this Header Parameter is OPTIONAL.

> [5.1](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1).  "typ" (Type) Header Parameter
>
>    The "typ" (type) Header Parameter defined by [[JWS](https://datatracker.ietf.org/doc/html/rfc7519#ref-JWS)] and [[JWE](https://datatracker.ietf.org/doc/html/rfc7519#ref-JWE)] is used
>    by JWT applications to declare the media type [[IANA.MediaTypes](https://datatracker.ietf.org/doc/html/rfc7519#ref-IANA.MediaTypes)] of
>    this complete JWT.  This is intended for use by the JWT application
>    when values that are not JWTs could also be present in an application
>    data structure that can contain a JWT object; the application can use
>    this value to disambiguate among the different kinds of objects that
>    might be present.  It will typically not be used by applications when
>    it is already known that the object is a JWT.  This parameter is
>    ignored by JWT implementations; any processing of this parameter is
>    performed by the JWT application.  If present, it is RECOMMENDED that
>    its value be "JWT" to indicate that this object is a JWT.  While
>    media type names are not case sensitive, it is RECOMMENDED that "JWT"
>    always be spelled using uppercase characters for compatibility with
>    legacy implementations.  Use of this Header Parameter is OPTIONAL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved JWT validation to be less restrictive, allowing tokens without the `typ` property in their header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->