### PR TITLE
fix(v4): avoid array item parsing for any/unknown validator

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1625,6 +1625,12 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
       });
       return payload;
     }
+    // We can skip per-item parsing if the element schema is truly open-ended (no checks and unknown/any)
+    if (["unknown", "any"].includes(def.element._zod.def.type) && !def.element._zod.def.checks?.length) {
+      payload.value = input;
+
+      return payload;
+    }
 
     payload.value = Array(input.length);
     const proms: Promise<any>[] = [];


### PR DESCRIPTION
This pull request introduces an optimisation to array parsing, specifically for arrays of `unknown` and `any` types. The improvement is that per-item parsing is skipped for these "noop" validators.

### Context
I had a use case, where I checked if a field in a response was an array, the item parsing was postponed to another step, to manually check each item to support partially valid arrays. I was using `z.array(z.unknown())` with the expectation of being a zod equivalent to `Array.isArray` check.

### Changes
Added logic in `$ZodArray` (in `schemas.ts`) to skip per-item parsing when the element schema is `unknown` or `any`, directly returning the input array as the parsed value.

### Testing
Introduced a new test in `array.test.ts` to verify that per-item parsing is skipped for arrays of `unknown` and `any`, using spies to ensure the schema's `run` method is not called.