### PR TITLE
Treat undefined as never

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -914,6 +914,8 @@ export const ZodUndefined: core.$constructor<ZodUndefined> = /*@__PURE__*/ core.
   (inst, def) => {
     core.$ZodUndefined.init(inst, def);
     ZodType.init(inst, def);
+    inst._zod.optin = "optional";
+    inst._zod.optout = "optional";
   }
 );
 

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1856,6 +1856,7 @@ test("input type", () => {
     c: z.string().default("hello"),
     d: z.string().nullable(),
     e: z.string().prefault("hello"),
+    f: z.undefined(),
   });
   expect(z.toJSONSchema(schema, { io: "input" })).toMatchInlineSnapshot(`
     {
@@ -1884,6 +1885,9 @@ test("input type", () => {
         "e": {
           "default": "hello",
           "type": "string",
+        },
+        "f": {
+          "not": {}
         },
       },
       "required": [
@@ -1920,6 +1924,9 @@ test("input type", () => {
         },
         "e": {
           "type": "string",
+        },
+        "f": {
+          "not": {}
         },
       },
       "required": [

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -31,7 +31,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(z.undefined())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "null",
+        "not": {},
       }
     `);
     expect(z.toJSONSchema(z.any())).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1887,7 +1887,7 @@ test("input type", () => {
           "type": "string",
         },
         "f": {
-          "not": {}
+          "not": {},
         },
       },
       "required": [
@@ -1926,7 +1926,7 @@ test("input type", () => {
           "type": "string",
         },
         "f": {
-          "not": {}
+          "not": {},
         },
       },
       "required": [

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -207,11 +207,6 @@ export class JSONSchemaGenerator {
             }
             break;
           }
-          case "undefined": {
-            const json = _json as JSONSchema.NullSchema;
-            json.type = "null";
-            break;
-          }
           case "null": {
             _json.type = "null";
             break;
@@ -222,6 +217,7 @@ export class JSONSchemaGenerator {
           case "unknown": {
             break;
           }
+          case "undefined":
           case "never": {
             _json.not = {};
             break;


### PR DESCRIPTION
Treat `undefined` the same as `never`

Given we can't actually send `undefined` in JSON land, we should probably treat it the same as `never`?

Implying we accept `null` isn't correct