### PR TITLE
feat(v4): Port v3 `discriminator` type inference

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1202,10 +1202,12 @@ export function union<const T extends readonly core.SomeType[]>(
 }
 
 // ZodDiscriminatedUnion
-export interface ZodDiscriminatedUnion<Options extends readonly core.SomeType[] = readonly core.$ZodType[]>
-  extends ZodUnion<Options>,
-    core.$ZodDiscriminatedUnion<Options> {
-  _zod: core.$ZodDiscriminatedUnionInternals<Options>;
+export interface ZodDiscriminatedUnion<
+  Options extends readonly core.SomeType[] = readonly core.$ZodType[],
+  Discriminator extends string = string,
+> extends ZodUnion<Options>,
+    core.$ZodDiscriminatedUnion<Options, Discriminator> {
+  _zod: core.$ZodDiscriminatedUnionInternals<Options, Discriminator>;
 }
 export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /*@__PURE__*/ core.$constructor(
   "ZodDiscriminatedUnion",
@@ -1216,12 +1218,13 @@ export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /
 );
 
 export function discriminatedUnion<
-  Types extends readonly [core.$ZodTypeDiscriminable, ...core.$ZodTypeDiscriminable[]],
+  Types extends readonly [core.$ZodTypeDiscriminable<Discriminator>, ...core.$ZodTypeDiscriminable<Discriminator>[]],
+  Discriminator extends string,
 >(
-  discriminator: string,
+  discriminator: Discriminator,
   options: Types,
   params?: string | core.$ZodDiscriminatedUnionParams
-): ZodDiscriminatedUnion<Types> {
+): ZodDiscriminatedUnion<Types, Discriminator> {
   // const [options, params] = args;
   return new ZodDiscriminatedUnion({
     type: "union",

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -590,3 +590,13 @@ test("nested discriminated unions", () => {
     }
   `);
 });
+
+test("discriminator type", () => {
+  const discriminator = z.discriminatedUnion("key", [
+    z.object({ key: z.literal("a") }),
+    z.object({ key: z.literal("b") }),
+  ])._zod.def.discriminator;
+
+  expectTypeOf<typeof discriminator>().not.toEqualTypeOf<string>();
+  expectTypeOf<typeof discriminator>().toEqualTypeOf<"key">();
+});

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1077,20 +1077,24 @@ export function _union<const T extends readonly schemas.$ZodObject[]>(
 }
 
 // ZodDiscriminatedUnion
-export interface $ZodTypeDiscriminableInternals extends schemas.$ZodTypeInternals {
+export interface $ZodTypeDiscriminableInternals<Discriminator extends string>
+  extends schemas.$ZodTypeInternals<unknown, { [key in Discriminator]?: unknown }> {
   propValues: util.PropValues;
 }
 
-export interface $ZodTypeDiscriminable extends schemas.$ZodType {
-  _zod: $ZodTypeDiscriminableInternals;
+export interface $ZodTypeDiscriminable<Discriminator extends string> extends schemas.$ZodType {
+  _zod: $ZodTypeDiscriminableInternals<Discriminator>;
 }
 export type $ZodDiscriminatedUnionParams = TypeParams<schemas.$ZodDiscriminatedUnion, "options" | "discriminator">;
-export function _discriminatedUnion<Types extends [$ZodTypeDiscriminable, ...$ZodTypeDiscriminable[]]>(
+export function _discriminatedUnion<
+  Types extends [$ZodTypeDiscriminable<Discriminator>, ...$ZodTypeDiscriminable<Discriminator>[]],
+  Discriminator extends string,
+>(
   Class: util.SchemaClass<schemas.$ZodDiscriminatedUnion>,
-  discriminator: string,
+  discriminator: Discriminator,
   options: Types,
   params?: string | $ZodDiscriminatedUnionParams
-): schemas.$ZodDiscriminatedUnion<Types> {
+): schemas.$ZodDiscriminatedUnion<Types, Discriminator> {
   return new Class({
     type: "union",
     options,

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1935,20 +1935,27 @@ export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$const
 //////////////////////////////////////////////////////
 //////////////////////////////////////////////////////
 
-export interface $ZodDiscriminatedUnionDef<Options extends readonly SomeType[] = readonly $ZodType[]>
-  extends $ZodUnionDef<Options> {
-  discriminator: string;
+export interface $ZodDiscriminatedUnionDef<
+  Options extends readonly SomeType[] = readonly $ZodType[],
+  Discriminator extends string = string,
+> extends $ZodUnionDef<Options> {
+  discriminator: Discriminator;
   unionFallback?: boolean;
 }
 
-export interface $ZodDiscriminatedUnionInternals<Options extends readonly SomeType[] = readonly $ZodType[]>
-  extends $ZodUnionInternals<Options> {
-  def: $ZodDiscriminatedUnionDef<Options>;
+export interface $ZodDiscriminatedUnionInternals<
+  Options extends readonly SomeType[] = readonly $ZodType[],
+  Discriminator extends string = string,
+> extends $ZodUnionInternals<Options> {
+  def: $ZodDiscriminatedUnionDef<Options, Discriminator>;
   propValues: util.PropValues;
 }
 
-export interface $ZodDiscriminatedUnion<T extends readonly SomeType[] = readonly $ZodType[]> extends $ZodType {
-  _zod: $ZodDiscriminatedUnionInternals<T>;
+export interface $ZodDiscriminatedUnion<
+  T extends readonly SomeType[] = readonly $ZodType[],
+  Discriminator extends string = string,
+> extends $ZodType {
+  _zod: $ZodDiscriminatedUnionInternals<T, Discriminator>;
 }
 
 export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
@@ -1974,7 +1981,7 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
     });
 
     const disc = util.cached(() => {
-      const opts = def.options as $ZodTypeDiscriminable[];
+      const opts = def.options as $ZodTypeDiscriminable<string>[];
       const map: Map<util.Primitive, $ZodType> = new Map();
       for (const o of opts) {
         const values = o._zod.propValues[def.discriminator];

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -873,9 +873,11 @@ export function union<const T extends readonly SomeType[]>(
 }
 
 // ZodMiniDiscriminatedUnion
-export interface ZodMiniDiscriminatedUnion<Options extends readonly SomeType[] = readonly core.$ZodType[]>
-  extends ZodMiniUnion<Options> {
-  _zod: core.$ZodDiscriminatedUnionInternals<Options>;
+export interface ZodMiniDiscriminatedUnion<
+  Options extends readonly SomeType[] = readonly core.$ZodType[],
+  Discriminator extends string = string,
+> extends ZodMiniUnion<Options> {
+  _zod: core.$ZodDiscriminatedUnionInternals<Options, Discriminator>;
 }
 export const ZodMiniDiscriminatedUnion: core.$constructor<ZodMiniDiscriminatedUnion> = /*@__PURE__*/ core.$constructor(
   "ZodMiniDiscriminatedUnion",
@@ -886,18 +888,19 @@ export const ZodMiniDiscriminatedUnion: core.$constructor<ZodMiniDiscriminatedUn
 );
 
 export function discriminatedUnion<
-  Types extends readonly [core.$ZodTypeDiscriminable, ...core.$ZodTypeDiscriminable[]],
+  Types extends readonly [core.$ZodTypeDiscriminable<Discriminator>, ...core.$ZodTypeDiscriminable<Discriminator>[]],
+  Discriminator extends string,
 >(
-  discriminator: string,
+  discriminator: Discriminator,
   options: Types,
   params?: string | core.$ZodDiscriminatedUnionParams
-): ZodMiniDiscriminatedUnion<Types> {
+): ZodMiniDiscriminatedUnion<Types, Discriminator> {
   return new ZodMiniDiscriminatedUnion({
     type: "union",
     options,
     discriminator,
     ...util.normalizeParams(params),
-  }) as ZodMiniDiscriminatedUnion<Types>;
+  }) as ZodMiniDiscriminatedUnion<Types, Discriminator>;
 }
 
 // ZodMiniIntersection


### PR DESCRIPTION
The type for `discriminator` i.e., `_zod.def.discriminator` was fixed as **string**.
Now the actual value is inferred.

The `Discriminator` generic was added in 2nd position compared to v3 — making it safe to update if your codebase already defined `Options` type.

Example:
```ts
const TestDiscriminator = z.discriminatedUnion("kind", [
  z.object({
    kind: z.literal("1st").optional(),
    a: z.string(),
  }),
  z.object({
    kind: z.literal("2nd"),
    b: z.string(),
  }),
]);

type ExtractedDiscriminator = typeof TestDiscriminator._zod.def.discriminator;
// returns `kind`
```