### PR TITLE
chore: add Clipboard to Bronze Sponsors

### DIFF
--- a/packages/docs/components/bronze.tsx
+++ b/packages/docs/components/bronze.tsx
@@ -60,6 +60,12 @@ export const Bronze = () => {
       url: "github.com/jasonLaster",
       href: "https://github.com/jasonLaster",
     },
+    {
+      name: "Clipboard",
+      logoSrc: "https://avatars.githubusercontent.com/u/28880063?s=200&v=4",
+      url: "clipboardhealth.com/engineering",
+      href: "https://www.clipboardhealth.com/engineering",
+    },
   ];
 
   return (


### PR DESCRIPTION
<!--

Development of the next major version of Zod (`v4`) is currently underway. During this phase, only bugfixes and documentation improvements are being accepted into the `main` branch. All other PRs should target the `v4` branch. Thanks for contribting to OSS!

-->

Clipboard sponsors Zod ($100 p/m) so this change adds to the Bronze sponsors list

https://github.com/orgs/ClipboardHealth/sponsoring


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added "Clipboard" as a new company entry in the Bronze section, including its logo and website link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->