### PR TITLE
fix: add sideEffects: false to stub package.json files

### DIFF
--- a/scripts/write-stub-package-jsons.ts
+++ b/scripts/write-stub-package-jsons.ts
@@ -7,7 +7,8 @@ const STUB_PACKAGE_JSON_CONTENT = `{
   "type": "module",
   "main": "./index.cjs",
   "module": "./index.js",
-  "types": "./index.d.cts" 
+  "types": "./index.d.cts",
+  "sideEffects": false 
 }
 `;
 


### PR DESCRIPTION
## Summary                                                                                                                                                                    
  - Adds `sideEffects: false` to stub package.json files to enable proper tree-shaking

## Context
The stub package.json files introduced in #5222 were missing the `sideEffects` field, preventing bundlers from tree-shaking unused submodules.

Related to:

- https://github.com/colinhacks/zod/issues/4433
- https://github.com/colinhacks/zod/issues/5641

## Reproduction

https://stackblitz.com/edit/vitejs-vite-dqpihhpx?file=src%2Findex.ts

When bundling for the web with webpack 5.105.0 using the `import * as z from "zod";`  syntax:

### Before

<img width="800" src="https://github.com/user-attachments/assets/0a42164f-d017-4d67-b27b-de2c97bc0f9c" />


### After

<img width="800" src="https://github.com/user-attachments/assets/53c7b6fa-2718-48fb-ae0c-759a6b03e62b" />
