### PR TITLE
(V4) fix: Add check for requiredKeys before assigning to json.required

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -281,7 +281,10 @@ export class JSONSchemaGenerator {
               }
             })
           );
-          json.required = Array.from(requiredKeys);
+
+          if (requiredKeys.size > 0) {
+            json.required = Array.from(requiredKeys);
+          }
 
           // catchall
           if (def.catchall?._zod.def.type === "never") {


### PR DESCRIPTION
According to the OAS validator the "required" array property in the json schema should not be empty, it should be omitted when empty.

```
{
  "type": "object",
  "properties": {
    "id": {
      "default": "1",
      "type": "string"
    }
  },
  "required": []
}
```

Give the error:

AssertionError: expected Array [] not to be empty (false negative fail)