### PR TITLE
fix: basics.mdx error typo

### DIFF
--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -82,9 +82,9 @@ When validation fails, the `.parse()` method will throw a `ZodError` instance wi
 ```ts
 try {
   Player.parse({ username: 42, xp: "100" });
-} catch(err){
+} catch(error){
   if(error instanceof z.ZodError){
-    err.issues; 
+    error.issues; 
     /* [
       {
         expected: 'string',
@@ -107,9 +107,9 @@ try {
 ```ts
 try {
   Player.parse({ username: 42, xp: "100" });
-} catch(err){
+} catch(error){
   if(error instanceof z.core.$ZodError){
-    err.issues; 
+    error.issues; 
     /* [
       {
         expected: 'string',


### PR DESCRIPTION
`if` clause was using `error` naming, but binding was called `err`. Renamed to `error` to follow more of Zod error naming