### PR TITLE
fix: coerce string 'false' to boolean false in z.coerce.boolean()

### DIFF
--- a/packages/zod/src/v4/classic/tests/coerce.test.ts
+++ b/packages/zod/src/v4/classic/tests/coerce.test.ts
@@ -53,7 +53,17 @@ test("number coercion", () => {
 test("boolean coercion", () => {
   const schema = z.coerce.boolean();
   expect(schema.parse("true")).toEqual(true);
-  expect(schema.parse("false")).toEqual(true);
+  expect(schema.parse("false")).toEqual(false);
+  // Explicitly test that "false" string returns false (unlike Boolean("false") which returns true)
+  // This addresses: https://github.com/colinhacks/zod/issues/5501
+  expect(Boolean("false")).toEqual(true); // JavaScript Boolean() behavior
+  expect(schema.parse("false")).toEqual(false); // Zod's improved behavior
+  expect(schema.parse("False")).toEqual(false);
+  expect(schema.parse("FALSE")).toEqual(false);
+  expect(schema.parse(" false ")).toEqual(false);
+  expect(schema.parse("True")).toEqual(true);
+  expect(schema.parse("TRUE")).toEqual(true);
+  expect(schema.parse(" true ")).toEqual(true);
   expect(schema.parse("0")).toEqual(true);
   expect(schema.parse("1")).toEqual(true);
   expect(schema.parse("")).toEqual(false);

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -56,7 +56,7 @@ test("z.coerce.boolean", () => {
   expect(z.parse(a, true)).toEqual(true);
   expect(z.parse(a, false)).toEqual(false);
   expect(z.parse(a, "true")).toEqual(true);
-  expect(z.parse(a, "false")).toEqual(true);
+  expect(z.parse(a, "false")).toEqual(false);
   expect(z.parse(a, 1)).toEqual(true);
   expect(z.parse(a, 0)).toEqual(false);
   expect(z.parse(a, {})).toEqual(true);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1164,7 +1164,21 @@ export const $ZodBoolean: core.$constructor<$ZodBoolean> = /*@__PURE__*/ core.$c
     inst._zod.parse = (payload, _ctx) => {
       if (def.coerce)
         try {
-          payload.value = Boolean(payload.value);
+          const value = payload.value;
+          // Handle string values "true" and "false" specially
+          if (typeof value === "string") {
+            const lowerValue = value.toLowerCase().trim();
+            if (lowerValue === "true") {
+              payload.value = true;
+            } else if (lowerValue === "false") {
+              payload.value = false;
+            } else {
+              // Fall back to standard Boolean coercion for other strings
+              payload.value = Boolean(value);
+            }
+          } else {
+            payload.value = Boolean(value);
+          }
         } catch (_) {}
       const input = payload.value;
       if (typeof input === "boolean") return payload;

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -56,7 +56,7 @@ test("z.coerce.boolean", () => {
   expect(z.parse(a, true)).toEqual(true);
   expect(z.parse(a, false)).toEqual(false);
   expect(z.parse(a, "true")).toEqual(true);
-  expect(z.parse(a, "false")).toEqual(true);
+  expect(z.parse(a, "false")).toEqual(false);
   expect(z.parse(a, 1)).toEqual(true);
   expect(z.parse(a, 0)).toEqual(false);
   expect(z.parse(a, {})).toEqual(true);


### PR DESCRIPTION
Fixes #5501

Previously, z.coerce.boolean() used Boolean() constructor which returns true for the string 'false' (since any non-empty string is truthy in JavaScript). This change adds special handling for string values 'true' and 'false' to properly coerce them to their boolean equivalents.

- String 'false' (case-insensitive, with whitespace trimming) now coerces to false
- String 'true' (case-insensitive, with whitespace trimming) now coerces to true
- Other values continue to use standard Boolean() coercion
- Added comprehensive test cases for various case and whitespace combinations