### PR TITLE
Add undefined check to refSeen.def

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -409,7 +409,11 @@ export function finalize<T extends schemas.$ZodType>(
       if (refSchema.$ref) {
         for (const key in schema) {
           if (key === "$ref" || key === "allOf") continue;
-          if (key in refSeen.def! && JSON.stringify(schema[key]) === JSON.stringify(refSeen.def![key])) {
+          if (
+            refSeen.def !== undefined &&
+            key in refSeen.def! &&
+            JSON.stringify(schema[key]) === JSON.stringify(refSeen.def![key])
+          ) {
             delete schema[key];
           }
         }


### PR DESCRIPTION
Fix for a bug we found when updating zod
"TypeError: Cannot use 'in' operator to search for 'default' in undefined