### PR TITLE
Fix optionality of schemas

### DIFF
--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -217,6 +217,16 @@ test("test inferred merged type", async () => {
   expectTypeOf<asdf>().toEqualTypeOf<{ a: number }>();
 });
 
+test("inferred type with Record shape", () => {
+  type A = z.ZodObject<Record<string, z.ZodType<string, number>>>;
+  expectTypeOf<z.infer<A>>().toEqualTypeOf<Record<string, string>>();
+  expectTypeOf<z.input<A>>().toEqualTypeOf<Record<string, number>>();
+
+  type B = z.ZodObject;
+  type sdf = z.infer<B>;
+  expectTypeOf<z.infer<B>>().toEqualTypeOf<Record<string, any>>();
+});
+
 test("inferred merged object type with optional properties", async () => {
   const Merged = z
     .object({ a: z.string(), b: z.string().optional() })

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -217,16 +217,6 @@ test("test inferred merged type", async () => {
   expectTypeOf<asdf>().toEqualTypeOf<{ a: number }>();
 });
 
-test("inferred type with Record shape", () => {
-  type A = z.ZodObject<Record<string, z.ZodType<string, number>>>;
-  expectTypeOf<z.infer<A>>().toEqualTypeOf<Record<string, string>>();
-  expectTypeOf<z.input<A>>().toEqualTypeOf<Record<string, number>>();
-
-  type B = z.ZodObject;
-  type sdf = z.infer<B>;
-  expectTypeOf<z.infer<B>>().toEqualTypeOf<Record<string, any>>();
-});
-
 test("inferred merged object type with optional properties", async () => {
   const Merged = z
     .object({ a: z.string(), b: z.string().optional() })

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -40,15 +40,15 @@ test("optionality", () => {
 
   // z.undefined should NOT be optional
   const f = z.undefined();
-  // expect(f._zod.optin).toEqual(undefined);
-  // expect(f._zod.optout).toEqual(undefined);
+  expect(f._zod.optin).toEqual("optional");
+  expect(f._zod.optout).toEqual("optional");
   expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
   // z.union should be optional if any of the types are optional
   const g = z.union([z.string(), z.undefined()]);
-  expect(g._zod.optin).toEqual(undefined);
-  expect(g._zod.optout).toEqual(undefined);
+  expect(g._zod.optin).toEqual("optional");
+  expect(g._zod.optout).toEqual("optional");
   expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof g._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -37,6 +37,26 @@ test("optionality", () => {
   const e = z.string().default("asdf").nullable();
   expect(e._zod.optin).toEqual("optional");
   expect(e._zod.optout).toEqual(undefined);
+
+  // z.undefined should NOT be optional
+  const f = z.undefined();
+  // expect(f._zod.optin).toEqual(undefined);
+  // expect(f._zod.optout).toEqual(undefined);
+  expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
+  expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
+
+  // z.union should be optional if any of the types are optional
+  const g = z.union([z.string(), z.undefined()]);
+  expect(g._zod.optin).toEqual(undefined);
+  expect(g._zod.optout).toEqual(undefined);
+  expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | undefined>();
+  expectTypeOf<typeof g._zod.optout>().toEqualTypeOf<"optional" | undefined>();
+
+  const h = z.union([z.string(), z.optional(z.string())]);
+  expect(h._zod.optin).toEqual("optional");
+  expect(h._zod.optout).toEqual("optional");
+  expectTypeOf<typeof h._zod.optin>().toEqualTypeOf<"optional">();
+  expectTypeOf<typeof h._zod.optout>().toEqualTypeOf<"optional">();
 });
 
 test("pipe optionality", () => {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1860,6 +1860,7 @@ test("input type", () => {
     g: z.never(),
     h: z.undefined(),
     i: z.union([z.string(), z.number().default(2)]),
+    j: z.union([z.string(), z.string().optional()]),
   });
   expect(z.toJSONSchema(schema, { io: "input" })).toMatchInlineSnapshot(`
     {
@@ -1907,6 +1908,16 @@ test("input type", () => {
             {
               "default": 2,
               "type": "number",
+            },
+          ],
+        },
+        "j": {
+          "anyOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "string",
             },
           ],
         },
@@ -1964,6 +1975,16 @@ test("input type", () => {
             {
               "default": 2,
               "type": "number",
+            },
+          ],
+        },
+        "j": {
+          "anyOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "string",
             },
           ],
         },

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1856,6 +1856,7 @@ test("input type", () => {
     c: z.string().default("hello"),
     d: z.string().nullable(),
     e: z.string().prefault("hello"),
+    f: z.string().catch("hello"),
   });
   expect(z.toJSONSchema(schema, { io: "input" })).toMatchInlineSnapshot(`
     {
@@ -1882,6 +1883,10 @@ test("input type", () => {
           ],
         },
         "e": {
+          "default": "hello",
+          "type": "string",
+        },
+        "f": {
           "default": "hello",
           "type": "string",
         },
@@ -1921,12 +1926,17 @@ test("input type", () => {
         "e": {
           "type": "string",
         },
+        "f": {
+          "default": "hello",
+          "type": "string",
+        },
       },
       "required": [
         "a",
         "c",
         "d",
         "e",
+        "f",
       ],
       "type": "object",
     }

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -31,7 +31,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(z.undefined())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "null",
+        "not": {},
       }
     `);
     expect(z.toJSONSchema(z.any())).toMatchInlineSnapshot(`
@@ -1857,6 +1857,9 @@ test("input type", () => {
     d: z.string().nullable(),
     e: z.string().prefault("hello"),
     f: z.string().catch("hello"),
+    g: z.never(),
+    h: z.undefined(),
+    i: z.union([z.string(), z.number().default(2)]),
   });
   expect(z.toJSONSchema(schema, { io: "input" })).toMatchInlineSnapshot(`
     {
@@ -1889,6 +1892,23 @@ test("input type", () => {
         "f": {
           "default": "hello",
           "type": "string",
+        },
+        "g": {
+          "not": {},
+        },
+        "h": {
+          "not": {},
+        },
+        "i": {
+          "anyOf": [
+            {
+              "type": "string",
+            },
+            {
+              "default": 2,
+              "type": "number",
+            },
+          ],
         },
       },
       "required": [
@@ -1930,6 +1950,23 @@ test("input type", () => {
           "default": "hello",
           "type": "string",
         },
+        "g": {
+          "not": {},
+        },
+        "h": {
+          "not": {},
+        },
+        "i": {
+          "anyOf": [
+            {
+              "type": "string",
+            },
+            {
+              "default": 2,
+              "type": "number",
+            },
+          ],
+        },
       },
       "required": [
         "a",
@@ -1937,6 +1974,7 @@ test("input type", () => {
         "d",
         "e",
         "f",
+        "i",
       ],
       "type": "object",
     }

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1925,6 +1925,7 @@ test("input type", () => {
       "required": [
         "a",
         "d",
+        "g",
       ],
       "type": "object",
     }
@@ -1995,6 +1996,7 @@ test("input type", () => {
         "d",
         "e",
         "f",
+        "g",
         "i",
       ],
       "type": "object",

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1379,9 +1379,6 @@ export interface $ZodNever extends $ZodType {
 
 export const $ZodNever: core.$constructor<$ZodNever> = /*@__PURE__*/ core.$constructor("$ZodNever", (inst, def) => {
   $ZodType.init(inst, def);
-
-  inst._zod.optin = "optional";
-  inst._zod.optout = "optional";
   inst._zod.parse = (payload, _ctx) => {
     payload.issues.push({
       expected: "never",

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1241,6 +1241,8 @@ export const $ZodUndefined: core.$constructor<$ZodUndefined> = /*@__PURE__*/ cor
     $ZodType.init(inst, def);
     inst._zod.pattern = regexes.undefined;
     inst._zod.values = new Set([undefined]);
+    inst._zod.optin = "optional";
+    inst._zod.optout = "optional";
 
     inst._zod.parse = (payload, _ctx) => {
       const { value: input } = payload;
@@ -1378,6 +1380,8 @@ export interface $ZodNever extends $ZodType {
 export const $ZodNever: core.$constructor<$ZodNever> = /*@__PURE__*/ core.$constructor("$ZodNever", (inst, def) => {
   $ZodType.init(inst, def);
 
+  inst._zod.optin = "optional";
+  inst._zod.optout = "optional";
   inst._zod.parse = (payload, _ctx) => {
     payload.issues.push({
       expected: "never",
@@ -1916,6 +1920,14 @@ function handleUnionResults(results: ParsePayload[], final: ParsePayload, inst: 
 
 export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$constructor("$ZodUnion", (inst, def) => {
   $ZodType.init(inst, def);
+
+  util.defineLazy(inst._zod, "optin", () =>
+    def.options.some((o) => o._zod.optin === "optional") ? "optional" : undefined
+  );
+
+  util.defineLazy(inst._zod, "optout", () =>
+    def.options.some((o) => o._zod.optout === "optional") ? "optional" : undefined
+  );
 
   util.defineLazy(inst._zod, "values", () => {
     if (def.options.every((o) => o._zod.values)) {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3272,7 +3272,7 @@ export interface $ZodCatch<T extends SomeType = $ZodType> extends $ZodType {
 
 export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$constructor("$ZodCatch", (inst, def) => {
   $ZodType.init(inst, def);
-  util.defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
+  inst._zod.optin = "optional";
   util.defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
   util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1889,11 +1889,17 @@ export interface $ZodUnionDef<Options extends readonly SomeType[] = readonly $Zo
   options: Options;
 }
 
+type IsOptionalIn<T extends SomeType> = T extends OptionalInSchema ? true : false;
+type IsOptionalOut<T extends SomeType> = T extends OptionalOutSchema ? true : false;
+
 export interface $ZodUnionInternals<T extends readonly SomeType[] = readonly $ZodType[]>
   extends $ZodTypeInternals<$InferUnionOutput<T[number]>, $InferUnionInput<T[number]>> {
   def: $ZodUnionDef<T>;
   isst: errors.$ZodIssueInvalidUnion;
   pattern: T[number]["_zod"]["pattern"];
+  // if any element in the union is optional, then the union is optional
+  optin: IsOptionalIn<T[number]> extends false ? "optional" | undefined : "optional";
+  optout: IsOptionalOut<T[number]> extends false ? "optional" | undefined : "optional";
 }
 
 export interface $ZodUnion<T extends readonly SomeType[] = readonly $ZodType[]> extends $ZodType {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -207,11 +207,6 @@ export class JSONSchemaGenerator {
             }
             break;
           }
-          case "undefined": {
-            const json = _json as JSONSchema.NullSchema;
-            json.type = "null";
-            break;
-          }
           case "null": {
             _json.type = "null";
             break;
@@ -222,6 +217,7 @@ export class JSONSchemaGenerator {
           case "unknown": {
             break;
           }
+          case "undefined":
           case "never": {
             _json.not = {};
             break;

--- a/play.ts
+++ b/play.ts
@@ -1,13 +1,3 @@
 import { z } from "zod/v4";
 
-z;
-
-function foo<T extends z.ZodObject<Record<string, z.ZodType<string>>>>(
-  schema: z.ZodObject<Record<string, z.ZodType<string>>>,
-  data: z.output<typeof schema>
-) {
-  // ❌ Record<string, unknown> is not assignable to Record<string, string>
-
-  data;
-  const data2: Record<string, string> = data;
-}
+console.dir(z.object({ a: z.never() }).parse({}), { depth: null });

--- a/play.ts
+++ b/play.ts
@@ -1,3 +1,13 @@
-import * as z from "zod/v4";
+import { z } from "zod/v4";
 
 z;
+
+function foo<T extends z.ZodObject<Record<string, z.ZodType<string>>>>(
+  schema: z.ZodObject<Record<string, z.ZodType<string>>>,
+  data: z.output<typeof schema>
+) {
+  // ❌ Record<string, unknown> is not assignable to Record<string, string>
+
+  data;
+  const data2: Record<string, string> = data;
+}


### PR DESCRIPTION
Resolves https://github.com/colinhacks/zod/issues/4768

Changes:
- Marks `.catch()` schemas as input optional.
- Marks `.never()` schemas as input and output optional.
- Marks `.undefined()` schemas as input and output optional.
- Changes `.undefined()` output to align with `.never()`. At the moment it outputs `null` which isn't strictly correct. The Zod Schema would never be able to accept `null`. We essentially want them to send us nothing right? As `undefined` doesn't exist we can treat it the same as `.never()`
- Marks `z.union()` schemas with optional members as `input` and `output` optional.


