### PR TITLE
docs: fix refine() when() example copy-pasted comment

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2078,7 +2078,7 @@ const schema = z
 schema.parse({
   password: "asdf",
   confirmPassword: "asdf",
-  anotherField: 1234 // ❌ this error will prevent the password check from running
+  anotherField: 1234 // ❌ this error will not prevent the password check from running
 });
 ```
 </Tab>


### PR DESCRIPTION
Fix refine() when() example copy-pasted comment. 