### PR TITLE
feat: add json-up to ecosystem

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -270,6 +270,12 @@ const poweredByZodProjects: ZodResource[] = [
     url: "https://github.com/endel/zodgres",
     description: "Postgres.js + Zod: Database collections with static type inference and automatic migrations",
     slug: "endel/zodgres",
+  },
+  {
+    name: "json-up",
+    url: "https://github.com/Nano-Collective/json-up",
+    description: "A fast, type-safe JSON migration tool with Zod schema validation.",
+    slug: "Nano-Collective/json-up",
   }
 ];
 


### PR DESCRIPTION
Hey there,

I would like to propose adding [https://github.com/Nano-Collective/json-up](https://github.com/Nano-Collective/json-up) to the Zod ecosystem list.

### What is json-up?

json-up is a fast, type-safe JSON migration tool built around Zod schema validation.

It provides:

* Type-safe JSON data migrations, with full TypeScript inference
* Zod schema validation at every migration step
* A fluent builder API for defining migration chains
* Zod is a key dependency for the project

It is designed for evolving persisted or user provided JSON data safely over time, while keeping schemas as the single source of truth.

### Why add it?

* Focused on a common real world problem: safely migrating versioned JSON state
* Minimal and dependency light
* Actively maintained by the Nano Collective

### Links

* Repository: [https://github.com/Nano-Collective/json-up](https://github.com/Nano-Collective/json-up)
* Documentation: [https://github.com/Nano-Collective/json-up/tree/main/docs](https://github.com/Nano-Collective/json-up/tree/main/docs)

Thanks for considering the addition and building Zod!

Happy to adjust the wording or structure as you need
