### PR TITLE
Remove deprecated downlevelIteration option

### DIFF
--- a/.configs/tsconfig.base.json
+++ b/.configs/tsconfig.base.json
@@ -28,7 +28,6 @@
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "downlevelIteration": true,
     "isolatedModules": true,
 
     "pretty": true


### PR DESCRIPTION
This option is deprecated in TypeScript 6.0. It doesn't do anything when `target` is `es2020`, so can be safely removed from this config file.