### PR TITLE
docs: disambiguate type from value in v4 release guide

### DIFF
--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -545,7 +545,7 @@ const Category = z.object({
   }
 });
 
-type Category = z.infer<typeof Category>;
+type CategoryType = z.infer<typeof Category>;
 // { name: string; subcategories: Category[] }
 ```
 


### PR DESCRIPTION
I got confused on the initial read, thinking that I was supposed to do `z.array(<typescript type>)` instead of `z.array(<zod object>)`. Maybe a silly error, but it cost me 10 minutes.