### PR TITLE
fix: Fix error details for tuples with too many elements

### DIFF
--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -30,9 +30,10 @@ test("successful validation", () => {
       {
         "code": "too_big",
         "maximum": 2,
+        "inclusive": true,
         "origin": "array",
         "path": [],
-        "message": "Too big: expected array to have <2 items"
+        "message": "Too big: expected array to have <=2 items"
       }
     ]]
   `);
@@ -82,9 +83,10 @@ test("async validation", async () => {
       {
         "code": "too_big",
         "maximum": 2,
+        "inclusive": true,
         "origin": "array",
         "path": [],
-        "message": "Too big: expected array to have <2 items"
+        "message": "Too big: expected array to have <=2 items"
       }
     ]]
   `);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2533,7 +2533,9 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       const tooSmall = input.length < optStart - 1;
       if (tooBig || tooSmall) {
         payload.issues.push({
-          ...(tooBig ? { code: "too_big", maximum: items.length } : { code: "too_small", minimum: items.length }),
+          ...(tooBig
+            ? { code: "too_big", maximum: items.length, inclusive: true }
+            : { code: "too_small", minimum: items.length }),
 
           input,
           inst,


### PR DESCRIPTION
Given a tuple type of size 2, parsing an array of size 3 or greater incorrectly claims that Zod "expected array to have <2 items". 2 is not "<2".

I fixed the existing tests that cover this behavior by setting the `inclusive` flag when generating the issue. While this makes sense for validating "maximum" constraints, for a "minimum" constraint it seems confusing. I think this confusion stems from humans' propensity to mix and match closed and half-open ranges willy nilly.

I should note, for follow up changes/issues:
- The "too small" error condition implemented in `schemas.ts:2536` does not seem to be triggered given a tuple of only one item — the error message generated is "Invalid input: expected number, received undefined".
- Tuple error messages should probably report that the size is expected to be _exactly_ 2, in this case, not merely "<=2"