### PR TITLE
Add the potential format parameter to the invalid type issue

### DIFF
--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -1,4 +1,4 @@
-import type { $ZodCheck, $ZodStringFormats } from "./checks.js";
+import type { $ZodCheck, $ZodNumberFormats, $ZodStringFormats } from "./checks.js";
 import { $constructor } from "./core.js";
 import type { $ZodType } from "./schemas.js";
 import type { StandardSchemaV1 } from "./standard-schema.js";
@@ -19,6 +19,7 @@ export interface $ZodIssueBase {
 ////////////////////////////////
 export interface $ZodIssueInvalidType<Input = unknown> extends $ZodIssueBase {
   readonly code: "invalid_type";
+  readonly format?: $ZodNumberFormats;
   readonly expected: $ZodType["_zod"]["def"]["type"];
   readonly input?: Input;
 }


### PR DESCRIPTION
This is more of an issue than an actual fix, as I'm not familiar enough with the codebase to ensure this is valid, but I wanted to at least start with some code rather than just opening an issue.

I'm trying to declare an expected validation error, and typescript is saying it's invalid. Here's my expectation:
```js
{
    code: "invalid_type",
    expected: "int",
    format: "safeint",
    message: "Invalid input: expected int, received number",
    path: ["sessions"],
}
```

And the typescript compiler is returning:
`error TS2353: Object literal may only specify known properties, and 'format' does not exist in type '$ZodIssueInvalidType<unknown>'.`

I tried to remove the `format` property from my expectation, but it is actually included in the zod response, so I'm presuming it's not correctly declared somewhere in this codebase...