### PR TITLE
fix: update correct JSON Schema identifiers

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -142,7 +142,7 @@ Below is a quick reference for each supported parameter. Each one is explained i
 interface ToJSONSchemaParams {
   /** The JSON Schema version to target.
    * - `"draft-2020-12"` — Default. JSON Schema Draft 2020-12
-   * - `"draft-7"` — Default. JSON Schema Draft 7 */
+   * - `"draft-7"` — JSON Schema Draft 7 */
   target?: "draft-7" | "draft-2020-12";
 
   /** A registry used to look up metadata for each schema. 

--- a/packages/zod/src/v4/classic/tests/json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/json-schema.test.ts
@@ -6,53 +6,53 @@ describe("toJSONSchema", () => {
   test("primitive types", () => {
     expect(toJSONSchema(z.string())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "string",
       }
     `);
     expect(toJSONSchema(z.number())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "number",
       }
     `);
     expect(toJSONSchema(z.boolean())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "boolean",
       }
     `);
     expect(toJSONSchema(z.null())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "null",
       }
     `);
     expect(toJSONSchema(z.undefined())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "null",
       }
     `);
     expect(toJSONSchema(z.any())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
       }
     `);
     expect(toJSONSchema(z.unknown())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
       }
     `);
     expect(toJSONSchema(z.never())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "not": {},
       }
     `);
     expect(toJSONSchema(z.email())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "email",
         "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
         "type": "string",
@@ -60,7 +60,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.iso.datetime())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "date-time",
         "pattern": "^((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))T([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(\\.\\d+)?(Z)$",
         "type": "string",
@@ -68,7 +68,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.iso.date())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "date",
         "pattern": "^((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))$",
         "type": "string",
@@ -76,7 +76,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.iso.time())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "time",
         "pattern": "^([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(\\.\\d+)?$",
         "type": "string",
@@ -84,7 +84,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.iso.duration())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "duration",
         "pattern": "^P(?:(\\d+W)|(?!.*W)(?=\\d|T\\d)(\\d+Y)?(\\d+M)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+([.,]\\d+)?S)?)?)$",
         "type": "string",
@@ -92,7 +92,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.ipv4())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "ipv4",
         "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$",
         "type": "string",
@@ -100,7 +100,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.ipv6())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "ipv6",
         "pattern": "^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|::|([0-9a-fA-F]{1,4})?::([0-9a-fA-F]{1,4}:?){0,6})$",
         "type": "string",
@@ -108,7 +108,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.uuid())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "uuid",
         "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
         "type": "string",
@@ -116,7 +116,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.guid())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "uuid",
         "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
         "type": "string",
@@ -124,14 +124,14 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.url())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "uri",
         "type": "string",
       }
     `);
     expect(toJSONSchema(z.base64())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "contentEncoding": "base64",
         "format": "base64",
         "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$",
@@ -140,7 +140,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.cuid())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "cuid",
         "pattern": "^[cC][^\\s-]{8,}$",
         "type": "string",
@@ -149,7 +149,7 @@ describe("toJSONSchema", () => {
     // expect(toJSONSchema(z.regex(/asdf/))).toMatchInlineSnapshot();
     expect(toJSONSchema(z.emoji())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "emoji",
         "pattern": "^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$",
         "type": "string",
@@ -157,7 +157,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.nanoid())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "nanoid",
         "pattern": "^[a-zA-Z0-9_-]{21}$",
         "type": "string",
@@ -165,7 +165,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.cuid2())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "cuid2",
         "pattern": "^[0-9a-z]+$",
         "type": "string",
@@ -173,7 +173,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.ulid())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "ulid",
         "pattern": "^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$",
         "type": "string",
@@ -182,13 +182,13 @@ describe("toJSONSchema", () => {
     // expect(toJSONSchema(z.cidr())).toMatchInlineSnapshot();
     expect(toJSONSchema(z.number())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "number",
       }
     `);
     expect(toJSONSchema(z.int())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 9007199254740991,
         "minimum": -9007199254740991,
         "type": "integer",
@@ -196,7 +196,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.int32())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 2147483647,
         "minimum": -2147483648,
         "type": "integer",
@@ -204,7 +204,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.float32())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 3.4028234663852886e+38,
         "minimum": -3.4028234663852886e+38,
         "type": "number",
@@ -212,7 +212,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.float64())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 1.7976931348623157e+308,
         "minimum": -1.7976931348623157e+308,
         "type": "number",
@@ -220,7 +220,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.jwt())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "jwt",
         "type": "string",
       }
@@ -249,7 +249,7 @@ describe("toJSONSchema", () => {
     const staticCatchSchema = z.string().catch(() => "sup");
     expect(toJSONSchema(staticCatchSchema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "default": "sup",
         "type": "string",
       }
@@ -263,7 +263,7 @@ describe("toJSONSchema", () => {
   test("string formats", () => {
     expect(toJSONSchema(z.string().email())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "email",
         "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$",
         "type": "string",
@@ -271,7 +271,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.string().uuid())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "uuid",
         "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$",
         "type": "string",
@@ -279,7 +279,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.iso.datetime())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "date-time",
         "pattern": "^((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))T([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(\\.\\d+)?(Z)$",
         "type": "string",
@@ -288,7 +288,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.iso.date())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "date",
         "pattern": "^((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))$",
         "type": "string",
@@ -296,7 +296,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.iso.time())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "time",
         "pattern": "^([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(\\.\\d+)?$",
         "type": "string",
@@ -304,7 +304,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.iso.duration())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "duration",
         "pattern": "^P(?:(\\d+W)|(?!.*W)(?=\\d|T\\d)(\\d+Y)?(\\d+M)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+([.,]\\d+)?S)?)?)$",
         "type": "string",
@@ -318,7 +318,7 @@ describe("toJSONSchema", () => {
     // `);
     expect(toJSONSchema(z.ipv4())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "ipv4",
         "pattern": "^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])\\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$",
         "type": "string",
@@ -327,7 +327,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.ipv6())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "ipv6",
         "pattern": "^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|::|([0-9a-fA-F]{1,4})?::([0-9a-fA-F]{1,4}:?){0,6})$",
         "type": "string",
@@ -336,7 +336,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.base64())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "contentEncoding": "base64",
         "format": "base64",
         "pattern": "^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$",
@@ -345,14 +345,14 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.url())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "uri",
         "type": "string",
       }
     `);
     expect(toJSONSchema(z.guid())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "uuid",
         "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
         "type": "string",
@@ -360,7 +360,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.string().regex(/asdf/))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "regex",
         "pattern": "asdf",
         "type": "string",
@@ -372,7 +372,7 @@ describe("toJSONSchema", () => {
     expect(toJSONSchema(z.number().min(5).max(10))).toMatchInlineSnapshot(
       `
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 10,
         "minimum": 5,
         "type": "number",
@@ -382,7 +382,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.number().gt(5).gt(10))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "exclusiveMinimum": 10,
         "type": "number",
       }
@@ -390,7 +390,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.number().gt(5).gte(10))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "minimum": 10,
         "type": "number",
       }
@@ -398,7 +398,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.number().lt(5).lt(3))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "exclusiveMaximum": 3,
         "type": "number",
       }
@@ -406,7 +406,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.number().lt(5).lt(3).lte(2))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 2,
         "type": "number",
       }
@@ -414,7 +414,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.number().lt(5).lte(3))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 3,
         "type": "number",
       }
@@ -422,7 +422,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(z.number().gt(5).lt(10))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "exclusiveMaximum": 10,
         "exclusiveMinimum": 5,
         "type": "number",
@@ -430,7 +430,7 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.number().gte(5).lte(10))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 10,
         "minimum": 5,
         "type": "number",
@@ -438,28 +438,28 @@ describe("toJSONSchema", () => {
     `);
     expect(toJSONSchema(z.number().positive())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "exclusiveMinimum": 0,
         "type": "number",
       }
     `);
     expect(toJSONSchema(z.number().negative())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "exclusiveMaximum": 0,
         "type": "number",
       }
     `);
     expect(toJSONSchema(z.number().nonpositive())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "maximum": 0,
         "type": "number",
       }
     `);
     expect(toJSONSchema(z.number().nonnegative())).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "minimum": 0,
         "type": "number",
       }
@@ -469,7 +469,7 @@ describe("toJSONSchema", () => {
   test("arrays", () => {
     expect(toJSONSchema(z.array(z.string()))).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "items": {
           "type": "string",
         },
@@ -482,7 +482,7 @@ describe("toJSONSchema", () => {
     const schema = z.union([z.string(), z.number()]);
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "anyOf": [
           {
             "type": "string",
@@ -500,7 +500,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "allOf": [
           {
             "properties": {
@@ -533,7 +533,7 @@ describe("toJSONSchema", () => {
     const schema = z.record(z.string(), z.boolean());
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": {
           "type": "boolean",
         },
@@ -549,7 +549,7 @@ describe("toJSONSchema", () => {
     const schema = z.tuple([z.string(), z.number()]).rest(z.boolean());
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "items": {
           "type": "boolean",
         },
@@ -570,7 +570,7 @@ describe("toJSONSchema", () => {
     const schema = z.promise(z.string());
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "string",
       }
     `);
@@ -580,7 +580,7 @@ describe("toJSONSchema", () => {
     const schema = z.lazy(() => z.string());
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "string",
       }
     `);
@@ -591,7 +591,7 @@ describe("toJSONSchema", () => {
     const schema = z.enum(["a", "b", "c"]);
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "enum": [
           "a",
           "b",
@@ -606,7 +606,7 @@ describe("toJSONSchema", () => {
     const a = z.literal("hello");
     expect(toJSONSchema(a)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "const": "hello",
       }
     `);
@@ -617,7 +617,7 @@ describe("toJSONSchema", () => {
     const c = z.literal(["hello", null, 5]);
     expect(toJSONSchema(c)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "enum": [
           "hello",
           null,
@@ -635,7 +635,7 @@ describe("toJSONSchema", () => {
       .pipe(z.number());
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "number",
       }
     `);
@@ -650,7 +650,7 @@ describe("toJSONSchema", () => {
     expect(toJSONSchema(schema)).toMatchInlineSnapshot(
       `
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "age": {
             "type": "number",
@@ -677,7 +677,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(a)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
         "properties": {
           "age": {
@@ -703,7 +703,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(b)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": {
           "type": "string",
         },
@@ -725,7 +725,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(c)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": {},
         "properties": {
           "name": {
@@ -751,7 +751,7 @@ describe("toJSONSchema", () => {
 
     expect(result).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "nonoptional": {
             "type": "string",
@@ -786,7 +786,7 @@ describe("toJSONSchema", () => {
     const result = toJSONSchema(categorySchema);
     expect(result).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "name": {
             "type": "string",
@@ -816,7 +816,7 @@ describe("toJSONSchema", () => {
     const result = toJSONSchema(userSchema);
     expect(result).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "properties": {
           "age": {
             "type": "number",
@@ -841,7 +841,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(a)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": false,
         "properties": {
           "age": {
@@ -867,7 +867,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(b)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": {
           "type": "string",
         },
@@ -889,7 +889,7 @@ describe("toJSONSchema", () => {
 
     expect(toJSONSchema(c)).toMatchInlineSnapshot(`
       {
-        "$schema": "https://json-schema.org/draft-2020-12/schema",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "additionalProperties": {},
         "properties": {
           "name": {
@@ -931,7 +931,7 @@ describe("toJSONSchema", () => {
           "id",
           "children"
         ],
-        "$schema": "https://json-schema.org/draft-2020-12/schema"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }"
     `
     );
@@ -986,7 +986,7 @@ describe("toJSONSchema", () => {
           "name",
           "files"
         ],
-        "$schema": "https://json-schema.org/draft-2020-12/schema"
+        "$schema": "https://json-schema.org/draft/2020-12/schema"
       }"
     `
     );
@@ -1003,7 +1003,7 @@ test("override", () => {
   });
   expect(schema).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "string",
       "whatever": "sup",
     }
@@ -1043,7 +1043,7 @@ test("override with refs", () => {
 
   expect(result).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "STRING",
     }
   `);
@@ -1084,7 +1084,7 @@ test("pipe", () => {
   const a = z.toJSONSchema(mySchema);
   expect(a).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "number",
     }
   `);
@@ -1093,7 +1093,7 @@ test("pipe", () => {
   const b = z.toJSONSchema(mySchema, { io: "input" });
   expect(b).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "string",
     }
   `);
@@ -1137,7 +1137,7 @@ test("passthrough schemas", () => {
           "type": "object",
         },
       },
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "a": {
           "$ref": "#/$defs/__schema0",
@@ -1188,7 +1188,7 @@ test("extract schemas with id", () => {
           "type": "string",
         },
       },
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "age": {
           "$ref": "#/$defs/age",
@@ -1224,7 +1224,7 @@ test("unrepresentable literal values are ignored", () => {
   const a = z.toJSONSchema(z.literal(["hello", null, 5, BigInt(1324), undefined]), { unrepresentable: "any" });
   expect(a).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [
         "hello",
         null,
@@ -1237,7 +1237,7 @@ test("unrepresentable literal values are ignored", () => {
   const b = z.toJSONSchema(z.literal([undefined, null, 5, BigInt(1324)]), { unrepresentable: "any" });
   expect(b).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "enum": [
         null,
         5,
@@ -1249,7 +1249,7 @@ test("unrepresentable literal values are ignored", () => {
   const c = z.toJSONSchema(z.literal([undefined]), { unrepresentable: "any" });
   expect(c).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
     }
   `);
 });
@@ -1271,7 +1271,7 @@ test("describe with id", () => {
           "type": "string",
         },
       },
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "current": {
           "$ref": "#/$defs/jobId",
@@ -1312,7 +1312,7 @@ test("overwrite id", () => {
           "id": "bbb",
         },
       },
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "current": {
           "$ref": "#/$defs/aaa",
@@ -1350,7 +1350,7 @@ test("overwrite id", () => {
           "id": "ccc",
         },
       },
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "current": {
           "$ref": "#/$defs/aaa",
@@ -1379,7 +1379,7 @@ test("overwrite descriptions", () => {
   );
   expect(a).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "d": {
           "description": "d",
@@ -1415,7 +1415,7 @@ test("overwrite descriptions", () => {
           "type": "string",
         },
       },
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "d": {
           "$ref": "#/$defs/__schema0",
@@ -1478,7 +1478,7 @@ test("top-level readonly", () => {
           "type": "object",
         },
       },
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "id": "A",
       "properties": {
         "b": {
@@ -1523,7 +1523,7 @@ test("basic registry", () => {
     {
       "schemas": {
         "Post": {
-          "$schema": "https://json-schema.org/draft-2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "properties": {
             "author": {
               "$ref": "User",
@@ -1543,7 +1543,7 @@ test("basic registry", () => {
           "type": "object",
         },
         "User": {
-          "$schema": "https://json-schema.org/draft-2020-12/schema",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
           "properties": {
             "name": {
               "type": "string",
@@ -1571,7 +1571,7 @@ test("_ref", () => {
   const a = z.toJSONSchema(z.promise(z.string().describe("a")));
   expect(a).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "a",
       "type": "string",
     }
@@ -1580,7 +1580,7 @@ test("_ref", () => {
   const b = z.toJSONSchema(z.lazy(() => z.string().describe("a")));
   expect(b).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "a",
       "type": "string",
     }
@@ -1589,7 +1589,7 @@ test("_ref", () => {
   const c = z.toJSONSchema(z.optional(z.string().describe("a")));
   expect(c).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "a",
       "type": "string",
     }
@@ -1607,13 +1607,13 @@ test("defaults/prefaults", () => {
   // a
   expect(toJSONSchema(a)).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "number",
     }
   `);
   expect(toJSONSchema(a, { io: "input" })).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "string",
     }
   `);
@@ -1621,13 +1621,13 @@ test("defaults/prefaults", () => {
   // b
   expect(toJSONSchema(b)).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "number",
     }
   `);
   expect(toJSONSchema(b, { io: "input" })).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "default": "hello",
       "type": "string",
     }
@@ -1635,14 +1635,14 @@ test("defaults/prefaults", () => {
   // c
   expect(toJSONSchema(c)).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "default": 1234,
       "type": "number",
     }
   `);
   expect(toJSONSchema(c, { io: "input" })).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "default": 1234,
       "type": "string",
     }
@@ -1659,7 +1659,7 @@ test("input type", () => {
   });
   expect(toJSONSchema(schema, { io: "input" })).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "a": {
           "type": "string",
@@ -1695,7 +1695,7 @@ test("input type", () => {
   `);
   expect(toJSONSchema(schema, { io: "output" })).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "a": {
           "type": "string",
@@ -1743,7 +1743,7 @@ test("examples on pipe", () => {
   const i = z.toJSONSchema(schema, { io: "input", unrepresentable: "any" });
   expect(i).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "examples": [
         "test",
       ],
@@ -1753,7 +1753,7 @@ test("examples on pipe", () => {
   const o = z.toJSONSchema(schema, { io: "output", unrepresentable: "any" });
   expect(o).toMatchInlineSnapshot(`
     {
-      "$schema": "https://json-schema.org/draft-2020-12/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "examples": [
         4,
       ],

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -719,9 +719,9 @@ export class JSONSchemaGenerator {
     }
 
     if (this.target === "draft-2020-12") {
-      result.$schema = "https://json-schema.org/draft-2020-12/schema";
+      result.$schema = "https://json-schema.org/draft/2020-12/schema";
     } else if (this.target === "draft-7") {
-      result.$schema = "https://json-schema.org/draft-07/schema";
+      result.$schema = "http://json-schema.org/draft-07/schema#";
     } else {
       console.warn(`Invalid target: ${this.target}`);
     }


### PR DESCRIPTION
update docs to correctly identify JSON Schema 2020-12 is the only default

fixes #4412

<!--

Development of the next major version of Zod (`v4`) is currently underway. During this phase, only bugfixes and documentation improvements are being accepted into the `main` branch. All other PRs should target the `v4` branch. Thanks for contribting to OSS!

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified which JSON Schema draft version is the default in the documentation.
- **Bug Fixes**
  - Corrected the JSON Schema $schema URI formats for both "draft-2020-12" and "draft-7" outputs.
- **Tests**
  - Updated test snapshots to reflect the corrected $schema URIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->