### PR TITLE
Add missing field to $ZodIssueInvalidType

### DIFF
--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -20,6 +20,7 @@ export interface $ZodIssueBase {
 export interface $ZodIssueInvalidType<Input = unknown> extends $ZodIssueBase {
   readonly code: "invalid_type";
   readonly expected: $ZodType["_zod"]["def"]["type"];
+  readonly received?: "NaN" | "Infinity" | "Invalid Date";
   readonly input: Input;
 }
 


### PR DESCRIPTION
The `received` field is present on some invalid_type issues, but gave a TypeScript error when I tried to use it.

PS. It seems to me like the `input` field should be marked as optional, since it's only present if the `reportInput` flag is set. Based on the TS typings, I assumed it's always present and tried to use it, only to find out it can be undefined.
But that's a slightly bigger change and should get its own PR.