### PR TITLE
[Docs] Fix typo in changelog for dropped ErrorMap

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -79,7 +79,7 @@ Error maps can also now return a plain `string` (instead of `{message: string}`)
 <Tabs groupId="error-map" items={["Zod 4", "Zod 3"]} persist>
 <Tab value="Zod 4">
 ```ts
-z.string({
+z.string().min(5, {
   error: (issue) => {
     if (issue.code === "too_small") {
       return `Value must be >${issue.minimum}`


### PR DESCRIPTION
Fixes a minor typo here that can potentially confuse folks migrating: https://zod.dev/v4/changelog?id=drops-errormap

<img width="817" alt="image" src="https://github.com/user-attachments/assets/0381f31f-1846-4d67-9e46-00ebcc16ebe8" />

Without specifying a min for the string in the example there is no issue code other than `"invalid_type"`: 
<img width="683" alt="image" src="https://github.com/user-attachments/assets/72102299-7cc6-4857-8bce-684d8a3080e8" />

*This comparison appears to be unintentional because the types '"invalid_type"' and '"too_small"' have no overlap.ts(2367)*

<img width="1465" alt="image" src="https://github.com/user-attachments/assets/5ac88d87-4f90-4629-b057-a2150ad6f978" />


tl;dr: tweak the example to specify a min for that string for the example to make sense and not cause type whining

```ts
z.string().min(5{
  error: (issue) => {
    if (issue.code === "too_small") {
      return `Value must be >${issue.minimum}`;
    }
  },
});
```