### PR TITLE
feat(v4): cron expression validation

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -370,6 +370,8 @@ export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> 
   cidrv6(params?: string | core.$ZodCheckCIDRv6Params): this;
   /** @deprecated Use `z.e164()` instead. */
   e164(params?: string | core.$ZodCheckE164Params): this;
+  /** @deprecated Use `z.cron()` instead. */
+  cron(params?: string | core.$ZodCheckCronParams): this;
 
   // ISO 8601 checks
   /** @deprecated Use `z.iso.datetime()` instead. */
@@ -417,6 +419,7 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   inst.cidrv4 = (params) => inst.check(core._cidrv4(ZodCIDRv4, params));
   inst.cidrv6 = (params) => inst.check(core._cidrv6(ZodCIDRv6, params));
   inst.e164 = (params) => inst.check(core._e164(ZodE164, params));
+  inst.cron = (params) => inst.check(core._cron(ZodCron, params));
 
   // iso
   inst.datetime = (params) => inst.check(iso.datetime(params as any));
@@ -755,6 +758,19 @@ export const ZodJWT: core.$constructor<ZodJWT> = /*@__PURE__*/ core.$constructor
 
 export function jwt(params?: string | core.$ZodJWTParams): ZodJWT {
   return core._jwt(ZodJWT, params);
+}
+
+// ZodCron
+export interface ZodCron extends ZodStringFormat<"cron"> {
+  _zod: core.$ZodCronInternals;
+}
+export const ZodCron: core.$constructor<ZodCron> = /*@__PURE__*/ core.$constructor("ZodCron", (inst, def) => {
+  core.$ZodCron.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+export function cron(params?: string | core.$ZodCronParams): ZodCron {
+  return core._cron(ZodCron, params);
 }
 
 // ZodCustomStringFormat

--- a/packages/zod/src/v4/classic/tests/cron.test.ts
+++ b/packages/zod/src/v4/classic/tests/cron.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "vitest";
+import * as z from "zod/v4";
+
+describe("z.cron()", () => {
+  const schema = z.cron();
+
+  describe("should parse valid expressions", () => {
+    test("wildcard expressions", () => {
+      expect(schema.safeParse("* * * * *").success).toBe(true);
+    });
+
+    test("specific values", () => {
+      expect(schema.safeParse("0 0 1 1 0").success).toBe(true);
+      expect(schema.safeParse("59 23 31 12 6").success).toBe(true);
+      expect(schema.safeParse("30 6 15 6 3").success).toBe(true);
+    });
+
+    test("step expressions", () => {
+      expect(schema.safeParse("*/5 * * * *").success).toBe(true);
+      expect(schema.safeParse("*/15 */6 * * *").success).toBe(true);
+      expect(schema.safeParse("0 */2 * * *").success).toBe(true);
+    });
+
+    test("range expressions", () => {
+      expect(schema.safeParse("0-30 * * * *").success).toBe(true);
+      expect(schema.safeParse("30 6 * * 1-5").success).toBe(true);
+      expect(schema.safeParse("0 9-17 * * 1-5").success).toBe(true);
+    });
+
+    test("list expressions", () => {
+      expect(schema.safeParse("0,30 * * * *").success).toBe(true);
+      expect(schema.safeParse("0 0 1,15 * *").success).toBe(true);
+      expect(schema.safeParse("0 8,12,17 * * 1-5").success).toBe(true);
+    });
+
+    test("combined expressions", () => {
+      expect(schema.safeParse("0-30/5 * * * *").success).toBe(true);
+      expect(schema.safeParse("0 0 * 1,6,12 *").success).toBe(true);
+    });
+  });
+
+  describe("should reject invalid expressions", () => {
+    test("empty strings", () => {
+      expect(schema.safeParse("").success).toBe(false);
+      expect(schema.safeParse(" ").success).toBe(false);
+      expect(schema.safeParse("\n").success).toBe(false);
+    });
+
+    test("wrong number of fields", () => {
+      expect(schema.safeParse("* * *").success).toBe(false); // too few
+      expect(schema.safeParse("* * * *").success).toBe(false); // too few
+      expect(schema.safeParse("* * * * * *").success).toBe(false); // too many
+    });
+
+    test("invalid characters", () => {
+      expect(schema.safeParse("abc * * * *").success).toBe(false);
+      expect(schema.safeParse("* * * * MON").success).toBe(false);
+      expect(schema.safeParse("? * * * *").success).toBe(false);
+    });
+
+    test("invalid separators", () => {
+      expect(schema.safeParse("* * * * *\t").success).toBe(false); // tab instead of space
+      expect(schema.safeParse("***** ").success).toBe(false); // no spaces
+    });
+
+    test("out-of-range values", () => {
+      expect(schema.safeParse("60 0 1 1 0").success).toBe(false); // minute > 59
+      expect(schema.safeParse("0 24 1 1 0").success).toBe(false); // hour > 23
+      expect(schema.safeParse("0 0 0 1 0").success).toBe(false); // day < 1
+      expect(schema.safeParse("0 0 32 1 0").success).toBe(false); // day > 31
+      expect(schema.safeParse("0 0 1 0 0").success).toBe(false); // month < 1
+      expect(schema.safeParse("0 0 1 13 0").success).toBe(false); // month > 12
+      expect(schema.safeParse("0 0 1 1 7").success).toBe(false); // weekday > 6
+      expect(schema.safeParse("99 25 32 13 8").success).toBe(false); // all out of range
+    });
+
+    test("invalid ranges", () => {
+      expect(schema.safeParse("30-10 * * * *").success).toBe(false); // from > to
+      expect(schema.safeParse("0 20-10 * * *").success).toBe(false); // from > to
+      expect(schema.safeParse("1-2-3 * * * *").success).toBe(false); // multiple range operators
+      expect(schema.safeParse("1- * * * *").success).toBe(false); // trailing dash
+    });
+
+    test("invalid step values", () => {
+      expect(schema.safeParse("*/0 * * * *").success).toBe(false); // step must be >= 1
+      expect(schema.safeParse("0 */0 * * *").success).toBe(false); // step must be >= 1
+      expect(schema.safeParse("1/2/3 * * * *").success).toBe(false); // multiple step operators
+    });
+
+    test("trailing operators", () => {
+      expect(schema.safeParse("1, * * * *").success).toBe(false); // trailing comma
+      expect(schema.safeParse("0,30, * * * *").success).toBe(false); // trailing comma in list
+    });
+  });
+
+  describe("error output", () => {
+    test("returns invalid_format error with format: cron", () => {
+      const result = schema.safeParse("not-a-cron");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].code).toBe("invalid_format");
+        expect((result.error.issues[0] as { format: string }).format).toBe("cron");
+      }
+    });
+
+    test("returns custom error message", () => {
+      const withMessage = z.cron("Invalid cron expression");
+      const result = withMessage.safeParse("bad");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe("Invalid cron expression");
+      }
+    });
+  });
+});
+
+describe("z.string().cron()", () => {
+  const schema = z.string().cron();
+
+  test("valid expression", () => {
+    expect(schema.safeParse("* * * * *").success).toBe(true);
+    expect(schema.safeParse("0 0 1 1 0").success).toBe(true);
+  });
+
+  test("invalid expression", () => {
+    expect(schema.safeParse("bad").success).toBe(false);
+    expect(schema.safeParse("* * *").success).toBe(false);
+  });
+
+  test("non-string input", () => {
+    expect(schema.safeParse(null).success).toBe(false);
+    expect(schema.safeParse(123).success).toBe(false);
+  });
+});

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -483,6 +483,23 @@ export function _jwt<T extends schemas.$ZodJWT>(
   });
 }
 
+// Cron
+export type $ZodCronParams = StringFormatParams<schemas.$ZodCron, "pattern" | "when">;
+export type $ZodCheckCronParams = CheckStringFormatParams<schemas.$ZodCron, "pattern" | "when">;
+// @__NO_SIDE_EFFECTS__
+export function _cron<T extends schemas.$ZodCron>(
+  Class: util.SchemaClass<T>,
+  params?: string | $ZodCronParams | $ZodCheckCronParams
+): T {
+  return new Class({
+    type: "string",
+    format: "cron",
+    check: "string_format",
+    abort: false,
+    ...util.normalizeParams(params),
+  });
+}
+
 export const TimePrecision = {
   Any: null,
   Minute: -1,

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -776,6 +776,7 @@ export type $ZodStringFormats =
   | "uppercase"
   | "regex"
   | "jwt"
+  | "cron"
   | "starts_with"
   | "ends_with"
   | "includes";

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -46,6 +46,7 @@ const error: () => errors.$ZodErrorMap = () => {
     json_string: "JSON string",
     e164: "E.164 number",
     jwt: "JWT",
+    cron: "cron expression",
     template_literal: "input",
   };
 

--- a/packages/zod/src/v4/locales/he.ts
+++ b/packages/zod/src/v4/locales/he.ts
@@ -85,6 +85,7 @@ const error: () => errors.$ZodErrorMap = () => {
     json_string: { label: "מחרוזת JSON", gender: "f" },
     e164: { label: "מספר E.164", gender: "m" },
     jwt: { label: "JWT", gender: "m" },
+    cron: { label: "ביטוי cron", gender: "m" },
     ends_with: { label: "קלט", gender: "m" },
     includes: { label: "קלט", gender: "m" },
     lowercase: { label: "קלט", gender: "m" },

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -467,6 +467,23 @@ export function jwt(params?: string | core.$ZodJWTParams): ZodMiniJWT {
   return core._jwt(ZodMiniJWT, params);
 }
 
+// ZodMiniCron
+export interface ZodMiniCron extends _ZodMiniString<core.$ZodCronInternals> {
+  // _zod: core.$ZodCronInternals;
+}
+export const ZodMiniCron: core.$constructor<ZodMiniCron> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniCron",
+  (inst, def) => {
+    core.$ZodCron.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+// @__NO_SIDE_EFFECTS__
+export function cron(params?: string | core.$ZodCronParams): ZodMiniCron {
+  return core._cron(ZodMiniCron, params);
+}
+
 // ZodMiniCustomStringFormat
 export interface ZodMiniCustomStringFormat<Format extends string = string>
   extends ZodMiniStringFormat<Format>,


### PR DESCRIPTION
# Overview

This PR adds a new built-in string format validator z.cron() for validating standard 5-field cron expressions (minute, hour, day-of-month, month, day-of-week).

# Why this is useful

Cron expressions are widely used in task scheduling, CI/CD pipelines, cloud functions (AWS EventBridge, GCP Cloud Scheduler, etc.), and configuration files. Validating them at the schema layer catches malformed expressions before they reach the scheduler, preventing silent failures or unexpected behavior at runtime.

Before this PR, users had to reach for a custom .refine() with a hand-written regex or a third-party package:

```typescript
// Before: verbose and error-prone
const schema = z.string().refine(val => /^(\*|[0-5]?\d).../.test(val), {
  message: "Invalid cron expression",
});
```

With `z.cron()`, this is a single, well-tested, semantically clear call.

# Usage

## Standalone schema

```typescript
import { z } from "zod";

const CronJob = z.object({
  name: z.string(),
  schedule: z.cron(),
});

CronJob.parse({ name: "cleanup", schedule: "0 2 * * *" }); // OK
CronJob.parse({ name: "cleanup", schedule: "60 * * * *" }); // NG. minute out of range
```

## As a string check

```typescript
z.string().cron();
```

## Supported syntax

```typescript
z.cron().parse("* * * * *");        // wildcard
z.cron().parse("0 9-17 * * 1-5");   // ranges (weekdays 9am–5pm)
z.cron().parse("*/15 * * * *");     // steps (every 15 min)
z.cron().parse("0 0 1,15 * *");     // lists (1st and 15th)
z.cron().parse("0-30/5 * * * *");   // combined (every 5 min for first 30 min)
```