### PR TITLE
Fix “Edit on Github” link

### DIFF
--- a/packages/docs/app/(doc)/[[...slug]]/page.tsx
+++ b/packages/docs/app/(doc)/[[...slug]]/page.tsx
@@ -33,7 +33,7 @@ export default async function Page(props: {
       editOnGithub={{
         owner: "colinhacks",
         repo: "zod",
-        sha: "v4",
+        sha: "main",
         path: `packages/docs/content/${page.file.path}`,
       }}
     >


### PR DESCRIPTION
## Why?

`v4` no longer exists as a branch…