### PR TITLE
Update z.function() type to support array input

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2059,11 +2059,11 @@ export const ZodFunction: core.$constructor<ZodFunction> = /*@__PURE__*/ core.$c
 );
 
 export function _function(): ZodFunction;
-export function _function<const In extends Array<core.$ZodType> = Array<core.$ZodType>>(params: {
+export function _function<const In extends readonly [core.$ZodType, ...core.$ZodType[]]>(params: {
   input: In;
 }): ZodFunction<ZodTuple<In, null>, core.$ZodFunctionOut>;
 export function _function<
-  const In extends Array<core.$ZodType> = Array<core.$ZodType>,
+  const In extends readonly [core.$ZodType, ...core.$ZodType[]],
   const Out extends core.$ZodFunctionOut = core.$ZodFunctionOut,
 >(params: {
   input: In;

--- a/packages/zod/src/v4/classic/tests/function.test.ts
+++ b/packages/zod/src/v4/classic/tests/function.test.ts
@@ -130,6 +130,46 @@ test("valid function run", () => {
   });
 });
 
+const args3 = [
+  z.object({
+    f1: z.number(),
+    f2: z.string().nullable(),
+    f3: z.array(z.boolean().optional()).optional(),
+  }),
+] as const;
+const returns3 = z.union([z.string(), z.number()]);
+
+const func3 = z.function({
+  input: args3,
+  output: returns3,
+});
+
+test("function inference 3", () => {
+  type func3 = (typeof func3)["_input"];
+
+  expectTypeOf<func3>().toEqualTypeOf<
+    (arg: {
+      f3?: (boolean | undefined)[] | undefined;
+      f1: number;
+      f2: string | null;
+    }) => string | number
+  >();
+});
+
+test("valid function run", () => {
+  const validFunc3Instance = func3.implement((_x) => {
+    _x.f2;
+    _x.f3![0];
+    return "adf" as any;
+  });
+
+  validFunc3Instance({
+    f1: 21,
+    f2: "asdf",
+    f3: [true, false],
+  });
+});
+
 test("input validation error", () => {
   const schema = z.function({
     input: z.tuple([z.string()]),


### PR DESCRIPTION
[It is documented](https://zod.dev/v4/changelog?id=zfunction) (and [in the main docs](https://zod.dev/api?id=functions) too) to work with array inputs like:

```ts
const myFunction = z.function({
  input: [z.object({
    name: z.string(),
    age: z.number().int(),
  })],
  output: z.string(),
});

myFunction.implement((input) => {
  return `Hello ${input.name}, you are ${input.age} years old.`;
});
```

But it doesn't work. Current type only supports `z.tuple()` (which is what's tested too).

Either the docs should be fixed to show a `z.tuple()` wrapper, or we could update the types to support both. In this PR, I went for the latter to have Zod v4 behave like the docs say. I've added a test to illustrate.

Feel free to decline and update the docs examples if you think it should not be like that.

Related to https://github.com/colinhacks/zod/issues/4143#issuecomment-3229560060