### PR TITLE
Avoid non null assertion in toJSONSchema

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2491,6 +2491,21 @@ test("_ref", () => {
       "type": "string",
     }
   `);
+
+  const d = z.toJSONSchema(z.string().meta({ id: "foo" }).describe("bar").optional());
+  expect(d).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "foo": {
+          "id": "foo",
+          "type": "string",
+        },
+      },
+      "$ref": "#/$defs/foo",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "bar",
+    }
+  `);
 });
 
 test("defaults/prefaults", () => {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -406,10 +406,10 @@ export function finalize<T extends schemas.$ZodType>(
       }
 
       // When ref was extracted to $defs, remove properties that match the definition
-      if (refSchema.$ref) {
+      if (refSchema.$ref && refSeen.def) {
         for (const key in schema) {
           if (key === "$ref" || key === "allOf") continue;
-          if (key in refSeen.def! && JSON.stringify(schema[key]) === JSON.stringify(refSeen.def![key])) {
+          if (key in refSeen.def && JSON.stringify(schema[key]) === JSON.stringify(refSeen.def[key])) {
             delete schema[key];
           }
         }


### PR DESCRIPTION
Howdy doody, this little line is throwing and reported via one of my repos.

Minimal Repro:

```ts
import * as z from 'zod';

console.log(
  z.toJSONSchema(
    z
      .string()
      .meta({ id: 'foo', description: 'foo' })
      .describe('bar')
      .optional(),
  ),
);
```

To be honest, I haven't taken too much time to understand what this bit of code is doing but adding a conditional before seems to work.

Resolves https://github.com/samchungy/fastify-zod-openapi/issues/352