### PR TITLE
#5088: improved validation messages for "invalid type" (de)

### DIFF
--- a/packages/zod/src/v4/core/tests/locales/de.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/de.test.ts
@@ -1,0 +1,17 @@
+import { beforeAll, expect, test } from "vitest";
+import { type ZodType, z } from "zod/v4";
+
+import de from "../../../locales/de.js";
+
+beforeAll(() => z.config(de()));
+
+test("invalid type localization", () => {
+  expect(validate(z.string(), null)).toBe("Wert erforderlich");
+  expect(validate(z.string(), undefined)).toBe("Wert erforderlich");
+  expect(validate(z.string(), 1)).toBe("Ungültige Eingabe: erwartet string, erhalten Zahl");
+});
+
+function validate(schema: ZodType, value: any): string | null {
+  const error = schema.safeParse(value).error;
+  return error?.issues ? error.issues[0]!.message : null;
+}

--- a/packages/zod/src/v4/locales/de.ts
+++ b/packages/zod/src/v4/locales/de.ts
@@ -73,6 +73,9 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
+        if (issue.input === undefined || issue.input === null) {
+          return `Wert erforderlich`;
+        }
         return `Ungültige Eingabe: erwartet ${issue.expected}, erhalten ${parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Ungültige Eingabe: erwartet ${util.stringifyPrimitive(issue.values[0])}`;


### PR DESCRIPTION
Provides improved German translations for null / undefined. Fixes #5088.