### PR TITLE
fix(v4): handle multi-digit exponents in floatSafeRemainder

### DIFF
--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -153,6 +153,22 @@ test(".multipleOf() with negative divisor", () => {
   expect(() => schema.parse(7.5)).toThrow();
 });
 
+test(".multipleOf() with scientific notation (multi-digit exponents)", () => {
+  // Regression test for https://github.com/colinhacks/zod/pull/5687
+  // The regex was using \d? which only matches single-digit exponents
+  const schema = z.number().multipleOf(1e-10);
+
+  // These should all pass - they are valid multiples of 1e-10
+  expect(schema.parse(1e-10)).toEqual(1e-10);
+  expect(schema.parse(5e-10)).toEqual(5e-10);
+  expect(schema.parse(1e-9)).toEqual(1e-9); // 10 * 1e-10
+
+  // Test with 1e-15 (exponent = 15, two digits)
+  const schema15 = z.number().multipleOf(1e-15);
+  expect(schema15.parse(1e-15)).toEqual(1e-15);
+  expect(schema15.parse(3e-15)).toEqual(3e-15);
+});
+
 test(".step() validation", () => {
   const schemaPointOne = z.number().step(0.1);
   const schemaPointZeroZeroZeroOne = z.number().step(0.0001);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -248,8 +248,8 @@ export function floatSafeRemainder(val: number, step: number): number {
   const valDecCount = (val.toString().split(".")[1] || "").length;
   const stepString = step.toString();
   let stepDecCount = (stepString.split(".")[1] || "").length;
-  if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
-    const match = stepString.match(/\d?e-(\d?)/);
+  if (stepDecCount === 0 && /\d?e-\d+/.test(stepString)) {
+    const match = stepString.match(/\d?e-(\d+)/);
     if (match?.[1]) {
       stepDecCount = Number.parseInt(match[1]);
     }


### PR DESCRIPTION
## Summary

The regex in `floatSafeRemainder` only matches single-digit exponents, causing `multipleOf` validation to incorrectly fail for steps with exponents >= 10 (e.g., `1e-10`, `1e-15`).

## The Bug

```typescript
// Before: \d? matches 0 or 1 digit
if (stepDecCount === 0 && /\d?e-\d?/.test(stepString)) {
  const match = stepString.match(/\d?e-(\d?)/);
```

For `step = 1e-10`:
- Regex matched `"1e-1"` instead of `"1e-10"`
- Captured exponent: `"1"` instead of `"10"`
- `stepDecCount` set to `1` instead of `10`
- `toFixed(1)` rounds both values to `"0.0"`
- `stepInt` becomes `0`, remainder becomes `NaN`
- Valid values incorrectly rejected

## The Fix

Changed `\d?` to `\d+` to capture multi-digit exponents:

```typescript
// After: \d+ matches 1 or more digits
if (stepDecCount === 0 && /\d?e-\d+/.test(stepString)) {
  const match = stepString.match(/\d?e-(\d+)/);
```

## Reproduction

```typescript
const step = 1e-10;
const regex = /\d?e-(\d?)/;
const match = step.toString().match(regex);
console.log(match); // ["1e-1", "1"] - captures only first digit
```

## Discovery

This bug was discovered by [whiterose](https://github.com/shakecodeslikecray/whiterose), an AI-powered bug hunter that uses LLM-based static analysis.

---

Scanned with [whiterose](https://github.com/shakecodeslikecray/whiterose)