### PR TITLE
Update basics.mdx: Fix #4479

### DIFF
--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -133,7 +133,7 @@ try {
 To avoid a `try/catch` block, you can use the `.safeParse()` method to get back a plain result object containing either the successfully parsed data or a `ZodError`. The result type is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions), so you can handle both cases conveniently.
 
 ```ts
-const result = Player.parse({ username: 42, xp: "100" });
+const result = Player.safeParse({ username: 42, xp: "100" });
 if (!result.success) {
   result.error;   // ZodError instance
 } else {


### PR DESCRIPTION
Fixes #4479

Replaces ".parse(" with ".safeParse(" in the code example for safeParse

<!--

Development of the next major version of Zod (`v4`) is currently underway. During this phase, only bugfixes and documentation improvements are being accepted into the `main` branch. All other PRs should target the `v4` branch. Thanks for contribting to OSS!

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example in the documentation to demonstrate parsing data with `.safeParse()` instead of `.parse()`, clarifying how to handle success and error cases without using try/catch blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->