### PR TITLE
Add JSONType export (fixes #5200)

### DIFF
--- a/packages/zod/src/v4/classic/external.ts
+++ b/packages/zod/src/v4/classic/external.ts
@@ -11,6 +11,7 @@ import en from "../locales/en.js";
 config(en());
 
 export type { infer, output, input } from "../core/index.js";
+export type { JSONType } from "../core/util.js";
 export {
   globalRegistry,
   type GlobalMeta,

--- a/packages/zod/src/v4/mini/external.ts
+++ b/packages/zod/src/v4/mini/external.ts
@@ -4,6 +4,7 @@ export * from "./schemas.js";
 export * from "./checks.js";
 
 export type { infer, output, input } from "../core/index.js";
+export type { JSONType } from "../core/util.js";
 export {
   globalRegistry,
   registry,


### PR DESCRIPTION
I ran into the issue described in #5200, where I got errors like the following when using inferred z.json types 

```
error TS2742: The inferred type of 'getData' cannot be named without a reference to '../node_modules/zod/v4/core/util.cjs'. This is likely not portable. A type annotation is necessary.
```


I tested that this was resolved this in my minimal reproduction repository (https://github.com/RobinVdBroeck/zod-ts2742-repro) by running `pnpm link` here and `pnpm link zod` in the reproduction. I also tested this in proprietary code which faced this issue, and it's also resolved there. (I cannot share this code)

I'm not sure how to write unit tests for this. I tried to add some tests based on https://github.com/colinhacks/zod/pull/5511, but those succeeded without any issues. This only shows up when running a typescript build, so I'm not even sure that you can test it?