### PR TITLE
Add `zod-to-mongo-schema` to ecosystem documentation

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -145,6 +145,12 @@ const zodToXConverters: ZodResource[] = [
     description: 'Build your own "Zod to x" library, or pick one of 25+ off-the-shelf transformers',
     slug: "traversable/schema",
   },
+  {
+    name: "zod-to-mongo-schema",
+    url: "https://github.com/udohjeremiah/zod-to-mongo-schema",
+    description: "Convert Zod schemas to MongoDB-compatible JSON Schemas effortlessly",
+    slug: "udohjeremiah/zod-to-mongo-schema",
+  },
 ];
 
 const xToZodConverters: ZodResource[] = [


### PR DESCRIPTION
Hey Zodians,

I made a zero-dependencies `zod-to-x` library: https://github.com/udohjeremiah/zod-to-mongo-schema. It takes your Zod schemas and converts it a JSON schema that can be used to annotate and validate MongoDB documents.

Please add it to the ecosystem page.

T for Thanks ☺️