### PR TITLE
v4: Add `discriminator` to Union Def type

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1852,6 +1852,7 @@ export type $InferUnionInput<T extends $ZodType> = T extends any ? core.input<T>
 export interface $ZodUnionDef<Options extends readonly $ZodType[] = readonly $ZodType[]> extends $ZodTypeDef {
   type: "union";
   options: Options;
+  discriminator?: string;
 }
 
 export interface $ZodUnionInternals<T extends readonly $ZodType[] = readonly $ZodType[]>


### PR DESCRIPTION
I need to access the `discriminator` field from within toJSONSchema to generate some OpenAPI specific discriminator fields and I noticed this wasn't available on the type definition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional discriminator property in union schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->