### PR TITLE
Fix regex for boolean and number

### DIFF
--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -122,8 +122,8 @@ export const string = (params?: { minimum?: number | undefined; maximum?: number
 
 export const bigint: RegExp = /^\d+n?$/;
 export const integer: RegExp = /^\d+$/;
-export const number: RegExp = /^-?\d+(?:\.\d+)?/i;
-export const boolean: RegExp = /true|false/i;
+export const number: RegExp = /^-?\d+(?:\.\d+)?$/i;
+export const boolean: RegExp = /^(?:true|false)$/i;
 const _null: RegExp = /null/i;
 export { _null as null };
 const _undefined: RegExp = /undefined/i;


### PR DESCRIPTION
## Summary
- anchor regexes for `number` and `boolean`

## Testing
- `pnpm test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68632d99c7b0832f8adbf107a5dba33b