### PR TITLE
v3.25.73

### DIFF
--- a/.cursor/rules/development-setup.mdc
+++ b/.cursor/rules/development-setup.mdc
@@ -1,0 +1,78 @@
+# Development Setup
+
+## Prerequisites
+
+### Node.js
+- **Required**: Node.js v24+ (project uses modern ES modules and features)
+- **Recommended**: Use nvm for Node.js version management
+- **Setup**: `nvm use default` to use the latest Node.js version
+
+### Package Manager
+- **Required**: pnpm v10.12.1 (specified in package.json)
+- **Install**: `npm install -g pnpm@10.12.1`
+
+## Environment Setup
+
+### 1. Install Dependencies
+```bash
+pnpm install
+```
+
+### 2. Verify Setup
+```bash
+node --version  # Should be v24+
+pnpm --version  # Should be 10.12.1
+```
+
+### 3. Build Project
+```bash
+pnpm build
+```
+
+### 4. Run Tests
+```bash
+pnpm test
+```
+
+## Development Workflow
+
+### Starting Development
+```bash
+pnpm dev          # Start development server
+pnpm dev:watch    # Start with watch mode
+pnpm dev:play     # Run play.ts for testing
+```
+
+### Code Quality
+```bash
+pnpm format       # Format code
+pnpm lint         # Lint and fix
+pnpm fix          # Format + lint
+```
+
+### Testing
+```bash
+pnpm test         # Run all tests
+pnpm test:watch   # Run tests in watch mode
+```
+
+## Troubleshooting
+
+### Node.js Version Issues
+- Ensure you're using Node.js v24+
+- Use `nvm use default` to switch to correct version
+- Check with `node --version`
+
+### Module Import Issues
+- Project uses ES modules (`"type": "module"`)
+- Use `.js` extensions in imports: `import { z } from "./index.js"`
+- Don't use `require()` - use `import` statements
+
+### Test Issues
+- Ensure Vitest is properly configured
+- Check that test files are in correct directories
+- Use `pnpm vitest run <specific-file>` for isolated testing
+description:
+globs:
+alwaysApply: false
+---

--- a/.cursor/rules/guidelines.mdc
+++ b/.cursor/rules/guidelines.mdc
@@ -1,0 +1,11 @@
+# Project Guidelines
+
+This file contains general coding guidelines for the project. Update this file with small rules and best practices that do not merit their own dedicated rule file.
+
+## Guidelines
+
+- Do not leave log statements (e.g., `console.log`, `debugger`) in tests or production code.
+description:
+globs:
+alwaysApply: false
+---

--- a/.cursor/rules/guidelines.mdc
+++ b/.cursor/rules/guidelines.mdc
@@ -9,3 +9,4 @@ description:
 globs:
 alwaysApply: false
 ---
+- Ask before generating any new files.

--- a/.cursor/rules/testing-workflow.mdc
+++ b/.cursor/rules/testing-workflow.mdc
@@ -1,0 +1,56 @@
+# Testing Workflow
+
+## Test Framework
+- **Vitest** is used for all testing
+- Tests are located in `packages/zod/src/v4/classic/tests/` and `packages/zod/src/v4/core/tests/`
+- Test files follow the pattern `*.test.ts`
+
+## Running Tests
+
+### All Tests
+```bash
+pnpm test
+```
+
+### Watch Mode
+```bash
+pnpm test:watch
+```
+
+### Specific Test File
+```bash
+pnpm vitest run packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+```
+
+### Specific Test Pattern
+```bash
+pnpm vitest run --reporter=verbose packages/zod/src/v4/classic/tests/
+```
+
+## Test Conventions
+
+- Use `test()` for individual test cases
+- Use `describe()` for test groups
+- Use `expect()` for assertions
+- Test files should be co-located with source files or in dedicated test directories
+- Follow the existing test patterns in the codebase
+
+## Test Structure Example
+```typescript
+import { z } from "../../index.js";
+
+test("test description", () => {
+  const schema = z.string();
+  const result = schema.parse("test");
+  expect(result).toBe("test");
+});
+```
+
+## Debugging Tests
+- Use `console.log()` for debugging
+- Run specific test files to isolate issues
+- Use watch mode for rapid iteration
+description:
+globs:
+alwaysApply: false
+---

--- a/.cursor/rules/zod-internals.mdc
+++ b/.cursor/rules/zod-internals.mdc
@@ -1,0 +1,280 @@
+# Zod Internals Comprehensive Guide
+
+## Core Architecture
+
+### Schema Type System
+All schemas extend `$ZodType` and implement `$ZodTypeInternals`. The core architecture is defined in:
+- [packages/zod/src/v4/core/schemas.ts](mdc:packages/zod/src/v4/core/schemas.ts) - All schema type definitions
+- [packages/zod/src/v4/core/core.ts](mdc:packages/zod/src/v4/core/core.ts) - Constructor system and type helpers
+- [packages/zod/src/v4/core/util.ts](mdc:packages/zod/src/v4/core/util.ts) - Utility functions and type helpers
+
+### Constructor Pattern
+Zod uses a custom constructor system via `$constructor()` function:
+```typescript
+export const $ZodReadonly: core.$constructor<$ZodReadonly> = /*@__PURE__*/ core.$constructor(
+  "$ZodReadonly",
+  (inst, def) => {
+    $ZodType.init(inst, def);
+    // Schema-specific initialization
+  }
+);
+```
+
+## Key Internal Properties
+
+### Core Properties
+- `def`: Schema definition object containing type and configuration
+- `traits`: Set of trait identifiers for this schema
+- `id`: Unique identifier for the schema instance
+- `version`: Zod core version
+- `constr`: Constructor function reference
+
+### Validation Properties
+- `propValues`: Used for discriminated unions to store literal values per property
+- `values`: Set of literal values that pass validation (for enums, literals, etc.)
+- `pattern`: RegExp for string validation patterns
+- `optin/optout`: Optionality flags for input/output types
+- `isst`: Set of possible issue types this schema can throw
+
+### Processing Properties
+- `parse`: Function that parses input without running checks
+- `run`: Function that parses input and runs all checks
+- `deferred`: Array of deferred initializers
+- `bag`: Metadata object for schema-specific data
+
+## Schema Categories
+
+### Primitive Schemas
+- `$ZodString`, `$ZodNumber`, `$ZodBoolean`, `$ZodBigInt`
+- `$ZodSymbol`, `$ZodUndefined`, `$ZodNull`, `$ZodAny`, `$ZodUnknown`
+- `$ZodNever`, `$ZodVoid`, `$ZodDate`, `$ZodLiteral`
+
+### Container Schemas
+- `$ZodArray`, `$ZodObject`, `$ZodTuple`, `$ZodRecord`
+- `$ZodMap`, `$ZodSet`, `$ZodUnion`, `$ZodIntersection`
+- `$ZodDiscriminatedUnion`
+
+### Wrapper Schemas
+- `$ZodOptional`, `$ZodNullable`, `$ZodReadonly`
+- `$ZodDefault`, `$ZodPrefault`, `$ZodNonOptional`
+- `$ZodTransform`, `$ZodPipe`, `$ZodCatch`
+
+### Special Schemas
+- `$ZodEnum`, `$ZodPromise`, `$ZodLazy`, `$ZodCustom`
+- `$ZodTemplateLiteral`, `$ZodNaN`, `$ZodSuccess`
+
+## Common Patterns
+
+### Wrapper Type Pattern
+Wrapper types must pass through internal properties from their inner type:
+
+```typescript
+// Correct pattern for wrapper types
+util.defineLazy(inst._zod, "propValues", () => def.innerType._zod.propValues);
+util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
+util.defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
+util.defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
+```
+
+### Lazy Property Definition
+Use `util.defineLazy()` to avoid circular dependencies:
+```typescript
+util.defineLazy(inst._zod, "propValues", () => {
+  // Computed property logic
+  return computedValue;
+});
+```
+
+### Parse Function Pattern
+Standard parse function structure:
+```typescript
+inst._zod.parse = (payload, ctx) => {
+  // Type checking
+  if (typeof payload.value !== "expected_type") {
+    payload.issues.push({
+      expected: "expected_type",
+      code: "invalid_type",
+      input: payload.value,
+      inst,
+    });
+    return payload;
+  }
+  
+  // Optional transformation
+  if (def.coerce) {
+    payload.value = transform(payload.value);
+  }
+  
+  return payload;
+};
+```
+
+## Error System
+
+### Error Types
+Defined in [packages/zod/src/v4/core/errors.ts](mdc:packages/zod/src/v4/core/errors.ts):
+- `$ZodIssueInvalidType` - Wrong type provided
+- `$ZodIssueTooBig/TooSmall` - Size/length constraints
+- `$ZodIssueInvalidStringFormat` - String format validation
+- `$ZodIssueInvalidUnion` - Union validation failures
+- `$ZodIssueCustom` - Custom validation errors
+
+### Error Creation
+```typescript
+payload.issues.push({
+  code: "invalid_type",
+  expected: "string",
+  input: payload.value,
+  inst,
+  // Optional fields
+  path: ["property"],
+  message: "Custom message",
+  continue: false, // Stop validation
+});
+```
+
+## Check System
+
+### Check Types
+Defined in [packages/zod/src/v4/core/checks.ts](mdc:packages/zod/src/v4/core/checks.ts):
+- Numeric checks: `$ZodCheckLessThan`, `$ZodCheckGreaterThan`, `$ZodCheckMultipleOf`
+- Size checks: `$ZodCheckMaxSize`, `$ZodCheckMinSize`, `$ZodCheckSizeEquals`
+- String checks: `$ZodCheckStringFormat`, `$ZodCheckRegex`, `$ZodCheckIncludes`
+- Custom checks: `$ZodCheckProperty`, `$ZodCheckOverwrite`
+
+### Check Pattern
+```typescript
+inst._zod.check = (payload) => {
+  if (validationPasses(payload.value)) {
+    return; // Success
+  }
+  
+  payload.issues.push({
+    code: "validation_code",
+    // ... other fields
+    inst,
+    continue: !def.abort,
+  });
+};
+```
+
+## Parsing System
+
+### Parse Functions
+Defined in [packages/zod/src/v4/core/parse.ts](mdc:packages/zod/src/v4/core/parse.ts):
+- `parse()` - Synchronous parsing
+- `parseAsync()` - Asynchronous parsing
+- `safeParse()` - Safe parsing (returns result object)
+- `safeParseAsync()` - Safe async parsing
+
+### Parse Context
+```typescript
+interface ParseContextInternal {
+  async?: boolean;
+  error?: $ZodErrorMap;
+  reportInput?: boolean;
+  jitless?: boolean;
+}
+```
+
+### Parse Payload
+```typescript
+interface ParsePayload<T = unknown> {
+  value: T;
+  issues: $ZodRawIssue[];
+}
+```
+
+## Utility Functions
+
+### Type Helpers
+- `util.defineLazy()` - Define lazy properties
+- `util.cached()` - Create cached getters
+- `util.prefixIssues()` - Add path prefixes to issues
+- `util.finalizeIssue()` - Finalize raw issues
+- `util.clone()` - Clone schemas
+
+### Type Utilities
+- `util.PrimitiveSet` - Set of primitive values
+- `util.PropValues` - Record of property value sets
+- `util.MaybeAsync<T>` - T | Promise<T>
+- `util.Literal` - Union of literal types
+
+## Discriminated Unions
+
+### Implementation
+Discriminated unions use `propValues` for fast-path validation:
+```typescript
+// In $ZodDiscriminatedUnion
+util.defineLazy(inst._zod, "propValues", () => {
+  const propValues: util.PropValues = {};
+  for (const option of def.options) {
+    const pv = option._zod.propValues;
+    // Merge propValues from all options
+  }
+  return propValues;
+});
+```
+
+### Requirements
+- Each option must have `propValues` with the discriminator key
+- Values must be unique across all options
+- Used for fast-path validation in `parse()`
+
+## Performance Optimizations
+
+### JIT Compilation
+- Fast-path generation for object parsing
+- Uses `eval()` when `jitless` is false
+- Generates optimized parsing functions
+
+### Lazy Evaluation
+- Properties computed on-demand using `util.defineLazy()`
+- Avoids circular dependency issues
+- Improves initialization performance
+
+### Caching
+- `util.cached()` for expensive computations
+- Schema normalization caching
+- Pattern compilation caching
+
+## Recent Fixes
+
+### Readonly Literal Discriminators
+- **Issue**: `$ZodReadonly` wasn't passing through `values` property
+- **Fix**: Added `values` to `$ZodReadonlyInternals` and lazy definition
+- **Impact**: Readonly literals can now be used as discriminators in discriminated unions
+- **Pattern**: Follow the wrapper type pattern for all internal properties
+
+## Development Guidelines
+
+### Creating New Schemas
+1. Define the schema definition interface
+2. Define the internals interface extending `$ZodTypeInternals`
+3. Define the schema interface extending `$ZodType`
+4. Create constructor using `$constructor()`
+5. Initialize with `$ZodType.init()`
+6. Implement `parse()` function
+7. Add lazy properties as needed
+8. Add tests for both public API and internal properties
+
+### Testing Internals
+- Test both public API and internal property access
+- Verify `propValues` are correctly computed
+- Check that wrapper types pass through properties correctly
+- Test error scenarios and edge cases
+
+### Common Pitfalls
+- Forgetting to pass through internal properties in wrapper types
+- Not using `util.defineLazy()` for computed properties
+- Missing error handling in parse functions
+- Incorrect issue code usage
+- Not testing internal property access
+
+### Best Practices
+- Always check if wrapper types pass through required internal properties
+- Use `util.defineLazy()` for computed properties to avoid circular dependencies
+- Follow existing patterns in similar schema types
+- Test both the public API and internal property access
+- Use proper TypeScript types for all interfaces
+- Document complex internal logic with comments

--- a/.cursor/rules/zod-project-guide.mdc
+++ b/.cursor/rules/zod-project-guide.mdc
@@ -1,0 +1,63 @@
+# Zod Project Guide
+
+This is the Zod TypeScript-first schema validation library project. The project uses **pnpm** as the package manager and **ES modules**.
+
+## Project Structure
+
+- **Root**: Monorepo with multiple packages
+- **Main package**: [packages/zod/](mdc:packages/zod/) - The core Zod library
+- **Package manager**: pnpm (version 10.12.1)
+- **Module system**: ES modules (`"type": "module"`)
+
+## Common Commands
+
+### Development
+- `pnpm dev` - Start development server with tsx
+- `pnpm dev:watch` - Start development server with watch mode
+- `pnpm dev:play` - Run play.ts file for testing
+
+### Testing
+- `pnpm test` - Run all tests with vitest
+- `pnpm test:watch` - Run tests in watch mode
+- `pnpm vitest run <file>` - Run specific test file
+- `pnpm vitest run packages/zod/src/v4/classic/tests/discriminated-unions.test.ts` - Run specific test
+
+### Building
+- `pnpm build` - Build all packages (excluding docs)
+- `pnpm clean` - Clean all packages
+
+### Code Quality
+- `pnpm format` - Format code with Biome
+- `pnpm format:check` - Check formatting without writing
+- `pnpm lint` - Lint and fix code with Biome
+- `pnpm lint:check` - Check linting without fixing
+- `pnpm fix` - Run both format and lint
+
+### Benchmarking
+- `pnpm bench` - Run benchmarks
+- `pnpm moltar` - Run specific benchmark (object-moltar)
+
+### Publishing
+- `pnpm prepublishOnly` - Run tests and build before publishing
+- `pnpm publish:jsr` - Publish to JSR (dry run)
+- `pnpm pub:beta` - Publish beta version
+
+## Key Files
+
+- [package.json](mdc:package.json) - Root package configuration
+- [packages/zod/package.json](mdc:packages/zod/package.json) - Main Zod package
+- [pnpm-workspace.yaml](mdc:pnpm-workspace.yaml) - Workspace configuration
+- [vitest.workspace.ts](mdc:vitest.workspace.ts) - Vitest workspace config
+
+## Development Notes
+
+- Use **pnpm** for all package management
+- Tests use **Vitest** framework
+- Code formatting/linting uses **Biome**
+- The project supports multiple Zod versions (v3, v4, v4-mini)
+- Source code uses TypeScript with ES modules
+- Node.js v24+ is required for development
+description:
+globs:
+alwaysApply: false
+---

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ packages/tsc-perf
 tsconfig.vitest-temp.json
 *.tgz
 
-

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -1,10 +1,6 @@
 {
   "name": "zod",
-<<<<<<< HEAD
-  "version": "3.25.72",
-=======
   "version": "3.25.73",
->>>>>>> 1d6ad2f7 (Fix partialRecord)
   "type": "module",
   "author": "Colin McDonnell <zod@colinhacks.com>",
   "description": "TypeScript-first schema declaration and validation library with static type inference",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -1,6 +1,10 @@
 {
   "name": "zod",
+<<<<<<< HEAD
   "version": "3.25.72",
+=======
+  "version": "3.25.73",
+>>>>>>> 1d6ad2f7 (Fix partialRecord)
   "type": "module",
   "author": "Colin McDonnell <zod@colinhacks.com>",
   "description": "TypeScript-first schema declaration and validation library with static type inference",

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1359,11 +1359,11 @@ export function partialRecord<Key extends core.$ZodRecordKey, Value extends core
   keyType: Key,
   valueType: Value,
   params?: string | core.$ZodRecordParams
-): ZodRecord<ZodUnion<[Key, ZodNever]>, Value> {
+): ZodRecord<Key, ZodOptional<Value>> {
   return new ZodRecord({
     type: "record",
     keyType: union([keyType, never()]),
-    valueType: valueType as any as core.$ZodType,
+    valueType: optional(valueType),
     ...util.normalizeParams(params),
   }) as any;
 }

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -365,6 +365,8 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   inst.duration = (params) => inst.check(iso.duration(params as any));
 });
 
+export function string(params?: string | core.$ZodStringParams): ZodString;
+export function string<T extends string>(params?: string | core.$ZodStringParams): core.$ZodType<T, T>;
 export function string(params?: string | core.$ZodStringParams): ZodString {
   return core._string(ZodString, params) as any;
 }

--- a/packages/zod/src/v4/classic/tests/brand.test.ts
+++ b/packages/zod/src/v4/classic/tests/brand.test.ts
@@ -59,7 +59,5 @@ test("$branded", () => {
 test("branded record", () => {
   const recordWithBrandedNumberKeys = z.record(z.string().brand("SomeBrand"), z.number());
   type recordWithBrandedNumberKeys = z.infer<typeof recordWithBrandedNumberKeys>;
-  expectTypeOf<recordWithBrandedNumberKeys>().toEqualTypeOf<
-    Record<string & z.core.$brand<"SomeBrand">, number | undefined>
-  >();
+  expectTypeOf<recordWithBrandedNumberKeys>().toEqualTypeOf<Record<string & z.core.$brand<"SomeBrand">, number>>();
 });

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -301,7 +301,7 @@ test("z.record", () => {
   // partial enum
   const d = z.record(z.enum(["a", "b"]).or(z.never()), z.string());
   type d = z.output<typeof d>;
-  expectTypeOf<d>().toEqualTypeOf<Partial<Record<"a" | "b", string>>>();
+  expectTypeOf<d>().toEqualTypeOf<Record<"a" | "b", string>>();
 });
 
 test("z.map", () => {

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -217,6 +217,16 @@ test("test inferred merged type", async () => {
   expectTypeOf<asdf>().toEqualTypeOf<{ a: number }>();
 });
 
+test("inferred type with Record shape", () => {
+  type A = z.ZodObject<Record<string, z.ZodType<string, number>>>;
+  expectTypeOf<z.infer<A>>().toEqualTypeOf<Record<string, string>>();
+  expectTypeOf<z.input<A>>().toEqualTypeOf<Record<string, number>>();
+
+  type B = z.ZodObject;
+  expectTypeOf<z.infer<B>>().toEqualTypeOf<Record<string, unknown>>();
+  expectTypeOf<z.input<B>>().toEqualTypeOf<Record<string, unknown>>();
+});
+
 test("inferred merged object type with optional properties", async () => {
   const Merged = z
     .object({ a: z.string(), b: z.string().optional() })
@@ -549,5 +559,5 @@ test("index signature in shape", () => {
   const schema = makeZodObj("foo");
   type schema = z.infer<typeof schema>;
 
-  expectTypeOf<schema>().toEqualTypeOf<Record<string, unknown>>();
+  expectTypeOf<schema>().toEqualTypeOf<Record<string, string>>();
 });

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -17,7 +17,7 @@ test("type inference", () => {
   expectTypeOf<booleanRecord>().toEqualTypeOf<Record<string, boolean>>();
   expectTypeOf<recordWithEnumKeys>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
   expectTypeOf<recordWithLiteralKey>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
-  expectTypeOf<recordWithLiteralUnionKeys>().toEqualTypeOf<Partial<Record<"Tuna" | "Salmon", string>>>();
+  expectTypeOf<recordWithLiteralUnionKeys>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
 });
 
 test("enum exhaustiveness", () => {
@@ -329,4 +329,10 @@ test("async parsing", async () => {
       }
     ]]
   `);
+});
+
+test("partial record", () => {
+  const schema = z.partialRecord(z.string(), z.string());
+  type schema = z.infer<typeof schema>;
+  expectTypeOf<schema>().toEqualTypeOf<Partial<Record<string, string>>>();
 });

--- a/packages/zod/src/v4/classic/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/recursive-types.test.ts
@@ -160,9 +160,10 @@ test("deferred self-recursion", () => {
   const Output = z.object({
     id: z.int(), //.nonnegative(),
     name: z.string(),
-    features: z.array(Feature), //.array(), // <—
+    get features(): z.ZodArray<typeof Feature> {
+      return Feature.array();
+    },
   });
-
   type Output = z.output<typeof Output>;
 
   type _Feature = {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1259,6 +1259,35 @@ test("override execution order", () => {
   `);
 });
 
+test("override with path", () => {
+  const userSchema = z.object({
+    name: z.string(),
+    age: z.number(),
+  });
+
+  const capturedPaths: (string | number)[][] = [];
+
+  z.toJSONSchema(userSchema, {
+    override(ctx) {
+      capturedPaths.push(ctx.path);
+    },
+  });
+
+  expect(capturedPaths).toMatchInlineSnapshot(`
+    [
+      [
+        "properties",
+        "age",
+      ],
+      [
+        "properties",
+        "name",
+      ],
+      [],
+    ]
+  `);
+});
+
 test("pipe", () => {
   const mySchema = z
     .string()

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -90,7 +90,7 @@ export interface _$ZodTypeInternals {
   // types: Types;
 
   /** @internal Randomly generated ID for this schema. */
-  id: string;
+  // id: string;
 
   /** @internal List of deferred initializers. */
   deferred: util.AnyFunc[] | undefined;
@@ -171,8 +171,7 @@ export interface _$ZodType<T extends $ZodTypeInternals = $ZodTypeInternals>
 
 export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constructor("$ZodType", (inst, def) => {
   inst ??= {} as any;
-  // avoids issues with using Math.random() in Next.js caching
-  util.defineLazy(inst._zod, "id", () => def.type + "_" + util.randomString(10));
+
   inst._zod.def = def; // set _def property
   inst._zod.bag = inst._zod.bag || {}; // initialize _bag object
   inst._zod.version = version;
@@ -1725,8 +1724,9 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     doc.write(`const input = payload.value;`);
 
     const ids: any = Object.create(null);
+    let counter = 0;
     for (const key of normalized.keys) {
-      ids[key] = util.randomString(15);
+      ids[key] = `key_${counter++}`;
     }
 
     // A: preserve key order {
@@ -1904,6 +1904,7 @@ export interface $ZodUnionInternals<T extends readonly SomeType[] = readonly $Zo
   def: $ZodUnionDef<T>;
   isst: errors.$ZodIssueInvalidUnion;
   pattern: T[number]["_zod"]["pattern"];
+  values: T[number]["_zod"]["values"]; //GetValues<T[number]>;
   output: $InferUnionOutput<T[number]>;
   input: $InferUnionInput<T[number]>;
   // if any element in the union is optional, then the union is optional
@@ -2385,7 +2386,7 @@ export type $InferZodRecordOutput<
       ? Record<core.output<Key>, core.output<Value>>
       : symbol extends core.output<Key>
         ? Record<core.output<Key>, core.output<Value>>
-        : Partial<Record<core.output<Key>, core.output<Value>>>
+        : Record<core.output<Key>, core.output<Value>>
   : Record<core.output<Key>, core.output<Value>>;
 
 export type $InferZodRecordInput<
@@ -2398,7 +2399,7 @@ export type $InferZodRecordInput<
       ? Record<core.input<Key>, core.input<Value>>
       : symbol extends core.input<Key>
         ? Record<core.input<Key>, core.input<Value>>
-        : Partial<Record<core.input<Key>, core.input<Value>>>
+        : Record<core.input<Key>, core.input<Value>>
   : Record<core.input<Key>, core.input<Value>>;
 
 export interface $ZodRecordInternals<Key extends $ZodRecordKey = $ZodRecordKey, Value extends SomeType = $ZodType>

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3441,6 +3441,7 @@ export interface $ZodReadonlyInternals<T extends SomeType = $ZodType>
   optout: T["_zod"]["optout"];
   isst: never;
   propValues: T["_zod"]["propValues"];
+  values: T["_zod"]["values"];
 }
 
 export interface $ZodReadonly<T extends SomeType = $ZodType> extends $ZodType {
@@ -3452,6 +3453,7 @@ export const $ZodReadonly: core.$constructor<$ZodReadonly> = /*@__PURE__*/ core.
   (inst, def) => {
     $ZodType.init(inst, def);
     util.defineLazy(inst._zod, "propValues", () => def.innerType._zod.propValues);
+    util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
     util.defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
     util.defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1498,14 +1498,15 @@ export interface $ZodArrayDef<T extends SomeType = $ZodType> extends $ZodTypeDef
   element: T;
 }
 
-export interface $ZodArrayInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<core.output<T>[], core.input<T>[]> {
+export interface $ZodArrayInternals<T extends SomeType = $ZodType> extends _$ZodTypeInternals {
+  //$ZodTypeInternals<core.output<T>[], core.input<T>[]> {
   def: $ZodArrayDef<T>;
   isst: errors.$ZodIssueInvalidType;
+  output: core.output<T>[];
+  input: core.input<T>[];
 }
 
-export interface $ZodArray<T extends SomeType = $ZodType>
-  extends $ZodType<core.output<T>[], core.input<T>[], $ZodArrayInternals<T>> {}
+export interface $ZodArray<T extends SomeType = $ZodType> extends $ZodType<any, any, $ZodArrayInternals<T>> {}
 
 function handleArrayResult(result: ParsePayload<any>, final: ParsePayload<any[]>, index: number) {
   if (result.issues.length) {
@@ -1895,17 +1896,19 @@ export interface $ZodUnionDef<Options extends readonly SomeType[] = readonly $Zo
 type IsOptionalIn<T extends SomeType> = T extends OptionalInSchema ? true : false;
 type IsOptionalOut<T extends SomeType> = T extends OptionalOutSchema ? true : false;
 
-export interface $ZodUnionInternals<T extends readonly SomeType[] = readonly $ZodType[]>
-  extends $ZodTypeInternals<$InferUnionOutput<T[number]>, $InferUnionInput<T[number]>> {
+export interface $ZodUnionInternals<T extends readonly SomeType[] = readonly $ZodType[]> extends _$ZodTypeInternals {
   def: $ZodUnionDef<T>;
   isst: errors.$ZodIssueInvalidUnion;
   pattern: T[number]["_zod"]["pattern"];
+  output: $InferUnionOutput<T[number]>;
+  input: $InferUnionInput<T[number]>;
   // if any element in the union is optional, then the union is optional
   optin: IsOptionalIn<T[number]> extends false ? "optional" | undefined : "optional";
   optout: IsOptionalOut<T[number]> extends false ? "optional" | undefined : "optional";
 }
 
-export interface $ZodUnion<T extends readonly SomeType[] = readonly $ZodType[]> extends $ZodType {
+export interface $ZodUnion<T extends readonly SomeType[] = readonly $ZodType[]>
+  extends $ZodType<any, any, $ZodUnionInternals<T>> {
   _zod: $ZodUnionInternals<T>;
 }
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -428,7 +428,9 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
   $ZodStringFormat.init(inst, def);
   inst._zod.check = (payload) => {
     try {
-      const url = new URL(payload.value);
+      const orig = payload.value;
+      const url = new URL(orig);
+      const href = url.href;
 
       if (def.hostname) {
         def.hostname.lastIndex = 0;
@@ -458,6 +460,13 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
             continue: !def.abort,
           });
         }
+      }
+
+      // payload.value = url.href;
+      if (!orig.endsWith("/") && href.endsWith("/")) {
+        payload.value = href.slice(0, -1);
+      } else {
+        payload.value = href;
       }
 
       return;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1570,7 +1570,9 @@ type OptionalOutSchema = { _zod: { optout: "optional" } };
 type OptionalInSchema = { _zod: { optin: "optional" } };
 
 export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<string, unknown>> = string extends keyof T
-  ? Record<string, unknown>
+  ? util.IsAny<T[keyof T]> extends true
+    ? Record<string, unknown>
+    : Record<string, core.output<T[keyof T]>>
   : keyof (T & Extra) extends never
     ? Record<string, never>
     : util.Prettify<
@@ -1582,7 +1584,9 @@ export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<st
       >;
 
 export type $InferObjectInput<T extends $ZodLooseShape, Extra extends Record<string, unknown>> = string extends keyof T
-  ? Record<string, unknown>
+  ? util.IsAny<T[keyof T]> extends true
+    ? Record<string, unknown>
+    : Record<string, core.input<T[keyof T]>>
   : keyof (T & Extra) extends never
     ? Record<string, never>
     : util.Prettify<

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1023,11 +1023,11 @@ export function partialRecord<Key extends core.$ZodRecordKey, Value extends Some
   keyType: Key,
   valueType: Value,
   params?: string | core.$ZodRecordParams
-): ZodMiniRecord<ZodMiniUnion<[Key, ZodMiniNever]>, Value> {
+): ZodMiniRecord<Key, ZodMiniOptional<Value>> {
   return new ZodMiniRecord({
     type: "record",
     keyType: union([keyType, never()]),
-    valueType: valueType as any as core.$ZodType,
+    valueType: optional(valueType),
     ...util.normalizeParams(params),
   }) as any;
 }

--- a/packages/zod/src/v4/mini/tests/string.test.ts
+++ b/packages/zod/src/v4/mini/tests/string.test.ts
@@ -99,6 +99,12 @@ test("z.url", () => {
   expect(a.parse("http://localhost:3000")).toEqual("http://localhost:3000");
   expect(a.parse("https://localhost:3000")).toEqual("https://localhost:3000");
 
+  // test trimming
+  expect(a.parse("  http://example.com  ")).toEqual("http://example.com");
+  expect(a.parse("  http://example.com/")).toEqual("http://example.com/");
+  expect(a.parse("  http://example.com")).toEqual("http://example.com");
+  expect(a.parse("  http://example.com//")).toEqual("http://example.com//");
+
   // invalid URLs
   expect(() => a.parse("not-a-url")).toThrow();
   // expect(() => a.parse("http:/example.com")).toThrow();

--- a/play.ts
+++ b/play.ts
@@ -1,3 +1,3 @@
 import { z } from "zod/v4";
 
-console.dir(z.object({ a: z.never() }).parse({}), { depth: null });
+z;

--- a/play.ts
+++ b/play.ts
@@ -1,3 +1,5 @@
 import { z } from "zod/v4";
 
 z;
+const A = z.partialRecord(z.string(), z.string());
+type A = z.infer<typeof A>;


### PR DESCRIPTION
- **Use cleaned URL minus trailing slash. Closes #4754**
- **Support readonly values. Closes #4767**
- **Add new cursor rule**
- **Make recursive unions and arrays more robust. Closes #4818 and #4751**
- **Improve inferrence when object shape contains index signature. Fixes #4817**
- **Make records non-optional. Use counter-based approach for id.**
- **Fix partialRecord**
