### PR TITLE
docs: fix README anchor links for async APIs

### DIFF
--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -169,7 +169,7 @@ if (!result.success) {
 }
 ```
 
-**Note** — If your schema uses certain asynchronous APIs like `async` [refinements](#refine) or [transforms](#transform), you'll need to use the `.safeParseAsync()` method instead.
+**Note** — If your schema uses certain asynchronous APIs like `async` [refinements](https://zod.dev/api#refinements) or [transforms](https://zod.dev/api#transforms), you'll need to use the `.safeParseAsync()` method instead.
 
 ```ts
 const schema = z.string().refine(async (val) => val.length <= 8);


### PR DESCRIPTION
The README note about async APIs when using `safeParseAsync()` currently links to internal anchors `#refine` / `#transform`, which don’t exist in the README.

This updates those links to the canonical docs sections:
- `https://zod.dev/api#refinements`
- `https://zod.dev/api#transforms`

Docs-only change.