### PR TITLE
fix: check `refSeen.def` when flattening ref

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -406,7 +406,7 @@ export function finalize<T extends schemas.$ZodType>(
       }
 
       // When ref was extracted to $defs, remove properties that match the definition
-      if (refSchema.$ref) {
+      if (refSchema.$ref && refSeen.def) {
         for (const key in schema) {
           if (key === "$ref" || key === "allOf") continue;
           if (key in refSeen.def! && JSON.stringify(schema[key]) === JSON.stringify(refSeen.def![key])) {


### PR DESCRIPTION
Fixes #5635 