### PR TITLE
refactor(v4): remove unnecessary type assertions

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -478,10 +478,10 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         }
         // Apply minItems/maxItems constraints to tuples
         if (typeof schema.minItems === "number") {
-          zodSchema = (zodSchema as any).check(z.minLength(schema.minItems));
+          zodSchema = zodSchema.check(z.minLength(schema.minItems));
         }
         if (typeof schema.maxItems === "number") {
-          zodSchema = (zodSchema as any).check(z.maxLength(schema.maxItems));
+          zodSchema = zodSchema.check(z.maxLength(schema.maxItems));
         }
       } else if (Array.isArray(items)) {
         // Tuple with items array (draft-7)
@@ -497,10 +497,10 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         }
         // Apply minItems/maxItems constraints to tuples
         if (typeof schema.minItems === "number") {
-          zodSchema = (zodSchema as any).check(z.minLength(schema.minItems));
+          zodSchema = zodSchema.check(z.minLength(schema.minItems));
         }
         if (typeof schema.maxItems === "number") {
-          zodSchema = (zodSchema as any).check(z.maxLength(schema.maxItems));
+          zodSchema = zodSchema.check(z.maxLength(schema.maxItems));
         }
       } else if (items !== undefined) {
         // Regular array
@@ -509,10 +509,10 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
 
         // Apply constraints
         if (typeof schema.minItems === "number") {
-          arraySchema = (arraySchema as any).min(schema.minItems);
+          arraySchema = arraySchema.min(schema.minItems);
         }
         if (typeof schema.maxItems === "number") {
-          arraySchema = (arraySchema as any).max(schema.maxItems);
+          arraySchema = arraySchema.max(schema.maxItems);
         }
 
         zodSchema = arraySchema;
@@ -532,7 +532,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
     zodSchema = zodSchema.describe(schema.description);
   }
   if (schema.default !== undefined) {
-    zodSchema = (zodSchema as any).default(schema.default);
+    zodSchema = zodSchema.default(schema.default);
   }
 
   return zodSchema;

--- a/packages/zod/src/v4/classic/parse.ts
+++ b/packages/zod/src/v4/classic/parse.ts
@@ -10,14 +10,14 @@ export const parse: <T extends core.$ZodType>(
   value: unknown,
   _ctx?: core.ParseContext<core.$ZodIssue>,
   _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
-) => core.output<T> = /* @__PURE__ */ core._parse(ZodRealError) as any;
+) => core.output<T> = /* @__PURE__ */ core._parse(ZodRealError);
 
 export const parseAsync: <T extends core.$ZodType>(
   schema: T,
   value: unknown,
   _ctx?: core.ParseContext<core.$ZodIssue>,
   _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
-) => Promise<core.output<T>> = /* @__PURE__ */ core._parseAsync(ZodRealError) as any;
+) => Promise<core.output<T>> = /* @__PURE__ */ core._parseAsync(ZodRealError);
 
 export const safeParse: <T extends core.$ZodType>(
   schema: T,
@@ -37,25 +37,25 @@ export const encode: <T extends core.$ZodType>(
   schema: T,
   value: core.output<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => core.input<T> = /* @__PURE__ */ core._encode(ZodRealError) as any;
+) => core.input<T> = /* @__PURE__ */ core._encode(ZodRealError);
 
 export const decode: <T extends core.$ZodType>(
   schema: T,
   value: core.input<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => core.output<T> = /* @__PURE__ */ core._decode(ZodRealError) as any;
+) => core.output<T> = /* @__PURE__ */ core._decode(ZodRealError);
 
 export const encodeAsync: <T extends core.$ZodType>(
   schema: T,
   value: core.output<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => Promise<core.input<T>> = /* @__PURE__ */ core._encodeAsync(ZodRealError) as any;
+) => Promise<core.input<T>> = /* @__PURE__ */ core._encodeAsync(ZodRealError);
 
 export const decodeAsync: <T extends core.$ZodType>(
   schema: T,
   value: core.input<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => Promise<core.output<T>> = /* @__PURE__ */ core._decodeAsync(ZodRealError) as any;
+) => Promise<core.output<T>> = /* @__PURE__ */ core._decodeAsync(ZodRealError);
 
 export const safeEncode: <T extends core.$ZodType>(
   schema: T,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -428,7 +428,7 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
 export function string(params?: string | core.$ZodStringParams): ZodString;
 export function string<T extends string>(params?: string | core.$ZodStringParams): core.$ZodType<T, T>;
 export function string(params?: string | core.$ZodStringParams): ZodString {
-  return core._string(ZodString, params) as any;
+  return core._string(ZodString, params);
 }
 
 // ZodStringFormat
@@ -874,7 +874,7 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
 });
 
 export function number(params?: string | core.$ZodNumberParams): ZodNumber {
-  return core._number(ZodNumber, params) as any;
+  return core._number(ZodNumber, params);
 }
 
 // ZodNumberFormat
@@ -929,7 +929,7 @@ export const ZodBoolean: core.$constructor<ZodBoolean> = /*@__PURE__*/ core.$con
 });
 
 export function boolean(params?: string | core.$ZodBooleanParams): ZodBoolean {
-  return core._boolean(ZodBoolean, params) as any;
+  return core._boolean(ZodBoolean, params);
 }
 
 // bigint
@@ -980,7 +980,7 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
 });
 
 export function bigint(params?: string | core.$ZodBigIntParams): ZodBigInt {
-  return core._bigint(ZodBigInt, params) as any;
+  return core._bigint(ZodBigInt, params);
 }
 // bigint formats
 
@@ -1143,7 +1143,7 @@ export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constru
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.arrayProcessor(inst, ctx, json, params);
 
-  inst.element = def.element as any;
+  inst.element = def.element;
   inst.min = (minLength, params) => inst.check(checks.minLength(minLength, params));
   inst.nonempty = (params) => inst.check(checks.minLength(1, params));
   inst.max = (maxLength, params) => inst.check(checks.maxLength(maxLength, params));
@@ -1702,7 +1702,7 @@ export function nativeEnum<T extends util.EnumLike>(entries: T, params?: string 
     type: "enum",
     entries,
     ...util.normalizeParams(params),
-  }) as any as ZodEnum<T>;
+  }) as ZodEnum<T>;
 }
 
 // ZodLiteral


### PR DESCRIPTION
Removes as any type assertions to improve type safety and leverage TypeScript's type inference.
## Changes
`from-json-schema.ts:` Removed as any from array/tuple constraint methods and default() calls
`parse.ts:` Removed as any from parse, parseAsync, encode, decode, encodeAsync, decodeAsync
`schemas.ts:` Removed as any from string(), number(), boolean(), bigint(), array.element, and nativeEnum()
