### PR TITLE
Include the received value in discriminated union errors

### DIFF
--- a/packages/zod/src/v3/ZodError.ts
+++ b/packages/zod/src/v3/ZodError.ts
@@ -63,6 +63,7 @@ export interface ZodInvalidUnionIssue extends ZodIssueBase {
 export interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
   code: typeof ZodIssueCode.invalid_union_discriminator;
   options: Primitive[];
+  received: string;
 }
 
 export interface ZodInvalidEnumValueIssue extends ZodIssueBase {

--- a/packages/zod/src/v3/locales/en.ts
+++ b/packages/zod/src/v3/locales/en.ts
@@ -21,7 +21,7 @@ const errorMap: ZodErrorMap = (issue, _ctx) => {
       message = `Invalid input`;
       break;
     case ZodIssueCode.invalid_union_discriminator:
-      message = `Invalid discriminator value. Expected ${util.joinValues(issue.options)}`;
+      message = `Invalid discriminator value. Expected ${util.joinValues(issue.options)}, received '${issue.received}'`;
       break;
     case ZodIssueCode.invalid_enum_value:
       message = `Invalid enum value. Expected ${util.joinValues(issue.options)}, received '${issue.received}'`;

--- a/packages/zod/src/v3/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v3/tests/discriminated-unions.test.ts
@@ -94,8 +94,9 @@ test("invalid discriminator value", () => {
       {
         code: z.ZodIssueCode.invalid_union_discriminator,
         options: ["a", "b"],
-        message: "Invalid discriminator value. Expected 'a' | 'b'",
+        message: "Invalid discriminator value. Expected 'a' | 'b', received 'x'",
         path: ["type"],
+        received: "x",
       },
     ]);
   }

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -3139,6 +3139,7 @@ export class ZodDiscriminatedUnion<
       addIssueToContext(ctx, {
         code: ZodIssueCode.invalid_union_discriminator,
         options: Array.from(this.optionsMap.keys()),
+        received: discriminatorValue,
         path: [discriminator],
       });
       return INVALID;


### PR DESCRIPTION
Discriminated union errors should be readable similar to enum errors.