### PR TITLE
docs: add zod2md to zodToXConverters

### DIFF
--- a/packages/docs/components/ecosystem-v3.tsx
+++ b/packages/docs/components/ecosystem-v3.tsx
@@ -277,6 +277,12 @@ const zodToXConverters: ZodResource[] = [
     description: "(De)serialization for zod schemas",
     slug: "commonbaseapp/zodex",
   },
+  {
+    name: "zod2md",
+    url: "https://github.com/matejchalk/zod2md",
+    description: "Generate Markdown docs from Zod schemas",
+    slug: "matejchalk/zod2md",
+  },
 ];
 
 const xToZodConverters: ZodResource[] = [

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -90,7 +90,14 @@ const formIntegrations: ZodResource[] = [
   },
 ];
 
-const zodToXConverters: ZodResource[] = [];
+const zodToXConverters: ZodResource[] = [
+  {
+    name: "zod2md",
+    url: "https://github.com/matejchalk/zod2md",
+    description: "Generate Markdown docs from Zod schemas",
+    slug: "matejchalk/zod2md",
+  },
+];
 
 const xToZodConverters: ZodResource[] = [
   {


### PR DESCRIPTION
Adds my [zod2md](https://github.com/matejchalk/zod2md) library to _Zod to X_ section of _Ecosystem_ docs page. Both Zod v4 and Zod v3 are supported by this library. (The migration approach described in #4371 helped a lot, BTW.)