### PR TITLE
Preserve shape key ordering in result

### DIFF
--- a/packages/bench/object-moltar.ts
+++ b/packages/bench/object-moltar.ts
@@ -1,4 +1,5 @@
 import * as z4 from "zod/v4";
+import * as z4lib from "./node_modules/zod/dist/esm/v4/index.js";
 import * as z3 from "zod3";
 import { metabench } from "./metabench.js";
 
@@ -15,6 +16,20 @@ const z3Schema = z3.object({
     bool: z3.boolean(),
   }).strict()
 }).strict();
+
+const z4LibSchema = z4lib.object({
+  number: z4lib.number(),
+  negNumber: z4lib.number(),
+  maxNumber: z4lib.number(),
+  string: z4lib.string(),
+  longString: z4lib.string(),
+  boolean: z4lib.boolean(),
+  deeplyNested: z4lib.strictObject({
+    foo: z4lib.string(),
+    num: z4lib.number(),
+    bool: z4lib.boolean(),
+  }),
+});
 
 const z4Schema = z4.object({
   number: z4.number(),
@@ -82,9 +97,12 @@ const bench = metabench("z.object() safeParse", {
   zod3() {
     for (const _ of DATA) z3Schema.parse(_);
   },
-  zod4() {
+  // zod4lib() {
+  //   for (const _ of DATA) z4LibSchema.parse(_);
+  // },
+  zod4(){
     for (const _ of DATA) z4Schema.parse(_);
-  },
+  }
   // zod4strict() {
   //   for (const _ of DATA) z4SchemaStrict.parse(_);
   // },

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -474,3 +474,20 @@ test("empty objects", () => {
   type Cin = z.input<typeof C>;
   expectTypeOf<Cin>().toEqualTypeOf<Record<string, never>>();
 });
+
+test("preserve key order", () => {
+  const schema = z.object({
+    a: z.string().optional(),
+    b: z.string(),
+  });
+  const r1 = schema.safeParse({ a: "asdf", b: "qwer" });
+  const r2 = schema.safeParse({ a: "asdf", b: "qwer" }, { jitless: true });
+
+  expect(Object.keys(r1.data!)).toMatchInlineSnapshot(`
+    [
+      "a",
+      "b",
+    ]
+  `);
+  expect(Object.keys(r1.data!)).toEqual(Object.keys(r2.data!));
+});

--- a/packages/zod/src/v4/core/doc.ts
+++ b/packages/zod/src/v4/core/doc.ts
@@ -38,6 +38,7 @@ export class Doc {
     const args = this?.args;
     const content = this?.content ?? [``];
     const lines = [...content.map((x) => `  ${x}`)];
+    // console.log(lines.join("\n"));
     return new F(...args, lines.join("\n"));
   }
 }

--- a/play.ts
+++ b/play.ts
@@ -1,12 +1,9 @@
 import * as z from "zod/v4";
 
-z;
-
-const schema = z.union([z.string(), z.number()]);
-
-z.toJSONSchema(schema, {
-  override(ctx) {
-    console.dir(ctx.zodSchema._zod.def.type, { depth: null });
-    console.dir(ctx.jsonSchema, { depth: null });
-  },
+const schema = z.object({
+  a: z.string().optional(),
+  b: z.string(),
 });
+
+console.dir(schema.safeParse({ a: "asdf", b: "qwer" }), { depth: null });
+console.dir(schema.safeParse({ a: "asdf", b: "qwer" }, { jitless: true }), { depth: null });


### PR DESCRIPTION
Modified the JIT pass for object parsing to preserve the shape key order in the result objects. Slight perf hit (~5%). I assumed it would be far more dramatic. I think it's worthwhile to preserve Zod 3 behavior.