### PR TITLE
test: clarify test description for recursive types

### DIFF
--- a/packages/zod/src/v4/classic/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/recursive-types.test.ts
@@ -1,7 +1,7 @@
 import { expect, expectTypeOf, test } from "vitest";
 import { z } from "zod/v4";
 
-test("recursion with z.lazy", () => {
+test("recursive types using getter property", () => {
   const data = {
     name: "I",
     subcategories: [

--- a/packages/zod/src/v4/mini/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/mini/tests/recursive-types.test.ts
@@ -1,7 +1,7 @@
 import { expect, expectTypeOf, test } from "vitest";
 import { z } from "zod/v4-mini";
 
-test("recursion with z.lazy", () => {
+test("recursive types using getter property", () => {
   const data = {
     name: "I",
     subcategories: [


### PR DESCRIPTION
Update test description from "recursion with z.lazy" to "recursive types using getter property" to better reflect the actual implementation being tested.

<!--

Development of the next major version of Zod (`v4`) is currently underway. During this phase, only bugfixes and documentation improvements are being accepted into the `main` branch. All other PRs should target the `v4` branch. Thanks for contribting to OSS!

-->
