### PR TITLE
Add GitHub sponsor button to docs

### DIFF
--- a/packages/docs/app/(doc)/layout.tsx
+++ b/packages/docs/app/(doc)/layout.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 
 import { SidebarItem, SidebarSeparator } from "@/components/sidebar-item";
 import { SidebarLogo } from "@/components/sidebar-logo";
+import { SponsorButton } from "@/components/sponsor-button";
 
 const layoutProps: DocsLayoutProps = {
   ...baseOptions,
@@ -46,6 +47,7 @@ const layoutProps: DocsLayoutProps = {
     transparentMode: "top",
     enabled: true,
     enableSearch: true,
+    children: <SponsorButton />,
   },
   links: [
     {

--- a/packages/docs/components/sponsor-button.tsx
+++ b/packages/docs/components/sponsor-button.tsx
@@ -1,0 +1,19 @@
+"use client";
+import Script from "next/script";
+
+export function SponsorButton() {
+  return (
+    <>
+      <Script src="https://buttons.github.io/buttons.js" strategy="lazyOnload" />
+      <a
+        className="github-button"
+        href="https://github.com/sponsors/colinhacks"
+        data-icon="octicon-heart"
+        data-color-scheme="no-preference: light; light: light; dark: dark;"
+        aria-label="Sponsor colinhacks on GitHub"
+      >
+        Sponsor
+      </a>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- show a GitHub Sponsors button next to the docs nav logo
- load the official GitHub Sponsors script

## Testing
- `pnpm test`
- `pnpm format:check`
- `pnpm lint:check`


------
https://chatgpt.com/codex/tasks/task_e_687970262dd4832fbb1353b0ce154232