### PR TITLE
docs: add note about removed `.errors` alias in v4 changelog

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -256,6 +256,10 @@ The `.flatten()` method on `ZodError` has also been deprecated. Instead use the 
 
 This API was identical to `.flatten()`. It exists for historical reasons and isn't documented.
 
+### drops `.errors`
+
+This API was an alias for `issues` in Zod v3 but has been removed. Use `.issues` instead.
+
 ### deprecates `.addIssue()` and `.addIssues()`
 
 Directly push to `err.issues` array instead, if necessary.

--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -258,7 +258,7 @@ This API was identical to `.flatten()`. It exists for historical reasons and isn
 
 ### drops `.errors`
 
-This API was an alias for `issues` in Zod v3 but has been removed. Use `.issues` instead.
+This API was an alias for `.issues` in Zod v3 but has been removed. Use `.issues` instead.
 
 ### deprecates `.addIssue()` and `.addIssues()`
 


### PR DESCRIPTION
follow-up https://github.com/colinhacks/zod/issues/5063

Add the migration guide entry for the removal of `.errors` alias in v4 (use `.issues` instead)