### PR TITLE
Add `zocker` to v4 Ecosystem Page

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -78,6 +78,7 @@ const mockingLibraries: ZodResource[] = [
     url: "https://zocker.sigrist.dev",
     description: "Generates valid, semantically meaningful data for your Zod schemas.",
     slug: "LorisSigrist/zocker",
+    v4: true,
   },
 ];
 

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -73,6 +73,12 @@ const mockingLibraries: ZodResource[] = [
     description: "Generate mock data from zod schemas. Powered by @faker-js/faker and randexp.js.",
     slug: "soc221b/zod-schema-faker",
   },
+  {
+    "name": "zocker",
+    url: "https://zocker.sigrist.dev",
+    description: "Generates valid, semantically meaningful data for your Zod schemas.",
+    slug: "LorisSigrist/zocker",
+  }
 ];
 
 const poweredByZodProjects: ZodResource[] = [

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -74,11 +74,11 @@ const mockingLibraries: ZodResource[] = [
     slug: "soc221b/zod-schema-faker",
   },
   {
-    "name": "zocker",
+    name: "zocker",
     url: "https://zocker.sigrist.dev",
     description: "Generates valid, semantically meaningful data for your Zod schemas.",
     slug: "LorisSigrist/zocker",
-  }
+  },
 ];
 
 const poweredByZodProjects: ZodResource[] = [


### PR DESCRIPTION
The [`zocker`](https://zocker.sigrist.dev) mock-data generation library has been part of the Zod 3 ecosystem for a long time & has just added support for Zod 4 and `@zod/mini` schemas in the `zocker@2.0.0` release. Zod 3 schemas still work. 

- [Zocker Website](https://zocker.sigrist.dev)
- [Zocker Repository](https://www.github.com/LorisSigrist/zocker)
- [StackBlitz Example with zod 4](https://stackblitz.com/github/LorisSigrist/zocker/tree/main/example?file=src%2Fmain.ts)

This PR adds `zocker` to the v4 ecosystem page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new resource entry for "zocker" in the ecosystem documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->