### PR TITLE
fix (v4) : adds strict validation to httpUrl() 

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -516,7 +516,7 @@ export function url(params?: string | core.$ZodURLParams): ZodURL {
 
 export function httpUrl(params?: string | Omit<core.$ZodURLParams, "protocol" | "hostname">): ZodURL {
   return core._url(ZodURL, {
-    protocol: /^https?$/,
+    protocol: core.regexes.httpProtocol,
     hostname: core.regexes.domain,
     ...util.normalizeParams(params),
   });

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -454,6 +454,12 @@ test("httpurl", () => {
   ).toThrow();
   expect(() => httpUrl.parse("http://asdf.c")).toThrow();
   expect(() => httpUrl.parse("mailto:asdf@lckj.com")).toThrow();
+  // missing // after protocol
+  expect(() => httpUrl.parse("http:example.com")).toThrow();
+  expect(() => httpUrl.parse("https:example.com")).toThrow();
+  // missing one /
+  expect(() => httpUrl.parse("https:/www.google.com")).toThrow();
+  expect(() => httpUrl.parse("http:/example.com")).toThrow();
 });
 
 test("url error overrides", () => {

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -81,6 +81,8 @@ export const hostname: RegExp =
 
 export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
 
+export const httpProtocol: RegExp = /^https?$/;
+
 // https://blog.stevenlevithan.com/archives/validate-phone-number#r4-3 (regex sans spaces)
 // E.164: leading digit must be 1-9; total digits (excluding '+') between 7-15
 export const e164: RegExp = /^\+[1-9]\d{6,14}$/;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -481,10 +481,9 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
       // Check for valid URL format before passing to URL constructor
       // URLs must have a protocol followed by :// (not just :)
       // This prevents strings like "http:example.com" or "https:/path" from being accepted
-      // Only apply this strict validation for http/https URLs (httpUrl validator)
-      if (def.protocol && def.protocol.source === "^https?$") {
-        const protocolMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
-        if (!protocolMatch) {
+      // Apply this strict validation for http/https URLs (httpUrl validator)
+      if (def.protocol && /https?/.test(def.protocol.source)) {
+        if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
           payload.issues.push({
             code: "invalid_format",
             format: "url",

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -477,6 +477,26 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
     try {
       // Trim whitespace from input
       const trimmed = payload.value.trim();
+
+      // Check for valid URL format before passing to URL constructor
+      // URLs must have a protocol followed by :// (not just :)
+      // This prevents strings like "http:example.com" or "https:/path" from being accepted
+      // Only apply this strict validation for http/https URLs (httpUrl validator)
+      if (def.protocol && def.protocol.source === "^https?$") {
+        const protocolMatch = trimmed.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+        if (!protocolMatch) {
+          payload.issues.push({
+            code: "invalid_format",
+            format: "url",
+            note: "Invalid URL format",
+            input: payload.value,
+            inst,
+            continue: !def.abort,
+          });
+          return;
+        }
+      }
+
       // @ts-ignore
       const url = new URL(trimmed);
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -478,12 +478,10 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
       // Trim whitespace from input
       const trimmed = payload.value.trim();
 
-      // Check for valid URL format before passing to URL constructor
-      // URLs must have a protocol followed by :// (not just :)
-      // This prevents strings like "http:example.com" or "https:/path" from being accepted
-      // Apply this strict validation for http/https URLs (httpUrl validator)
-      if (def.protocol && /https?/.test(def.protocol.source)) {
-        if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+      // When normalize is off, require :// for http/https URLs
+      // This prevents strings like "http:example.com" or "https:/path" from being silently accepted
+      if (!def.normalize && def.protocol?.source === regexes.httpProtocol.source) {
+        if (!/^https?:\/\//i.test(trimmed)) {
           payload.issues.push({
             code: "invalid_format",
             format: "url",

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -200,7 +200,7 @@ export function url(params?: string | core.$ZodURLParams): ZodMiniURL {
 // @__NO_SIDE_EFFECTS__
 export function httpUrl(params?: string | Omit<core.$ZodURLParams, "protocol" | "hostname">): ZodMiniURL {
   return core._url(ZodMiniURL, {
-    protocol: /^https?$/,
+    protocol: core.regexes.httpProtocol,
     hostname: core.regexes.domain,
     ...util.normalizeParams(params),
   });


### PR DESCRIPTION
Solves #5284 

httpUrl allow single slash (http:/example.com) and no slash (http:example.com) 

example :
{
"parsedUser": {
"website": "http:example.com"
}
}

{
"parsedUser": {
"website": "https:/[www.google.com]
}
}

Add strict protocol:// check before new URL() for httpUrl()