### PR TITLE
fix: use static components

### DIFF
--- a/packages/docs/app/(doc)/[[...slug]]/page.tsx
+++ b/packages/docs/app/(doc)/[[...slug]]/page.tsx
@@ -1,15 +1,10 @@
-import { Heading } from "@/components/heading";
-import { Tabs, Tab } from "@/components/tabs";
 import { Accordion, Accordions } from "@/components/accordion";
+import { Heading } from "@/components/heading";
+import { Tab, Tabs } from "@/components/tabs";
 import { source } from "@/loaders/source";
 import { Callout } from "fumadocs-ui/components/callout";
 import defaultMdxComponents, { createRelativeLink } from "fumadocs-ui/mdx";
-import {
-  DocsBody,
-  DocsDescription,
-  DocsPage,
-  DocsTitle,
-} from "fumadocs-ui/page";
+import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
 
 export const revalidate = 86400;

--- a/packages/docs/app/(doc)/[[...slug]]/page.tsx
+++ b/packages/docs/app/(doc)/[[...slug]]/page.tsx
@@ -1,9 +1,15 @@
 import { Heading } from "@/components/heading";
-import { Tabs } from "@/components/tabs";
+import { Tabs, Tab } from "@/components/tabs";
+import { Accordion, Accordions } from "@/components/accordion";
 import { source } from "@/loaders/source";
 import { Callout } from "fumadocs-ui/components/callout";
 import defaultMdxComponents, { createRelativeLink } from "fumadocs-ui/mdx";
-import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page";
+import {
+  DocsBody,
+  DocsDescription,
+  DocsPage,
+  DocsTitle,
+} from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
 
 export const revalidate = 86400;
@@ -48,6 +54,9 @@ export default async function Page(props: {
             // you can add other MDX components here
             blockquote: Callout,
             Tabs,
+            Tab,
+            Accordion,
+            Accordions,
             h1: (props) => <Heading as="h1" {...props} />,
             h2: (props) => <Heading as="h2" {...props} />,
             h3: (props) => <Heading as="h3" {...props} />,

--- a/packages/docs/components/accordion.tsx
+++ b/packages/docs/components/accordion.tsx
@@ -3,6 +3,7 @@
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { ChevronRight } from "lucide-react";
 import { type ComponentPropsWithoutRef, forwardRef } from "react";
+export { Accordions } from "fumadocs-ui/components/accordion";
 
 export const Accordion = forwardRef<
   HTMLDivElement,

--- a/packages/docs/components/tabs.tsx
+++ b/packages/docs/components/tabs.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  Tabs as PrimitiveTabs,
-  Tab as PrimitiveTab,
-  type TabProps,
-  type TabsProps,
-} from "fumadocs-ui/components/tabs";
+import { Tab as PrimitiveTab, Tabs as PrimitiveTabs, type TabProps, type TabsProps } from "fumadocs-ui/components/tabs";
 
 export const Tabs = (props: TabsProps) => <PrimitiveTabs {...props} />;
 export const Tab = (props: TabProps) => <PrimitiveTab {...props} className="data-[state=inactive]:hidden" forceMount />;

--- a/packages/docs/components/tabs.tsx
+++ b/packages/docs/components/tabs.tsx
@@ -1,61 +1,11 @@
 "use client";
 
-import { Primitive, Tab, type TabsProps } from "fumadocs-ui/components/tabs";
-import React from "react";
+import {
+  Tabs as PrimitiveTabs,
+  Tab as PrimitiveTab,
+  type TabProps,
+  type TabsProps,
+} from "fumadocs-ui/components/tabs";
 
-interface ChildProps {
-  title: string;
-  children: React.ReactNode;
-}
-
-const Tabs = ({ children, ...rest }: TabsProps) => {
-  const validChildren = React.Children.toArray(children)
-    .filter(React.isValidElement)
-    .filter((child: any) => child.props.title);
-
-  if (validChildren.length === 0) {
-    console.warn("Tabs expects at least one valid Tab child, but none were found.");
-    return null;
-  }
-
-  const tabs = validChildren.map((child) => {
-    const { title } = child.props as ChildProps;
-    return title;
-  });
-
-  return (
-    <Primitive.Tabs items={tabs} className="border-none rounded-none px-0" defaultValue={tabs[0]} {...rest}>
-      <Primitive.TabsList className="px-0 bg-transparent border-b gap-6">
-        {validChildren.map((child) => {
-          const { title } = child.props as ChildProps;
-          return (
-            <Primitive.TabsTrigger
-              key={title}
-              value={title}
-              className="font-medium data-[state=active]:shadow-[inset_0_-1px_0_0_currentColor,_0_1px_0_0_currentColor]"
-            >
-              {title}
-            </Primitive.TabsTrigger>
-          );
-        })}
-      </Primitive.TabsList>
-      {validChildren.map((child) => {
-        const { title, children: childContent, ...props } = child.props as ChildProps;
-
-        return (
-          <Primitive.TabsContent
-            forceMount
-            key={title}
-            value={title}
-            className="px-0 data-[state=inactive]:hidden"
-            {...props}
-          >
-            {childContent}
-          </Primitive.TabsContent>
-        );
-      })}
-    </Primitive.Tabs>
-  );
-};
-
-export { Tabs, Tab };
+export const Tabs = (props: TabsProps) => <PrimitiveTabs {...props} />;
+export const Tab = (props: TabProps) => <PrimitiveTab {...props} className="data-[state=inactive]:hidden" forceMount />;

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2,9 +2,8 @@
 title: Defining schemas
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
 import { Callout } from "fumadocs-ui/components/callout"
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+
 
 To validate data, you must first define a *schema*. Schemas represent *types*, from simple primitive values to complex nested objects and arrays. 
 

--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -2,9 +2,7 @@
 title: Basic usage
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
 import { Callout } from "fumadocs-ui/components/callout";
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 This page will walk you through the basics of creating schemas, parsing data, and using inferred types. For complete documentation on Zod's schema API, refer to [Defining schemas](/api).
 

--- a/packages/docs/content/error-formatting.mdx
+++ b/packages/docs/content/error-formatting.mdx
@@ -3,7 +3,6 @@ title: Formatting errors
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 Zod emphasizes _completeness_ and _correctness_ in its error reporting. In many cases, it's helpful to convert the `$ZodError` to a more useful format. Zod provides some utilities for this.
 

--- a/packages/docs/content/index.mdx
+++ b/packages/docs/content/index.mdx
@@ -3,8 +3,6 @@ title: "Intro"
 mode: "center"
 ---
 
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
-import { Tabs } from 'fumadocs-ui/components/tabs';
 
 import { Featured } from '../components/featured';
 import { Platinum } from '../components/platinum';

--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -2,9 +2,7 @@
 title: "JSON Schema"
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
 import { Callout } from "fumadocs-ui/components/callout"
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 <Callout icon={'💎'}>
   **New** — Zod 4 introduces a new feature: native [JSON Schema](https://json-schema.org/) conversion. JSON Schema is a standard for describing the structure of JSON (with JSON). It's widely used in [OpenAPI](https://www.openapis.org/) definitions and defining [structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat) for AI.

--- a/packages/docs/content/packages/core.mdx
+++ b/packages/docs/content/packages/core.mdx
@@ -3,7 +3,6 @@ title: Zod Core
 ---
 
 import { Callout } from "fumadocs-ui/components/callout"
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 This sub-package exports the core classes and utilities that are consumed by `zod/v4` and `zod/v4-mini`. It is not intended to be used directly; instead it's designed to be extended by other packages. It implements:
 

--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -3,8 +3,6 @@ title: Introducing Zod 4
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
-import { Tabs, Tab } from "fumadocs-ui/components/tabs";
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 After a year of active development: Zod 4 is now stable! It's faster, slimmer, more `tsc`-efficient, and implements some long-requested features. 
 


### PR DESCRIPTION
Updates Accordion and Tabs to use static components, so content can be crawled by LLM