### PR TITLE
fix(v4): treeify error nested union bug

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -80,7 +80,10 @@ test(".flatten()", () => {
 
 test("custom .flatten()", () => {
   type ErrorType = { message: string; code: number };
-  const flattened = parsed.error!.flatten((iss) => ({ message: iss.message, code: 1234 }));
+  const flattened = parsed.error!.flatten((iss) => ({
+    message: iss.message,
+    code: 1234,
+  }));
   expectTypeOf(flattened).toMatchTypeOf<{
     formErrors: ErrorType[];
     fieldErrors: {
@@ -160,7 +163,10 @@ test(".format()", () => {
 
 test("custom .format()", () => {
   type ErrorType = { message: string; code: number };
-  const formatted = parsed.error!.format((iss) => ({ message: iss.message, code: 1234 }));
+  const formatted = parsed.error!.format((iss) => ({
+    message: iss.message,
+    code: 1234,
+  }));
   expectTypeOf(formatted).toMatchTypeOf<{
     _errors: ErrorType[];
     f2?: { _errors: ErrorType[] };
@@ -219,7 +225,7 @@ test("all errors", () => {
       (val) => {
         return val.a === val.b;
       },
-      { message: "Must be equal" }
+      { message: "Must be equal" },
     );
 
   const r1 = schema.safeParse({
@@ -252,7 +258,8 @@ test("all errors", () => {
     }
   `);
 
-  expect(z.core.flattenError(r2.error!, (iss) => iss.message.toUpperCase())).toMatchInlineSnapshot(`
+  expect(z.core.flattenError(r2.error!, (iss) => iss.message.toUpperCase()))
+    .toMatchInlineSnapshot(`
     {
       "fieldErrors": {
         "a": [
@@ -267,7 +274,8 @@ test("all errors", () => {
   `);
   // Test identity
 
-  expect(z.core.flattenError(r2.error!, (i: z.ZodIssue) => i)).toMatchInlineSnapshot(`
+  expect(z.core.flattenError(r2.error!, (i: z.ZodIssue) => i))
+    .toMatchInlineSnapshot(`
     {
       "fieldErrors": {
         "a": [
@@ -296,7 +304,10 @@ test("all errors", () => {
   `);
 
   // Test mapping
-  const f1 = z.core.flattenError(r2.error!, (i: z.ZodIssue) => i.message.length);
+  const f1 = z.core.flattenError(
+    r2.error!,
+    (i: z.ZodIssue) => i.message.length,
+  );
   expect(f1).toMatchInlineSnapshot(`
     {
       "fieldErrors": {
@@ -454,39 +465,51 @@ test("z.prettifyError", () => {
 });
 
 test("z.toDotPath", () => {
-  expect(z.core.toDotPath(["a", "b", 0, "c"])).toMatchInlineSnapshot(`"a.b[0].c"`);
+  expect(z.core.toDotPath(["a", "b", 0, "c"])).toMatchInlineSnapshot(
+    `"a.b[0].c"`,
+  );
 
-  expect(z.core.toDotPath(["a", Symbol("b"), 0, "c"])).toMatchInlineSnapshot(`"a["Symbol(b)"][0].c"`);
+  expect(z.core.toDotPath(["a", Symbol("b"), 0, "c"])).toMatchInlineSnapshot(
+    `"a["Symbol(b)"][0].c"`,
+  );
 
   // Test with periods in keys
-  expect(z.core.toDotPath(["user.name", "first.last"])).toMatchInlineSnapshot(`"["user.name"]["first.last"]"`);
+  expect(z.core.toDotPath(["user.name", "first.last"])).toMatchInlineSnapshot(
+    `"["user.name"]["first.last"]"`,
+  );
 
   // Test with special characters
-  expect(z.core.toDotPath(["user", "$special", Symbol("#symbol")])).toMatchInlineSnapshot(
-    `"user.$special["Symbol(#symbol)"]"`
-  );
+  expect(
+    z.core.toDotPath(["user", "$special", Symbol("#symbol")]),
+  ).toMatchInlineSnapshot(`"user.$special["Symbol(#symbol)"]"`);
 
   // Test with dots and quotes
-  expect(z.core.toDotPath(["search", `query("foo.bar"="abc")`])).toMatchInlineSnapshot(
-    `"search["query(\\"foo.bar\\"=\\"abc\\")"]"`
-  );
+  expect(
+    z.core.toDotPath(["search", `query("foo.bar"="abc")`]),
+  ).toMatchInlineSnapshot(`"search["query(\\"foo.bar\\"=\\"abc\\")"]"`);
 
   // Test with newlines
-  expect(z.core.toDotPath(["search", `foo\nbar`])).toMatchInlineSnapshot(`"search["foo\\nbar"]"`);
+  expect(z.core.toDotPath(["search", `foo\nbar`])).toMatchInlineSnapshot(
+    `"search["foo\\nbar"]"`,
+  );
 
   // Test with empty strings
   expect(z.core.toDotPath(["", "empty"])).toMatchInlineSnapshot(`".empty"`);
 
   // Test with array indices
-  expect(z.core.toDotPath(["items", 0, 1, 2])).toMatchInlineSnapshot(`"items[0][1][2]"`);
-
-  // Test with mixed path elements
-  expect(z.core.toDotPath(["users", "user.config", 0, "settings.theme"])).toMatchInlineSnapshot(
-    `"users["user.config"][0]["settings.theme"]"`
+  expect(z.core.toDotPath(["items", 0, 1, 2])).toMatchInlineSnapshot(
+    `"items[0][1][2]"`,
   );
 
+  // Test with mixed path elements
+  expect(
+    z.core.toDotPath(["users", "user.config", 0, "settings.theme"]),
+  ).toMatchInlineSnapshot(`"users["user.config"][0]["settings.theme"]"`);
+
   // Test with square brackets in keys
-  expect(z.core.toDotPath(["data[0]", "value"])).toMatchInlineSnapshot(`"["data[0]"].value"`);
+  expect(z.core.toDotPath(["data[0]", "value"])).toMatchInlineSnapshot(
+    `"["data[0]"].value"`,
+  );
 
   // Test with empty path
   expect(z.core.toDotPath([])).toMatchInlineSnapshot(`""`);
@@ -519,7 +542,7 @@ test("disc union treeify/format", () => {
     ],
     {
       error: "Invalid discriminator",
-    }
+    },
   );
 
   const error = schema.safeParse({ foo: "invalid" }).error;
@@ -592,4 +615,159 @@ test("update message after adding issues", () => {
       }
     ]"
   `);
+});
+
+test("z.treeifyError nested union preserves parent path", () => {
+  // When a nested invalid_union appears inside another invalid_union,
+  // the inner errors must stay nested under their parent path, not flatten to root.
+  const syntheticError = new z.ZodError([
+    {
+      code: "invalid_union",
+      path: ["parent"],
+      message: "Invalid input",
+      errors: [
+        [
+          {
+            code: "invalid_type",
+            expected: "string",
+            path: [],
+            message: "Expected string",
+            input: {},
+          },
+        ],
+        [
+          {
+            code: "invalid_union",
+            path: ["child"],
+            message: "Invalid input",
+            errors: [
+              [
+                {
+                  code: "invalid_type",
+                  expected: "string",
+                  path: [],
+                  message: "Expected string",
+                  input: true,
+                },
+              ],
+              [
+                {
+                  code: "invalid_type",
+                  expected: "number",
+                  path: [],
+                  message: "Expected number",
+                  input: true,
+                },
+              ],
+            ],
+          },
+        ],
+      ],
+    },
+  ] as any);
+
+  const tree: any = z.treeifyError(syntheticError);
+
+  // "child" must be nested under "parent", not at root
+  expect(tree.properties).not.toHaveProperty("child");
+  expect(tree.properties).toHaveProperty("parent");
+  expect(tree.properties.parent.properties).toHaveProperty("child");
+  expect(tree.properties.parent.properties.child.errors).toContain(
+    "Expected string",
+  );
+  expect(tree.properties.parent.properties.child.errors).toContain(
+    "Expected number",
+  );
+  expect(tree.properties.parent.errors).toContain("Expected string");
+});
+
+test("z.treeifyError deeply nested union (4 levels) preserves full path", () => {
+  // a > b > c > d — each level wrapped in an invalid_union
+  const syntheticError = new z.ZodError([
+    {
+      code: "invalid_union",
+      path: ["a"],
+      message: "Invalid input",
+      errors: [
+        [
+          {
+            code: "invalid_union",
+            path: ["b"],
+            message: "Invalid input",
+            errors: [
+              [
+                {
+                  code: "invalid_union",
+                  path: ["c"],
+                  message: "Invalid input",
+                  errors: [
+                    [
+                      {
+                        code: "invalid_type",
+                        expected: "string",
+                        path: ["d"],
+                        message: "Expected string",
+                        input: 123,
+                      },
+                    ],
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+      ],
+    },
+  ] as any);
+
+  const tree: any = z.treeifyError(syntheticError);
+
+  // The full path must be preserved: a.b.c.d
+  expect(tree.properties).toHaveProperty("a");
+  expect(tree.properties).not.toHaveProperty("b");
+  expect(tree.properties).not.toHaveProperty("c");
+
+  const lvlA = tree.properties.a;
+  expect(lvlA.properties).toHaveProperty("b");
+
+  const lvlB = lvlA.properties.b;
+  expect(lvlB.properties).toHaveProperty("c");
+
+  const lvlC = lvlB.properties.c;
+  expect(lvlC.properties).toHaveProperty("d");
+  expect(lvlC.properties.d.errors).toContain("Expected string");
+});
+
+test("z.treeifyError nested union with real schema", () => {
+  const innerUnion = z.union([
+    z.object({ type: z.literal("a"), value: z.string() }),
+    z.object({ type: z.literal("b"), value: z.number() }),
+  ]);
+
+  const schema = z.string().or(
+    z.object({
+      settings: z.object({ name: z.string() }).and(innerUnion),
+    }),
+  );
+
+  const result = schema.safeParse({
+    settings: { name: 123, type: "x", value: true },
+  });
+
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const tree: any = z.treeifyError(result.error);
+
+    // All settings-related errors should be under "settings", not at root
+    if (tree.properties?.settings) {
+      for (const key of Object.keys(
+        tree.properties.settings.properties ?? {},
+      )) {
+        // Every sub-property under settings should NOT also appear at root
+        if (key !== "settings") {
+          expect(tree.properties).not.toHaveProperty(key);
+        }
+      }
+    }
+  }
 });

--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -600,6 +600,64 @@ test("update message after adding issues", () => {
   `);
 });
 
+test("z.formatError nested union preserves parent path", () => {
+  const syntheticError = new z.ZodError([
+    {
+      code: "invalid_union",
+      path: ["parent"],
+      message: "Invalid input",
+      errors: [
+        [
+          {
+            code: "invalid_type",
+            expected: "string",
+            path: [],
+            message: "Expected string",
+            input: {},
+          },
+        ],
+        [
+          {
+            code: "invalid_union",
+            path: ["child"],
+            message: "Invalid input",
+            errors: [
+              [
+                {
+                  code: "invalid_type",
+                  expected: "string",
+                  path: [],
+                  message: "Expected string",
+                  input: true,
+                },
+              ],
+              [
+                {
+                  code: "invalid_type",
+                  expected: "number",
+                  path: [],
+                  message: "Expected number",
+                  input: true,
+                },
+              ],
+            ],
+          },
+        ],
+      ],
+    },
+  ] as any);
+
+  const formatted: any = z.formatError(syntheticError);
+
+  // "child" must be nested under "parent", not at root
+  expect(formatted).not.toHaveProperty("child");
+  expect(formatted).toHaveProperty("parent");
+  expect(formatted.parent).toHaveProperty("child");
+  expect(formatted.parent.child._errors).toContain("Expected string");
+  expect(formatted.parent.child._errors).toContain("Expected number");
+  expect(formatted.parent._errors).toContain("Expected string");
+});
+
 test("z.treeifyError nested union preserves parent path", () => {
   // When a nested invalid_union appears inside another invalid_union,
   // the inner errors must stay nested under their parent path, not flatten to root.

--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -225,7 +225,7 @@ test("all errors", () => {
       (val) => {
         return val.a === val.b;
       },
-      { message: "Must be equal" },
+      { message: "Must be equal" }
     );
 
   const r1 = schema.safeParse({
@@ -258,8 +258,7 @@ test("all errors", () => {
     }
   `);
 
-  expect(z.core.flattenError(r2.error!, (iss) => iss.message.toUpperCase()))
-    .toMatchInlineSnapshot(`
+  expect(z.core.flattenError(r2.error!, (iss) => iss.message.toUpperCase())).toMatchInlineSnapshot(`
     {
       "fieldErrors": {
         "a": [
@@ -274,8 +273,7 @@ test("all errors", () => {
   `);
   // Test identity
 
-  expect(z.core.flattenError(r2.error!, (i: z.ZodIssue) => i))
-    .toMatchInlineSnapshot(`
+  expect(z.core.flattenError(r2.error!, (i: z.ZodIssue) => i)).toMatchInlineSnapshot(`
     {
       "fieldErrors": {
         "a": [
@@ -304,10 +302,7 @@ test("all errors", () => {
   `);
 
   // Test mapping
-  const f1 = z.core.flattenError(
-    r2.error!,
-    (i: z.ZodIssue) => i.message.length,
-  );
+  const f1 = z.core.flattenError(r2.error!, (i: z.ZodIssue) => i.message.length);
   expect(f1).toMatchInlineSnapshot(`
     {
       "fieldErrors": {
@@ -465,51 +460,39 @@ test("z.prettifyError", () => {
 });
 
 test("z.toDotPath", () => {
-  expect(z.core.toDotPath(["a", "b", 0, "c"])).toMatchInlineSnapshot(
-    `"a.b[0].c"`,
-  );
+  expect(z.core.toDotPath(["a", "b", 0, "c"])).toMatchInlineSnapshot(`"a.b[0].c"`);
 
-  expect(z.core.toDotPath(["a", Symbol("b"), 0, "c"])).toMatchInlineSnapshot(
-    `"a["Symbol(b)"][0].c"`,
-  );
+  expect(z.core.toDotPath(["a", Symbol("b"), 0, "c"])).toMatchInlineSnapshot(`"a["Symbol(b)"][0].c"`);
 
   // Test with periods in keys
-  expect(z.core.toDotPath(["user.name", "first.last"])).toMatchInlineSnapshot(
-    `"["user.name"]["first.last"]"`,
-  );
+  expect(z.core.toDotPath(["user.name", "first.last"])).toMatchInlineSnapshot(`"["user.name"]["first.last"]"`);
 
   // Test with special characters
-  expect(
-    z.core.toDotPath(["user", "$special", Symbol("#symbol")]),
-  ).toMatchInlineSnapshot(`"user.$special["Symbol(#symbol)"]"`);
+  expect(z.core.toDotPath(["user", "$special", Symbol("#symbol")])).toMatchInlineSnapshot(
+    `"user.$special["Symbol(#symbol)"]"`
+  );
 
   // Test with dots and quotes
-  expect(
-    z.core.toDotPath(["search", `query("foo.bar"="abc")`]),
-  ).toMatchInlineSnapshot(`"search["query(\\"foo.bar\\"=\\"abc\\")"]"`);
+  expect(z.core.toDotPath(["search", `query("foo.bar"="abc")`])).toMatchInlineSnapshot(
+    `"search["query(\\"foo.bar\\"=\\"abc\\")"]"`
+  );
 
   // Test with newlines
-  expect(z.core.toDotPath(["search", `foo\nbar`])).toMatchInlineSnapshot(
-    `"search["foo\\nbar"]"`,
-  );
+  expect(z.core.toDotPath(["search", `foo\nbar`])).toMatchInlineSnapshot(`"search["foo\\nbar"]"`);
 
   // Test with empty strings
   expect(z.core.toDotPath(["", "empty"])).toMatchInlineSnapshot(`".empty"`);
 
   // Test with array indices
-  expect(z.core.toDotPath(["items", 0, 1, 2])).toMatchInlineSnapshot(
-    `"items[0][1][2]"`,
-  );
+  expect(z.core.toDotPath(["items", 0, 1, 2])).toMatchInlineSnapshot(`"items[0][1][2]"`);
 
   // Test with mixed path elements
-  expect(
-    z.core.toDotPath(["users", "user.config", 0, "settings.theme"]),
-  ).toMatchInlineSnapshot(`"users["user.config"][0]["settings.theme"]"`);
+  expect(z.core.toDotPath(["users", "user.config", 0, "settings.theme"])).toMatchInlineSnapshot(
+    `"users["user.config"][0]["settings.theme"]"`
+  );
 
   // Test with square brackets in keys
-  expect(z.core.toDotPath(["data[0]", "value"])).toMatchInlineSnapshot(
-    `"["data[0]"].value"`,
-  );
+  expect(z.core.toDotPath(["data[0]", "value"])).toMatchInlineSnapshot(`"["data[0]"].value"`);
 
   // Test with empty path
   expect(z.core.toDotPath([])).toMatchInlineSnapshot(`""`);
@@ -542,7 +525,7 @@ test("disc union treeify/format", () => {
     ],
     {
       error: "Invalid discriminator",
-    },
+    }
   );
 
   const error = schema.safeParse({ foo: "invalid" }).error;
@@ -672,12 +655,8 @@ test("z.treeifyError nested union preserves parent path", () => {
   expect(tree.properties).not.toHaveProperty("child");
   expect(tree.properties).toHaveProperty("parent");
   expect(tree.properties.parent.properties).toHaveProperty("child");
-  expect(tree.properties.parent.properties.child.errors).toContain(
-    "Expected string",
-  );
-  expect(tree.properties.parent.properties.child.errors).toContain(
-    "Expected number",
-  );
+  expect(tree.properties.parent.properties.child.errors).toContain("Expected string");
+  expect(tree.properties.parent.properties.child.errors).toContain("Expected number");
   expect(tree.properties.parent.errors).toContain("Expected string");
 });
 
@@ -747,7 +726,7 @@ test("z.treeifyError nested union with real schema", () => {
   const schema = z.string().or(
     z.object({
       settings: z.object({ name: z.string() }).and(innerUnion),
-    }),
+    })
   );
 
   const result = schema.safeParse({
@@ -760,9 +739,7 @@ test("z.treeifyError nested union with real schema", () => {
 
     // All settings-related errors should be under "settings", not at root
     if (tree.properties?.settings) {
-      for (const key of Object.keys(
-        tree.properties.settings.properties ?? {},
-      )) {
+      for (const key of Object.keys(tree.properties.settings.properties ?? {})) {
         // Every sub-property under settings should NOT also appear at root
         if (key !== "settings") {
           expect(tree.properties).not.toHaveProperty(key);

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -49,7 +49,16 @@ export interface $ZodIssueInvalidType<Input = unknown> extends $ZodIssueBase {
 
 export interface $ZodIssueTooBig<Input = unknown> extends $ZodIssueBase {
   readonly code: "too_big";
-  readonly origin: "number" | "int" | "bigint" | "date" | "string" | "array" | "set" | "file" | (string & {});
+  readonly origin:
+    | "number"
+    | "int"
+    | "bigint"
+    | "date"
+    | "string"
+    | "array"
+    | "set"
+    | "file"
+    | (string & {});
   readonly maximum: number | bigint;
   readonly inclusive?: boolean;
   readonly exact?: boolean;
@@ -58,7 +67,16 @@ export interface $ZodIssueTooBig<Input = unknown> extends $ZodIssueBase {
 
 export interface $ZodIssueTooSmall<Input = unknown> extends $ZodIssueBase {
   readonly code: "too_small";
-  readonly origin: "number" | "int" | "bigint" | "date" | "string" | "array" | "set" | "file" | (string & {});
+  readonly origin:
+    | "number"
+    | "int"
+    | "bigint"
+    | "date"
+    | "string"
+    | "array"
+    | "set"
+    | "file"
+    | (string & {});
   readonly minimum: number | bigint;
   /** True if the allowable range includes the minimum */
   readonly inclusive?: boolean;
@@ -74,7 +92,9 @@ export interface $ZodIssueInvalidStringFormat extends $ZodIssueBase {
   readonly input?: string;
 }
 
-export interface $ZodIssueNotMultipleOf<Input extends number | bigint = number | bigint> extends $ZodIssueBase {
+export interface $ZodIssueNotMultipleOf<
+  Input extends number | bigint = number | bigint,
+> extends $ZodIssueBase {
   readonly code: "not_multiple_of";
   readonly divisor: number;
   readonly input?: Input;
@@ -102,7 +122,9 @@ interface $ZodIssueInvalidUnionMultipleMatch extends $ZodIssueBase {
   readonly inclusive: false;
 }
 
-export type $ZodIssueInvalidUnion = $ZodIssueInvalidUnionNoMatch | $ZodIssueInvalidUnionMultipleMatch;
+export type $ZodIssueInvalidUnion =
+  | $ZodIssueInvalidUnionNoMatch
+  | $ZodIssueInvalidUnionMultipleMatch;
 
 export interface $ZodIssueInvalidKey<Input = unknown> extends $ZodIssueBase {
   readonly code: "invalid_key";
@@ -111,7 +133,9 @@ export interface $ZodIssueInvalidKey<Input = unknown> extends $ZodIssueBase {
   readonly input?: Input;
 }
 
-export interface $ZodIssueInvalidElement<Input = unknown> extends $ZodIssueBase {
+export interface $ZodIssueInvalidElement<
+  Input = unknown,
+> extends $ZodIssueBase {
   readonly code: "invalid_element";
   readonly origin: "map" | "set";
   readonly key: unknown;
@@ -136,7 +160,10 @@ export interface $ZodIssueCustom extends $ZodIssueBase {
 ////////////////////////////////////////////
 
 export interface $ZodIssueStringCommonFormats extends $ZodIssueInvalidStringFormat {
-  format: Exclude<$ZodStringFormats, "regex" | "jwt" | "starts_with" | "ends_with" | "includes">;
+  format: Exclude<
+    $ZodStringFormats,
+    "regex" | "jwt" | "starts_with" | "ends_with" | "includes"
+  >;
 }
 
 export interface $ZodIssueStringInvalidRegex extends $ZodIssueInvalidStringFormat {
@@ -191,7 +218,8 @@ export type $ZodIssue =
 
 export type $ZodIssueCode = $ZodIssue["code"];
 
-export type $ZodInternalIssue<T extends $ZodIssueBase = $ZodIssue> = T extends any ? RawIssue<T> : never;
+export type $ZodInternalIssue<T extends $ZodIssueBase = $ZodIssue> =
+  T extends any ? RawIssue<T> : never;
 type RawIssue<T extends $ZodIssueBase> = T extends any
   ? util.Flatten<
       util.MakePartial<T, "message" | "path"> & {
@@ -205,7 +233,8 @@ type RawIssue<T extends $ZodIssueBase> = T extends any
     >
   : never;
 
-export type $ZodRawIssue<T extends $ZodIssueBase = $ZodIssue> = $ZodInternalIssue<T>;
+export type $ZodRawIssue<T extends $ZodIssueBase = $ZodIssue> =
+  $ZodInternalIssue<T>;
 
 export interface $ZodErrorMap<T extends $ZodIssueBase = $ZodIssue> {
   // biome-ignore lint:
@@ -244,9 +273,16 @@ const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
   });
 };
 
-export const $ZodError: $constructor<$ZodError> = $constructor("$ZodError", initializer);
+export const $ZodError: $constructor<$ZodError> = $constructor(
+  "$ZodError",
+  initializer,
+);
 interface $ZodRealError<T = any> extends $ZodError<T> {}
-export const $ZodRealError: $constructor<$ZodRealError> = $constructor("$ZodError", initializer, { Parent: Error });
+export const $ZodRealError: $constructor<$ZodRealError> = $constructor(
+  "$ZodError",
+  initializer,
+  { Parent: Error },
+);
 
 ///////////////////    ERROR UTILITIES   ////////////////////////
 
@@ -260,8 +296,14 @@ type _FlattenedError<T, U = string> = {
 };
 
 export function flattenError<T>(error: $ZodError<T>): _FlattenedError<T>;
-export function flattenError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): _FlattenedError<T, U>;
-export function flattenError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
+export function flattenError<T, U>(
+  error: $ZodError<T>,
+  mapper?: (issue: $ZodIssue) => U,
+): _FlattenedError<T, U>;
+export function flattenError<T, U>(
+  error: $ZodError<T>,
+  mapper = (issue: $ZodIssue) => issue.message as U,
+) {
   const fieldErrors: Record<PropertyKey, any> = {};
   const formErrors: U[] = [];
   for (const sub of error.issues) {
@@ -288,8 +330,14 @@ export type $ZodFormattedError<T, U = string> = {
 } & util.Flatten<_ZodFormattedError<T, U>>;
 
 export function formatError<T>(error: $ZodError<T>): $ZodFormattedError<T>;
-export function formatError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodFormattedError<T, U>;
-export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
+export function formatError<T, U>(
+  error: $ZodError<T>,
+  mapper?: (issue: $ZodIssue) => U,
+): $ZodFormattedError<T, U>;
+export function formatError<T, U>(
+  error: $ZodError<T>,
+  mapper = (issue: $ZodIssue) => issue.message as U,
+) {
   const fieldErrors: $ZodFormattedError<T> = { _errors: [] } as any;
   const processError = (error: { issues: $ZodIssue[] }) => {
     for (const issue of error.issues) {
@@ -332,22 +380,36 @@ export type $ZodErrorTree<T, U = string> = T extends util.Primitive
     : T extends any[]
       ? { errors: U[]; items?: Array<$ZodErrorTree<T[number], U>> }
       : T extends object
-        ? { errors: U[]; properties?: { [K in keyof T]?: $ZodErrorTree<T[K], U> } }
+        ? {
+            errors: U[];
+            properties?: { [K in keyof T]?: $ZodErrorTree<T[K], U> };
+          }
         : { errors: U[] };
 
 export function treeifyError<T>(error: $ZodError<T>): $ZodErrorTree<T>;
-export function treeifyError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodErrorTree<T, U>;
-export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
+export function treeifyError<T, U>(
+  error: $ZodError<T>,
+  mapper?: (issue: $ZodIssue) => U,
+): $ZodErrorTree<T, U>;
+export function treeifyError<T, U>(
+  error: $ZodError<T>,
+  mapper = (issue: $ZodIssue) => issue.message as U,
+) {
   const result: $ZodErrorTree<T, U> = { errors: [] } as any;
-  const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
+  const processError = (
+    error: { issues: $ZodIssue[] },
+    path: PropertyKey[] = [],
+  ) => {
     for (const issue of error.issues) {
       if (issue.code === "invalid_union" && issue.errors.length) {
         // regular union error
-        issue.errors.map((issues) => processError({ issues }, issue.path));
+        issue.errors.map((issues) =>
+          processError({ issues }, [...path, ...issue.path]),
+        );
       } else if (issue.code === "invalid_key") {
-        processError({ issues: issue.issues }, issue.path);
+        processError({ issues: issue.issues }, [...path, ...issue.path]);
       } else if (issue.code === "invalid_element") {
-        processError({ issues: issue.issues }, issue.path);
+        processError({ issues: issue.issues }, [...path, ...issue.path]);
       } else {
         const fullpath = [...path, ...issue.path];
         if (fullpath.length === 0) {
@@ -416,12 +478,17 @@ export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIss
  *   ✖ Invalid input: expected number
  * ```
  */
-export function toDotPath(_path: readonly (string | number | symbol | StandardSchemaV1.PathSegment)[]): string {
+export function toDotPath(
+  _path: readonly (string | number | symbol | StandardSchemaV1.PathSegment)[],
+): string {
   const segs: string[] = [];
-  const path: PropertyKey[] = _path.map((seg: any) => (typeof seg === "object" ? seg.key : seg));
+  const path: PropertyKey[] = _path.map((seg: any) =>
+    typeof seg === "object" ? seg.key : seg,
+  );
   for (const seg of path) {
     if (typeof seg === "number") segs.push(`[${seg}]`);
-    else if (typeof seg === "symbol") segs.push(`[${JSON.stringify(String(seg))}]`);
+    else if (typeof seg === "symbol")
+      segs.push(`[${JSON.stringify(String(seg))}]`);
     else if (/[^\w$]/.test(seg)) segs.push(`[${JSON.stringify(seg)}]`);
     else {
       if (segs.length) segs.push(".");
@@ -435,7 +502,9 @@ export function toDotPath(_path: readonly (string | number | symbol | StandardSc
 export function prettifyError(error: StandardSchemaV1.FailureResult): string {
   const lines: string[] = [];
   // sort by path length
-  const issues = [...error.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
+  const issues = [...error.issues].sort(
+    (a, b) => (a.path ?? []).length - (b.path ?? []).length,
+  );
 
   // Process each issue
   for (const issue of issues) {

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -291,32 +291,35 @@ export function formatError<T>(error: $ZodError<T>): $ZodFormattedError<T>;
 export function formatError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodFormattedError<T, U>;
 export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
   const fieldErrors: $ZodFormattedError<T> = { _errors: [] } as any;
-  const processError = (error: { issues: $ZodIssue[] }) => {
+  const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
     for (const issue of error.issues) {
       if (issue.code === "invalid_union" && issue.errors.length) {
-        issue.errors.map((issues) => processError({ issues }));
+        issue.errors.map((issues) => processError({ issues }, [...path, ...issue.path]));
       } else if (issue.code === "invalid_key") {
-        processError({ issues: issue.issues });
+        processError({ issues: issue.issues }, [...path, ...issue.path]);
       } else if (issue.code === "invalid_element") {
-        processError({ issues: issue.issues });
-      } else if (issue.path.length === 0) {
-        (fieldErrors as any)._errors.push(mapper(issue));
+        processError({ issues: issue.issues }, [...path, ...issue.path]);
       } else {
-        let curr: any = fieldErrors;
-        let i = 0;
-        while (i < issue.path.length) {
-          const el = issue.path[i]!;
-          const terminal = i === issue.path.length - 1;
+        const fullpath = [...path, ...issue.path];
+        if (fullpath.length === 0) {
+          (fieldErrors as any)._errors.push(mapper(issue));
+        } else {
+          let curr: any = fieldErrors;
+          let i = 0;
+          while (i < fullpath.length) {
+            const el = fullpath[i]!;
+            const terminal = i === fullpath.length - 1;
 
-          if (!terminal) {
-            curr[el] = curr[el] || { _errors: [] };
-          } else {
-            curr[el] = curr[el] || { _errors: [] };
-            curr[el]._errors.push(mapper(issue));
+            if (!terminal) {
+              curr[el] = curr[el] || { _errors: [] };
+            } else {
+              curr[el] = curr[el] || { _errors: [] };
+              curr[el]._errors.push(mapper(issue));
+            }
+
+            curr = curr[el];
+            i++;
           }
-
-          curr = curr[el];
-          i++;
         }
       }
     }

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -49,16 +49,7 @@ export interface $ZodIssueInvalidType<Input = unknown> extends $ZodIssueBase {
 
 export interface $ZodIssueTooBig<Input = unknown> extends $ZodIssueBase {
   readonly code: "too_big";
-  readonly origin:
-    | "number"
-    | "int"
-    | "bigint"
-    | "date"
-    | "string"
-    | "array"
-    | "set"
-    | "file"
-    | (string & {});
+  readonly origin: "number" | "int" | "bigint" | "date" | "string" | "array" | "set" | "file" | (string & {});
   readonly maximum: number | bigint;
   readonly inclusive?: boolean;
   readonly exact?: boolean;
@@ -67,16 +58,7 @@ export interface $ZodIssueTooBig<Input = unknown> extends $ZodIssueBase {
 
 export interface $ZodIssueTooSmall<Input = unknown> extends $ZodIssueBase {
   readonly code: "too_small";
-  readonly origin:
-    | "number"
-    | "int"
-    | "bigint"
-    | "date"
-    | "string"
-    | "array"
-    | "set"
-    | "file"
-    | (string & {});
+  readonly origin: "number" | "int" | "bigint" | "date" | "string" | "array" | "set" | "file" | (string & {});
   readonly minimum: number | bigint;
   /** True if the allowable range includes the minimum */
   readonly inclusive?: boolean;
@@ -92,9 +74,7 @@ export interface $ZodIssueInvalidStringFormat extends $ZodIssueBase {
   readonly input?: string;
 }
 
-export interface $ZodIssueNotMultipleOf<
-  Input extends number | bigint = number | bigint,
-> extends $ZodIssueBase {
+export interface $ZodIssueNotMultipleOf<Input extends number | bigint = number | bigint> extends $ZodIssueBase {
   readonly code: "not_multiple_of";
   readonly divisor: number;
   readonly input?: Input;
@@ -122,9 +102,7 @@ interface $ZodIssueInvalidUnionMultipleMatch extends $ZodIssueBase {
   readonly inclusive: false;
 }
 
-export type $ZodIssueInvalidUnion =
-  | $ZodIssueInvalidUnionNoMatch
-  | $ZodIssueInvalidUnionMultipleMatch;
+export type $ZodIssueInvalidUnion = $ZodIssueInvalidUnionNoMatch | $ZodIssueInvalidUnionMultipleMatch;
 
 export interface $ZodIssueInvalidKey<Input = unknown> extends $ZodIssueBase {
   readonly code: "invalid_key";
@@ -133,9 +111,7 @@ export interface $ZodIssueInvalidKey<Input = unknown> extends $ZodIssueBase {
   readonly input?: Input;
 }
 
-export interface $ZodIssueInvalidElement<
-  Input = unknown,
-> extends $ZodIssueBase {
+export interface $ZodIssueInvalidElement<Input = unknown> extends $ZodIssueBase {
   readonly code: "invalid_element";
   readonly origin: "map" | "set";
   readonly key: unknown;
@@ -160,10 +136,7 @@ export interface $ZodIssueCustom extends $ZodIssueBase {
 ////////////////////////////////////////////
 
 export interface $ZodIssueStringCommonFormats extends $ZodIssueInvalidStringFormat {
-  format: Exclude<
-    $ZodStringFormats,
-    "regex" | "jwt" | "starts_with" | "ends_with" | "includes"
-  >;
+  format: Exclude<$ZodStringFormats, "regex" | "jwt" | "starts_with" | "ends_with" | "includes">;
 }
 
 export interface $ZodIssueStringInvalidRegex extends $ZodIssueInvalidStringFormat {
@@ -218,8 +191,7 @@ export type $ZodIssue =
 
 export type $ZodIssueCode = $ZodIssue["code"];
 
-export type $ZodInternalIssue<T extends $ZodIssueBase = $ZodIssue> =
-  T extends any ? RawIssue<T> : never;
+export type $ZodInternalIssue<T extends $ZodIssueBase = $ZodIssue> = T extends any ? RawIssue<T> : never;
 type RawIssue<T extends $ZodIssueBase> = T extends any
   ? util.Flatten<
       util.MakePartial<T, "message" | "path"> & {
@@ -233,8 +205,7 @@ type RawIssue<T extends $ZodIssueBase> = T extends any
     >
   : never;
 
-export type $ZodRawIssue<T extends $ZodIssueBase = $ZodIssue> =
-  $ZodInternalIssue<T>;
+export type $ZodRawIssue<T extends $ZodIssueBase = $ZodIssue> = $ZodInternalIssue<T>;
 
 export interface $ZodErrorMap<T extends $ZodIssueBase = $ZodIssue> {
   // biome-ignore lint:
@@ -273,16 +244,9 @@ const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
   });
 };
 
-export const $ZodError: $constructor<$ZodError> = $constructor(
-  "$ZodError",
-  initializer,
-);
+export const $ZodError: $constructor<$ZodError> = $constructor("$ZodError", initializer);
 interface $ZodRealError<T = any> extends $ZodError<T> {}
-export const $ZodRealError: $constructor<$ZodRealError> = $constructor(
-  "$ZodError",
-  initializer,
-  { Parent: Error },
-);
+export const $ZodRealError: $constructor<$ZodRealError> = $constructor("$ZodError", initializer, { Parent: Error });
 
 ///////////////////    ERROR UTILITIES   ////////////////////////
 
@@ -296,14 +260,8 @@ type _FlattenedError<T, U = string> = {
 };
 
 export function flattenError<T>(error: $ZodError<T>): _FlattenedError<T>;
-export function flattenError<T, U>(
-  error: $ZodError<T>,
-  mapper?: (issue: $ZodIssue) => U,
-): _FlattenedError<T, U>;
-export function flattenError<T, U>(
-  error: $ZodError<T>,
-  mapper = (issue: $ZodIssue) => issue.message as U,
-) {
+export function flattenError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): _FlattenedError<T, U>;
+export function flattenError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
   const fieldErrors: Record<PropertyKey, any> = {};
   const formErrors: U[] = [];
   for (const sub of error.issues) {
@@ -330,14 +288,8 @@ export type $ZodFormattedError<T, U = string> = {
 } & util.Flatten<_ZodFormattedError<T, U>>;
 
 export function formatError<T>(error: $ZodError<T>): $ZodFormattedError<T>;
-export function formatError<T, U>(
-  error: $ZodError<T>,
-  mapper?: (issue: $ZodIssue) => U,
-): $ZodFormattedError<T, U>;
-export function formatError<T, U>(
-  error: $ZodError<T>,
-  mapper = (issue: $ZodIssue) => issue.message as U,
-) {
+export function formatError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodFormattedError<T, U>;
+export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
   const fieldErrors: $ZodFormattedError<T> = { _errors: [] } as any;
   const processError = (error: { issues: $ZodIssue[] }) => {
     for (const issue of error.issues) {
@@ -387,25 +339,14 @@ export type $ZodErrorTree<T, U = string> = T extends util.Primitive
         : { errors: U[] };
 
 export function treeifyError<T>(error: $ZodError<T>): $ZodErrorTree<T>;
-export function treeifyError<T, U>(
-  error: $ZodError<T>,
-  mapper?: (issue: $ZodIssue) => U,
-): $ZodErrorTree<T, U>;
-export function treeifyError<T, U>(
-  error: $ZodError<T>,
-  mapper = (issue: $ZodIssue) => issue.message as U,
-) {
+export function treeifyError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodErrorTree<T, U>;
+export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
   const result: $ZodErrorTree<T, U> = { errors: [] } as any;
-  const processError = (
-    error: { issues: $ZodIssue[] },
-    path: PropertyKey[] = [],
-  ) => {
+  const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
     for (const issue of error.issues) {
       if (issue.code === "invalid_union" && issue.errors.length) {
         // regular union error
-        issue.errors.map((issues) =>
-          processError({ issues }, [...path, ...issue.path]),
-        );
+        issue.errors.map((issues) => processError({ issues }, [...path, ...issue.path]));
       } else if (issue.code === "invalid_key") {
         processError({ issues: issue.issues }, [...path, ...issue.path]);
       } else if (issue.code === "invalid_element") {
@@ -478,17 +419,12 @@ export function treeifyError<T, U>(
  *   ✖ Invalid input: expected number
  * ```
  */
-export function toDotPath(
-  _path: readonly (string | number | symbol | StandardSchemaV1.PathSegment)[],
-): string {
+export function toDotPath(_path: readonly (string | number | symbol | StandardSchemaV1.PathSegment)[]): string {
   const segs: string[] = [];
-  const path: PropertyKey[] = _path.map((seg: any) =>
-    typeof seg === "object" ? seg.key : seg,
-  );
+  const path: PropertyKey[] = _path.map((seg: any) => (typeof seg === "object" ? seg.key : seg));
   for (const seg of path) {
     if (typeof seg === "number") segs.push(`[${seg}]`);
-    else if (typeof seg === "symbol")
-      segs.push(`[${JSON.stringify(String(seg))}]`);
+    else if (typeof seg === "symbol") segs.push(`[${JSON.stringify(String(seg))}]`);
     else if (/[^\w$]/.test(seg)) segs.push(`[${JSON.stringify(seg)}]`);
     else {
       if (segs.length) segs.push(".");
@@ -502,9 +438,7 @@ export function toDotPath(
 export function prettifyError(error: StandardSchemaV1.FailureResult): string {
   const lines: string[] = [];
   // sort by path length
-  const issues = [...error.issues].sort(
-    (a, b) => (a.path ?? []).length - (b.path ?? []).length,
-  );
+  const issues = [...error.issues].sort((a, b) => (a.path ?? []).length - (b.path ?? []).length);
 
   // Process each issue
   for (const issue of issues) {


### PR DESCRIPTION


## Fix: `treeifyError` discards accumulated path when recursing into nested unions

### Problem

In `treeifyError`, when recursing into nested `invalid_union`, `invalid_key`, or `invalid_element` issues, the function passed only `issue.path` to the recursive call — discarding the `path` accumulated from parent recursions. This caused nested union errors to lose their parent path context, resulting in incorrect (shallow) paths in the output tree.

For example, given a schema like `z.object({ a: z.union([z.string(), z.number()]) })`, if the union inside property `a` failed, the inner issues' paths would not include the parent `"a"` segment, so errors would be placed at the root of the tree instead of under `properties.a`.

### Fix

In the `processError` inner function of `treeifyError`, changed the recursive calls to prepend the accumulated `path`:

```diff
-  issue.errors.map((issues) => processError({ issues }, issue.path));
+  issue.errors.map((issues) => processError({ issues }, [...path, ...issue.path]));

-  processError({ issues: issue.issues }, issue.path);
+  processError({ issues: issue.issues }, [...path, ...issue.path]);
```

This matches the pattern already used when computing `fullpath` for leaf issues (`const fullpath = [...path, ...issue.path]`) and ensures the full path context is preserved through arbitrarily nested union/key/element structures.

### Affected file

- errors.ts