### PR TITLE
fixes `z.core.File` type incompatibility with `globalThis.File`

### DIFF
--- a/packages/zod/src/v4/classic/tests/file.test.ts
+++ b/packages/zod/src/v4/classic/tests/file.test.ts
@@ -1,6 +1,6 @@
 import { File as WebFile } from "@web-std/file";
 
-import { afterEach, beforeEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, expectTypeOf, test } from "vitest";
 
 import * as z from "zod/v4";
 
@@ -24,6 +24,10 @@ test("passing validations", () => {
   mimeCheck.safeParse(new File([""], "test.csv", { type: "text/plain" }));
   expect(() => mimeCheck.parse(new File([""], "test.txt"))).toThrow();
   expect(() => mimeCheck.parse(new File([""], "test.txt", { type: "text/csv" }))).toThrow();
+});
+
+test("types", () => {
+  expectTypeOf(z.file().parse(new File([], "test.txt"))).toEqualTypeOf(new File([], "test.txt"));
 });
 
 test("failing validations", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2862,8 +2862,8 @@ export const $ZodLiteral: core.$constructor<$ZodLiteral> = /*@__PURE__*/ core.$c
 type _File = typeof globalThis extends { File: infer F extends new (...args: any[]) => any } ? InstanceType<F> : {};
 /** Do not reference this directly. */
 export interface File extends _File {
-  type: string;
-  size: number;
+  readonly type: string;
+  readonly size: number;
 }
 
 export interface $ZodFileDef extends $ZodTypeDef {


### PR DESCRIPTION
Closes #4973 