### PR TITLE
Add `svelte-jsonschema-form` to form integrations

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -78,6 +78,12 @@ const formIntegrations: ZodResource[] = [
     description: "Generate user-friendly error messages from ZodError instances.",
     slug: "causaly/zod-validation-error",
   },
+  {
+    name: "svelte-jsonschema-form",
+    url: "https://x0k.dev/svelte-jsonschema-form/validators/zod4/",
+    description: "Svelte 5 library for creating forms based on JSON schema.",
+    slug: "x0k/svelte-jsonschema-form"
+  }
 ];
 
 const zodToXConverters: ZodResource[] = [];


### PR DESCRIPTION
I have implemented Zod v4 validator support in `svelte-jsonschema-form`.
- [Docs](https://x0k.dev/svelte-jsonschema-form/validators/zod4/)
- Related PR https://github.com/x0k/svelte-jsonschema-form/pull/140
- Discussion https://github.com/colinhacks/zod/discussions/4712