### PR TITLE
fix(util): cross realm IsPlainObject check

### DIFF
--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -329,11 +329,27 @@ export const allowsEval: { value: boolean } = cached(() => {
 });
 
 export function isPlainObject(data: any): data is Record<PropertyKey, unknown> {
-  return (
+  if (
     typeof data === "object" &&
     data !== null &&
     (Object.getPrototypeOf(data) === Object.prototype || Object.getPrototypeOf(data) === null)
-  );
+  ) {
+    return true;
+  }
+
+  if (isObject(data) === false) return false;
+
+  const ctor = data.constructor;
+  if (ctor === undefined) return true;
+
+  const prot = ctor.prototype;
+  if (isObject(prot) === false) return false;
+
+  if (!prot || Object.prototype.hasOwnProperty.call(prot, "isPrototypeOf") === false) {
+    return false;
+  }
+
+  return true;
 }
 
 export function numKeys(data: any): number {


### PR DESCRIPTION
I ran into an issue when creating zod schemas and passing them into a `vm.Script` which then performs validation on objects created in that script. Here's a test which illustrates the issue:

```ts
import vm from "node:vm";
import { z } from "zod/v4";

describe("Zod Issue", () => {
  it("should validate", () => {
    const MyKeys = z.literal(["key"]);
    const MySchema = z.record(MyKeys, z.string());

    const args = {
      key: "value",
    };

    // This works
    const data = MySchema.parse(args);
    console.log(data);

    // Running this in the VM context fails
    // since the `isPlainObject` check fails
    // the Object constructors are different between host and 'VM'
    // so a more robust `isPlainObject` implementation is needed
    const code = `
            const args = {
              key: "value"
            };

            const data = MySchema.parse({
              key: "value",
            });

            console.log(data);
        `;

    const context = vm.createContext({
      MySchema,
      console,
    });
    const script = new vm.Script(code);

    try {
      script.runInContext(context);
    } catch (error) {
      if (error instanceof z.ZodError) {
        console.error("Error running script:", error.issues);
      } else {
        throw error;
      }
    }
  });
});
```

which outputs:

```
host { key: 'value' }
Error running script: [
  {
    expected: 'record',
    code: 'invalid_type',
    path: [],
    message: 'Invalid input: expected record, received Object'
  }
]
```

The issue stems from the fact that inside the context there's a different `Object` constructor hence `isPlainObject` fails which produces the error. Ive adapted the `isPlainObject` to include additional checks if the previous one hasn't been conclusive. The fix is inspired: https://www.npmjs.com/package/is-plain-object

I've kept the fast path the same as in the original implementation