### PR TITLE
feat: add map support to Uzbek locale

### DIFF
--- a/packages/zod/src/v4/core/tests/locales/uz.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/uz.test.ts
@@ -80,4 +80,26 @@ test("locales - uz", () => {
   const invalidElement = z.array(z.string()).safeParse([1, 2, 3]);
   expect(invalidElement.error!.issues[0].code).toBe("invalid_type");
   expect(invalidElement.error!.issues[0].message).toContain("raqam");
+
+  const tooSmallMap = z
+    .map(z.string(), z.string())
+    .min(3)
+    .safeParse(new Map([["a", "b"]]));
+  expect(tooSmallMap.error!.issues[0].code).toBe("too_small");
+  expect(tooSmallMap.error!.issues[0].message).toContain("yozuv");
+  expect(tooSmallMap.error!.issues[0].message).toContain("bo‘lishi kerak");
+
+  const tooBigMap = z
+    .map(z.string(), z.string())
+    .max(2)
+    .safeParse(
+      new Map([
+        ["a", "b"],
+        ["c", "d"],
+        ["e", "f"],
+      ])
+    );
+  expect(tooBigMap.error!.issues[0].code).toBe("too_big");
+  expect(tooBigMap.error!.issues[0].message).toContain("yozuv");
+  expect(tooBigMap.error!.issues[0].message).toContain("bo‘lishi kerak");
 });

--- a/packages/zod/src/v4/locales/uz.ts
+++ b/packages/zod/src/v4/locales/uz.ts
@@ -8,6 +8,7 @@ const error: () => errors.$ZodErrorMap = () => {
     file: { unit: "bayt", verb: "bo‘lishi kerak" },
     array: { unit: "element", verb: "bo‘lishi kerak" },
     set: { unit: "element", verb: "bo‘lishi kerak" },
+    map: { unit: "yozuv", verb: "bo‘lishi kerak" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {


### PR DESCRIPTION
## Summary
This PR adds missing `map` support to the Uzbek locale file.

## Changes
- Added `map` entry to `Sizable` object in Uzbek locale with unit "yozuv" (entries)
- Added tests for map min/max validation error messages in Uzbek locale

## Testing
- All existing tests pass
- New tests added for map validation error messages
- Lint checks pass

## Related
Fixes missing localization for Map schema error messages in Uzbek locale.