### PR TITLE
fix(v4): align object and tuple optionality handling

### DIFF
--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -128,7 +128,8 @@ test("native enum", () => {
     fruit: z.nativeEnum(Fruits).catch(Fruits.apple),
   });
 
-  expect(schema.parse({})).toEqual({ fruit: Fruits.apple });
+  expect(schema.safeParse({}).success).toEqual(false);
+  expect(schema.safeParse({}, { jitless: true }).success).toEqual(false);
   expect(schema.parse({ fruit: 15 })).toEqual({ fruit: Fruits.apple });
 });
 
@@ -137,7 +138,8 @@ test("enum", () => {
     fruit: z.enum(["apple", "orange"]).catch("apple"),
   });
 
-  expect(schema.parse({})).toEqual({ fruit: "apple" });
+  expect(schema.safeParse({}).success).toEqual(false);
+  expect(schema.safeParse({}, { jitless: true }).success).toEqual(false);
   expect(schema.parse({ fruit: true })).toEqual({ fruit: "apple" });
   expect(schema.parse({ fruit: 15 })).toEqual({ fruit: "apple" });
 });

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -135,6 +135,52 @@ test("optional prop with pipe", () => {
   schema.parse({}, { jitless: true });
 });
 
+test("object absent keys require optin optional", () => {
+  const valueUndefined = z.object({
+    value: z.undefined(),
+    union: z.union([z.string(), z.undefined()]),
+  });
+
+  expect(valueUndefined.safeParse({}).error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_type",
+        "expected": "nonoptional",
+        "message": "Invalid input: expected nonoptional, received undefined",
+        "path": [
+          "value",
+        ],
+      },
+      {
+        "code": "invalid_type",
+        "expected": "nonoptional",
+        "message": "Invalid input: expected nonoptional, received undefined",
+        "path": [
+          "union",
+        ],
+      },
+    ]
+  `);
+  expect(valueUndefined.safeParse({}, { jitless: true }).success).toEqual(false);
+  expect(valueUndefined.parse({ value: undefined, union: undefined })).toEqual({
+    value: undefined,
+    union: undefined,
+  });
+
+  const optionalOutOnly = z.object({
+    value: z
+      .string()
+      .transform((val) => (Math.random() ? val : undefined))
+      .pipe(z.string().optional()),
+  });
+  expect(optionalOutOnly.safeParse({}).success).toEqual(false);
+  expect(optionalOutOnly.safeParse({}, { jitless: true }).success).toEqual(false);
+
+  const defaulted = z.object({ value: z.string().default("fallback") });
+  expect(defaulted.parse({})).toEqual({ value: "fallback" });
+  expect(defaulted.parse({}, { jitless: true })).toEqual({ value: "fallback" });
+});
+
 // exactOptional tests
 test(".exactOptional()", () => {
   const schema = z.string().exactOptional();

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -41,14 +41,14 @@ test("optionality", () => {
   // z.undefined should NOT be optional
   const f = z.undefined();
   expect(f._zod.optin).toEqual("optional");
-  expect(f._zod.optout).toEqual("optional");
+  expect(f._zod.optout).toEqual(undefined);
   expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
   // z.union should be optional if any of the types are optional
   const g = z.union([z.string(), z.undefined()]);
   expect(g._zod.optin).toEqual("optional");
-  expect(g._zod.optout).toEqual("optional");
+  expect(g._zod.optout).toEqual(undefined);
   expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof g._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -40,14 +40,14 @@ test("optionality", () => {
 
   // z.undefined should NOT be optional
   const f = z.undefined();
-  expect(f._zod.optin).toEqual("optional");
+  expect(f._zod.optin).toEqual(undefined);
   expect(f._zod.optout).toEqual(undefined);
   expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
   // z.union should be optional if any of the types are optional
   const g = z.union([z.string(), z.undefined()]);
-  expect(g._zod.optin).toEqual("optional");
+  expect(g._zod.optin).toEqual(undefined);
   expect(g._zod.optout).toEqual(undefined);
   expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof g._zod.optout>().toEqualTypeOf<"optional" | undefined>();

--- a/packages/zod/src/v4/classic/tests/partial.test.ts
+++ b/packages/zod/src/v4/classic/tests/partial.test.ts
@@ -156,7 +156,33 @@ test("catch/prefault/default", () => {
     f: z.string().prefault("prefault value"),
   });
 
-  expect(mySchema.parse({})).toMatchInlineSnapshot(`
+  expect(mySchema.safeParse({}).error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_type",
+        "expected": "nonoptional",
+        "message": "Invalid input: expected nonoptional, received undefined",
+        "path": [
+          "d",
+        ],
+      },
+    ]
+  `);
+
+  expect(mySchema.safeParse({}, { jitless: true }).error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_type",
+        "expected": "nonoptional",
+        "message": "Invalid input: expected nonoptional, received undefined",
+        "path": [
+          "d",
+        ],
+      },
+    ]
+  `);
+
+  expect(mySchema.parse({ d: undefined })).toMatchInlineSnapshot(`
     {
       "b": "default value",
       "c": "prefault value",
@@ -166,7 +192,7 @@ test("catch/prefault/default", () => {
     }
   `);
 
-  expect(mySchema.parse({}, { jitless: true })).toMatchInlineSnapshot(`
+  expect(mySchema.parse({ d: undefined }, { jitless: true })).toMatchInlineSnapshot(`
     {
       "b": "default value",
       "c": "prefault value",

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -246,6 +246,55 @@ test("tuple result is dense when optional precedes a default", () => {
   expect(1 in out && 3 in out).toEqual(true);
 });
 
+test("tuple breaks and truncates on first absent-optional rejection", () => {
+  // An `.optional()` slot that rejects `undefined` (e.g. via a refine) past
+  // optStart must (a) swallow the issue, (b) truncate the result there, and
+  // (c) NOT materialize any later defaults — otherwise the parser would
+  // happily fill in slots after a slot it just decided was missing/invalid.
+  const refusesUndefined = z
+    .string()
+    .optional()
+    .refine((s) => s !== undefined, "must not be undefined");
+
+  const trailingDefault = z.tuple([z.string(), refusesUndefined, z.string().default("d")]);
+  const r1 = trailingDefault.safeParse(["alpha"]);
+  expect(r1.success).toBe(true);
+  expect(r1.data).toEqual(["alpha"]);
+
+  // Optional slots BEFORE the rejected one collapse away with the truncate
+  // (mirrors the trailing-trim behaviour for absent optionals).
+  const beforeReject = z.tuple([z.string(), z.string().optional(), refusesUndefined, z.string().default("d")]);
+  expect(beforeReject.safeParse(["alpha"]).data).toEqual(["alpha"]);
+
+  // No default after — truncate still applies, no spurious issue surfaces.
+  const noTrailingDefault = z.tuple([z.string(), refusesUndefined]);
+  const r3 = noTrailingDefault.safeParse(["alpha"]);
+  expect(r3.success).toBe(true);
+  expect(r3.data).toEqual(["alpha"]);
+});
+
+test("tuple breaks on absent-optional rejection under async parse", async () => {
+  const refusesUndefined = z
+    .string()
+    .optional()
+    .refine(async (s) => s !== undefined, "must not be undefined");
+
+  const schema = z.tuple([z.string(), refusesUndefined, z.string().default("d")]);
+  const r = await schema.safeParseAsync(["alpha"]);
+  expect(r.success).toBe(true);
+  expect(r.data).toEqual(["alpha"]);
+});
+
+test("tuple does NOT break when a required slot fails past input length", () => {
+  // A required slot (no `.optional()` chain, so optout !== "optional") past
+  // input length must still surface an issue rather than silently swallowing
+  // it. Otherwise we'd accept arbitrarily short tuples for required-tail
+  // schemas.
+  const schema = z.tuple([z.string(), z.string()]);
+  const r = schema.safeParse(["alpha"]);
+  expect(r.success).toBe(false);
+});
+
 test("tuple with rest schema", () => {
   const myTuple = z.tuple([z.string(), z.number()]).rest(z.boolean());
   expect(myTuple.parse(["asdf", 1234, true, false, true])).toEqual(["asdf", 1234, true, false, true]);

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -212,6 +212,23 @@ test("tuple keeps length-1 array for missing `.optional()` elements", () => {
 
   expect(z.tuple([z.string(), z.undefined()]).parse(["alpha"])).toHaveLength(1);
   expect(z.tuple([z.string(), z.string().optional().nullable()]).parse(["alpha"])).toHaveLength(1);
+
+  // Multiple trailing optionals trim the same way — we don't fill the tail
+  // with literal `undefined`s.
+  const many = z.tuple([z.string(), z.string().optional(), z.string().optional(), z.string().optional()]);
+  expect(many.parse(["alpha"])).toEqual(["alpha"]);
+  expect(many.parse(["alpha", "beta"])).toEqual(["alpha", "beta"]);
+
+  // Explicit `undefined` inside `input.length` IS preserved — only slots
+  // past the input get trimmed.
+  const r = many.parse(["alpha", undefined]);
+  expect(r.length).toEqual(2);
+  expect(1 in r).toEqual(true);
+
+  // Trailing optionals after a default that fires are still trimmed.
+  expect(
+    z.tuple([z.string(), z.string().default("d"), z.string().optional(), z.string().optional()]).parse(["alpha"])
+  ).toEqual(["alpha", "d"]);
 });
 
 test("tuple result is dense when optional precedes a default", () => {

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -210,7 +210,26 @@ test("tuple keeps length-1 array for missing `.optional()` elements", () => {
   expect(out).toEqual(["alpha"]);
   expect(out.length).toEqual(1);
 
-  expect(z.tuple([z.string(), z.undefined()]).parse(["alpha"])).toHaveLength(1);
+  // `z.undefined()` is NOT a synonym for `.optional()` — its value type is
+  // *must be undefined*, so the slot is required input. Omitting it triggers
+  // a single `too_small` (no element-level errors, matching v3's abort
+  // semantics); passing explicit `undefined` succeeds and is preserved.
+  expect(z.tuple([z.string(), z.undefined()]).safeParse(["alpha"]).error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "too_small",
+        "inclusive": true,
+        "message": "Too small: expected array to have >=2 items",
+        "minimum": 2,
+        "origin": "array",
+        "path": [],
+      },
+    ]
+  `);
+  expect(z.tuple([z.string(), z.undefined()]).parse(["alpha", undefined])).toHaveLength(2);
+
+  // `.optional().nullable()` still trims — `.optional()` propagates the
+  // optin/optout flags through the nullable wrapper.
   expect(z.tuple([z.string(), z.string().optional().nullable()]).parse(["alpha"])).toHaveLength(1);
 
   // Multiple trailing optionals trim the same way — we don't fill the tail
@@ -338,10 +357,20 @@ test("tuple does NOT break when a required slot fails past input length", () => 
   // A required slot (no `.optional()` chain, so optout !== "optional") past
   // input length must still surface an issue rather than silently swallowing
   // it. Otherwise we'd accept arbitrarily short tuples for required-tail
-  // schemas.
+  // schemas. The precheck collapses this into a single `too_small`.
   const schema = z.tuple([z.string(), z.string()]);
-  const r = schema.safeParse(["alpha"]);
-  expect(r.success).toBe(false);
+  expect(schema.safeParse(["alpha"]).error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "too_small",
+        "inclusive": true,
+        "message": "Too small: expected array to have >=2 items",
+        "minimum": 2,
+        "origin": "array",
+        "path": [],
+      },
+    ]
+  `);
 });
 
 test("tuple with rest schema", () => {

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -169,6 +169,51 @@ test("tuple with all optional elements", () => {
   expect(() => allOptionalTuple.parse(["hello", 42, true, "extra"])).toThrow();
 });
 
+test("tuple fills defaults for missing trailing elements", () => {
+  // Issue #5229: trailing `.default()`/`.prefault()` elements should be
+  // filled in when the input array is shorter than the tuple.
+  const t = z.tuple([z.string(), z.string().default("bravo")]);
+  expectTypeOf<typeof t._output>().toEqualTypeOf<[string, string]>();
+  expectTypeOf<typeof t._input>().toEqualTypeOf<[string, string?]>();
+
+  expect(t.parse(["alpha", "charlie"])).toEqual(["alpha", "charlie"]);
+  expect(t.parse(["alpha"])).toEqual(["alpha", "bravo"]);
+
+  // Multiple trailing defaults
+  const multi = z.tuple([z.string(), z.number().default(42), z.boolean().default(true)]);
+  expect(multi.parse(["hello"])).toEqual(["hello", 42, true]);
+  expect(multi.parse(["hello", 100])).toEqual(["hello", 100, true]);
+  expect(multi.parse(["hello", 100, false])).toEqual(["hello", 100, false]);
+
+  // Prefault parity
+  expect(z.tuple([z.string(), z.string().prefault("delta")]).parse(["alpha"])).toEqual(["alpha", "delta"]);
+
+  // Defaults wrapped in modifiers: `optout` propagates through these, so the
+  // fix is not type-name specific.
+  expect(z.tuple([z.string(), z.string().default("x").nullable()]).parse(["alpha"])).toEqual(["alpha", "x"]);
+  expect(z.tuple([z.string(), z.string().default("x").readonly()]).parse(["alpha"])).toEqual(["alpha", "x"]);
+  expect(z.tuple([z.string(), z.string().default("x").catch("y")]).parse(["alpha"])).toEqual(["alpha", "x"]);
+  expect(z.tuple([z.string(), z.string().default("x").pipe(z.string())]).parse(["alpha"])).toEqual(["alpha", "x"]);
+});
+
+test("tuple fills defaults under async parse", async () => {
+  const t = z.tuple([z.string(), z.string().default("zulu")]);
+  await expect(t.parseAsync(["alpha"])).resolves.toEqual(["alpha", "zulu"]);
+});
+
+test("tuple keeps length-1 array for missing `.optional()` elements", () => {
+  // Backwards compat: a trailing `.optional()` element that is omitted from
+  // the input must NOT be filled with `undefined` — the result stays length-1.
+  // Only schemas that produce a defined value get materialized.
+  const t = z.tuple([z.string(), z.string().optional()]);
+  const out = t.parse(["alpha"]);
+  expect(out).toEqual(["alpha"]);
+  expect(out.length).toEqual(1);
+
+  expect(z.tuple([z.string(), z.undefined()]).parse(["alpha"])).toHaveLength(1);
+  expect(z.tuple([z.string(), z.string().optional().nullable()]).parse(["alpha"])).toHaveLength(1);
+});
+
 test("tuple with rest schema", () => {
   const myTuple = z.tuple([z.string(), z.number()]).rest(z.boolean());
   expect(myTuple.parse(["asdf", 1234, true, false, true])).toEqual(["asdf", 1234, true, false, true]);

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -214,6 +214,38 @@ test("tuple keeps length-1 array for missing `.optional()` elements", () => {
   expect(z.tuple([z.string(), z.string().optional().nullable()]).parse(["alpha"])).toHaveLength(1);
 });
 
+test("tuple result is dense when optional precedes a default", () => {
+  // `.optional()` before a `.default()` must produce an explicit `undefined`
+  // (not a sparse hole), otherwise `1 in r`, `JSON.stringify`, `Object.keys`,
+  // and iteration all behave wrong.
+  const t = z.tuple([z.string(), z.string().optional(), z.string().default("z")]);
+  const r = t.parse(["alpha"]);
+  expect(r).toEqual(["alpha", undefined, "z"]);
+  expect(r.length).toEqual(3);
+  expect(1 in r).toEqual(true);
+  expect(JSON.stringify(r)).toEqual('["alpha",null,"z"]');
+
+  // Trailing optional after a default is still dropped (no later default
+  // forces it to materialize).
+  expect(z.tuple([z.string(), z.string().default("d"), z.string().optional()]).parse(["alpha"])).toEqual([
+    "alpha",
+    "d",
+  ]);
+
+  // Multiple interleaved optional/default — every slot up to the last
+  // default must be present and dense.
+  const interleaved = z.tuple([
+    z.string(),
+    z.string().optional(),
+    z.string().default("d"),
+    z.string().optional(),
+    z.string().default("e"),
+  ]);
+  const out = interleaved.parse(["alpha"]);
+  expect(out).toEqual(["alpha", undefined, "d", undefined, "e"]);
+  expect(1 in out && 3 in out).toEqual(true);
+});
+
 test("tuple with rest schema", () => {
   const myTuple = z.tuple([z.string(), z.number()]).rest(z.boolean());
   expect(myTuple.parse(["asdf", 1234, true, false, true])).toEqual(["asdf", 1234, true, false, true]);

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -302,6 +302,38 @@ test("tuple breaks on absent-optional rejection under async parse", async () => 
   expect(r.data).toEqual(["alpha"]);
 });
 
+test("tuple preserves explicit undefined inside input even for optional-out schemas", () => {
+  // The trim only runs for slots PAST `input.length`. An explicit `undefined`
+  // value supplied by the caller at index < input.length must survive, even
+  // when the schema produces undefined as a valid output (e.g.
+  // `z.string().or(z.undefined())`, `z.string().optional()`, `z.undefined()`).
+  const orUndefined = z.tuple([z.string(), z.string().or(z.undefined())]);
+  const r1 = orUndefined.parse(["alpha", undefined]);
+  expect(r1.length).toEqual(2);
+  expect(r1[1]).toBeUndefined();
+  expect(1 in r1).toEqual(true);
+  expect(JSON.stringify(r1)).toEqual('["alpha",null]');
+
+  // Same for `.optional()`.
+  const opt = z.tuple([z.string(), z.string().optional()]);
+  const r2 = opt.parse(["alpha", undefined]);
+  expect(r2.length).toEqual(2);
+  expect(1 in r2).toEqual(true);
+
+  // Same for `z.undefined()` literal.
+  const lit = z.tuple([z.string(), z.undefined()]);
+  const r3 = lit.parse(["alpha", undefined]);
+  expect(r3.length).toEqual(2);
+  expect(1 in r3).toEqual(true);
+
+  // Mid-tuple explicit undefined surrounded by defined values is also kept.
+  const mid = z.tuple([z.string(), z.string().or(z.undefined()), z.string()]);
+  const r4 = mid.parse(["alpha", undefined, "gamma"]);
+  expect(r4).toEqual(["alpha", undefined, "gamma"]);
+  expect(r4.length).toEqual(3);
+  expect(1 in r4).toEqual(true);
+});
+
 test("tuple does NOT break when a required slot fails past input length", () => {
   // A required slot (no `.optional()` chain, so optout !== "optional") past
   // input length must still surface an issue rather than silently swallowing

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -174,7 +174,7 @@ test("tuple fills defaults for missing trailing elements", () => {
   // filled in when the input array is shorter than the tuple.
   const t = z.tuple([z.string(), z.string().default("bravo")]);
   expectTypeOf<typeof t._output>().toEqualTypeOf<[string, string]>();
-  expectTypeOf<typeof t._input>().toEqualTypeOf<[string, string?]>();
+  expectTypeOf<typeof t._input>().toEqualTypeOf<[string, (string | undefined)?]>();
 
   expect(t.parse(["alpha", "charlie"])).toEqual(["alpha", "charlie"]);
   expect(t.parse(["alpha"])).toEqual(["alpha", "bravo"]);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2662,14 +2662,22 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       }
     }
 
-    let i = -1;
-    for (const item of items) {
-      i++;
-      // `optout === "optional"` means running with undefined yields undefined,
-      // so skipping is a no-op. `.default()`/`.prefault()` (and any chain
-      // wrapping one) have a defined output type and fall through to run.
-      if (i >= input.length && item._zod.optout === "optional") continue;
-      const result = item._zod.run(
+    // Find the highest index that must materialize: any slot past
+    // `input.length` whose schema fills missing input (`optout !==
+    // "optional"`, i.e. `.default()`, `.prefault()`, or any chain wrapping
+    // one). Run every slot before `runUntil` so `.optional()` items reached
+    // while padding for a later default produce explicit `undefined`
+    // instead of a sparse hole.
+    let runUntil = Math.min(input.length, items.length);
+    for (let j = items.length - 1; j >= runUntil; j--) {
+      if (items[j]._zod.optout !== "optional") {
+        runUntil = j + 1;
+        break;
+      }
+    }
+
+    for (let i = 0; i < runUntil; i++) {
+      const result = items[i]._zod.run(
         {
           value: input[i],
           issues: [],
@@ -2685,6 +2693,7 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
     }
 
     if (def.rest) {
+      let i = items.length - 1;
       const rest = input.slice(items.length);
       for (const el of rest) {
         i++;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1358,7 +1358,6 @@ export const $ZodUndefined: core.$constructor<$ZodUndefined> = /*@__PURE__*/ cor
     $ZodType.init(inst, def);
     inst._zod.pattern = regexes.undefined;
     inst._zod.values = new Set([undefined]);
-    inst._zod.optin = "optional";
 
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2662,33 +2662,20 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       }
     }
 
-    // Find the highest index that must materialize: any slot past
-    // `input.length` whose schema fills missing input (`optout !==
-    // "optional"`, i.e. `.default()`, `.prefault()`, or any chain wrapping
-    // one). Run every slot before `runUntil` so `.optional()` items reached
-    // while padding for a later default produce explicit `undefined`
-    // instead of a sparse hole.
-    let runUntil = Math.min(input.length, items.length);
-    for (let j = items.length - 1; j >= runUntil; j--) {
-      if (items[j]._zod.optout !== "optional") {
-        runUntil = j + 1;
-        break;
-      }
-    }
-
-    for (let i = 0; i < runUntil; i++) {
-      const result = items[i]._zod.run(
-        {
-          value: input[i],
-          issues: [],
-        },
-        ctx
-      );
-
+    // Mirror $ZodObject: run every item, passing `undefined` for slots past
+    // the input. Each schema decides what undefined means — `.optional()`
+    // and `z.undefined()` pass it through, `.default()`/`.prefault()` (and
+    // any chain wrapping one) substitute their value, required schemas
+    // fail. `handleTupleResult` swallows the failure for absent optional-out
+    // slots, the same way `handlePropertyResult` does for absent keys.
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const isOptionalOut = item._zod.optout === "optional";
+      const result = item._zod.run({ value: input[i], issues: [] }, ctx);
       if (result instanceof Promise) {
-        proms.push(result.then((result) => handleTupleResult(result, payload, i)));
+        proms.push(result.then((r) => handleTupleResult(r, payload, i, input, isOptionalOut)));
       } else {
-        handleTupleResult(result, payload, i);
+        handleTupleResult(result, payload, i, input, isOptionalOut);
       }
     }
 
@@ -2697,29 +2684,45 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       const rest = input.slice(items.length);
       for (const el of rest) {
         i++;
-        const result = def.rest._zod.run(
-          {
-            value: el,
-            issues: [],
-          },
-          ctx
-        );
-
+        const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
         if (result instanceof Promise) {
-          proms.push(result.then((result) => handleTupleResult(result, payload, i)));
+          proms.push(result.then((r) => handleTupleResult(r, payload, i, input, false)));
         } else {
-          handleTupleResult(result, payload, i);
+          handleTupleResult(result, payload, i, input, false);
         }
       }
     }
 
-    if (proms.length) return Promise.all(proms).then(() => payload);
-    return payload;
+    // Trim trailing slots whose schema produced `undefined` for absent input
+    // (mirrors the object parser dropping absent optional keys). Only items
+    // past `input.length` with `optout === "optional"` are eligible — a
+    // `.default()` past input always materializes, breaking the trim.
+    const finalize = () => {
+      for (let i = items.length - 1; i >= input.length; i--) {
+        if (items[i]._zod.optout === "optional" && payload.value[i] === undefined) {
+          payload.value.length = i;
+        } else {
+          break;
+        }
+      }
+      return payload;
+    };
+
+    if (proms.length) return Promise.all(proms).then(finalize);
+    return finalize();
   };
 });
 
-function handleTupleResult(result: ParsePayload, final: ParsePayload<any[]>, index: number) {
+function handleTupleResult(
+  result: ParsePayload,
+  final: ParsePayload<any[]>,
+  index: number,
+  input: unknown[],
+  isOptionalOut: boolean
+) {
   if (result.issues.length) {
+    // mirror $ZodObject: swallow errors from absent optional-out slots
+    if (isOptionalOut && index >= input.length) return;
     final.issues.push(...util.prefixIssues(index, result.issues));
   }
   final.value[index] = result.value;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2662,20 +2662,21 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       }
     }
 
-    // Mirror $ZodObject: run every item, passing `undefined` for slots past
-    // the input. Each schema decides what undefined means — `.optional()`
-    // and `z.undefined()` pass it through, `.default()`/`.prefault()` (and
-    // any chain wrapping one) substitute their value, required schemas
-    // fail. `handleTupleResult` swallows the failure for absent optional-out
-    // slots, the same way `handlePropertyResult` does for absent keys.
+    // Run every item in parallel, collecting results into an indexed array.
+    // We process them in order during `finalize` so we can break on the
+    // first absent-optional error: once a slot rejects `undefined`, the
+    // tuple is malformed at that index and any later defaults must NOT fire.
+    const itemResults: ParsePayload[] = new Array(items.length);
     for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      const isOptionalOut = item._zod.optout === "optional";
-      const result = item._zod.run({ value: input[i], issues: [] }, ctx);
-      if (result instanceof Promise) {
-        proms.push(result.then((r) => handleTupleResult(r, payload, i, input, isOptionalOut)));
+      const r = items[i]._zod.run({ value: input[i], issues: [] }, ctx);
+      if (r instanceof Promise) {
+        proms.push(
+          r.then((rr) => {
+            itemResults[i] = rr;
+          })
+        );
       } else {
-        handleTupleResult(result, payload, i, input, isOptionalOut);
+        itemResults[i] = r;
       }
     }
 
@@ -2686,19 +2687,38 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
         i++;
         const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
         if (result instanceof Promise) {
-          proms.push(result.then((r) => handleTupleResult(r, payload, i, input, false)));
+          proms.push(result.then((r) => handleTupleResult(r, payload, i)));
         } else {
-          handleTupleResult(result, payload, i, input, false);
+          handleTupleResult(result, payload, i);
         }
       }
     }
 
-    // Trim trailing slots whose schema produced `undefined` for absent input
-    // (mirrors the object parser dropping absent optional keys). Only items
-    // past `input.length` with `optout === "optional"` are eligible — a
-    // `.default()` past input always materializes, breaking the trim.
     const finalize = () => {
-      for (let i = items.length - 1; i >= input.length; i--) {
+      // Walk results in order. Mirror $ZodObject's swallow-on-absent-optional
+      // rule, but for a tuple "absent" is a positional concept: once we
+      // swallow at index k, every later index is also absent-or-corrupted,
+      // so we truncate the result there and stop processing — including
+      // skipping any later defaults.
+      for (let i = 0; i < items.length; i++) {
+        const r = itemResults[i];
+        const isOptionalOut = items[i]._zod.optout === "optional";
+        const isPresent = i < input.length;
+        if (r.issues.length) {
+          if (isOptionalOut && !isPresent) {
+            payload.value.length = i;
+            break;
+          }
+          payload.issues.push(...util.prefixIssues(i, r.issues));
+        }
+        payload.value[i] = r.value;
+      }
+
+      // Drop trailing slots that produced `undefined` for absent input
+      // (the array analog of an absent optional key on an object). Runs
+      // after a truncate too, so optional slots between the last real
+      // input and the rejected slot collapse away as well.
+      for (let i = payload.value.length - 1; i >= input.length; i--) {
         if (items[i]._zod.optout === "optional" && payload.value[i] === undefined) {
           payload.value.length = i;
         } else {
@@ -2713,16 +2733,8 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
   };
 });
 
-function handleTupleResult(
-  result: ParsePayload,
-  final: ParsePayload<any[]>,
-  index: number,
-  input: unknown[],
-  isOptionalOut: boolean
-) {
+function handleTupleResult(result: ParsePayload, final: ParsePayload<any[]>, index: number) {
   if (result.issues.length) {
-    // mirror $ZodObject: swallow errors from absent optional-out slots
-    if (isOptionalOut && index >= input.length) return;
     final.issues.push(...util.prefixIssues(index, result.issues));
   }
   final.value[index] = result.value;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1359,7 +1359,6 @@ export const $ZodUndefined: core.$constructor<$ZodUndefined> = /*@__PURE__*/ cor
     inst._zod.pattern = regexes.undefined;
     inst._zod.values = new Set([undefined]);
     inst._zod.optin = "optional";
-    inst._zod.optout = "optional";
 
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2665,7 +2665,10 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
     let i = -1;
     for (const item of items) {
       i++;
-      if (i >= input.length) if (i >= optStart) continue;
+      // `optout === "optional"` means running with undefined yields undefined,
+      // so skipping is a no-op. `.default()`/`.prefault()` (and any chain
+      // wrapping one) have a defined output type and fall through to run.
+      if (i >= input.length && item._zod.optout === "optional") continue;
       const result = item._zod.run(
         {
           value: input[i],

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1747,18 +1747,32 @@ function handlePropertyResult(
   final: ParsePayload,
   key: PropertyKey,
   input: any,
+  isOptionalIn: boolean,
   isOptionalOut: boolean
 ) {
+  const isPresent = key in input;
   if (result.issues.length) {
-    // For optional-out schemas, ignore errors on absent keys
-    if (isOptionalOut && !(key in input)) {
+    // For optional-in/out schemas, ignore errors on absent keys.
+    if (isOptionalIn && isOptionalOut && !isPresent) {
       return;
     }
     final.issues.push(...util.prefixIssues(key, result.issues));
   }
 
+  if (!isPresent && !isOptionalIn) {
+    if (!result.issues.length) {
+      final.issues.push({
+        code: "invalid_type",
+        expected: "nonoptional",
+        input: undefined,
+        path: [key],
+      });
+    }
+    return;
+  }
+
   if (result.value === undefined) {
-    if (key in input) {
+    if (isPresent) {
       (final.value as any)[key] = undefined;
     }
   } else {
@@ -1846,6 +1860,7 @@ function handleCatchall(
   const keySet = def.keySet;
   const _catchall = def.catchall!._zod;
   const t = _catchall.def.type;
+  const isOptionalIn = _catchall.optin === "optional";
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
     // skip __proto__ so it can't replace the result prototype via the
@@ -1859,9 +1874,9 @@ function handleCatchall(
     const r = _catchall.run({ value: input[key], issues: [] }, ctx);
 
     if (r instanceof Promise) {
-      proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, isOptionalOut)));
+      proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut)));
     } else {
-      handlePropertyResult(r, payload, key, input, isOptionalOut);
+      handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
     }
   }
 
@@ -1939,13 +1954,14 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
 
     for (const key of value.keys) {
       const el = shape[key]!;
+      const isOptionalIn = el._zod.optin === "optional";
       const isOptionalOut = el._zod.optout === "optional";
 
       const r = el._zod.run({ value: input[key], issues: [] }, ctx);
       if (r instanceof Promise) {
-        proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, isOptionalOut)));
+        proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut)));
       } else {
-        handlePropertyResult(r, payload, key, input, isOptionalOut);
+        handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
       }
     }
 
@@ -1989,12 +2005,13 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         const id = ids[key];
         const k = util.esc(key);
         const schema = shape[key];
+        const isOptionalIn = schema?._zod?.optin === "optional";
         const isOptionalOut = schema?._zod?.optout === "optional";
 
         doc.write(`const ${id} = ${parseStr(key)};`);
 
-        if (isOptionalOut) {
-          // For optional-out schemas, ignore errors on absent keys
+        if (isOptionalIn && isOptionalOut) {
+          // For optional-in/out schemas, ignore errors on absent keys
           doc.write(`
         if (${id}.issues.length) {
           if (${k} in input) {
@@ -2011,6 +2028,33 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
           }
         } else {
           newResult[${k}] = ${id}.value;
+        }
+        
+      `);
+        } else if (!isOptionalIn) {
+          doc.write(`
+        const ${id}_present = ${k} in input;
+        if (${id}.issues.length) {
+          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
+            ...iss,
+            path: iss.path ? [${k}, ...iss.path] : [${k}]
+          })));
+        }
+        if (!${id}_present && !${id}.issues.length) {
+          payload.issues.push({
+            code: "invalid_type",
+            expected: "nonoptional",
+            input: undefined,
+            path: [${k}]
+          });
+        }
+        
+        if (${id}_present) {
+          if (${id}.value === undefined) {
+            newResult[${k}] = undefined;
+          } else {
+            newResult[${k}] = ${id}.value;
+          }
         }
         
       `);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2662,10 +2662,11 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       }
     }
 
-    // Run every item in parallel, collecting results into an indexed array.
-    // We process them in order during `finalize` so we can break on the
-    // first absent-optional error: once a slot rejects `undefined`, the
-    // tuple is malformed at that index and any later defaults must NOT fire.
+    // Run every item in parallel, collecting results into an indexed
+    // array. The post-processing in `handleTupleResults` walks them in
+    // order so it can break on the first absent-optional error: once a
+    // slot rejects `undefined`, the tuple is malformed at that index and
+    // any later defaults must NOT fire.
     const itemResults: ParsePayload[] = new Array(items.length);
     for (let i = 0; i < items.length; i++) {
       const r = items[i]._zod.run({ value: input[i], issues: [] }, ctx);
@@ -2694,42 +2695,8 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       }
     }
 
-    const finalize = () => {
-      // Walk results in order. Mirror $ZodObject's swallow-on-absent-optional
-      // rule, but for a tuple "absent" is a positional concept: once we
-      // swallow at index k, every later index is also absent-or-corrupted,
-      // so we truncate the result there and stop processing — including
-      // skipping any later defaults.
-      for (let i = 0; i < items.length; i++) {
-        const r = itemResults[i];
-        const isOptionalOut = items[i]._zod.optout === "optional";
-        const isPresent = i < input.length;
-        if (r.issues.length) {
-          if (isOptionalOut && !isPresent) {
-            payload.value.length = i;
-            break;
-          }
-          payload.issues.push(...util.prefixIssues(i, r.issues));
-        }
-        payload.value[i] = r.value;
-      }
-
-      // Drop trailing slots that produced `undefined` for absent input
-      // (the array analog of an absent optional key on an object). Runs
-      // after a truncate too, so optional slots between the last real
-      // input and the rejected slot collapse away as well.
-      for (let i = payload.value.length - 1; i >= input.length; i--) {
-        if (items[i]._zod.optout === "optional" && payload.value[i] === undefined) {
-          payload.value.length = i;
-        } else {
-          break;
-        }
-      }
-      return payload;
-    };
-
-    if (proms.length) return Promise.all(proms).then(finalize);
-    return finalize();
+    if (proms.length) return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input));
+    return handleTupleResults(itemResults, payload, items, input);
   };
 });
 
@@ -2738,6 +2705,54 @@ function handleTupleResult(result: ParsePayload, final: ParsePayload<any[]>, ind
     final.issues.push(...util.prefixIssues(index, result.issues));
   }
   final.value[index] = result.value;
+}
+
+// Post-processes the per-item results collected by the tuple parser.
+// `optStart` is intentionally NOT consulted here — it's an input-length
+// concern handled by the `too_small` precheck at the top of parse. This
+// step is purely about output shaping, which is governed by `optout`:
+// a `.default()` tail item sits inside the optStart region (its `optin`
+// is optional), but it must NOT be dropped or have its errors swallowed
+// because it materializes a defined value (`optout !== "optional"`).
+function handleTupleResults(
+  itemResults: ParsePayload[],
+  final: ParsePayload<any[]>,
+  items: readonly $ZodType[],
+  input: unknown[]
+) {
+  // Walk results in order. Mirror $ZodObject's swallow-on-absent-optional
+  // rule, but for a tuple "absent" is a positional concept: once we
+  // swallow at index k, every later index is also absent-or-corrupted,
+  // so we truncate the result there and stop processing — including
+  // skipping any later defaults.
+  for (let i = 0; i < items.length; i++) {
+    const r = itemResults[i];
+    const isOptionalOut = items[i]._zod.optout === "optional";
+    const isPresent = i < input.length;
+    if (r.issues.length) {
+      if (isOptionalOut && !isPresent) {
+        final.value.length = i;
+        break;
+      }
+      final.issues.push(...util.prefixIssues(i, r.issues));
+    }
+    final.value[i] = r.value;
+  }
+
+  // Drop trailing slots that produced `undefined` for absent input
+  // (the array analog of an absent optional key on an object). The
+  // `i >= input.length` floor is critical: an explicit `undefined`
+  // *inside* the input must be preserved even when the schema is
+  // optional-out (e.g. `z.string().or(z.undefined())` accepting an
+  // explicit undefined value).
+  for (let i = final.value.length - 1; i >= input.length; i--) {
+    if (items[i]._zod.optout === "optional" && final.value[i] === undefined) {
+      final.value.length = i;
+    } else {
+      break;
+    }
+  }
+  return final;
 }
 
 //////////////////////////////////////////


### PR DESCRIPTION

> This PR started as a focused fix for #5229, but I slightly hijacked it while reviewing the related optionality semantics.

It now aligns object and tuple handling around the internal `optin` / `optout` split:

- Tuple parsing still uses `optin` for input-length validation and `optout` for output shaping, so trailing `.default()` / `.prefault()` elements materialize while purely optional tails still trim away.
- Object parsing now also requires `optin === "optional"` before treating an absent key as valid. Schemas like `z.undefined()`, `z.union([z.string(), z.undefined()])`, and required `.catch()` fields no longer make a missing object key acceptable just because parsing `undefined` can succeed or be recovered.
- `optout` continues to control whether absent optional output is omitted, including the `.optional()` / `.exactOptional()` cases.

The net effect is that absence has to be explicitly represented by input-side optionality. Defaults still bubble through missing object keys and tuple slots; bare `.catch()` still recovers explicit invalid values, but no longer acts like a missing-key default unless the field is also optional.



---

>  Original PR Body

## Summary

Fixes #5229

When parsing tuples with missing trailing elements that have `.default()` values, the default values were not being applied. Instead, the elements were simply skipped.

### Before (As-is)
```typescript
const myTuple = z.tuple([z.string(), z.string().default('bravo')]);
myTuple.parse(['alpha']); // => ['alpha'] (default ignored)
```

### After (To-be)
```typescript
const myTuple = z.tuple([z.string(), z.string().default('bravo')]);
myTuple.parse(['alpha']); // => ['alpha', 'bravo'] (default applied)
```

## Changes
Modified the tuple parsing logic to run the schema for default type elements even when the input array is shorter, allowing $ZodDefault to apply its default value.
File: packages/zod/src/v4/core/schemas.ts
```diff
- if (i >= input.length) if (i >= optStart) continue;
+ if (i >= input.length && i >= optStart && item._zod.def.type !== "default") continue;
```

## Test Plan
✅ Added test case for tuple with default elements in tuple.test.ts
✅ All existing tests pass

### Verified Issue Examples
All examples from #5229 now work correctly:
```typescript
// Example 1: Basic tuple with default
z.tuple([z.string(), z.string().default('bravo')]).parse(['alpha']);
// ✅ Now returns: ['alpha', 'bravo']

// Example 2: Skipped - this correctly throws an error (expected behavior, not a bug)

// Example 3: ZodFunction with correct API
z.function().input([z.string(), z.string().default('bravo')])
.implement((name, company) => console.log(name, company));
// ✅ Now logs: "alpha bravo"

// Example 4: Destructuring
const [name, company] = z.tuple([z.string(), z.string().default('bravo')]).parse(['alpha']);
// ✅ Now: name = "alpha", company = "bravo"
```


