### PR TITLE
fix(v4): prevent superRefine suppression on missing optional fields (#5653)

### DIFF
--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -155,7 +155,7 @@ test("exactOptional unwrap", () => {
 test("exactOptional optionality", () => {
   const a = z.string().exactOptional();
   expect(a._zod.optin).toEqual("optional");
-  expect(a._zod.optout).toEqual("optional");
+  expect(a._zod.optout).toEqual("exactOptional");
   expectTypeOf<typeof a._zod.optin>().toEqualTypeOf<"optional">();
   expectTypeOf<typeof a._zod.optout>().toEqualTypeOf<"optional">();
 });

--- a/packages/zod/src/v4/classic/tests/repro_5653.test.ts
+++ b/packages/zod/src/v4/classic/tests/repro_5653.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+import { z } from "../index.js";
+
+test("superRefine on optional field should run even if field is undefined", () => {
+  const schema = z.object({
+    field: z
+      .any()
+      .optional()
+      .superRefine((_val: any, ctx: z.RefinementCtx) => {
+        ctx.addIssue({
+          code: "custom",
+          message: "This validation should fail",
+        });
+      }),
+  });
+
+  expect(() => schema.parse({})).toThrow("This validation should fail");
+  expect(() => schema.parse({ field: undefined })).toThrow("This validation should fail");
+});
+
+test("superRefine on optional standalone should run on undefined", () => {
+  const worksOutsideObject = z
+    .any()
+    .optional()
+    .superRefine((_val: any, ctx: z.RefinementCtx) => {
+      ctx.addIssue({
+        code: "custom",
+        message: "This validation should fail",
+      });
+    });
+
+  expect(() => worksOutsideObject.parse(undefined)).toThrow("This validation should fail");
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1899,7 +1899,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
 
     for (const key of value.keys) {
       const el = shape[key]!;
-      const isOptionalOut = el._zod.optout === "optional";
+      const isOptionalOut = (el._zod.optout as any) === "exactOptional";
 
       const r = el._zod.run({ value: input[key], issues: [] }, ctx);
       if (r instanceof Promise) {
@@ -1949,7 +1949,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         const id = ids[key];
         const k = util.esc(key);
         const schema = shape[key];
-        const isOptionalOut = schema?._zod?.optout === "optional";
+        const isOptionalOut = (schema?._zod?.optout as any) === "exactOptional";
 
         doc.write(`const ${id} = ${parseStr(key)};`);
 
@@ -2107,9 +2107,11 @@ export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$const
     def.options.some((o) => o._zod.optin === "optional") ? "optional" : undefined
   );
 
-  util.defineLazy(inst._zod, "optout", () =>
-    def.options.some((o) => o._zod.optout === "optional") ? "optional" : undefined
-  );
+  util.defineLazy(inst._zod, "optout", () => {
+    if (def.options.some((o) => o._zod.optout === "optional")) return "optional";
+    if (def.options.some((o) => (o._zod.optout as any) === "exactOptional")) return "exactOptional" as any;
+    return undefined;
+  });
 
   util.defineLazy(inst._zod, "values", () => {
     if (def.options.every((o) => o._zod.values)) {
@@ -3378,6 +3380,7 @@ export const $ZodExactOptional: core.$constructor<$ZodExactOptional> = /*@__PURE
   (inst, def) => {
     // Call parent init - inherits optin/optout = "optional"
     $ZodOptional.init(inst, def);
+    inst._zod.optout = "exactOptional" as any;
 
     // Override values/pattern to NOT add undefined
     util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -565,7 +565,10 @@ export function stringifyPrimitive(value: any): string {
 
 export function optionalKeys(shape: schemas.$ZodShape): string[] {
   return Object.keys(shape).filter((k) => {
-    return shape[k]!._zod.optin === "optional" && shape[k]!._zod.optout === "optional";
+    return (
+      shape[k]!._zod.optin === "optional" &&
+      (shape[k]!._zod.optout === "optional" || (shape[k]!._zod.optout as any) === "exactOptional")
+    );
   });
 }
 


### PR DESCRIPTION
Fixes #5653

## Description
This PR fixes a regression in v4.3.0 where `superRefine` errors on `optional()` fields were suppressed if the field was missing from the input object.

The issue was caused by `ZodObject` suppressing errors for missing keys if `optout` was "optional". This behavior is correct for `exactOptional` (where missing keys are valid but explicit undefined is not), but incorrect for standard `optional` fields which handle `undefined` internally (and should surface errors from refinements).

## Changes
- Updated `ZodExactOptional` to use `optout="exactOptional"` at runtime.
- Updated `ZodObject` (standard and JIT) to only suppress errors if `optout === "exactOptional"`.
- Updated `ZodUnion` to correctly infer `optout` status.
- Added reproduction test case.

## Notes
To avoid breaking public types and massive variance issues, `optout` remains typed as `"optional" | undefined` in the interface, but we cast to `any` internally to assign/check `"exactOptional"`.
