### PR TITLE
feat: allow setting transform input and output JSON schema

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1586,11 +1586,13 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
 );
 
 export function transform<I = unknown, O = I>(
-  fn: (input: I, ctx: core.ParsePayload) => O
+  fn: (input: I, ctx: core.ParsePayload) => O,
+  params?: core.$ZodTransformParams
 ): ZodTransform<Awaited<O>, I> {
   return new ZodTransform({
     type: "transform",
     transform: fn as any,
+    toJSONSchema: params?.toJSONSchema,
   }) as any;
 }
 

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -256,6 +256,32 @@ describe("toJSONSchema", () => {
     expect(() => z.toJSONSchema(dynamicCatchSchema)).toThrow("Dynamic catch values are not supported in JSON Schema");
   });
 
+  test("override for transform", () => {
+    const noSchemaForIo = z.transform(() => true, {
+      toJSONSchema: () => undefined,
+    });
+    const schemaForInput = z.transform(() => true, {
+      toJSONSchema: (io) => (io === "input" ? { type: "string" } : undefined),
+    });
+    const schemaForOutput = z.transform(() => true, {
+      toJSONSchema: (io) => (io === "output" ? { type: "string" } : undefined),
+    });
+
+    expect(() => z.toJSONSchema(noSchemaForIo)).toThrow("Transforms cannot be represented in JSON Schema");
+    expect(z.toJSONSchema(schemaForInput, { io: "input" })).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string",
+      }
+    `);
+    expect(z.toJSONSchema(schemaForOutput, { io: "output" })).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string",
+      }
+    `);
+  });
+
   test("string formats", () => {
     expect(z.toJSONSchema(z.string().email())).toMatchInlineSnapshot(`
       {

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1272,11 +1272,13 @@ export function _file(Class: util.SchemaClass<schemas.$ZodFile>, params?: string
 export type $ZodTransformParams = TypeParams<schemas.$ZodTransform, "transform">;
 export function _transform<I = unknown, O = I>(
   Class: util.SchemaClass<schemas.$ZodTransform>,
-  fn: (input: I, ctx?: schemas.ParsePayload) => O
+  fn: (input: I, ctx?: schemas.ParsePayload) => O,
+  params?: $ZodTransformParams
 ): schemas.$ZodTransform<Awaited<O>, I> {
   return new Class({
     type: "transform",
     transform: fn as any,
+    toJSONSchema: params?.toJSONSchema,
   }) as any;
 }
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3,6 +3,7 @@ import * as checks from "./checks.js";
 import * as core from "./core.js";
 import { Doc } from "./doc.js";
 import type * as errors from "./errors.js";
+import type { BaseSchema } from "./json-schema.js";
 import { safeParse, safeParseAsync } from "./parse.js";
 import * as regexes from "./regexes.js";
 import type { StandardSchemaV1 } from "./standard-schema.js";
@@ -2830,6 +2831,7 @@ export const $ZodFile: core.$constructor<$ZodFile> = /*@__PURE__*/ core.$constru
 export interface $ZodTransformDef extends $ZodTypeDef {
   type: "transform";
   transform: (input: unknown, payload: ParsePayload<unknown>) => util.MaybeAsync<unknown>;
+  toJSONSchema?: ((io: "input" | "output") => BaseSchema | undefined) | undefined;
 }
 export interface $ZodTransformInternals<O = unknown, I = unknown> extends $ZodTypeInternals<O, I> {
   def: $ZodTransformDef;

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -475,6 +475,13 @@ export class JSONSchemaGenerator {
           break;
         }
         case "transform": {
+          const schema = def.toJSONSchema?.(this.io);
+
+          if (schema) {
+            Object.assign(_json, schema);
+            break;
+          }
+
           if (this.unrepresentable === "throw") {
             throw new Error("Transforms cannot be represented in JSON Schema");
           }

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1143,11 +1143,13 @@ export const ZodMiniTransform: core.$constructor<ZodMiniTransform> = /*@__PURE__
 );
 
 export function transform<I = unknown, O = I>(
-  fn: (input: I, ctx: core.ParsePayload) => O
+  fn: (input: I, ctx: core.ParsePayload) => O,
+  params?: core.$ZodTransformParams
 ): ZodMiniTransform<Awaited<O>, I> {
   return new ZodMiniTransform({
     type: "transform",
     transform: fn as any,
+    toJSONSchema: params?.toJSONSchema,
   }) as any;
 }
 


### PR DESCRIPTION
So far there was no way to set the JSON schema for a transform, even though a `transform` could represent valid JSON values in either input or output, in contrast to other types like e.g. `bigint`.

While there is a `_zod.toJSONSchema`, that one has a) no typed return value and b) only serves as a base for an actually generated schema.

This PR adds an optional params object to `transform`, both classic and miniy, which accepts an optional `toJSONSchema(io: "input" | "output")`. It can then decide whether to return `undefined` or an actual JSON schema object. In case `toJSONSchema` is not defined or the function returns `undefined`, the previous default behavior stays in place and an exception is thrown.

I'm open to other ideas to make this happen, but this seemed the cleanest considering this is an edge case.