### PR TITLE
fix(v4): toJSONSchema - wrong record tuple output when targeting `openapi-3.0`

### DIFF
--- a/packages/docs/loaders/get-llm-text.ts
+++ b/packages/docs/loaders/get-llm-text.ts
@@ -13,7 +13,7 @@ const processor = remark().use(remarkMdx).use(remarkInclude).use(remarkGfm).use(
 export async function getLLMText(page: InferPageType<typeof source>): Promise<string> {
   const filePath = page.data._file.absolutePath;
   const fileContent = await fs.readFile(filePath);
-  const { content, data } = matter(fileContent.toString());
+  const { content } = matter(fileContent.toString());
 
   const processed = await processor.process({
     path: filePath,

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -653,6 +653,24 @@ describe("toJSONSchema", () => {
   });
 
   test("tuple", () => {
+    const schema = z.tuple([z.string(), z.number()]);
+    expect(z.toJSONSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "prefixItems": [
+          {
+            "type": "string",
+          },
+          {
+            "type": "number",
+          },
+        ],
+        "type": "array",
+      }
+    `);
+  });
+
+  test("tuple with rest", () => {
     const schema = z.tuple([z.string(), z.number()]).rest(z.boolean());
     expect(z.toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
@@ -668,6 +686,46 @@ describe("toJSONSchema", () => {
             "type": "number",
           },
         ],
+        "type": "array",
+      }
+    `);
+  });
+
+  test("tuple openapi", () => {
+    const schema = z.tuple([z.string(), z.number()]);
+    expect(z.toJSONSchema(schema, { target: "openapi-3.0" })).toMatchInlineSnapshot(`
+      {
+        "items": [
+          {
+            "type": "string",
+          },
+          {
+            "type": "number",
+          },
+        ],
+        "maxItems": 2,
+        "minItems": 2,
+        "type": "array",
+      }
+    `);
+  });
+
+  test("tuple with rest openapi", () => {
+    const schema = z.tuple([z.string(), z.number()]).rest(z.boolean());
+    expect(z.toJSONSchema(schema, { target: "openapi-3.0" })).toMatchInlineSnapshot(`
+      {
+        "items": [
+          {
+            "type": "string",
+          },
+          {
+            "type": "number",
+          },
+          {
+            "type": "boolean",
+          },
+        ],
+        "minItems": 2,
         "type": "array",
       }
     `);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -371,30 +371,32 @@ export class JSONSchemaGenerator {
             const prefixItems = def.items.map((x, i) =>
               this.process(x, { ...params, path: [...params.path, "prefixItems", i] })
             );
+            const rest = def.rest
+              ? this.process(def.rest, {
+                  ...params,
+                  path: [...params.path, "items"],
+                })
+              : null;
+
             if (this.target === "draft-2020-12") {
               json.prefixItems = prefixItems;
+              if (rest) {
+                json.items = rest;
+              }
+            } else if (this.target === "openapi-3.0") {
+              json.items = [...prefixItems];
+              if (rest) {
+                json.items.push(rest);
+              }
+              json.minItems = prefixItems.length;
+              if (!rest) {
+                json.maxItems = prefixItems.length;
+              }
             } else {
               json.items = prefixItems;
-            }
-
-            if (def.rest) {
-              const rest = this.process(def.rest, {
-                ...params,
-                path: [...params.path, "items"],
-              });
-              if (this.target === "draft-2020-12") {
-                json.items = rest;
-              } else {
+              if (rest) {
                 json.additionalItems = rest;
               }
-            }
-
-            // additionalItems
-            if (def.rest) {
-              json.items = this.process(def.rest, {
-                ...params,
-                path: [...params.path, "items"],
-              });
             }
 
             // length


### PR DESCRIPTION
- closes #5143

---

I refactored the logic for converting tuples in a JSON schema:
1. Retrieve the static elements  
2. Retrieve any additional elements (if available)  
3. Assemble the properties into the `json` variable based on the target  

---

I also added a separate commit to remove the unused variable `data` in  `get-llm-text.ts`, 
which eliminates warnings when running `biome` checks.
