### PR TITLE
fix: add options to invalid discriminator errors

### DIFF
--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -158,10 +158,14 @@ test("invalid discriminator value", () => {
         "errors": [],
         "note": "No matching discriminator",
         "discriminator": "type",
+        "options": [
+          "a",
+          "b"
+        ],
         "path": [
           "type"
         ],
-        "message": "Invalid input"
+        "message": "Invalid discriminator value. Expected 'a' | 'b'"
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -91,6 +91,7 @@ interface $ZodIssueInvalidUnionNoMatch extends $ZodIssueBase {
   readonly errors: $ZodIssue[][];
   readonly input?: unknown;
   readonly discriminator?: string | undefined;
+  readonly options?: util.Primitive[];
   readonly inclusive?: true;
 }
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2354,10 +2354,10 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
       // no matching discriminator
       payload.issues.push({
         code: "invalid_union",
-
         errors: [],
         note: "No matching discriminator",
         discriminator: def.discriminator,
+        options: Array.from(disc.value.keys()),
         input,
         path: [def.discriminator],
         inst,

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -103,6 +103,10 @@ const error: () => errors.$ZodErrorMap = () => {
       case "invalid_key":
         return `Invalid key in ${issue.origin}`;
       case "invalid_union":
+        if (issue.options && Array.isArray(issue.options) && issue.options.length > 0) {
+          const opts = issue.options.map((o) => `'${o}'`).join(" | ");
+          return `Invalid discriminator value. Expected ${opts}`;
+        }
         return "Invalid input";
       case "invalid_element":
         return `Invalid value in ${issue.origin}`;


### PR DESCRIPTION
**Title:**

```
fix: add options to invalid discriminator errors
```

**Description:**

````markdown
## Summary

Restores the `options` field to invalid discriminator errors that was present in Zod 3 but missing in Zod 4.

## Changes

- Added `options: Array.from(disc.value.keys())` to invalid discriminator error in `schemas.ts`
- Updated English locale to display valid discriminator values in error message
- Updated snapshot test to reflect new behavior

## Before

```json
{
  "code": "invalid_union",
  "discriminator": "type",
  "message": "Invalid input"
}
```
````

## After

```json
{
  "code": "invalid_union",
  "discriminator": "type",
  "options": ["fruit", "vegetable"],
  "message": "Invalid discriminator value. Expected 'fruit' | 'vegetable'"
}
```

## Testing

- [x] All existing tests pass
- [x] Updated snapshot test to reflect improved output
- [x] Manually tested with example code

Fixes #5670

````