### PR TITLE
feat: add capitalize() and titleCase() string methods

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -225,7 +225,7 @@ To perform some simple string transforms:
 z.string().trim(); // trim whitespace
 z.string().toLowerCase(); // toLowerCase
 z.string().toUpperCase(); // toUpperCase
-z.string().capitalize(); // capitalize first character
+z.string().capitalize(); // uppercase first character + lowercase remainder
 z.string().titleCase(); // capitalize each space-separated word
 z.string().normalize(); // normalize unicode characters
 ```
@@ -235,12 +235,12 @@ z.string().normalize(); // normalize unicode characters
 z.string().check(z.trim()); // trim whitespace
 z.string().check(z.toLowerCase()); // toLowerCase
 z.string().check(z.toUpperCase()); // toUpperCase
-z.string().check(z.capitalize()); // capitalize first character
-z.string().check(z.titleCase()); // capitalize each space-separated word
 z.string().check(z.normalize()); // normalize unicode characters
 ```
 </Tab>
 </Tabs>
+
+In Zod, `z.string().capitalize()` is opinionated: it uppercases the first character and lowercases the rest of the string. For example, `"HELLO WORLD"` becomes `"Hello world"`.
 
 ## String formats
 

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -225,6 +225,8 @@ To perform some simple string transforms:
 z.string().trim(); // trim whitespace
 z.string().toLowerCase(); // toLowerCase
 z.string().toUpperCase(); // toUpperCase
+z.string().capitalize(); // capitalize first character
+z.string().titleCase(); // capitalize each space-separated word
 z.string().normalize(); // normalize unicode characters
 ```
 </Tab>
@@ -233,6 +235,8 @@ z.string().normalize(); // normalize unicode characters
 z.string().check(z.trim()); // trim whitespace
 z.string().check(z.toLowerCase()); // toLowerCase
 z.string().check(z.toUpperCase()); // toUpperCase
+z.string().check(z.capitalize()); // capitalize first character
+z.string().check(z.titleCase()); // capitalize each space-separated word
 z.string().check(z.normalize()); // normalize unicode characters
 ```
 </Tab>

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -191,6 +191,8 @@ z.normalize();
 z.trim();
 z.toLowerCase();
 z.toUpperCase();
+z.capitalize();
+z.titleCase();
 
 // metadata (registers schema in z.globalRegistry)
 z.meta({ title: "...", description: "..." });

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -191,8 +191,6 @@ z.normalize();
 z.trim();
 z.toLowerCase();
 z.toUpperCase();
-z.capitalize();
-z.titleCase();
 
 // metadata (registers schema in z.globalRegistry)
 z.meta({ title: "...", description: "..." });

--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -393,6 +393,8 @@ z.normalize();
 z.trim();
 z.toLowerCase();
 z.toUpperCase();
+z.capitalize();
+z.titleCase();
 ```
 
 
@@ -908,7 +910,7 @@ z.number().overwrite(val => val ** 2).max(100);
 // => ZodNumber
 ```
 
-> The existing `.trim()`, `.toLowerCase()` and `.toUpperCase()` methods have been reimplemented using `.overwrite()`.
+> The existing `.trim()`, `.toLowerCase()`, `.toUpperCase()`, `.capitalize()`, and `.titleCase()` methods have been reimplemented using `.overwrite()`.
 
 ## An extensible foundation: `zod/v4/core`
 

--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -393,8 +393,6 @@ z.normalize();
 z.trim();
 z.toLowerCase();
 z.toUpperCase();
-z.capitalize();
-z.titleCase();
 ```
 
 

--- a/packages/zod/src/v4/classic/checks.ts
+++ b/packages/zod/src/v4/classic/checks.ts
@@ -17,6 +17,8 @@ export {
   _regex as regex,
   _lowercase as lowercase,
   _uppercase as uppercase,
+  _capitalize as capitalize,
+  _titleCase as titleCase,
   _includes as includes,
   _startsWith as startsWith,
   _endsWith as endsWith,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -174,7 +174,11 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
         checks: [
           ...(def.checks ?? []),
           ...checks.map((ch) =>
-            typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+            typeof ch === "function"
+              ? {
+                  _zod: { check: ch, def: { check: "custom" }, onattach: [] },
+                }
+              : ch
           ),
         ],
       }),
@@ -282,6 +286,8 @@ export interface _ZodString<T extends core.$ZodStringInternals<unknown> = core.$
   normalize(form?: "NFC" | "NFD" | "NFKC" | "NFKD" | (string & {})): this;
   toLowerCase(): this;
   toUpperCase(): this;
+  titleCase(): this;
+  capitalize(): this;
   slugify(): this;
 }
 
@@ -314,6 +320,8 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
   inst.normalize = (...args) => inst.check(checks.normalize(...args));
   inst.toLowerCase = () => inst.check(checks.toLowerCase());
   inst.toUpperCase = () => inst.check(checks.toUpperCase());
+  inst.capitalize = () => inst.check(checks.capitalize());
+  inst.titleCase = () => inst.check(checks.titleCase());
   inst.slugify = () => inst.check(checks.slugify());
 });
 
@@ -1264,7 +1272,11 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
   });
 
   inst.keyof = () => _enum(Object.keys(inst._zod.def.shape)) as any;
-  inst.catchall = (catchall) => inst.clone({ ...inst._zod.def, catchall: catchall as any as core.$ZodType }) as any;
+  inst.catchall = (catchall) =>
+    inst.clone({
+      ...inst._zod.def,
+      catchall: catchall as any as core.$ZodType,
+    }) as any;
   inst.passthrough = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
   inst.loose = () => inst.clone({ ...inst._zod.def, catchall: unknown() });
   inst.strict = () => inst.clone({ ...inst._zod.def, catchall: never() });
@@ -2246,16 +2258,14 @@ export const ZodFunction: core.$constructor<ZodFunction> = /*@__PURE__*/ core.$c
 );
 
 export function _function(): ZodFunction;
-export function _function<const In extends ReadonlyArray<core.$ZodType>>(params: {
-  input: In;
-}): ZodFunction<ZodTuple<In, null>, core.$ZodFunctionOut>;
+export function _function<const In extends ReadonlyArray<core.$ZodType>>(params: { input: In }): ZodFunction<
+  ZodTuple<In, null>,
+  core.$ZodFunctionOut
+>;
 export function _function<
   const In extends ReadonlyArray<core.$ZodType>,
   const Out extends core.$ZodFunctionOut = core.$ZodFunctionOut,
->(params: {
-  input: In;
-  output: Out;
-}): ZodFunction<ZodTuple<In, null>, Out>;
+>(params: { input: In; output: Out }): ZodFunction<ZodTuple<In, null>, Out>;
 export function _function<const In extends core.$ZodFunctionIn = core.$ZodFunctionIn>(params: {
   input: In;
 }): ZodFunction<In, core.$ZodFunctionOut>;
@@ -2265,10 +2275,7 @@ export function _function<const Out extends core.$ZodFunctionOut = core.$ZodFunc
 export function _function<
   In extends core.$ZodFunctionIn = core.$ZodFunctionIn,
   Out extends core.$ZodType = core.$ZodType,
->(params?: {
-  input: In;
-  output: Out;
-}): ZodFunction<In, Out>;
+>(params?: { input: In; output: Out }): ZodFunction<In, Out>;
 export function _function(params?: {
   output?: core.$ZodType;
   input?: core.$ZodFunctionArgs | Array<core.$ZodType>;

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -847,8 +847,29 @@ test("trim", () => {
 test("lowerCase", () => {
   expect(z.string().toLowerCase().parse("ASDF")).toEqual("asdf");
   expect(z.string().toUpperCase().parse("asdf")).toEqual("ASDF");
-  expect(z.string().capitalize().parse("alice")).toEqual("Alice");
-  expect(z.string().titleCase().parse("the great gatsby")).toEqual("The Great Gatsby");
+});
+
+test("capitalize", () => {
+  const schema = z.string().capitalize();
+  expect(schema.parse("hello world")).toBe("Hello world");
+  expect(schema.parse("HELLO WORLD")).toBe("Hello world");
+  expect(schema.parse("HELLO")).toBe("Hello");
+  expect(schema.parse("h")).toBe("H");
+  expect(schema.parse("123ABC")).toBe("123abc");
+  expect(schema.parse(" hello")).toBe(" hello");
+  expect(schema.parse("")).toBe("");
+});
+
+test("titleCase", () => {
+  const schema = z.string().titleCase();
+  expect(schema.parse("hello world")).toBe("Hello World");
+  expect(schema.parse("Hello World")).toBe("Hello World");
+  expect(schema.parse("the great gatsby")).toBe("The Great Gatsby");
+  expect(schema.parse("hELLO wORLD")).toBe("HELLO WORLD");
+  expect(schema.parse("  hello   world  ")).toBe(" Hello World ");
+  expect(schema.parse("hello-world")).toBe("Hello-world");
+  expect(schema.parse("hello, world!")).toBe("Hello, World!");
+  expect(schema.parse("")).toBe("");
 });
 
 test("slugify", () => {

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -847,6 +847,8 @@ test("trim", () => {
 test("lowerCase", () => {
   expect(z.string().toLowerCase().parse("ASDF")).toEqual("asdf");
   expect(z.string().toUpperCase().parse("asdf")).toEqual("ASDF");
+  expect(z.string().capitalize().parse("alice")).toEqual("Alice");
+  expect(z.string().titleCase().parse("the great gatsby")).toEqual("The Great Gatsby");
 });
 
 test("slugify", () => {

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1133,7 +1133,7 @@ export function _toLowerCase(): checks.$ZodCheckOverwrite<string> {
 export function _toUpperCase(): checks.$ZodCheckOverwrite<string> {
   return _overwrite((input) => input.toUpperCase());
 }
-// Capitalize
+// capitalize
 // @__NO_SIDE_EFFECTS__
 export function _capitalize(): checks.$ZodCheckOverwrite<string> {
   return _overwrite((input) => input.charAt(0).toUpperCase() + input.slice(1).toLowerCase());

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1133,6 +1133,16 @@ export function _toLowerCase(): checks.$ZodCheckOverwrite<string> {
 export function _toUpperCase(): checks.$ZodCheckOverwrite<string> {
   return _overwrite((input) => input.toUpperCase());
 }
+// Capitalize
+// @__NO_SIDE_EFFECTS__
+export function _capitalize(): checks.$ZodCheckOverwrite<string> {
+  return _overwrite((input) => input.charAt(0).toUpperCase() + input.slice(1).toLowerCase());
+}
+// titleCase
+// @__NO_SIDE_EFFECTS__
+export function _titleCase(): checks.$ZodCheckOverwrite<string> {
+  return _overwrite((input) => input.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase()));
+}
 // slugify
 // @__NO_SIDE_EFFECTS__
 export function _slugify(): checks.$ZodCheckOverwrite<string> {

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1141,7 +1141,12 @@ export function _capitalize(): checks.$ZodCheckOverwrite<string> {
 // titleCase
 // @__NO_SIDE_EFFECTS__
 export function _titleCase(): checks.$ZodCheckOverwrite<string> {
-  return _overwrite((input) => input.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase()));
+  return _overwrite((input) =>
+    input
+      .split(/\s+/u)
+      .map((word) => (word ? word[0].toLocaleUpperCase() + word.slice(1) : ""))
+      .join(" ")
+  );
 }
 // slugify
 // @__NO_SIDE_EFFECTS__


### PR DESCRIPTION
Fixes #5668

Adds `.capitalize()` and `.titleCase()` methods to string schema.