### PR TITLE
Represent `z.undefined()` as `{ "type": "null" }` for JSON Schemas

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -55,9 +55,10 @@ describe("toJSONSchema", () => {
         "type": "null",
       }
     `);
-    expect(z.toJSONSchema(z.undefined(), { unrepresentable: "any" })).toMatchInlineSnapshot(`
+    expect(z.toJSONSchema(z.undefined())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "null",
       }
     `);
     expect(z.toJSONSchema(z.any())).toMatchInlineSnapshot(`
@@ -282,7 +283,6 @@ describe("toJSONSchema", () => {
     expect(() => z.toJSONSchema(z.int64())).toThrow("BigInt cannot be represented in JSON Schema");
     expect(() => z.toJSONSchema(z.symbol())).toThrow("Symbols cannot be represented in JSON Schema");
     expect(() => z.toJSONSchema(z.void())).toThrow("Void cannot be represented in JSON Schema");
-    expect(() => z.toJSONSchema(z.undefined())).toThrow("Undefined cannot be represented in JSON Schema");
     expect(() => z.toJSONSchema(z.date())).toThrow("Date cannot be represented in JSON Schema");
     expect(() => z.toJSONSchema(z.map(z.string(), z.number()))).toThrow("Map cannot be represented in JSON Schema");
     expect(() => z.toJSONSchema(z.set(z.string()))).toThrow("Set cannot be represented in JSON Schema");

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -250,9 +250,7 @@ export class JSONSchemaGenerator {
             break;
           }
           case "undefined": {
-            if (this.unrepresentable === "throw") {
-              throw new Error("Undefined cannot be represented in JSON Schema");
-            }
+            _json.type = "null";
             break;
           }
           case "void": {


### PR DESCRIPTION
Related issue: https://github.com/colinhacks/zod/issues/5503

Currently, the documentation does not include `z.undefined()` as unrepresentable in JSON Schema, and declares that

> Zod converts both undefined/null to { type: "null" } in JSON Schema.

This PR updates the implementation to match the documentation . Alternatively, see https://github.com/colinhacks/zod/pull/5504

Possibly, we can implement this new behavior under an option to `toJSONSchema`?