### PR TITLE
Fix isPlainObject util

### DIFF
--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -779,6 +779,7 @@ test("z.promise", async () => {
 test("isPlainObject", () => {
   expect(z.core.util.isPlainObject({})).toEqual(true);
   expect(z.core.util.isPlainObject(Object.create(null))).toEqual(true);
+  expect(z.core.util.isPlainObject(Object.create(Object.create(null)))).toEqual(true);
   expect(z.core.util.isPlainObject([])).toEqual(false);
   expect(z.core.util.isPlainObject(new Date())).toEqual(false);
   expect(z.core.util.isPlainObject(null)).toEqual(false);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -335,11 +335,20 @@ export const allowsEval: { value: boolean } = cached(() => {
 });
 
 export function isPlainObject(data: any): data is Record<PropertyKey, unknown> {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    (Object.getPrototypeOf(data) === Object.prototype || Object.getPrototypeOf(data) === null)
-  );
+  if (typeof data !== "object" || data === null) return false;
+  if (Object.prototype.toString.call(data) !== Object.prototype.toString.call({})) return false;
+  let proto = Object.getPrototypeOf(data);
+  if (proto === null || proto === Object.prototype) {
+    return true;
+  }
+  while (proto !== null) {
+    const nextProto = Object.getPrototypeOf(proto);
+    if (nextProto === Object.prototype || nextProto === null) {
+      return true;
+    }
+    proto = nextProto;
+  }
+  return false;
 }
 
 export function numKeys(data: any): number {


### PR DESCRIPTION
Closes https://github.com/colinhacks/zod/issues/4573
Following up of https://github.com/colinhacks/zod/commit/33495d51f2c5ca48311e68fd25db331b81e7cf75
`isPlainObject` utility function now also checks for object with a nested null prototype.