### PR TITLE
fix: api.mdx to use hostname regex

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -335,7 +335,7 @@ schema.parse("http://example.com"); // ❌
   ```ts
   const httpUrl = z.url({
     protocol: /^https?$/,
-    hostname: z.regexes.domain
+    hostname: z.regexes.hostname
   });
   ```
 


### PR DESCRIPTION
Updating the the docs as it mentions `z.regexes.domain` instead of `z.regexes.hostname`