### PR TITLE
Loosen and expand metadata typing

### DIFF
--- a/packages/zod/src/v4/core/registries.ts
+++ b/packages/zod/src/v4/core/registries.ts
@@ -66,18 +66,11 @@ export interface JSONSchemaMeta {
   id?: string | undefined;
   title?: string | undefined;
   description?: string | undefined;
-  examples?: $output[] | undefined;
+  example?: unknown | undefined;
+  examples?: unknown[] | Record<string, { value: unknown; [k: string]: unknown }> | undefined; // allow array or example map
+  deprecated?: boolean | undefined;
   [k: string]: unknown;
 }
-
-// export class $ZodJSONSchemaRegistry<
-//   Meta extends JSONSchemaMeta = JSONSchemaMeta,
-//   Schema extends $ZodType = $ZodType,
-// > extends $ZodRegistry<Meta, Schema> {
-//   toJSONSchema(_schema: Schema): object {
-//     return {};
-//   }
-// }
 
 export interface GlobalMeta extends JSONSchemaMeta {}
 


### PR DESCRIPTION
- Loosen type of `examples` to `unknown[]` (from `$output[]`)
- Adds `example` 
- Adds `deprecated`

Why loosen the type?

- Everything is simpler if Zod dumbly patches all metadata to the generated JSON Schema. Getting too clever just makes things surprising and is bad DX. 
- Sidesteps concerns about whether `examples` should accept input or output types https://github.com/colinhacks/zod/issues/4516
- Allows for OpenAPI's record-style `examples` field: https://swagger.io/docs/specification/v3_0/adding-examples/
- Avoids materializing the inferred types, which prevents circularity errors when using `.meta()` on recursive schemas https://github.com/colinhacks/zod/issues/4570
- Users who want to do typechecking on their examples can opt-in with `satisfies z.output<typeof MySchema>`


Closes https://github.com/colinhacks/zod/issues/4516
Closes https://github.com/colinhacks/zod/issues/4570