### PR TITLE
Add `z.stringFormat()`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,7 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
-    "source.fixAll": "always",
-    "quickfix.biome": "explicit"
+    "source.fixAll.biome": "always"
   },
   "files.exclude": {
     "./scratch": false,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -674,6 +674,28 @@ export function jwt(params?: string | core.$ZodJWTParams): ZodJWT {
   return core._jwt(ZodJWT, params);
 }
 
+// ZodCustomStringFormat
+export interface ZodCustomStringFormat<Format extends string = string>
+  extends ZodStringFormat<Format>,
+    core.$ZodCustomStringFormat<Format> {
+  _zod: core.$ZodCustomStringFormatInternals<Format>;
+}
+export const ZodCustomStringFormat: core.$constructor<ZodCustomStringFormat> = /*@__PURE__*/ core.$constructor(
+  "ZodCustomStringFormat",
+  (inst, def) => {
+    // ZodStringFormat.init(inst, def);
+    core.$ZodCustomStringFormat.init(inst, def);
+    ZodStringFormat.init(inst, def);
+  }
+);
+export function stringFormat<Format extends string>(
+  format: Format,
+  fnOrRegex: ((arg: string) => util.MaybeAsync<unknown>) | RegExp,
+  _params: string | core.$ZodStringFormatParams = {}
+): ZodCustomStringFormat<Format> {
+  return core._stringFormat(ZodCustomStringFormat, format, fnOrRegex, _params) as any;
+}
+
 // ZodNumber
 export interface _ZodNumber<Internals extends core.$ZodNumberInternals = core.$ZodNumberInternals>
   extends _ZodType<Internals> {
@@ -1911,7 +1933,6 @@ export const ZodCustom: core.$constructor<ZodCustom> = /*@__PURE__*/ core.$const
 export function check<O = unknown>(fn: core.CheckFn<O>, params?: string | core.$ZodCustomParams): core.$ZodCheck<O> {
   const ch = new core.$ZodCheck({
     check: "custom",
-
     ...util.normalizeParams(params),
   });
 
@@ -2026,28 +2047,4 @@ export function preprocess<A, U extends core.SomeType, B = unknown>(
   schema: U
 ): ZodPipe<ZodTransform<A, B>, U> {
   return pipe(transform(fn as any), schema as any) as any;
-}
-
-interface $ZodStringFormatParams {
-  abort?: boolean;
-  error?: string | core.$ZodErrorMap<core.$ZodIssueInvalidStringFormat>;
-  // pattern?:
-}
-// export function stringFormat(format: string, )
-
-uuidv4();
-export function stringFormat<T>(
-  format: string,
-  fn: (arg: NoInfer<T>) => util.MaybeAsync<unknown>,
-  _params: string | core.$ZodCustomParams = {}
-): ZodStringFormat {
-  const params = util.normalizeParams(_params);
-  const inst = new ZodStringFormat({
-    ...util.normalizeParams(_params),
-    check: "string_format",
-    type: "string",
-    format,
-    ...params,
-  });
-  return inst;
 }

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -370,7 +370,7 @@ export function string(params?: string | core.$ZodStringParams): ZodString {
 }
 
 // ZodStringFormat
-export interface ZodStringFormat<Format extends core.$ZodStringFormats = core.$ZodStringFormats>
+export interface ZodStringFormat<Format extends string | string[] = string>
   extends _ZodString<core.$ZodStringFormatInternals<Format>> {}
 export const ZodStringFormat: core.$constructor<ZodStringFormat> = /*@__PURE__*/ core.$constructor(
   "ZodStringFormat",
@@ -2026,4 +2026,28 @@ export function preprocess<A, U extends core.SomeType, B = unknown>(
   schema: U
 ): ZodPipe<ZodTransform<A, B>, U> {
   return pipe(transform(fn as any), schema as any) as any;
+}
+
+interface $ZodStringFormatParams {
+  abort?: boolean;
+  error?: string | core.$ZodErrorMap<core.$ZodIssueInvalidStringFormat>;
+  // pattern?:
+}
+// export function stringFormat(format: string, )
+
+uuidv4();
+export function stringFormat<T>(
+  format: string,
+  fn: (arg: NoInfer<T>) => util.MaybeAsync<unknown>,
+  _params: string | core.$ZodCustomParams = {}
+): ZodStringFormat {
+  const params = util.normalizeParams(_params);
+  const inst = new ZodStringFormat({
+    ...util.normalizeParams(_params),
+    check: "string_format",
+    type: "string",
+    format,
+    ...params,
+  });
+  return inst;
 }

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -370,7 +370,7 @@ export function string(params?: string | core.$ZodStringParams): ZodString {
 }
 
 // ZodStringFormat
-export interface ZodStringFormat<Format extends string | string[] = string>
+export interface ZodStringFormat<Format extends string = string>
   extends _ZodString<core.$ZodStringFormatInternals<Format>> {}
 export const ZodStringFormat: core.$constructor<ZodStringFormat> = /*@__PURE__*/ core.$constructor(
   "ZodStringFormat",

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -79,6 +79,10 @@ export function _coercedString<T extends schemas.$ZodString>(
   });
 }
 
+export type $ZodStringFormatParams = CheckTypeParams<schemas.$ZodStringFormat, "format" | "coerce">;
+export type $ZodCheckStringFormatParams = CheckParams<checks.$ZodCheckStringFormat, "format">;
+// custom format
+
 // Email
 export type $ZodEmailParams = StringFormatParams<schemas.$ZodEmail>;
 export type $ZodCheckEmailParams = CheckStringFormatParams<schemas.$ZodEmail>;

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1566,3 +1566,26 @@ export function _stringbool(
   });
   return outerPipe as any;
 }
+
+export function _stringFormat<Format extends string>(
+  Class: typeof schemas.$ZodCustomStringFormat,
+  format: Format,
+  fnOrRegex: ((arg: string) => util.MaybeAsync<unknown>) | RegExp,
+  _params: string | $ZodStringFormatParams = {}
+): schemas.$ZodCustomStringFormat<Format> {
+  const params = util.normalizeParams(_params);
+  const def: schemas.$ZodCustomStringFormatDef = {
+    ...util.normalizeParams(_params),
+    check: "string_format",
+    type: "string",
+    format,
+    fn: typeof fnOrRegex === "function" ? fnOrRegex : (val) => fnOrRegex.test(val),
+    ...params,
+  };
+  if (fnOrRegex instanceof RegExp) {
+    def.pattern = fnOrRegex;
+  }
+
+  const inst = new Class(def);
+  return inst as any;
+}

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -1280,26 +1280,4 @@ export type $ZodStringFormatChecks =
   | $ZodCheckIncludes
   | $ZodCheckStartsWith
   | $ZodCheckEndsWith
-  | schemas.$ZodGUID
-  | schemas.$ZodUUID
-  | schemas.$ZodEmail
-  | schemas.$ZodURL
-  | schemas.$ZodEmoji
-  | schemas.$ZodNanoID
-  | schemas.$ZodCUID
-  | schemas.$ZodCUID2
-  | schemas.$ZodULID
-  | schemas.$ZodXID
-  | schemas.$ZodKSUID
-  | schemas.$ZodISODateTime
-  | schemas.$ZodISODate
-  | schemas.$ZodISOTime
-  | schemas.$ZodISODuration
-  | schemas.$ZodIPv4
-  | schemas.$ZodIPv6
-  | schemas.$ZodCIDRv4
-  | schemas.$ZodCIDRv6
-  | schemas.$ZodBase64
-  | schemas.$ZodBase64URL
-  | schemas.$ZodE164
-  | schemas.$ZodJWT;
+  | schemas.$ZodStringFormatTypes; // union of string format schema types

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -770,7 +770,7 @@ export type $ZodStringFormats =
   | "starts_with"
   | "ends_with"
   | "includes";
-export interface $ZodCheckStringFormatDef<Format extends $ZodStringFormats = $ZodStringFormats> extends $ZodCheckDef {
+export interface $ZodCheckStringFormatDef<Format extends string = string> extends $ZodCheckDef {
   check: "string_format";
   format: Format;
   pattern?: RegExp | undefined;
@@ -799,20 +799,21 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
       }
     });
 
-    inst._zod.check ??= (payload) => {
-      if (!def.pattern) throw new Error("Not implemented.");
-      def.pattern.lastIndex = 0;
-      if (def.pattern.test(payload.value)) return;
-      payload.issues.push({
-        origin: "string",
-        code: "invalid_format",
-        format: def.format,
-        input: payload.value,
-        ...(def.pattern ? { pattern: def.pattern.toString() } : {}),
-        inst,
-        continue: !def.abort,
-      });
-    };
+    if (def.pattern)
+      inst._zod.check ??= (payload) => {
+        def.pattern!.lastIndex = 0;
+        if (def.pattern!.test(payload.value)) return;
+        payload.issues.push({
+          origin: "string",
+          code: "invalid_format",
+          format: def.format,
+          input: payload.value,
+          ...(def.pattern ? { pattern: def.pattern.toString() } : {}),
+          inst,
+          continue: !def.abort,
+        });
+      };
+    else inst._zod.check ??= () => {};
   }
 );
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -932,6 +932,39 @@ export const $ZodJWT: core.$constructor<$ZodJWT> = /*@__PURE__*/ core.$construct
   };
 });
 
+//////////////////////////////   ZodCustomStringFormat   //////////////////////////////
+
+export interface $ZodCustomStringFormatDef<Format extends string = string> extends $ZodStringFormatDef<Format> {
+  fn: (val: string) => unknown;
+}
+
+export interface $ZodCustomStringFormatInternals<Format extends string = string>
+  extends $ZodStringFormatInternals<Format> {
+  def: $ZodCustomStringFormatDef<Format>;
+}
+
+export interface $ZodCustomStringFormat<Format extends string = string> extends $ZodStringFormat<Format> {
+  _zod: $ZodCustomStringFormatInternals<Format>;
+}
+
+export const $ZodCustomStringFormat: core.$constructor<$ZodCustomStringFormat> = /*@__PURE__*/ core.$constructor(
+  "$ZodCustomStringFormat",
+  (inst, def): void => {
+    $ZodStringFormat.init(inst, def);
+    inst._zod.check = (payload) => {
+      if (def.fn(payload.value)) return;
+
+      payload.issues.push({
+        code: "invalid_format",
+        format: def.format,
+        input: payload.value,
+        inst,
+        continue: !def.abort,
+      });
+    };
+  }
+);
+
 /////////////////////////////////////////
 /////////////////////////////////////////
 //////////                     //////////

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -326,16 +326,16 @@ export const $ZodString: core.$constructor<$ZodString> = /*@__PURE__*/ core.$con
 
 //////////////////////////////   ZodStringFormat   //////////////////////////////
 
-export interface $ZodStringFormatDef<Format extends checks.$ZodStringFormats = checks.$ZodStringFormats>
+export interface $ZodStringFormatDef<Format extends string = string>
   extends $ZodStringDef,
     checks.$ZodCheckStringFormatDef<Format> {}
 
-export interface $ZodStringFormatInternals<Format extends checks.$ZodStringFormats = checks.$ZodStringFormats>
+export interface $ZodStringFormatInternals<Format extends string = string>
   extends $ZodStringInternals<string>,
     checks.$ZodCheckStringFormatInternals {
   def: $ZodStringFormatDef<Format>;
 }
-export interface $ZodStringFormat<Format extends checks.$ZodStringFormats = checks.$ZodStringFormats> extends $ZodType {
+export interface $ZodStringFormat<Format extends string = string> extends $ZodType {
   _zod: $ZodStringFormatInternals<Format>;
 }
 

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -94,7 +94,7 @@ export function string(params?: string | core.$ZodStringParams): ZodMiniString<s
 }
 
 // ZodMiniStringFormat
-export interface ZodMiniStringFormat<Format extends core.$ZodStringFormats = core.$ZodStringFormats>
+export interface ZodMiniStringFormat<Format extends string = string>
   extends _ZodMiniString<core.$ZodStringFormatInternals<Format>>,
     core.$ZodStringFormat<Format> {
   // _zod: core.$ZodStringFormatInternals<Format>;
@@ -412,6 +412,28 @@ export const ZodMiniJWT: core.$constructor<ZodMiniJWT> = /*@__PURE__*/ core.$con
 
 export function jwt(params?: string | core.$ZodJWTParams): ZodMiniJWT {
   return core._jwt(ZodMiniJWT, params);
+}
+
+// ZodMiniCustomStringFormat
+export interface ZodMiniCustomStringFormat<Format extends string = string>
+  extends ZodMiniStringFormat<Format>,
+    core.$ZodCustomStringFormat<Format> {
+  _zod: core.$ZodCustomStringFormatInternals<Format>;
+}
+export const ZodMiniCustomStringFormat: core.$constructor<ZodMiniCustomStringFormat> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniCustomStringFormat",
+  (inst, def) => {
+    core.$ZodCustomStringFormat.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function stringFormat<Format extends string>(
+  format: Format,
+  fnOrRegex: ((arg: string) => util.MaybeAsync<unknown>) | RegExp,
+  _params: string | core.$ZodStringFormatParams = {}
+): ZodMiniCustomStringFormat<Format> {
+  return core._stringFormat(ZodMiniCustomStringFormat, format, fnOrRegex, _params) as any;
 }
 
 // ZodMiniNumber

--- a/play.ts
+++ b/play.ts
@@ -1,5 +1,3 @@
 import { z } from "zod/v4";
 
-z.string().parse(12, {
-  reportInput: true,
-});
+z;

--- a/play.ts
+++ b/play.ts
@@ -1,3 +1,10 @@
-import { z } from "zod/v4-mini";
+import { z } from "zod/v4";
 
 z;
+
+// function form
+const a = z.stringFormat("creditCard", (val) => /\d{16}/.test(val));
+
+// regex form
+const b = z.stringFormat("creditCard", /\d{16}/);
+b.parse("asdf");

--- a/play.ts
+++ b/play.ts
@@ -1,10 +1,3 @@
 import { z } from "zod/v4";
 
 z;
-
-// function form
-const a = z.stringFormat("creditCard", (val) => /\d{16}/.test(val));
-
-// regex form
-const b = z.stringFormat("creditCard", /\d{16}/);
-b.parse("asdf");

--- a/play.ts
+++ b/play.ts
@@ -1,3 +1,3 @@
-import { z } from "zod/v4";
+import { z } from "zod/v4-mini";
 
 z;


### PR DESCRIPTION
Implement `z.stringFormat()` to enable custom string format schemas. 

```ts
// function form
const a = z.stringFormat("creditCard", (val) => /\d{16}/.test(val))

// regex form
const b = z.stringFormat("creditCard",  /\d{16}/)
```

These schemas produce proper `invalid_format` issues, unlike a naive approach with `z.custom()` or `.refine()`:

```ts
const b = z.stringFormat("creditCard", /\d{16}/);
b.parse("asdf");
// ZodError: [
//   {
//     code: "invalid_format",
//     format: "creditCard",
//     path: [],
//     message: "Invalid creditCard",
//   },
// ];
```

