### PR TITLE
docs: fix safeParse sentence

### DIFF
--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -133,7 +133,7 @@ try {
 To avoid a `try/catch` block, you can use the `.safeParse()` method to get back a plain result object containing either the successfully parsed data or a `ZodError`. The result type is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions), so you can handle both cases conveniently.
 
 ```ts
-const result = Player.parse({ username: 42, xp: "100" });
+const result = Player.safeParse({ username: 42, xp: "100" });
 if (!result.success) {
   result.error;   // ZodError instance
 } else {


### PR DESCRIPTION
<!--

Development of the next major version of Zod (`v4`) is currently underway. During this phase, only bugfixes and documentation improvements are being accepted into the `main` branch. All other PRs should target the `v4` branch. Thanks for contribting to OSS!

-->

Documantation fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the code example to use `.safeParse()` for parsing data, providing clearer guidance on handling results without exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->