### PR TITLE
RFC: Validate Codec Output

### DIFF
--- a/packages/zod/src/v4/classic/parse.ts
+++ b/packages/zod/src/v4/classic/parse.ts
@@ -80,3 +80,30 @@ export const safeDecodeAsync: <T extends core.$ZodType>(
   value: core.input<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
 ) => Promise<ZodSafeParseResult<core.output<T>>> = /* @__PURE__ */ core._safeDecodeAsync(ZodRealError) as any;
+
+// Validate output functions
+export const validateOutput: <T extends core.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: core.ParseContext<core.$ZodIssue>,
+  _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
+) => core.output<T> = /* @__PURE__ */ core._validateOutput(ZodRealError) as any;
+
+export const validateOutputAsync: <T extends core.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: core.ParseContext<core.$ZodIssue>,
+  _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
+) => Promise<core.output<T>> = /* @__PURE__ */ core._validateOutputAsync(ZodRealError) as any;
+
+export const safeValidateOutput: <T extends core.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: core.ParseContext<core.$ZodIssue>
+) => ZodSafeParseResult<core.output<T>> = /* @__PURE__ */ core._safeValidateOutput(ZodRealError) as any;
+
+export const safeValidateOutputAsync: <T extends core.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: core.ParseContext<core.$ZodIssue>
+) => Promise<ZodSafeParseResult<core.output<T>>> = /* @__PURE__ */ core._safeValidateOutputAsync(ZodRealError) as any;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -87,6 +87,16 @@ export interface ZodType<
     data: core.input<this>,
     params?: core.ParseContext<core.$ZodIssue>
   ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
+  validateOutput(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>): core.output<this>;
+  validateOutputAsync(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>): Promise<core.output<this>>;
+  safeValidateOutput(
+    data: core.output<this>,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): parse.ZodSafeParseResult<core.output<this>>;
+  safeValidateOutputAsync(
+    data: core.output<this>,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
 
   // refinements
   refine<Ch extends (arg: core.output<this>) => unknown | Promise<unknown>>(
@@ -207,6 +217,10 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   inst.safeDecode = (data, params) => parse.safeDecode(inst, data, params);
   inst.safeEncodeAsync = async (data, params) => parse.safeEncodeAsync(inst, data, params);
   inst.safeDecodeAsync = async (data, params) => parse.safeDecodeAsync(inst, data, params);
+  inst.validateOutput = (data, params) => parse.validateOutput(inst, data, params);
+  inst.validateOutputAsync = async (data, params) => parse.validateOutputAsync(inst, data, params);
+  inst.safeValidateOutput = (data, params) => parse.safeValidateOutput(inst, data, params);
+  inst.safeValidateOutputAsync = async (data, params) => parse.safeValidateOutputAsync(inst, data, params);
 
   // refinements
   inst.refine = (check, params) => inst.check(refine(check, params)) as never;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -145,6 +145,16 @@ export interface ZodType<
     data: core.input<this>,
     params?: core.ParseContext<core.$ZodIssue>
   ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
+  validateOutput(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>): core.output<this>;
+  validateOutputAsync(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>): Promise<core.output<this>>;
+  safeValidateOutput(
+    data: core.output<this>,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): parse.ZodSafeParseResult<core.output<this>>;
+  safeValidateOutputAsync(
+    data: core.output<this>,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
 
   // refinements
   refine<Ch extends (arg: core.output<this>) => unknown | Promise<unknown>>(
@@ -244,6 +254,10 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   inst.safeDecode = (data, params) => parse.safeDecode(inst, data, params);
   inst.safeEncodeAsync = async (data, params) => parse.safeEncodeAsync(inst, data, params);
   inst.safeDecodeAsync = async (data, params) => parse.safeDecodeAsync(inst, data, params);
+  inst.validateOutput = (data, params) => parse.validateOutput(inst, data, params);
+  inst.validateOutputAsync = async (data, params) => parse.validateOutputAsync(inst, data, params);
+  inst.safeValidateOutput = (data, params) => parse.safeValidateOutput(inst, data, params);
+  inst.safeValidateOutputAsync = async (data, params) => parse.safeValidateOutputAsync(inst, data, params);
 
   // All builder methods are placed on the internal prototype as lazy-bind
   // getters. On first access per-instance, a bound thunk is allocated and

--- a/packages/zod/src/v4/classic/tests/codec.test.ts
+++ b/packages/zod/src/v4/classic/tests/codec.test.ts
@@ -701,3 +701,366 @@ describe("context immutability", () => {
     expect("direction" in ctx).toBe(false);
   });
 });
+
+test("validateOutput - valid output passes", () => {
+  // Create a schema with codec
+  const formSchema = z.object({
+    age: z.codec(z.string().regex(/^\d+$/), z.number().int().min(0), {
+      decode: (str) => Number.parseInt(str, 10),
+      encode: (num) => num.toString(),
+    }),
+    name: z.string(),
+  });
+
+  // Client submits data, form validates and transforms
+  const transformed = formSchema.parse({ age: "30", name: "Alice" });
+  expect(transformed).toEqual({ age: 30, name: "Alice" });
+
+  // Server re-validates the already-transformed data
+  const validated = z.validateOutput(formSchema, transformed);
+  expect(validated).toEqual({ age: 30, name: "Alice" });
+  expect(typeof validated.age).toBe("number");
+});
+
+test("validateOutput - invalid output throws", () => {
+  const formSchema = z.object({
+    age: z.codec(z.string().regex(/^\d+$/), z.number().int().min(0), {
+      decode: (str) => Number.parseInt(str, 10),
+      encode: (num) => num.toString(),
+    }),
+    name: z.string(),
+  });
+
+  // Invalid data: age is negative
+  expect(() => {
+    z.validateOutput(formSchema, { age: -5, name: "Bob" });
+  }).toThrow();
+});
+
+test("validateOutput - validates against output schema not input", () => {
+  const schema = z.object({
+    value: z.codec(
+      z
+        .string()
+        .regex(/^\d+$/), // Input must be string matching digits
+      z
+        .number()
+        .int()
+        .min(0)
+        .max(100), // Output must be number 0-100
+      {
+        decode: (str) => Number.parseInt(str, 10),
+        encode: (num) => num.toString(),
+      }
+    ),
+  });
+
+  // Valid number should pass (validating output, not input)
+  const result = z.validateOutput(schema, { value: 50 });
+  expect(result).toEqual({ value: 50 });
+
+  // Invalid number should fail (outside range)
+  expect(() => z.validateOutput(schema, { value: 150 })).toThrow();
+
+  // String should fail (validateOutput expects output type = number)
+  expect(() => z.validateOutput(schema, { value: "50" } as any)).toThrow();
+});
+
+test("validateOutput - works with refinements on output schema", () => {
+  // Put the refinement on the output schema, not the codec
+  const schema = z.object({
+    value: z.codec(
+      z.string().regex(/^\d+$/),
+      z
+        .number()
+        .int()
+        .refine((val) => val % 2 === 0, { error: "Must be even" }),
+      {
+        decode: (str) => Number.parseInt(str, 10),
+        encode: (num) => num.toString(),
+      }
+    ),
+  });
+
+  // Even number passes
+  expect(z.validateOutput(schema, { value: 42 })).toEqual({ value: 42 });
+
+  // Odd number fails
+  expect(() => z.validateOutput(schema, { value: 43 })).toThrow();
+});
+
+test("safeValidateOutput - success case", () => {
+  const schema = z.object({
+    value: z.codec(z.string(), z.number().min(0), {
+      decode: (str) => Number.parseFloat(str),
+      encode: (num) => num.toString(),
+    }),
+  });
+
+  const result = z.safeValidateOutput(schema, { value: 42.5 });
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.data).toEqual({ value: 42.5 });
+  }
+});
+
+test("safeValidateOutput - failure case", () => {
+  const schema = z.object({
+    value: z.codec(z.string(), z.number().min(0), {
+      decode: (str) => Number.parseFloat(str),
+      encode: (num) => num.toString(),
+    }),
+  });
+
+  const result = z.safeValidateOutput(schema, { value: -10 });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "too_small",
+          "inclusive": true,
+          "message": "Too small: expected number to be >=0",
+          "minimum": 0,
+          "origin": "number",
+          "path": [
+            "value",
+          ],
+        },
+      ]
+    `);
+  }
+});
+
+test("validateOutputAsync - valid output", async () => {
+  const schema = z.object({
+    value: z.codec(
+      z.string(),
+      z
+        .number()
+        .int()
+        .superRefine(async (val, ctx) => {
+          // Simulate async validation (e.g., checking database)
+          if (val < 0) {
+            ctx.addIssue({ code: "custom", error: "Must be non-negative" });
+          }
+        }),
+      {
+        decode: (str) => Number.parseInt(str, 10),
+        encode: (num) => num.toString(),
+      }
+    ),
+  });
+
+  const result = await z.validateOutputAsync(schema, { value: 42 });
+  expect(result).toEqual({ value: 42 });
+});
+
+test("validateOutputAsync - invalid output", async () => {
+  const schema = z.object({
+    value: z.codec(
+      z.string(),
+      z
+        .number()
+        .int()
+        .superRefine(async (val, ctx) => {
+          if (val < 0) {
+            ctx.addIssue({ code: "custom", error: "Must be non-negative" });
+          }
+        }),
+      {
+        decode: (str) => Number.parseInt(str, 10),
+        encode: (num) => num.toString(),
+      }
+    ),
+  });
+
+  await expect(z.validateOutputAsync(schema, { value: -5 })).rejects.toThrow();
+});
+
+test("safeValidateOutputAsync - success", async () => {
+  const schema = z.object({
+    value: z.codec(z.string(), z.number().min(0), {
+      decode: (str) => Number.parseFloat(str),
+      encode: (num) => num.toString(),
+    }),
+  });
+
+  const result = await z.safeValidateOutputAsync(schema, { value: 42.5 });
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.data).toEqual({ value: 42.5 });
+  }
+});
+
+test("safeValidateOutputAsync - failure", async () => {
+  const schema = z.object({
+    value: z.codec(z.string(), z.number().min(0), {
+      decode: (str) => Number.parseFloat(str),
+      encode: (num) => num.toString(),
+    }),
+  });
+
+  const result = await z.safeValidateOutputAsync(schema, { value: -10 });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "too_small",
+          "inclusive": true,
+          "message": "Too small: expected number to be >=0",
+          "minimum": 0,
+          "origin": "number",
+          "path": [
+            "value",
+          ],
+        },
+      ]
+    `);
+  }
+});
+
+test("validateOutput - nested codec in object", () => {
+  const formSchema = z.object({
+    user: z.object({
+      id: z.codec(z.string().regex(/^\d+$/), z.number().int().positive(), {
+        decode: (str) => Number.parseInt(str, 10),
+        encode: (num) => num.toString(),
+      }),
+      email: z.string().email(),
+    }),
+  });
+
+  // Valid transformed data
+  const data = { user: { id: 123, email: "test@example.com" } };
+
+  const validated = z.validateOutput(formSchema, data);
+  expect(validated).toEqual(data);
+});
+
+test("validateOutput - complex form example", () => {
+  // Real-world example: form handling
+  const formSchema = z.object({
+    age: z.codec(z.string().regex(/^\d+$/), z.number().int().min(18).max(120), {
+      decode: (str) => Number.parseInt(str, 10),
+      encode: (num) => num.toString(),
+    }),
+    salary: z.codec(z.string().regex(/^\d+(\.\d{2})?$/), z.number().min(0), {
+      decode: (str) => Number.parseFloat(str),
+      encode: (num) => num.toFixed(2),
+    }),
+    active: z.codec(z.enum(["true", "false"]), z.boolean(), {
+      decode: (str) => str === "true",
+      encode: (bool) => (bool ? "true" : "false"),
+    }),
+  });
+
+  // Client-side: User submits form
+  const formData = { age: "25", salary: "50000.00", active: "true" };
+  const parsed = formSchema.parse(formData);
+  expect(parsed).toEqual({ age: 25, salary: 50000, active: true });
+
+  // Server-side: Re-validate transformed data
+  const validated = z.validateOutput(formSchema, parsed);
+  expect(validated).toEqual({ age: 25, salary: 50000, active: true });
+
+  // Server-side: Invalid transformed data fails
+  expect(() => {
+    z.validateOutput(formSchema, { age: 15, salary: 50000, active: true }); // age < 18
+  }).toThrow();
+});
+
+test("validateOutput - wrong type fails validation", () => {
+  const schema = z.object({
+    value: z.codec(z.string(), z.number(), {
+      decode: (str) => Number.parseFloat(str),
+      encode: (num) => num.toString(),
+    }),
+  });
+
+  // String instead of number should fail
+  expect(() => z.validateOutput(schema, { value: "42" } as any)).toThrow();
+
+  // Boolean instead of number should fail
+  expect(() => z.validateOutput(schema, { value: true } as any)).toThrow();
+});
+
+test("schema.validateOutput() - method API works", () => {
+  const schema = z.object({
+    num: z.codec(z.string().regex(/^\d+$/), z.number().int().min(0), {
+      decode: (str) => Number.parseInt(str, 10),
+      encode: (num) => num.toString(),
+    }),
+    name: z.string(),
+  });
+
+  // Valid output passes
+  const validated = schema.validateOutput({ num: 42, name: "Alice" });
+  expect(validated).toEqual({ num: 42, name: "Alice" });
+
+  // Invalid output throws
+  expect(() => schema.validateOutput({ num: -5, name: "Bob" })).toThrow();
+  expect(() => schema.validateOutput({ num: "42" as any, name: "Bob" })).toThrow();
+});
+
+test("schema.validateOutputAsync() - method API works", async () => {
+  const schema = z.object({
+    value: z.codec(
+      z.string(),
+      z
+        .number()
+        .int()
+        .superRefine(async (val, ctx) => {
+          if (val < 0) {
+            ctx.addIssue({ code: "custom", error: "Must be non-negative" });
+          }
+        }),
+      {
+        decode: (str) => Number.parseInt(str, 10),
+        encode: (num) => num.toString(),
+      }
+    ),
+  });
+
+  const result = await schema.validateOutputAsync({ value: 42 });
+  expect(result).toEqual({ value: 42 });
+
+  await expect(schema.validateOutputAsync({ value: -5 })).rejects.toThrow();
+});
+
+test("schema.safeValidateOutput() - method API works", () => {
+  const schema = z.object({
+    value: z.codec(z.string(), z.number().min(0), {
+      decode: (str) => Number.parseFloat(str),
+      encode: (num) => num.toString(),
+    }),
+  });
+
+  const successResult = schema.safeValidateOutput({ value: 42.5 });
+  expect(successResult.success).toBe(true);
+  if (successResult.success) {
+    expect(successResult.data).toEqual({ value: 42.5 });
+  }
+
+  const failResult = schema.safeValidateOutput({ value: -10 });
+  expect(failResult.success).toBe(false);
+});
+
+test("schema.safeValidateOutputAsync() - method API works", async () => {
+  const schema = z.object({
+    value: z.codec(z.string(), z.number().min(0), {
+      decode: (str) => Number.parseFloat(str),
+      encode: (num) => num.toString(),
+    }),
+  });
+
+  const successResult = await schema.safeValidateOutputAsync({ value: 42.5 });
+  expect(successResult.success).toBe(true);
+  if (successResult.success) {
+    expect(successResult.data).toEqual({ value: 42.5 });
+  }
+
+  const failResult = await schema.safeValidateOutputAsync({ value: -10 });
+  expect(failResult.success).toBe(false);
+});

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -193,3 +193,71 @@ export const _safeDecodeAsync: (_Err: $ZodErrorClass) => $SafeDecodeAsync = (_Er
 };
 
 export const safeDecodeAsync: $SafeDecodeAsync = /* @__PURE__*/ _safeDecodeAsync(errors.$ZodRealError);
+
+///////////        VALIDATE OUTPUT       ///////////
+
+export type $ValidateOutput = <T extends schemas.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>,
+  _params?: { callee?: util.AnyFunc; Err?: $ZodErrorClass }
+) => core.output<T>;
+
+export const _validateOutput: (_Err: $ZodErrorClass) => $ValidateOutput = (_Err) => (schema, value, _ctx, _params) => {
+  const ctx = _ctx
+    ? Object.assign(_ctx, { direction: "validate-output" as const })
+    : { direction: "validate-output" as const };
+  return _parse(_Err)(schema, value, ctx as any, _params);
+};
+
+export const validateOutput: $ValidateOutput = /* @__PURE__*/ _validateOutput(errors.$ZodRealError);
+
+export type $ValidateOutputAsync = <T extends schemas.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>,
+  _params?: { callee?: util.AnyFunc; Err?: $ZodErrorClass }
+) => Promise<core.output<T>>;
+
+export const _validateOutputAsync: (_Err: $ZodErrorClass) => $ValidateOutputAsync =
+  (_Err) => async (schema, value, _ctx, _params) => {
+    const ctx = _ctx
+      ? Object.assign(_ctx, { direction: "validate-output" as const })
+      : { direction: "validate-output" as const };
+    return _parseAsync(_Err)(schema, value, ctx as any, _params);
+  };
+
+export const validateOutputAsync: $ValidateOutputAsync = /* @__PURE__*/ _validateOutputAsync(errors.$ZodRealError);
+
+export type $SafeValidateOutput = <T extends schemas.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>
+) => util.SafeParseResult<core.output<T>>;
+
+export const _safeValidateOutput: (_Err: $ZodErrorClass) => $SafeValidateOutput = (_Err) => (schema, value, _ctx) => {
+  const ctx = _ctx
+    ? Object.assign(_ctx, { direction: "validate-output" as const })
+    : { direction: "validate-output" as const };
+  return _safeParse(_Err)(schema, value, ctx as any) as any;
+};
+
+export const safeValidateOutput: $SafeValidateOutput = /* @__PURE__*/ _safeValidateOutput(errors.$ZodRealError);
+
+export type $SafeValidateOutputAsync = <T extends schemas.$ZodType>(
+  schema: T,
+  value: core.output<T>,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>
+) => Promise<util.SafeParseResult<core.output<T>>>;
+
+export const _safeValidateOutputAsync: (_Err: $ZodErrorClass) => $SafeValidateOutputAsync =
+  (_Err) => async (schema, value, _ctx) => {
+    const ctx = _ctx
+      ? Object.assign(_ctx, { direction: "validate-output" as const })
+      : { direction: "validate-output" as const };
+    return _safeParseAsync(_Err)(schema, value, ctx as any) as any;
+  };
+
+export const safeValidateOutputAsync: $SafeValidateOutputAsync = /* @__PURE__*/ _safeValidateOutputAsync(
+  errors.$ZodRealError
+);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -27,7 +27,7 @@ export interface ParseContext<T extends errors.$ZodIssueBase = never> {
 /** @internal */
 export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> extends ParseContext<T> {
   readonly async?: boolean | undefined;
-  readonly direction?: "forward" | "backward";
+  readonly direction?: "forward" | "backward" | "validate-output";
   readonly skipChecks?: boolean;
 }
 
@@ -3922,6 +3922,9 @@ export const $ZodCodec: core.$constructor<$ZodCodec> = /*@__PURE__*/ core.$const
         return left.then((left) => handleCodecAResult(left, def, ctx));
       }
       return handleCodecAResult(left, def, ctx);
+    } else if (direction === "validate-output") {
+      // Validate-output: just validate against output schema without transformation
+      return def.out._zod.run(payload, ctx);
     } else {
       const right = def.out._zod.run(payload, ctx);
       if (right instanceof Promise) {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -27,7 +27,7 @@ export interface ParseContext<T extends errors.$ZodIssueBase = never> {
 /** @internal */
 export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> extends ParseContext<T> {
   readonly async?: boolean | undefined;
-  readonly direction?: "forward" | "backward";
+  readonly direction?: "forward" | "backward" | "validate-output";
   readonly skipChecks?: boolean;
 }
 
@@ -4085,6 +4085,9 @@ export const $ZodCodec: core.$constructor<$ZodCodec> = /*@__PURE__*/ core.$const
         return left.then((left) => handleCodecAResult(left, def, ctx));
       }
       return handleCodecAResult(left, def, ctx);
+    } else if (direction === "validate-output") {
+      // Validate-output: just validate against output schema without transformation
+      return def.out._zod.run(payload, ctx);
     } else {
       const right = def.out._zod.run(payload, ctx);
       if (right instanceof Promise) {

--- a/packages/zod/src/v4/mini/parse.ts
+++ b/packages/zod/src/v4/mini/parse.ts
@@ -11,4 +11,8 @@ export {
   safeDecode,
   safeEncodeAsync,
   safeDecodeAsync,
+  validateOutput,
+  validateOutputAsync,
+  safeValidateOutput,
+  safeValidateOutputAsync,
 } from "../core/index.js";

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -34,6 +34,16 @@ export interface ZodMiniType<
     data: unknown,
     params?: core.ParseContext<core.$ZodIssue>
   ): Promise<util.SafeParseResult<core.output<this>>>;
+  validateOutput(data: unknown, params?: core.ParseContext<core.$ZodIssue>): core.output<this>;
+  safeValidateOutput(
+    data: unknown,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): util.SafeParseResult<core.output<this>>;
+  validateOutputAsync(data: unknown, params?: core.ParseContext<core.$ZodIssue>): Promise<core.output<this>>;
+  safeValidateOutputAsync(
+    data: unknown,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): Promise<util.SafeParseResult<core.output<this>>>;
   apply<T>(fn: (schema: this) => T): T;
 }
 
@@ -53,6 +63,10 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
     inst.safeParse = (data, params) => parse.safeParse(inst, data, params);
     inst.parseAsync = async (data, params) => parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
     inst.safeParseAsync = async (data, params) => parse.safeParseAsync(inst, data, params);
+    inst.validateOutput = (data, params) => parse.validateOutput(inst, data, params);
+    inst.safeValidateOutput = (data, params) => parse.safeValidateOutput(inst, data, params);
+    inst.validateOutputAsync = async (data, params) => parse.validateOutputAsync(inst, data, params);
+    inst.safeValidateOutputAsync = async (data, params) => parse.safeValidateOutputAsync(inst, data, params);
     inst.check = (...checks) => {
       return inst.clone(
         {

--- a/packages/zod/src/v4/mini/tests/codec.test.ts
+++ b/packages/zod/src/v4/mini/tests/codec.test.ts
@@ -546,3 +546,298 @@ test("invertCodec", () => {
   const doubleInverted = z.invertCodec(z.invertCodec(isoDateCodec));
   expect(z.decode(doubleInverted, "2024-01-15T10:30:00.000Z")).toBeInstanceOf(Date);
 });
+
+test("validateOutput - valid output passes", () => {
+  // Create a codec: string -> number
+  const ageCodec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseInt(str, 10),
+    encode: (num) => num.toString(),
+  });
+
+  // Client submits data, form validates and transforms
+  const transformed = ageCodec.parse("30");
+  expect(transformed).toBe(30);
+
+  // Server re-validates the already-transformed data
+  const validated = ageCodec.validateOutput(transformed);
+  expect(validated).toBe(30);
+  expect(typeof validated).toBe("number");
+});
+
+test("validateOutput - invalid output throws", () => {
+  const ageCodec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseInt(str, 10),
+    encode: (num) => num.toString(),
+  });
+
+  // Check with refinement
+  const ageCodecWithCheck = ageCodec.check((v) => {
+    if (v.value < 0) v.issues.push({ code: "custom", message: "Must be non-negative", input: v.value });
+  });
+
+  // Invalid data: age is negative
+  expect(() => {
+    ageCodecWithCheck.validateOutput(-5);
+  }).toThrow();
+});
+
+test("validateOutput - validates against output schema not input", () => {
+  const codec = z.codec(
+    z.string(), // Input must be string
+    z.number(), // Output must be number
+    {
+      decode: (str) => Number.parseInt(str, 10),
+      encode: (num) => num.toString(),
+    }
+  );
+
+  const codecWithCheck = codec.check((v) => {
+    if (v.value < 0 || v.value > 100) {
+      v.issues.push({ code: "custom", message: "Must be between 0 and 100", input: v.value });
+    }
+  });
+
+  // Valid number should pass (validating output, not input)
+  const result = codecWithCheck.validateOutput(50);
+  expect(result).toBe(50);
+
+  // Invalid number should fail (outside range)
+  expect(() => codecWithCheck.validateOutput(150)).toThrow();
+
+  // String should fail (validateOutput expects output type = number)
+  expect(() => codec.validateOutput("50" as any)).toThrow();
+});
+
+test("safeValidateOutput - success case", () => {
+  const codec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseFloat(str),
+    encode: (num) => num.toString(),
+  });
+
+  const codecWithCheck = codec.check((v) => {
+    if (v.value < 0) v.issues.push({ code: "custom", message: "Must be at least 0", input: v.value });
+  });
+
+  const result = codecWithCheck.safeValidateOutput(42.5);
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.data).toBe(42.5);
+  }
+});
+
+test("safeValidateOutput - failure case", () => {
+  const codec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseFloat(str),
+    encode: (num) => num.toString(),
+  });
+
+  const codecWithCheck = codec.check((v) => {
+    if (v.value < 0) v.issues.push({ code: "custom", message: "Must be at least 0", input: v.value });
+  });
+
+  const result = codecWithCheck.safeValidateOutput(-10);
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "custom",
+          "message": "Must be at least 0",
+          "path": [],
+        },
+      ]
+    `);
+  }
+});
+
+test("validateOutputAsync - valid output", async () => {
+  const codec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseInt(str, 10),
+    encode: (num) => num.toString(),
+  });
+
+  const codecWithCheck = codec.check((v) => {
+    if (v.value < 0) v.issues.push({ code: "custom", message: "Must be non-negative", input: v.value });
+  });
+
+  const result = await codecWithCheck.validateOutputAsync(42);
+  expect(result).toBe(42);
+});
+
+test("validateOutputAsync - invalid output", async () => {
+  const codec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseInt(str, 10),
+    encode: (num) => num.toString(),
+  });
+
+  const codecWithCheck = codec.check((v) => {
+    if (v.value < 0) v.issues.push({ code: "custom", message: "Must be non-negative", input: v.value });
+  });
+
+  await expect(codecWithCheck.validateOutputAsync(-5)).rejects.toThrow();
+});
+
+test("safeValidateOutputAsync - success", async () => {
+  const codec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseFloat(str),
+    encode: (num) => num.toString(),
+  });
+
+  const codecWithCheck = codec.check((v) => {
+    if (v.value < 0) v.issues.push({ code: "custom", message: "Must be at least 0", input: v.value });
+  });
+
+  const result = await codecWithCheck.safeValidateOutputAsync(42.5);
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.data).toBe(42.5);
+  }
+});
+
+test("safeValidateOutputAsync - failure", async () => {
+  const codec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseFloat(str),
+    encode: (num) => num.toString(),
+  });
+
+  const codecWithCheck = codec.check((v) => {
+    if (v.value < 0) v.issues.push({ code: "custom", message: "Must be at least 0", input: v.value });
+  });
+
+  const result = await codecWithCheck.safeValidateOutputAsync(-10);
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "custom",
+          "message": "Must be at least 0",
+          "path": [],
+        },
+      ]
+    `);
+  }
+});
+
+test("validateOutput - complex form example", () => {
+  // Real-world example: form handling
+  const ageCodec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseInt(str, 10),
+    encode: (num) => num.toString(),
+  });
+
+  const ageCodecWithCheck = ageCodec.check((v) => {
+    if (v.value < 18 || v.value > 120) {
+      v.issues.push({ code: "custom", message: "Age must be between 18 and 120", input: v.value });
+    }
+  });
+
+  const salaryCodec = z.codec(z.string(), z.number(), {
+    decode: (str) => Number.parseFloat(str),
+    encode: (num) => num.toFixed(2),
+  });
+
+  const salaryCodecWithCheck = salaryCodec.check((v) => {
+    if (v.value < 0) v.issues.push({ code: "custom", message: "Salary must be non-negative", input: v.value });
+  });
+
+  const activeCodec = z.codec(z.enum(["true", "false"]), z.boolean(), {
+    decode: (str) => str === "true",
+    encode: (bool) => (bool ? "true" : "false"),
+  });
+
+  // Client-side: User submits form
+  const age = ageCodecWithCheck.parse("25");
+  const salary = salaryCodecWithCheck.parse("50000.00");
+  const active = activeCodec.parse("true");
+
+  expect(age).toBe(25);
+  expect(salary).toBe(50000);
+  expect(active).toBe(true);
+
+  // Server-side: Re-validate transformed data
+  const validatedAge = ageCodecWithCheck.validateOutput(age);
+  const validatedSalary = salaryCodecWithCheck.validateOutput(salary);
+  const validatedActive = activeCodec.validateOutput(active);
+
+  expect(validatedAge).toBe(25);
+  expect(validatedSalary).toBe(50000);
+  expect(validatedActive).toBe(true);
+
+  // Server-side: Invalid transformed data fails
+  expect(() => {
+    ageCodecWithCheck.validateOutput(15); // age < 18
+  }).toThrow();
+});
+
+test("schema.validateOutput() - method API works", () => {
+  const schema = z.codec(z.string().check(z.regex(/^\d+$/)), z.number().check(z.minimum(0)), {
+    decode: (str) => Number.parseInt(str, 10),
+    encode: (num) => num.toString(),
+  });
+  const formSchema = z.object({
+    num: schema,
+    name: z.string(),
+  });
+
+  // Valid output passes
+  const validated = formSchema.validateOutput({ num: 42, name: "Alice" });
+  expect(validated).toEqual({ num: 42, name: "Alice" });
+
+  // Invalid output throws
+  expect(() => formSchema.validateOutput({ num: -5, name: "Bob" })).toThrow();
+  expect(() => formSchema.validateOutput({ num: "42" as any, name: "Bob" })).toThrow();
+});
+
+test("schema.validateOutputAsync() - method API works", async () => {
+  const schema = z
+    .codec(z.string(), z.number(), {
+      decode: (str) => Number.parseInt(str, 10),
+      encode: (num) => num.toString(),
+    })
+    .check(
+      z.refine(async (val) => val >= 0, {
+        error: "Must be non-negative",
+      })
+    );
+  const formSchema = z.object({ value: schema });
+
+  const result = await formSchema.validateOutputAsync({ value: 42 });
+  expect(result).toEqual({ value: 42 });
+
+  await expect(formSchema.validateOutputAsync({ value: -5 })).rejects.toThrow();
+});
+
+test("schema.safeValidateOutput() - method API works", () => {
+  const schema = z.codec(z.string(), z.number().check(z.minimum(0)), {
+    decode: (str) => Number.parseFloat(str),
+    encode: (num) => num.toString(),
+  });
+  const formSchema = z.object({ value: schema });
+
+  const successResult = formSchema.safeValidateOutput({ value: 42.5 });
+  expect(successResult.success).toBe(true);
+  if (successResult.success) {
+    expect(successResult.data).toEqual({ value: 42.5 });
+  }
+
+  const failResult = formSchema.safeValidateOutput({ value: -10 });
+  expect(failResult.success).toBe(false);
+});
+
+test("schema.safeValidateOutputAsync() - method API works", async () => {
+  const schema = z.codec(z.string(), z.number().check(z.minimum(0)), {
+    decode: (str) => Number.parseFloat(str),
+    encode: (num) => num.toString(),
+  });
+  const formSchema = z.object({ value: schema });
+
+  const successResult = await formSchema.safeValidateOutputAsync({ value: 42.5 });
+  expect(successResult.success).toBe(true);
+  if (successResult.success) {
+    expect(successResult.data).toEqual({ value: 42.5 });
+  }
+
+  const failResult = await formSchema.safeValidateOutputAsync({ value: -10 });
+  expect(failResult.success).toBe(false);
+});


### PR DESCRIPTION
fixes #5377

This PR implements four extra functions on the schema object. It validates an object based out the Output types of a codec in a schema. This is useful for something like react-hook-form, that validates client-side, then transmits the already transformed data to the server, where these functions will `validateOutput` of the codecs.

This code was written in concert with Copilot. It is working for me in production (working with Temporal and Temporal strings, that can't be passed between the server and client without converting to a string).

For example, consider the following:

```typescript
const schema = z.object({
  num: z.codec(z.string().regex(z.regexes.integer), z.int(), {
    decode: (str) => Number.parseInt(str, 10),
    encode: (num) => num.toString(),
  })
});
```

- On the server, a function gets `value` from a database.
- The `value` is a number, but maybe numbers are difficult to work with in forms, so we `schema.encode(42)` => `"42"`
- The `value`, now a string, is sent to the form for manipulation.
- The form uses a `zodResolver(schema)`, which, on submit decodes the data. `"42"` => `42`.
- The `value`, now back on the server, is back to a number.
- Before database entry, we want to make sure the value wasn't changed on the wire.
  - `schema.decode(42)` doesn't work, because decode will only work on a `z.string().regex(z.regexes.integer)`. (see codec)
  - `schema.validateOutput(42)` will work, because it's pulling the output of the codec (`z.int()`) (see codec)
- `value`, now validated correctly as a number, can be safely inserted into the database

Improvements:
- validateInput?
- Better function names? (reparse)
- Could this be some type of plugin, or maybe another way to pull the input/output of a schema into another schema? (`const validator = schema.codecOutput();` => `validator = z.object({num: z.int()})`?

The code itself is actually pretty minimal. I was surprised it took so little. The majority is for tests.

Thank you for considering