### PR TITLE
Add deprecated target aliases to toJSONSchema types

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -18,10 +18,18 @@ export interface JSONSchemaGeneratorParams {
   metadata?: $ZodRegistry<Record<string, any>>;
   /** The JSON Schema version to target.
    * - `"draft-2020-12"` — Default. JSON Schema Draft 2020-12
-   * - `"draft-07"` — JSON Schema Draft 7
-   * - `"draft-04"` — JSON Schema Draft 4
+   * - `"draft-07"` — JSON Schema Draft 7 (alias: `"draft-7"`)
+   * - `"draft-04"` — JSON Schema Draft 4 (alias: `"draft-4"`)
    * - `"openapi-3.0"` — OpenAPI 3.0 Schema Object */
-  target?: "draft-04" | "draft-07" | "draft-2020-12" | "openapi-3.0" | ({} & string) | undefined;
+  target?:
+    | "draft-04"
+    | "draft-07"
+    | "draft-2020-12"
+    | "openapi-3.0"
+    | "draft-4"
+    | "draft-7"
+    | ({} & string)
+    | undefined;
   /** How to handle unrepresentable types.
    * - `"throw"` — Default. Unrepresentable types throw an error
    * - `"any"` — Unrepresentable types become `{}` */
@@ -84,7 +92,7 @@ export interface Seen {
 export interface ToJSONSchemaContext {
   processors: Record<string, Processor>;
   metadataRegistry: $ZodRegistry<Record<string, any>>;
-  target: "draft-04" | "draft-07" | "draft-2020-12" | "openapi-3.0" | ({} & string);
+  target: "draft-04" | "draft-07" | "draft-2020-12" | "openapi-3.0" | "draft-4" | "draft-7" | ({} & string);
   unrepresentable: "throw" | "any";
   override: (ctx: {
     // must be schemas.$ZodType to prevent recursive type resolution error


### PR DESCRIPTION
Adds "draft-4" and "draft-7" in the target types for `z.toJSONSchema()`.

These aliases are already supported at runtime via normalization but were not discoverable via TypeScript autocomplete.

https://github.com/colinhacks/zod/blob/7b43bc64e7a2720fe66d6e99239c2a00c782e06b/packages/zod/src/v4/core/json-schema-generator.ts#L86-L87

Rationale is we target `"draft-07"` in `@supabase/mcp-server-supabase` but consume this package from apps that use both 4+ and 3.25+ Zod versions.
https://github.com/supabase-community/supabase-mcp/blob/f4c1a1f2a7a839ecc75e9bdc92832f2144689c76/packages/mcp-utils/src/server.ts#L445

This unknowingly introduced runtime errors for apps that use the older v4 Zod APIs that don't recognize `"draft-07"`. We'd like to instead target `"draft-7"` which is supported in both versions, but not clear from the types.