### PR TITLE
z.hash

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -309,6 +309,26 @@ export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> 
   cidrv6(params?: string | core.$ZodCheckCIDRv6Params): this;
   /** @deprecated Use `z.e164()` instead. */
   e164(params?: string | core.$ZodCheckE164Params): this;
+  /** @deprecated Use `z.md5()` instead. */
+  md5(params?: string | core.$ZodCheckMD5Params): this;
+  /** @deprecated Use `z.md5Base64()` instead. */
+  md5Base64(params?: string | core.$ZodCheckMD5Base64Params): this;
+  /** @deprecated Use `z.sha1()` instead. */
+  sha1(params?: string | core.$ZodCheckSHA1Params): this;
+  /** @deprecated Use `z.sha1Base64()` instead. */
+  sha1Base64(params?: string | core.$ZodCheckSHA1Base64Params): this;
+  /** @deprecated Use `z.sha256()` instead. */
+  sha256(params?: string | core.$ZodCheckSHA256Params): this;
+  /** @deprecated Use `z.sha256Base64()` instead. */
+  sha256Base64(params?: string | core.$ZodCheckSHA256Base64Params): this;
+  /** @deprecated Use `z.sha384()` instead. */
+  sha384(params?: string | core.$ZodCheckSHA384Params): this;
+  /** @deprecated Use `z.sha384Base64()` instead. */
+  sha384Base64(params?: string | core.$ZodCheckSHA384Base64Params): this;
+  /** @deprecated Use `z.sha512()` instead. */
+  sha512(params?: string | core.$ZodCheckSHA512Params): this;
+  /** @deprecated Use `z.sha512Base64()` instead. */
+  sha512Base64(params?: string | core.$ZodCheckSHA512Base64Params): this;
 
   // ISO 8601 checks
   /** @deprecated Use `z.iso.datetime()` instead. */
@@ -356,6 +376,16 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   inst.cidrv4 = (params) => inst.check(core._cidrv4(ZodCIDRv4, params));
   inst.cidrv6 = (params) => inst.check(core._cidrv6(ZodCIDRv6, params));
   inst.e164 = (params) => inst.check(core._e164(ZodE164, params));
+  inst.md5 = (params) => inst.check(core._md5(ZodMD5, params));
+  inst.md5Base64 = (params) => inst.check(core._md5Base64(ZodMD5Base64, params));
+  inst.sha1 = (params) => inst.check(core._sha1(ZodSHA1, params));
+  inst.sha1Base64 = (params) => inst.check(core._sha1Base64(ZodSHA1Base64, params));
+  inst.sha256 = (params) => inst.check(core._sha256(ZodSHA256, params));
+  inst.sha256Base64 = (params) => inst.check(core._sha256Base64(ZodSHA256Base64, params));
+  inst.sha384 = (params) => inst.check(core._sha384(ZodSHA384, params));
+  inst.sha384Base64 = (params) => inst.check(core._sha384Base64(ZodSHA384Base64, params));
+  inst.sha512 = (params) => inst.check(core._sha512(ZodSHA512, params));
+  inst.sha512Base64 = (params) => inst.check(core._sha512Base64(ZodSHA512Base64, params));
 
   // iso
   inst.datetime = (params) => inst.check(iso.datetime(params as any));
@@ -659,6 +689,151 @@ export const ZodE164: core.$constructor<ZodE164> = /*@__PURE__*/ core.$construct
 
 export function e164(params?: string | core.$ZodE164Params): ZodE164 {
   return core._e164(ZodE164, params);
+}
+
+// ZodMD5
+export interface ZodMD5 extends ZodStringFormat<"md5"> {
+  _zod: core.$ZodMD5Internals;
+}
+export const ZodMD5: core.$constructor<ZodMD5> = /*@__PURE__*/ core.$constructor("ZodMD5", (inst, def) => {
+  core.$ZodMD5.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+export function md5(params?: string | core.$ZodMD5Params): ZodMD5 {
+  return core._md5(ZodMD5, params);
+}
+
+// ZodMD5Base64
+export interface ZodMD5Base64 extends ZodStringFormat<"md5_base64"> {
+  _zod: core.$ZodMD5Base64Internals;
+}
+export const ZodMD5Base64: core.$constructor<ZodMD5Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodMD5Base64",
+  (inst, def) => {
+    core.$ZodMD5Base64.init(inst, def);
+    ZodStringFormat.init(inst, def);
+  }
+);
+
+export function md5Base64(params?: string | core.$ZodMD5Base64Params): ZodMD5Base64 {
+  return core._md5Base64(ZodMD5Base64, params);
+}
+
+// ZodSHA1
+export interface ZodSHA1 extends ZodStringFormat<"sha1"> {
+  _zod: core.$ZodSHA1Internals;
+}
+export const ZodSHA1: core.$constructor<ZodSHA1> = /*@__PURE__*/ core.$constructor("ZodSHA1", (inst, def) => {
+  core.$ZodSHA1.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+export function sha1(params?: string | core.$ZodSHA1Params): ZodSHA1 {
+  return core._sha1(ZodSHA1, params);
+}
+
+// ZodSHA1Base64
+export interface ZodSHA1Base64 extends ZodStringFormat<"sha1_base64"> {
+  _zod: core.$ZodSHA1Base64Internals;
+}
+export const ZodSHA1Base64: core.$constructor<ZodSHA1Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodSHA1Base64",
+  (inst, def) => {
+    core.$ZodSHA1Base64.init(inst, def);
+    ZodStringFormat.init(inst, def);
+  }
+);
+
+export function sha1Base64(params?: string | core.$ZodSHA1Base64Params): ZodSHA1Base64 {
+  return core._sha1Base64(ZodSHA1Base64, params);
+}
+
+// ZodSHA256
+export interface ZodSHA256 extends ZodStringFormat<"sha256"> {
+  _zod: core.$ZodSHA256Internals;
+}
+export const ZodSHA256: core.$constructor<ZodSHA256> = /*@__PURE__*/ core.$constructor("ZodSHA256", (inst, def) => {
+  core.$ZodSHA256.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+export function sha256(params?: string | core.$ZodSHA256Params): ZodSHA256 {
+  return core._sha256(ZodSHA256, params);
+}
+
+// ZodSHA256Base64
+export interface ZodSHA256Base64 extends ZodStringFormat<"sha256_base64"> {
+  _zod: core.$ZodSHA256Base64Internals;
+}
+export const ZodSHA256Base64: core.$constructor<ZodSHA256Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodSHA256Base64",
+  (inst, def) => {
+    core.$ZodSHA256Base64.init(inst, def);
+    ZodStringFormat.init(inst, def);
+  }
+);
+
+export function sha256Base64(params?: string | core.$ZodSHA256Base64Params): ZodSHA256Base64 {
+  return core._sha256Base64(ZodSHA256Base64, params);
+}
+
+// ZodSHA384
+export interface ZodSHA384 extends ZodStringFormat<"sha384"> {
+  _zod: core.$ZodSHA384Internals;
+}
+export const ZodSHA384: core.$constructor<ZodSHA384> = /*@__PURE__*/ core.$constructor("ZodSHA384", (inst, def) => {
+  core.$ZodSHA384.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+export function sha384(params?: string | core.$ZodSHA384Params): ZodSHA384 {
+  return core._sha384(ZodSHA384, params);
+}
+
+// ZodSHA384Base64
+export interface ZodSHA384Base64 extends ZodStringFormat<"sha384_base64"> {
+  _zod: core.$ZodSHA384Base64Internals;
+}
+export const ZodSHA384Base64: core.$constructor<ZodSHA384Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodSHA384Base64",
+  (inst, def) => {
+    core.$ZodSHA384Base64.init(inst, def);
+    ZodStringFormat.init(inst, def);
+  }
+);
+
+export function sha384Base64(params?: string | core.$ZodSHA384Base64Params): ZodSHA384Base64 {
+  return core._sha384Base64(ZodSHA384Base64, params);
+}
+
+// ZodSHA512
+export interface ZodSHA512 extends ZodStringFormat<"sha512"> {
+  _zod: core.$ZodSHA512Internals;
+}
+export const ZodSHA512: core.$constructor<ZodSHA512> = /*@__PURE__*/ core.$constructor("ZodSHA512", (inst, def) => {
+  core.$ZodSHA512.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+export function sha512(params?: string | core.$ZodSHA512Params): ZodSHA512 {
+  return core._sha512(ZodSHA512, params);
+}
+
+// ZodSHA512Base64
+export interface ZodSHA512Base64 extends ZodStringFormat<"sha512_base64"> {
+  _zod: core.$ZodSHA512Base64Internals;
+}
+export const ZodSHA512Base64: core.$constructor<ZodSHA512Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodSHA512Base64",
+  (inst, def) => {
+    core.$ZodSHA512Base64.init(inst, def);
+    ZodStringFormat.init(inst, def);
+  }
+);
+
+export function sha512Base64(params?: string | core.$ZodSHA512Base64Params): ZodSHA512Base64 {
+  return core._sha512Base64(ZodSHA512Base64, params);
 }
 
 // ZodJWT

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -309,26 +309,6 @@ export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> 
   cidrv6(params?: string | core.$ZodCheckCIDRv6Params): this;
   /** @deprecated Use `z.e164()` instead. */
   e164(params?: string | core.$ZodCheckE164Params): this;
-  /** @deprecated Use `z.md5()` instead. */
-  md5(params?: string | core.$ZodCheckMD5Params): this;
-  /** @deprecated Use `z.md5Base64()` instead. */
-  md5Base64(params?: string | core.$ZodCheckMD5Base64Params): this;
-  /** @deprecated Use `z.sha1()` instead. */
-  sha1(params?: string | core.$ZodCheckSHA1Params): this;
-  /** @deprecated Use `z.sha1Base64()` instead. */
-  sha1Base64(params?: string | core.$ZodCheckSHA1Base64Params): this;
-  /** @deprecated Use `z.sha256()` instead. */
-  sha256(params?: string | core.$ZodCheckSHA256Params): this;
-  /** @deprecated Use `z.sha256Base64()` instead. */
-  sha256Base64(params?: string | core.$ZodCheckSHA256Base64Params): this;
-  /** @deprecated Use `z.sha384()` instead. */
-  sha384(params?: string | core.$ZodCheckSHA384Params): this;
-  /** @deprecated Use `z.sha384Base64()` instead. */
-  sha384Base64(params?: string | core.$ZodCheckSHA384Base64Params): this;
-  /** @deprecated Use `z.sha512()` instead. */
-  sha512(params?: string | core.$ZodCheckSHA512Params): this;
-  /** @deprecated Use `z.sha512Base64()` instead. */
-  sha512Base64(params?: string | core.$ZodCheckSHA512Base64Params): this;
 
   // ISO 8601 checks
   /** @deprecated Use `z.iso.datetime()` instead. */
@@ -376,16 +356,6 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   inst.cidrv4 = (params) => inst.check(core._cidrv4(ZodCIDRv4, params));
   inst.cidrv6 = (params) => inst.check(core._cidrv6(ZodCIDRv6, params));
   inst.e164 = (params) => inst.check(core._e164(ZodE164, params));
-  inst.md5 = (params) => inst.check(core._md5(ZodMD5, params));
-  inst.md5Base64 = (params) => inst.check(core._md5Base64(ZodMD5Base64, params));
-  inst.sha1 = (params) => inst.check(core._sha1(ZodSHA1, params));
-  inst.sha1Base64 = (params) => inst.check(core._sha1Base64(ZodSHA1Base64, params));
-  inst.sha256 = (params) => inst.check(core._sha256(ZodSHA256, params));
-  inst.sha256Base64 = (params) => inst.check(core._sha256Base64(ZodSHA256Base64, params));
-  inst.sha384 = (params) => inst.check(core._sha384(ZodSHA384, params));
-  inst.sha384Base64 = (params) => inst.check(core._sha384Base64(ZodSHA384Base64, params));
-  inst.sha512 = (params) => inst.check(core._sha512(ZodSHA512, params));
-  inst.sha512Base64 = (params) => inst.check(core._sha512Base64(ZodSHA512Base64, params));
 
   // iso
   inst.datetime = (params) => inst.check(iso.datetime(params as any));

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -956,3 +956,257 @@ test("E.164 validation", () => {
   expect(validE164Numbers.every((number) => e164Number.safeParse(number).success)).toBe(true);
   expect(invalidE164Numbers.every((number) => e164Number.safeParse(number).success === false)).toBe(true);
 });
+
+test("MD5 hash validation", () => {
+  const md5Schema = z.string().md5();
+
+  // Valid MD5 hashes
+  const validMD5Hashes = [
+    "5d41402abc4b2a76b9719d911017c592", // "hello"
+    "098f6bcd4621d373cade4e832627b4f6", // "test"
+    "d41d8cd98f00b204e9800998ecf8427e", // empty string
+    "ACBD18DB4CC2F85CEDEF654FCCC4A4D8", // uppercase
+    "acbd18db4cc2f85cedef654fccc4a4d8", // lowercase
+  ];
+
+  // Invalid MD5 hashes
+  const invalidMD5Hashes = [
+    "", // empty
+    "5d41402abc4b2a76b9719d911017c59", // too short (31 chars)
+    "5d41402abc4b2a76b9719d911017c5922", // too long (33 chars)
+    "5d41402abc4b2a76b9719d911017c59g", // invalid character 'g'
+    "5d41402abc4b2a76b9719d911017c59!", // special character
+    "5d41402a bc4b2a76b9719d911017c592", // space in middle
+  ];
+
+  expect(validMD5Hashes.every((hash) => md5Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidMD5Hashes.every((hash) => md5Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("MD5 Base64 hash validation", () => {
+  const md5Base64Schema = z.string().md5Base64();
+
+  // Valid MD5 Base64 hashes
+  const validMD5Base64Hashes = [
+    "XUFAKrxLKna5cZ2REBfFkg==", // "hello" in base64
+    "CY9rzUYh03PK3k6DJie09g==", // "test" in base64
+    "1B2M2Y8AsgTpgAmY7PhCfg==", // empty string in base64
+    "rL0Y20zC+Fzt72VPzMSk2A==", // "foo" in base64
+  ];
+
+  // Invalid MD5 Base64 hashes
+  const invalidMD5Base64Hashes = [
+    "", // empty
+    "XUFAKrxLKna5cZ2REBfFk", // too short
+    "XUFAKrxLKna5cZ2REBfFkg===", // too many padding chars
+    "XUFAKrxLKna5cZ2REBfFk@==", // invalid character '@'
+    "XUFAKrxL Kna5cZ2REBfFkg==", // space in middle
+  ];
+
+  expect(validMD5Base64Hashes.every((hash) => md5Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidMD5Base64Hashes.every((hash) => md5Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-1 hash validation", () => {
+  const sha1Schema = z.string().sha1();
+
+  // Valid SHA-1 hashes
+  const validSHA1Hashes = [
+    "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d", // "hello"
+    "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3", // "test"
+    "da39a3ee5e6b4b0d3255bfef95601890afd80709", // empty string
+    "AAF4C61DDCC5E8A2DABEDE0F3B482CD9AEA9434D", // uppercase
+  ];
+
+  // Invalid SHA-1 hashes
+  const invalidSHA1Hashes = [
+    "", // empty
+    "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434", // too short
+    "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434dd", // too long
+    "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434g", // invalid character
+  ];
+
+  expect(validSHA1Hashes.every((hash) => sha1Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA1Hashes.every((hash) => sha1Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-1 Base64 hash validation", () => {
+  const sha1Base64Schema = z.string().sha1Base64();
+
+  // Valid SHA-1 Base64 hashes
+  const validSHA1Base64Hashes = [
+    "qvTGHdzF6KLavt4PO0gs2a6pQ00=", // 28 chars for SHA-1 base64
+    "qUqP5cyxm6YcTAhz05Hph5gvu9M=", // 28 chars for SHA-1 base64
+    "2jmj7l5rSw0yVb/vlWAYkK/YBwk=", // 28 chars for SHA-1 base64
+  ];
+
+  // Invalid SHA-1 Base64 hashes
+  const invalidSHA1Base64Hashes = [
+    "", // empty
+    "qvTGHdzF6KLavt4PO0gs2a6pQ0", // too short
+    "qvTGHdzF6KLavt4PO0gs2a6pQ00==", // too many padding chars
+    "qvTGHdzF6KLavt4PO0gs2a6pQ0@=", // invalid character
+  ];
+
+  expect(validSHA1Base64Hashes.every((hash) => sha1Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA1Base64Hashes.every((hash) => sha1Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-256 hash validation", () => {
+  const sha256Schema = z.string().sha256();
+
+  // Valid SHA-256 hashes
+  const validSHA256Hashes = [
+    "2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a04366", // "hello" (corrected)
+    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", // "test"
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", // empty string
+  ];
+
+  // Invalid SHA-256 hashes
+  const invalidSHA256Hashes = [
+    "", // empty
+    "2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a043", // too short
+    "2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a04366aa", // too long
+    "2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a0436g", // invalid character
+  ];
+
+  expect(validSHA256Hashes.every((hash) => sha256Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA256Hashes.every((hash) => sha256Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-256 Base64 hash validation", () => {
+  const sha256Base64Schema = z.string().sha256Base64();
+
+  // Valid SHA-256 Base64 hashes
+  const validSHA256Base64Hashes = [
+    "LPJNuk8h1CiAlMFLDysM3t7sAG/dfHOmHVuzyka6BDY=", // "hello" in base64 (corrected)
+    "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=", // "test" in base64
+    "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", // empty string in base64
+  ];
+
+  // Invalid SHA-256 Base64 hashes
+  const invalidSHA256Base64Hashes = [
+    "", // empty
+    "LPJNuk8h1CiAlMFLDysM3t7sAG/dfHOmHVuzyka6BD", // too short
+    "LPJNuk8h1CiAlMFLDysM3t7sAG/dfHOmHVuzyka6BDY==", // too many padding chars
+    "LPJNuk8h1CiAlMFLDysM3t7sAG/dfHOmHVuzyka6BD@=", // invalid character
+  ];
+
+  expect(validSHA256Base64Hashes.every((hash) => sha256Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA256Base64Hashes.every((hash) => sha256Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-384 hash validation", () => {
+  const sha384Schema = z.string().sha384();
+
+  // Valid SHA-384 hashes
+  const validSHA384Hashes = [
+    "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f", // "hello"
+    "768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9", // "test"
+    "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b", // empty string (corrected)
+  ];
+
+  // Invalid SHA-384 hashes
+  const invalidSHA384Hashes = [
+    "", // empty
+    "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684", // too short
+    "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684ff", // too long
+    "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684g", // invalid character
+  ];
+
+  expect(validSHA384Hashes.every((hash) => sha384Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA384Hashes.every((hash) => sha384Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-384 Base64 hash validation", () => {
+  const sha384Base64Schema = z.string().sha384Base64();
+
+  // Valid SHA-384 Base64 hashes
+  const validSHA384Base64Hashes = [
+    "WeF0h3dEjGnetoANejO7+5/xtGPkQ1TDVTPNO8ZsZpoSWjx5+QOXvfX2oT3oKGhP", // "hello" in base64
+    "doQSMg97CqWBL85CjcRwazzqUOAqZMqhamgkm/6O/Et+8cy9EmJV0ZYEff7fF6Cp", // "test" in base64
+  ];
+
+  // Invalid SHA-384 Base64 hashes
+  const invalidSHA384Base64Hashes = [
+    "", // empty
+    "WeF0h3dEjGnetoANejO7+5/xtGPkQ1TDVTPNO8ZsZpoSWjx5+QOXvfX2oT3oKGh", // too short
+    "WeF0h3dEjGnetoANejO7+5/xtGPkQ1TDVTPNO8ZsZpoSWjx5+QOXvfX2oT3oKGhPP", // too long
+    "WeF0h3dEjGnetoANejO7+5/xtGPkQ1TDVTPNO8ZsZpoSWjx5+QOXvfX2oT3oKGh@", // invalid character
+  ];
+
+  expect(validSHA384Base64Hashes.every((hash) => sha384Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA384Base64Hashes.every((hash) => sha384Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-512 hash validation", () => {
+  const sha512Schema = z.string().sha512();
+
+  // Valid SHA-512 hashes
+  const validSHA512Hashes = [
+    "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043", // "hello"
+    "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff", // "test"
+  ];
+
+  // Invalid SHA-512 hashes
+  const invalidSHA512Hashes = [
+    "", // empty
+    "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec04", // too short
+    "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec0433", // too long
+    "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec04g", // invalid character
+  ];
+
+  expect(validSHA512Hashes.every((hash) => sha512Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA512Hashes.every((hash) => sha512Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-512 Base64 hash validation", () => {
+  const sha512Base64Schema = z.string().sha512Base64();
+
+  // Valid SHA-512 Base64 hashes
+  const validSHA512Base64Hashes = [
+    "m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDreT2c7zewEQw==", // "hello" in base64
+    "7iaw3Ur350mqGo7jwQrpkj9hiYB3LkQ/iBlp1JQODbJ6wYX4oOHV+E+IvIh/1nsUNzLDBMxfqargb1f1ACio/w==", // "test" in base64
+  ];
+
+  // Invalid SHA-512 Base64 hashes
+  const invalidSHA512Base64Hashes = [
+    "", // empty
+    "m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDreT2c7zewEQ", // too short
+    "m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDreT2c7zewEQw===", // too many padding chars
+    "m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDreT2c7zewEQ@==", // invalid character
+  ];
+
+  expect(validSHA512Base64Hashes.every((hash) => sha512Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA512Base64Hashes.every((hash) => sha512Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("hash format error messages", () => {
+  const md5Schema = z.string().md5();
+  const sha256Schema = z.string().sha256();
+
+  // Test error codes for invalid hashes
+  const md5Result = md5Schema.safeParse("invalid");
+  const sha256Result = sha256Schema.safeParse("invalid");
+
+  if (!md5Result.success) {
+    expect(md5Result.error.issues[0].code).toBe("invalid_format");
+  }
+
+  if (!sha256Result.success) {
+    expect(sha256Result.error.issues[0].code).toBe("invalid_format");
+  }
+});
+
+test("hash format chaining with other validations", () => {
+  const chainedMd5 = z.string().md5().min(32).max(32);
+  const chainedSha256 = z.string().sha256().length(64);
+
+  expect(chainedMd5.safeParse("5d41402abc4b2a76b9719d911017c592").success).toBe(true);
+  expect(chainedSha256.safeParse("2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a04366").success).toBe(
+    true
+  ); // corrected - now valid
+  expect(chainedSha256.safeParse("2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a0436").success).toBe(
+    false
+  ); // invalid format (63 chars)
+});

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -958,7 +958,7 @@ test("E.164 validation", () => {
 });
 
 test("MD5 hash validation", () => {
-  const md5Schema = z.string().md5();
+  const md5Schema = z.md5();
 
   // Valid MD5 hashes
   const validMD5Hashes = [
@@ -984,7 +984,7 @@ test("MD5 hash validation", () => {
 });
 
 test("MD5 Base64 hash validation", () => {
-  const md5Base64Schema = z.string().md5Base64();
+  const md5Base64Schema = z.md5Base64();
 
   // Valid MD5 Base64 hashes
   const validMD5Base64Hashes = [
@@ -1008,7 +1008,7 @@ test("MD5 Base64 hash validation", () => {
 });
 
 test("SHA-1 hash validation", () => {
-  const sha1Schema = z.string().sha1();
+  const sha1Schema = z.sha1();
 
   // Valid SHA-1 hashes
   const validSHA1Hashes = [
@@ -1031,7 +1031,7 @@ test("SHA-1 hash validation", () => {
 });
 
 test("SHA-1 Base64 hash validation", () => {
-  const sha1Base64Schema = z.string().sha1Base64();
+  const sha1Base64Schema = z.sha1Base64();
 
   // Valid SHA-1 Base64 hashes
   const validSHA1Base64Hashes = [
@@ -1053,7 +1053,7 @@ test("SHA-1 Base64 hash validation", () => {
 });
 
 test("SHA-256 hash validation", () => {
-  const sha256Schema = z.string().sha256();
+  const sha256Schema = z.sha256();
 
   // Valid SHA-256 hashes
   const validSHA256Hashes = [
@@ -1075,7 +1075,7 @@ test("SHA-256 hash validation", () => {
 });
 
 test("SHA-256 Base64 hash validation", () => {
-  const sha256Base64Schema = z.string().sha256Base64();
+  const sha256Base64Schema = z.sha256Base64();
 
   // Valid SHA-256 Base64 hashes
   const validSHA256Base64Hashes = [
@@ -1097,7 +1097,7 @@ test("SHA-256 Base64 hash validation", () => {
 });
 
 test("SHA-384 hash validation", () => {
-  const sha384Schema = z.string().sha384();
+  const sha384Schema = z.sha384();
 
   // Valid SHA-384 hashes
   const validSHA384Hashes = [
@@ -1119,7 +1119,7 @@ test("SHA-384 hash validation", () => {
 });
 
 test("SHA-384 Base64 hash validation", () => {
-  const sha384Base64Schema = z.string().sha384Base64();
+  const sha384Base64Schema = z.sha384Base64();
 
   // Valid SHA-384 Base64 hashes
   const validSHA384Base64Hashes = [
@@ -1140,7 +1140,7 @@ test("SHA-384 Base64 hash validation", () => {
 });
 
 test("SHA-512 hash validation", () => {
-  const sha512Schema = z.string().sha512();
+  const sha512Schema = z.sha512();
 
   // Valid SHA-512 hashes
   const validSHA512Hashes = [
@@ -1161,7 +1161,7 @@ test("SHA-512 hash validation", () => {
 });
 
 test("SHA-512 Base64 hash validation", () => {
-  const sha512Base64Schema = z.string().sha512Base64();
+  const sha512Base64Schema = z.sha512Base64();
 
   // Valid SHA-512 Base64 hashes
   const validSHA512Base64Hashes = [
@@ -1182,8 +1182,8 @@ test("SHA-512 Base64 hash validation", () => {
 });
 
 test("hash format error messages", () => {
-  const md5Schema = z.string().md5();
-  const sha256Schema = z.string().sha256();
+  const md5Schema = z.md5();
+  const sha256Schema = z.sha256();
 
   // Test error codes for invalid hashes
   const md5Result = md5Schema.safeParse("invalid");
@@ -1199,8 +1199,8 @@ test("hash format error messages", () => {
 });
 
 test("hash format chaining with other validations", () => {
-  const chainedMd5 = z.string().md5().min(32).max(32);
-  const chainedSha256 = z.string().sha256().length(64);
+  const chainedMd5 = z.md5().min(32).max(32);
+  const chainedSha256 = z.sha256().length(64);
 
   expect(chainedMd5.safeParse("5d41402abc4b2a76b9719d911017c592").success).toBe(true);
   expect(chainedSha256.safeParse("2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a04366").success).toBe(

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -1209,6 +1209,7 @@ test("hash format chaining with other validations", () => {
   expect(chainedSha256.safeParse("2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a0436").success).toBe(
     false
   ); // invalid format (63 chars)
+});
 
 test("hostname", () => {
   const hostname = z.hostname();
@@ -1246,4 +1247,258 @@ test("hostname", () => {
   expect(() => hostname.parse("exa mple.com")).toThrow();
   expect(() => hostname.parse("-example.com")).toThrow();
   expect(() => hostname.parse("example..com")).toThrow();
+});
+
+test("MD5 hash validation", () => {
+  const md5Schema = z.md5();
+
+  // Valid MD5 hashes
+  const validMD5Hashes = [
+    "5d41402abc4b2a76b9719d911017c592", // "hello"
+    "098f6bcd4621d373cade4e832627b4f6", // "test"
+    "d41d8cd98f00b204e9800998ecf8427e", // empty string
+    "ACBD18DB4CC2F85CEDEF654FCCC4A4D8", // uppercase
+    "acbd18db4cc2f85cedef654fccc4a4d8", // lowercase
+  ];
+
+  // Invalid MD5 hashes
+  const invalidMD5Hashes = [
+    "", // empty
+    "5d41402abc4b2a76b9719d911017c59", // too short (31 chars)
+    "5d41402abc4b2a76b9719d911017c5922", // too long (33 chars)
+    "5d41402abc4b2a76b9719d911017c59g", // invalid character 'g'
+    "5d41402abc4b2a76b9719d911017c59!", // special character
+    "5d41402a bc4b2a76b9719d911017c592", // space in middle
+  ];
+
+  expect(validMD5Hashes.every((hash) => md5Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidMD5Hashes.every((hash) => md5Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("MD5 Base64 hash validation", () => {
+  const md5Base64Schema = z.md5Base64();
+
+  // Valid MD5 Base64 hashes
+  const validMD5Base64Hashes = [
+    "XUFAKrxLKna5cZ2REBfFkg==", // "hello" in base64
+    "CY9rzUYh03PK3k6DJie09g==", // "test" in base64
+    "1B2M2Y8AsgTpgAmY7PhCfg==", // empty string in base64
+    "rL0Y20zC+Fzt72VPzMSk2A==", // "foo" in base64
+  ];
+
+  // Invalid MD5 Base64 hashes
+  const invalidMD5Base64Hashes = [
+    "", // empty
+    "XUFAKrxLKna5cZ2REBfFk", // too short
+    "XUFAKrxLKna5cZ2REBfFkg===", // too many padding chars
+    "XUFAKrxLKna5cZ2REBfFk@==", // invalid character '@'
+    "XUFAKrxL Kna5cZ2REBfFkg==", // space in middle
+  ];
+
+  expect(validMD5Base64Hashes.every((hash) => md5Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidMD5Base64Hashes.every((hash) => md5Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-1 hash validation", () => {
+  const sha1Schema = z.sha1();
+
+  // Valid SHA-1 hashes
+  const validSHA1Hashes = [
+    "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d", // "hello"
+    "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3", // "test"
+    "da39a3ee5e6b4b0d3255bfef95601890afd80709", // empty string
+    "AAF4C61DDCC5E8A2DABEDE0F3B482CD9AEA9434D", // uppercase
+  ];
+
+  // Invalid SHA-1 hashes
+  const invalidSHA1Hashes = [
+    "", // empty
+    "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434", // too short
+    "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434dd", // too long
+    "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434g", // invalid character
+  ];
+
+  expect(validSHA1Hashes.every((hash) => sha1Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA1Hashes.every((hash) => sha1Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-1 Base64 hash validation", () => {
+  const sha1Base64Schema = z.sha1Base64();
+
+  // Valid SHA-1 Base64 hashes
+  const validSHA1Base64Hashes = [
+    "qvTGHdzF6KLavt4PO0gs2a6pQ00=", // 28 chars for SHA-1 base64
+    "qUqP5cyxm6YcTAhz05Hph5gvu9M=", // 28 chars for SHA-1 base64
+    "2jmj7l5rSw0yVb/vlWAYkK/YBwk=", // 28 chars for SHA-1 base64
+  ];
+
+  // Invalid SHA-1 Base64 hashes
+  const invalidSHA1Base64Hashes = [
+    "", // empty
+    "qvTGHdzF6KLavt4PO0gs2a6pQ0", // too short
+    "qvTGHdzF6KLavt4PO0gs2a6pQ00==", // too many padding chars
+    "qvTGHdzF6KLavt4PO0gs2a6pQ0@=", // invalid character
+  ];
+
+  expect(validSHA1Base64Hashes.every((hash) => sha1Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA1Base64Hashes.every((hash) => sha1Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-256 hash validation", () => {
+  const sha256Schema = z.sha256();
+
+  // Valid SHA-256 hashes
+  const validSHA256Hashes = [
+    "2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a04366", // "hello" (corrected)
+    "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", // "test"
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", // empty string
+  ];
+
+  // Invalid SHA-256 hashes
+  const invalidSHA256Hashes = [
+    "", // empty
+    "2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a043", // too short
+    "2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a04366aa", // too long
+    "2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a0436g", // invalid character
+  ];
+
+  expect(validSHA256Hashes.every((hash) => sha256Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA256Hashes.every((hash) => sha256Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-256 Base64 hash validation", () => {
+  const sha256Base64Schema = z.sha256Base64();
+
+  // Valid SHA-256 Base64 hashes
+  const validSHA256Base64Hashes = [
+    "LPJNuk8h1CiAlMFLDysM3t7sAG/dfHOmHVuzyka6BDY=", // "hello" in base64 (corrected)
+    "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=", // "test" in base64
+    "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", // empty string in base64
+  ];
+
+  // Invalid SHA-256 Base64 hashes
+  const invalidSHA256Base64Hashes = [
+    "", // empty
+    "LPJNuk8h1CiAlMFLDysM3t7sAG/dfHOmHVuzyka6BD", // too short
+    "LPJNuk8h1CiAlMFLDysM3t7sAG/dfHOmHVuzyka6BDY==", // too many padding chars
+    "LPJNuk8h1CiAlMFLDysM3t7sAG/dfHOmHVuzyka6BD@=", // invalid character
+  ];
+
+  expect(validSHA256Base64Hashes.every((hash) => sha256Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA256Base64Hashes.every((hash) => sha256Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-384 hash validation", () => {
+  const sha384Schema = z.sha384();
+
+  // Valid SHA-384 hashes
+  const validSHA384Hashes = [
+    "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f", // "hello"
+    "768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9", // "test"
+    "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b", // empty string (corrected)
+  ];
+
+  // Invalid SHA-384 hashes
+  const invalidSHA384Hashes = [
+    "", // empty
+    "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684", // too short
+    "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684ff", // too long
+    "59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684g", // invalid character
+  ];
+
+  expect(validSHA384Hashes.every((hash) => sha384Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA384Hashes.every((hash) => sha384Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-384 Base64 hash validation", () => {
+  const sha384Base64Schema = z.sha384Base64();
+
+  // Valid SHA-384 Base64 hashes
+  const validSHA384Base64Hashes = [
+    "WeF0h3dEjGnetoANejO7+5/xtGPkQ1TDVTPNO8ZsZpoSWjx5+QOXvfX2oT3oKGhP", // "hello" in base64
+    "doQSMg97CqWBL85CjcRwazzqUOAqZMqhamgkm/6O/Et+8cy9EmJV0ZYEff7fF6Cp", // "test" in base64
+  ];
+
+  // Invalid SHA-384 Base64 hashes
+  const invalidSHA384Base64Hashes = [
+    "", // empty
+    "WeF0h3dEjGnetoANejO7+5/xtGPkQ1TDVTPNO8ZsZpoSWjx5+QOXvfX2oT3oKGh", // too short
+    "WeF0h3dEjGnetoANejO7+5/xtGPkQ1TDVTPNO8ZsZpoSWjx5+QOXvfX2oT3oKGhPP", // too long
+    "WeF0h3dEjGnetoANejO7+5/xtGPkQ1TDVTPNO8ZsZpoSWjx5+QOXvfX2oT3oKGh@", // invalid character
+  ];
+
+  expect(validSHA384Base64Hashes.every((hash) => sha384Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA384Base64Hashes.every((hash) => sha384Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-512 hash validation", () => {
+  const sha512Schema = z.sha512();
+
+  // Valid SHA-512 hashes
+  const validSHA512Hashes = [
+    "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043", // "hello"
+    "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff", // "test"
+  ];
+
+  // Invalid SHA-512 hashes
+  const invalidSHA512Hashes = [
+    "", // empty
+    "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec04", // too short
+    "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec0433", // too long
+    "9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec04g", // invalid character
+  ];
+
+  expect(validSHA512Hashes.every((hash) => sha512Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA512Hashes.every((hash) => sha512Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("SHA-512 Base64 hash validation", () => {
+  const sha512Base64Schema = z.sha512Base64();
+
+  // Valid SHA-512 Base64 hashes
+  const validSHA512Base64Hashes = [
+    "m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDreT2c7zewEQw==", // "hello" in base64
+    "7iaw3Ur350mqGo7jwQrpkj9hiYB3LkQ/iBlp1JQODbJ6wYX4oOHV+E+IvIh/1nsUNzLDBMxfqargb1f1ACio/w==", // "test" in base64
+  ];
+
+  // Invalid SHA-512 Base64 hashes
+  const invalidSHA512Base64Hashes = [
+    "", // empty
+    "m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDreT2c7zewEQ", // too short
+    "m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDreT2c7zewEQw===", // too many padding chars
+    "m3HSJL1i83hdltRq0+o9czGb+8KJDKra4t/3JRlnPKcjI8PZm6XBHXx6zG4UuMXaDEZjR1wuXDreT2c7zewEQ@==", // invalid character
+  ];
+
+  expect(validSHA512Base64Hashes.every((hash) => sha512Base64Schema.safeParse(hash).success)).toBe(true);
+  expect(invalidSHA512Base64Hashes.every((hash) => sha512Base64Schema.safeParse(hash).success === false)).toBe(true);
+});
+
+test("hash format error messages", () => {
+  const md5Schema = z.md5();
+  const sha256Schema = z.sha256();
+
+  // Test error codes for invalid hashes
+  const md5Result = md5Schema.safeParse("invalid");
+  const sha256Result = sha256Schema.safeParse("invalid");
+
+  if (!md5Result.success) {
+    expect(md5Result.error.issues[0].code).toBe("invalid_format");
+  }
+
+  if (!sha256Result.success) {
+    expect(sha256Result.error.issues[0].code).toBe("invalid_format");
+  }
+});
+
+test("hash format chaining with other validations", () => {
+  const chainedMd5 = z.md5().min(32).max(32);
+  const chainedSha256 = z.sha256().length(64);
+
+  expect(chainedMd5.safeParse("5d41402abc4b2a76b9719d911017c592").success).toBe(true);
+  expect(chainedSha256.safeParse("2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a04366").success).toBe(
+    true
+  ); // corrected - now valid
+  expect(chainedSha256.safeParse("2cf24dba4f21d4288094c14b0f2b0336deec006fdd7c73a61d5bb3ca46a0436").success).toBe(
+    false
+  ); // invalid format (63 chars)
 });

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -425,6 +425,166 @@ export function _e164<T extends schemas.$ZodE164>(
   });
 }
 
+// MD5
+export type $ZodMD5Params = StringFormatParams<schemas.$ZodMD5, "when">;
+export type $ZodCheckMD5Params = CheckStringFormatParams<schemas.$ZodMD5, "when">;
+export function _md5<T extends schemas.$ZodMD5>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodMD5Params | $ZodCheckMD5Params
+): T {
+  return new Class({
+    type: "string",
+    format: "md5",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// MD5 Base64
+export type $ZodMD5Base64Params = StringFormatParams<schemas.$ZodMD5Base64, "when">;
+export type $ZodCheckMD5Base64Params = CheckStringFormatParams<schemas.$ZodMD5Base64, "when">;
+export function _md5Base64<T extends schemas.$ZodMD5Base64>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodMD5Base64Params | $ZodCheckMD5Base64Params
+): T {
+  return new Class({
+    type: "string",
+    format: "md5_base64",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// SHA1
+export type $ZodSHA1Params = StringFormatParams<schemas.$ZodSHA1, "when">;
+export type $ZodCheckSHA1Params = CheckStringFormatParams<schemas.$ZodSHA1, "when">;
+export function _sha1<T extends schemas.$ZodSHA1>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodSHA1Params | $ZodCheckSHA1Params
+): T {
+  return new Class({
+    type: "string",
+    format: "sha1",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// SHA1 Base64
+export type $ZodSHA1Base64Params = StringFormatParams<schemas.$ZodSHA1Base64, "when">;
+export type $ZodCheckSHA1Base64Params = CheckStringFormatParams<schemas.$ZodSHA1Base64, "when">;
+export function _sha1Base64<T extends schemas.$ZodSHA1Base64>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodSHA1Base64Params | $ZodCheckSHA1Base64Params
+): T {
+  return new Class({
+    type: "string",
+    format: "sha1_base64",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// SHA256
+export type $ZodSHA256Params = StringFormatParams<schemas.$ZodSHA256, "when">;
+export type $ZodCheckSHA256Params = CheckStringFormatParams<schemas.$ZodSHA256, "when">;
+export function _sha256<T extends schemas.$ZodSHA256>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodSHA256Params | $ZodCheckSHA256Params
+): T {
+  return new Class({
+    type: "string",
+    format: "sha256",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// SHA256 Base64
+export type $ZodSHA256Base64Params = StringFormatParams<schemas.$ZodSHA256Base64, "when">;
+export type $ZodCheckSHA256Base64Params = CheckStringFormatParams<schemas.$ZodSHA256Base64, "when">;
+export function _sha256Base64<T extends schemas.$ZodSHA256Base64>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodSHA256Base64Params | $ZodCheckSHA256Base64Params
+): T {
+  return new Class({
+    type: "string",
+    format: "sha256_base64",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// SHA384
+export type $ZodSHA384Params = StringFormatParams<schemas.$ZodSHA384, "when">;
+export type $ZodCheckSHA384Params = CheckStringFormatParams<schemas.$ZodSHA384, "when">;
+export function _sha384<T extends schemas.$ZodSHA384>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodSHA384Params | $ZodCheckSHA384Params
+): T {
+  return new Class({
+    type: "string",
+    format: "sha384",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// SHA384 Base64
+export type $ZodSHA384Base64Params = StringFormatParams<schemas.$ZodSHA384Base64, "when">;
+export type $ZodCheckSHA384Base64Params = CheckStringFormatParams<schemas.$ZodSHA384Base64, "when">;
+export function _sha384Base64<T extends schemas.$ZodSHA384Base64>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodSHA384Base64Params | $ZodCheckSHA384Base64Params
+): T {
+  return new Class({
+    type: "string",
+    format: "sha384_base64",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// SHA512
+export type $ZodSHA512Params = StringFormatParams<schemas.$ZodSHA512, "when">;
+export type $ZodCheckSHA512Params = CheckStringFormatParams<schemas.$ZodSHA512, "when">;
+export function _sha512<T extends schemas.$ZodSHA512>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodSHA512Params | $ZodCheckSHA512Params
+): T {
+  return new Class({
+    type: "string",
+    format: "sha512",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
+// SHA512 Base64
+export type $ZodSHA512Base64Params = StringFormatParams<schemas.$ZodSHA512Base64, "when">;
+export type $ZodCheckSHA512Base64Params = CheckStringFormatParams<schemas.$ZodSHA512Base64, "when">;
+export function _sha512Base64<T extends schemas.$ZodSHA512Base64>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodSHA512Base64Params | $ZodCheckSHA512Base64Params
+): T {
+  return new Class({
+    type: "string",
+    format: "sha512_base64",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
 // JWT
 export type $ZodJWTParams = StringFormatParams<schemas.$ZodJWT, "pattern" | "when">;
 export type $ZodCheckJWTParams = CheckStringFormatParams<schemas.$ZodJWT, "pattern" | "when">;

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -769,7 +769,17 @@ export type $ZodStringFormats =
   | "jwt"
   | "starts_with"
   | "ends_with"
-  | "includes";
+  | "includes"
+  | "md5"
+  | "md5_base64"
+  | "sha1"
+  | "sha1_base64"
+  | "sha256"
+  | "sha256_base64"
+  | "sha384"
+  | "sha384_base64"
+  | "sha512"
+  | "sha512_base64";
 export interface $ZodCheckStringFormatDef<Format extends string = string> extends $ZodCheckDef {
   check: "string_format";
   format: Format;

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -153,7 +153,7 @@ export const sha512: RegExp = /^[a-fA-F0-9]{128}$/;
 export const md5Base64: RegExp = /^[A-Za-z0-9+/]{22}={0,2}$/;
 
 /** SHA-1 hash in base64: 28 characters (20 bytes * 4/3, with padding) */
-export const sha1Base64: RegExp = /^[A-Za-z0-9+/]{26}={0,2}$/;
+export const sha1Base64: RegExp = /^[A-Za-z0-9+/]{27}={1}$/;
 
 /** SHA-256 hash in base64: 44 characters (32 bytes * 4/3, with padding) */
 export const sha256Base64: RegExp = /^[A-Za-z0-9+/]{43}={1}$/;

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -133,3 +133,59 @@ export { _undefined as undefined };
 export const lowercase: RegExp = /^[^A-Z]*$/;
 // regex for string with no lowercase letters
 export const uppercase: RegExp = /^[^a-z]*$/;
+
+/** MD5 hash: 32 hexadecimal characters */
+export const md5: RegExp = /^[a-fA-F0-9]{32}$/;
+
+/** SHA-1 hash: 40 hexadecimal characters */
+export const sha1: RegExp = /^[a-fA-F0-9]{40}$/;
+
+/** SHA-256 hash: 64 hexadecimal characters */
+export const sha256: RegExp = /^[a-fA-F0-9]{64}$/;
+
+/** SHA-384 hash: 96 hexadecimal characters */
+export const sha384: RegExp = /^[a-fA-F0-9]{96}$/;
+
+/** SHA-512 hash: 128 hexadecimal characters */
+export const sha512: RegExp = /^[a-fA-F0-9]{128}$/;
+
+/** MD5 hash in base64: 24 characters (16 bytes * 4/3, with padding) */
+export const md5Base64: RegExp = /^[A-Za-z0-9+/]{22}={0,2}$/;
+
+/** SHA-1 hash in base64: 28 characters (20 bytes * 4/3, with padding) */
+export const sha1Base64: RegExp = /^[A-Za-z0-9+/]{26}={0,2}$/;
+
+/** SHA-256 hash in base64: 44 characters (32 bytes * 4/3, with padding) */
+export const sha256Base64: RegExp = /^[A-Za-z0-9+/]{43}={1}$/;
+
+/** SHA-384 hash in base64: 64 characters (48 bytes * 4/3) */
+export const sha384Base64: RegExp = /^[A-Za-z0-9+/]{64}$/;
+
+/** SHA-512 hash in base64: 88 characters (64 bytes * 4/3, with padding) */
+export const sha512Base64: RegExp = /^[A-Za-z0-9+/]{86}={0,2}$/;
+
+/** Generic hash validation function for various algorithms */
+export const hash = (algorithm: "md5" | "sha1" | "sha256" | "sha384" | "sha512"): RegExp => {
+  const lengths = {
+    md5: 32,
+    sha1: 40,
+    sha256: 64,
+    sha384: 96,
+    sha512: 128,
+  };
+
+  return new RegExp(`^[a-fA-F0-9]{${lengths[algorithm]}}$`);
+};
+
+/** Generic hash validation function for base64-encoded algorithms */
+export const hashBase64 = (algorithm: "md5" | "sha1" | "sha256" | "sha384" | "sha512"): RegExp => {
+  const regexMap = {
+    md5: md5Base64,
+    sha1: sha1Base64,
+    sha256: sha256Base64,
+    sha384: sha384Base64,
+    sha512: sha512Base64,
+  };
+
+  return regexMap[algorithm];
+};

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -902,6 +902,170 @@ export const $ZodE164: core.$constructor<$ZodE164> = /*@__PURE__*/ core.$constru
   $ZodStringFormat.init(inst, def);
 });
 
+//////////////////////////////   ZodMD5   //////////////////////////////
+
+export interface $ZodMD5Def extends $ZodStringFormatDef<"md5"> {}
+export interface $ZodMD5Internals extends $ZodStringFormatInternals<"md5"> {}
+
+export interface $ZodMD5 extends $ZodType {
+  _zod: $ZodMD5Internals;
+}
+
+export const $ZodMD5: core.$constructor<$ZodMD5> = /*@__PURE__*/ core.$constructor("$ZodMD5", (inst, def): void => {
+  def.pattern ??= regexes.md5;
+  $ZodStringFormat.init(inst, def);
+});
+
+//////////////////////////////   ZodMD5Base64   //////////////////////////////
+
+export interface $ZodMD5Base64Def extends $ZodStringFormatDef<"md5_base64"> {}
+export interface $ZodMD5Base64Internals extends $ZodStringFormatInternals<"md5_base64"> {}
+
+export interface $ZodMD5Base64 extends $ZodType {
+  _zod: $ZodMD5Base64Internals;
+}
+
+export const $ZodMD5Base64: core.$constructor<$ZodMD5Base64> = /*@__PURE__*/ core.$constructor(
+  "$ZodMD5Base64",
+  (inst, def): void => {
+    def.pattern ??= regexes.md5Base64;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
+//////////////////////////////   ZodSHA1   //////////////////////////////
+
+export interface $ZodSHA1Def extends $ZodStringFormatDef<"sha1"> {}
+export interface $ZodSHA1Internals extends $ZodStringFormatInternals<"sha1"> {}
+
+export interface $ZodSHA1 extends $ZodType {
+  _zod: $ZodSHA1Internals;
+}
+
+export const $ZodSHA1: core.$constructor<$ZodSHA1> = /*@__PURE__*/ core.$constructor("$ZodSHA1", (inst, def): void => {
+  def.pattern ??= regexes.sha1;
+  $ZodStringFormat.init(inst, def);
+});
+
+//////////////////////////////   ZodSHA1Base64   //////////////////////////////
+
+export interface $ZodSHA1Base64Def extends $ZodStringFormatDef<"sha1_base64"> {}
+export interface $ZodSHA1Base64Internals extends $ZodStringFormatInternals<"sha1_base64"> {}
+
+export interface $ZodSHA1Base64 extends $ZodType {
+  _zod: $ZodSHA1Base64Internals;
+}
+
+export const $ZodSHA1Base64: core.$constructor<$ZodSHA1Base64> = /*@__PURE__*/ core.$constructor(
+  "$ZodSHA1Base64",
+  (inst, def): void => {
+    def.pattern ??= regexes.sha1Base64;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
+//////////////////////////////   ZodSHA256   //////////////////////////////
+
+export interface $ZodSHA256Def extends $ZodStringFormatDef<"sha256"> {}
+export interface $ZodSHA256Internals extends $ZodStringFormatInternals<"sha256"> {}
+
+export interface $ZodSHA256 extends $ZodType {
+  _zod: $ZodSHA256Internals;
+}
+
+export const $ZodSHA256: core.$constructor<$ZodSHA256> = /*@__PURE__*/ core.$constructor(
+  "$ZodSHA256",
+  (inst, def): void => {
+    def.pattern ??= regexes.sha256;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
+//////////////////////////////   ZodSHA256Base64   //////////////////////////////
+
+export interface $ZodSHA256Base64Def extends $ZodStringFormatDef<"sha256_base64"> {}
+export interface $ZodSHA256Base64Internals extends $ZodStringFormatInternals<"sha256_base64"> {}
+
+export interface $ZodSHA256Base64 extends $ZodType {
+  _zod: $ZodSHA256Base64Internals;
+}
+
+export const $ZodSHA256Base64: core.$constructor<$ZodSHA256Base64> = /*@__PURE__*/ core.$constructor(
+  "$ZodSHA256Base64",
+  (inst, def): void => {
+    def.pattern ??= regexes.sha256Base64;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
+//////////////////////////////   ZodSHA384   //////////////////////////////
+
+export interface $ZodSHA384Def extends $ZodStringFormatDef<"sha384"> {}
+export interface $ZodSHA384Internals extends $ZodStringFormatInternals<"sha384"> {}
+
+export interface $ZodSHA384 extends $ZodType {
+  _zod: $ZodSHA384Internals;
+}
+
+export const $ZodSHA384: core.$constructor<$ZodSHA384> = /*@__PURE__*/ core.$constructor(
+  "$ZodSHA384",
+  (inst, def): void => {
+    def.pattern ??= regexes.sha384;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
+//////////////////////////////   ZodSHA384Base64   //////////////////////////////
+
+export interface $ZodSHA384Base64Def extends $ZodStringFormatDef<"sha384_base64"> {}
+export interface $ZodSHA384Base64Internals extends $ZodStringFormatInternals<"sha384_base64"> {}
+
+export interface $ZodSHA384Base64 extends $ZodType {
+  _zod: $ZodSHA384Base64Internals;
+}
+
+export const $ZodSHA384Base64: core.$constructor<$ZodSHA384Base64> = /*@__PURE__*/ core.$constructor(
+  "$ZodSHA384Base64",
+  (inst, def): void => {
+    def.pattern ??= regexes.sha384Base64;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
+//////////////////////////////   ZodSHA512   //////////////////////////////
+
+export interface $ZodSHA512Def extends $ZodStringFormatDef<"sha512"> {}
+export interface $ZodSHA512Internals extends $ZodStringFormatInternals<"sha512"> {}
+
+export interface $ZodSHA512 extends $ZodType {
+  _zod: $ZodSHA512Internals;
+}
+
+export const $ZodSHA512: core.$constructor<$ZodSHA512> = /*@__PURE__*/ core.$constructor(
+  "$ZodSHA512",
+  (inst, def): void => {
+    def.pattern ??= regexes.sha512;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
+//////////////////////////////   ZodSHA512Base64   //////////////////////////////
+
+export interface $ZodSHA512Base64Def extends $ZodStringFormatDef<"sha512_base64"> {}
+export interface $ZodSHA512Base64Internals extends $ZodStringFormatInternals<"sha512_base64"> {}
+
+export interface $ZodSHA512Base64 extends $ZodType {
+  _zod: $ZodSHA512Base64Internals;
+}
+
+export const $ZodSHA512Base64: core.$constructor<$ZodSHA512Base64> = /*@__PURE__*/ core.$constructor(
+  "$ZodSHA512Base64",
+  (inst, def): void => {
+    def.pattern ??= regexes.sha512Base64;
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
 //////////////////////////////   ZodJWT   //////////////////////////////
 
 export function isValidJWT(token: string, algorithm: util.JWTAlgorithm | null = null): boolean {

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -67,6 +67,16 @@ const error: () => errors.$ZodErrorMap = () => {
     json_string: "JSON string",
     e164: "E.164 number",
     jwt: "JWT",
+    md5: "MD5 hash",
+    md5_base64: "MD5 hash (Base64)",
+    sha1: "SHA-1 hash",
+    sha1_base64: "SHA-1 hash (Base64)",
+    sha256: "SHA-256 hash",
+    sha256_base64: "SHA-256 hash (Base64)",
+    sha384: "SHA-384 hash",
+    sha384_base64: "SHA-384 hash (Base64)",
+    sha512: "SHA-512 hash",
+    sha512_base64: "SHA-512 hash (Base64)",
     template_literal: "input",
   };
 

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -414,6 +414,143 @@ export function jwt(params?: string | core.$ZodJWTParams): ZodMiniJWT {
   return core._jwt(ZodMiniJWT, params);
 }
 
+// ZodMiniMD5
+export interface ZodMiniMD5 extends _ZodMiniString<core.$ZodMD5Internals> {}
+export const ZodMiniMD5: core.$constructor<ZodMiniMD5> = /*@__PURE__*/ core.$constructor("ZodMiniMD5", (inst, def) => {
+  core.$ZodMD5.init(inst, def);
+  ZodMiniStringFormat.init(inst, def);
+});
+
+export function md5(params?: string | core.$ZodMD5Params): ZodMiniMD5 {
+  return core._md5(ZodMiniMD5, params);
+}
+
+// ZodMiniMD5Base64
+export interface ZodMiniMD5Base64 extends _ZodMiniString<core.$ZodMD5Base64Internals> {}
+export const ZodMiniMD5Base64: core.$constructor<ZodMiniMD5Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniMD5Base64",
+  (inst, def) => {
+    core.$ZodMD5Base64.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function md5Base64(params?: string | core.$ZodMD5Base64Params): ZodMiniMD5Base64 {
+  return core._md5Base64(ZodMiniMD5Base64, params);
+}
+
+// ZodMiniSHA1
+export interface ZodMiniSHA1 extends _ZodMiniString<core.$ZodSHA1Internals> {}
+export const ZodMiniSHA1: core.$constructor<ZodMiniSHA1> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniSHA1",
+  (inst, def) => {
+    core.$ZodSHA1.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function sha1(params?: string | core.$ZodSHA1Params): ZodMiniSHA1 {
+  return core._sha1(ZodMiniSHA1, params);
+}
+
+// ZodMiniSHA1Base64
+export interface ZodMiniSHA1Base64 extends _ZodMiniString<core.$ZodSHA1Base64Internals> {}
+export const ZodMiniSHA1Base64: core.$constructor<ZodMiniSHA1Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniSHA1Base64",
+  (inst, def) => {
+    core.$ZodSHA1Base64.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function sha1Base64(params?: string | core.$ZodSHA1Base64Params): ZodMiniSHA1Base64 {
+  return core._sha1Base64(ZodMiniSHA1Base64, params);
+}
+
+// ZodMiniSHA256
+export interface ZodMiniSHA256 extends _ZodMiniString<core.$ZodSHA256Internals> {}
+export const ZodMiniSHA256: core.$constructor<ZodMiniSHA256> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniSHA256",
+  (inst, def) => {
+    core.$ZodSHA256.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function sha256(params?: string | core.$ZodSHA256Params): ZodMiniSHA256 {
+  return core._sha256(ZodMiniSHA256, params);
+}
+
+// ZodMiniSHA256Base64
+export interface ZodMiniSHA256Base64 extends _ZodMiniString<core.$ZodSHA256Base64Internals> {}
+export const ZodMiniSHA256Base64: core.$constructor<ZodMiniSHA256Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniSHA256Base64",
+  (inst, def) => {
+    core.$ZodSHA256Base64.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function sha256Base64(params?: string | core.$ZodSHA256Base64Params): ZodMiniSHA256Base64 {
+  return core._sha256Base64(ZodMiniSHA256Base64, params);
+}
+
+// ZodMiniSHA384
+export interface ZodMiniSHA384 extends _ZodMiniString<core.$ZodSHA384Internals> {}
+export const ZodMiniSHA384: core.$constructor<ZodMiniSHA384> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniSHA384",
+  (inst, def) => {
+    core.$ZodSHA384.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function sha384(params?: string | core.$ZodSHA384Params): ZodMiniSHA384 {
+  return core._sha384(ZodMiniSHA384, params);
+}
+
+// ZodMiniSHA384Base64
+export interface ZodMiniSHA384Base64 extends _ZodMiniString<core.$ZodSHA384Base64Internals> {}
+export const ZodMiniSHA384Base64: core.$constructor<ZodMiniSHA384Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniSHA384Base64",
+  (inst, def) => {
+    core.$ZodSHA384Base64.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function sha384Base64(params?: string | core.$ZodSHA384Base64Params): ZodMiniSHA384Base64 {
+  return core._sha384Base64(ZodMiniSHA384Base64, params);
+}
+
+// ZodMiniSHA512
+export interface ZodMiniSHA512 extends _ZodMiniString<core.$ZodSHA512Internals> {}
+export const ZodMiniSHA512: core.$constructor<ZodMiniSHA512> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniSHA512",
+  (inst, def) => {
+    core.$ZodSHA512.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function sha512(params?: string | core.$ZodSHA512Params): ZodMiniSHA512 {
+  return core._sha512(ZodMiniSHA512, params);
+}
+
+// ZodMiniSHA512Base64
+export interface ZodMiniSHA512Base64 extends _ZodMiniString<core.$ZodSHA512Base64Internals> {}
+export const ZodMiniSHA512Base64: core.$constructor<ZodMiniSHA512Base64> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniSHA512Base64",
+  (inst, def) => {
+    core.$ZodSHA512Base64.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+export function sha512Base64(params?: string | core.$ZodSHA512Base64Params): ZodMiniSHA512Base64 {
+  return core._sha512Base64(ZodMiniSHA512Base64, params);
+}
+
 // ZodMiniCustomStringFormat
 export interface ZodMiniCustomStringFormat<Format extends string = string>
   extends ZodMiniStringFormat<Format>,


### PR DESCRIPTION
- **feat: add hash format validation schemas**
- **feat: add hash format API functions**
- **feat: add hash format methods to classic API**
- **feat: add hash format methods to mini API**
- **feat: add English locale messages for hash formats**
- **fix: SHA-1 hash regex**
- **test: add comprehensive hash format validation tests**
- **refactor: remove deprecated hash chaining methods from ZodString**
- **test: add comprehensive hash format validation tests**
