### PR TITLE
fix: use oneOf for discriminated unions in JSON Schema

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -657,6 +657,54 @@ describe("toJSONSchema", () => {
     `);
   });
 
+  test("discriminated unions", () => {
+    const schema = z.discriminatedUnion("type", [
+      z.object({ type: z.literal("success"), data: z.string() }),
+      z.object({ type: z.literal("error"), message: z.string() }),
+    ]);
+    expect(z.toJSONSchema(schema)).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "data": {
+                "type": "string",
+              },
+              "type": {
+                "const": "success",
+                "type": "string",
+              },
+            },
+            "required": [
+              "type",
+              "data",
+            ],
+            "type": "object",
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "message": {
+                "type": "string",
+              },
+              "type": {
+                "const": "error",
+                "type": "string",
+              },
+            },
+            "required": [
+              "type",
+              "message",
+            ],
+            "type": "object",
+          },
+        ],
+      }
+    `);
+  });
+
   test("intersections", () => {
     const schema = z.intersection(z.object({ name: z.string() }), z.object({ age: z.number() }));
 

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -330,13 +330,20 @@ export class JSONSchemaGenerator {
           }
           case "union": {
             const json: JSONSchema.BaseSchema = _json as any;
+            // Discriminated unions use oneOf (exactly one match) instead of anyOf (one or more matches)
+            // because the discriminator field ensures mutual exclusivity between options in JSON Schema
+            const isDiscriminated = (def as any).discriminator !== undefined;
             const options = def.options.map((x, i) =>
               this.process(x, {
                 ...params,
-                path: [...params.path, "anyOf", i],
+                path: [...params.path, isDiscriminated ? "oneOf" : "anyOf", i],
               })
             );
-            json.anyOf = options;
+            if (isDiscriminated) {
+              json.oneOf = options;
+            } else {
+              json.anyOf = options;
+            }
             break;
           }
           case "intersection": {


### PR DESCRIPTION
## Description

Fixes #4089 - discriminated unions generating `anyOf` instead of `oneOf` in JSON Schema output.

Discriminated unions should use `oneOf` (exactly one match) instead of `anyOf` (one or more matches) because the discriminator field ensures mutual exclusivity between options. This is semantically correct according to JSON Schema specifications.

## Changes

- Modified `to-json-schema.ts` to detect discriminated unions via the `discriminator` property
- Discriminated unions now generate `oneOf` in JSON Schema
- Regular unions continue to use `anyOf` as before
- Added test case for discriminated unions in `to-json-schema.test.ts`

Testing
✅ All existing tests pass
✅ Added new test case for discriminated unions
✅ Test validates correct [oneOf](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) generation with proper schema structure

