### PR TITLE
feat(v4): add min, max, nonempty, & size to ZodMap

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1433,12 +1433,20 @@ export interface ZodMap<Key extends core.SomeType = core.$ZodType, Value extends
     core.$ZodMap<Key, Value> {
   keyType: Key;
   valueType: Value;
+  min(minSize: number, params?: string | core.$ZodCheckMinSizeParams): this;
+  nonempty(params?: string | core.$ZodCheckMinSizeParams): this;
+  max(maxSize: number, params?: string | core.$ZodCheckMaxSizeParams): this;
+  size(size: number, params?: string | core.$ZodCheckSizeEqualsParams): this;
 }
 export const ZodMap: core.$constructor<ZodMap> = /*@__PURE__*/ core.$constructor("ZodMap", (inst, def) => {
   core.$ZodMap.init(inst, def);
   ZodType.init(inst, def);
   inst.keyType = def.keyType;
   inst.valueType = def.valueType;
+  inst.min = (...args) => inst.check(core._minSize(...args));
+  inst.nonempty = (params) => inst.check(core._minSize(1, params));
+  inst.max = (...args) => inst.check(core._maxSize(...args));
+  inst.size = (...args) => inst.check(core._size(...args));
 });
 
 export function map<Key extends core.SomeType, Value extends core.SomeType>(

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -31,6 +31,7 @@ const error: () => errors.$ZodErrorMap = () => {
     file: { unit: "bytes", verb: "to have" },
     array: { unit: "items", verb: "to have" },
     set: { unit: "items", verb: "to have" },
+    map: { unit: "entries", verb: "to have" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {


### PR DESCRIPTION
This adds the missing methods `min`, `max`, and `nonempty` to `ZodMap`, as well as the missing `size` property.

Fixes #5313.
