### PR TITLE
Remove Juno

### DIFF
--- a/packages/docs-v3/README.md
+++ b/packages/docs-v3/README.md
@@ -409,11 +409,6 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
       <br />
       <a style="text-decoration:none;" href="https://cybozu.co.jp/index.html" target="_blank">Cybozu</a>
     </td>
-    <td align="center">
-      <img src="https://avatars.githubusercontent.com/u/147273133?s=200&v=4" height="50px;" alt="Juno logo" />
-      <br />
-      <a style="text-decoration:none;" href="https://juno.build/?utm_source=zod" target="_blank">Juno</a>
-    </td>
   </tr>
 </table>
 

--- a/packages/docs/components/silver.tsx
+++ b/packages/docs/components/silver.tsx
@@ -5,12 +5,6 @@ export const Silver = () => {
       logoSrc: "https://avatars.githubusercontent.com/u/176449348?s=200&v=4",
       url: "subtotal.com",
       href: "https://www.subtotal.com/?utm_source=zod",
-    },
-    {
-      name: "Juno",
-      logoSrc: "https://avatars.githubusercontent.com/u/147273133?s=200&v=4",
-      url: "juno.build",
-      href: "https://juno.build/?utm_source=zod",
     },{
       name: "Nitric",
       logoSrc: "https://avatars.githubusercontent.com/u/72055470?s=200&v=4",


### PR DESCRIPTION
# Motivation

Hi Colin,

My sponsorship has been drastically decreased and by extension I cannot allocate the same amount of budget for sponsoring, therefore I cannot continue to be a silver sponsor of Zod with Juno. Happy to revisit this in the future if things change.

Best
David

# Changes

- Remove juno.build in `silver.tsx`
- Remove entry in README