### PR TITLE
v4: Preserve function types in `.meta()`

### DIFF
--- a/packages/zod/src/v4/core/registries.ts
+++ b/packages/zod/src/v4/core/registries.ts
@@ -12,9 +12,11 @@ export type $replace<Meta, S extends $ZodType> = Meta extends $output
     ? core.input<S>
     : Meta extends (infer M)[]
       ? $replace<M, S>[]
-      : Meta extends (...args: any[]) => any
+      : // Preserve functions
+        Meta extends (...args: any[]) => any
         ? Meta
-        : Meta extends object
+        : // handle objects
+          Meta extends object
           ? { [K in keyof Meta]: $replace<Meta[K], S> }
           : Meta;
 

--- a/packages/zod/src/v4/core/registries.ts
+++ b/packages/zod/src/v4/core/registries.ts
@@ -12,10 +12,11 @@ export type $replace<Meta, S extends $ZodType> = Meta extends $output
     ? core.input<S>
     : Meta extends (infer M)[]
       ? $replace<M, S>[]
-      : // handle objecs
-        Meta extends object
-        ? { [K in keyof Meta]: $replace<Meta[K], S> }
-        : Meta;
+      : Meta extends (...args: any[]) => any
+        ? Meta
+        : Meta extends object
+          ? { [K in keyof Meta]: $replace<Meta[K], S> }
+          : Meta;
 
 type MetadataType = Record<string, unknown> | undefined;
 export class $ZodRegistry<Meta extends MetadataType = MetadataType, Schema extends $ZodType = $ZodType> {


### PR DESCRIPTION
Hey Colin, I currently offer some per schema options, eg: `unionOneOf` which mkaes an instance of a Zod Union produce an oneOf schema instead, even it isn't quite accurate.

There's a few others I offer which are in a similar vein but I was hoping to instead offer a similar `override` hook on a schema level.

Eg.

```ts
z.union([
  z.string()
]).meta({
  override: ( { jsonSchema }) => {
    jsonSchema.oneOf = jsonSchema.anyOf;
    delete jsonSchema.anyOf
  }});
```

I currently extend the types something like:

```ts
declare module 'zod/v4' {
  interface GlobalMeta
    extends Omit<oas31.SchemaObject, 'examples' | 'example'> {
    /**
     * Use to override the default schema
     */
    override?: core.JSONSchemaGeneratorParams['override'];
  }
}
```

But it appears this function:

https://github.com/colinhacks/zod/blob/44141ea1dbd48403f14704386119884aeda5cb27/packages/zod/src/v4/core/registries.ts#L9

strips the function typing away:

<img width="638" alt="image" src="https://github.com/user-attachments/assets/ba08c8fd-dabd-4cad-8f11-315b3d45231e" />

Lemme know if this is a bad approach to take.