### PR TITLE
fix: enum type in json schema

### DIFF
--- a/packages/zod/src/v4/classic/tests/json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/json-schema.test.ts
@@ -597,6 +597,12 @@ describe("toJSONSchema", () => {
           "b",
           "c",
         ],
+        "type": "string",
+        "x-enumNames": [
+          "a",
+          "b",
+          "c",
+        ],
       }
     `);
   });

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -384,7 +384,10 @@ export class JSONSchemaGenerator {
         }
         case "enum": {
           const json: JSONSchema.BaseSchema = _json as any;
-          json.enum = Object.values(def.entries);
+          const values = Object.values(def.entries);
+          json.type = typeof values[0] === "number" ? "number" : "string";
+          json.enum = values;
+          json["x-enumNames"] = Object.keys(def.entries);
           break;
         }
         case "literal": {


### PR DESCRIPTION
<!--

Development of the next major version of Zod (`v4`) is currently underway. During this phase, only bugfixes and documentation improvements are being accepted into the `main` branch. All other PRs should target the `v4` branch. Thanks for contribting to OSS!

-->
fixes: #4429

Since native enum can have number values too so I added a check to see typeof first value. Only first value check if enough as enums generate value first then name