### PR TITLE
fix: allow coerce date in to-json-schema

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -58,6 +58,13 @@ describe("toJSONSchema", () => {
         "type": "string",
       }
     `);
+    expect(z.toJSONSchema(z.coerce.date())).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "date-time",
+        "type": "string",
+      }
+    `);
     expect(z.toJSONSchema(z.iso.datetime())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -245,6 +245,12 @@ export class JSONSchemaGenerator {
           break;
         }
         case "date": {
+          if (def.coerce) {
+            const json = _json as JSONSchema.StringSchema;
+            json.type = "string";
+            json.format = "date-time";
+            break;
+          }
           if (this.unrepresentable === "throw") {
             throw new Error("Date cannot be represented in JSON Schema");
           }


### PR DESCRIPTION
We often need to take date in apis so we use `z.coerce.date()` to allow string input which gets converted to date. So `coerce` can be allowed as date-time string without any pattern