### PR TITLE
fix: JSON Schema > override section typo

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -398,7 +398,7 @@ z.toJSONSchema(User, { reused: "ref" });
 
 ### `override`
 
-To define some custom override logic, use `override`. The provided callback has access to the original Zod schema and the default JSON Schema. *This function should dircectly modify `ctx.jsonSchema`.*
+To define some custom override logic, use `override`. The provided callback has access to the original Zod schema and the default JSON Schema. *This function should directly modify `ctx.jsonSchema`.*
 
 
 ```ts


### PR DESCRIPTION
replaces "dircectly" with "directly"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typo in the description of the `override` option in the JSON Schema conversion section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->