### PR TITLE
fix(JSONSchema): add type for enum

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -639,8 +639,8 @@ describe("toJSONSchema", () => {
 
   // enum
   test("enum", () => {
-    const schema = z.enum(["a", "b", "c"]);
-    expect(z.toJSONSchema(schema)).toMatchInlineSnapshot(`
+    const a = z.enum(["a", "b", "c"]);
+    expect(z.toJSONSchema(a)).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "enum": [
@@ -648,6 +648,29 @@ describe("toJSONSchema", () => {
           "b",
           "c",
         ],
+        "type": "string",
+      }
+    `);
+
+    enum B {
+      A = 0,
+      B = 1,
+      C = 2,
+    }
+
+    const b = z.enum(B);
+    expect(z.toJSONSchema(b)).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "enum": [
+          "A",
+          "B",
+          "C",
+          0,
+          1,
+          2,
+        ],
+        "type": "number",
       }
     `);
   });

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -400,7 +400,10 @@ export class JSONSchemaGenerator {
         }
         case "enum": {
           const json: JSONSchema.BaseSchema = _json as any;
-          json.enum = Object.values(def.entries);
+          const values = Object.values(def.entries);
+          // Number enums can have both string and number values
+          json.type = values.some((v) => typeof v === "number") ? "number" : "string";
+          json.enum = values;
           break;
         }
         case "literal": {


### PR DESCRIPTION
Adds `type` for enum in `toJSONSchema` to make it more swagger/openapi friendly.
Redo of #4430 without x-enumNames
Fixes: #4429

ref: https://x.com/colinhacks/status/1928526844397043787