### PR TITLE
Add safeExtend for objects

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1046,6 +1046,16 @@ export function keyof<T extends ZodObject>(schema: T): ZodLiteral<Exclude<keyof 
 
 // ZodObject
 
+export type SafeExtendShape<Base extends core.$ZodShape, Ext extends core.$ZodLooseShape> = {
+  [K in keyof Ext]: K extends keyof Base
+    ? core.output<Ext[K]> extends core.output<Base[K]>
+      ? core.input<Ext[K]> extends core.input<Base[K]>
+        ? Ext[K]
+        : never
+      : never
+    : Ext[K];
+};
+
 export interface ZodObject<
   /** @ts-ignore Cast variance */
   out Shape extends core.$ZodShape = core.$ZodLooseShape,
@@ -1071,6 +1081,10 @@ export interface ZodObject<
 
   extend<U extends core.$ZodLooseShape & Partial<Record<keyof Shape, core.SomeType>>>(
     shape: U
+  ): ZodObject<util.Extend<Shape, U>, Config>;
+
+  safeExtend<U extends core.$ZodLooseShape>(
+    shape: SafeExtendShape<Shape, U> & Partial<Record<keyof Shape, core.SomeType>>
   ): ZodObject<util.Extend<Shape, U>, Config>;
 
   /**
@@ -1148,6 +1162,9 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
 
   inst.extend = (incoming: any) => {
     return util.extend(inst, incoming);
+  };
+  inst.safeExtend = (incoming: any) => {
+    return util.safeExtend(inst, incoming);
   };
   inst.merge = (other) => util.merge(inst, other);
   inst.pick = (mask) => util.pick(inst, mask);

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -420,6 +420,17 @@ test("extend() should have power to override existing key", () => {
   expectTypeOf<PersonWithNumberAsLastName>().toEqualTypeOf<{ firstName: string; lastName: number }>();
 });
 
+test("safeExtend() maintains refinements", () => {
+  const schema = z.object({ name: z.string().min(1) });
+  const extended = schema.safeExtend({ name: z.string().min(2) });
+  expect(() => extended.parse({ name: "" })).toThrow();
+  expect(extended.parse({ name: "ab" })).toEqual({ name: "ab" });
+  type Extended = z.infer<typeof extended>;
+  expectTypeOf<Extended>().toEqualTypeOf<{ name: string }>();
+  // @ts-expect-error
+  schema.safeExtend({ name: z.number() });
+});
+
 test("passthrough index signature", () => {
   const a = z.object({ a: z.string() });
   type a = z.infer<typeof a>;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -589,6 +589,22 @@ export function extend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): an
   return clone(schema, def) as any;
 }
 
+export function safeExtend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): any {
+  if (!isPlainObject(shape)) {
+    throw new Error("Invalid input to safeExtend: expected a plain object");
+  }
+  const def = {
+    ...schema._zod.def,
+    get shape() {
+      const _shape = { ...schema._zod.def.shape, ...shape };
+      assignProp(this, "shape", _shape); // self-caching
+      return _shape;
+    },
+    checks: schema._zod.def.checks,
+  } as any;
+  return clone(schema, def) as any;
+}
+
 export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
   return clone(a, {
     ...a._zod.def,

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -790,6 +790,23 @@ export function extend<T extends ZodMiniObject, U extends core.$ZodLooseShape>(
   return util.extend(schema, shape);
 }
 
+export type SafeExtendShape<Base extends core.$ZodShape, Ext extends core.$ZodLooseShape> = {
+  [K in keyof Ext]: K extends keyof Base
+    ? core.output<Ext[K]> extends core.output<Base[K]>
+      ? core.input<Ext[K]> extends core.input<Base[K]>
+        ? Ext[K]
+        : never
+      : never
+    : Ext[K];
+};
+
+export function safeExtend<T extends ZodMiniObject, U extends core.$ZodLooseShape>(
+  schema: T,
+  shape: SafeExtendShape<T["shape"], U>
+): ZodMiniObject<util.Extend<T["shape"], U>, T["_zod"]["config"]> {
+  return util.safeExtend(schema, shape as any);
+}
+
 /** @deprecated Identical to `z.extend(A, B)` */
 export function merge<T extends ZodMiniObject, U extends ZodMiniObject>(
   a: T,

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -110,6 +110,15 @@ test("z.extend", () => {
   expect(z.safeParse(extendedSchema, { name: "John", age: 30, isAdmin: true }).success).toBe(true);
 });
 
+test("z.safeExtend", () => {
+  const extended = z.safeExtend(userSchema, { name: z.string() });
+  expect(z.safeParse(extended, { name: "John", age: 30 }).success).toBe(true);
+  type Extended = z.infer<typeof extended>;
+  expectTypeOf<Extended>().toEqualTypeOf<{ name: string; age: number; email?: string }>();
+  // @ts-expect-error
+  z.safeExtend(userSchema, { name: z.number() });
+});
+
 test("z.pick", () => {
   const pickedSchema = z.pick(userSchema, { name: true, email: true });
   type PickedUser = z.infer<typeof pickedSchema>;


### PR DESCRIPTION
## Summary
- introduce `safeExtend` utility in core
- expose `safeExtend` method on `ZodObject`
- add `safeExtend` for ZodMini
- test safeExtend in both Classic and Mini variants

## Testing
- `npx biome check packages/zod/src/v4/mini/schemas.ts`
- `npx biome check packages/zod/src/v4/classic/schemas.ts`
- `npx biome check packages/zod/src/v4/mini/tests/object.test.ts`
- `npx biome check packages/zod/src/v4/classic/tests/object.test.ts`
- `npx biome check packages/zod/src/v4/core/util.ts`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686efeb26058832f824fe50333b23f9e