### PR TITLE
fix(docs): remove z.literal(Symbol)

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -89,7 +89,6 @@ const tuna = z.literal("tuna");
 const twelve = z.literal(12);
 const twobig = z.literal(2n);
 const tru = z.literal(true);
-const terrific = z.literal(Symbol("terrific"));
 ```
 
 To represent the JavaScript literals `null` and `undefined`:


### PR DESCRIPTION
Zod 4 (colinhacks#4074)

- Remove `z.literal(Symbol("terrific"));` from docs in api.mdx