### PR TITLE
fix: ensure keyof returns enum

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -850,7 +850,7 @@ Branding is now handled with a direct modification to the inferred type, instead
 {/* - Dropping support for ES5
   - Zod relies on `Set` internally */}
 
-{/* - ZodObject `.keyof()` now returns `ZodLiteral` not `ZodEnum` */}
+{/* - `z.keyof` now returns `ZodEnum` instead of `ZodLiteral` */}
 
 
 

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1038,9 +1038,9 @@ export function array<T extends core.SomeType>(element: T, params?: string | cor
 }
 
 // .keyof
-export function keyof<T extends ZodObject>(schema: T): ZodLiteral<Exclude<keyof T["_zod"]["output"], symbol>> {
+export function keyof<T extends ZodObject>(schema: T): ZodEnum<util.KeysEnum<T["_zod"]["output"]>> {
   const shape = schema._zod.def.shape;
-  return literal(Object.keys(shape)) as any;
+  return _enum(Object.keys(shape)) as any;
 }
 
 // ZodObject

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -261,6 +261,21 @@ test("inferred enum type", async () => {
   expectTypeOf<Enum>().toEqualTypeOf<"a" | "b">();
 });
 
+test("z.keyof returns enum", () => {
+  const User = z.object({ name: z.string(), age: z.number() });
+  const keysSchema = z.keyof(User);
+  expect(keysSchema.enum).toEqual({
+    name: "name",
+    age: "age",
+  });
+  expect(keysSchema._zod.def.entries).toEqual({
+    name: "name",
+    age: "age",
+  });
+  type Keys = z.infer<typeof keysSchema>;
+  expectTypeOf<Keys>().toEqualTypeOf<"name" | "age">();
+});
+
 test("inferred partial object type with optional properties", async () => {
   const Partial = z.object({ a: z.string(), b: z.string().optional() }).partial();
   type Partial = z.infer<typeof Partial>;

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -712,9 +712,9 @@ export function array<T extends SomeType>(element: SomeType, params?: any): ZodM
 }
 
 // .keyof
-export function keyof<T extends ZodMiniObject>(schema: T): ZodMiniLiteral<Exclude<keyof T["shape"], symbol>> {
+export function keyof<T extends ZodMiniObject>(schema: T): ZodMiniEnum<util.KeysEnum<T["shape"]>> {
   const shape = schema._zod.def.shape;
-  return literal(Object.keys(shape)) as any;
+  return _enum(Object.keys(shape)) as any;
 }
 
 // ZodMiniObject

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -89,6 +89,12 @@ test("z.keyof", () => {
   type UserKeys = z.infer<typeof userKeysSchema>;
   expectTypeOf<UserKeys>().toEqualTypeOf<"name" | "age" | "email">();
   expect(userKeysSchema).toBeDefined();
+  expect(userKeysSchema._zod.def.type).toBe("enum");
+  expect(userKeysSchema._zod.def.entries).toEqual({
+    name: "name",
+    age: "age",
+    email: "email",
+  });
   expect(z.safeParse(userKeysSchema, "name").success).toBe(true);
   expect(z.safeParse(userKeysSchema, "age").success).toBe(true);
   expect(z.safeParse(userKeysSchema, "email").success).toBe(true);


### PR DESCRIPTION
## Summary
- ensure `z.keyof` returns `ZodEnum` in both classic and mini implementations
- add tests confirming `z.keyof` produces enum schemas
- note enum behavior in v4 changelog

## Testing
- `pnpm test packages/zod`

------
https://chatgpt.com/codex/tasks/task_e_689247454b8c832f8ad085cef6fab0ea