### PR TITLE
Fix invalid `robots.txt`

### DIFF
--- a/packages/docs/public/robots.txt
+++ b/packages/docs/public/robots.txt
@@ -1,1 +1,2 @@
-Allow: /api/og/*
+User-agent: * 
+Disallow: 


### PR DESCRIPTION
Fix invalid `robots.txt` by adding a `User-agent` directive and allowing all paths, same as the v3 docs [`robots.txt`](https://github.com/colinhacks/zod/blob/main/packages/docs-v3/robots.txt).