### PR TITLE
fix(v4): parsedType() returns "infinity" for Infinity/-Infinity, fixing misleading error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ packages/tsc-perf
 tsconfig.vitest-temp.json
 *.tgz
 
+bun.lock

--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -22,7 +22,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -36,7 +36,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -194,7 +194,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -208,7 +208,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -881,7 +881,9 @@ export function parsedType(data: unknown): errors.$ZodInvalidTypeExpected {
   const t = typeof data;
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "nan" : "number";
+      if (Number.isNaN(data)) return "nan";
+      if (!Number.isFinite(data)) return "infinity";
+      return "number";
     }
     case "object": {
       if (data === null) {

--- a/packages/zod/src/v4/locales/ar.ts
+++ b/packages/zod/src/v4/locales/ar.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/az.ts
+++ b/packages/zod/src/v4/locales/az.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/be.ts
+++ b/packages/zod/src/v4/locales/be.ts
@@ -107,6 +107,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "лік",
     array: "масіў",
   };

--- a/packages/zod/src/v4/locales/bg.ts
+++ b/packages/zod/src/v4/locales/bg.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "число",
     array: "масив",
   };

--- a/packages/zod/src/v4/locales/ca.ts
+++ b/packages/zod/src/v4/locales/ca.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/cs.ts
+++ b/packages/zod/src/v4/locales/cs.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "číslo",
     string: "řetězec",
     function: "funkce",

--- a/packages/zod/src/v4/locales/da.ts
+++ b/packages/zod/src/v4/locales/da.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     string: "streng",
     number: "tal",
     boolean: "boolean",

--- a/packages/zod/src/v4/locales/de.ts
+++ b/packages/zod/src/v4/locales/de.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "Zahl",
     array: "Array",
   };

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -53,9 +53,9 @@ const error: () => errors.$ZodErrorMap = () => {
   const TypeDictionary: {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
-    // Compatibility: "nan" -> "NaN" for display
+    // Compatibility: lowercase internal keys -> human-readable display strings
     nan: "NaN",
-    // All other type names omitted - they fall back to raw values via ?? operator
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/eo.ts
+++ b/packages/zod/src/v4/locales/eo.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "nombro",
     array: "tabelo",
     null: "senvalora",

--- a/packages/zod/src/v4/locales/es.ts
+++ b/packages/zod/src/v4/locales/es.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     string: "texto",
     number: "número",
     boolean: "booleano",

--- a/packages/zod/src/v4/locales/fa.ts
+++ b/packages/zod/src/v4/locales/fa.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "عدد",
     array: "آرایه",
   };

--- a/packages/zod/src/v4/locales/fi.ts
+++ b/packages/zod/src/v4/locales/fi.ts
@@ -55,6 +55,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/fr-CA.ts
+++ b/packages/zod/src/v4/locales/fr-CA.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/fr.ts
+++ b/packages/zod/src/v4/locales/fr.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "nombre",
     array: "tableau",
   };

--- a/packages/zod/src/v4/locales/he.ts
+++ b/packages/zod/src/v4/locales/he.ts
@@ -96,6 +96,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/hr.ts
+++ b/packages/zod/src/v4/locales/hr.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     string: "tekst",
     number: "broj",
     boolean: "boolean",

--- a/packages/zod/src/v4/locales/hu.ts
+++ b/packages/zod/src/v4/locales/hu.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "szám",
     array: "tömb",
   };

--- a/packages/zod/src/v4/locales/hy.ts
+++ b/packages/zod/src/v4/locales/hy.ts
@@ -94,6 +94,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "թիվ",
     array: "զանգված",
   };

--- a/packages/zod/src/v4/locales/id.ts
+++ b/packages/zod/src/v4/locales/id.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/is.ts
+++ b/packages/zod/src/v4/locales/is.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "númer",
     array: "fylki",
   };

--- a/packages/zod/src/v4/locales/it.ts
+++ b/packages/zod/src/v4/locales/it.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "numero",
     array: "vettore",
   };

--- a/packages/zod/src/v4/locales/ja.ts
+++ b/packages/zod/src/v4/locales/ja.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "数値",
     array: "配列",
   };

--- a/packages/zod/src/v4/locales/ka.ts
+++ b/packages/zod/src/v4/locales/ka.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "რიცხვი",
     string: "ველი",
     boolean: "ბულეანი",

--- a/packages/zod/src/v4/locales/km.ts
+++ b/packages/zod/src/v4/locales/km.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "លេខ",
     array: "អារេ (Array)",
     null: "គ្មានតម្លៃ (null)",

--- a/packages/zod/src/v4/locales/ko.ts
+++ b/packages/zod/src/v4/locales/ko.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/lt.ts
+++ b/packages/zod/src/v4/locales/lt.ts
@@ -152,6 +152,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "skaičius",
     bigint: "sveikasis skaičius",
     string: "eilutė",

--- a/packages/zod/src/v4/locales/mk.ts
+++ b/packages/zod/src/v4/locales/mk.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "број",
     array: "низа",
   };

--- a/packages/zod/src/v4/locales/ms.ts
+++ b/packages/zod/src/v4/locales/ms.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "nombor",
   };
 

--- a/packages/zod/src/v4/locales/nl.ts
+++ b/packages/zod/src/v4/locales/nl.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "getal",
   };
 

--- a/packages/zod/src/v4/locales/no.ts
+++ b/packages/zod/src/v4/locales/no.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "tall",
     array: "liste",
   };

--- a/packages/zod/src/v4/locales/ota.ts
+++ b/packages/zod/src/v4/locales/ota.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "numara",
     array: "saf",
     null: "gayb",

--- a/packages/zod/src/v4/locales/pl.ts
+++ b/packages/zod/src/v4/locales/pl.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "liczba",
     array: "tablica",
   };

--- a/packages/zod/src/v4/locales/ps.ts
+++ b/packages/zod/src/v4/locales/ps.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "عدد",
     array: "ارې",
   };

--- a/packages/zod/src/v4/locales/pt.ts
+++ b/packages/zod/src/v4/locales/pt.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "número",
     null: "nulo",
   };

--- a/packages/zod/src/v4/locales/ru.ts
+++ b/packages/zod/src/v4/locales/ru.ts
@@ -107,6 +107,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "число",
     array: "массив",
   };

--- a/packages/zod/src/v4/locales/sl.ts
+++ b/packages/zod/src/v4/locales/sl.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "število",
     array: "tabela",
   };

--- a/packages/zod/src/v4/locales/sv.ts
+++ b/packages/zod/src/v4/locales/sv.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "antal",
     array: "lista",
   };

--- a/packages/zod/src/v4/locales/ta.ts
+++ b/packages/zod/src/v4/locales/ta.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "எண்",
     array: "அணி",
     null: "வெறுமை",

--- a/packages/zod/src/v4/locales/th.ts
+++ b/packages/zod/src/v4/locales/th.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "ตัวเลข",
     array: "อาร์เรย์ (Array)",
     null: "ไม่มีค่า (null)",

--- a/packages/zod/src/v4/locales/tr.ts
+++ b/packages/zod/src/v4/locales/tr.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {

--- a/packages/zod/src/v4/locales/uk.ts
+++ b/packages/zod/src/v4/locales/uk.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "число",
     array: "масив",
   };

--- a/packages/zod/src/v4/locales/ur.ts
+++ b/packages/zod/src/v4/locales/ur.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "نمبر",
     array: "آرے",
     null: "نل",

--- a/packages/zod/src/v4/locales/uz.ts
+++ b/packages/zod/src/v4/locales/uz.ts
@@ -53,6 +53,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "raqam",
     array: "massiv",
   };

--- a/packages/zod/src/v4/locales/vi.ts
+++ b/packages/zod/src/v4/locales/vi.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "số",
     array: "mảng",
   };

--- a/packages/zod/src/v4/locales/yo.ts
+++ b/packages/zod/src/v4/locales/yo.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "nọ́mbà",
     array: "akopọ",
   };

--- a/packages/zod/src/v4/locales/zh-CN.ts
+++ b/packages/zod/src/v4/locales/zh-CN.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
     number: "数字",
     array: "数组",
     null: "空值(null)",

--- a/packages/zod/src/v4/locales/zh-TW.ts
+++ b/packages/zod/src/v4/locales/zh-TW.ts
@@ -51,6 +51,7 @@ const error: () => errors.$ZodErrorMap = () => {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
     nan: "NaN",
+    infinity: "Infinity",
   };
 
   return (issue) => {


### PR DESCRIPTION
## Problem

When `Infinity` or `-Infinity` is passed to `z.number()`, the error message is confusingly self-contradictory:

```ts
z.number().parse(Infinity)
// ZodError: Invalid input: expected number, received number  ← ???
```

The same message appears with `.finite()`:

```ts
z.number().finite().parse(Infinity)
// ZodError: Invalid input: expected number, received number
```

This was reported in #5697.

## Root Cause

`parsedType()` in `util.ts` only checks `Number.isNaN` but not `Number.isFinite`:

```ts
case "number": {
  return Number.isNaN(data) ? "nan" : "number";  // ← Infinity falls through as "number"
}
```

The locale formatter then calls `parsedType(issue.input)` to generate the `received` string in the message, so it produces `"number"` for both finite and infinite numbers.

Note: `schemas.ts` was already correctly setting `received: "Infinity"` on the raw issue object — the bug was only in the message rendering path through `parsedType`.

## Fix

1. **`util.ts`** — extend the `number` case to return `"infinity"` for non-finite values:

```ts
case "number": {
  if (Number.isNaN(data)) return "nan";
  if (!Number.isFinite(data)) return "infinity";
  return "number";
}
```

2. **All locale files** — add `infinity: "Infinity"` to each locale's `TypeDictionary`, following the same pattern as the existing `nan: "NaN"` entry.

## Result

```ts
z.number().parse(Infinity)
// ZodError: Invalid input: expected number, received Infinity  ← clear
```

All 3575 tests pass.

Fixes #5697
