### PR TITLE
docs: fix stringbool link

### DIFF
--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -769,7 +769,7 @@ z.stringbool({
 })
 ```
 
-Refer to the [`z.stringbool()` docs](/api#stringbools) for more information.
+Refer to the [`z.stringbool()` docs](/api#stringbool) for more information.
 
 ## Simplified error customization
 


### PR DESCRIPTION
Fix broken link to `z.stringbool()` docs on the release notes page:
https://zod.dev/v4?id=stringbool
