### PR TITLE
fix: use #/components/schemas/ refs for openapi-3.0 recursive schemas

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -247,7 +247,8 @@ export function extractDefs<T extends schemas.$ZodType>(
     // e.g. lazy
 
     // external is configured
-    const defsSegment = ctx.target === "draft-2020-12" ? "$defs" : "definitions";
+    const defsSegment =
+      ctx.target === "draft-2020-12" ? "$defs" : ctx.target === "openapi-3.0" ? "components/schemas" : "definitions";
     if (ctx.external) {
       const externalId = ctx.external.registry.get(entry[0])?.id; // ?? "__shared";// `__schema${ctx.counter++}`;
 
@@ -486,6 +487,8 @@ export function finalize<T extends schemas.$ZodType>(
     if (Object.keys(defs).length > 0) {
       if (ctx.target === "draft-2020-12") {
         result.$defs = defs;
+      } else if (ctx.target === "openapi-3.0") {
+        result.components = { schemas: defs };
       } else {
         result.definitions = defs;
       }


### PR DESCRIPTION
Fixes #5693

When `toJSONSchema()` is called with `target: "openapi-3.0"` on recursive schemas (`z.lazy()`), the output currently contains `#/definitions/` references and a `definitions` block, which are JSON Schema conventions — not valid OpenAPI 3.0.

According to the [OpenAPI 3.0.3 spec](https://spec.openapis.org/oas/v3.0.3#reference-object), `$ref` values must use paths like `#/components/schemas/...`, and the `definitions` keyword is not part of the OpenAPI 3.0 Schema Object.

### Changes

Two small changes in `to-json-schema.ts`:

1. **`makeURI`**: When target is `openapi-3.0`, use `components/schemas` as the defs segment instead of `definitions`
2. **`finalize`**: When target is `openapi-3.0`, place extracted defs under `result.components = { schemas: defs }` instead of `result.definitions`

### Before

```json
{
  "type": "object",
  "properties": {
    "data": { "$ref": "#/definitions/__schema0" }
  },
  "definitions": {
    "__schema0": { ... }
  }
}
```

### After

```json
{
  "type": "object",
  "properties": {
    "data": { "$ref": "#/components/schemas/__schema0" }
  },
  "components": {
    "schemas": {
      "__schema0": { ... }
    }
  }
}
```

### Tests

Added two tests:
- Recursive schema with `openapi-3.0` verifying `#/components/schemas/` refs and `components.schemas` structure
- Self-referencing root schema with `openapi-3.0` verifying `#` self-refs still work correctly

All existing tests pass.