### PR TITLE
Docs: Warn about `id` uniqueness check on Metadata page

### DIFF
--- a/packages/docs/content/metadata.mdx
+++ b/packages/docs/content/metadata.mdx
@@ -37,6 +37,9 @@ myRegistry.add(mySchema, { description: "A cool schema!" }); // ✅
 myRegistry.add(mySchema, { description: 123 }); // ❌
 ```
 
+> **Important** —  If you register metadata on a schema and include an `id` property, Zod will throw an error if multiple schemas share the same `id` value. Make sure all registered `id` values are unique per registry. This also applies to the global registry.
+
+
 ### `.register()`
 
 > **Note** — This method is special in that it does not return a new schema; instead, it returns the original schema. No other Zod method does this! That includes `.meta()` and `.describe()` (documented below) which return a new instance.


### PR DESCRIPTION
I was surprised to encounter uniqueness checks on the `id` property of metadata for my custom registry.  Based on #4145, this feature is intentional.  So, I figured I would update the docs!

That said, I do wonder if the uniqueness check should be reserved for the global registry.  My custom registry has nothing to do with JSON Schema generation.  My `id` property was meant to be a `boolean`, which controls something about a custom Zod-Mongoose integration I'm working on.

Anyway, thanks for the truly outstanding library.