### PR TITLE
docs(ecosystem): Add react-f3

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -106,6 +106,12 @@ const formIntegrations: ZodResource[] = [
     description: "Tiny 0.5kb Zod-based, HTML form abstraction that goes brr.",
     slug: "schalkventer/frrm",
   },
+  {
+    name: "react-f3",
+    url: "https://www.npmjs.com/package/react-f3",
+    description: "Components, hooks & utilities for creating and managing delightfully simple form experiences in React.",
+    slug: "maanlamp/react-f3",
+  },
 ];
 
 const zodToXConverters: ZodResource[] = [


### PR DESCRIPTION
This PR adds react-f3 to the ecosystem documentation.

React-f3 is some sort of "spiritual successor" to [react-zorm](https://github.com/esamattis/react-zorm) which seems to be abandoned.