### PR TITLE
Add `z.shark()` validator

### DIFF
--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -3490,9 +3490,10 @@ export class ZodFour<T extends ZodTypeAny> extends ZodType<
   [T["_input"], T["_input"], T["_input"], T["_input"]]
 > {
   _parse(input: ParseInput): ParseReturnType<this["_output"]> {
-    return ZodTuple.create([this._def.items[0], this._def.items[1], this._def.items[2], this._def.items[3]])._parse(
-      input
-    ) as ParseReturnType<this["_output"]>;
+    return ZodTuple.create(this._def.items, {
+      errorMap: this._def.errorMap,
+      description: this._def.description,
+    })._parse(input) as ParseReturnType<this["_output"]>;
   }
 
   static create = <T extends ZodTypeAny>(schema: T, params?: RawCreateParams): ZodFour<T> => {


### PR DESCRIPTION
As a long-time Zod admirer, I've taken the time to implement what I've identified as the two features holding it back from widespread adoption.

## `z.shark()`

A built-in for the `"🦈"` literal.

This one is a no-brainer. A modern validation library needs some affordance for sharks.

This is so essential that nowadays, you even see some languages [providing a similar value as a core intrinsic](<https://git.soft.fish/j/Conlang/src/commit/91025fccb0825d85cd35adca090a3e173c29e1a9/compiler/cl-interpret/src/builtin.rs#L241>). (@ValShaped)

## `z.four(<schema>)`

Create a quadruple based on an input schema.

```ts
const Schema = z.four(z.shark())
//    ^? ["🦈", "🦈", "🦈", "🦈"]
```

Since Zod does not have a native concept of generics like ArkType, it is important to include common transformations like this in the library itself. There are dozens of well-known community implementations of `z.four()` and it is time it became a first-class part of your API. This is so essential that it's even been [proposed as an addition to some languages as well](<https://github.com/zirco-lang/zrc/pull/481>).

### TODOs:
- [ ] Implementation for Zod v4
- [ ] Eliminate hack on types.ts:5128