### PR TITLE
Update docs z.enum with object literal example

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -695,7 +695,7 @@ FishEnum.parse("Swordfish"); // => ❌
   ```
 </Callout>
 
-Object literals are supported.
+Enum-like object literals (`{ [key: string]: string | number }`) are supported.
 
 ```ts
 const Fish = {

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -700,7 +700,7 @@ Object literals are supported.
 ```ts
 const Fish = {
   Salmon: "Salmon",
-  Tuna: "Tuna,
+  Tuna: "Tuna
 } as const
 
 const FishEnum = z.enum(Fish)

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -700,7 +700,7 @@ Object literals are supported.
 ```ts
 const Fish = {
   Salmon: "Salmon",
-  "Tuna": "Tuna,
+  Tuna: "Tuna,
 } as const
 
 const FishEnum = z.enum(Fish)

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -695,6 +695,19 @@ FishEnum.parse("Swordfish"); // => ❌
   ```
 </Callout>
 
+Object literals are supported.
+
+```ts
+const Fish = {
+  Salmon: "Salmon",
+  "Tuna": "Tuna,
+} as const
+
+const FishEnum = z.enum(Fish)
+FishEnum.parse("Salmon"); // => "Salmon"
+FishEnum.parse("Swordfish"); // => ❌
+```
+
 You can also pass in an externally-declared TypeScript enum. 
 
 <Callout>

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -700,7 +700,7 @@ Object literals are supported.
 ```ts
 const Fish = {
   Salmon: "Salmon",
-  Tuna: "Tuna
+  Tuna: "Tuna"
 } as const
 
 const FishEnum = z.enum(Fish)


### PR DESCRIPTION
From the tests, it looks like `z.enum` supports object literal comprehension out-of-the-box:

https://github.com/colinhacks/zod/blob/3048d14bc7b803507302b8ee3cd1eeeffbd27396/packages/zod/src/v4/classic/tests/enum.test.ts#L12-L24

But it doesn't look like the rest of the world realizes it. Googling for "zod z.enum object literal" leads me to stackoverflow discussions ([1](https://stackoverflow.com/questions/73825273/creating-a-zod-enum-from-an-object), [2](https://stackoverflow.com/questions/75217817/zod-enum-and-object-as-const)) that keep trying to use `Object.values` or other stuff to get this working. I don't really understand. Cursor is yelling at me for no good reason:

<img width="789" height="296" alt="Screenshot 2025-07-24 at 10 17 05 AM" src="https://github.com/user-attachments/assets/1c9c8755-d9c2-41f3-8cf7-d8239f55c645" />


Updates the documentation with an object literal example, in the hopes that this knowledge propagates and people stop trying to hack around something that works out-of-the-box natively.

Note that [valibot's enum docs](https://valibot.dev/guides/enums/) call this out explicitly and provide an example for each:

> Since TypeScript enums are transpiled to JavaScript objects by the TypeScript compiler, you can use the `enum` schema function for both. Just pass your enumerated data type as the first argument to the schema function.

<img width="1345" height="1316" alt="Screenshot 2025-07-24 at 9 30 25 AM" src="https://github.com/user-attachments/assets/7b72c513-d43f-482e-a465-93154a3becd3" />
