### PR TITLE
perf: lazy initialize ~standard schema property

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -302,34 +302,18 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   }
 
   // Lazy initialize ~standard to avoid creating objects for every schema
-  Object.defineProperty(inst, "~standard", {
-    get() {
-      const standardSchema = {
-        validate: (value: unknown) => {
-          try {
-            const r = safeParse(inst, value);
-            return r.success ? { value: r.data } : { issues: r.error?.issues };
-          } catch (_) {
-            return safeParseAsync(inst, value).then((r) =>
-              r.success ? { value: r.data } : { issues: r.error?.issues }
-            );
-          }
-        },
-        vendor: "zod",
-        version: 1 as const,
-      };
-      // Cache the result after first access
-      Object.defineProperty(this, "~standard", {
-        value: standardSchema,
-        writable: false,
-        enumerable: false,
-        configurable: false,
-      });
-      return standardSchema;
+  util.defineLazy(inst, "~standard", () => ({
+    validate: (value: unknown) => {
+      try {
+        const r = safeParse(inst, value);
+        return r.success ? { value: r.data } : { issues: r.error?.issues };
+      } catch (_) {
+        return safeParseAsync(inst, value).then((r) => (r.success ? { value: r.data } : { issues: r.error?.issues }));
+      }
     },
-    enumerable: false,
-    configurable: true,
-  });
+    vendor: "zod",
+    version: 1 as const,
+  }));
 });
 
 export { clone } from "./util.js";


### PR DESCRIPTION
This PR improves schema initialization performance by (~5-15%) by deferring the creation of the "~standard" property until it's actually accessed.

## Problem

 The ~standard property implements the https://github.com/standard-schema/standard-schema but is rarely used in typical applications. Currently, this object is created eagerly for every schema during initialization, adding unnecessary overhead:

```ts
  inst["~standard"] = {
    validate: (value: unknown) => { ... },
    vendor: "zod",
    version: 1 as const,
  };
``` 

## Solution

  Convert the property to a lazy getter that only creates the object when accessed, then caches the result:

```ts
  Object.defineProperty(inst, "~standard", {
    get() {
      const standardSchema = {
        validate: (value: unknown) => { ... },
        vendor: "zod",
        version: 1 as const,
      };
      // Cache the result after first access
      Object.defineProperty(this, "~standard", {
        value: standardSchema,
        writable: false,
        enumerable: false,
        configurable: false,
      });
      return standardSchema;
    },
    enumerable: false,
    configurable: true,
  });
```