### PR TITLE
ecosystem: `eslint-plugin-zod-x` is `eslint-plugin-zod` now

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -287,10 +287,10 @@ const zodUtilities: ZodResource[] = [
     slug: "marilari88/zod-playground",
   },
   {
-    name: "eslint-plugin-zod-x",
-    url: "https://github.com/marcalexiei/eslint-plugin-zod-x",
+    name: "eslint-plugin-zod",
+    url: "https://github.com/marcalexiei/eslint-plugin-zod",
     description: "ESLint plugin that adds custom linting rules to enforce best practices when using Zod",
-    slug: "marcalexiei/eslint-plugin-zod-x",
+    slug: "marcalexiei/eslint-plugin-zod",
   },
   {
     name: "Zod Compare",


### PR DESCRIPTION
- https://github.com/marcalexiei/eslint-plugin-zod/issues/171