### PR TITLE
Fix URL sup example

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -306,7 +306,7 @@ const schema = z.url();
 schema.parse("https://example.com"); // ✅
 schema.parse("http://localhost"); // ✅
 schema.parse("mailto:noreply@zod.dev"); // ✅
-schema.parse("sup"); // ✅
+schema.parse("sup"); // ❌
 ```
 
 As you can see this is quite permissive. Internally this uses the `new URL()` constructor to validate inputs; this behavior may differ across platforms and runtimes but it's the mostly rigorous way to validate URIs/URLs on any given JS runtime/engine. 


### PR DESCRIPTION
> Internally this uses the `new URL()` constructor to validate inputs

Bellow code will fail

```ts
const schema = z.url();
schema.parse("sup");
```