### PR TITLE
docs: Add conform to the ecosystem page

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -47,6 +47,13 @@ const formIntegrations: ZodResource[] = [
     description: "Headless form validation library for Vue.js.",
     slug: "victorgarciaesgi/regle",
   },
+  {
+    name: "conform",
+    url: "https://conform.guide/api/zod/parseWithZod",
+    description:
+      "A type-safe form validation library utilizing web fundamentals to progressively enhance HTML Forms with full support for server frameworks like Remix and Next.js.",
+    slug: "edmundhung/conform",
+  },
 ];
 
 const zodToXConverters: ZodResource[] = [];


### PR DESCRIPTION
## Overview

Conform has released a version that supports Zod v4.
So I added Conform back to the Ecosystem page.

https://github.com/edmundhung/conform/pull/902
https://www.npmjs.com/package/@conform-to/zod