### PR TITLE
v4: set `additionalProperties` to `false` when catchall is never

### DIFF
--- a/packages/zod/src/v4/classic/tests/json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/json-schema.test.ts
@@ -530,9 +530,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(a)).toMatchInlineSnapshot(`
       {
-        "additionalProperties": {
-          "not": {},
-        },
+        "additionalProperties": false,
         "properties": {
           "age": {
             "type": "number",
@@ -690,9 +688,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(a)).toMatchInlineSnapshot(`
       {
-        "additionalProperties": {
-          "not": {},
-        },
+        "additionalProperties": false,
         "properties": {
           "age": {
             "type": "number",

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -303,7 +303,9 @@ export class JSONSchemaGenerator {
           json.required = Array.from(requiredKeys);
 
           // catchall
-          if (def.catchall) {
+          if (def.catchall?._zod.def.type === "never") {
+            json.additionalProperties = false;
+          } else if (def.catchall) {
             json.additionalProperties = this.process(def.catchall, {
               ...params,
               path: [...params.path, "additionalProperties"],


### PR DESCRIPTION
addresses #4123