### PR TITLE
Fix two tiny grammatical errors in the docs.

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -572,7 +572,7 @@ const coolId = z.stringFormat("cool-id", ()=>{
 z.stringFormat("cool-id", /^cool-[a-z0-9]{95}$/);
 ```
 
-This schema will produce `"invalid_format"` issues, which are more descriptive that the `"custom"` errors produces by refinements or `z.custom()`.
+This schema will produce `"invalid_format"` issues, which are more descriptive than the `"custom"` errors produced by refinements or `z.custom()`.
 
 ```ts
 myFormat.parse("invalid input!");


### PR DESCRIPTION
I noticed a sentence in the 'custom formats' section of the docs which didn't read very well.
This PR suggests a fix.