### PR TITLE
Fix number of errors in doc

### DIFF
--- a/packages/docs/content/error-formatting.mdx
+++ b/packages/docs/content/error-formatting.mdx
@@ -18,7 +18,7 @@ const schema = z.strictObject({
 });
 ```
 
-Attempting to parse this invalid data results in an error containing two issues.
+Attempting to parse this invalid data results in an error containing three issues.
 
 ```ts
 const result = schema.safeParse({


### PR DESCRIPTION
Doc says "two issues" but the example shows three