### PR TITLE
fix: use JSON.stringify to escape toDotPath keys w/ quotes

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -399,6 +399,14 @@ test("z.toDotPath", () => {
     `"user.$special["Symbol(#symbol)"]"`
   );
 
+  // Test with dots and quotes
+  expect(z.core.toDotPath(["search", `query("foo.bar"="abc")`])).toMatchInlineSnapshot(
+    `"search["query(\\"foo.bar\\"=\\"abc\\")"]"`
+  );
+
+  // Test with newlines
+  expect(z.core.toDotPath(["search", `foo\nbar`])).toMatchInlineSnapshot(`"search["foo\\nbar"]"`);
+
   // Test with empty strings
   expect(z.core.toDotPath(["", "empty"])).toMatchInlineSnapshot(`".empty"`);
 
@@ -411,7 +419,7 @@ test("z.toDotPath", () => {
   );
 
   // Test with square brackets in keys
-  expect(z.core.toDotPath(["data[0]", "value"])).toMatchInlineSnapshot(`"data[0].value"`);
+  expect(z.core.toDotPath(["data[0]", "value"])).toMatchInlineSnapshot(`"["data[0]"].value"`);
 
   // Test with empty path
   expect(z.core.toDotPath([])).toMatchInlineSnapshot(`""`);

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -451,8 +451,8 @@ export function toDotPath(path: (string | number | symbol)[]): string {
   const segs: string[] = [];
   for (const seg of path) {
     if (typeof seg === "number") segs.push(`[${seg}]`);
-    else if (typeof seg === "symbol") segs.push(`["${String(seg)}"]`);
-    else if (seg.includes(".")) segs.push(`["${seg}"]`);
+    else if (typeof seg === "symbol") segs.push(`[${JSON.stringify(String(seg))}]`);
+    else if (/[^\w$]/.test(seg)) segs.push(`[${JSON.stringify(seg)}]`);
     else {
       if (segs.length) segs.push(".");
       segs.push(seg);


### PR DESCRIPTION
This should also correctly handle even weirder stuff like newlines in proeprty keys. JSON.stringify should do all the right escaping - if it's a valid JSON string, it's a valid key.

Note: one existing test was updated:

```ts
expect(z.core.toDotPath(["data[0]", "value"])).toMatchInlineSnapshot(`"data[0].value"`); // <- before
expect(z.core.toDotPath(["data[0]", "value"])).toMatchInlineSnapshot(`"["data[0]"].value"`); // <- after
```

This looks correct to me: Previously it was implying a shape of
`{data: [{value: '...'}]}` when actually it should be a shape of
`{'data[0]': {value: '...'}}`