### PR TITLE
chore: allow readonly arrays in `z.literal`

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1510,7 +1510,7 @@ export const ZodLiteral: core.$constructor<ZodLiteral> = /*@__PURE__*/ core.$con
   });
 });
 
-export function literal<const T extends Array<util.Literal>>(
+export function literal<const T extends Array<util.Literal> | ReadonlyArray<util.Literal>>(
   value: T,
   params?: string | core.$ZodLiteralParams
 ): ZodLiteral<T[number]>;

--- a/play.ts
+++ b/play.ts
@@ -13,3 +13,10 @@ export const createSortItemSchema = <T extends z.ZodType<string>>(sortKeySchema:
 
 const error = <T extends z.ZodType<string>>(sortKeySchema: T, defaultSortBy: SortItem<z.output<T>>[] = []) =>
   createSortItemSchema(sortKeySchema).array().default(defaultSortBy);
+
+const readonlyArray = ["a", "b", "c"] as const;
+
+const literalValidator = z.literal(readonlyArray);
+
+const result = literalValidator.safeParse("d");
+console.log(result);


### PR DESCRIPTION
This PR fixes a type-error when using `z.literal` with a `readonly` / `const` array 

See https://github.com/discordjs/discord.js/pull/10922/files#diff-59f89a435004f01781c0f55a059480576a62675bd42e3d68e3bef6106be51fa9R38-R41