### PR TITLE
feat(locale): Add Pashto (ps) locale support

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -353,6 +353,7 @@ The following locales are available:
 - `nl` — Dutch
 - `no` — Norwegian
 - `ota` — Türkî
+- `ps` — Pashto
 - `pl` — Polish
 - `pt` — Portuguese
 - `ru` — Russian

--- a/packages/zod/src/v4/locales/index.ts
+++ b/packages/zod/src/v4/locales/index.ts
@@ -22,6 +22,7 @@ export { default as ms } from "./ms.js";
 export { default as nl } from "./nl.js";
 export { default as no } from "./no.js";
 export { default as ota } from "./ota.js";
+export { default as ps } from "./ps.js";
 export { default as pl } from "./pl.js";
 export { default as pt } from "./pt.js";
 export { default as ru } from "./ru.js";

--- a/packages/zod/src/v4/locales/ps.ts
+++ b/packages/zod/src/v4/locales/ps.ts
@@ -28,10 +28,7 @@ const error: () => errors.$ZodErrorMap = () => {
         if (data === null) {
           return "null";
         }
-        if (
-          Object.getPrototypeOf(data) !== Object.prototype &&
-          data.constructor
-        ) {
+        if (Object.getPrototypeOf(data) !== Object.prototype && data.constructor) {
           return data.constructor.name;
         }
       }

--- a/packages/zod/src/v4/locales/ps.ts
+++ b/packages/zod/src/v4/locales/ps.ts
@@ -1,0 +1,136 @@
+import type { $ZodStringFormats } from "../core/checks.js";
+import type * as errors from "../core/errors.js";
+import * as util from "../core/util.js";
+
+const error: () => errors.$ZodErrorMap = () => {
+  const Sizable: Record<string, { unit: string; verb: string }> = {
+    string: { unit: "توکي", verb: "ولري" },
+    file: { unit: "بایټس", verb: "ولري" },
+    array: { unit: "توکي", verb: "ولري" },
+    set: { unit: "توکي", verb: "ولري" },
+  };
+
+  function getSizing(origin: string): { unit: string; verb: string } | null {
+    return Sizable[origin] ?? null;
+  }
+
+  const parsedType = (data: any): string => {
+    const t = typeof data;
+
+    switch (t) {
+      case "number": {
+        return Number.isNaN(data) ? "NaN" : "عدد";
+      }
+      case "object": {
+        if (Array.isArray(data)) {
+          return "ارې";
+        }
+        if (data === null) {
+          return "null";
+        }
+        if (
+          Object.getPrototypeOf(data) !== Object.prototype &&
+          data.constructor
+        ) {
+          return data.constructor.name;
+        }
+      }
+    }
+    return t;
+  };
+
+  const Nouns: {
+    [k in $ZodStringFormats | (string & {})]?: string;
+  } = {
+    regex: "ورودي",
+    email: "بریښنالیک",
+    url: "یو آر ال",
+    emoji: "ایموجي",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "نیټه او وخت",
+    date: "نېټه",
+    time: "وخت",
+    duration: "موده",
+    ipv4: "د IPv4 پته",
+    ipv6: "د IPv6 پته",
+    cidrv4: "د IPv4 ساحه",
+    cidrv6: "د IPv6 ساحه",
+    base64: "base64-encoded متن",
+    base64url: "base64url-encoded متن",
+    json_string: "JSON متن",
+    e164: "د E.164 شمېره",
+    jwt: "JWT",
+    template_literal: "ورودي",
+  };
+
+  return (issue) => {
+    switch (issue.code) {
+      case "invalid_type":
+        return `ناسم ورودي: باید ${issue.expected} وای, مګر ${parsedType(issue.input)} ترلاسه شو`;
+      case "invalid_value":
+        if (issue.values.length === 1) {
+          return `ناسم ورودي: باید ${util.stringifyPrimitive(issue.values[0])} وای`;
+        }
+        return `ناسم انتخاب: باید یو له ${util.joinValues(issue.values, "|")} څخه وای`;
+      case "too_big": {
+        const adj = issue.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue.origin);
+        if (sizing) {
+          return `ډیر لوی: ${issue.origin ?? "ارزښت"} باید ${adj}${issue.maximum.toString()} ${sizing.unit ?? "عنصرونه"} ولري`;
+        }
+        return `ډیر لوی: ${issue.origin ?? "ارزښت"} باید ${adj}${issue.maximum.toString()} وي`;
+      }
+      case "too_small": {
+        const adj = issue.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue.origin);
+        if (sizing) {
+          return `ډیر کوچنی: ${issue.origin} باید ${adj}${issue.minimum.toString()} ${sizing.unit} ولري`;
+        }
+        return `ډیر کوچنی: ${issue.origin} باید ${adj}${issue.minimum.toString()} وي`;
+      }
+      case "invalid_format": {
+        const _issue = issue as errors.$ZodStringFormatIssues;
+        if (_issue.format === "starts_with") {
+          return `ناسم متن: باید د "${_issue.prefix}" سره پیل شي`;
+        }
+        if (_issue.format === "ends_with") {
+          return `ناسم متن: باید د "${_issue.suffix}" سره پای ته ورسيږي`;
+        }
+        if (_issue.format === "includes") {
+          return `ناسم متن: باید "${_issue.includes}" ولري`;
+        }
+        if (_issue.format === "regex") {
+          return `ناسم متن: باید د ${_issue.pattern} سره مطابقت ولري`;
+        }
+        return `${Nouns[_issue.format] ?? issue.format} ناسم دی`;
+      }
+      case "not_multiple_of":
+        return `ناسم عدد: باید د ${issue.divisor} مضرب وي`;
+      case "unrecognized_keys":
+        return `ناسم ${issue.keys.length > 1 ? "کلیډونه" : "کلیډ"}: ${util.joinValues(issue.keys, ", ")}`;
+      case "invalid_key":
+        return `ناسم کلیډ په ${issue.origin} کې`;
+      case "invalid_union":
+        return `ناسمه ورودي`;
+      case "invalid_element":
+        return `ناسم عنصر په ${issue.origin} کې`;
+      default:
+        return `ناسمه ورودي`;
+    }
+  };
+};
+
+export default function (): { localeError: errors.$ZodErrorMap } {
+  return {
+    localeError: error(),
+  };
+}


### PR DESCRIPTION
This PR adds Pashto (ps) locale support to Zod, enabling validation error messages.