### PR TITLE
Make catchall observable

### DIFF
--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -127,6 +127,11 @@ test("catchall inference", () => {
   const d1 = o1.parse({ first: "asdf", num: 1243 });
   // expectTypeOf<(typeof d1)["asdf"]>().toEqualTypeOf<number>();
   expectTypeOf<(typeof d1)["first"]>().toEqualTypeOf<string>();
+
+  type CatchAllSchema = typeof o1 extends z.ZodObject<any, infer Config extends z.core.$catchall<any>>
+    ? Config["catchall"]
+    : never;
+  expectTypeOf<CatchAllSchema>().toEqualTypeOf<z.ZodNumber>();
 });
 
 test("catchall overrides strict", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1718,6 +1718,7 @@ export type $strip = {
 export type $catchall<T extends SomeType> = {
   out: { [k: string]: core.output<T> };
   in: { [k: string]: core.input<T> };
+  catchall: T;
 };
 
 export type $ZodShape = Readonly<{ [k: string]: $ZodType }>;


### PR DESCRIPTION
This PR makes catchall observable (inferable) because right now it is not. For some reason this does not work:

```ts
type InferCatchAll<T extends z.ZodObject> =
  T extends z.ZodObject<any, infer _C extends z.core.$catchall<infer CatchAll>>
    ? CatchAll
    : never
```

With my changes, this makes that syntax working:
```ts
type InferCatchAll<T extends z.ZodObject> =
  T extends z.ZodObject<any, infer Config extends z.core.$catchall<any>>
    ? Config["catchall"]
    : never
```

This is a fix for #5372.