### PR TITLE
chore: add `path` back to `ctx`

### DIFF
--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -1082,6 +1082,7 @@ export const $ZodCheckProperty: core.$constructor<$ZodCheckProperty> = /*@__PURE
         {
           value: (payload.value as any)[def.property],
           issues: [],
+          path: payload.path,
         },
         {}
       );

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -15,7 +15,7 @@ export type $Parse = <T extends schemas.$ZodType>(
 
 export const _parse: (_Err: $ZodErrorClass) => $Parse = (_Err) => (schema, value, _ctx, _params) => {
   const ctx: schemas.ParseContextInternal = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
-  const result = schema._zod.run({ value, issues: [] }, ctx);
+  const result = schema._zod.run({ value, issues: [], path: [] }, ctx);
   if (result instanceof Promise) {
     throw new core.$ZodAsyncError();
   }
@@ -38,7 +38,7 @@ export type $ParseAsync = <T extends schemas.$ZodType>(
 
 export const _parseAsync: (_Err: $ZodErrorClass) => $ParseAsync = (_Err) => async (schema, value, _ctx, params) => {
   const ctx: schemas.ParseContextInternal = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
-  let result = schema._zod.run({ value, issues: [] }, ctx);
+  let result = schema._zod.run({ value, issues: [], path: [] }, ctx);
   if (result instanceof Promise) result = await result;
   if (result.issues.length) {
     const e = new (params?.Err ?? _Err)(result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())));
@@ -58,7 +58,7 @@ export type $SafeParse = <T extends schemas.$ZodType>(
 
 export const _safeParse: (_Err: $ZodErrorClass) => $SafeParse = (_Err) => (schema, value, _ctx) => {
   const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
-  const result = schema._zod.run({ value, issues: [] }, ctx);
+  const result = schema._zod.run({ value, issues: [], path: [] }, ctx);
   if (result instanceof Promise) {
     throw new core.$ZodAsyncError();
   }
@@ -80,7 +80,7 @@ export type $SafeParseAsync = <T extends schemas.$ZodType>(
 
 export const _safeParseAsync: (_Err: $ZodErrorClass) => $SafeParseAsync = (_Err) => async (schema, value, _ctx) => {
   const ctx: schemas.ParseContextInternal = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
-  let result = schema._zod.run({ value, issues: [] }, ctx);
+  let result = schema._zod.run({ value, issues: [], path: [] }, ctx);
   if (result instanceof Promise) result = await result;
 
   return result.issues.length

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -30,7 +30,6 @@ export interface ParsePayload<T = unknown> {
   value: T;
   issues: errors.$ZodRawIssue[];
   path: (string | number)[];
-  custom?: unknown;
 }
 
 export type CheckFn<T> = (input: ParsePayload<T>) => util.MaybeAsync<void>;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -30,6 +30,7 @@ export interface ParsePayload<T = unknown> {
   value: T;
   issues: errors.$ZodRawIssue[];
   path: (string | number)[];
+  custom?: unknown;
 }
 
 export type CheckFn<T> = (input: ParsePayload<T>) => util.MaybeAsync<void>;
@@ -1731,7 +1732,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
 
     const parseStr = (key: string) => {
       const k = util.esc(key);
-      return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
+      return `shape[${k}]._zod.run({ value: input[${k}], issues: [], path: [...payload.path, ${k}.toString()] }, ctx)`;
     };
 
     // doc.write(`const shape = inst._zod.def.shape;`);
@@ -1803,8 +1804,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
   const jit = !core.globalConfig.jitless;
   const allowsEval = util.allowsEval;
 
-  // const fastEnabled = jit && allowsEval.value; // && !def.catchall;
-  const fastEnabled = false;
+  const fastEnabled = jit && allowsEval.value; // && !def.catchall;
   const { catchall } = def;
 
   let value!: typeof _normalized.value;


### PR DESCRIPTION
This is a pretty crude approach at adding back `path` to the `ctx` object. I saw that the `path` argument in `ParseParams` was [intentionally removed for performance](https://github.com/colinhacks/zod/issues/4128#issuecomment-2882857695) but I wasn't sure if those same architecture changes necessitated the removal in the `ParsePayload`, which is where I need it.

If it was an oversight I'm happy to follow through on this PR and whip it into shape.