### PR TITLE
docs(codecs): update example to use payloadSchema

### DIFF
--- a/packages/docs/content/codecs.mdx
+++ b/packages/docs/content/codecs.mdx
@@ -46,10 +46,10 @@ In these cases, `z.decode()` and `z.encode()` behave quite differently.
 ```ts
 const payloadSchema = z.object({ startDate: stringToDate });
 
-stringToDate.decode("2024-01-15T10:30:00.000Z")
+payloadSchema.decode("2024-01-15T10:30:00.000Z")
 // => Date
 
-stringToDate.encode(new Date("2024-01-15T10:30:00.000Z"))
+payloadSchema.encode(new Date("2024-01-15T10:30:00.000Z"))
 // => string
 ```
 


### PR DESCRIPTION
You've probably meant to use `payloadSchema` instead of `stringToDate`?

Reference: https://zod.dev/codecs