### PR TITLE
fix: add missing re-exports files and add new entries the published files

### DIFF
--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "author": "Colin McDonnell <zod@colinhacks.com>",
   "description": "TypeScript-first schema declaration and validation library with static type inference",
-  "files": ["dist"],
+  "files": ["dist", "v3", "v4", "v4-mini"],
   "funding": "https://github.com/sponsors/colinhacks",
   "homepage": "https://zod.dev",
   "keywords": ["typescript", "schema", "validation", "type", "inference"],

--- a/packages/zod/v4/core/index.d.ts
+++ b/packages/zod/v4/core/index.d.ts
@@ -1,0 +1,1 @@
+export * from "../../dist/types/v4/core/index.d.ts";

--- a/packages/zod/v4/core/index.js
+++ b/packages/zod/v4/core/index.js
@@ -1,0 +1,1 @@
+export * from "../../dist/esm/v4/core/index.js";

--- a/packages/zod/v4/locales/en.d.ts
+++ b/packages/zod/v4/locales/en.d.ts
@@ -1,0 +1,2 @@
+export * from "../../dist/types/v4/locales/en.d.ts";
+export { default } from "../../dist/types/v4/locales/en.d.ts";

--- a/packages/zod/v4/locales/en.js
+++ b/packages/zod/v4/locales/en.js
@@ -1,0 +1,2 @@
+export * from "../../dist/esm/v4/locales/en.js";
+export { default } from "../../dist/esm/v4/locales/en.js";

--- a/packages/zod/v4/locales/index.d.ts
+++ b/packages/zod/v4/locales/index.d.ts
@@ -1,0 +1,1 @@
+export * from "../../dist/types/v4/locales/index.d.ts";

--- a/packages/zod/v4/locales/index.js
+++ b/packages/zod/v4/locales/index.js
@@ -1,0 +1,1 @@
+export * from "../../dist/esm/v4/locales/index.js";


### PR DESCRIPTION
Follow up for https://github.com/colinhacks/zod/pull/4489

fixes #4470

In that PR was missing:
- adding the new entries to the `files` array in the package.json to make them part of the published package
- filling the missing entries required for the internal imports

Tested on React Native 0.76.7 using the following snippet:
```
import { z } from "zod";
import * as zMini from "zod/v4-mini";
import * as z3 from "zod/v3";
import * as z4 from "zod/v4";

console.log(z.object({ name: z.string() }).parse({ name: "John" }));
console.log(z3.object({ name: z3.string() }).parse({ name: "John" }));
console.log(zMini.object({ name: zMini.string() }).parse({ name: "John" }));
console.log(z4.object({ name: z4.string() }).parse({ name: "John" }));
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new entry points for core and locale modules, allowing easier imports for consumers.
  - Included additional directories in the package to make new modules available.

- **Chores**
  - Updated packaging configuration to include new directories and files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->