### PR TITLE
fix(v4): ensure array defaults are shallow-cloned

### DIFF
--- a/packages/zod/src/v4/classic/tests/default.test.ts
+++ b/packages/zod/src/v4/classic/tests/default.test.ts
@@ -324,6 +324,14 @@ test("defaulted object schema returns shallow clone", () => {
   expect(result1).toEqual(result2);
 });
 
+test("defaulted array schema returns shallow clone", () => {
+  const schema = z.array(z.string()).default(["x"]);
+  const result1 = schema.parse(undefined);
+  const result2 = schema.parse(undefined);
+  expect(result1).not.toBe(result2);
+  expect(result1).toEqual(result2);
+});
+
 test("direction-aware defaults", () => {
   const schema = z.string().default("hello");
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -395,6 +395,7 @@ export function isPlainObject(o: any): o is Record<PropertyKey, unknown> {
 
 export function shallowClone(o: any): any {
   if (isPlainObject(o)) return { ...o };
+  if (Array.isArray(o)) return [...o];
   return o;
 }
 


### PR DESCRIPTION
in v3, `.default` was parsed after the fact so `.default([])` would end up getting copied into a new array each time it was used. v4 returns reference values directly so default array values should also be getting shallow-cloned.