### PR TITLE
feat: Filter out unrepresentable schemas from unions

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -224,7 +224,8 @@ interface ToJSONSchemaParams {
 
   /** How to handle unrepresentable types.
    * - `"throw"` — Default. Unrepresentable types throw an error
-   * - `"any"` — Unrepresentable types become `{}` */
+   * - `"any"` — Unrepresentable types become `{}`
+   * - `"filter"` — Unrepresentable types are filtered out from unions and become `{}` elsewhere */
   unrepresentable?: "throw" | "any";
 
   /** How to handle cycles.


### PR DESCRIPTION
I needed this to properly create openapi types for example my date schema:
```
export const zodISODateTime = () => {
	return z
		.union([z.date(), z.iso.datetime()])
		.overwrite((v) => {
			if (typeof v === 'string') {
				return new Date(v)
			}
			return v
		})
		.pipe(z.date())
}
```

`z.date()` is not representable, but I still want it to work internally. The resulting json schema should skip it.

I was thinking we should not create an extra unrepresentable option "filter" but instead include it in the "any" option, because this is also done for `z.literal()`