### PR TITLE
fix: remove redundant Required<> from input and output type definitions

### DIFF
--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -84,8 +84,8 @@ export class $ZodAsyncError extends Error {
 // export type output<T extends schemas.$ZodType> = T["_zod"]["output"];
 // export type input<T extends schemas.$ZodType> = T["_zod"]["input"];
 // export type output<T extends schemas.$ZodType> = T["_zod"]["output"];
-export type input<T> = T extends { _zod: { input: any } } ? Required<T["_zod"]>["input"] : unknown;
-export type output<T> = T extends { _zod: { output: any } } ? Required<T["_zod"]>["output"] : unknown;
+export type input<T> = T extends { _zod: { input: any } } ? T["_zod"]["input"] : unknown;
+export type output<T> = T extends { _zod: { output: any } } ? T["_zod"]["output"] : unknown;
 
 // Mk2
 // export type input<T> = T extends { _zod: { "~input": any } }


### PR DESCRIPTION
## Summary
- Removes redundant `Required<>` utility type from both `input` and `output` type definitions
- Fixes TS2615 circular reference errors in TypeScript 5.9+
- No functional changes - the type behavior remains identical

## Problem
The `Required<>` utility type in both type definitions was redundant:

```typescript
export type input<T> = T extends { _zod: { input: any } } ? Required<T["_zod"]>["input"] : unknown;
export type output<T> = T extends { _zod: { output: any } } ? Required<T["_zod"]>["output"] : unknown;
```

The type guards `T extends { _zod: { input: any } }` and `T extends { _zod: { output: any } }` already ensure that `input` and `output` are required properties. If either were optional, the conditions would fail and return `unknown`.

This redundant `Required<>` caused TS2615 errors in TypeScript 5.9+ when using recursive schemas because it introduced unnecessary mapped types in circular reference chains.

## Solution
Simplified both type definitions to:
```typescript
export type input<T> = T extends { _zod: { input: any } } ? T["_zod"]["input"] : unknown;
export type output<T> = T extends { _zod: { output: any } } ? T["_zod"]["output"] : unknown;
```

The type behavior remains exactly the same, but without the redundant mapped type transformations.

## Test plan
- [x] Tested with TypeScript 5.5.4 - all tests pass (283 test files, 2805 tests)
- [x] Tested with TypeScript 5.9.2 - all tests pass (283 test files, 2805 tests)
- [x] Verified recursive type definitions work correctly

## Related
Fixes #5035

🤖 Generated with [Claude Code](https://claude.ai/code)