### PR TITLE
RecordKeys shold only care about output

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2524,7 +2524,7 @@ function handleTupleResult(result: ParsePayload, final: ParsePayload<any[]>, ind
 //////////////////////////////////////////
 //////////////////////////////////////////
 
-export type $ZodRecordKey = $ZodType<string | number | symbol, any>; // $HasValues | $HasPattern;
+export type $ZodRecordKey = $ZodType<string | number | symbol, unknown>; // $HasValues | $HasPattern;
 export interface $ZodRecordDef<Key extends $ZodRecordKey = $ZodRecordKey, Value extends SomeType = $ZodType>
   extends $ZodTypeDef {
   type: "record";
@@ -2563,12 +2563,13 @@ export type $InferZodRecordOutput<
 //         ? Record<core.input<Key>, core.input<Value>>
 //         : Record<core.input<Key>, core.input<Value>>
 //   : Record<core.input<Key>, core.input<Value>>;
+
 export type $InferZodRecordInput<
   Key extends $ZodRecordKey = $ZodRecordKey,
   Value extends SomeType = $ZodType,
 > = Key extends $partial
-  ? Partial<Record<core.input<Key>, core.input<Value>>>
-  : Record<core.input<Key>, core.input<Value>>;
+  ? Partial<Record<core.input<Key> & PropertyKey, core.input<Value>>>
+  : Record<core.input<Key> & PropertyKey, core.input<Value>>;
 
 export interface $ZodRecordInternals<Key extends $ZodRecordKey = $ZodRecordKey, Value extends SomeType = $ZodType>
   extends $ZodTypeInternals<$InferZodRecordOutput<Key, Value>, $InferZodRecordInput<Key, Value>> {


### PR DESCRIPTION
Because keys are always strings in Javascript, a record will never parse when the schema specifies it should be a number.

```ts
const schema = z.record(z.number(), z.number());
schema.parse({ 1: 100, 2: 88, 3: 99, 4: 60 })
```

A workaround or the right way would be to coerce the number instead:
```ts
const schema = z.record(z.coerce.number(), z.number());
schema.parse({ 1: 100, 2: 88, 3: 99, 4: 60 })
```
Only problem being the record throwing type error as the coerced number doesnt have a number input.

This seems to be okay as the number type doesnt leek anywhere it should not:
```ts
z.record(z.coerce.number(), z.number()) // Record<number, number>
Object.keys(result); // string[]
Object.entries(result); // [string, number][]
for (const key /*: string */ in result) {

}
```

I am aware of the docs mentioning using string for record keys (image below) but I think we can embrace using coerced number without problem (or any other schema that outputs a valid key).
<img width="1772" height="990" alt="image" src="https://github.com/user-attachments/assets/87bb796e-a912-4000-ac3b-2f1b8f15ec6f" />


Asserts: 
- #5521
- #4383
- #4665