### PR TITLE
v4(toJSONSchema): Add multiple string pattern support

### DIFF
--- a/packages/zod/src/v4/classic/tests/json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/json-schema.test.ts
@@ -368,6 +368,52 @@ describe("toJSONSchema", () => {
     `);
   });
 
+  test("string patterns", () => {
+    expect(z.toJSONSchema(z.string().startsWith("hello").includes("cruel").endsWith("world"))).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+          {
+            "pattern": "^hello.*",
+            "type": "string",
+          },
+          {
+            "pattern": "cruel",
+            "type": "string",
+          },
+          {
+            "pattern": ".*world$",
+            "type": "string",
+          },
+        ],
+      }
+    `);
+
+    expect(
+      z.toJSONSchema(
+        z
+          .string()
+          .regex(/^hello/)
+          .regex(/world$/)
+      )
+    ).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+          {
+            "format": "regex",
+            "pattern": "^hello",
+            "type": "string",
+          },
+          {
+            "pattern": "world$",
+            "type": "string",
+          },
+        ],
+      }
+    `);
+  });
+
   test("number constraints", () => {
     expect(z.toJSONSchema(z.number().min(5).max(10))).toMatchInlineSnapshot(
       `

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -780,9 +780,9 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
     $ZodCheck.init(inst, def);
 
     inst._zod.onattach.push((inst) => {
-      inst._zod.bag.format = def.format;
+      const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+      bag.format = def.format;
       if (def.pattern) {
-        const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
         if (bag.patterns) {
           bag.patterns.add(def.pattern);
         } else {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -4,7 +4,6 @@ import * as core from "./core.js";
 import type * as errors from "./errors.js";
 import * as regexes from "./regexes.js";
 import type * as schemas from "./schemas.js";
-import type { $ZodStringInternals } from "./schemas.js";
 import * as util from "./util.js";
 
 //////////////////////////////   CHECKS   ///////////////////////////////////////
@@ -780,7 +779,7 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
     $ZodCheck.init(inst, def);
 
     inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
       bag.format = def.format;
       if (def.pattern) {
         if (bag.patterns) {
@@ -951,7 +950,7 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     const pattern = new RegExp(util.escapeRegex(def.includes));
     def.pattern = pattern;
     inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
       if (bag.patterns) {
         bag.patterns.add(pattern);
       } else {
@@ -998,7 +997,7 @@ export const $ZodCheckStartsWith: core.$constructor<$ZodCheckStartsWith> = /*@__
     const pattern = new RegExp(`^${util.escapeRegex(def.prefix)}.*`);
     def.pattern ??= pattern;
     inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
       if (bag.patterns) {
         bag.patterns.add(pattern);
       } else {
@@ -1045,7 +1044,7 @@ export const $ZodCheckEndsWith: core.$constructor<$ZodCheckEndsWith> = /*@__PURE
     const pattern = new RegExp(`.*${util.escapeRegex(def.suffix)}$`);
     def.pattern ??= pattern;
     inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
       if (bag.patterns) {
         bag.patterns.add(pattern);
       } else {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -782,11 +782,8 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
       const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
       bag.format = def.format;
       if (def.pattern) {
-        if (bag.patterns) {
-          bag.patterns.add(def.pattern);
-        } else {
-          bag.patterns = new Set([def.pattern]);
-        }
+        bag.patterns ??= new Set();
+        bag.patterns.add(def.pattern);
       }
     });
 
@@ -951,11 +948,8 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     def.pattern = pattern;
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      if (bag.patterns) {
-        bag.patterns.add(pattern);
-      } else {
-        bag.patterns = new Set([pattern]);
-      }
+      bag.patterns ??= new Set();
+      bag.patterns.add(pattern);
     });
 
     inst._zod.check = (payload) => {
@@ -998,11 +992,8 @@ export const $ZodCheckStartsWith: core.$constructor<$ZodCheckStartsWith> = /*@__
     def.pattern ??= pattern;
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      if (bag.patterns) {
-        bag.patterns.add(pattern);
-      } else {
-        bag.patterns = new Set([pattern]);
-      }
+      bag.patterns ??= new Set();
+      bag.patterns.add(pattern);
     });
 
     inst._zod.check = (payload) => {
@@ -1045,11 +1036,8 @@ export const $ZodCheckEndsWith: core.$constructor<$ZodCheckEndsWith> = /*@__PURE
     def.pattern ??= pattern;
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      if (bag.patterns) {
-        bag.patterns.add(pattern);
-      } else {
-        bag.patterns = new Set([pattern]);
-      }
+      bag.patterns ??= new Set();
+      bag.patterns.add(pattern);
     });
 
     inst._zod.check = (payload) => {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -4,6 +4,7 @@ import * as core from "./core.js";
 import type * as errors from "./errors.js";
 import * as regexes from "./regexes.js";
 import type * as schemas from "./schemas.js";
+import type { $ZodStringInternals } from "./schemas.js";
 import * as util from "./util.js";
 
 //////////////////////////////   CHECKS   ///////////////////////////////////////
@@ -780,7 +781,14 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
 
     inst._zod.onattach.push((inst) => {
       inst._zod.bag.format = def.format;
-      if (def.pattern) inst._zod.bag.pattern = def.pattern;
+      if (def.pattern) {
+        const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+        if (bag.patterns) {
+          bag.patterns.add(def.pattern);
+        } else {
+          bag.patterns = new Set([def.pattern]);
+        }
+      }
     });
 
     inst._zod.check ??= (payload) => {
@@ -943,7 +951,12 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     const pattern = new RegExp(util.escapeRegex(def.includes));
     def.pattern = pattern;
     inst._zod.onattach.push((inst) => {
-      inst._zod.bag.pattern = pattern;
+      const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+      if (bag.patterns) {
+        bag.patterns.add(pattern);
+      } else {
+        bag.patterns = new Set([pattern]);
+      }
     });
 
     inst._zod.check = (payload) => {
@@ -985,7 +998,12 @@ export const $ZodCheckStartsWith: core.$constructor<$ZodCheckStartsWith> = /*@__
     const pattern = new RegExp(`^${util.escapeRegex(def.prefix)}.*`);
     def.pattern ??= pattern;
     inst._zod.onattach.push((inst) => {
-      inst._zod.bag.pattern = pattern;
+      const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+      if (bag.patterns) {
+        bag.patterns.add(pattern);
+      } else {
+        bag.patterns = new Set([pattern]);
+      }
     });
 
     inst._zod.check = (payload) => {
@@ -1027,7 +1045,12 @@ export const $ZodCheckEndsWith: core.$constructor<$ZodCheckEndsWith> = /*@__PURE
     const pattern = new RegExp(`.*${util.escapeRegex(def.suffix)}$`);
     def.pattern ??= pattern;
     inst._zod.onattach.push((inst) => {
-      inst._zod.bag.pattern = new RegExp(`.*${util.escapeRegex(def.suffix)}$`);
+      const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+      if (bag.patterns) {
+        bag.patterns.add(pattern);
+      } else {
+        bag.patterns = new Set([pattern]);
+      }
     });
 
     inst._zod.check = (payload) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -302,7 +302,7 @@ export interface $ZodString<Input = unknown> extends $ZodType {
 
 export const $ZodString: core.$constructor<$ZodString> = /*@__PURE__*/ core.$constructor("$ZodString", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.pattern = inst?._zod.bag?.patterns?.values().next().value ?? regexes.string(inst._zod.bag);
+  inst._zod.pattern = Array.from(inst?._zod.bag?.patterns ?? []).at(-1) ?? regexes.string(inst._zod.bag);
   inst._zod.parse = (payload, _) => {
     if (def.coerce)
       try {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -290,8 +290,9 @@ export interface $ZodStringInternals<Input> extends $ZodTypeInternals<string, In
   bag: util.LoosePartial<{
     minimum: number;
     maximum: number;
-    pattern: RegExp;
+    patterns: Set<RegExp>;
     format: string;
+    contentEncoding: string;
   }>;
 }
 
@@ -301,7 +302,7 @@ export interface $ZodString<Input = unknown> extends $ZodType {
 
 export const $ZodString: core.$constructor<$ZodString> = /*@__PURE__*/ core.$constructor("$ZodString", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.pattern = inst?._zod.bag?.pattern ?? regexes.string(inst._zod.bag);
+  inst._zod.pattern = inst?._zod.bag?.patterns?.values().next().value ?? regexes.string(inst._zod.bag);
   inst._zod.parse = (payload, _) => {
     if (def.coerce)
       try {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -689,7 +689,8 @@ export const $ZodIPv4: core.$constructor<$ZodIPv4> = /*@__PURE__*/ core.$constru
   def.pattern ??= regexes.ipv4;
   $ZodStringFormat.init(inst, def);
   inst._zod.onattach.push((inst) => {
-    inst._zod.bag.format = `ipv4`;
+    const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+    bag.format = `ipv4`;
   });
 });
 
@@ -712,7 +713,8 @@ export const $ZodIPv6: core.$constructor<$ZodIPv6> = /*@__PURE__*/ core.$constru
   $ZodStringFormat.init(inst, def);
 
   inst._zod.onattach.push((inst) => {
-    inst._zod.bag.format = `ipv6`;
+    const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+    bag.format = `ipv6`;
   });
 
   inst._zod.check = (payload) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -302,7 +302,7 @@ export interface $ZodString<Input = unknown> extends $ZodType {
 
 export const $ZodString: core.$constructor<$ZodString> = /*@__PURE__*/ core.$constructor("$ZodString", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.pattern = Array.from(inst?._zod.bag?.patterns ?? []).at(-1) ?? regexes.string(inst._zod.bag);
+  inst._zod.pattern = [...(inst?._zod.bag?.patterns ?? [])].pop() ?? regexes.string(inst._zod.bag);
   inst._zod.parse = (payload, _) => {
     if (def.coerce)
       try {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -161,16 +161,16 @@ export class JSONSchemaGenerator {
           }
           if (contentEncoding) json.contentEncoding = contentEncoding;
           if (patterns) {
-            const patternsItems = Array.from(patterns);
-            json.pattern = patternsItems[0].source;
+            const regexes = [...patterns];
+            json.pattern = regexes[0].source;
 
-            if (patternsItems.length > 1) {
+            if (regexes.length > 1) {
               result.schema = {
                 allOf: [
                   json,
-                  ...patternsItems.slice(1).map((pattern) => ({
+                  ...regexes.slice(1).map((regex) => ({
                     type: "string",
-                    pattern: pattern.source,
+                    pattern: regex.source,
                   })),
                 ],
               };

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -1,9 +1,7 @@
 import type * as checks from "./checks.js";
-import type { $ZodStringFormats } from "./checks.js";
 import type * as JSONSchema from "./json-schema.js";
 import { $ZodRegistry, globalRegistry } from "./registries.js";
 import type * as schemas from "./schemas.js";
-import type { $ZodStringInternals } from "./schemas.js";
 
 interface JSONSchemaGeneratorParams {
   /** A registry used to look up metadata for each schema. Any schema with an `id` property will be extracted as a $def.
@@ -152,12 +150,12 @@ export class JSONSchemaGenerator {
           const json: JSONSchema.StringSchema = _json as any;
           json.type = "string";
           const { minimum, maximum, format, patterns, contentEncoding } = schema._zod
-            .bag as $ZodStringInternals<unknown>["bag"];
+            .bag as schemas.$ZodStringInternals<unknown>["bag"];
           if (typeof minimum === "number") json.minLength = minimum;
           if (typeof maximum === "number") json.maxLength = maximum;
           // custom pattern overrides format
           if (format) {
-            json.format = formatMap[format as $ZodStringFormats] ?? format;
+            json.format = formatMap[format as checks.$ZodStringFormats] ?? format;
           }
           if (contentEncoding) json.contentEncoding = contentEncoding;
           if (patterns) {


### PR DESCRIPTION
<!--

Development of the next major version of Zod (`v4`) is currently underway. During this phase, only bugfixes and documentation improvements are being accepted into the `main` branch. All other PRs should target the `v4` branch. Thanks for contribting to OSS!

-->

Resolves https://github.com/colinhacks/zod/issues/4499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added tests verifying JSON Schema output for string schemas with multiple pattern constraints, including chained pattern methods and multiple regex patterns.  
- **Refactor**
  - Enhanced internal handling of multiple string patterns to support complex pattern combinations in schemas.  
- **Bug Fixes**
  - Improved JSON Schema generation to correctly represent multiple string patterns using combined schema definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->