### PR TITLE
Fix typos

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -363,7 +363,7 @@ type schemaInput = z.input<typeof schema>;
 
 ## `.default()` updates
 
-The application of `.default()` has changed in a subtle way. If the input is `undefined`, `ZodDefault` short-circuits the parsing process and returns the default value. The the default value must be assignable to the *output type*.
+The application of `.default()` has changed in a subtle way. If the input is `undefined`, `ZodDefault` short-circuits the parsing process and returns the default value. The default value must be assignable to the *output type*.
 
 ```ts
 const schema = z.string()

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -313,7 +313,7 @@ export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /
               input,
               code: "too_big",
               maximum: Number.MAX_SAFE_INTEGER,
-              note: "Integers must be within the the safe integer range.",
+              note: "Integers must be within the safe integer range.",
               inst,
               origin,
               continue: !def.abort,


### PR DESCRIPTION
While reading the migration guide to v4 I noticed a little typo (`The the`). After a quick search, I found another similar one in the `checks.ts`. It's not much, but a little polish 💅 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the changelog for improved clarity.

- **Style**
  - Fixed a minor typo in an error message to enhance readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->