### PR TITLE
`frrm` now supports Zod 4 in latest release

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -99,6 +99,12 @@ const formIntegrations: ZodResource[] = [
     description: "Svelte 5 library for creating forms based on JSON schema.",
     slug: "x0k/svelte-jsonschema-form",
   },
+  {
+    name: "frrm",
+    url: "https://www.npmjs.com/package/frrm",
+    description: "Tiny 0.5kb Zod-based, HTML form abstraction that goes brr.",
+    slug: "schalkventer/frrm",
+  },
 ];
 
 const zodToXConverters: ZodResource[] = [


### PR DESCRIPTION
`package.json`:

```
{
  "name": "frrm",
  "type": "module",
  "version": "2.0.1",
  "description": "Tiny 0.5kb Zod-based, HTML form abstraction that goes brr.",
  "author": "Schalk Venter <venterschalk@gmail.com> (http://schalkventer.me/)",
  "source": "src/index.ts",
  "types": "dist/index.d.ts",
  "exports": {
    "require": "./dist/index.cjs",
    "default": "./dist/index.modern.js"
  },
  "main": "./dist/index.cjs",
  "module": "./dist/index.module.js",
  "unpkg": "./dist/index.umd.js",
  "scripts": {
    "build": "microbundle"
  },
  "devDependencies": {
    "@types/react": "^18.3.12",
    "microbundle": "^0.15.1",
    "react": "^18.3.1",
    "zod": "^4.1.11"
  },
  "peerDependencies": {
    "zod": "^3.25.0 || ^4.0.0"
  },
  "repository": {
    "type": "git",
    "url": "https://github.com/schalkventer/frrm.git"
  },
  "keywords": [
    "zod",
    "form"
  ],
  "bugs": "https://github.com/schalkventer/frrm/issues",
  "license": "MIT"
}
```