### PR TITLE
Typo fix in ISO time documentation

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -466,7 +466,7 @@ date.parse("2020-01-32"); // ❌
 
 ### ISO times
 
-The `z.iso.time()` method validates strings in the format `HH:MM[:SS[.s+]]`. By default seconds are optional, as are sub-second deciams.
+The `z.iso.time()` method validates strings in the format `HH:MM[:SS[.s+]]`. By default seconds are optional, as are sub-second decimals.
 
 ```ts
 const time = z.iso.time();


### PR DESCRIPTION
There is a typo in the ["Defining schemas"](https://github.com/colinhacks/zod/blob/62bf4e439e287e55c843245b49f8d34b1ad024ee/packages/docs/content/api.mdx#L469) documentation page, under "Strings" > "ISO times": "deciams" should be "decimals". This PR fixes it.