### PR TITLE
fix: include format property in z.iso.time() toJSONSchema output

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -103,6 +103,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(z.iso.time())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "time",
         "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?$",
         "type": "string",
       }
@@ -110,6 +111,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(z.iso.time({ precision: -1 }))).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "time",
         "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d$",
         "type": "string",
       }
@@ -117,6 +119,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(z.iso.time({ precision: 0 }))).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "time",
         "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$",
         "type": "string",
       }
@@ -124,6 +127,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(z.iso.time({ precision: 3 }))).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "time",
         "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d\\.\\d{3}$",
         "type": "string",
       }
@@ -364,6 +368,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(z.iso.time())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "time",
         "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?$",
         "type": "string",
       }

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -35,12 +35,6 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
   if (format) {
     json.format = formatMap[format as checks.$ZodStringFormats] ?? format;
     if (json.format === "") delete json.format; // empty format is not valid
-
-    // JSON Schema format: "time" requires a full time with offset or Z
-    // z.iso.time() does not include timezone information, so format: "time" should never be used
-    if (format === "time") {
-      delete json.format;
-    }
   }
   if (contentEncoding) json.contentEncoding = contentEncoding;
   if (patterns && patterns.size > 0) {


### PR DESCRIPTION
## Summary

Fixes #5673

The documentation states that `z.iso.time()` should output `{ type: 'string', format: 'time' }` but the code was explicitly deleting the `format` property.

## Changes

Removed the special case that deleted `format: 'time'` from the JSON Schema output. This aligns the behavior with:
1. The documentation at https://zod.dev/json-schema?id=string-formats
2. The behavior of `z.iso.date()` which includes `format: 'date'`
3. The behavior of `z.iso.duration()` which includes `format: 'duration'`

The `pattern` property already provides strict validation of the time format, so `format: 'time'` serves as a useful hint for JSON Schema consumers.

## Before

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?$",
  "type": "string"
}
```

## After

```json
{
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "format": "time",
  "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?$",
  "type": "string"
}
```

## Testing

Updated the inline snapshots in `to-json-schema.test.ts` to include the `format` property. All tests pass.