### PR TITLE
Drop JIT in Zod Mini `z.object()` (reduces bundle size by 20%)

### DIFF
--- a/packages/bench/index.ts
+++ b/packages/bench/index.ts
@@ -6,8 +6,8 @@ async function run() {
   const files = process.argv[2].split(",").map((file) => import.meta.resolve(`./${file}`).replace("file://", ""));
 
   for (const file of files) {
-    // await $`pnpm tsx --conditions @zod/source ${file}`;
-    await $`pnpm tsx ${file}`;
+    await $`pnpm tsx --conditions @zod/source ${file}`;
+    // await $`pnpm tsx ${file}`;
   }
 }
 

--- a/packages/bench/object-moltar.ts
+++ b/packages/bench/object-moltar.ts
@@ -3,42 +3,42 @@ import * as z4lib from "zod4/v4";
 import * as z3 from "zod3";
 import { metabench } from "./metabench.js";
 
-const z3Schema = z3.object({
+const z3Schema = z3.strictObject({
   number: z3.number(),
   negNumber: z3.number(),
   maxNumber: z3.number(),
   string: z3.string(),
   longString: z3.string(),
   boolean: z3.boolean(),
-  deeplyNested: z3.object({
+  deeplyNested: z3.strictObject({
     foo: z3.string(),
     num: z3.number(),
     bool: z3.boolean(),
   })
 })
 
-const z4LibSchema = z4lib.object({
+const z4LibSchema = z4lib.strictObject({
   number: z4lib.number(),
   negNumber: z4lib.number(),
   maxNumber: z4lib.number(),
   string: z4lib.string(),
   longString: z4lib.string(),
   boolean: z4lib.boolean(),
-  deeplyNested: z4lib.object({
+  deeplyNested: z4lib.strictObject({
     foo: z4lib.string(),
     num: z4lib.number(),
     bool: z4lib.boolean(),
   }),
 });
 
-const z4Schema = z4.object({
+const z4Schema = z4.strictObject({
   number: z4.number(),
   negNumber: z4.number(),
   maxNumber: z4.number(),
   string: z4.string(),
   longString: z4.string(),
   boolean: z4.boolean(),
-  deeplyNested: z4.object({
+  deeplyNested: z4.strictObject({
     foo: z4.string(),
     num: z4.number(),
     bool: z4.boolean(),

--- a/packages/treeshake/package.json
+++ b/packages/treeshake/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bundle": "rollup -c rollup.config.js --input",
     "bundle:rollup": "rollup --input",
-    "bundle:esbuild": "esbuild --bundle ./in.ts --outfile=./out.js --bundle --format=esm"
+    "bundle:esbuild": "esbuild --bundle ./in.ts --conditions=@zod/source --outfile=./out.js --bundle --format=esm"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",

--- a/packages/treeshake/rollup.config.js
+++ b/packages/treeshake/rollup.config.js
@@ -14,14 +14,10 @@ export default {
     // sourcemap: true, // Generate sourcemaps for easier debugging
   },
   plugins: [
-    resolve({
-      
-    }), // Resolve node_modules
+    resolve(), // Resolve node_modules
     commonjs(), // Convert CommonJS modules to ES6
     typescript(), // Compile TypeScript
-    // bundleSize(),
     filesize(), // Display bundle size
-    // terser(),
   ],
   treeshake: {
     preset: "smallest",

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1135,7 +1135,7 @@ export interface ZodObject<
 }
 
 export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$constructor("ZodObject", (inst, def) => {
-  core.$ZodObject.init(inst, def);
+  core.$ZodObjectJIT.init(inst, def);
   ZodType.init(inst, def);
 
   util.defineLazy(inst, "shape", () => def.shape);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -185,7 +185,6 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   if (inst._zod.traits.has("$ZodCheck")) {
     checks.unshift(inst as any);
   }
-  //
 
   for (const ch of checks) {
     for (const fn of ch._zod.onattach) {
@@ -1725,7 +1724,6 @@ function normalizeDef(def: $ZodObjectDef) {
 
   return {
     ...def,
-    // shape: def.shape,
     keys,
     keySet: new Set(keys),
     numKeys: keys.length,
@@ -1739,7 +1737,6 @@ function handleCatchall(
   payload: ParsePayload,
   ctx: ParseContext,
   def: ReturnType<typeof normalizeDef>,
-  // catchall: $ZodType,
   inst: $ZodObject
 ) {
   const unrecognized: string[] = [];
@@ -1834,39 +1831,6 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     }
 
     return handleCatchall(proms, input, payload, ctx, _normalized.value, inst);
-    // const unrecognized: string[] = [];
-    // // iterate over input keys
-    // const keySet = value.keySet;
-    // const _catchall = catchall._zod;
-    // const t = _catchall.def.type;
-    // for (const key of Object.keys(input)) {
-    //   if (keySet.has(key)) continue;
-    //   if (t === "never") {
-    //     unrecognized.push(key);
-    //     continue;
-    //   }
-    //   const r = _catchall.run({ value: input[key], issues: [] }, ctx);
-
-    //   if (r instanceof Promise) {
-    //     proms.push(r.then((r) => handlePropertyResult(r, payload, key, input)));
-    //   } else {
-    //     handlePropertyResult(r, payload, key, input);
-    //   }
-    // }
-
-    // if (unrecognized.length) {
-    //   payload.issues.push({
-    //     code: "unrecognized_keys",
-    //     keys: unrecognized,
-    //     input,
-    //     inst,
-    //   });
-    // }
-
-    // if (!proms.length) return payload;
-    // return Promise.all(proms).then(() => {
-    //   return payload;
-    // });
   };
 });
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1714,27 +1714,74 @@ export interface $ZodObject<
   "~standard": $ZodStandardSchema<this>;
 }
 
+function normalizeDef(def: $ZodObjectDef) {
+  const keys = Object.keys(def.shape);
+  for (const k of keys) {
+    if (!(def.shape[k] instanceof $ZodType)) {
+      throw new Error(`Invalid element at key "${k}": expected a Zod schema`);
+    }
+  }
+  const okeys = util.optionalKeys(def.shape);
+
+  return {
+    ...def,
+    // shape: def.shape,
+    keys,
+    keySet: new Set(keys),
+    numKeys: keys.length,
+    optionalKeys: new Set(okeys),
+  };
+}
+
+function handleCatchall(
+  proms: Promise<any>[],
+  input: any,
+  payload: ParsePayload,
+  ctx: ParseContext,
+  def: ReturnType<typeof normalizeDef>,
+  // catchall: $ZodType,
+  inst: $ZodObject
+) {
+  const unrecognized: string[] = [];
+  // iterate over input keys
+  const keySet = def.keySet;
+  const _catchall = def.catchall!._zod;
+  const t = _catchall.def.type;
+  for (const key of Object.keys(input)) {
+    if (keySet.has(key)) continue;
+    if (t === "never") {
+      unrecognized.push(key);
+      continue;
+    }
+    const r = _catchall.run({ value: input[key], issues: [] }, ctx);
+
+    if (r instanceof Promise) {
+      proms.push(r.then((r) => handlePropertyResult(r, payload, key, input)));
+    } else {
+      handlePropertyResult(r, payload, key, input);
+    }
+  }
+
+  if (unrecognized.length) {
+    payload.issues.push({
+      code: "unrecognized_keys",
+      keys: unrecognized,
+      input,
+      inst,
+    });
+  }
+
+  if (!proms.length) return payload;
+  return Promise.all(proms).then(() => {
+    return payload;
+  });
+}
+
 export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$constructor("$ZodObject", (inst, def) => {
   // requires cast because technically $ZodObject doesn't extend
   $ZodType.init(inst, def);
 
-  const _normalized = util.cached(() => {
-    const keys = Object.keys(def.shape);
-    for (const k of keys) {
-      if (!(def.shape[k] instanceof $ZodType)) {
-        throw new Error(`Invalid element at key "${k}": expected a Zod schema`);
-      }
-    }
-    const okeys = util.optionalKeys(def.shape);
-
-    return {
-      shape: def.shape,
-      keys,
-      keySet: new Set(keys),
-      numKeys: keys.length,
-      optionalKeys: new Set(okeys),
-    };
-  });
+  const _normalized = util.cached(() => normalizeDef(def));
 
   util.defineLazy(inst._zod, "propValues", () => {
     const shape = def.shape;
@@ -1749,60 +1796,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     return propValues;
   });
 
-  const generateFastpass = (shape: any) => {
-    const doc = new Doc(["shape", "payload", "ctx"]);
-    const normalized = _normalized.value;
-
-    const parseStr = (key: string) => {
-      const k = util.esc(key);
-      return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
-    };
-
-    doc.write(`const input = payload.value;`);
-
-    const ids: any = Object.create(null);
-    let counter = 0;
-    for (const key of normalized.keys) {
-      ids[key] = `key_${counter++}`;
-    }
-
-    // A: preserve key order {
-    doc.write(`const newResult = {}`);
-    for (const key of normalized.keys) {
-      const id = ids[key];
-      const k = util.esc(key);
-      doc.write(`const ${id} = ${parseStr(key)};`);
-      doc.write(`
-        if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
-        }
-        
-        if (${id}.value === undefined) {
-          if (${k} in input) {
-            newResult[${k}] = undefined;
-          }
-        } else {
-          newResult[${k}] = ${id}.value;
-        }
-      `);
-    }
-
-    doc.write(`payload.value = newResult;`);
-    doc.write(`return payload;`);
-    const fn = doc.compile();
-    return (payload: any, ctx: any) => fn(shape, payload, ctx);
-  };
-
-  let fastpass!: ReturnType<typeof generateFastpass>;
-
   const isObject = util.isObject;
-  const jit = !core.globalConfig.jitless;
-  const allowsEval = util.allowsEval;
-
-  const fastEnabled = jit && allowsEval.value; // && !def.catchall;
   const catchall = def.catchall;
 
   let value!: typeof _normalized.value;
@@ -1821,43 +1815,13 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
       return payload;
     }
 
+    payload.value = {};
+
     const proms: Promise<any>[] = [];
-
-    if (jit && fastEnabled && ctx?.async === false && ctx.jitless !== true) {
-      // always synchronous
-      if (!fastpass) fastpass = generateFastpass(def.shape);
-      payload = fastpass(payload, ctx);
-    } else {
-      payload.value = {};
-
-      const shape = value.shape;
-      for (const key of value.keys) {
-        const el = shape[key]!;
-        const r = el._zod.run({ value: input[key], issues: [] }, ctx);
-        if (r instanceof Promise) {
-          proms.push(r.then((r) => handlePropertyResult(r, payload, key, input)));
-        } else {
-          handlePropertyResult(r, payload, key, input);
-        }
-      }
-    }
-
-    if (!catchall) {
-      return proms.length ? Promise.all(proms).then(() => payload) : payload;
-    }
-    const unrecognized: string[] = [];
-    // iterate over input keys
-    const keySet = value.keySet;
-    const _catchall = catchall._zod;
-    const t = _catchall.def.type;
-    for (const key of Object.keys(input)) {
-      if (keySet.has(key)) continue;
-      if (t === "never") {
-        unrecognized.push(key);
-        continue;
-      }
-      const r = _catchall.run({ value: input[key], issues: [] }, ctx);
-
+    const shape = value.shape;
+    for (const key of value.keys) {
+      const el = shape[key]!;
+      const r = el._zod.run({ value: input[key], issues: [] }, ctx);
       if (r instanceof Promise) {
         proms.push(r.then((r) => handlePropertyResult(r, payload, key, input)));
       } else {
@@ -1865,22 +1829,140 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
       }
     }
 
-    if (unrecognized.length) {
-      payload.issues.push({
-        code: "unrecognized_keys",
-
-        keys: unrecognized,
-        input,
-        inst,
-      });
+    if (!catchall) {
+      return proms.length ? Promise.all(proms).then(() => payload) : payload;
     }
 
-    if (!proms.length) return payload;
-    return Promise.all(proms).then(() => {
-      return payload;
-    });
+    return handleCatchall(proms, input, payload, ctx, _normalized.value, inst);
+    // const unrecognized: string[] = [];
+    // // iterate over input keys
+    // const keySet = value.keySet;
+    // const _catchall = catchall._zod;
+    // const t = _catchall.def.type;
+    // for (const key of Object.keys(input)) {
+    //   if (keySet.has(key)) continue;
+    //   if (t === "never") {
+    //     unrecognized.push(key);
+    //     continue;
+    //   }
+    //   const r = _catchall.run({ value: input[key], issues: [] }, ctx);
+
+    //   if (r instanceof Promise) {
+    //     proms.push(r.then((r) => handlePropertyResult(r, payload, key, input)));
+    //   } else {
+    //     handlePropertyResult(r, payload, key, input);
+    //   }
+    // }
+
+    // if (unrecognized.length) {
+    //   payload.issues.push({
+    //     code: "unrecognized_keys",
+    //     keys: unrecognized,
+    //     input,
+    //     inst,
+    //   });
+    // }
+
+    // if (!proms.length) return payload;
+    // return Promise.all(proms).then(() => {
+    //   return payload;
+    // });
   };
 });
+
+export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$constructor(
+  "$ZodObjectJIT",
+  (inst, def) => {
+    // requires cast because technically $ZodObject doesn't extend
+    $ZodObject.init(inst, def);
+
+    const superParse = inst._zod.parse;
+    const _normalized = util.cached(() => normalizeDef(def));
+
+    const generateFastpass = (shape: any) => {
+      const doc = new Doc(["shape", "payload", "ctx"]);
+      const normalized = _normalized.value;
+
+      const parseStr = (key: string) => {
+        const k = util.esc(key);
+        return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
+      };
+
+      doc.write(`const input = payload.value;`);
+
+      const ids: any = Object.create(null);
+      let counter = 0;
+      for (const key of normalized.keys) {
+        ids[key] = `key_${counter++}`;
+      }
+
+      // A: preserve key order {
+      doc.write(`const newResult = {}`);
+      for (const key of normalized.keys) {
+        const id = ids[key];
+        const k = util.esc(key);
+        doc.write(`const ${id} = ${parseStr(key)};`);
+        doc.write(`
+        if (${id}.issues.length) {
+          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
+            ...iss,
+            path: iss.path ? [${k}, ...iss.path] : [${k}]
+          })));
+        }
+        
+        if (${id}.value === undefined) {
+          if (${k} in input) {
+            newResult[${k}] = undefined;
+          }
+        } else {
+          newResult[${k}] = ${id}.value;
+        }
+      `);
+      }
+
+      doc.write(`payload.value = newResult;`);
+      doc.write(`return payload;`);
+      const fn = doc.compile();
+      return (payload: any, ctx: any) => fn(shape, payload, ctx);
+    };
+
+    let fastpass!: ReturnType<typeof generateFastpass>;
+
+    const isObject = util.isObject;
+    const jit = !core.globalConfig.jitless;
+    const allowsEval = util.allowsEval;
+
+    const fastEnabled = jit && allowsEval.value; // && !def.catchall;
+    const catchall = def.catchall;
+
+    let value!: typeof _normalized.value;
+
+    inst._zod.parse = (payload, ctx) => {
+      value ??= _normalized.value;
+      const input = payload.value;
+      if (!isObject(input)) {
+        payload.issues.push({
+          expected: "object",
+          code: "invalid_type",
+          input,
+          inst,
+        });
+        return payload;
+      }
+
+      if (jit && fastEnabled && ctx?.async === false && ctx.jitless !== true) {
+        // always synchronous
+        if (!fastpass) fastpass = generateFastpass(def.shape);
+        payload = fastpass(payload, ctx);
+
+        if (!catchall) return payload;
+        return handleCatchall([], input, payload, ctx, value, inst);
+      }
+
+      return superParse(payload, ctx);
+    };
+  }
+);
 
 /////////////////////////////////////////
 /////////////////////////////////////////


### PR DESCRIPTION
Before:

```
$ pnpm bundle zod-mini-object.ts

> @zod/treeshaking@ bundle /Users/colinmcd94/Documents/projects/zod/packages/treeshake
> rollup -c rollup.config.js --input zod-mini-object.ts


zod-mini-object.ts → ./out.js...
┌──────────────────────────────┐
│                              │
│   Destination: ./out.js      │
│   Bundle Size:  24.49 KB     │
│   Minified Size:  11.73 KB   │
│   Gzipped Size:  3.91 KB     │
│                              │
└──────────────────────────────┘
created ./out.js in 968ms
```

After: 
```
$ pnpm bundle zod-mini-object.ts

> @zod/treeshaking@ bundle /Users/colinmcd94/Documents/projects/zod/packages/treeshake
> rollup -c rollup.config.js --input zod-mini-object.ts


zod-mini-object.ts → ./out.js...
┌────────────────────────────┐
│                            │
│   Destination: ./out.js    │
│   Bundle Size:  20.36 KB   │
│   Minified Size:  9.6 KB   │
│   Gzipped Size:  3.14 KB   │
│                            │
└────────────────────────────┘
created ./out.js in 944ms
```