### PR TITLE
Fix typo in README.md in the safeParse() usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ try {
 To avoid a `try/catch` block, you can use the `.safeParse()` method to get back a plain result object containing either the successfully parsed data or a `ZodError`. The result type is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions), so you can handle both cases conveniently.
 
 ```ts
-const result = Player.parse({ username: 42, xp: "100" });
+const result = Player.safeParse({ username: 42, xp: "100" });
 if (!result.success) {
   result.error;   // ZodError instance
 } else {


### PR DESCRIPTION
I noticed a typo in the safeParse() section of the readme; the code example used parse() instead of safeParse().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the example in the README to use `.safeParse()` instead of `.parse()` for safer error handling when parsing data with Zod.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->