### PR TITLE
[docs] Fix migration guide upgrade command

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -11,7 +11,7 @@ This migration guide aims to list the breaking changes in Zod 4 in order of high
 {/* To give the ecosystem time to migrate, Zod 4 will initially be published alongside Zod v3.25. To use Zod 4, upgrade to `zod@3.25.0` or later: */}
 
 ```
-npm upgrade zod@^4.0.0
+npm install zod@^4.0.0
 ```
 
 {/* Zod 4 is available at the `"/v4"` subpath:


### PR DESCRIPTION
Use `npm install` instead of `npm upgrade`.

Fixes: #5019