### PR TITLE
minor grammar typo fix

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2535,7 +2535,7 @@ This function will throw a `ZodError` if the input is invalid:
 computeTrimmedLength(42); // throws ZodError
 ```
 
-If you only care about validating inputs, omit the `output` field is optional.
+If you only care about validating inputs, you can omit the `output` field as it is optional.
 
 ```ts
 const MyFunction = z.function({

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2535,7 +2535,7 @@ This function will throw a `ZodError` if the input is invalid:
 computeTrimmedLength(42); // throws ZodError
 ```
 
-If you only care about validating inputs, you can omit the `output` field as it is optional.
+If you only care about validating inputs, you can omit the `output` field.
 
 ```ts
 const MyFunction = z.function({


### PR DESCRIPTION
Noticed a tiny typo. 

Changed 
> If you only care about validating inputs, _omit the `output` field is optional._

to

> If you only care about validating inputs, _**you can** omit the `output` field **as it** is optional._

Tried to keep your prose style intact.