### PR TITLE
Docs - Use consistent variable names for IP examples

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -435,10 +435,10 @@ time.parse("00:00:00"); // ❌
 
 ```ts
 const ipv4 = z.ipv4();
-v4.parse("192.168.0.0"); // ✅
+ipv4.parse("192.168.0.0"); // ✅
 
 const ipv6 = z.ipv6();
-v6.parse("2001:db8:85a3::8a2e:370:7334"); // ✅
+ipv6.parse("2001:db8:85a3::8a2e:370:7334"); // ✅
 ```
 
 ### IP blocks (CIDR)


### PR DESCRIPTION
Just a small tweak to the variable names to make the example consistent