### PR TITLE
fix(v4): improve error messages for Infinity, NaN, and Invalid Date

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -551,6 +551,24 @@ test("disc union treeify/format", () => {
   `);
 });
 
+test("prettifyError for Infinity and NaN", () => {
+  const numberSchema = z.number();
+
+  const infinityResult = numberSchema.safeParse(Number.POSITIVE_INFINITY);
+  expect(infinityResult.success).toBe(false);
+  if (!infinityResult.success) {
+    expect(z.prettifyError(infinityResult.error)).toMatchInlineSnapshot(
+      `"✖ Invalid input: expected number, received Infinity"`
+    );
+  }
+
+  const nanResult = numberSchema.safeParse(Number.NaN);
+  expect(nanResult.success).toBe(false);
+  if (!nanResult.success) {
+    expect(z.prettifyError(nanResult.error)).toMatchInlineSnapshot(`"✖ Invalid input: expected number, received NaN"`);
+  }
+});
+
 test("update message after adding issues", () => {
   const e = new z.ZodError([]);
   e.addIssue({

--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -10,6 +10,17 @@ test("z.number() basic validation", () => {
 test("NaN validation", () => {
   const schema = z.number();
   expect(() => schema.parse(Number.NaN)).toThrow();
+
+  const result = schema.safeParse(Number.NaN);
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues[0]).toMatchObject({
+      code: "invalid_type",
+      expected: "number",
+      received: "NaN",
+      message: "Invalid input: expected number, received NaN",
+    });
+  }
 });
 
 test("Infinity validation", () => {
@@ -22,7 +33,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -36,7 +47,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -178,7 +189,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -192,7 +203,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/classic/tests/primitive.test.ts
+++ b/packages/zod/src/v4/classic/tests/primitive.test.ts
@@ -108,7 +108,7 @@ test("date schema", async () => {
         "code": "invalid_type",
         "received": "Invalid Date",
         "path": [],
-        "message": "Invalid input: expected date, received Date"
+        "message": "Invalid input: expected date, received Invalid Date"
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/locales/ar.ts
+++ b/packages/zod/src/v4/locales/ar.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `مدخلات غير مقبولة: يفترض إدخال ${issue.expected}، ولكن تم إدخال ${parsedType(issue.input)}`;
+        return `مدخلات غير مقبولة: يفترض إدخال ${issue.expected}، ولكن تم إدخال ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)
           return `مدخلات غير مقبولة: يفترض إدخال ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/az.ts
+++ b/packages/zod/src/v4/locales/az.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Yanlış dəyər: gözlənilən ${issue.expected}, daxil olan ${parsedType(issue.input)}`;
+        return `Yanlış dəyər: gözlənilən ${issue.expected}, daxil olan ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Yanlış dəyər: gözlənilən ${util.stringifyPrimitive(issue.values[0])}`;
         return `Yanlış seçim: aşağıdakılardan biri olmalıdır: ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/be.ts
+++ b/packages/zod/src/v4/locales/be.ts
@@ -75,7 +75,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "лік";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "лік";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -129,7 +129,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Няправільны ўвод: чакаўся ${issue.expected}, атрымана ${parsedType(issue.input)}`;
+        return `Няправільны ўвод: чакаўся ${issue.expected}, атрымана ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Няправільны ўвод: чакалася ${util.stringifyPrimitive(issue.values[0])}`;
         return `Няправільны варыянт: чакаўся адзін з ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/bg.ts
+++ b/packages/zod/src/v4/locales/bg.ts
@@ -7,7 +7,7 @@ export const parsedType = (data: any): string => {
 
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "NaN" : "число";
+      return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "число";
     }
     case "object": {
       if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Невалиден вход: очакван ${issue.expected}, получен ${parsedType(issue.input)}`;
+        return `Невалиден вход: очакван ${issue.expected}, получен ${issue.received ?? parsedType(issue.input)}`;
 
       case "invalid_value":
         if (issue.values.length === 1) return `Невалиден вход: очакван ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/ca.ts
+++ b/packages/zod/src/v4/locales/ca.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Tipus invàlid: s'esperava ${issue.expected}, s'ha rebut ${parsedType(issue.input)}`;
+        return `Tipus invàlid: s'esperava ${issue.expected}, s'ha rebut ${issue.received ?? parsedType(issue.input)}`;
       // return `Tipus invàlid: s'esperava ${issue.expected}, s'ha rebut ${util.getParsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Valor invàlid: s'esperava ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/cs.ts
+++ b/packages/zod/src/v4/locales/cs.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "číslo";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "číslo";
       }
       case "string": {
         return "řetězec";
@@ -91,7 +91,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Neplatný vstup: očekáváno ${issue.expected}, obdrženo ${parsedType(issue.input)}`;
+        return `Neplatný vstup: očekáváno ${issue.expected}, obdrženo ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Neplatný vstup: očekáváno ${util.stringifyPrimitive(issue.values[0])}`;
         return `Neplatná možnost: očekávána jedna z hodnot ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/da.ts
+++ b/packages/zod/src/v4/locales/da.ts
@@ -33,7 +33,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "tal";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "tal";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -88,7 +88,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Ugyldigt input: forventede ${getTypeName(issue.expected)}, fik ${getTypeName(parsedType(issue.input))}`;
+        return `Ugyldigt input: forventede ${getTypeName(issue.expected)}, fik ${(issue as any).received ?? getTypeName(parsedType(issue.input))}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Ugyldig værdi: forventede ${util.stringifyPrimitive(issue.values[0])}`;
         return `Ugyldigt valg: forventede en af følgende ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/de.ts
+++ b/packages/zod/src/v4/locales/de.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "Zahl";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "Zahl";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Ungültige Eingabe: erwartet ${issue.expected}, erhalten ${parsedType(issue.input)}`;
+        return `Ungültige Eingabe: erwartet ${issue.expected}, erhalten ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Ungültige Eingabe: erwartet ${util.stringifyPrimitive(issue.values[0])}`;
         return `Ungültige Option: erwartet eine von ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -7,7 +7,7 @@ export const parsedType = (data: any): string => {
 
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "NaN" : "number";
+      return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
     }
     case "object": {
       if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Invalid input: expected ${issue.expected}, received ${parsedType(issue.input)}`;
+        return `Invalid input: expected ${issue.expected}, received ${issue.received ?? parsedType(issue.input)}`;
 
       case "invalid_value":
         if (issue.values.length === 1) return `Invalid input: expected ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/eo.ts
+++ b/packages/zod/src/v4/locales/eo.ts
@@ -7,7 +7,7 @@ export const parsedType = (data: any): string => {
 
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "NaN" : "nombro";
+      return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "nombro";
     }
     case "object": {
       if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Nevalida enigo: atendiĝis ${issue.expected}, riceviĝis ${parsedType(issue.input)}`;
+        return `Nevalida enigo: atendiĝis ${issue.expected}, riceviĝis ${issue.received ?? parsedType(issue.input)}`;
 
       case "invalid_value":
         if (issue.values.length === 1) return `Nevalida enigo: atendiĝis ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/es.ts
+++ b/packages/zod/src/v4/locales/es.ts
@@ -50,7 +50,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -104,7 +104,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Entrada inválida: se esperaba ${getTypeName(issue.expected)}, recibido ${getTypeName(parsedType(issue.input))}`;
+        return `Entrada inválida: se esperaba ${getTypeName(issue.expected)}, recibido ${(issue as any).received ?? getTypeName(parsedType(issue.input))}`;
       // return `Entrada inválida: se esperaba ${issue.expected}, recibido ${util.getParsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)

--- a/packages/zod/src/v4/locales/fa.ts
+++ b/packages/zod/src/v4/locales/fa.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "عدد";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "عدد";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `ورودی نامعتبر: می‌بایست ${issue.expected} می‌بود، ${parsedType(issue.input)} دریافت شد`;
+        return `ورودی نامعتبر: می‌بایست ${issue.expected} می‌بود، ${issue.received ?? parsedType(issue.input)} دریافت شد`;
       case "invalid_value":
         if (issue.values.length === 1) {
           return `ورودی نامعتبر: می‌بایست ${util.stringifyPrimitive(issue.values[0])} می‌بود`;

--- a/packages/zod/src/v4/locales/fi.ts
+++ b/packages/zod/src/v4/locales/fi.ts
@@ -23,7 +23,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -77,7 +77,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Virheellinen tyyppi: odotettiin ${issue.expected}, oli ${parsedType(issue.input)}`;
+        return `Virheellinen tyyppi: odotettiin ${issue.expected}, oli ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)
           return `Virheellinen syöte: täytyy olla ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/fr-CA.ts
+++ b/packages/zod/src/v4/locales/fr-CA.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Entrée invalide : attendu ${issue.expected}, reçu ${parsedType(issue.input)}`;
+        return `Entrée invalide : attendu ${issue.expected}, reçu ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Entrée invalide : attendu ${util.stringifyPrimitive(issue.values[0])}`;
         return `Option invalide : attendu l'une des valeurs suivantes ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/fr.ts
+++ b/packages/zod/src/v4/locales/fr.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "nombre";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "nombre";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Entrée invalide : ${issue.expected} attendu, ${parsedType(issue.input)} reçu`;
+        return `Entrée invalide : ${issue.expected} attendu, ${issue.received ?? parsedType(issue.input)} reçu`;
       case "invalid_value":
         if (issue.values.length === 1) return `Entrée invalide : ${util.stringifyPrimitive(issue.values[0])} attendu`;
         return `Option invalide : une valeur parmi ${util.joinValues(issue.values, "|")} attendue`;

--- a/packages/zod/src/v4/locales/he.ts
+++ b/packages/zod/src/v4/locales/he.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `קלט לא תקין: צריך ${issue.expected}, התקבל ${parsedType(issue.input)}`;
+        return `קלט לא תקין: צריך ${issue.expected}, התקבל ${issue.received ?? parsedType(issue.input)}`;
       // return `Invalid input: expected ${issue.expected}, received ${util.getParsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `קלט לא תקין: צריך ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/hu.ts
+++ b/packages/zod/src/v4/locales/hu.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "szám";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "szám";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Érvénytelen bemenet: a várt érték ${issue.expected}, a kapott érték ${parsedType(issue.input)}`;
+        return `Érvénytelen bemenet: a várt érték ${issue.expected}, a kapott érték ${issue.received ?? parsedType(issue.input)}`;
       // return `Invalid input: expected ${issue.expected}, received ${util.getParsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)

--- a/packages/zod/src/v4/locales/id.ts
+++ b/packages/zod/src/v4/locales/id.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Input tidak valid: diharapkan ${issue.expected}, diterima ${parsedType(issue.input)}`;
+        return `Input tidak valid: diharapkan ${issue.expected}, diterima ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)
           return `Input tidak valid: diharapkan ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/is.ts
+++ b/packages/zod/src/v4/locales/is.ts
@@ -7,7 +7,7 @@ export const parsedType = (data: any): string => {
 
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "NaN" : "númer";
+      return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "númer";
     }
     case "object": {
       if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Rangt gildi: Þú slóst inn ${parsedType(issue.input)} þar sem á að vera ${issue.expected}`;
+        return `Rangt gildi: Þú slóst inn ${issue.received ?? parsedType(issue.input)} þar sem á að vera ${issue.expected}`;
 
       case "invalid_value":
         if (issue.values.length === 1) return `Rangt gildi: gert ráð fyrir ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/it.ts
+++ b/packages/zod/src/v4/locales/it.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "numero";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "numero";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Input non valido: atteso ${issue.expected}, ricevuto ${parsedType(issue.input)}`;
+        return `Input non valido: atteso ${issue.expected}, ricevuto ${issue.received ?? parsedType(issue.input)}`;
       // return `Input non valido: atteso ${issue.expected}, ricevuto ${util.getParsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Input non valido: atteso ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/ja.ts
+++ b/packages/zod/src/v4/locales/ja.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "数値";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "数値";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `無効な入力: ${issue.expected}が期待されましたが、${parsedType(issue.input)}が入力されました`;
+        return `無効な入力: ${issue.expected}が期待されましたが、${issue.received ?? parsedType(issue.input)}が入力されました`;
       case "invalid_value":
         if (issue.values.length === 1) return `無効な入力: ${util.stringifyPrimitive(issue.values[0])}が期待されました`;
         return `無効な選択: ${util.joinValues(issue.values, "、")}のいずれかである必要があります`;

--- a/packages/zod/src/v4/locales/ka.ts
+++ b/packages/zod/src/v4/locales/ka.ts
@@ -7,7 +7,7 @@ export const parsedType = (data: any): string => {
 
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "NaN" : "რიცხვი";
+      return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "რიცხვი";
     }
     case "object": {
       if (Array.isArray(data)) {
@@ -83,7 +83,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `არასწორი შეყვანა: მოსალოდნელი ${issue.expected}, მიღებული ${parsedType(issue.input)}`;
+        return `არასწორი შეყვანა: მოსალოდნელი ${issue.expected}, მიღებული ${issue.received ?? parsedType(issue.input)}`;
 
       case "invalid_value":
         if (issue.values.length === 1)

--- a/packages/zod/src/v4/locales/km.ts
+++ b/packages/zod/src/v4/locales/km.ts
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ ${issue.expected} ប៉ុន្តែទទួលបាន ${parsedType(issue.input)}`;
+        return `ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ ${issue.expected} ប៉ុន្តែទទួលបាន ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ ${util.stringifyPrimitive(issue.values[0])}`;
         return `ជម្រើសមិនត្រឹមត្រូវ៖ ត្រូវជាមួយក្នុងចំណោម ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/ko.ts
+++ b/packages/zod/src/v4/locales/ko.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `잘못된 입력: 예상 타입은 ${issue.expected}, 받은 타입은 ${parsedType(issue.input)}입니다`;
+        return `잘못된 입력: 예상 타입은 ${issue.expected}, 받은 타입은 ${issue.received ?? parsedType(issue.input)}입니다`;
       case "invalid_value":
         if (issue.values.length === 1)
           return `잘못된 입력: 값은 ${util.stringifyPrimitive(issue.values[0])} 이어야 합니다`;

--- a/packages/zod/src/v4/locales/lt.ts
+++ b/packages/zod/src/v4/locales/lt.ts
@@ -10,7 +10,7 @@ export const parsedType = (data: any): string => {
 const parsedTypeFromType = (t: string, data: any = undefined): string => {
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "NaN" : "skaičius";
+      return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "skaičius";
     }
     case "bigint": {
       return "sveikasis skaičius";
@@ -200,7 +200,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Gautas tipas ${parsedType(issue.input)}, o tikėtasi - ${parsedTypeFromType(issue.expected)}`;
+        return `Gautas tipas ${issue.received ?? parsedType(issue.input)}, o tikėtasi - ${parsedTypeFromType(issue.expected)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Privalo būti ${util.stringifyPrimitive(issue.values[0])}`;
         return `Privalo būti vienas iš ${util.joinValues(issue.values, "|")} pasirinkimų`;

--- a/packages/zod/src/v4/locales/mk.ts
+++ b/packages/zod/src/v4/locales/mk.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "број";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "број";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Грешен внес: се очекува ${issue.expected}, примено ${parsedType(issue.input)}`;
+        return `Грешен внес: се очекува ${issue.expected}, примено ${issue.received ?? parsedType(issue.input)}`;
       // return `Invalid input: expected ${issue.expected}, received ${util.getParsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Invalid input: expected ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/ms.ts
+++ b/packages/zod/src/v4/locales/ms.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "nombor";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "nombor";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Input tidak sah: dijangka ${issue.expected}, diterima ${parsedType(issue.input)}`;
+        return `Input tidak sah: dijangka ${issue.expected}, diterima ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Input tidak sah: dijangka ${util.stringifyPrimitive(issue.values[0])}`;
         return `Pilihan tidak sah: dijangka salah satu daripada ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/nl.ts
+++ b/packages/zod/src/v4/locales/nl.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "getal";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "getal";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Ongeldige invoer: verwacht ${issue.expected}, ontving ${parsedType(issue.input)}`;
+        return `Ongeldige invoer: verwacht ${issue.expected}, ontving ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Ongeldige invoer: verwacht ${util.stringifyPrimitive(issue.values[0])}`;
         return `Ongeldige optie: verwacht één van ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/no.ts
+++ b/packages/zod/src/v4/locales/no.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "tall";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "tall";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Ugyldig input: forventet ${issue.expected}, fikk ${parsedType(issue.input)}`;
+        return `Ugyldig input: forventet ${issue.expected}, fikk ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Ugyldig verdi: forventet ${util.stringifyPrimitive(issue.values[0])}`;
         return `Ugyldig valg: forventet en av ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/ota.ts
+++ b/packages/zod/src/v4/locales/ota.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "numara";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "numara";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Fâsit giren: umulan ${issue.expected}, alınan ${parsedType(issue.input)}`;
+        return `Fâsit giren: umulan ${issue.expected}, alınan ${issue.received ?? parsedType(issue.input)}`;
       // return `Fâsit giren: umulan ${issue.expected}, alınan ${util.getParsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Fâsit giren: umulan ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/pl.ts
+++ b/packages/zod/src/v4/locales/pl.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "liczba";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "liczba";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Nieprawidłowe dane wejściowe: oczekiwano ${issue.expected}, otrzymano ${parsedType(issue.input)}`;
+        return `Nieprawidłowe dane wejściowe: oczekiwano ${issue.expected}, otrzymano ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)
           return `Nieprawidłowe dane wejściowe: oczekiwano ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/ps.ts
+++ b/packages/zod/src/v4/locales/ps.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "عدد";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "عدد";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -72,7 +72,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `ناسم ورودي: باید ${issue.expected} وای, مګر ${parsedType(issue.input)} ترلاسه شو`;
+        return `ناسم ورودي: باید ${issue.expected} وای, مګر ${issue.received ?? parsedType(issue.input)} ترلاسه شو`;
       case "invalid_value":
         if (issue.values.length === 1) {
           return `ناسم ورودي: باید ${util.stringifyPrimitive(issue.values[0])} وای`;

--- a/packages/zod/src/v4/locales/pt.ts
+++ b/packages/zod/src/v4/locales/pt.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "número";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "número";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -72,7 +72,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Tipo inválido: esperado ${issue.expected}, recebido ${parsedType(issue.input)}`;
+        return `Tipo inválido: esperado ${issue.expected}, recebido ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Entrada inválida: esperado ${util.stringifyPrimitive(issue.values[0])}`;
         return `Opção inválida: esperada uma das ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/ru.ts
+++ b/packages/zod/src/v4/locales/ru.ts
@@ -75,7 +75,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "число";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "число";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -129,7 +129,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Неверный ввод: ожидалось ${issue.expected}, получено ${parsedType(issue.input)}`;
+        return `Неверный ввод: ожидалось ${issue.expected}, получено ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Неверный ввод: ожидалось ${util.stringifyPrimitive(issue.values[0])}`;
         return `Неверный вариант: ожидалось одно из ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/sl.ts
+++ b/packages/zod/src/v4/locales/sl.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "število";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "število";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Neveljaven vnos: pričakovano ${issue.expected}, prejeto ${parsedType(issue.input)}`;
+        return `Neveljaven vnos: pričakovano ${issue.expected}, prejeto ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)
           return `Neveljaven vnos: pričakovano ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/sv.ts
+++ b/packages/zod/src/v4/locales/sv.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "antal";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "antal";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Ogiltig inmatning: förväntat ${issue.expected}, fick ${parsedType(issue.input)}`;
+        return `Ogiltig inmatning: förväntat ${issue.expected}, fick ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)
           return `Ogiltig inmatning: förväntat ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/ta.ts
+++ b/packages/zod/src/v4/locales/ta.ts
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `தவறான உள்ளீடு: எதிர்பார்க்கப்பட்டது ${issue.expected}, பெறப்பட்டது ${parsedType(issue.input)}`;
+        return `தவறான உள்ளீடு: எதிர்பார்க்கப்பட்டது ${issue.expected}, பெறப்பட்டது ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `தவறான உள்ளீடு: எதிர்பார்க்கப்பட்டது ${util.stringifyPrimitive(issue.values[0])}`;
         return `தவறான விருப்பம்: எதிர்பார்க்கப்பட்டது ${util.joinValues(issue.values, "|")} இல் ஒன்று`;

--- a/packages/zod/src/v4/locales/th.ts
+++ b/packages/zod/src/v4/locales/th.ts
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `ประเภทข้อมูลไม่ถูกต้อง: ควรเป็น ${issue.expected} แต่ได้รับ ${parsedType(issue.input)}`;
+        return `ประเภทข้อมูลไม่ถูกต้อง: ควรเป็น ${issue.expected} แต่ได้รับ ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `ค่าไม่ถูกต้อง: ควรเป็น ${util.stringifyPrimitive(issue.values[0])}`;
         return `ตัวเลือกไม่ถูกต้อง: ควรเป็นหนึ่งใน ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/tr.ts
+++ b/packages/zod/src/v4/locales/tr.ts
@@ -7,7 +7,7 @@ export const parsedType = (data: any): string => {
 
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "NaN" : "number";
+      return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
     }
     case "object": {
       if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Geçersiz değer: beklenen ${issue.expected}, alınan ${parsedType(issue.input)}`;
+        return `Geçersiz değer: beklenen ${issue.expected}, alınan ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `Geçersiz değer: beklenen ${util.stringifyPrimitive(issue.values[0])}`;
         return `Geçersiz seçenek: aşağıdakilerden biri olmalı: ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/uk.ts
+++ b/packages/zod/src/v4/locales/uk.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "число";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "число";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Неправильні вхідні дані: очікується ${issue.expected}, отримано ${parsedType(issue.input)}`;
+        return `Неправильні вхідні дані: очікується ${issue.expected}, отримано ${issue.received ?? parsedType(issue.input)}`;
       // return `Неправильні вхідні дані: очікується ${issue.expected}, отримано ${util.getParsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)

--- a/packages/zod/src/v4/locales/ur.ts
+++ b/packages/zod/src/v4/locales/ur.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "نمبر";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "نمبر";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `غلط ان پٹ: ${issue.expected} متوقع تھا، ${parsedType(issue.input)} موصول ہوا`;
+        return `غلط ان پٹ: ${issue.expected} متوقع تھا، ${issue.received ?? parsedType(issue.input)} موصول ہوا`;
       case "invalid_value":
         if (issue.values.length === 1) return `غلط ان پٹ: ${util.stringifyPrimitive(issue.values[0])} متوقع تھا`;
         return `غلط آپشن: ${util.joinValues(issue.values, "|")} میں سے ایک متوقع تھا`;

--- a/packages/zod/src/v4/locales/vi.ts
+++ b/packages/zod/src/v4/locales/vi.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "số";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "số";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Đầu vào không hợp lệ: mong đợi ${issue.expected}, nhận được ${parsedType(issue.input)}`;
+        return `Đầu vào không hợp lệ: mong đợi ${issue.expected}, nhận được ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1)
           return `Đầu vào không hợp lệ: mong đợi ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/yo.ts
+++ b/packages/zod/src/v4/locales/yo.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "nọ́mbà";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "nọ́mbà";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -72,7 +72,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `Ìbáwọlé aṣìṣe: a ní láti fi ${issue.expected}, àmọ̀ a rí ${parsedType(issue.input)}`;
+        return `Ìbáwọlé aṣìṣe: a ní láti fi ${issue.expected}, àmọ̀ a rí ${issue.received ?? parsedType(issue.input)}`;
 
       case "invalid_value":
         if (issue.values.length === 1) return `Ìbáwọlé aṣìṣe: a ní láti fi ${util.stringifyPrimitive(issue.values[0])}`;

--- a/packages/zod/src/v4/locales/zh-CN.ts
+++ b/packages/zod/src/v4/locales/zh-CN.ts
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `无效输入：期望 ${issue.expected}，实际接收 ${parsedType(issue.input)}`;
+        return `无效输入：期望 ${issue.expected}，实际接收 ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `无效输入：期望 ${util.stringifyPrimitive(issue.values[0])}`;
         return `无效选项：期望以下之一 ${util.joinValues(issue.values, "|")}`;

--- a/packages/zod/src/v4/locales/zh-TW.ts
+++ b/packages/zod/src/v4/locales/zh-TW.ts
@@ -19,7 +19,7 @@ const error: () => errors.$ZodErrorMap = () => {
 
     switch (t) {
       case "number": {
-        return Number.isNaN(data) ? "NaN" : "number";
+        return Number.isNaN(data) ? "NaN" : !Number.isFinite(data) ? "Infinity" : "number";
       }
       case "object": {
         if (Array.isArray(data)) {
@@ -73,7 +73,7 @@ const error: () => errors.$ZodErrorMap = () => {
   return (issue) => {
     switch (issue.code) {
       case "invalid_type":
-        return `無效的輸入值：預期為 ${issue.expected}，但收到 ${parsedType(issue.input)}`;
+        return `無效的輸入值：預期為 ${issue.expected}，但收到 ${issue.received ?? parsedType(issue.input)}`;
       case "invalid_value":
         if (issue.values.length === 1) return `無效的輸入值：預期為 ${util.stringifyPrimitive(issue.values[0])}`;
         return `無效的選項：預期為以下其中之一 ${util.joinValues(issue.values, "|")}`;


### PR DESCRIPTION
# Summary

This PR fixes the confusing error messages when validating special numeric values (Infinity, NaN) and invalid dates with Zod schemas. Closes #5186

## Problem

When parsing Infinity with z.number(), the error message was: `Invalid input: expected number, received number`

This was confusing because it appeared to say the same type was both expected and received.

## Solution

- Update parsedType() function in all locales to detect Infinity using Number.isFinite()
- Modify error message generation to check for `issue.received` field before falling back to parsedType()
- Update error message generation across all locale files to properly display:
	- "received Infinity" for infinite values
	- "received NaN" for NaN values
	- "received Invalid Date" for invalid dates