### PR TITLE
Add z.typeid validator

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -298,6 +298,8 @@ export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> 
   xid(params?: string | core.$ZodCheckXIDParams): this;
   /** @deprecated Use `z.ksuid()` instead. */
   ksuid(params?: string | core.$ZodCheckKSUIDParams): this;
+  /** @deprecated Use `z.typeid()` instead. */
+  typeid(params?: string | core.$ZodCheckTypeIDParams): this;
   // /** @deprecated Use `z.ipv4()` or `z.ipv6()` instead. */
   // ip(params?: string | (core.$ZodCheckIPv4Params & { version?: "v4" | "v6" })): ZodUnion<[this, this]>;
   /** @deprecated Use `z.ipv4()` instead. */
@@ -352,6 +354,7 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   inst.base64url = (params) => inst.check(core._base64url(ZodBase64URL, params));
   inst.xid = (params) => inst.check(core._xid(ZodXID, params));
   inst.ksuid = (params) => inst.check(core._ksuid(ZodKSUID, params));
+  inst.typeid = (params) => inst.check(core._typeid(ZodTypeID, params));
   inst.ipv4 = (params) => inst.check(core._ipv4(ZodIPv4, params));
   inst.ipv6 = (params) => inst.check(core._ipv6(ZodIPv6, params));
   inst.cidrv4 = (params) => inst.check(core._cidrv4(ZodCIDRv4, params));
@@ -548,6 +551,19 @@ export const ZodKSUID: core.$constructor<ZodKSUID> = /*@__PURE__*/ core.$constru
 
 export function ksuid(params?: string | core.$ZodKSUIDParams): ZodKSUID {
   return core._ksuid(ZodKSUID, params);
+}
+
+// ZodTypeID
+export interface ZodTypeID extends ZodStringFormat<"typeid"> {
+  _zod: core.$ZodTypeIDInternals;
+}
+export const ZodTypeID: core.$constructor<ZodTypeID> = /*@__PURE__*/ core.$constructor("ZodTypeID", (inst, def) => {
+  core.$ZodTypeID.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+export function typeid(params?: string | core.$ZodTypeIDParams): ZodTypeID {
+  return core._typeid(ZodTypeID, params);
 }
 
 // ZodIP

--- a/packages/zod/src/v4/classic/tests/continuability.test.ts
+++ b/packages/zod/src/v4/classic/tests/continuability.test.ts
@@ -349,4 +349,26 @@ test("continuability", () => {
       },
     ]
   `);
+  expect(
+    z
+      .typeid()
+      .refine(() => false)
+      .safeParse("invalid_value").error!.issues
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_format",
+        "format": "typeid",
+        "message": "Invalid TypeID",
+        "origin": "string",
+        "path": [],
+        "pattern": "/^(?:[a-z](?:[a-z_]{0,61}[a-z])?_)?[0-7][0-9a-hjkmnpqrstvwxyz]{25}$/",
+      },
+      {
+        "code": "custom",
+        "message": "Invalid input",
+        "path": [],
+      },
+    ]
+  `);
 });

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -612,6 +612,25 @@ test("ksuid", () => {
   `);
 });
 
+test("typeid", () => {
+  const tid = z.string().typeid();
+  tid.parse("user_01h5fskfsk4fpeqwnsyz5hj55t");
+  const result = tid.safeParse("invalidtypeid");
+  expect(result).toMatchObject({ success: false });
+  expect(result.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_format",
+        "format": "typeid",
+        "message": "Invalid TypeID",
+        "origin": "string",
+        "path": [],
+        "pattern": "/^(?:[a-z](?:[a-z_]{0,61}[a-z])?_)?[0-7][0-9a-hjkmnpqrstvwxyz]{25}$/",
+      },
+    ]
+  `);
+});
+
 test("regex", () => {
   z.string()
     .regex(/^moo+$/)
@@ -690,6 +709,7 @@ test("format", () => {
   // expect(z.string().json().format).toEqual("json_string");
   expect(z.string().xid().format).toEqual("xid");
   expect(z.string().ksuid().format).toEqual("ksuid");
+  expect(z.string().typeid().format).toEqual("typeid");
   // expect(z.string().ip().format).toEqual("ip");
   expect(z.string().ipv4().format).toEqual("ipv4");
   expect(z.string().ipv6().format).toEqual("ipv6");

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -310,6 +310,22 @@ export function _ksuid<T extends schemas.$ZodKSUID>(
   });
 }
 
+// TypeID
+export type $ZodTypeIDParams = StringFormatParams<schemas.$ZodTypeID>;
+export type $ZodCheckTypeIDParams = CheckStringFormatParams<schemas.$ZodTypeID>;
+export function _typeid<T extends schemas.$ZodTypeID>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodTypeIDParams | $ZodCheckTypeIDParams
+): T {
+  return new Class({
+    type: "string",
+    format: "typeid",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
 // IP
 // export type $ZodIPParams = StringFormatParams<schemas.$ZodIP, "pattern">;
 // export type $ZodCheckIPParams = CheckStringFormatParams<schemas.$ZodIP, "pattern">;

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -753,6 +753,7 @@ export type $ZodStringFormats =
   | "ulid"
   | "xid"
   | "ksuid"
+  | "typeid"
   | "datetime"
   | "date"
   | "time"

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -3,6 +3,7 @@ export const cuid2: RegExp = /^[0-9a-z]+$/;
 export const ulid: RegExp = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
 export const xid: RegExp = /^[0-9a-vA-V]{20}$/;
 export const ksuid: RegExp = /^[A-Za-z0-9]{27}$/;
+export const typeid: RegExp = /^(?:[a-z](?:[a-z_]{0,61}[a-z])?_)?[0-7][0-9a-hjkmnpqrstvwxyz]{25}$/;
 export const nanoid: RegExp = /^[a-zA-Z0-9_-]{21}$/;
 
 /** ISO 8601-1 duration regex. Does not support the 8601-2 extensions like negative durations or fractional/negative components. */

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -583,6 +583,23 @@ export const $ZodKSUID: core.$constructor<$ZodKSUID> = /*@__PURE__*/ core.$const
   }
 );
 
+//////////////////////////////   ZodTypeID   //////////////////////////////
+
+export interface $ZodTypeIDDef extends $ZodStringFormatDef<"typeid"> {}
+export interface $ZodTypeIDInternals extends $ZodStringFormatInternals<"typeid"> {}
+
+export interface $ZodTypeID extends $ZodType {
+  _zod: $ZodTypeIDInternals;
+}
+
+export const $ZodTypeID: core.$constructor<$ZodTypeID> = /*@__PURE__*/ core.$constructor(
+  "$ZodTypeID",
+  (inst, def): void => {
+    def.pattern ??= regexes.typeid;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
 //////////////////////////////   ZodISODateTime   //////////////////////////////
 
 export interface $ZodISODateTimeDef extends $ZodStringFormatDef<"datetime"> {
@@ -3767,6 +3784,7 @@ export type $ZodStringFormatTypes =
   | $ZodULID
   | $ZodXID
   | $ZodKSUID
+  | $ZodTypeID
   | $ZodISODateTime
   | $ZodISODate
   | $ZodISOTime

--- a/packages/zod/src/v4/locales/ar.ts
+++ b/packages/zod/src/v4/locales/ar.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "تاريخ ووقت بمعيار ISO",
     date: "تاريخ بمعيار ISO",
     time: "وقت بمعيار ISO",

--- a/packages/zod/src/v4/locales/az.ts
+++ b/packages/zod/src/v4/locales/az.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO datetime",
     date: "ISO date",
     time: "ISO time",

--- a/packages/zod/src/v4/locales/be.ts
+++ b/packages/zod/src/v4/locales/be.ts
@@ -110,6 +110,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO дата і час",
     date: "ISO дата",
     time: "ISO час",

--- a/packages/zod/src/v4/locales/ca.ts
+++ b/packages/zod/src/v4/locales/ca.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "data i hora ISO",
     date: "data ISO",
     time: "hora ISO",

--- a/packages/zod/src/v4/locales/cs.ts
+++ b/packages/zod/src/v4/locales/cs.ts
@@ -72,6 +72,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "datum a čas ve formátu ISO",
     date: "datum ve formátu ISO",
     time: "čas ve formátu ISO",

--- a/packages/zod/src/v4/locales/de.ts
+++ b/packages/zod/src/v4/locales/de.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO-Datum und -Uhrzeit",
     date: "ISO-Datum",
     time: "ISO-Uhrzeit",

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO datetime",
     date: "ISO date",
     time: "ISO time",

--- a/packages/zod/src/v4/locales/es.ts
+++ b/packages/zod/src/v4/locales/es.ts
@@ -53,6 +53,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "fecha y hora ISO",
     date: "fecha ISO",
     time: "hora ISO",

--- a/packages/zod/src/v4/locales/fa.ts
+++ b/packages/zod/src/v4/locales/fa.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "تاریخ و زمان ایزو",
     date: "تاریخ ایزو",
     time: "زمان ایزو",

--- a/packages/zod/src/v4/locales/fi.ts
+++ b/packages/zod/src/v4/locales/fi.ts
@@ -58,6 +58,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO-aikaleima",
     date: "ISO-päivämäärä",
     time: "ISO-aika",

--- a/packages/zod/src/v4/locales/fr-CA.ts
+++ b/packages/zod/src/v4/locales/fr-CA.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "date-heure ISO",
     date: "date ISO",
     time: "heure ISO",

--- a/packages/zod/src/v4/locales/fr.ts
+++ b/packages/zod/src/v4/locales/fr.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "date et heure ISO",
     date: "date ISO",
     time: "heure ISO",

--- a/packages/zod/src/v4/locales/he.ts
+++ b/packages/zod/src/v4/locales/he.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "תאריך וזמן ISO",
     date: "תאריך ISO",
     time: "זמן ISO",

--- a/packages/zod/src/v4/locales/hu.ts
+++ b/packages/zod/src/v4/locales/hu.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO időbélyeg",
     date: "ISO dátum",
     time: "ISO idő",

--- a/packages/zod/src/v4/locales/id.ts
+++ b/packages/zod/src/v4/locales/id.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "tanggal dan waktu format ISO",
     date: "tanggal format ISO",
     time: "jam format ISO",

--- a/packages/zod/src/v4/locales/it.ts
+++ b/packages/zod/src/v4/locales/it.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "data e ora ISO",
     date: "data ISO",
     time: "ora ISO",

--- a/packages/zod/src/v4/locales/ja.ts
+++ b/packages/zod/src/v4/locales/ja.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO日時",
     date: "ISO日付",
     time: "ISO時刻",

--- a/packages/zod/src/v4/locales/kh.ts
+++ b/packages/zod/src/v4/locales/kh.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "កាលបរិច្ឆេទ និងម៉ោង ISO",
     date: "កាលបរិច្ឆេទ ISO",
     time: "ម៉ោង ISO",

--- a/packages/zod/src/v4/locales/ko.ts
+++ b/packages/zod/src/v4/locales/ko.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO 날짜시간",
     date: "ISO 날짜",
     time: "ISO 시간",

--- a/packages/zod/src/v4/locales/mk.ts
+++ b/packages/zod/src/v4/locales/mk.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO датум и време",
     date: "ISO датум",
     time: "ISO време",

--- a/packages/zod/src/v4/locales/ms.ts
+++ b/packages/zod/src/v4/locales/ms.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "tarikh masa ISO",
     date: "tarikh ISO",
     time: "masa ISO",

--- a/packages/zod/src/v4/locales/nl.ts
+++ b/packages/zod/src/v4/locales/nl.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO datum en tijd",
     date: "ISO datum",
     time: "ISO tijd",

--- a/packages/zod/src/v4/locales/no.ts
+++ b/packages/zod/src/v4/locales/no.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO dato- og klokkeslett",
     date: "ISO-dato",
     time: "ISO-klokkeslett",

--- a/packages/zod/src/v4/locales/ota.ts
+++ b/packages/zod/src/v4/locales/ota.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO hengâmı",
     date: "ISO tarihi",
     time: "ISO zamanı",

--- a/packages/zod/src/v4/locales/pl.ts
+++ b/packages/zod/src/v4/locales/pl.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "data i godzina w formacie ISO",
     date: "data w formacie ISO",
     time: "godzina w formacie ISO",

--- a/packages/zod/src/v4/locales/ps.ts
+++ b/packages/zod/src/v4/locales/ps.ts
@@ -53,6 +53,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "نیټه او وخت",
     date: "نېټه",
     time: "وخت",

--- a/packages/zod/src/v4/locales/pt.ts
+++ b/packages/zod/src/v4/locales/pt.ts
@@ -53,6 +53,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "data e hora ISO",
     date: "data ISO",
     time: "hora ISO",

--- a/packages/zod/src/v4/locales/ru.ts
+++ b/packages/zod/src/v4/locales/ru.ts
@@ -110,6 +110,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO дата и время",
     date: "ISO дата",
     time: "ISO время",

--- a/packages/zod/src/v4/locales/sl.ts
+++ b/packages/zod/src/v4/locales/sl.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO datum in čas",
     date: "ISO datum",
     time: "ISO čas",

--- a/packages/zod/src/v4/locales/sv.ts
+++ b/packages/zod/src/v4/locales/sv.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO-datum och tid",
     date: "ISO-datum",
     time: "ISO-tid",

--- a/packages/zod/src/v4/locales/ta.ts
+++ b/packages/zod/src/v4/locales/ta.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO தேதி நேரம்",
     date: "ISO தேதி",
     time: "ISO நேரம்",

--- a/packages/zod/src/v4/locales/th.ts
+++ b/packages/zod/src/v4/locales/th.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "วันที่เวลาแบบ ISO",
     date: "วันที่แบบ ISO",
     time: "เวลาแบบ ISO",

--- a/packages/zod/src/v4/locales/tr.ts
+++ b/packages/zod/src/v4/locales/tr.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO tarih ve saat",
     date: "ISO tarih",
     time: "ISO saat",

--- a/packages/zod/src/v4/locales/ua.ts
+++ b/packages/zod/src/v4/locales/ua.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "дата та час ISO",
     date: "дата ISO",
     time: "час ISO",

--- a/packages/zod/src/v4/locales/ur.ts
+++ b/packages/zod/src/v4/locales/ur.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "یو ایل آئی ڈی",
     xid: "ایکس آئی ڈی",
     ksuid: "کے ایس یو آئی ڈی",
+    typeid: "TypeID",
     datetime: "آئی ایس او ڈیٹ ٹائم",
     date: "آئی ایس او تاریخ",
     time: "آئی ایس او وقت",

--- a/packages/zod/src/v4/locales/vi.ts
+++ b/packages/zod/src/v4/locales/vi.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ngày giờ ISO",
     date: "ngày ISO",
     time: "giờ ISO",

--- a/packages/zod/src/v4/locales/zh-CN.ts
+++ b/packages/zod/src/v4/locales/zh-CN.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO日期时间",
     date: "ISO日期",
     time: "ISO时间",

--- a/packages/zod/src/v4/locales/zh-TW.ts
+++ b/packages/zod/src/v4/locales/zh-TW.ts
@@ -54,6 +54,7 @@ const error: () => errors.$ZodErrorMap = () => {
     ulid: "ULID",
     xid: "XID",
     ksuid: "KSUID",
+    typeid: "TypeID",
     datetime: "ISO 日期時間",
     date: "ISO 日期",
     time: "ISO 時間",

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -291,6 +291,22 @@ export function ksuid(params?: string | core.$ZodKSUIDParams): ZodMiniKSUID {
   return core._ksuid(ZodMiniKSUID, params);
 }
 
+// ZodMiniTypeID
+export interface ZodMiniTypeID extends _ZodMiniString<core.$ZodTypeIDInternals> {
+  // _zod: core.$ZodTypeIDInternals;
+}
+export const ZodMiniTypeID: core.$constructor<ZodMiniTypeID> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniTypeID",
+  (inst, def) => {
+    core.$ZodTypeID.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function typeid(params?: string | core.$ZodTypeIDParams): ZodMiniTypeID {
+  return core._typeid(ZodMiniTypeID, params);
+}
+
 // ZodMiniIPv4
 export interface ZodMiniIPv4 extends _ZodMiniString<core.$ZodIPv4Internals> {
   // _zod: core.$ZodIPv4Internals;

--- a/packages/zod/src/v4/mini/tests/string.test.ts
+++ b/packages/zod/src/v4/mini/tests/string.test.ts
@@ -201,6 +201,12 @@ test("z.ksuid", () => {
   expect(() => z.parse(a, "abc")).toThrow();
 });
 
+test("z.typeid", () => {
+  const a = z.typeid();
+  expect(z.parse(a, "user_01h5fskfsk4fpeqwnsyz5hj55t")).toEqual("user_01h5fskfsk4fpeqwnsyz5hj55t");
+  expect(() => z.parse(a, "abc")).toThrow();
+});
+
 // test("z.ip", () => {
 //   const a = z.ip();
 //   expect(z.parse(a, "127.0.0.1")).toEqual("127.0.0.1");


### PR DESCRIPTION
## Summary
- implement `typeid` string format validator
- expose new TypeID schema in core API and classic/mini APIs
- update locales with TypeID noun
- add tests for `typeid`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6866355de178832fa2c7ba3f38e32f3b