### PR TITLE
Fix Lambda typo

### DIFF
--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -89,7 +89,7 @@ The API of Zod Mini is more verbose and less discoverable. The methods in Zod's 
 
 ### Backend development
 
-If you are using Zod on the backend, bundle size on the scale of Zod is not meaningful. This is true even in resource-constrained environments like Lamdba. [This post](https://medium.com/@adtanasa/size-is-almost-all-that-matters-for-optimizing-aws-lambda-cold-starts-cad54f65cbb) benchmarks cold start times with bundles of various sizes. Here is a subset of the results:
+If you are using Zod on the backend, bundle size on the scale of Zod is not meaningful. This is true even in resource-constrained environments like Lambda. [This post](https://medium.com/@adtanasa/size-is-almost-all-that-matters-for-optimizing-aws-lambda-cold-starts-cad54f65cbb) benchmarks cold start times with bundles of various sizes. Here is a subset of the results:
 
 | Bundle size | Lambda cold start time |
 |-------------|----------------|


### PR DESCRIPTION
## Summary
- fix a typo in docs referencing AWS Lambda

## Testing
- `pnpm test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6865d2b82c70832f9a4bfe36df6ae4a3