### PR TITLE
Support type predicates on `.refine()`

### DIFF
--- a/packages/zod/src/v4/classic/tests/refine.test.ts
+++ b/packages/zod/src/v4/classic/tests/refine.test.ts
@@ -416,84 +416,49 @@ describe("chained refinements", () => {
   });
 });
 
-// Commented tests can be uncommented once type-checking issues are resolved
-/*
-describe("type refinement", () => {
-  test("refinement type guard", () => {
-    const validationSchema = z.object({
-      a: z.string().refine((s): s is "a" => s === "a"),
-    });
-    type Input = z.input<typeof validationSchema>;
-    type Schema = z.infer<typeof validationSchema>;
+describe("type refinement with type guards", () => {
+  test("type guard narrows output type", () => {
+    const schema = z.string().refine((s): s is "a" => s === "a");
 
-    expectTypeOf<Input["a"]>().not.toEqualTypeOf<"a">();
-    expectTypeOf<Input["a"]>().toEqualTypeOf<string>();
-
-    expectTypeOf<Schema["a"]>().toEqualTypeOf<"a">();
-    expectTypeOf<Schema["a"]>().not.toEqualTypeOf<string>();
+    expectTypeOf<z.input<typeof schema>>().toEqualTypeOf<string>();
+    expectTypeOf<z.output<typeof schema>>().toEqualTypeOf<"a">();
   });
 
-  test("superRefine - type narrowing", () => {
-    type NarrowType = { type: string; age: number };
-    const schema = z
-      .object({
-        type: z.string(),
-        age: z.number(),
-      })
-      .nullable()
-      .superRefine((arg, ctx): arg is NarrowType => {
-        if (!arg) {
-          // still need to make a call to ctx.addIssue
-          ctx.addIssue({
-            input: arg,
-            code: "custom",
-            message: "cannot be null",
-            fatal: true,
-          });
-          return false;
-        }
-        return true;
-      });
+  test("non-type-guard refine does not narrow", () => {
+    const schema = z.string().refine((s) => s.length > 0);
 
-    expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<NarrowType>();
-
-    expect(schema.safeParse({ type: "test", age: 0 }).success).toEqual(true);
-    expect(schema.safeParse(null).success).toEqual(false);
+    expectTypeOf<z.input<typeof schema>>().toEqualTypeOf<string>();
+    expectTypeOf<z.output<typeof schema>>().toEqualTypeOf<string>();
   });
 
-  test("chained mixed refining types", () => {
-    type firstRefinement = { first: string; second: number; third: true };
-    type secondRefinement = { first: "bob"; second: number; third: true };
-    type thirdRefinement = { first: "bob"; second: 33; third: true };
-    const schema = z
-      .object({
-        first: z.string(),
-        second: z.number(),
-        third: z.boolean(),
-      })
-      .nullable()
-      .refine((arg): arg is firstRefinement => !!arg?.third)
-      .superRefine((arg, ctx): arg is secondRefinement => {
-        expectTypeOf<typeof arg>().toEqualTypeOf<firstRefinement>();
-        if (arg.first !== "bob") {
-          ctx.addIssue({
-            input: arg,
-            code: "custom",
-            message: "`first` property must be `bob`",
-          });
-          return false;
-        }
-        return true;
-      })
-      .refine((arg): arg is thirdRefinement => {
-        expectTypeOf<typeof arg>().toEqualTypeOf<secondRefinement>();
-        return arg.second === 33;
-      });
-
-    expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<thirdRefinement>();
-  });
+  // TODO: Implement type narrowing for superRefine
+  // test("superRefine - type narrowing", () => {
+  //   type NarrowType = { type: string; age: number };
+  //   const schema = z
+  //     .object({
+  //       type: z.string(),
+  //       age: z.number(),
+  //     })
+  //     .nullable()
+  //     .superRefine((arg, ctx): arg is NarrowType => {
+  //       if (!arg) {
+  //         ctx.addIssue({
+  //           input: arg,
+  //           code: "custom",
+  //           message: "cannot be null",
+  //           fatal: true,
+  //         });
+  //         return false;
+  //       }
+  //       return true;
+  //     });
+  //
+  //   expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<NarrowType>();
+  //
+  //   expect(schema.safeParse({ type: "test", age: 0 }).success).toEqual(true);
+  //   expect(schema.safeParse(null).success).toEqual(false);
+  // });
 });
-*/
 
 test("when", () => {
   const schema = z
@@ -602,67 +567,4 @@ test("when", () => {
       "success": false,
     }
   `);
-});
-
-describe("type predicate refinements", () => {
-  test("refine with type predicate narrows output type", () => {
-    const schema = z.string().refine((val): val is "specific" => val === "specific");
-
-    type SchemaInput = z.input<typeof schema>;
-    type SchemaOutput = z.infer<typeof schema>;
-
-    // Input type should remain string
-    expectTypeOf<SchemaInput>().toEqualTypeOf<string>();
-    // Output type should be narrowed to "specific"
-    expectTypeOf<SchemaOutput>().toEqualTypeOf<"specific">();
-
-    // Runtime behavior should still work
-    expect(schema.safeParse("specific").success).toBe(true);
-    expect(schema.safeParse("other").success).toBe(false);
-  });
-
-  test("refine with type predicate on unknown narrows to specific type", () => {
-    const schema = z.unknown().refine((val): val is string => typeof val === "string");
-
-    type SchemaOutput = z.infer<typeof schema>;
-
-    expectTypeOf<SchemaOutput>().toEqualTypeOf<string>();
-
-    expect(schema.safeParse("hello").success).toBe(true);
-    expect(schema.safeParse(123).success).toBe(false);
-  });
-
-  test("refine without type predicate preserves original type", () => {
-    const schema = z.string().refine((val) => val.length > 0);
-
-    type SchemaOutput = z.infer<typeof schema>;
-
-    // Should still be string, not narrowed
-    expectTypeOf<SchemaOutput>().toEqualTypeOf<string>();
-  });
-
-  test("refine with type predicate on nullable narrows to non-null", () => {
-    const schema = z
-      .string()
-      .nullable()
-      .refine((val): val is string => val !== null);
-
-    type SchemaOutput = z.infer<typeof schema>;
-
-    expectTypeOf<SchemaOutput>().toEqualTypeOf<string>();
-
-    expect(schema.safeParse("hello").success).toBe(true);
-    expect(schema.safeParse(null).success).toBe(false);
-  });
-
-  test("refine with type predicate narrowing number to literal", () => {
-    const schema = z.number().refine((val): val is 42 => val === 42);
-
-    type SchemaOutput = z.infer<typeof schema>;
-
-    expectTypeOf<SchemaOutput>().toEqualTypeOf<42>();
-
-    expect(schema.safeParse(42).success).toBe(true);
-    expect(schema.safeParse(43).success).toBe(false);
-  });
 });

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -93,9 +93,7 @@ export type $ZodBranded<
       ? { _zod: { input: input<T> & $brand<Brand> } }
       : { _zod: { output: output<T> & $brand<Brand> } });
 
-export type $ZodRefined<T extends schemas.SomeType, RefinedOutput> = T & {
-  _zod: { output: RefinedOutput };
-};
+export type $ZodNarrow<T extends schemas.SomeType, Out> = T & { _zod: { output: Out } };
 
 export class $ZodAsyncError extends Error {
   constructor() {

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -11,6 +11,10 @@ export interface ZodMiniType<
 > extends core.$ZodType<Output, Input, Internals> {
   type: Internals["def"]["type"];
   check(...checks: (core.CheckFn<core.output<this>> | core.$ZodCheck<core.output<this>>)[]): this;
+  refine<Ch extends (arg: core.output<this>) => unknown | Promise<unknown>>(
+    check: Ch,
+    params?: string | core.$ZodCustomParams
+  ): Ch extends (arg: any) => arg is infer R ? core.$ZodNarrow<this, R> : this;
   clone(def?: Internals["def"], params?: { parent: boolean }): this;
   register<R extends core.$ZodRegistry>(
     registry: R,
@@ -65,6 +69,7 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
         // { parent: true }
       );
     };
+    inst.refine = (check, params) => inst.check(refine(check, params)) as never;
     inst.clone = (_def, params) => core.clone(inst, _def, params);
     inst.brand = () => inst as any;
     inst.register = ((reg: any, meta: any) => {
@@ -1639,14 +1644,6 @@ export function custom<O = unknown, I = O>(
 }
 
 // refine
-export function refine<T, RefinedOutput extends T>(
-  fn: (arg: NoInfer<T>) => arg is RefinedOutput,
-  _params?: string | core.$ZodCustomParams
-): core.$ZodCheck<T> & { _zod: { output: RefinedOutput } };
-export function refine<T>(
-  fn: (arg: NoInfer<T>) => util.MaybeAsync<unknown>,
-  _params?: string | core.$ZodCustomParams
-): core.$ZodCheck<T>;
 export function refine<T>(
   fn: (arg: NoInfer<T>) => util.MaybeAsync<unknown>,
   _params: string | core.$ZodCustomParams = {}

--- a/packages/zod/src/v4/mini/tests/refine.test.ts
+++ b/packages/zod/src/v4/mini/tests/refine.test.ts
@@ -1,0 +1,19 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type * as core from "../../core/index.js";
+import * as z from "../index.js";
+
+describe("type refinement with type guards", () => {
+  test("type guard narrows output type", () => {
+    const schema = z.string().refine((s): s is "a" => s === "a");
+
+    expectTypeOf<core.input<typeof schema>>().toEqualTypeOf<string>();
+    expectTypeOf<core.output<typeof schema>>().toEqualTypeOf<"a">();
+  });
+
+  test("non-type-guard refine does not narrow", () => {
+    const schema = z.string().refine((s) => s.length > 0);
+
+    expectTypeOf<core.input<typeof schema>>().toEqualTypeOf<string>();
+    expectTypeOf<core.output<typeof schema>>().toEqualTypeOf<string>();
+  });
+});

--- a/play.ts
+++ b/play.ts
@@ -1,3 +1,6 @@
 import * as z from "zod/v4";
 
 z;
+z.unknown()
+  .refine((val) => typeof val === "number")
+  .parse(1);


### PR DESCRIPTION
- **Add back type predicate support**
- **Support type predicated on refine**
