### PR TITLE
Fix variable name inconsistency in coercion documentation code example

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -95,7 +95,7 @@ type BInput = z.infer<typeof B>; // => number
   By default the _input_ type of any `z.coerce` schema is `unknown`. In some cases, it may be preferable for the input type to be more specific. You can specify the input type with a generic parameter.
 
   ```ts
-  const regular = z.coerce.string();
+  const regularCoerce = z.coerce.string();
   type RegularInput = z.input<typeof regularCoerce>; // => unknown
   type RegularOutput = z.output<typeof regularCoerce>; // => string
 


### PR DESCRIPTION
This PR addresses issue #5180 by fixing a variable naming inconsistency in the documentation for Zod's coercion feature. The code example in the "Customizing the input type" section had a mismatch between the variable declaration and its usage in type definitions.

## The Problem
In the documentation at https://zod.dev/api?id=coercion, under the "Customizing the input type" accordion section, there was a code snippet demonstrating how to work with coercion schemas:

```typescript
// Before (incorrect):
const regular = z.coerce.string();
type RegularInput = z.input<typeof regularCoerce>; // => unknown
type RegularOutput = z.output<typeof regularCoerce>; // => string
```

The variable was declared as `regular` but referenced as `regularCoerce` in the subsequent type definitions, which would cause a TypeScript error if users copied this code directly.

## The Solution
This PR corrects the variable name to be consistent throughout the example:

```typescript
// After (correct):
const regularCoerce = z.coerce.string();
type RegularInput = z.input<typeof regularCoerce>; // => unknown
type RegularOutput = z.output<typeof regularCoerce>; // => string
```

## Impact
- **Documentation clarity**: Users copying code examples from the documentation will no longer encounter reference errors
- **Learning experience**: Removes confusion for developers learning about Zod's coercion feature
- **No breaking changes**: This is purely a documentation fix with no impact on the library's functionality

## File Changed
- `packages/docs/content/api.mdx` (line 98)

## Testing
- Verified the fix renders correctly in the documentation
- Confirmed no impact on existing tests (pre-existing test failures are unrelated to this documentation change)
- The change is isolated to a single line in the documentation file

## Related Issues
Fixes #5180

## Additional Context
This issue was initially identified by @daniel-campbell who correctly pointed out that the variable naming was inconsistent. The fix ensures that the documentation provides accurate, copy-paste-ready code examples for users learning about Zod's coercion capabilities with custom input types.