### PR TITLE
test: add result verification to test cases

### DIFF
--- a/packages/zod/src/v3/tests/complex.test.ts
+++ b/packages/zod/src/v3/tests/complex.test.ts
@@ -1,4 +1,4 @@
-import { test } from "vitest";
+import { expect, test } from "vitest";
 import * as z from "zod/v3";
 
 const crazySchema = z.object({
@@ -40,7 +40,7 @@ const crazySchema = z.object({
 // });
 
 test("parse", () => {
-  crazySchema.parse({
+  const input = {
     tuple: ["asdf", 1234, true, null, undefined, "1234"],
     merged: { k1: "asdf", k2: 12 },
     union: ["asdf", 12, "asdf", 12, "asdf", 12],
@@ -52,5 +52,19 @@ test("parse", () => {
     nonstrict: { points: 1234 },
     numProm: Promise.resolve(12),
     lenfun: (x: string) => x.length,
-  });
+  };
+
+  const result = crazySchema.parse(input);
+
+  // Verify the parsed result structure
+  expect(result.tuple).toEqual(input.tuple);
+  expect(result.merged).toEqual(input.merged);
+  expect(result.union).toEqual(input.union);
+  expect(result.array).toEqual(input.array);
+  expect(result.sumMinLength).toEqual(input.sumMinLength);
+  expect(result.intersection).toEqual(input.intersection);
+  expect(result.enum).toEqual(input.enum);
+  expect(result.nonstrict).toEqual(input.nonstrict);
+  expect(result.numProm).toBeInstanceOf(Promise);
+  expect(typeof result.lenfun).toBe("function");
 });

--- a/packages/zod/src/v3/tests/function.test.ts
+++ b/packages/zod/src/v3/tests/function.test.ts
@@ -10,7 +10,8 @@ const func1 = z.function(args1, returns1);
 
 test("function parsing", () => {
   const parsed = func1.parse((arg: any) => arg.length);
-  parsed("asdf");
+  const result = parsed("asdf");
+  expect(result).toBe(4);
 });
 
 test("parsed function fail 1", () => {
@@ -226,8 +227,11 @@ test("allow extra parameters", () => {
 test("params and returnType getters", () => {
   const func = z.function().args(z.string()).returns(z.string());
 
-  func.parameters().items[0].parse("asdf");
-  func.returnType().parse("asdf");
+  const paramResult = func.parameters().items[0].parse("asdf");
+  expect(paramResult).toBe("asdf");
+
+  const returnResult = func.returnType().parse("asdf");
+  expect(returnResult).toBe("asdf");
 });
 
 test("inference with transforms", () => {

--- a/packages/zod/src/v3/tests/nan.test.ts
+++ b/packages/zod/src/v3/tests/nan.test.ts
@@ -6,8 +6,11 @@ import * as z from "zod/v3";
 const schema = z.nan();
 
 test("passing validations", () => {
-  schema.parse(Number.NaN);
-  schema.parse(Number("Not a number"));
+  const result1 = schema.parse(Number.NaN);
+  expect(Number.isNaN(result1)).toBe(true);
+
+  const result2 = schema.parse(Number("Not a number"));
+  expect(Number.isNaN(result2)).toBe(true);
 });
 
 test("failing validations", () => {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -199,7 +199,7 @@ export function assertNotEqual<A, B>(val: AssertNotEqual<A, B>): AssertNotEqual<
 export function assertIs<T>(_arg: T): void {}
 
 export function assertNever(_x: never): never {
-  throw new Error();
+  throw new Error("Unexpected value in exhaustive check");
 }
 export function assert<T>(_: any): asserts _ is T {}
 


### PR DESCRIPTION
Enhance test cases by adding proper assertions to verify parsed results instead of just calling parse without validation:

- nan.test.ts: Verify parsed NaN values using Number.isNaN()
- complex.test.ts: Add comprehensive assertions to verify all parsed fields match the input structure
- function.test.ts: Verify function parsing returns correct values and verify params/returnType getter parse results
- util.ts: Improve error message in assertNever for better debugging