### PR TITLE
Fix: $ZodCatch schema catchValue handling on validation error

### DIFF
--- a/packages/zod/src/v4/classic/tests/pipe.test.ts
+++ b/packages/zod/src/v4/classic/tests/pipe.test.ts
@@ -15,6 +15,20 @@ test("string to number pipe async", async () => {
   expect(await schema.parseAsync("1234")).toEqual(1234);
 });
 
+test("string with default fallback", () => {
+  const stringWithDefault = z
+    .pipe(
+      z.transform((v) => (v === "none" ? undefined : v)),
+      z.string()
+    )
+    .catch("default");
+
+  expect(stringWithDefault.parse("ok")).toBe("ok");
+  expect(stringWithDefault.parse(undefined)).toBe("default");
+  expect(stringWithDefault.parse("none")).toBe("default");
+  expect(stringWithDefault.parse(15)).toBe("default");
+});
+
 test("continue on non-fatal errors", () => {
   const schema = z
     .string()

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3248,6 +3248,7 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
     const result = def.innerType._zod.run(payload, ctx);
     if (result instanceof Promise) {
       return result.then((result) => {
+        payload.value = result.value;
         if (result.issues.length) {
           payload.value = def.catchValue({
             ...payload,
@@ -3258,12 +3259,12 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
           });
           payload.issues = [];
         }
-        payload.value = result.value;
 
         return payload;
       });
     }
 
+    payload.value = result.value;
     if (result.issues.length) {
       payload.value = def.catchValue({
         ...payload,
@@ -3274,7 +3275,6 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
       });
       payload.issues = [];
     }
-    payload.value = result.value;
 
     return payload;
   };


### PR DESCRIPTION
## Overview

Fixed a bug in handling the error value of `catchValue` in the pipe schema.

## Details

The value defined in catch is not set in the following schema.

```ts
const stringWithDefault = z
  .pipe(
    z.transform((v) => (v === "none" ? undefined : v)),
    z.string()
  )
  .catch("default");

expect(stringWithDefault.parse(undefined)).toBe("default"); // <-- The value is set to `undefined`.
```