### PR TITLE
fix(docs): correct example to use `LooseDog` instead of `Dog`

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1099,7 +1099,7 @@ const LooseDog = z.looseObject({
   name: z.string(),
 });
 
-Dog.parse({ name: "Yeller", extraKey: true });
+LooseDog.parse({ name: "Yeller", extraKey: true });
 // => { name: "Yeller", extraKey: true }
 ```
 


### PR DESCRIPTION
This PR corrects the example of `z.looseObject` API to use `LooseDog` schema instead of `Dog`, which should address confusion and improve clarity.