### PR TITLE
fix: iso timezone docs typo

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -345,7 +345,7 @@ datetime.parse("2020-01-01T00:00:00.123456Z"); // ✅ (arbitrary precision)
 datetime.parse("2020-01-01T00:00:00+02:00"); // ❌ (no offsets allowed)
 ```
 
-To allow timesone offsets:
+To allow timezone offsets:
 
 ```ts
 const datetime = z.iso.datetime({ offset: true });


### PR DESCRIPTION
Small docs typo fix about datetime timezone offsets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typographical error in the API documentation by correcting "timesone" to "timezone".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->