### PR TITLE
fix(v4): z.coerce.date() error message not showing original input type

### DIFF
--- a/packages/zod/src/v4/classic/tests/date.test.ts
+++ b/packages/zod/src/v4/classic/tests/date.test.ts
@@ -60,3 +60,57 @@ test("min max getters", () => {
   expect(maxCheck.maxDate).toEqual(benchmarkDate);
   expect(maxCheck.max(beforeBenchmarkDate).maxDate).toEqual(beforeBenchmarkDate);
 });
+
+test("invalid string error message", () => {
+  const schema = z.coerce.date();
+  const result = schema.safeParse("www");
+
+  expect(result.success).toEqual(false);
+  expect(result.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_type",
+        "expected": "date",
+        "message": "Invalid input: expected date, received string",
+        "path": [],
+        "received": "Invalid Date",
+      },
+    ]
+  `);
+});
+
+test("invalid number error message", () => {
+  const schema = z.coerce.date();
+  const result = schema.safeParse(Number.NaN);
+
+  expect(result.success).toEqual(false);
+  expect(result.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_type",
+        "expected": "date",
+        "message": "Invalid input: expected date, received NaN",
+        "path": [],
+        "received": "Invalid Date",
+      },
+    ]
+  `);
+});
+
+test("invalid date object error message", () => {
+  const schema = z.coerce.date();
+  const result = schema.safeParse(new Date("invalid"));
+
+  expect(result.success).toEqual(false);
+  expect(result.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_type",
+        "expected": "date",
+        "message": "Invalid input: expected date, received Date",
+        "path": [],
+        "received": "Invalid Date",
+      },
+    ]
+  `);
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1538,6 +1538,7 @@ export const $ZodDate: core.$constructor<$ZodDate> = /*@__PURE__*/ core.$constru
   $ZodType.init(inst, def);
 
   inst._zod.parse = (payload, _ctx) => {
+    const originalInput = payload.value;
     if (def.coerce) {
       try {
         payload.value = new Date(payload.value as string | number | Date);
@@ -1552,7 +1553,7 @@ export const $ZodDate: core.$constructor<$ZodDate> = /*@__PURE__*/ core.$constru
       expected: "date",
       code: "invalid_type",
 
-      input,
+      input: originalInput,
       ...(isDate ? { received: "Invalid Date" } : {}),
       inst,
     });


### PR DESCRIPTION
## Summary
Fixes misleading error message from `z.coerce.date()` when invalid inputs are provided. Closes #5408

```ts
z.coerce.date().parse('www');
// BEFORE:
// => ZodError: Invalid input: expected date, received Date
// NOW:
// => ZodError: Invalid input: expected date, received string
```

## Problem
`$ZodDate` parse function (`packages/zod/src/v4/core/schemas.ts:1537`) did not preserve the original input during coercion. Coercion overwrote `payload.value`, which was later pushed to the `input` field of `payload.issues`.

## Solution
- Modified `$ZodDate` parse function to preserve original input before coercion
- Added tests for error messages with various invalid inputs (`packages/zod/src/v4/classic/tests/date.test.ts`)