### PR TITLE
feat: make $ZodFunction extend $ZodType

### DIFF
--- a/packages/zod/src/v4/classic/tests/firstparty.test.ts
+++ b/packages/zod/src/v4/classic/tests/firstparty.test.ts
@@ -168,6 +168,8 @@ test("$ZodSchemaTypes", () => {
       break;
     case "lazy":
       break;
+    case "function":
+      break;
 
     default:
       expectTypeOf(type).toEqualTypeOf<never>();

--- a/packages/zod/src/v4/core/function.ts
+++ b/packages/zod/src/v4/core/function.ts
@@ -15,7 +15,7 @@ import type * as util from "./util.js";
 export interface $ZodFunctionDef<
   In extends $ZodFunctionIn = $ZodFunctionIn,
   Out extends $ZodFunctionOut = $ZodFunctionOut,
-> {
+> extends schemas.$ZodTypeDef {
   type: "function";
   input: In;
   output: Out;
@@ -44,7 +44,7 @@ export type $InferOuterFunctionTypeAsync<Args extends $ZodFunctionIn, Returns ex
 export class $ZodFunction<
   Args extends $ZodFunctionIn = $ZodFunctionIn,
   Returns extends $ZodFunctionOut = $ZodFunctionOut,
-> {
+> extends schemas.$ZodType {
   def: $ZodFunctionDef<Args, Returns>;
 
   /** @deprecated */
@@ -53,6 +53,7 @@ export class $ZodFunction<
   _output!: $InferOuterFunctionType<Args, Returns>;
 
   constructor(def: $ZodFunctionDef<Args, Returns>) {
+    super(def);
     this._def = def;
     this.def = def;
   }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -44,6 +44,7 @@ export interface $ZodTypeDef {
     | "boolean"
     | "bigint"
     | "symbol"
+    | "function"
     | "null"
     | "undefined"
     | "void" // merge with undefined?


### PR DESCRIPTION
## Summary
- have `$ZodFunction` extend `$ZodType`
- add "function" to `$ZodTypeDef` type list
- update v4 tests for the new `function` type

## Testing
- `npx biome lint packages/zod/src/v4/core/function.ts`
- `npx biome lint packages/zod/src/v4/core/schemas.ts`
- `npx biome lint packages/zod/src/v4/classic/tests/firstparty.test.ts`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6892b45c9030832f9d41a58455ba9ba1