### PR TITLE
Fix infinite recursion on circular object validation

### DIFF
--- a/packages/zod/src/v4/classic/tests/circular.test.ts
+++ b/packages/zod/src/v4/classic/tests/circular.test.ts
@@ -151,4 +151,293 @@ describe("circular object validation", () => {
       expect(result.data.next).toBe(result.data);
     }
   });
+
+  it("should work with async parsing", async () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      value: z.number(),
+      next: z.lazy(() => NodeSchema).optional(),
+    });
+
+    const node: any = { value: 42 };
+    node.next = node;
+
+    const result = await NodeSchema.safeParseAsync(node);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.value).toBe(42);
+      expect(result.data.next).toBe(result.data);
+    }
+  });
+
+  it("should handle array referencing itself", () => {
+    const Schema: z.ZodType<any> = z.array(z.union([z.number(), z.lazy(() => Schema)]));
+
+    // Array that contains itself
+    const arr: any[] = [1, 2, 3];
+    arr.push(arr);
+
+    const result = Schema.safeParse(arr);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0]).toBe(1);
+      expect(result.data[3]).toBe(result.data); // Circular reference preserved
+    }
+  });
+
+  it("should collect multiple errors in circular graph", () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      id: z.number(),
+      name: z.string(),
+      next: z.lazy(() => NodeSchema).optional(),
+    });
+
+    // Create A -> B -> A where both have errors
+    const a: any = { id: "not a number", name: "valid" }; // id invalid
+    const b: any = { id: 2, name: 123 }; // name invalid
+    a.next = b;
+    b.next = a;
+
+    const result = NodeSchema.safeParse(a);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // Should have errors for both a.id and b.name
+      expect(result.error.issues.length).toBe(2);
+    }
+  });
+
+  it("should handle records with circular values", () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      id: z.number(),
+      children: z.record(
+        z.string(),
+        z.lazy(() => NodeSchema)
+      ),
+    });
+
+    const node: any = { id: 1, children: {} };
+    node.children.self = node;
+    node.children.also_self = node;
+
+    const result = NodeSchema.safeParse(node);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.children.self).toBe(result.data);
+      expect(result.data.children.also_self).toBe(result.data);
+    }
+  });
+
+  it("should handle nullable circular references", () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      value: z.number(),
+      next: z.lazy(() => NodeSchema).nullable(),
+    });
+
+    const node: any = { value: 1, next: null };
+    node.next = node;
+
+    const result = NodeSchema.safeParse(node);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.next).toBe(result.data);
+    }
+  });
+
+  it("should handle complex graph with multiple cycles", () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      id: z.number(),
+      links: z.array(z.lazy(() => NodeSchema)),
+    });
+
+    // Create a complex graph: A <-> B, A <-> C, B <-> C (fully connected)
+    const a: any = { id: 1, links: [] };
+    const b: any = { id: 2, links: [] };
+    const c: any = { id: 3, links: [] };
+
+    a.links.push(b, c);
+    b.links.push(a, c);
+    c.links.push(a, b);
+
+    const result = NodeSchema.safeParse(a);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe(1);
+      expect(result.data.links[0].id).toBe(2);
+      expect(result.data.links[1].id).toBe(3);
+      // Verify cycles are preserved
+      expect(result.data.links[0].links[0]).toBe(result.data);
+    }
+  });
+
+  it("should work with parse() not just safeParse()", () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      value: z.number(),
+      self: z.lazy(() => NodeSchema).optional(),
+    });
+
+    const node: any = { value: 42 };
+    node.self = node;
+
+    // Should not throw
+    const result = NodeSchema.parse(node);
+    expect(result.value).toBe(42);
+    expect(result.self).toBe(result);
+  });
+
+  it("should throw with parse() on invalid circular data", () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      value: z.number(),
+      self: z.lazy(() => NodeSchema).optional(),
+    });
+
+    const node: any = { value: "invalid" };
+    node.self = node;
+
+    expect(() => NodeSchema.parse(node)).toThrow();
+  });
+
+  it("should handle circular references with default values", () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      id: z.number(),
+      name: z.string().default("unnamed"),
+      next: z.lazy(() => NodeSchema).optional(),
+    });
+
+    const node: any = { id: 1 };
+    node.next = node;
+
+    const result = NodeSchema.safeParse(node);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("unnamed");
+      expect(result.data.next).toBe(result.data);
+    }
+  });
+
+  it("should handle circular references in strict objects", () => {
+    const NodeSchema: z.ZodType<any> = z
+      .object({
+        id: z.number(),
+        next: z.lazy(() => NodeSchema).optional(),
+      })
+      .strict();
+
+    const node: any = { id: 1 };
+    node.next = node;
+
+    const result = NodeSchema.safeParse(node);
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject extra keys in strict circular objects", () => {
+    const NodeSchema: z.ZodType<any> = z
+      .object({
+        id: z.number(),
+        next: z.lazy(() => NodeSchema).optional(),
+      })
+      .strict();
+
+    const node: any = { id: 1, extra: "not allowed" };
+    node.next = node;
+
+    const result = NodeSchema.safeParse(node);
+    expect(result.success).toBe(false);
+  });
+
+  it("should handle tuple with circular reference", () => {
+    const Schema: z.ZodType<any> = z.tuple([z.number(), z.lazy(() => Schema).optional()]);
+
+    const tuple: any = [42, null];
+    tuple[1] = tuple;
+
+    const result = Schema.safeParse(tuple);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[0]).toBe(42);
+      expect(result.data[1]).toBe(result.data);
+    }
+  });
+
+  it("should handle same object appearing multiple times (diamond pattern)", () => {
+    const NodeSchema: z.ZodType<any> = z.object({
+      id: z.number(),
+      left: z.lazy(() => NodeSchema).optional(),
+      right: z.lazy(() => NodeSchema).optional(),
+    });
+
+    // Diamond: A -> B, A -> C, B -> D, C -> D (D is shared)
+    const d: any = { id: 4 };
+    const b: any = { id: 2, left: d };
+    const c: any = { id: 3, left: d };
+    const a: any = { id: 1, left: b, right: c };
+
+    const result = NodeSchema.safeParse(a);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Same object D should be reused
+      expect(result.data.left.left).toBe(result.data.right.left);
+    }
+  });
+
+  it("should handle circular reference with passthrough", () => {
+    const NodeSchema: z.ZodType<any> = z
+      .object({
+        id: z.number(),
+        next: z.lazy(() => NodeSchema).optional(),
+      })
+      .passthrough();
+
+    const node: any = { id: 1, extra: "allowed" };
+    node.next = node;
+
+    const result = NodeSchema.safeParse(node);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.extra).toBe("allowed");
+      expect(result.data.next).toBe(result.data);
+    }
+  });
+
+  it("should handle deeply nested object inside circular structure", () => {
+    const InnerSchema = z.object({
+      deep: z.object({
+        value: z.number(),
+      }),
+    });
+
+    const NodeSchema: z.ZodType<any> = z.object({
+      id: z.number(),
+      inner: InnerSchema,
+      next: z.lazy(() => NodeSchema).optional(),
+    });
+
+    const node: any = { id: 1, inner: { deep: { value: 42 } } };
+    node.next = node;
+
+    const result = NodeSchema.safeParse(node);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.inner.deep.value).toBe(42);
+      expect(result.data.next).toBe(result.data);
+    }
+  });
+
+  it("should not use circular tracking for simple objects (performance)", () => {
+    // This test verifies that simple objects without nested objects
+    // don't incur the overhead of circular reference tracking
+    const SimpleSchema = z.object({
+      a: z.number(),
+      b: z.string(),
+      c: z.boolean(),
+    });
+
+    // Parse many simple objects - should be fast
+    const start = performance.now();
+    for (let i = 0; i < 10000; i++) {
+      SimpleSchema.parse({ a: i, b: "test", c: true });
+    }
+    const elapsed = performance.now() - start;
+
+    // Should complete quickly (less than 1 second for 10k parses)
+    expect(elapsed).toBeLessThan(1000);
+  });
 });


### PR DESCRIPTION
## Summary
This PR fixes an infinite recursion issue that occurs when validating objects with circular references using Zod schemas. Previously, schemas with lazy circular references would hang indefinitely during validation. This change introduces circular reference detection using a `WeakMap`-based tracking system.

## Key Changes

- **Added circular reference tracking to `ParseContextInternal`**: Introduced a `visited` WeakMap that tracks (input object, schema instance) pairs to detect when the same object is being validated by the same schema.

- **Updated all parse entry points**: Modified `_parse`, `_parseAsync`, `_safeParse`, and `_safeParseAsync` in `parse.ts` to initialize and maintain the `visited` WeakMap across the validation context.

- **Implemented cycle detection in `$ZodArray`**: Added checks before and after array validation to detect circular references. The output array is cached before recursing into elements, allowing circular references to resolve to the cached output.

- **Implemented cycle detection in `$ZodObject`**: Added similar circular reference detection for object validation, caching the output object before recursing into properties.

- **Updated `$ZodObjectJIT` to respect visited tracking**: Modified the JIT optimization path to skip fast-path validation when circular reference tracking is enabled, ensuring proper cycle detection.

- **Added comprehensive test suite**: Created `circular.test.ts` with four test cases covering:
  - Mutually recursive schemas (User ↔ Post)
  - Direct self-references
  - Deeply nested circular cycles (A → B → C → A)
  - Validation still rejects invalid circular objects

## Implementation Details

The solution uses a nested WeakMap structure: `WeakMap<input object, WeakMap<schema instance, output object>>`. This allows:
- Tracking the same object across different schemas (important for intersections)
- Automatic garbage collection when objects are no longer referenced
- Early return with cached output when a circular reference is detected

The cached output is stored *before* recursing into nested properties, which allows circular references to find and use the partially-constructed object, breaking the infinite recursion cycle.