### PR TITLE
feat: add codec encode decode support

### DIFF
--- a/packages/zod/src/v4/classic/external.ts
+++ b/packages/zod/src/v4/classic/external.ts
@@ -29,6 +29,7 @@ export {
   toJSONSchema,
   TimePrecision,
   NEVER,
+  $ZodEncodeError as ZodEncodeError,
 } from "../core/index.js";
 
 export * as locales from "../locales/index.js";

--- a/packages/zod/src/v4/classic/parse.ts
+++ b/packages/zod/src/v4/classic/parse.ts
@@ -31,3 +31,34 @@ export const safeParseAsync: <T extends core.$ZodType>(
   value: unknown,
   _ctx?: core.ParseContext<core.$ZodIssue>
 ) => Promise<ZodSafeParseResult<core.output<T>>> = /* @__PURE__ */ core._safeParseAsync(ZodRealError) as any;
+
+export const encode: <T extends core.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: core.ParseContext<core.$ZodIssue>,
+  _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
+) => core.input<T> = /* @__PURE__ */ core._encode(ZodRealError) as any;
+
+export const encodeAsync: <T extends core.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: core.ParseContext<core.$ZodIssue>,
+  _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
+) => Promise<core.input<T>> = /* @__PURE__ */ core._encodeAsync(ZodRealError) as any;
+
+export const safeEncode: <T extends core.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: core.ParseContext<core.$ZodIssue>
+) => ZodSafeParseResult<core.input<T>> = /* @__PURE__ */ core._safeEncode(ZodRealError) as any;
+
+export const safeEncodeAsync: <T extends core.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: core.ParseContext<core.$ZodIssue>
+) => Promise<ZodSafeParseResult<core.input<T>>> = /* @__PURE__ */ core._safeEncodeAsync(ZodRealError) as any;
+
+export const decode = parse;
+export const decodeAsync = parseAsync;
+export const safeDecode = safeParse;
+export const safeDecodeAsync = safeParseAsync;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -54,6 +54,23 @@ export interface ZodType<
     data: unknown,
     params?: core.ParseContext<core.$ZodIssue>
   ) => Promise<parse.ZodSafeParseResult<core.output<this>>>;
+  decode(data: unknown, params?: core.ParseContext<core.$ZodIssue>): core.output<this>;
+  decodeAsync(data: unknown, params?: core.ParseContext<core.$ZodIssue>): Promise<core.output<this>>;
+  safeDecode(data: unknown, params?: core.ParseContext<core.$ZodIssue>): parse.ZodSafeParseResult<core.output<this>>;
+  safeDecodeAsync(
+    data: unknown,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
+  encode(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>): core.input<this>;
+  encodeAsync(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>): Promise<core.input<this>>;
+  safeEncode(
+    data: core.output<this>,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): parse.ZodSafeParseResult<core.input<this>>;
+  safeEncodeAsync(
+    data: core.output<this>,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): Promise<parse.ZodSafeParseResult<core.input<this>>>;
 
   // refinements
   refine(check: (arg: core.output<this>) => unknown | Promise<unknown>, params?: string | core.$ZodCustomParams): this;
@@ -148,6 +165,15 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   inst.parseAsync = async (data, params) => parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
   inst.safeParseAsync = async (data, params) => parse.safeParseAsync(inst, data, params);
   inst.spa = inst.safeParseAsync;
+  inst.decode = inst.parse as any;
+  inst.decodeAsync = inst.parseAsync as any;
+  inst.safeDecode = inst.safeParse as any;
+  inst.safeDecodeAsync = inst.safeParseAsync as any;
+  inst.encode = (data, params) => parse.encode(inst, data as any, params, { callee: inst.encode }) as any;
+  inst.encodeAsync = async (data, params) =>
+    parse.encodeAsync(inst, data as any, params, { callee: inst.encodeAsync }) as any;
+  inst.safeEncode = (data, params) => parse.safeEncode(inst, data as any, params) as any;
+  inst.safeEncodeAsync = async (data, params) => parse.safeEncodeAsync(inst, data as any, params) as any;
 
   // refinements
   inst.refine = (check, params) => inst.check(refine(check, params));
@@ -1834,6 +1860,38 @@ export function pipe(in_: core.SomeType, out: core.SomeType) {
     in: in_ as unknown as core.$ZodType,
     out: out as unknown as core.$ZodType,
     // ...util.normalizeParams(params),
+  });
+}
+
+// ZodCodec
+export interface ZodCodec<A extends core.SomeType = core.$ZodType, B extends core.SomeType = core.$ZodType>
+  extends _ZodType<core.$ZodCodecInternals<A, B>>,
+    core.$ZodCodec<A, B> {
+  in: A;
+  out: B;
+}
+export const ZodCodec: core.$constructor<ZodCodec> = /*@__PURE__*/ core.$constructor("ZodCodec", (inst, def) => {
+  core.$ZodCodec.init(inst, def);
+  ZodType.init(inst, def);
+  inst.in = def.in as any;
+  inst.out = def.out as any;
+});
+
+export function codec<const A extends core.SomeType, const B extends core.SomeType>(
+  in_: A,
+  out: B,
+  handlers: {
+    decode: (value: core.output<A>, ctx: core.ParsePayload<core.output<A>>) => any;
+    encode: (value: core.output<B>, ctx: core.ParsePayload<core.output<B>>) => any;
+  }
+): ZodCodec<A, B>;
+export function codec(in_: core.SomeType, out: core.SomeType, handlers: any) {
+  return new ZodCodec({
+    type: "codec",
+    in: in_ as unknown as core.$ZodType,
+    out: out as unknown as core.$ZodType,
+    decode: handlers.decode,
+    encode: handlers.encode,
   });
 }
 

--- a/packages/zod/src/v4/classic/tests/codec.test.ts
+++ b/packages/zod/src/v4/classic/tests/codec.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+import * as z from "../../index.js";
+
+test("codec encode decode", async () => {
+  const schema = z.codec(z.string(), z.object({ a: z.number() }), {
+    decode: (str: string) => JSON.parse(str),
+    encode: (obj: { a: number }) => JSON.stringify(obj),
+  });
+
+  const decoded = z.decode(schema, '{"a":1}');
+  expect(decoded).toEqual({ a: 1 });
+
+  const encoded = await z.encodeAsync(schema, { a: 1 });
+  expect(encoded).toBe('{"a":1}');
+});
+
+test("safe encode decode", () => {
+  const schema = z.codec(z.string(), z.object({ a: z.number() }), {
+    decode: (str: string) => JSON.parse(str),
+    encode: (obj: { a: number }) => JSON.stringify(obj),
+  });
+
+  const decoded = z.safeDecode(schema, '{"a":1}');
+  expect(decoded).toEqual({ success: true, data: { a: 1 } });
+
+  const encoded = z.safeEncode(schema, { a: 1 });
+  expect(encoded).toEqual({ success: true, data: '{"a":1}' });
+});
+
+test("encode throws on transform", () => {
+  const schema = z.string().transform((v: string) => v);
+  expect(() => z.encode(schema as any, "a")).toThrow(z.ZodEncodeError);
+});
+
+test("safeEncode fails on transform", () => {
+  const schema = z.string().transform((v: string) => v);
+  const result = z.safeEncode(schema as any, "a");
+  expect(result.success).toBe(false);
+});

--- a/packages/zod/src/v4/classic/tests/firstparty.test.ts
+++ b/packages/zod/src/v4/classic/tests/firstparty.test.ts
@@ -74,6 +74,8 @@ test("first party switch", () => {
       break;
     case "pipe":
       break;
+    case "codec":
+      break;
     case "success":
       break;
     case "catch":
@@ -83,7 +85,7 @@ test("first party switch", () => {
     case "lazy":
       break;
     default:
-      expectTypeOf(def).toEqualTypeOf<never>();
+      expectTypeOf(def).toEqualTypeOf<never>(def);
   }
 });
 
@@ -160,6 +162,8 @@ test("$ZodSchemaTypes", () => {
       break;
     case "pipe":
       break;
+    case "codec":
+      break;
     case "success":
       break;
     case "catch":
@@ -170,6 +174,6 @@ test("$ZodSchemaTypes", () => {
       break;
 
     default:
-      expectTypeOf(type).toEqualTypeOf<never>();
+      expectTypeOf(type).toEqualTypeOf<never>(type);
   }
 });

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1383,6 +1383,25 @@ export function _pipe<
   }) as any;
 }
 
+// ZodCodec
+export function _codec<const A extends schemas.$ZodType, const B extends schemas.$ZodType>(
+  Class: util.SchemaClass<schemas.$ZodCodec>,
+  in_: A,
+  out: B,
+  codec: {
+    decode: (value: core.output<A>) => util.MaybeAsync<core.input<B>>;
+    encode: (value: core.output<B>) => util.MaybeAsync<core.input<A>>;
+  }
+): schemas.$ZodCodec<A, B> {
+  return new Class({
+    type: "codec",
+    in: in_,
+    out,
+    decode: (v: any) => codec.decode(v),
+    encode: (v: any) => codec.encode(v),
+  }) as any;
+}
+
 // ZodReadonly
 export type $ZodReadonlyParams = TypeParams<schemas.$ZodReadonly, "innerType">;
 export function _readonly<T extends schemas.$ZodObject>(

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -78,6 +78,12 @@ export class $ZodAsyncError extends Error {
   }
 }
 
+export class $ZodEncodeError extends Error {
+  constructor() {
+    super(`Cannot encode schema containing unidirectional transforms.`);
+  }
+}
+
 ////////////////////////////  TYPE HELPERS  ///////////////////////////////////
 
 // export type input<T extends schemas.$ZodType> = T["_zod"]["input"];

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -565,6 +565,12 @@ export class JSONSchemaGenerator {
             result.ref = innerType;
             break;
           }
+          case "codec": {
+            const innerType = this.io === "input" ? def.in : def.out;
+            this.process(innerType, params);
+            result.ref = innerType;
+            break;
+          }
           case "readonly": {
             this.process(def.innerType, params);
             result.ref = def.innerType;
@@ -988,6 +994,9 @@ function isTransforming(
       return true;
     }
     case "pipe": {
+      return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
+    }
+    case "codec": {
       return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
     }
     case "success": {

--- a/packages/zod/src/v4/mini/external.ts
+++ b/packages/zod/src/v4/mini/external.ts
@@ -21,6 +21,7 @@ export {
   toJSONSchema,
   TimePrecision,
   NEVER,
+  $ZodEncodeError as ZodEncodeError,
 } from "../core/index.js";
 
 export * as locales from "../locales/index.js";

--- a/packages/zod/src/v4/mini/parse.ts
+++ b/packages/zod/src/v4/mini/parse.ts
@@ -1,1 +1,14 @@
-export { parse, safeParse, parseAsync, safeParseAsync } from "../core/index.js";
+export {
+  parse,
+  safeParse,
+  parseAsync,
+  safeParseAsync,
+  encode,
+  encodeAsync,
+  safeEncode,
+  safeEncodeAsync,
+  decode,
+  decodeAsync,
+  safeDecode,
+  safeDecodeAsync,
+} from "../core/index.js";

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1392,6 +1392,35 @@ export function pipe<
   }) as any;
 }
 
+// ZodMiniCodec
+export interface ZodMiniCodec<A extends SomeType = core.$ZodType, B extends SomeType = core.$ZodType>
+  extends _ZodMiniType<core.$ZodCodecInternals<A, B>> {}
+export const ZodMiniCodec: core.$constructor<ZodMiniCodec> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniCodec",
+  (inst, def) => {
+    core.$ZodCodec.init(inst, def);
+    ZodMiniType.init(inst, def);
+  }
+);
+
+export function codec<const A extends SomeType, const B extends SomeType>(
+  in_: A,
+  out: B,
+  handlers: {
+    decode: (value: core.output<A>, ctx: core.ParsePayload<core.output<A>>) => any;
+    encode: (value: core.output<B>, ctx: core.ParsePayload<core.output<B>>) => any;
+  }
+): ZodMiniCodec<A, B>;
+export function codec(in_: SomeType, out: SomeType, handlers: any) {
+  return new ZodMiniCodec({
+    type: "codec",
+    in: in_ as any as core.$ZodType,
+    out: out as any as core.$ZodType,
+    decode: handlers.decode,
+    encode: handlers.encode,
+  }) as any;
+}
+
 // /** @deprecated Use `z.pipe()` and `z.transform()` instead. */
 // export function preprocess<A, U extends core.$ZodType>(
 //   fn: (arg: unknown, ctx: core.ParsePayload) => A,

--- a/packages/zod/src/v4/mini/tests/assignability.test.ts
+++ b/packages/zod/src/v4/mini/tests/assignability.test.ts
@@ -106,6 +106,9 @@ test("assignability", () => {
   // $ZodPipe
   z.pipe(z.unknown(), z.number()) satisfies z.core.$ZodPipe;
 
+  // $ZodCodec
+  z.codec(z.unknown(), z.unknown(), { decode: (v) => v, encode: (v) => v }) satisfies z.core.$ZodCodec;
+
   // $ZodSuccess
   z.success(z.string()) satisfies z.core.$ZodSuccess;
 

--- a/packages/zod/src/v4/mini/tests/codec.test.ts
+++ b/packages/zod/src/v4/mini/tests/codec.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "vitest";
+import * as z from "zod/mini";
+
+test("codec encode decode", async () => {
+  const schema = z.codec(z.string(), z.object({ a: z.number() }), {
+    decode: (str: string) => JSON.parse(str),
+    encode: (obj: { a: number }) => JSON.stringify(obj),
+  });
+
+  const decoded = z.decode(schema, '{"a":1}');
+  expect(decoded).toEqual({ a: 1 });
+
+  const encoded = await z.encodeAsync(schema, { a: 1 });
+  expect(encoded).toBe('{"a":1}');
+});


### PR DESCRIPTION
## Summary
- replace encode flag with internal forward/backward direction
- expose safeEncode/safeDecode helpers alongside encode/decode
- add ZodMiniCodec for mini build compatibility

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68950afcaa60832f91e0e6c620a3357f