### PR TITLE
fix(v4): toJSONSchema - add missing oneOf inside items in tuple conversion

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -696,7 +696,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(schema, { target: "openapi-3.0" })).toMatchInlineSnapshot(`
       {
         "items": {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
             },
@@ -717,7 +717,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(schema, { target: "openapi-3.0" })).toMatchInlineSnapshot(`
       {
         "items": {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
             },

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -695,14 +695,16 @@ describe("toJSONSchema", () => {
     const schema = z.tuple([z.string(), z.number()]);
     expect(z.toJSONSchema(schema, { target: "openapi-3.0" })).toMatchInlineSnapshot(`
       {
-        "items": [
-          {
-            "type": "string",
-          },
-          {
-            "type": "number",
-          },
-        ],
+        "items": {
+          "oneOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "number",
+            },
+          ],
+        },
         "maxItems": 2,
         "minItems": 2,
         "type": "array",
@@ -714,17 +716,19 @@ describe("toJSONSchema", () => {
     const schema = z.tuple([z.string(), z.number()]).rest(z.boolean());
     expect(z.toJSONSchema(schema, { target: "openapi-3.0" })).toMatchInlineSnapshot(`
       {
-        "items": [
-          {
-            "type": "string",
-          },
-          {
-            "type": "number",
-          },
-          {
-            "type": "boolean",
-          },
-        ],
+        "items": {
+          "oneOf": [
+            {
+              "type": "string",
+            },
+            {
+              "type": "number",
+            },
+            {
+              "type": "boolean",
+            },
+          ],
+        },
         "minItems": 2,
         "type": "array",
       }

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -384,9 +384,11 @@ export class JSONSchemaGenerator {
                 json.items = rest;
               }
             } else if (this.target === "openapi-3.0") {
-              json.items = [...prefixItems];
+              json.items = {
+                oneOf: [...prefixItems],
+              };
               if (rest) {
-                json.items.push(rest);
+                json.items.oneOf!.push(rest);
               }
               json.minItems = prefixItems.length;
               if (!rest) {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -385,10 +385,10 @@ export class JSONSchemaGenerator {
               }
             } else if (this.target === "openapi-3.0") {
               json.items = {
-                oneOf: [...prefixItems],
+                anyOf: [...prefixItems],
               };
               if (rest) {
-                json.items.oneOf!.push(rest);
+                json.items.anyOf!.push(rest);
               }
               json.minItems = prefixItems.length;
               if (!rest) {


### PR DESCRIPTION
- really closes #5143
- fixes oversight of #5145

---

In #5145 I forgot that `items` shouldn't be an array...
but an object with a `oneOf` property which is the array containing the items:

<img width="1707" height="441" alt="image" src="https://github.com/user-attachments/assets/7da2d6e7-6d13-48e8-b764-8bd4c981135e" />


Sorry about the fuss 😅

  