### PR TITLE
fix: JSON .optional().default() fields marked as required

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -122,7 +122,12 @@ export class JSONSchemaGenerator {
     }
 
     // initialize
-    const result: Seen = { schema: {}, count: 1, cycle: undefined, path: _params.path };
+    const result: Seen = {
+      schema: {},
+      count: 1,
+      cycle: undefined,
+      path: _params.path,
+    };
     this.seen.set(schema, result);
 
     // custom method overrides default behavior
@@ -278,7 +283,10 @@ export class JSONSchemaGenerator {
             if (typeof maximum === "number") json.maxItems = maximum;
 
             json.type = "array";
-            json.items = this.process(def.element, { ...params, path: [...params.path, "items"] });
+            json.items = this.process(def.element, {
+              ...params,
+              path: [...params.path, "items"],
+            });
             break;
           }
           case "object": {
@@ -303,6 +311,14 @@ export class JSONSchemaGenerator {
                 if (this.io === "input") {
                   return v.optin === undefined;
                 } else {
+                  // For .optional().default() the outer optout is undefined but the
+                  // inner type (optional) has optout="optional", so check inner type
+                  if (v.def.type === "default" || v.def.type === "prefault") {
+                    const innerType = (v.def as any).innerType._zod;
+                    if (innerType.optout === "optional") {
+                      return false;
+                    }
+                  }
                   return v.optout === undefined;
                 }
               })
@@ -512,7 +528,10 @@ export class JSONSchemaGenerator {
                 Object.assign(json, file);
               } else {
                 json.anyOf = mime.map((m) => {
-                  const mFile: JSONSchema.StringSchema = { ...file, contentMediaType: m };
+                  const mFile: JSONSchema.StringSchema = {
+                    ...file,
+                    contentMediaType: m,
+                  };
                   return mFile;
                 });
               }
@@ -698,7 +717,10 @@ export class JSONSchemaGenerator {
         // otherwise, add to __shared
         const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${this.counter++}`;
         entry[1].defId = id; // set defId so it will be reused if needed
-        return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+        return {
+          defId: id,
+          ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}`,
+        };
       }
 
       if (entry[1] === root) {


### PR DESCRIPTION
**Package:** zod@v4

**Problem:** Fields marked as `.optional().default()` were incorrectly being included in the JSON schema's required array.

**Root Cause:** The JSON schema generator only checked the outer `optout` flag. When you chain `.optional().default()`, the outer type is default (which has `optout=undefined`), but the inner type is `optional` (which has `optout="optional"`).

**Solution:** Check the inner type when the outer type is `default` or `prefault`. If the inner type has `optout="optional"`, don't mark the field as required.
