### PR TITLE
v4 docs: Escape `.` in example Regex for `z.url` with `hostname`

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -311,7 +311,7 @@ schema.parse("sup"); // ❌
 To validate the hostname against a specific regex:
 
 ```ts
-const schema = z.url({ hostname: /^example.com$/ });
+const schema = z.url({ hostname: /^example\.com$/ });
 
 schema.parse("https://example.com"); // ✅
 schema.parse("https://zombo.com"); // ❌


### PR DESCRIPTION
The Documentation for V4 has an example for using `z.url` with the `hostname` option. It looks like this:
```ts
const schema = z.url({ hostname: /^example.com$/ });
```
This allows `example.com`, but it also allows hostnames like `exampleacom`, which is not intended. Probably not an Issue here, but it might make it possible to sneak in unintended Hostnames on certain URLs if devs aren't careful. 

This PR explicitly escapes the `.` in the example to reduce mistakes. 
```ts
const schema = z.url({ hostname: /^example\.com$/ });
```