### PR TITLE
fix: add type to literal enum

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -721,6 +721,19 @@ describe("toJSONSchema", () => {
         ],
       }
     `);
+
+    const d = z.literal(["hello", "zod", "v4"]);
+    expect(z.toJSONSchema(d)).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "enum": [
+          "hello",
+          "zod",
+          "v4",
+        ],
+        "type": "string",
+      }
+    `);
   });
 
   // pipe

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -707,11 +707,20 @@ describe("toJSONSchema", () => {
       }
     `);
 
-    const b = z.literal(["hello", undefined, null, 5, BigInt(1324)]);
-    expect(() => z.toJSONSchema(b)).toThrow();
+    const b = z.literal(7);
+    expect(z.toJSONSchema(b)).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "const": 7,
+        "type": "number",
+      }
+    `);
 
-    const c = z.literal(["hello", null, 5]);
-    expect(z.toJSONSchema(c)).toMatchInlineSnapshot(`
+    const c = z.literal(["hello", undefined, null, 5, BigInt(1324)]);
+    expect(() => z.toJSONSchema(c)).toThrow();
+
+    const d = z.literal(["hello", null, 5]);
+    expect(z.toJSONSchema(d)).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "enum": [
@@ -722,8 +731,8 @@ describe("toJSONSchema", () => {
       }
     `);
 
-    const d = z.literal(["hello", "zod", "v4"]);
-    expect(z.toJSONSchema(d)).toMatchInlineSnapshot(`
+    const e = z.literal(["hello", "zod", "v4"]);
+    expect(z.toJSONSchema(e)).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "enum": [


### PR DESCRIPTION
followup of: #4577
fixes: #4249
probably also fixes: https://github.com/vercel/ai/pull/6421#issuecomment-2925378022

Since google and other packages like swagger expects a `type` in it so adding support for it will be better I think
