### PR TITLE
Add safety check to handle undefined refSeen.def

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -409,7 +409,7 @@ export function finalize<T extends schemas.$ZodType>(
       if (refSchema.$ref) {
         for (const key in schema) {
           if (key === "$ref" || key === "allOf") continue;
-          if (key in refSeen.def! && JSON.stringify(schema[key]) === JSON.stringify(refSeen.def![key])) {
+          if (refSeen.def && key in refSeen.def && JSON.stringify(schema[key]) === JSON.stringify(refSeen.def[key])) {
             delete schema[key];
           }
         }


### PR DESCRIPTION
Fix the following issue after upgrading from `4.2.1` to `4.3.5`:

```
node_modules/.pnpm/zod@4.3.5/node_modules/zod/v4/core/to-json-schema.cjs:267
                    if (key in refSeen.def && JSON.stringify(schema[key]) === JSON.stringify(refSeen.def[key])) {
                            ^
TypeError: Cannot use 'in' operator to search for 'id' in undefined
    at flattenRef (node_modules/.pnpm/zod@4.3.5/node_modules/zod/v4/core/to-json-schema.cjs:267:29)
```

As per flagged by copilot bot here: https://github.com/colinhacks/zod/pull/5578#discussion_r2652580788

Confirmed this change fixes the issue for me by using `pnpm patch`.

cc @colinhacks 