### PR TITLE
fix: preserve context immutability in parse functions

### DIFF
--- a/packages/zod/src/v4/classic/tests/codec.test.ts
+++ b/packages/zod/src/v4/classic/tests/codec.test.ts
@@ -1,4 +1,4 @@
-import { expect, expectTypeOf, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 import * as z from "zod/v4";
 
 const isoDateCodec = z.codec(
@@ -616,4 +616,88 @@ test("invertCodec with custom codec", () => {
 
   const back = z.encode(stringToInt, 42);
   expect(back).toBe("42");
+});
+
+describe("context immutability", () => {
+  test("decode/encode", () => {
+    const stringToDateCodec = z.codec(z.iso.datetime(), z.date(), {
+      decode: (isoString) => new Date(isoString),
+      encode: (date) => date.toISOString(),
+    });
+
+    const ctx = { reportInput: true } as const;
+
+    const result1 = z.decode(stringToDateCodec, "2024-01-15T10:30:00.000Z", ctx);
+    expect(result1).toBeInstanceOf(Date);
+
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+    expect("direction" in ctx).toBe(false);
+
+    const result2 = z.decode(stringToDateCodec, "2024-12-25T15:45:30.123Z", ctx);
+    expect(result2).toBeInstanceOf(Date);
+
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+    expect("direction" in ctx).toBe(false);
+
+    z.encode(stringToDateCodec, new Date("2024-01-01T00:00:00.000Z"), ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("direction" in ctx).toBe(false);
+
+    z.safeEncode(stringToDateCodec, new Date("2024-01-01T00:00:00.000Z"), ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("direction" in ctx).toBe(false);
+  });
+
+  test("parse functions", () => {
+    const schema = z.string().min(1);
+    const ctx = { reportInput: true } as const;
+
+    z.parse(schema, "asdf", ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+
+    z.safeParse(schema, "asdf", ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+  });
+
+  test("async functions", async () => {
+    const stringToDateCodec = z.codec(z.iso.datetime(), z.date(), {
+      decode: (isoString) => new Date(isoString),
+      encode: (date) => date.toISOString(),
+    });
+
+    const ctx = { reportInput: true } as const;
+
+    const schema = z.string();
+    await z.parseAsync(schema, "asdf", ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+
+    await z.safeParseAsync(schema, "asdf", ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+
+    await z.decodeAsync(stringToDateCodec, "2024-01-15T10:30:00.000Z", ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+    expect("direction" in ctx).toBe(false);
+
+    await z.encodeAsync(stringToDateCodec, new Date("2024-01-01T00:00:00.000Z"), ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+    expect("direction" in ctx).toBe(false);
+
+    await z.safeDecodeAsync(stringToDateCodec, "2024-01-15T10:30:00.000Z", ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+    expect("direction" in ctx).toBe(false);
+
+    await z.safeEncodeAsync(stringToDateCodec, new Date("2024-01-01T00:00:00.000Z"), ctx);
+    expect(ctx).toEqual({ reportInput: true });
+    expect("async" in ctx).toBe(false);
+    expect("direction" in ctx).toBe(false);
+  });
 });

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -14,7 +14,7 @@ export type $Parse = <T extends schemas.$ZodType>(
 ) => core.output<T>;
 
 export const _parse: (_Err: $ZodErrorClass) => $Parse = (_Err) => (schema, value, _ctx, _params) => {
-  const ctx: schemas.ParseContextInternal = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
+  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
   const result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new core.$ZodAsyncError();
@@ -37,7 +37,7 @@ export type $ParseAsync = <T extends schemas.$ZodType>(
 ) => Promise<core.output<T>>;
 
 export const _parseAsync: (_Err: $ZodErrorClass) => $ParseAsync = (_Err) => async (schema, value, _ctx, params) => {
-  const ctx: schemas.ParseContextInternal = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
+  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) result = await result;
   if (result.issues.length) {
@@ -79,7 +79,7 @@ export type $SafeParseAsync = <T extends schemas.$ZodType>(
 ) => Promise<util.SafeParseResult<core.output<T>>>;
 
 export const _safeParseAsync: (_Err: $ZodErrorClass) => $SafeParseAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx: schemas.ParseContextInternal = _ctx ? Object.assign(_ctx, { async: true }) : { async: true };
+  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) result = await result;
 
@@ -101,7 +101,7 @@ export type $Encode = <T extends schemas.$ZodType>(
 ) => core.input<T>;
 
 export const _encode: (_Err: $ZodErrorClass) => $Encode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" as const }) : { direction: "backward" as const };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" as const } : { direction: "backward" as const };
   return _parse(_Err)(schema, value, ctx as any) as any;
 };
 
@@ -126,7 +126,7 @@ export type $EncodeAsync = <T extends schemas.$ZodType>(
 ) => Promise<core.input<T>>;
 
 export const _encodeAsync: (_Err: $ZodErrorClass) => $EncodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" as const }) : { direction: "backward" as const };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" as const } : { direction: "backward" as const };
   return _parseAsync(_Err)(schema, value, ctx as any) as any;
 };
 
@@ -151,7 +151,7 @@ export type $SafeEncode = <T extends schemas.$ZodType>(
 ) => util.SafeParseResult<core.input<T>>;
 
 export const _safeEncode: (_Err: $ZodErrorClass) => $SafeEncode = (_Err) => (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" as const }) : { direction: "backward" as const };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" as const } : { direction: "backward" as const };
   return _safeParse(_Err)(schema, value, ctx as any) as any;
 };
 
@@ -176,7 +176,7 @@ export type $SafeEncodeAsync = <T extends schemas.$ZodType>(
 ) => Promise<util.SafeParseResult<core.input<T>>>;
 
 export const _safeEncodeAsync: (_Err: $ZodErrorClass) => $SafeEncodeAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx = _ctx ? Object.assign(_ctx, { direction: "backward" as const }) : { direction: "backward" as const };
+  const ctx = _ctx ? { ..._ctx, direction: "backward" as const } : { direction: "backward" as const };
   return _safeParseAsync(_Err)(schema, value, ctx as any) as any;
 };
 


### PR DESCRIPTION
## Summary
Fixes mutation of user-provided `ctx` parameter in parse functions by replacing `Object.assign` with object spread syntax.

## Problem
Using `Object.assign(_ctx, {…})` mutates the original context object passed by the user.

**Before Example:**
```ts
const ctx: schemas.ParseContextInternal = _ctx ? Object.assign(_ctx, { async: false }) : { async: false };
```
**After Example:**
```ts
const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
```

## Affected Functions
- _parse
- _parseAsync
- _safeParseAsync
- _encode
- _encodeAsync
- _safeEncode
- _safeEncodeAsync

Note: `_safeParse` already used spread operator.

## Changes
- `packages/zod/src/v4/core/parse.ts` - Replace Object.assign with spread operator
- `packages/zod/src/v4/classic/tests/codec.test.ts` - Add context immutability tests

Fixes #5466 