### PR TITLE
fix #4700: Use array as argument of templateLiteral

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -480,7 +480,7 @@ cidrv6.parse("2001:db8::/32"); // ✅
 To define a template literal schema:
 
 ```ts
-const schema = z.templateLiteral("hello, ", z.string(), "!");
+const schema = z.templateLiteral([ "hello, ", z.string(), "!" ]);
 // `hello, ${string}!`
 ```
 


### PR DESCRIPTION
#4700 