### PR TITLE
feat: add export entries for bundlers that don't support exports field

### DIFF
--- a/packages/zod/v3/index.d.ts
+++ b/packages/zod/v3/index.d.ts
@@ -1,0 +1,1 @@
+export * from "../dist/types/v3/index.d.ts";

--- a/packages/zod/v3/index.js
+++ b/packages/zod/v3/index.js
@@ -1,0 +1,1 @@
+export * from "../dist/esm/v3/index.js";

--- a/packages/zod/v4-mini/index.d.ts
+++ b/packages/zod/v4-mini/index.d.ts
@@ -1,0 +1,1 @@
+export * from "../dist/types/v4/mini/index.d.ts";

--- a/packages/zod/v4-mini/index.js
+++ b/packages/zod/v4-mini/index.js
@@ -1,0 +1,1 @@
+export * from "../dist/esm/v4/mini/index.js";

--- a/packages/zod/v4/index.d.ts
+++ b/packages/zod/v4/index.d.ts
@@ -1,0 +1,1 @@
+export * from "../dist/types/v4/index.d.ts";

--- a/packages/zod/v4/index.js
+++ b/packages/zod/v4/index.js
@@ -1,0 +1,1 @@
+export * from "../dist/esm/v4/index.js";


### PR DESCRIPTION
fixes #4470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new entry points for v3, v4, and v4-mini versions, allowing imports from simplified paths for both JavaScript and TypeScript users.
  - Improved accessibility of type declarations and exports, making it easier to integrate and use different versions of the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->