### PR TITLE
Allow closure in object.extend

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1070,7 +1070,7 @@ export interface ZodObject<
   strip(): ZodObject<Shape, core.$strip>;
 
   extend<U extends core.$ZodLooseShape & Partial<Record<keyof Shape, core.SomeType>>>(
-    shape: U
+    shape: U | ((shape: Shape) => U)
   ): ZodObject<util.Extend<Shape, U>, Config>;
 
   /**

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -420,6 +420,17 @@ test("extend() should have power to override existing key", () => {
   expectTypeOf<PersonWithNumberAsLastName>().toEqualTypeOf<{ firstName: string; lastName: number }>();
 });
 
+test("extend() accepts a closure over shape", () => {
+  const WithMinLastName = personToExtend.extend((shape) => ({
+    lastName: shape.lastName.min(5),
+  }));
+  expect(WithMinLastName.parse({ firstName: "f", lastName: "abcdef" })).toEqual({
+    firstName: "f",
+    lastName: "abcdef",
+  });
+  expect(() => WithMinLastName.parse({ firstName: "f", lastName: "abc" })).toThrow();
+});
+
 test("passthrough index signature", () => {
   const a = z.object({ a: z.string() });
   type a = z.infer<typeof a>;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -573,7 +573,11 @@ export function omit(schema: schemas.$ZodObject, mask: object): any {
   });
 }
 
-export function extend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): any {
+export function extend(
+  schema: schemas.$ZodObject,
+  shapeOrFactory: schemas.$ZodShape | ((shape: schemas.$ZodShape) => schemas.$ZodShape)
+): any {
+  const shape = typeof shapeOrFactory === "function" ? shapeOrFactory(schema._zod.def.shape) : shapeOrFactory;
   if (!isPlainObject(shape)) {
     throw new Error("Invalid input to extend: expected a plain object");
   }

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -785,9 +785,9 @@ export function looseObject<T extends core.$ZodLooseShape>(
 // object methods
 export function extend<T extends ZodMiniObject, U extends core.$ZodLooseShape>(
   schema: T,
-  shape: U
+  shape: U | ((shape: T["shape"]) => U)
 ): ZodMiniObject<util.Extend<T["shape"], U>, T["_zod"]["config"]> {
-  return util.extend(schema, shape);
+  return util.extend(schema, shape as any);
 }
 
 /** @deprecated Identical to `z.extend(A, B)` */

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -110,6 +110,14 @@ test("z.extend", () => {
   expect(z.safeParse(extendedSchema, { name: "John", age: 30, isAdmin: true }).success).toBe(true);
 });
 
+test("z.extend with closure", () => {
+  const extendedSchema = z.extend(userSchema, (shape) => ({
+    name: shape.name.check(z.minLength(3)),
+  }));
+  expect(z.safeParse(extendedSchema, { name: "John", age: 30 }).success).toBe(true);
+  expect(z.safeParse(extendedSchema, { name: "Jo", age: 30 }).success).toBe(false);
+});
+
 test("z.pick", () => {
   const pickedSchema = z.pick(userSchema, { name: true, email: true });
   type PickedUser = z.infer<typeof pickedSchema>;


### PR DESCRIPTION
## Summary
- support passing a callback to `extend` giving access to the current shape
- test classic and mini APIs

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686eff033598832fa2c79432e3c667a3