### PR TITLE
Added Parent property to RefinementCtx

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ import {
 
 export interface RefinementCtx {
   addIssue: (arg: IssueData) => void;
+  data: any;
   path: (string | number)[];
 }
 export type ZodRawShape = { [k: string]: ZodTypeAny };
@@ -4639,6 +4640,9 @@ export class ZodEffects<
         } else {
           status.dirty();
         }
+      },
+      get data() {
+        return ctx.data;
       },
       get path() {
         return ctx.path;


### PR DESCRIPTION
There is a very important use case mentioned here: https://github.com/colinhacks/zod/issues/3982 where we need to evaluate a value only when another optional value is set.

