### PR TITLE
Add convex-helpers to the ecosystem docs

### DIFF
--- a/packages/docs-v3/README.md
+++ b/packages/docs-v3/README.md
@@ -572,6 +572,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`fastify-zod-openapi`](https://github.com/samchungy/fastify-zod-openapi): Fastify type provider, validation, serialization and @fastify/swagger support for Zod schemas.
 - [`typeschema`](https://typeschema.com/): Universal adapter for schema validation.
 - [`zodex`](https://github.com/commonbaseapp/zodex): (De)serialization for zod schemas
+- [`convex-helpers`](https://github.com/get-convex/convex-helpers/blob/main/packages/convex-helpers/README.md#zod-validation): Use Zod to validate arguments and return values of Convex functions, and to create Convex database schemas.
 
 #### X to Zod
 
@@ -591,6 +592,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`java-to-zod`](https://github.com/ivangreene/java-to-zod): Convert POJOs to Zod schemas
 - [`Orval`](https://github.com/anymaniax/orval): Generate Zod schemas from OpenAPI schemas
 - [`Kubb`](https://github.com/kubb-labs/kubb): Generate SDKs and Zod schemas from your OpenAPI schemas
+- [`convex-helpers`](https://github.com/get-convex/convex-helpers/blob/main/packages/convex-helpers/README.md#zod-validation): Generate Zod schemas from Convex validators.
 
 #### Mocking
 

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -151,6 +151,12 @@ const zodToXConverters: ZodResource[] = [
     description: "Convert Zod schemas to MongoDB-compatible JSON Schemas effortlessly",
     slug: "udohjeremiah/zod-to-mongo-schema",
   },
+  {
+    name: "convex-helpers",
+    url: "https://github.com/get-convex/convex-helpers/blob/main/packages/convex-helpers/README.md#zod-validation",
+    description: "Use Zod to validate arguments and return values of Convex functions, and to create Convex database schemas",
+    slug: "get-convex/convex-helpers",
+  },
 ];
 
 const xToZodConverters: ZodResource[] = [
@@ -192,6 +198,12 @@ const xToZodConverters: ZodResource[] = [
       "Drizzle ORM toolkit that can generate Zod validators from schema(s), plus typed services and strongly typed routers (oRPC/tRPC/etc).",
     slug: "use-drzl/drzl",
   },
+  {
+    name: "convex-helpers",
+    url: "https://github.com/get-convex/convex-helpers/blob/main/packages/convex-helpers/README.md#zod-validation",
+    description: "Generate Zod schemas from Convex validators",
+    slug: "get-convex/convex-helpers",
+  }
 ];
 
 const mockingLibraries: ZodResource[] = [


### PR DESCRIPTION
Convex supports conversion of Convex validators to and from Zod schemas for both Zod 3 and Zod 4, through the convex-helpers package (see our [docs](https://github.com/get-convex/convex-helpers/blob/main/packages/convex-helpers/README.md#zod-validation) and the [Zod 4 support PR](https://github.com/get-convex/convex-helpers/pull/840)). This package would make a great addition to the _Ecosystem_ page of the Zod docs.