### PR TITLE
Add the origin property to the invalid string format

### DIFF
--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -46,7 +46,7 @@ export interface $ZodIssueTooSmall<Input = unknown> extends $ZodIssueBase {
 export interface $ZodIssueInvalidStringFormat extends $ZodIssueBase {
   readonly code: "invalid_format";
   readonly format: $ZodStringFormats | (string & {});
-  readonly origin: "string";
+  readonly origin?: "string";
   readonly pattern?: string;
   readonly input?: string;
 }


### PR DESCRIPTION
Similar to #5370 given the following expected validation issue:
```
{
    code: "invalid_format",
    format: "regex",
    message: "Must be between 50 and 60 alphanumeric characters",
    origin: "string",
    path: ["key"],
    pattern: "/[a-z0-9]{6,50}/",
}
```
Typescript complains that: ` error TS2353: Object literal may only specify known properties, and 'origin' does not exist in type '$ZodIssueInvalidStringFormat'`