### PR TITLE
fix(v4): toJSONSchema - wrong record output when targeting `openapi-3.0`

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -652,6 +652,18 @@ describe("toJSONSchema", () => {
     `);
   });
 
+  test("record openapi", () => {
+    const schema = z.record(z.string(), z.boolean());
+    expect(z.toJSONSchema(schema, { target: "openapi-3.0" })).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": {
+          "type": "boolean",
+        },
+        "type": "object",
+      }
+    `);
+  });
+
   test("tuple", () => {
     const schema = z.tuple([z.string(), z.number()]).rest(z.boolean());
     expect(z.toJSONSchema(schema)).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -409,7 +409,7 @@ export class JSONSchemaGenerator {
           case "record": {
             const json: JSONSchema.ObjectSchema = _json as any;
             json.type = "object";
-            if (this.target !== "draft-4") {
+            if (this.target === "draft-7" || this.target === "draft-2020-12") {
               json.propertyNames = this.process(def.keyType, {
                 ...params,
                 path: [...params.path, "propertyNames"],


### PR DESCRIPTION
- closes #5140

---

Previously, the code applied to all drafts except `"draft-4"`.
Since `openapi-3.0` doesn’t require `propertyNames`, 
I inverted the condition to explicitly state when it should be included, rather than relying on exclusion.