### PR TITLE
test: add edge case tests for boundary values

### DIFF
--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -264,6 +264,31 @@ test("string format methods", () => {
   expect(() => a.parse(1)).toThrow();
 });
 
+test("negative zero edge case", () => {
+  const schema = z.number();
+  const negativeZero = -0;
+  const positiveZero = 0;
+
+  // Both -0 and 0 should be valid (parse succeeds)
+  expect(schema.safeParse(negativeZero).success).toBe(true);
+  expect(schema.safeParse(positiveZero).success).toBe(true);
+  // Note: -0 is normalized to 0 after parsing
+  expect(schema.parse(negativeZero) === 0).toBe(true);
+  expect(schema.parse(positiveZero)).toEqual(0);
+
+  // With positive() constraint, both should be invalid (0 is not positive)
+  const positiveSchema = z.number().positive();
+  expect(() => positiveSchema.parse(negativeZero)).toThrow();
+  expect(() => positiveSchema.parse(positiveZero)).toThrow();
+
+  // With nonnegative(), both should be valid (0 is non-negative)
+  const nonnegativeSchema = z.number().nonnegative();
+  expect(nonnegativeSchema.safeParse(negativeZero).success).toBe(true);
+  expect(nonnegativeSchema.safeParse(positiveZero).success).toBe(true);
+  expect(nonnegativeSchema.parse(negativeZero) === 0).toBe(true);
+  expect(nonnegativeSchema.parse(positiveZero)).toEqual(0);
+});
+
 test("error customization", () => {
   z.number().gte(5, { error: (iss) => "Min: " + iss.minimum.valueOf() });
   z.number().lte(5, { error: (iss) => "Max: " + iss.maximum.valueOf() });

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -811,6 +811,25 @@ test("min max getters", () => {
   expect(z.string().maxLength).toEqual(null);
 });
 
+test("boundary cases with zero length", () => {
+  // Test length(0) - only empty string should pass
+  const lengthZero = z.string().length(0);
+  expect(lengthZero.parse("")).toEqual("");
+  expect(() => lengthZero.parse("a")).toThrow();
+
+  // Test min(0) - all strings including empty should pass
+  const minZero = z.string().min(0);
+  expect(minZero.parse("")).toEqual("");
+  expect(minZero.parse("a")).toEqual("a");
+  expect(minZero.parse("hello")).toEqual("hello");
+
+  // Test max(0) - only empty string should pass
+  const maxZero = z.string().max(0);
+  expect(maxZero.parse("")).toEqual("");
+  expect(() => maxZero.parse("a")).toThrow();
+  expect(() => maxZero.parse("hello")).toThrow();
+});
+
 test("trim", () => {
   expect(z.string().trim().min(2).parse(" 12 ")).toEqual("12");
 


### PR DESCRIPTION
- Add tests for string boundary cases: length(0), min(0), max(0)
- Add tests for number negative zero (-0) edge case
- Improves test coverage for edge cases that were previously untested