### PR TITLE
[Docs] Update migration guide docs for deprecation of message

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -34,9 +34,9 @@ Many of Zod's behaviors and APIs have been made more intuitive and cohesive. The
 
 Zod 4 standardizes the APIs for error customization under a single, unified `error` param. Previously Zod's error customization APIs were fragmented and inconsistent. This is cleaned up in Zod 4. 
 
-### deprecates `message`
+### deprecates `message` parameter
 
-Replaces `message` with `error`. The deprecation of the `message` parameter applies to schema-level error customization, but when adding custom issues in `superRefine` (or similar methods), the `message` property is still supported and expected.
+Replaces `message` param with `error`. The old `message` parameter is still supported but deprecated.
 
 <Tabs groupId="error-message" items={["Zod 4", "Zod 3"]} persist>
 <Tab value="Zod 4">


### PR DESCRIPTION
In relation to https://github.com/colinhacks/zod/issues/5594#issuecomment-3704712921 this PR introduce clarification for deprecation of `message` which refers only to schema declarations not other methods e.g `addIssue` and other methods  