### PR TITLE
support react native not setting userAgent on navigator global (#4690)

### DIFF
--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -323,7 +323,7 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
 }
 
 export const allowsEval: { value: boolean } = cached(() => {
-  if (typeof navigator !== "undefined" && navigator?.userAgent.includes("Cloudflare")) {
+  if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
     return false;
   }
 


### PR DESCRIPTION
React Native does not set a `userAgent` property on `navigator` global. This PR adds a guard against `navigator.userAgent` being `undefined`.

Semi-related:
- https://github.com/apollographql/apollo-client/issues/3137