### PR TITLE
Fixed allowsEval for RN

### DIFF
--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -319,7 +319,11 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
 }
 
 export const allowsEval: { value: boolean } = cached(() => {
-  if (typeof navigator !== "undefined" && navigator?.userAgent.includes("Cloudflare")) {
+  if (
+    typeof navigator !== "undefined" &&
+    typeof navigator?.userAgent === "string" &&
+    navigator?.userAgent.includes("Cloudflare")
+  ) {
     return false;
   }
 


### PR DESCRIPTION
In React Native navigator is defined but doesn't contain the userAgent property, thus throwing an error when trying to call String#includes().

By first verifying the type of navigator.userAgent to be a string, it doesnt crash.

![image](https://github.com/user-attachments/assets/784a52ac-e36a-43a9-a87c-2498a922f8bc)
