### PR TITLE
feat(v4): add explicit z.precompile(...) for startup-restricted runtimes

### DIFF
--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -600,6 +600,32 @@ z.config(z.locales.en());
 
 See the full list of supported locales in [Customizing errors](/error-customization#locales); this section is always updated with a list of supported languages as they become available.
 
+## Precompiling object schemas for startup-restricted runtimes
+
+In some runtimes, `new Function` is only available during startup. Zod's object fast-path uses generated functions, so those schemas must be compiled while that window is open.
+
+You can do this explicitly with `z.precompile(...)`:
+
+```ts
+import * as z from "zod";
+
+const User = z.object({
+  id: z.uuidv4(),
+  email: z.email(),
+});
+
+// Call at module scope during startup.
+z.precompile(User);
+```
+
+`z.precompile` is best-effort and safe to call in all environments:
+
+- It traverses the schema graph and compiles object fast-paths where possible.
+- If compilation is unavailable, parsing falls back to the non-JIT path.
+- It only helps schemas that are reachable from the value(s) you pass in.
+
+This is mainly useful for edge runtimes (for example Cloudflare Workers) where startup and request phases have different `eval` policies.
+
 ## Error pretty-printing
 
 The popularity of the [`zod-validation-error`](https://www.npmjs.com/package/zod-validation-error) package demonstrates that there's significant demand for an official API for pretty-printing errors. If you are using that package currently, by all means continue using it. 

--- a/packages/zod/src/v4/classic/external.ts
+++ b/packages/zod/src/v4/classic/external.ts
@@ -27,6 +27,7 @@ export {
   flattenError,
   TimePrecision,
   util,
+  precompile,
   NEVER,
 } from "../core/index.js";
 export { toJSONSchema } from "../core/json-schema-processors.js";

--- a/packages/zod/src/v4/classic/tests/workers-jit.test.ts
+++ b/packages/zod/src/v4/classic/tests/workers-jit.test.ts
@@ -1,0 +1,70 @@
+import { expect, test, vi } from "vitest";
+import * as z from "zod/v4";
+
+test("precompile compiles object schemas", () => {
+  const schema = z.object({
+    a: z.string(),
+  });
+
+  const result = z.precompile(schema);
+  expect(result.compiled).toBe(1);
+  expect(result.visited).toBeGreaterThanOrEqual(2);
+});
+
+test("precompile walks nested schemas", () => {
+  const schema = z.object({
+    nested: z.object({
+      value: z.number(),
+    }),
+  });
+
+  const result = z.precompile(schema);
+  expect(result.compiled).toBe(2);
+});
+
+test("precompile traverses wrapped and recursive schema graphs", () => {
+  const User = z.object({
+    id: z.uuidv4(),
+    profile: z.object({
+      name: z.string(),
+    }),
+  });
+
+  const Node: z.ZodType<{ value: number; next?: any }> = z.lazy(() =>
+    z.object({
+      value: z.number(),
+      next: Node.optional(),
+    })
+  );
+
+  const Wrapped = z
+    .object({
+      data: z.union([User, Node]),
+      payload: z.record(z.string(), User).optional(),
+    })
+    .readonly()
+    .catch({
+      data: { id: "00000000-0000-4000-8000-000000000000", profile: { name: "fallback" } },
+    });
+
+  const result = z.precompile([Wrapped, Node]);
+  expect(result.compiled).toBeGreaterThanOrEqual(4);
+  expect(result.visited).toBeGreaterThan(result.compiled);
+});
+
+test("object parse falls back gracefully when Function constructor is blocked", () => {
+  const schema = z.object({
+    a: z.string(),
+  });
+
+  vi.stubGlobal("Function", function ThrowingFunction() {
+    throw new Error("Function constructor disabled");
+  });
+
+  try {
+    const result = schema.safeParse({ a: "ok" });
+    expect(result.success).toBe(true);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});

--- a/packages/zod/src/v4/core/index.ts
+++ b/packages/zod/src/v4/core/index.ts
@@ -13,4 +13,5 @@ export * from "./api.js";
 export * from "./to-json-schema.js";
 export { toJSONSchema } from "./json-schema-processors.js";
 export { JSONSchemaGenerator } from "./json-schema-generator.js";
+export * from "./precompile.js";
 export * as JSONSchema from "./json-schema.js";

--- a/packages/zod/src/v4/core/precompile.ts
+++ b/packages/zod/src/v4/core/precompile.ts
@@ -1,0 +1,77 @@
+import type * as schemas from "./schemas.js";
+import { JIT_COMPILE_BAG_KEY } from "./util.js";
+
+export interface $ZodPrecompileResult {
+  visited: number;
+  compiled: number;
+}
+
+export function precompile(input: schemas.SomeType | readonly schemas.SomeType[]): $ZodPrecompileResult {
+  const stack = Array.isArray(input) ? [...input] : [input];
+  const visited = new Set<schemas.SomeType>();
+  let compiled = 0;
+
+  while (stack.length) {
+    const schema = stack.pop()!;
+    if (visited.has(schema)) continue;
+    visited.add(schema);
+
+    const compile = (schema._zod.bag as any)[JIT_COMPILE_BAG_KEY];
+    if (typeof compile === "function" && compile()) {
+      compiled++;
+    }
+
+    pushChildren(schema._zod.def, stack);
+  }
+
+  return {
+    visited: visited.size,
+    compiled,
+  };
+}
+
+function pushChildren(def: unknown, stack: schemas.SomeType[]) {
+  if (!isObjectLike(def)) return;
+
+  const seen = new Set<object>();
+  const walk = (value: unknown) => {
+    if (isSchema(value)) {
+      stack.push(value);
+      return;
+    }
+
+    if (!isObjectLike(value)) return;
+    if (seen.has(value)) return;
+    seen.add(value);
+
+    if ((value as any).type === "lazy" && typeof (value as any).getter === "function") {
+      try {
+        walk((value as any).getter());
+      } catch (_) {
+        // Lazy getter may throw before dependent modules are initialized.
+        // Ignore and keep traversal best-effort.
+      }
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        walk(item);
+      }
+      return;
+    }
+
+    for (const nested of Object.values(value)) {
+      walk(nested);
+    }
+  };
+
+  walk(def);
+}
+
+function isObjectLike(value: unknown): value is Record<PropertyKey, unknown> {
+  return !!value && typeof value === "object";
+}
+
+function isSchema(value: unknown): value is schemas.SomeType {
+  return isObjectLike(value) && "_zod" in value;
+}

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -368,12 +368,7 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
   return typeof data === "object" && data !== null && !Array.isArray(data);
 }
 
-export const allowsEval: { value: boolean } = cached(() => {
-  // @ts-ignore
-  if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
-    return false;
-  }
-
+function canUseFunctionConstructor(): boolean {
   try {
     const F = Function;
     new F("");
@@ -381,7 +376,12 @@ export const allowsEval: { value: boolean } = cached(() => {
   } catch (_) {
     return false;
   }
-});
+}
+
+export const allowsEval: { value: boolean } = cached(canUseFunctionConstructor);
+
+/** @internal */
+export const JIT_COMPILE_BAG_KEY = "__zod_jit_compile";
 
 export function isPlainObject(o: any): o is Record<PropertyKey, unknown> {
   if (isObject(o) === false) return false;


### PR DESCRIPTION
## Summary

This PR adds an explicit `z.precompile(...)` API to precompile object fast-paths in environments where `new Function` may only be available during startup (for example Cloudflare Workers).

Instead of relying on implicit runtime heuristics/timing, this makes the behavior deterministic and opt-in.

## Prior context

This builds on earlier exploration in **#5462** and **#5565**. The approach here favors an explicit precompile API over implicit runtime heuristics/timing so behavior is deterministic and easier to reason about in startup-restricted runtimes.

## What changed

- Added `precompile(schema | schema[])` in core:
  - `packages/zod/src/v4/core/precompile.ts`
- Exported publicly:
  - `packages/zod/src/v4/core/index.ts`
  - `packages/zod/src/v4/classic/external.ts` (`z.precompile(...)`)
- Updated object JIT internals:
  - `packages/zod/src/v4/core/schemas.ts`
  - object schemas now expose an internal compile hook and gracefully fall back to the non-JIT path if compile fails.
- Updated eval capability check:
  - `packages/zod/src/v4/core/util.ts`
  - switched to feature detection (`new Function`) without hardcoded Cloudflare user-agent disabling.
- Added docs section:
  - `packages/docs/content/v4/index.mdx`
  - includes startup/module-scope precompile guidance.

## API

```ts
import * as z from "zod";

const User = z.object({
  id: z.uuidv4(),
  email: z.email(),
});

z.precompile(User);
```

`z.precompile(...)` is best-effort:
- compiles reachable object fast-paths where possible,
- no throw required for unavailable compilation,
- parsing falls back safely.

## Test approach

### New focused tests
Added `packages/zod/src/v4/classic/tests/workers-jit.test.ts` with coverage for:

1. **Direct object precompile**
   - verifies object schemas are compiled.
2. **Nested object traversal**
   - verifies nested object graph compilation.
3. **Wrapped + recursive traversal**
   - verifies traversal through wrappers/compositions (`union`, `record`, `optional`, `readonly`, `catch`, `lazy`).
4. **Graceful fallback**
   - stubs `Function` to throw and verifies object parse still succeeds via non-JIT path.

### Regression checks run locally
- `pnpm test packages/zod/src/v4/classic/tests/workers-jit.test.ts`
- `pnpm test packages/zod/src/v4/classic/tests/object.test.ts packages/zod/src/v4/classic/tests/lazy.test.ts packages/zod/src/v4/classic/tests/record.test.ts`
- pre-push hook also ran full suite (`pnpm test`) successfully.

## Notes

- This keeps default behavior safe and adds an explicit path for users who can/want to precompile during startup.
- This does not force eager compilation globally and avoids per-parse environment probing.
