### PR TITLE
fix: Support overriding `$defs` / `definition`

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1535,6 +1535,52 @@ test("describe with id", () => {
   `);
 });
 
+test("override with id", () => {
+  const jobId = z.string().meta({ id: "jobId" });
+
+  const a = z.z.toJSONSchema(
+    z.object({
+      current: jobId.describe("Current job"),
+      previous: jobId.describe("Previous job"),
+    }),
+    {
+      override(ctx) {
+        if (ctx.path.join("/") === "$defs/jobId") {
+          ctx.jsonSchema.id = "jobIdChanged";
+        }
+      },
+    }
+  );
+
+  expect(a).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "jobId": {
+          "id": "jobIdChanged",
+          "type": "string",
+        },
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "$ref": "#/$defs/jobId",
+          "description": "Current job",
+        },
+        "previous": {
+          "$ref": "#/$defs/jobId",
+          "description": "Previous job",
+        },
+      },
+      "required": [
+        "current",
+        "previous",
+      ],
+      "type": "object",
+    }
+  `);
+});
+
 test("overwrite id", () => {
   const jobId = z.string().meta({ id: "aaa" });
 

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1536,7 +1536,7 @@ test("describe with id", () => {
 });
 
 test("override with id", () => {
-  const jobId = z.string().meta({ id: "jobId" });
+  const jobId = z.string().meta({ id: "jobIdFoo" });
 
   const a = z.z.toJSONSchema(
     z.object({
@@ -1545,7 +1545,7 @@ test("override with id", () => {
     }),
     {
       override(ctx) {
-        if (ctx.path.join("/") === "$defs/jobId") {
+        if (ctx.path.join("/") === "$defs/jobIdFoo") {
           ctx.jsonSchema.id = "jobIdChanged";
         }
       },
@@ -1555,7 +1555,7 @@ test("override with id", () => {
   expect(a).toMatchInlineSnapshot(`
     {
       "$defs": {
-        "jobId": {
+        "jobIdFoo": {
           "id": "jobIdChanged",
           "type": "string",
         },
@@ -1564,11 +1564,11 @@ test("override with id", () => {
       "additionalProperties": false,
       "properties": {
         "current": {
-          "$ref": "#/$defs/jobId",
+          "$ref": "#/$defs/jobIdFoo",
           "description": "Current job",
         },
         "previous": {
-          "$ref": "#/$defs/jobId",
+          "$ref": "#/$defs/jobIdFoo",
           "description": "Previous job",
         },
       },

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -817,9 +817,17 @@ export class JSONSchemaGenerator {
 
     // build defs object
     const defs: JSONSchema.BaseSchema["$defs"] = params.external?.defs ?? {};
+
+    const rootKey = this.target === "draft-2020-12" ? "$defs" : "definitions";
+
     for (const entry of this.seen.entries()) {
       const seen = entry[1];
       if (seen.def && seen.defId) {
+        this.override({
+          zodSchema: entry[0] as schemas.$ZodTypes,
+          jsonSchema: seen.def,
+          path: [rootKey, seen.defId],
+        });
         defs[seen.defId] = seen.def;
       }
     }


### PR DESCRIPTION
Closes #5103

The previous behavior had this logic:

- If schema has parent, override isn’t called on child schema
- A .describe or .meta will set a parent

However, this logic considers the concept of a parent based on the Zod schema;  which in certain cases makes it impossible to override a schema with no parent in the outputted JSON Schema. This is a bug fix to support overriding schemas at the root level. An alternative fix would be smarter detection of what counts as a parent schema: considering the concept of 'parent' in a JSON Schema `$ref` as well.