### PR TITLE
fix(locales): correct Georgian translation for 'string' to 'ველი'

### DIFF
--- a/packages/zod/src/v4/classic/tests/datetime.test.ts
+++ b/packages/zod/src/v4/classic/tests/datetime.test.ts
@@ -299,4 +299,4 @@ test("redos checker", () => {
     const result = checkSync(schema._zod.pattern.source, "");
     if (result.status !== "safe") throw Error("ReDoS issue");
   }
-}, 20000);
+});

--- a/packages/zod/src/v4/classic/tests/datetime.test.ts
+++ b/packages/zod/src/v4/classic/tests/datetime.test.ts
@@ -299,4 +299,4 @@ test("redos checker", () => {
     const result = checkSync(schema._zod.pattern.source, "");
     if (result.status !== "safe") throw Error("ReDoS issue");
   }
-});
+}, 20000);

--- a/packages/zod/src/v4/classic/tests/locales_ka.test.ts
+++ b/packages/zod/src/v4/classic/tests/locales_ka.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+import * as z from "zod/v4";
+
+test("Georgian locale uses 'ველი' instead of 'სტრინგი'", () => {
+  // Save original error map to restore later if needed, though tests are usually isolated or we can reset
+  // const originalErrorMap = z.getErrorMap(); // z.getErrorMap might not exist, but let's assume isolation or just set it
+
+  z.setErrorMap(z.locales.ka().localeError);
+
+  // Test 1: Invalid type (Expected string, received number)
+  const stringSchema = z.string();
+  const numberResult = stringSchema.safeParse(123);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    // Expected: "არასწორი შეყვანა: მოსალოდნელი ველი, მიღებული რიცხვი"
+    expect(numberResult.error.issues[0].message).toBe("არასწორი შეყვანა: მოსალოდნელი ველი, მიღებული რიცხვი");
+  }
+
+  // Test 2: Invalid base64
+  const base64Schema = z.string().base64();
+  const base64Result = base64Schema.safeParse("not base64!");
+  expect(base64Result.success).toBe(false);
+  if (!base64Result.success) {
+    // Expected: "არასწორი base64-კოდირებული ველი"
+    // "არასწორი ${FormatDictionary[_issue.format] ?? issue.format}"
+    // FormatDictionary['base64'] is "base64-კოდირებული ველი"
+    expect(base64Result.error.issues[0].message).toBe("არასწორი base64-კოდირებული ველი");
+  }
+});

--- a/packages/zod/src/v4/locales/ka.ts
+++ b/packages/zod/src/v4/locales/ka.ts
@@ -39,9 +39,9 @@ const error: () => errors.$ZodErrorMap = () => {
     ipv6: "IPv6 მისამართი",
     cidrv4: "IPv4 დიაპაზონი",
     cidrv6: "IPv6 დიაპაზონი",
-    base64: "base64-კოდირებული სტრინგი",
-    base64url: "base64url-კოდირებული სტრინგი",
-    json_string: "JSON სტრინგი",
+    base64: "base64-კოდირებული ველი",
+    base64url: "base64url-კოდირებული ველი",
+    json_string: "JSON ველი",
     e164: "E.164 ნომერი",
     jwt: "JWT",
     template_literal: "შეყვანა",
@@ -52,7 +52,7 @@ const error: () => errors.$ZodErrorMap = () => {
   } = {
     nan: "NaN",
     number: "რიცხვი",
-    string: "სტრინგი",
+    string: "ველი",
     boolean: "ბულეანი",
     function: "ფუნქცია",
     array: "მასივი",
@@ -93,11 +93,11 @@ const error: () => errors.$ZodErrorMap = () => {
       case "invalid_format": {
         const _issue = issue as errors.$ZodStringFormatIssues;
         if (_issue.format === "starts_with") {
-          return `არასწორი სტრინგი: უნდა იწყებოდეს "${_issue.prefix}"-ით`;
+          return `არასწორი ველი: უნდა იწყებოდეს "${_issue.prefix}"-ით`;
         }
-        if (_issue.format === "ends_with") return `არასწორი სტრინგი: უნდა მთავრდებოდეს "${_issue.suffix}"-ით`;
-        if (_issue.format === "includes") return `არასწორი სტრინგი: უნდა შეიცავდეს "${_issue.includes}"-ს`;
-        if (_issue.format === "regex") return `არასწორი სტრინგი: უნდა შეესაბამებოდეს შაბლონს ${_issue.pattern}`;
+        if (_issue.format === "ends_with") return `არასწორი ველი: უნდა მთავრდებოდეს "${_issue.suffix}"-ით`;
+        if (_issue.format === "includes") return `არასწორი ველი: უნდა შეიცავდეს "${_issue.includes}"-ს`;
+        if (_issue.format === "regex") return `არასწორი ველი: უნდა შეესაბამებოდეს შაბლონს ${_issue.pattern}`;
         return `არასწორი ${FormatDictionary[_issue.format] ?? issue.format}`;
       }
       case "not_multiple_of":


### PR DESCRIPTION
Replaces 'სტრინგი' (transliteration) with 'ველი' (field) in Georgian locale as it is the more natural and widely used term in validation contexts. Fixes #5617.