### PR TITLE
fix: enhance union error messages to show expected and received value…

### DIFF
--- a/packages/zod/src/v4/classic/tests/union.test.ts
+++ b/packages/zod/src/v4/classic/tests/union.test.ts
@@ -94,6 +94,23 @@ test("union values", () => {
   `);
 });
 
+test("informative error for union of literals", () => {
+  const MySchemaType = z.union([z.literal("a"), z.literal("b")]);
+  const MySchema = z.object({
+    type: MySchemaType,
+  });
+
+  const result = MySchema.safeParse({ type: "c" });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues[0].path).toEqual(["type"]);
+    expect(result.error.issues[0].message).toContain("expected one of");
+    expect(result.error.issues[0].message).toContain('"a"');
+    expect(result.error.issues[0].message).toContain('"b"');
+    expect(result.error.issues[0].message).toContain('"c"');
+  }
+});
+
 test("non-aborted errors", () => {
   const zItemTest = z.union([
     z.object({


### PR DESCRIPTION
…s for literal unions

- Modified invalid_union error handler in en.ts locale to provide informative messages
- When union contains literal values, error now shows all expected values and the received value
- Format: 'Invalid input: expected one of "a", "b", but received "c"'
- Falls back to generic message for non-literal unions
- Added comprehensive test case to verify the new error format
- Resolves issue #2