### PR TITLE
fix: no json-schema default for piped type w/ input=io

### DIFF
--- a/packages/zod/src/v4/classic/tests/json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/json-schema.test.ts
@@ -1643,7 +1643,6 @@ test("defaults/prefaults", () => {
   expect(toJSONSchema(c, { io: "input" })).toMatchInlineSnapshot(`
     {
       "$schema": "https://json-schema.org/draft-2020-12/schema",
-      "default": 1234,
       "type": "string",
     }
   `);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -448,7 +448,11 @@ export class JSONSchemaGenerator {
         case "default": {
           this.process(def.innerType, params);
           result.ref = def.innerType;
-          _json.default = def.defaultValue;
+          if (this.io === "output" || def.innerType._zod.def.type !== "pipe") {
+            // the default value is the default for the output type - see https://zod.dev/v4/changelog?id=default-updates
+            // so it's ok to use if a) the user wants the output type of b) it's not a pipe, so the input and output types are the same
+            _json.default = def.defaultValue;
+          }
           break;
         }
         case "prefault": {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -450,7 +450,7 @@ export class JSONSchemaGenerator {
           result.ref = def.innerType;
           if (this.io === "output" || def.innerType._zod.def.type !== "pipe") {
             // the default value is the default for the output type - see https://zod.dev/v4/changelog?id=default-updates
-            // so it's ok to use if a) the user wants the output type of b) it's not a pipe, so the input and output types are the same
+            // so it's ok to use if a) the user wants the output type or b) it's not a pipe, so the input and output types are the same
             _json.default = def.defaultValue;
           }
           break;


### PR DESCRIPTION
this was a minor bug (I believe) in `toJsonSchema`. Basically this:

```ts
const StringLength = z.string().transform(s => s.length).default(5)
z.toJSONSchema(StringLength, { io: 'input' })
```

should result in `{type: 'string'}` but instead it's `{type: 'string', default: 5}` which doesn't make sense - the default of `5` is internal to zod's piping process, when the user asks for input: 'io', they shouldn't care that zod will apply a default when it transforms the string into a number.

Ideally there would be some way of at least documenting "btw this is going to be transformed, and when it's transformed if you pass undefined it'll default to 5" but I think when passing `input: 'io'`, that transformation is essentially private. Someone reading the json schema should probably know it's optional somehow though?

there was actually a test that caught this, previously we were ending up with nonsenical defaults like the below (see test diff)

```
{
  "$schema": "https://json-schema.org/draft-2020-12/schema",
  "default": 1234,
  "type": "string",
}
```

<!--

Development of the next major version of Zod (`v4`) is currently underway. During this phase, only bugfixes and documentation improvements are being accepted into the `main` branch. All other PRs should target the `v4` branch. Thanks for contribting to OSS!

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted JSON schema generation to include default values only in output schemas when appropriate, improving accuracy for schemas with default values.

- **Tests**
  - Updated test cases to align with the revised handling of default values in JSON schema output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->