### PR TITLE
add Swedish locale

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -368,7 +368,8 @@ The following locales are available:
 - `pt` — Portuguese  
 - `ru` — Russian  
 - `sl` — Slovenian  
-- `ta` — Tamil  
+- `sv` — Swedish
+- `ta` — Tamil
 - `th` — Thai  
 - `tr` — Türkçe  
 - `ua` — Ukrainian  

--- a/packages/zod/src/v4/locales/index.ts
+++ b/packages/zod/src/v4/locales/index.ts
@@ -24,6 +24,7 @@ export { default as pl } from "./pl.js";
 export { default as pt } from "./pt.js";
 export { default as ru } from "./ru.js";
 export { default as sl } from "./sl.js";
+export { default as sv } from "./sv.js";
 export { default as ta } from "./ta.js";
 export { default as th } from "./th.js";
 export { default as tr } from "./tr.js";

--- a/packages/zod/src/v4/locales/sv.ts
+++ b/packages/zod/src/v4/locales/sv.ts
@@ -79,9 +79,10 @@ const error: errors.$ZodErrorMap = (issue) => {
     case "too_big": {
       const adj = issue.inclusive ? "<=" : "<";
       const sizing = getSizing(issue.origin);
-      if (sizing)
+      if (sizing) {
         return `För stor(t): förväntade ${issue.origin ?? "värdet"} att ha ${adj}${issue.maximum.toString()} ${sizing.unit ?? "element"}`;
-      return `För stor(t): förväntat ${issue.origin ?? "värdet"} to be ${adj}${issue.maximum.toString()}`;
+      }
+      return `För stor(t): förväntat ${issue.origin ?? "värdet"} att ha ${adj}${issue.maximum.toString()}`;
     }
     case "too_small": {
       const adj = issue.inclusive ? ">=" : ">";
@@ -98,7 +99,7 @@ const error: errors.$ZodErrorMap = (issue) => {
       }
       if (_issue.format === "ends_with") return `Ogiltig sträng: måste sluta med "${_issue.suffix}"`;
       if (_issue.format === "includes") return `Ogiltig sträng: måste innehålla "${_issue.includes}"`;
-      if (_issue.format === "regex") return `Ogiltig sträng: måste matcha mönstret ${_issue.pattern}`;
+      if (_issue.format === "regex") return `Ogiltig sträng: måste matcha mönstret "${_issue.pattern}"`;
       return `Ogiltig(t) ${Nouns[_issue.format] ?? issue.format}`;
     }
     case "not_multiple_of":

--- a/packages/zod/src/v4/locales/sv.ts
+++ b/packages/zod/src/v4/locales/sv.ts
@@ -39,7 +39,7 @@ export const parsedType = (data: any): string => {
 const Nouns: {
   [k in $ZodStringFormats | (string & {})]?: string;
 } = {
-  regex: "input",
+  regex: "reguljärt uttryck",
   email: "e-postadress",
   url: "URL",
   emoji: "emoji",
@@ -66,7 +66,7 @@ const Nouns: {
   json_string: "JSON-sträng",
   e164: "E.164-nummer",
   jwt: "JWT",
-  template_literal: "input",
+  template_literal: "mall-literal",
 };
 
 const error: errors.$ZodErrorMap = (issue) => {
@@ -80,22 +80,21 @@ const error: errors.$ZodErrorMap = (issue) => {
       const adj = issue.inclusive ? "<=" : "<";
       const sizing = getSizing(issue.origin);
       if (sizing)
-        return `För stor(t): förväntade ${issue.origin ?? "värde"} att ha ${adj}${issue.maximum.toString()} ${sizing.unit ?? "element"}`;
-      return `För stor(t): förväntat ${issue.origin ?? "värde"} to be ${adj}${issue.maximum.toString()}`;
+        return `För stor(t): förväntade ${issue.origin ?? "värdet"} att ha ${adj}${issue.maximum.toString()} ${sizing.unit ?? "element"}`;
+      return `För stor(t): förväntat ${issue.origin ?? "värdet"} to be ${adj}${issue.maximum.toString()}`;
     }
     case "too_small": {
       const adj = issue.inclusive ? ">=" : ">";
       const sizing = getSizing(issue.origin);
       if (sizing) {
-        return `För lite(t): förväntade ${issue.origin} att ha ${adj}${issue.minimum.toString()} ${sizing.unit}`;
+        return `För lite(t): förväntade ${issue.origin ?? "värdet"} att ha ${adj}${issue.minimum.toString()} ${sizing.unit}`;
       }
-
-      return `För lite(t): förväntade ${issue.origin} att ha ${adj}${issue.minimum.toString()}`;
+      return `För lite(t): förväntade ${issue.origin ?? "värdet"} att ha ${adj}${issue.minimum.toString()}`;
     }
     case "invalid_format": {
       const _issue = issue as errors.$ZodStringFormatIssues;
       if (_issue.format === "starts_with") {
-        return `Ogiltig sträng: måsta börja med "${_issue.prefix}"`;
+        return `Ogiltig sträng: måste börja med "${_issue.prefix}"`;
       }
       if (_issue.format === "ends_with") return `Ogiltig sträng: måste sluta med "${_issue.suffix}"`;
       if (_issue.format === "includes") return `Ogiltig sträng: måste innehålla "${_issue.includes}"`;
@@ -107,11 +106,11 @@ const error: errors.$ZodErrorMap = (issue) => {
     case "unrecognized_keys":
       return `${issue.keys.length > 1 ? "Okända nycklar" : "Okänd nyckel"}: ${util.joinValues(issue.keys, ", ")}`;
     case "invalid_key":
-      return `Ogiltig nyckel i ${issue.origin}`;
+      return `Ogiltig nyckel i ${issue.origin ?? "värdet"}`;
     case "invalid_union":
       return "Ogiltig input";
     case "invalid_element":
-      return `Ogiltigt värde i ${issue.origin}`;
+      return `Ogiltigt värde i ${issue.origin ?? "värdet"}`;
     default:
       return `Ogiltig input`;
   }

--- a/packages/zod/src/v4/locales/sv.ts
+++ b/packages/zod/src/v4/locales/sv.ts
@@ -1,0 +1,126 @@
+import type { $ZodStringFormats } from "../core/checks.js";
+import type * as errors from "../core/errors.js";
+import * as util from "../core/util.js";
+
+const Sizable: Record<string, { unit: string; verb: string }> = {
+  string: { unit: "tecken", verb: "att ha" },
+  file: { unit: "bytes", verb: "att ha" },
+  array: { unit: "objekt", verb: "att innehålla" },
+  set: { unit: "objekt", verb: "att innehålla" },
+};
+
+function getSizing(origin: string): { unit: string; verb: string } | null {
+  return Sizable[origin] ?? null;
+}
+
+export const parsedType = (data: any): string => {
+  const t = typeof data;
+
+  switch (t) {
+    case "number": {
+      return Number.isNaN(data) ? "NaN" : "antal";
+    }
+    case "object": {
+      if (Array.isArray(data)) {
+        return "lista";
+      }
+      if (data === null) {
+        return "null";
+      }
+
+      if (Object.getPrototypeOf(data) !== Object.prototype && data.constructor) {
+        return data.constructor.name;
+      }
+    }
+  }
+  return t;
+};
+
+const Nouns: {
+  [k in $ZodStringFormats | (string & {})]?: string;
+} = {
+  regex: "input",
+  email: "e-postadress",
+  url: "URL",
+  emoji: "emoji",
+  uuid: "UUID",
+  uuidv4: "UUIDv4",
+  uuidv6: "UUIDv6",
+  nanoid: "nanoid",
+  guid: "GUID",
+  cuid: "cuid",
+  cuid2: "cuid2",
+  ulid: "ULID",
+  xid: "XID",
+  ksuid: "KSUID",
+  datetime: "ISO-datum och tid",
+  date: "ISO-datum",
+  time: "ISO-tid",
+  duration: "ISO-varaktighet",
+  ipv4: "IPv4-intervall",
+  ipv6: "IPv6-intervall",
+  cidrv4: "IPv4-spektrum",
+  cidrv6: "IPv6-spektrum",
+  base64: "base64-kodad sträng",
+  base64url: "base64url-kodad sträng",
+  json_string: "JSON-sträng",
+  e164: "E.164-nummer",
+  jwt: "JWT",
+  template_literal: "input",
+};
+
+const error: errors.$ZodErrorMap = (issue) => {
+  switch (issue.code) {
+    case "invalid_type":
+      return `Ogiltig inmatning: förväntat ${issue.expected}, fick ${parsedType(issue.input)}`;
+    case "invalid_value":
+      if (issue.values.length === 1) return `Ogiltig inmatning: förväntat ${util.stringifyPrimitive(issue.values[0])}`;
+      return `Ogiltigt val: förväntade en av ${util.joinValues(issue.values, "|")}`;
+    case "too_big": {
+      const adj = issue.inclusive ? "<=" : "<";
+      const sizing = getSizing(issue.origin);
+      if (sizing)
+        return `För stor(t): förväntade ${issue.origin ?? "värde"} att ha ${adj}${issue.maximum.toString()} ${sizing.unit ?? "element"}`;
+      return `För stor(t): förväntat ${issue.origin ?? "värde"} to be ${adj}${issue.maximum.toString()}`;
+    }
+    case "too_small": {
+      const adj = issue.inclusive ? ">=" : ">";
+      const sizing = getSizing(issue.origin);
+      if (sizing) {
+        return `För lite(t): förväntade ${issue.origin} att ha ${adj}${issue.minimum.toString()} ${sizing.unit}`;
+      }
+
+      return `För lite(t): förväntade ${issue.origin} att ha ${adj}${issue.minimum.toString()}`;
+    }
+    case "invalid_format": {
+      const _issue = issue as errors.$ZodStringFormatIssues;
+      if (_issue.format === "starts_with") {
+        return `Ogiltig sträng: måsta börja med "${_issue.prefix}"`;
+      }
+      if (_issue.format === "ends_with") return `Ogiltig sträng: måste sluta med "${_issue.suffix}"`;
+      if (_issue.format === "includes") return `Ogiltig sträng: måste innehålla "${_issue.includes}"`;
+      if (_issue.format === "regex") return `Ogiltig sträng: måste matcha mönstret ${_issue.pattern}`;
+      return `Ogiltig(t) ${Nouns[_issue.format] ?? issue.format}`;
+    }
+    case "not_multiple_of":
+      return `Ogiltigt tal: måste vara en multipel av ${issue.divisor}`;
+    case "unrecognized_keys":
+      return `${issue.keys.length > 1 ? "Okända nycklar" : "Okänd nyckel"}: ${util.joinValues(issue.keys, ", ")}`;
+    case "invalid_key":
+      return `Ogiltig nyckel i ${issue.origin}`;
+    case "invalid_union":
+      return "Ogiltig input";
+    case "invalid_element":
+      return `Ogiltigt värde i ${issue.origin}`;
+    default:
+      return `Ogiltig input`;
+  }
+};
+
+export { error };
+
+export default function (): { localeError: errors.$ZodErrorMap } {
+  return {
+    localeError: error,
+  };
+}


### PR DESCRIPTION
Add Swedish locale for Swedish translation for error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Swedish-language error messages in validation error outputs.
  - Updated documentation to include Swedish as an available locale option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->