### PR TITLE
fix: `edit this page` button, now redirects to correct url using the new path

### DIFF
--- a/packages/docs/app/(doc)/[[...slug]]/page.tsx
+++ b/packages/docs/app/(doc)/[[...slug]]/page.tsx
@@ -26,10 +26,12 @@ export default async function Page(props: {
       return item;
     });
 
+  console.log(`Page file path = ${page.file.path}`);
+
   const editOnGithub = (
     <h3 className="border-[var(--color-fd-border)] pb-0 mb-0 inline-flex items-center gap-1.5 text-sm text-fd-muted-foreground">
       <a
-        href={`https://github.com/colinhacks/zod/blob/main/content/packages/docs/${page.file.path}`}
+        href={`https://github.com/colinhacks/zod/blob/main/packages/docs/content/${page.file.path}`}
         rel="noreferrer noopener"
         target="_blank"
         className="text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300 text-sm no-underline"

--- a/packages/docs/app/(doc)/[[...slug]]/page.tsx
+++ b/packages/docs/app/(doc)/[[...slug]]/page.tsx
@@ -26,8 +26,6 @@ export default async function Page(props: {
       return item;
     });
 
-  console.log(`Page file path = ${page.file.path}`);
-
   const editOnGithub = (
     <h3 className="border-[var(--color-fd-border)] pb-0 mb-0 inline-flex items-center gap-1.5 text-sm text-fd-muted-foreground">
       <a


### PR DESCRIPTION
While checking the [migration guide](https://zod.dev/v4/changelog) from z3 to z4 I saw that the `edit this page` button was redirecting to incorrect path,

Redirecting page on the official site:
<img width="1722" height="354" alt="Screenshot 2025-08-06 at 19 31 39" src="https://github.com/user-attachments/assets/9db1217e-6f0d-47e3-9857-396702c0bd15" />

The correct path:
<img width="1724" height="281" alt="Screenshot 2025-08-06 at 19 34 08" src="https://github.com/user-attachments/assets/b0a8d587-36c6-4b65-8da0-1fbd17b0c6af" />

