### PR TITLE
Add `jitless` flag to avoid `eval`/`new Function`

### DIFF
--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -76,11 +76,13 @@ export interface $ZodConfig {
   customError?: errors.$ZodErrorMap | undefined;
   /** Localized error map. Lowest priority. */
   localeError?: errors.$ZodErrorMap | undefined;
+  /** Disable JIT schema compilation. Useful in environments that disallow `eval`. */
+  jitless?: boolean | undefined;
 }
 
 export const globalConfig: $ZodConfig = {};
 
-export function config(config?: Partial<$ZodConfig>): $ZodConfig {
-  if (config) Object.assign(globalConfig, config);
+export function config(newConfig?: Partial<$ZodConfig>): $ZodConfig {
+  if (newConfig) Object.assign(globalConfig, newConfig);
   return globalConfig;
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1728,8 +1728,12 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
   };
 
   let fastpass!: ReturnType<typeof generateFastpass>;
-  const fastEnabled = util.allowsEval.value; // && !def.catchall;
+
   const isObject = util.isObject;
+  const jit = !core.globalConfig.jitless;
+  const allowsEval = util.allowsEval;
+
+  const fastEnabled = jit && allowsEval.value; // && !def.catchall;
   const { catchall } = def;
 
   let value!: typeof _normalized.value;
@@ -1749,7 +1753,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
 
     const proms: Promise<any>[] = [];
 
-    if (fastEnabled && ctx?.async === false && ctx.noPrecompilation !== true) {
+    if (jit && fastEnabled && ctx?.async === false && ctx.noPrecompilation !== true) {
       // always synchronous
       if (!fastpass) fastpass = generateFastpass(def.shape);
       payload = fastpass(payload, ctx);

--- a/play.ts
+++ b/play.ts
@@ -1,15 +1,15 @@
 import { z } from "zod/v4";
 
-// const schema = z.url();
+z.config({
+  jitless: true,
+});
 
-// schema.parse("https://example.com"); // ✅
-// schema.parse("http://localhost"); // ✅
-// schema.parse("sup");
+const A = z.object({
+  a: z.string(),
+});
 
-// const schema = z.url({ hostname: /^example.com$/ });
-// schema.parse("https://example.com"); // ✅
-// schema.parse("https://zombo.com"); // ❌
-
-// const schema = z.url({ protocol: /^https$/ });
-// schema.parse("https://example.com"); // ✅
-// schema.parse("httpss://example.com"); // ❌
+console.log(
+  A.parse({
+    a: "hello",
+  })
+);


### PR DESCRIPTION
Run this before any Zod code:

```ts
import { z } from "zod/v4"

z.config({ jitless: true })
```

This short-circuits all code paths that would call `eval`/`new Function`. 

Some runtimes (Next middleware) seem to detect usage of these APIs during build-time. Fixing that will require something more involved.