### PR TITLE
docs: warns about codec usage in discriminatedUnion

### DIFF
--- a/packages/docs/content/codecs.mdx
+++ b/packages/docs/content/codecs.mdx
@@ -108,6 +108,12 @@ payloadSchema.decode({
 }); // => { startDate: Date }
 ```
 
+<Callout type="warn">
+  Use codecs as discriminators in `z.discriminatedUnion()` with caution.
+  Discriminated unions select branches using the input schema (`in`) only. When a discriminator is implemented as a `z.codec()`, this fast path does not work correctly in the `encode()` direction and may result in **"No matching discriminator"** errors.
+  As a workaround, enable `{ unionFallback: true }` or avoid codecs in the discriminator field.
+</Callout>
+
 
 ### Type-safe inputs
 


### PR DESCRIPTION
This PR adds a warning to the Codecs documentation about using `z.codec()` as a
discriminator in `z.discriminatedUnion()`.

When a discriminator is implemented as a codec, the fast discriminator path
relies on the input (`in`) schema only, which can cause `.encode()` to fail with
"No matching discriminator".

The added note highlights this limitation and documents available workarounds
(`{ unionFallback: true }` or avoiding codecs in discriminator fields).

Related issue: https://github.com/colinhacks/zod/issues/5593
