### PR TITLE
fix(implementasync): Inferred type should always be a promise

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3972,7 +3972,7 @@ export type $InferOuterFunctionType<Args extends $ZodFunctionIn, Returns extends
 
 export type $InferOuterFunctionTypeAsync<Args extends $ZodFunctionIn, Returns extends $ZodFunctionOut> = (
   ...args: $ZodFunctionIn extends Args ? never[] : core.input<Args>
-) => util.MaybeAsync<core.output<Returns>>;
+) => Promise<core.output<Returns>>;
 
 export interface $ZodFunctionDef<
   In extends $ZodFunctionIn = $ZodFunctionIn,


### PR DESCRIPTION
This pr tries to fix the inferred types when using implementasync functions for interface implementations. I am uncertain if my fix was the "correct" fix but essentially this fixes the second issue described here https://github.com/colinhacks/zod/issues/5459. 

Now it's still unclear to ma as to why this used to be typed as a MaybeAsync and not a Promise. I assume I am missing some context and by that I also think that there must be something wrong with the change I have done but can't immediately see what. There were no tests indicating what the behavior should be as well

I also wonder why it's only an issue when using the transform function and otherwise it is not.

Another thing I'm wondering is if the output is already types as Promise, should the type still do `Promise<T>` Or should we check if `T` already extends `Promise` so we don't get `Promise<Promise<T>>` in edge cases.