### PR TITLE
Allow JWT extension typ values

### DIFF
--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -706,7 +706,7 @@ function isValidJWT(jwt: string, alg?: string): boolean {
       .padEnd(header.length + ((4 - (header.length % 4)) % 4), "=");
     const decoded = JSON.parse(atob(base64));
     if (typeof decoded !== "object" || decoded === null) return false;
-    if ("typ" in decoded && decoded?.typ !== "JWT") return false;
+    if ("typ" in decoded && !decoded.typ?.startsWith("JWT")) return false;
     if (!decoded.alg) return false;
     if (alg && decoded.alg !== alg) return false;
     return true;


### PR DESCRIPTION
We use `JWT+s2s` for our service-to-service JWT tokens and `JWT+at`, `JWT+aut`, etc for other forms of tokens. Since updating to the latest v3, those tokens don't pass validation.

NOTE: I just did this in the GitHub UI. I should write a test for it before merging. Opening a PR now for a sanity check though.