### PR TITLE
docs(error-customization): wrong usage example in global error customization

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -276,8 +276,8 @@ The `iss` object is a [discriminated union](https://www.typescriptlang.org/docs/
 > For a breakdown of all Zod issue codes, see the [`zod/v4/core`](/packages/core#issue-types) documentation.
 
 ```ts
-const result = schema.safeParse(12, {
-  error: (iss) => {
+z.config({
+  customError: (iss) => {
     if (iss.code === "invalid_type") {
       return `invalid type, expected ${iss.expected}`;
     }
@@ -285,8 +285,8 @@ const result = schema.safeParse(12, {
       return `minimum is ${iss.minimum}`;
     }
     // ...
-  }
-})
+  },
+});
 ```
 
 ## Internationalization


### PR DESCRIPTION
### Background
Hi team,

I just read [Zod v4 Global error customization](https://zod.dev/error-customization?id=global-error-customization) and found out this example is wrong:
<img width="828" height="748" alt="image" src="https://github.com/user-attachments/assets/39104485-e2ec-4fad-8583-6c26bd92249f" />

### Root Cause
It seems to be mistakenly duplicated from [Per-parse error customization](https://zod.dev/error-customization?id=per-parse-error-customization).

### Testing
I fixed it locally and ran the `pnpm run dev` again. Everything looks fine.
<img width="777" height="782" alt="image" src="https://github.com/user-attachments/assets/f72d0327-7beb-48df-9dd2-947c65a4d918" />

