### PR TITLE
chore(docs): include zod-validation-error lib to Ecosystem page

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -72,6 +72,12 @@ const formIntegrations: ZodResource[] = [
     description: "Making SvelteKit forms a pleasure to use!",
     slug: "ciscoheat/sveltekit-superforms",
   },
+  {
+    name: "zod-validation-error",
+    url: "https://github.com/causaly/zod-validation-error",
+    description: "Generate user-friendly error messages from ZodError instances.",
+    slug: "causaly/zod-validation-error",
+  },
 ];
 
 const zodToXConverters: ZodResource[] = [];


### PR DESCRIPTION
**Summary:**
This PR adds [zod-validation-error](https://github.com/causaly/zod-validation-error) to the [Ecosystem](https://zod.dev/ecosystem?id=form-integrations) page to highlight it as a useful utility for formatting and handling Zod validation errors in a developer-friendly way.

**Why:**
To improve discoverability of helpful tooling.