### PR TITLE
docs: fix mentions of `v3.25.0` to `v3.25.1`

### DIFF
--- a/packages/docs/content/library-authors.mdx
+++ b/packages/docs/content/library-authors.mdx
@@ -12,7 +12,7 @@ Zod `4.0.0` has been released on `npm`. This completes the incremental rollout p
 // package.json
 {
   "peerDependencies": {
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^3.25.1 || ^4.0.0"
   }
 }
 ```
@@ -45,7 +45,7 @@ Any library built on top of Zod should include `"zod"` in `"peerDependencies"`. 
 {
   // ...
   "peerDependencies": {
-    "zod": "^3.25.0 || ^4.0.0" // the "zod/v4" subpath was added in 3.25.0
+    "zod": "^3.25.1 || ^4.0.0" // the "zod/v4" subpath was added in 3.25.0
   }
 }
 ```
@@ -56,30 +56,30 @@ During development, you need to meet your own peer dependency requirement, to do
 // package.json
 {
   "peerDependencies": {
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^3.25.1 || ^4.0.0"
   },
   "devDependencies": {
     // generally, you should develop against the latest version of Zod
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^3.25.1 || ^4.0.0"
   }
 }
 ```
 
 ## How to support Zod 4?
 
-To support Zod 4, update the minimum version for your `"zod"` peer dependency to `^3.25.0 || ^4.0.0`. 
+To support Zod 4, update the minimum version for your `"zod"` peer dependency to `^3.25.1 || ^4.0.0`. 
 
 ```json
 // package.json
 {
   // ...
   "peerDependencies": {
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^3.25.1 || ^4.0.0"
   }
 }
 ```
 
-Starting with `v3.25.0`, the Zod 4 core package is available at the `"zod/v4/core"` subpath. Read the [Versioning in Zod 4](https://github.com/colinhacks/zod/issues/4371) writeup for full context on this versioning approach.
+Starting with `v3.25.1`, the Zod 4 core package is available at the `"zod/v4/core"` subpath. Read the [Versioning in Zod 4](https://github.com/colinhacks/zod/issues/4371) writeup for full context on this versioning approach.
 
 ```ts
 import * as z4 from "zod/v4/core";
@@ -100,11 +100,11 @@ You generally shouldn't be importing from any other paths. The Zod Core library 
 
 No, you should not need to publish a new major version of your library to support Zod 4 (unless you are dropping support for Zod 3, which isn't recommended). 
 
-You will need to bump your peer dependency to `^3.25.0`, thus your users will need to `npm upgrade zod`. But there were no breaking changes made to Zod 3 between `zod@3.24` and `zod@3.25`; in fact, there were no code changes whatsoever. As code changes will be required on the part of your users, I do not believe this constitutes a breaking change. I recommend against publishing a new major version.
+You will need to bump your peer dependency to `^3.25.1`, thus your users will need to `npm upgrade zod`. But there were no breaking changes made to Zod 3 between `zod@3.24` and `zod@3.25`; in fact, there were no code changes whatsoever. As code changes will be required on the part of your users, I do not believe this constitutes a breaking change. I recommend against publishing a new major version.
 
 ## How to support Zod 3 and Zod 4 simultaneously?
 
-Starting in `v3.25.0`, the package contains copies of both Zod 3 and Zod 4 at their respective subpaths. This makes it easy to support both versions simultaneously.
+Starting in `v3.25.1`, the package contains copies of both Zod 3 and Zod 4 at their respective subpaths. This makes it easy to support both versions simultaneously.
 
 ```ts
 import * as z3 from "zod/v3";

--- a/packages/docs/content/packages/core.mdx
+++ b/packages/docs/content/packages/core.mdx
@@ -451,7 +451,7 @@ Since package managers generally won't install your own `peerDependencies`, you'
     "zod": "*"
   },
   "devDependencies": {
-    "zod": "^3.25.0"
+    "zod": "^3.25.1"
   }
 }
 ``` */}

--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -8,7 +8,7 @@ import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
 This migration guide aims to list the breaking changes in Zod 4 in order of highest to lowest impact. To learn more about the performance enhancements and new features of Zod 4, read the [introductory post](/v4). 
 
-{/* To give the ecosystem time to migrate, Zod 4 will initially be published alongside Zod v3.25. To use Zod 4, upgrade to `zod@3.25.0` or later: */}
+{/* To give the ecosystem time to migrate, Zod 4 will initially be published alongside Zod v3.25. To use Zod 4, upgrade to `zod@3.25.1` or later: */}
 
 ```
 npm install zod@^4.0.0

--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -287,7 +287,7 @@ The core bundle is ~57% smaller in Zod 4 (2.3x). That's good! But we can do a lo
 Zod's method-heavy API is fundamentally difficult to tree-shake. Even our simple `z.boolean()` script pulls in the implementations of a bunch of methods we didn't use, like `.optional()`, `.array()`, etc. Writing slimmer implementations can only get you so far. That's where Zod Mini comes in. 
 
 ```sh
-npm install zod@^3.25.0
+npm install zod@^3.25.1
 ```
 
 It's a Zod variant with a functional, tree-shakable API that corresponds one-to-one with `zod`. Where Zod uses methods, Zod Mini generally uses wrapper functions:

--- a/packages/docs/content/v4/versioning.mdx
+++ b/packages/docs/content/v4/versioning.mdx
@@ -33,7 +33,7 @@ If you are using Zod 4, your existing imports (`"zod/v4"` and `"zod/v4-mini"`) w
 // package.json
 {
   "peerDependencies": {
-    "zod": "^3.25.0 || ^4.0.0"
+    "zod": "^3.25.1 || ^4.0.0"
   }
 }
 ```
@@ -54,7 +54,7 @@ This is a writeup of Zod 4's approach to versioning, with the goal of making it 
 
 The general approach:
 
-- Zod 4 will not initially be published as `zod@4.0.0` on npm. Instead it will be exported at a subpath (`"zod/v4"`) alongside `zod@3.25.0` 
+- Zod 4 will not initially be published as `zod@4.0.0` on npm. Instead it will be exported at a subpath (`"zod/v4"`) alongside `zod@3.25.1` 
 - Despite this, Zod 4 is considered stable and production-ready
 - Zod 3 will continue to be exported from the package root (`"zod"`) as well as a new subpath `"zod/v3"`. It will continue to receive bug fixes & stability improvements.
  
@@ -79,7 +79,7 @@ If I naively published `zod@4.0.0` to npm, the vast majority of the libraries in
   
 With subpath versioning, we solve this problem. it provides a straightforward way for libraries to support Zod 3 and Zod 4 (including Zod Mini) simultaneously. They can continue defining a single peerDependency on `"zod"`; no need for more arcane solutions like npm aliases, optional peer dependencies, a `"zod-compat"` package, or other such hacks.
 
-Libraries will need to bump the minimum version of their `"zod"` peer dependency to `zod@^3.25.0`. They can then reference both Zod 3 and Zod 4 in their implementation:
+Libraries will need to bump the minimum version of their `"zod"` peer dependency to `zod@^3.25.1`. They can then reference both Zod 3 and Zod 4 in their implementation:
 
   ```ts 
   import * as z3 from "zod/v3"

--- a/packages/treeshake/package.json
+++ b/packages/treeshake/package.json
@@ -20,6 +20,6 @@
     "rollup-plugin-bundle-size": "^1.0.3",
     "valibot": "^1.0.0",
     "zod3": "npm:zod@^3.24.0",
-    "zod4": "npm:zod@^3.25.0"
+    "zod4": "npm:zod@^3.25.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,7 @@ importers:
         specifier: npm:zod@^3.24.0
         version: zod@3.24.3
       zod4:
-        specifier: npm:zod@^3.25.0
+        specifier: npm:zod@^3.25.1
         version: zod@3.25.67
 
   packages/tsc:


### PR DESCRIPTION
`v3.25.0` didn't upload the `dist` assets, so it shouldn't be mentioned as the baseline of supported versions.