### PR TITLE
Update Hey API link to Zod plugin

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -127,7 +127,7 @@ const xToZodConverters: ZodResource[] = [
   {
 
     name: "Hey API",
-    url: "https://github.com/hey-api/openapi-ts",
+    url: "https://heyapi.dev/openapi-ts/plugins/zod",
     description: "The OpenAPI to TypeScript codegen. Generate clients, SDKs, validators, and more.",
     slug: "hey-api/openapi-ts",
   },


### PR DESCRIPTION
This should make Hey API more relevant when people search for things like "openapi zod"