### PR TITLE
Fix: Iterate over keys in catchall object using "in" operator.

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1783,7 +1783,7 @@ function handleCatchall(
   const keySet = def.keySet;
   const _catchall = def.catchall!._zod;
   const t = _catchall.def.type;
-  for (const key of Object.keys(input)) {
+  for (const key in input) {
     if (keySet.has(key)) continue;
     if (t === "never") {
       unrecognized.push(key);


### PR DESCRIPTION
use the same way as zod3