### PR TITLE
fix: add missing addIssue to transform context

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1814,7 +1814,7 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
 );
 
 export function transform<I = unknown, O = I>(
-  fn: (input: I, ctx: core.ParsePayload) => O
+  fn: (input: I, ctx: core.$RefinementCtx) => O
 ): ZodTransform<Awaited<O>, I> {
   return new ZodTransform({
     type: "transform",

--- a/packages/zod/src/v4/classic/tests/transform.test.ts
+++ b/packages/zod/src/v4/classic/tests/transform.test.ts
@@ -359,3 +359,20 @@ test("encode error", () => {
     `[ZodEncodeError: Encountered unidirectional transform during encode: ZodTransform]`
   );
 });
+
+test("transform context should have addIssue", () => {
+  const schema = z.transform((val, ctx) => {
+    ctx.addIssue({
+      code: "custom",
+      message: "Not valid",
+    });
+    return val;
+  });
+
+  const result = schema.safeParse("test");
+
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toBe("Not valid");
+  }
+});


### PR DESCRIPTION
This PR adds the missing addIssue method to the transform callback context, resolving the issue where manual issue reporting was unavailable in transformations.

Closes #5678