### PR TITLE
Fix copy/paste v4 docs typo

### DIFF
--- a/packages/docs/content/library-authors.mdx
+++ b/packages/docs/content/library-authors.mdx
@@ -219,7 +219,7 @@ To constrain the inferred output type of the input schema:
 
 import * as z from "zod/v4";
 
-// only accepts object schemas
+// only accepts string schemas
 function inferSchema<T extends z.core.$ZodType<string>>(schema: T) {
   return schema;
 }


### PR DESCRIPTION
loving zod v4 :) just a small doc fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify that the `inferSchema` function now only accepts string schemas, not object schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->