### PR TITLE
feat: redo destructuring

### DIFF
--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1508,11 +1508,11 @@ export function _stringbool(
   schemas.$ZodPipe<schemas.$ZodString, schemas.$ZodTransform<boolean, string>>,
   schemas.$ZodBoolean<boolean>
 > {
-  const params = util.normalizeParams(_params);
+  const { case: _case, error, truthy, falsy } = util.normalizeParams(_params);
 
-  let truthyArray = params.truthy ?? ["true", "1", "yes", "on", "y", "enabled"];
-  let falsyArray = params.falsy ?? ["false", "0", "no", "off", "n", "disabled"];
-  if (params.case !== "sensitive") {
+  let truthyArray = truthy ?? ["true", "1", "yes", "on", "y", "enabled"];
+  let falsyArray = falsy ?? ["false", "0", "no", "off", "n", "disabled"];
+  if (_case !== "sensitive") {
     truthyArray = truthyArray.map((v) => (typeof v === "string" ? v.toLowerCase() : v));
     falsyArray = falsyArray.map((v) => (typeof v === "string" ? v.toLowerCase() : v));
   }
@@ -1529,7 +1529,7 @@ export function _stringbool(
     type: "transform",
     transform: (input, payload: schemas.ParsePayload<unknown>) => {
       let data: string = input as string;
-      if (params.case !== "sensitive") data = data.toLowerCase();
+      if (_case !== "sensitive") data = data.toLowerCase();
       if (truthySet.has(data)) {
         return true;
       } else if (falsySet.has(data)) {
@@ -1545,15 +1545,14 @@ export function _stringbool(
         return {} as never;
       }
     },
-    error: params.error,
+    error,
   });
-  // params.error;
 
   const innerPipe = new _Pipe({
     type: "pipe",
-    in: new _String({ type: "string", error: params.error }),
+    in: new _String({ type: "string", error }),
     out: tx,
-    error: params.error,
+    error,
   });
 
   const outerPipe = new _Pipe({
@@ -1561,9 +1560,9 @@ export function _stringbool(
     in: innerPipe,
     out: new _Boolean({
       type: "boolean",
-      error: params.error,
+      error,
     }),
-    error: params.error,
+    error,
   });
   return outerPipe as any;
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1139,12 +1139,12 @@ export const $ZodBigInt: core.$constructor<$ZodBigInt> = /*@__PURE__*/ core.$con
       try {
         payload.value = BigInt(payload.value);
       } catch (_) {}
-
-    if (typeof payload.value === "bigint") return payload;
+    const { value: input } = payload;
+    if (typeof input === "bigint") return payload;
     payload.issues.push({
       expected: "bigint",
       code: "invalid_type",
-      input: payload.value,
+      input,
       inst,
     });
     return payload;
@@ -1198,7 +1198,7 @@ export const $ZodSymbol: core.$constructor<$ZodSymbol> = /*@__PURE__*/ core.$con
   $ZodType.init(inst, def);
 
   inst._zod.parse = (payload, _ctx) => {
-    const input = payload.value;
+    const { value: input } = payload;
     if (typeof input === "symbol") return payload;
     payload.issues.push({
       expected: "symbol",
@@ -1240,7 +1240,7 @@ export const $ZodUndefined: core.$constructor<$ZodUndefined> = /*@__PURE__*/ cor
     inst._zod.values = new Set([undefined]);
 
     inst._zod.parse = (payload, _ctx) => {
-      const input = payload.value;
+      const { value: input } = payload;
       if (typeof input === "undefined") return payload;
       payload.issues.push({
         expected: "undefined",
@@ -1282,7 +1282,7 @@ export const $ZodNull: core.$constructor<$ZodNull> = /*@__PURE__*/ core.$constru
   inst._zod.values = new Set([null]);
 
   inst._zod.parse = (payload, _ctx) => {
-    const input = payload.value;
+    const { value: input } = payload;
     if (input === null) return payload;
     payload.issues.push({
       expected: "null",
@@ -1411,7 +1411,7 @@ export const $ZodVoid: core.$constructor<$ZodVoid> = /*@__PURE__*/ core.$constru
   $ZodType.init(inst, def);
 
   inst._zod.parse = (payload, _ctx) => {
-    const input = payload.value;
+    const { value: input } = payload;
     if (typeof input === "undefined") return payload;
     payload.issues.push({
       expected: "void",
@@ -1700,7 +1700,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
 
   const generateFastpass = (shape: any) => {
     const doc = new Doc(["shape", "payload", "ctx"]);
-    const normalized = _normalized.value;
+    const { keys, optionalKeys } = _normalized.value;
 
     const parseStr = (key: string) => {
       const k = util.esc(key);
@@ -1710,14 +1710,14 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     doc.write(`const input = payload.value;`);
 
     const ids: any = Object.create(null);
-    for (const key of normalized.keys) {
+    for (const key of keys) {
       ids[key] = util.randomString(15);
     }
 
     // A: preserve key order {
     doc.write(`const newResult = {}`);
-    for (const key of normalized.keys) {
-      if (normalized.optionalKeys.has(key)) {
+    for (const key of keys) {
+      if (optionalKeys.has(key)) {
         const id = ids[key];
         doc.write(`const ${id} = ${parseStr(key)};`);
         const k = util.esc(key);
@@ -1767,7 +1767,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
   const allowsEval = util.allowsEval;
 
   const fastEnabled = jit && allowsEval.value; // && !def.catchall;
-  const catchall = def.catchall;
+  const { catchall } = def;
 
   let value!: typeof _normalized.value;
 
@@ -2086,7 +2086,7 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
     $ZodType.init(inst, def);
 
     inst._zod.parse = (payload, ctx) => {
-      const input = payload.value;
+      const { value: input } = payload;
       const left = def.left._zod.run({ value: input, issues: [] }, ctx);
       const right = def.right._zod.run({ value: input, issues: [] }, ctx);
       const async = left instanceof Promise || right instanceof Promise;

--- a/packages/zod/src/v4/core/tests/locales/be.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/be.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import be from "../../../locales/be.js";
 
 describe("Belarusian localization", () => {
-  const localeError = be().localeError;
+  const { localeError } = be();
 
   describe("pluralization rules", () => {
     for (const { type, cases } of TEST_CASES) {

--- a/packages/zod/src/v4/core/tests/locales/ru.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ru.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import ru from "../../../locales/ru.js";
 
 describe("Russian localization", () => {
-  const localeError = ru().localeError;
+  const { localeError } = ru();
 
   describe("pluralization rules", () => {
     for (const { type, cases } of TEST_CASES) {


### PR DESCRIPTION
# Motivation

The commit dfda9931e00faaba1a7fd453330902ce16af45b9 aimed to minimize the use of destructuring patterns in order to resolve #4773. After debugging (way) much further, I finally realized that the issue wasn't related to Zod, but was actually a side effect of a bug in my project, triggered by Zod v4 starting to generate random constants at runtime.

As a result, I decided to submit this PR to reintroduce the destructuring pattern, which was the preferred style in the first place.

# Notes

The commit dfda9931e00faaba1a7fd453330902ce16af45b9 appeared to contain various changes that were not all related to this concern. Therefore, I manually cherry-picked what seemed relevant to the destructuring topic.
