### PR TITLE
docs: add 'cd zod' step to development setup instructions

### DIFF
--- a/packages/docs-v3/CONTRIBUTING.md
+++ b/packages/docs-v3/CONTRIBUTING.md
@@ -36,10 +36,7 @@ The following steps will get you setup to contribute changes to this repo:
 
 2. Clone your forked repo: `git clone git@github.com:{your_username}/zod.git`
 
-3. Navigate into the project directory:
-```bash
-cd zod
-```
+3. Navigate into the project directory: `cd zod`
 
 4. Run `yarn` to install dependencies.
 


### PR DESCRIPTION
This PR adds a missing step (`cd zod`) in the Development setup instructions to help new contributors navigate into the project directory before installing dependencies.
