### PR TITLE
Include export to `zod/core` + update documentation and tests

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -220,7 +220,7 @@ result.error.issues;
 
 The `iss` object is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) of all possible issue types. Use the `code` property to discriminate between them.
 
-> For a breakdown of all Zod issue codes, see the [`zod/v4/core`](/packages/core#issue-types) documentation.
+> For a breakdown of all Zod issue codes, see the [`zod/core`](/packages/core#issue-types) documentation.
 
 ```ts
 const result = schema.safeParse(12, {
@@ -272,7 +272,7 @@ Global error messages have *lower precedence* than schema-level or per-parse err
 
 The `iss` object is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) of all possible issue types. Use the `code` property to discriminate between them.
 
-> For a breakdown of all Zod issue codes, see the [`zod/v4/core`](/packages/core#issue-types) documentation.
+> For a breakdown of all Zod issue codes, see the [`zod/core`](/packages/core#issue-types) documentation.
 
 ```ts
 const result = schema.safeParse(12, {
@@ -290,7 +290,7 @@ const result = schema.safeParse(12, {
 
 ## Internationalization
 
-To support internationalization of error message, Zod provides several built-in **locales**. These are exported from the `zod/v4/core` package.
+To support internationalization of error message, Zod provides several built-in **locales**. These are exported from the `zod/core` package.
 
 > **Note** — The regular `zod` library automatically loads the `en` locale automatically. Zod Mini does not load any locale by default; instead all error messages default to `Invalid input`.
 

--- a/packages/docs/content/library-authors.mdx
+++ b/packages/docs/content/library-authors.mdx
@@ -4,7 +4,7 @@ title: For library authors
 
 import { Callout } from "fumadocs-ui/components/callout"
 
-<Callout title="Update — July 10th, 2025">
+<Callout title="Update — July 12th, 2025">
 Zod `4.0.0` has been released on `npm`. This completes the incremental rollout process described below. To add support, bump your peer dependency to include `zod@^4.0.0`:
 
 ```json
@@ -16,7 +16,7 @@ Zod `4.0.0` has been released on `npm`. This completes the incremental rollout p
 }
 ```
 
-If you'd already implemented Zod 4 support according to the best practices described below (e.g. using the `"zod/v4/core"` subpath), then no other code changes should be necessary. This should not require a major version bump in your library.
+If you'd already implemented Zod 4 support according to the best practices described below (e.g. using the `"zod/v4/core"` or `"zod/core"`), then no other code changes should be necessary. This should not require a major version bump in your library.
 </Callout>
  
 
@@ -78,21 +78,21 @@ To support Zod 4, update the minimum version for your `"zod"` peer dependency to
 }
 ```
 
-Starting with `v3.25.0`, the Zod 4 core package is available at the `"zod/v4/core"` subpath. Read the [Versioning in Zod 4](https://github.com/colinhacks/zod/issues/4371) writeup for full context on this versioning approach.
+Starting with `v3.25.0`, the Zod 4 core package is available at the `"zod/v4/core"` subpath. With the latest version of Zod you can also import from `"zod/core"`, that's the recommended way to import the core package from now on. Read the [Versioning in Zod 4](https://github.com/colinhacks/zod/issues/4371) writeup for full context on this versioning approach.
 
 ```ts
-import * as z4 from "zod/v4/core";
+import * as z4 from "zod/core";
 ```
 
 Import from these subpaths only. Think of them like "permalinks" to their respective Zod versions. These will remain available forever.
 
 - `"zod/v3"` for Zod 3 ✅ 
-- `"zod/v4/core"` for the Zod 4 Core package ✅
+- `"zod/core"` for the Zod 4 Core package ✅
 
 You generally shouldn't be importing from any other paths. The Zod Core library is a shared library that undergirds both Zod 4 Classic and Zod 4 Mini. It's generally a bad idea to implement any functionality that is specific to one or the other. Do not import from these subpaths:
 
 - `"zod"` — ❌ In 3.x releases, this exports Zod 3. In 4.x releases, this will export Zod 4. Use the permalinks instead. 
-- `"zod/v4"` and `"zod/v4/mini"`— ❌ These subpaths are the homes of Zod 4 Classic and Mini, respectively. If you want your library to work with both Zod and Zod Mini, you should build against the base classes defined in `"zod/v4/core"`. If you reference classes from the `"zod/v4"` module, your library will not work with Zod Mini, and vice versa. This is extremely discouraged. Use `"zod/v4/core"` instead, which exports the `$`-prefixed subclasses that are extended by Zod Classic and Zod Mini. The internals of the classic & mini subclasses are identical; they only differ in which helper methods they implement.
+- `"zod/v4"` and `"zod/v4/mini"`— ❌ These subpaths are the homes of Zod 4 Classic and Mini, respectively. If you want your library to work with both Zod and Zod Mini, you should build against the base classes defined in `"zod/core"`. If you reference classes from the `"zod/v4"` module, your library will not work with Zod Mini, and vice versa. This is extremely discouraged. Use `"zod/core"` instead, which exports the `$`-prefixed subclasses that are extended by Zod Classic and Zod Mini. The internals of the classic & mini subclasses are identical; they only differ in which helper methods they implement.
 
 
 ## Do I need to publish a new major version?
@@ -107,7 +107,7 @@ Starting in `v3.25.0`, the package contains copies of both Zod 3 and Zod 4 at th
 
 ```ts
 import * as z3 from "zod/v3";
-import * as z4 from "zod/v4/core";
+import * as z4 from "zod/core";
 
 type Schema = z3.ZodTypeAny | z4.$ZodType;
 
@@ -120,7 +120,7 @@ To differentiate between Zod 3 and Zod 4 schemas at runtime, check for the `"_zo
 
 ```ts
 import type * as z3 from "zod/v3";
-import type * as z4 from "zod/v4/core";
+import type * as z4 from "zod/core";
 
 declare const schema: z3.ZodTypeAny | v4.$ZodType;
 
@@ -133,11 +133,11 @@ if ("_zod" in schema) {
 
 ## How to support Zod and Zod Mini simultaneously?
 
-Your library code should only import from `"zod/v4/core"`. This sub-package defines the interfaces, classes, and utilities that are shared between Zod and Zod Mini. 
+Your library code should only import from `"zod/core"`. This sub-package defines the interfaces, classes, and utilities that are shared between Zod and Zod Mini. 
 
 ```ts
 // library code
-import * as z4 from "zod/v4/core";
+import * as z4 from "zod/core";
 
 export function acceptObjectSchema<T extends z4.$ZodObject>(schema: T){
   // parse data
@@ -197,7 +197,7 @@ Accepting user-defined schemas is the a fundamental operation for any library bu
 When starting out, it may be tempting to write a function that accepts a Zod schema like this:
 
 ```ts
-import * as z4 from "zod/v4/core";
+import * as z4 from "zod/core";
 
 function inferSchema<T>(schema: z4.$ZodType<T>) {
   return schema;
@@ -226,7 +226,7 @@ To constrain the input schema to a specific subclass:
 
 ```ts
 
-import * as z4 from "zod/v4/core";
+import * as z4 from "zod/core";
 
 // only accepts object schemas
 function inferSchema<T>(schema: z4.$ZodObject) {
@@ -238,7 +238,7 @@ To constrain the inferred output type of the input schema:
 
 ```ts
 
-import * as z4 from "zod/v4/core";
+import * as z4 from "zod/core";
 
 // only accepts string schemas
 function inferSchema<T extends z4.$ZodType<string>>(schema: T) {

--- a/packages/docs/content/packages/core.mdx
+++ b/packages/docs/content/packages/core.mdx
@@ -8,7 +8,7 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 This sub-package exports the core classes and utilities that are consumed by Zod and Zod Mini. It is not intended to be used directly; instead it's designed to be extended by other packages. It implements:
 
 ```ts
-import * as z from "zod/v4/core";
+import * as z from "zod/core";
 
 // the base class for all Zod schemas
 z.$ZodType;
@@ -46,7 +46,7 @@ export class $ZodType<Output = unknown, Input = unknown> {
 }
 ```
 
-`zod/v4/core` exports a number of subclasses that implement some common parsers. A union of all first-party subclasses is exported as `z.$ZodTypes`.
+`zod/core` exports a number of subclasses that implement some common parsers. A union of all first-party subclasses is exported as `z.$ZodTypes`.
 
 ```ts
 export type $ZodTypes =
@@ -164,7 +164,7 @@ export type $ZodTypes =
 
 ## Internals
 
-All `zod/v4/core` subclasses only contain a single property: `_zod`. This property is an object containing the schemas *internals*. The goal is to make `zod/v4/core` as extensible and unopinionated as possible. Other libraries can "build their own Zod" on top of these classes without `zod/v4/core` cluttering up the interface. Refer to the implementations of `zod` and `zod/mini` for examples of how to extend these classes. 
+All `zod/core` subclasses only contain a single property: `_zod`. This property is an object containing the schemas *internals*. The goal is to make `zod/core` as extensible and unopinionated as possible. Other libraries can "build their own Zod" on top of these classes without `zod/core` cluttering up the interface. Refer to the implementations of `zod` and `zod/mini` for examples of how to extend these classes. 
 
 The `_zod` internals property contains some notable properties:
 
@@ -229,7 +229,7 @@ export type $ZodStringFormatTypes =
 As the Zod Core schema classes have no methods, there are top-level functions for parsing data.
 
 ```ts
-import * as z from "zod/v4/core";
+import * as z from "zod/core";
 
 const schema = new z.$ZodString({ type: "string" });
 z.parse(schema, "hello");
@@ -265,7 +265,7 @@ The `_zod` internals property contains some notable properties:
   - `.def.check` — A string representing the check's type, e.g. `"min_length"`, `"less_than"`, `"string_format"`, etc.
 - `.check()` — Contains the check's validation logic.
 
-`zod/v4/core` exports a number of subclasses that perform some common refinements. All first-party subclasses are exported as a union called `z.$ZodChecks`.
+`zod/core` exports a number of subclasses that perform some common refinements. All first-party subclasses are exported as a union called `z.$ZodChecks`.
 
 ```ts
 export type $ZodChecks =

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -108,7 +108,7 @@ Generally, the round trip time to the server (`100-200ms`) will dwarf the time r
 
 ## `ZodMiniType`
 
-All Zod Mini schemas extend the `z.ZodMiniType` base class, which in turn extends `z.core.$ZodType` from [`zod/v4/core`](/packages/core). While this class implements far fewer methods than `ZodType` in `zod`, some particularly useful methods remain.
+All Zod Mini schemas extend the `z.ZodMiniType` base class, which in turn extends `z.core.$ZodType` from [`zod/core`](/packages/core). While this class implements far fewer methods than `ZodType` in `zod`, some particularly useful methods remain.
 
 
 ### `.parse`

--- a/packages/docs/content/packages/zod.mdx
+++ b/packages/docs/content/packages/zod.mdx
@@ -27,7 +27,7 @@ z.string()
   .toLowerCase();
 ```
 
-All schemas extend the `z.ZodType` base class, which in turn extends `z.$ZodType` from [`zod/v4/core`](/packages/core). All instance of `ZodType` implement the following methods:
+All schemas extend the `z.ZodType` base class, which in turn extends `z.$ZodType` from [`zod/core`](/packages/core). All instance of `ZodType` implement the following methods:
 
 ```ts
 import * as z from "zod";

--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -911,13 +911,13 @@ z.number().overwrite(val => val ** 2).max(100);
 
 > The existing `.trim()`, `.toLowerCase()` and `.toUpperCase()` methods have been reimplemented using `.overwrite()`.
 
-## An extensible foundation: `zod/v4/core`
+## An extensible foundation: `zod/core`
 
-While this will not be relevant to the majority of Zod users, it's worth highlighting. The addition of Zod Mini necessitated the creation of a shared sub-package `zod/v4/core` which contains the core functionality shared between Zod and Zod Mini. 
+While this will not be relevant to the majority of Zod users, it's worth highlighting. The addition of Zod Mini necessitated the creation of a shared sub-package `zod/core` which contains the core functionality shared between Zod and Zod Mini. 
 
 I was resistant to this at first, but now I see it as one of Zod 4's most important features. It lets Zod level up from a simple library to a fast validation "substrate" that can be sprinkled into other libraries.
 
-If you're building a schema library, refer to the implementations of Zod and Zod Mini to see how to build on top of the foundation `zod/v4/core` provides. Don't hesitate to get in touch in GitHub discussions or via [X](https://x.com/colinhacks)/[Bluesky](https://bsky.app/profile/colinhacks.com) for help or feedback.
+If you're building a schema library, refer to the implementations of Zod and Zod Mini to see how to build on top of the foundation `zod/core` provides. Don't hesitate to get in touch in GitHub discussions or via [X](https://x.com/colinhacks)/[Bluesky](https://bsky.app/profile/colinhacks.com) for help or feedback.
 
 
 ## Wrapping up

--- a/packages/resolution/attw.test.ts
+++ b/packages/resolution/attw.test.ts
@@ -56,6 +56,15 @@ describe("Are The Types Wrong (attw) tests", () => {
 
       ***********************************
 
+      "zod/core"
+
+      node10: 🟢 
+      node16 (from CJS): 🟢 (CJS)
+      node16 (from ESM): 🎭 Masquerading as CJS
+      bundler: 🟢 
+
+      ***********************************
+
       "zod/locales"
 
       node10: 🟢 

--- a/packages/zod/jsr.json
+++ b/packages/zod/jsr.json
@@ -5,6 +5,7 @@
     "./package.json": "./package.json",
     ".": "./src/index.ts",
     "./mini": "./src/v4/mini/index.ts",
+    "./core": "./src/v4/core/index.ts",
     "./v3": "./src/v3/index.ts",
     "./v4": "./src/v4/index.ts",
     "./v4-mini": "./src/v4-mini/index.ts",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -32,6 +32,7 @@
       "./package.json": "./package.json",
       ".": "./src/index.ts",
       "./mini": "./src/mini/index.ts",
+      "./core": "./src/core/index.ts",
       "./locales": "./src/locales/index.ts",
       "./v3": "./src/v3/index.ts",
       "./v4": "./src/v4/index.ts",
@@ -58,6 +59,12 @@
       "types": "./mini/index.d.cts",
       "import": "./mini/index.js",
       "require": "./mini/index.cjs"
+    },
+    "./core": {
+      "@zod/source": "./src/core/index.ts",
+      "types": "./core/index.d.cts",
+      "import": "./core/index.js",
+      "require": "./core/index.cjs"
     },
     "./locales": {
       "@zod/source": "./src/locales/index.ts",

--- a/packages/zod/src/core/index.ts
+++ b/packages/zod/src/core/index.ts
@@ -1,0 +1,1 @@
+export * from "../v4/core/index.js";

--- a/packages/zod/src/v4/classic/tests/firstparty.test.ts
+++ b/packages/zod/src/v4/classic/tests/firstparty.test.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, test } from "vitest";
+import type * as core from "zod/core";
 import * as z from "zod/v4";
-import type * as core from "zod/v4/core";
 
 test("first party switch", () => {
   const myType = z.string() as core.$ZodTypes;

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, expectTypeOf, test } from "vitest";
+import type { util } from "zod/core";
 import * as z from "zod/v4";
-import type { util } from "zod/v4/core";
 
 test("z.boolean", () => {
   const a = z.boolean();

--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -1,5 +1,5 @@
 import { expect, expectTypeOf, test } from "vitest";
-import type { util } from "zod/v4/core";
+import type { util } from "zod/core";
 
 import * as z from "zod/v4";
 

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -1,6 +1,6 @@
 import { expect, expectTypeOf, test } from "vitest";
+import * as core from "zod/core";
 import * as z from "zod/v4";
-import * as core from "zod/v4/core";
 
 const Test = z.object({
   f1: z.number(),

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import * as z from "zod/v4";
-// import * as zCore from "zod/v4/core";
+// import * as zCore from "zod/core";
 
 describe("toJSONSchema", () => {
   test("primitive types", () => {

--- a/packages/zod/src/v4/mini/tests/computed.test.ts
+++ b/packages/zod/src/v4/mini/tests/computed.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
+import { util as zc } from "zod/core";
 import * as z from "zod/mini";
-import { util as zc } from "zod/v4/core";
 
 test("min/max", () => {
   const a = z.number().check(z.minimum(5), z.minimum(6), z.minimum(7), z.maximum(10), z.maximum(11), z.maximum(12));

--- a/packages/zod/src/v4/mini/tests/functions.test.ts
+++ b/packages/zod/src/v4/mini/tests/functions.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-// import * as z from "zod/v4/core";
+// import * as z from "zod/core";
 
 test("z.function", () => {
   expect(true).toEqual(true);

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, expectTypeOf, test } from "vitest";
+import type { util } from "zod/core";
 import * as z from "zod/mini";
-import type { util } from "zod/v4/core";
 
 test("z.boolean", () => {
   const a = z.boolean();


### PR DESCRIPTION
With the release of Zod ^4.0.0, we now have clean exports for modules like `zod/mini`, which is great. I think it makes sense to also add a similar export for the core package (`zod/core`).  WDYT?

I've opened a quick PR to introduce this—curious to hear your thoughts! If you notice any missing doc updates or anything else that needs tweaking, feel free to point it out and I’ll fix it. 

Thanks!

CC: @colinhacks 