### PR TITLE
chore(doc): update metadata.tsx

### DIFF
--- a/packages/docs/content/metadata.mdx
+++ b/packages/docs/content/metadata.mdx
@@ -115,7 +115,7 @@ declare module "zod" {
   }
 }
 
-// It is always important to ensure you import/export something when augmenting a type
+// forces TypeScript to consider the file a module
 export {}
 ```
 


### PR DESCRIPTION
When augmenting `z.globalRegistry` in a `.d.ts` file, the file should have `export {}` statement to make the file take effect. Adding it to the code example would be a lot help to many developers.