### PR TITLE
docs: fix broken link in Zod Core errors docs

### DIFF
--- a/packages/docs/content/packages/core.mdx
+++ b/packages/docs/content/packages/core.mdx
@@ -418,7 +418,7 @@ export type $ZodIssue =
   | $ZodIssueCustom;
   ```
 
-For details on each type, refer to [the implementation](https://github.com/colinhacks/zod/blob/v4/packages/core/src/errors.ts).
+For details on each type, refer to [the implementation](https://github.com/colinhacks/zod/blob/main/packages/zod/src/v4/core/errors.ts).
 
 
 {/* ## Best practices


### PR DESCRIPTION
Fix broken link at the bottom of https://zod.dev/packages/core#errors page

Not sure if it should keep pointing to the `v4` branch or using `main` is ok now?