### PR TITLE
docs: fix README links for async refinements/transforms

### DIFF
--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -169,7 +169,7 @@ if (!result.success) {
 }
 ```
 
-**Note** — If your schema uses certain asynchronous APIs like `async` [refinements](#refine) or [transforms](#transform), you'll need to use the `.safeParseAsync()` method instead.
+**Note** — If your schema uses certain asynchronous APIs like `async` [refinements](https://zod.dev/api#refinements) or [transforms](https://zod.dev/api#transforms), you'll need to use the `.safeParseAsync()` method instead.
 
 ```ts
 const schema = z.string().refine(async (val) => val.length <= 8);


### PR DESCRIPTION
The README note for `safeParseAsync()` referenced `#refine`/`#transform` anchors that don’t exist on GitHub, resulting in broken links. This updates them to the canonical docs anchors for refinements and transforms.