### PR TITLE
feat: allow 'when' parameter in .superRefine

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -94,7 +94,8 @@ export interface ZodType<
     params?: string | core.$ZodCustomParams
   ): Ch extends (arg: any) => arg is infer R ? this & ZodType<R, core.input<this>> : this;
   superRefine(
-    refinement: (arg: core.output<this>, ctx: core.$RefinementCtx<core.output<this>>) => void | Promise<void>
+    refinement: (arg: core.output<this>, ctx: core.$RefinementCtx<core.output<this>>) => void | Promise<void>,
+    params?: string | core.$ZodCustomParams
   ): this;
   overwrite(fn: (x: core.output<this>) => core.output<this>): this;
 
@@ -210,7 +211,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
 
   // refinements
   inst.refine = (check, params) => inst.check(refine(check, params)) as never;
-  inst.superRefine = (refinement) => inst.check(superRefine(refinement));
+  inst.superRefine = (refinement, params) => inst.check(superRefine(refinement, params));
   inst.overwrite = (fn) => inst.check(checks.overwrite(fn));
 
   // wrappers
@@ -2321,9 +2322,10 @@ export function refine<T>(
 
 // superRefine
 export function superRefine<T>(
-  fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>
+  fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>,
+  params?: string | core.$ZodCustomParams
 ): core.$ZodCheck<T> {
-  return core._superRefine(fn);
+  return core._superRefine(fn, params);
 }
 
 // Re-export describe and meta from core

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -95,7 +95,7 @@ export interface ZodType<
   ): Ch extends (arg: any) => arg is infer R ? this & ZodType<R, core.input<this>> : this;
   superRefine(
     refinement: (arg: core.output<this>, ctx: core.$RefinementCtx<core.output<this>>) => void | Promise<void>,
-    params?: string | core.$ZodCustomParams
+    params?: core.$ZodSuperRefineParams
   ): this;
   overwrite(fn: (x: core.output<this>) => core.output<this>): this;
 
@@ -2323,7 +2323,7 @@ export function refine<T>(
 // superRefine
 export function superRefine<T>(
   fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>,
-  params?: string | core.$ZodCustomParams
+  params?: core.$ZodSuperRefineParams
 ): core.$ZodCheck<T> {
   return core._superRefine(fn, params);
 }

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1634,7 +1634,10 @@ export interface $RefinementCtx<T = unknown> extends schemas.ParsePayload<T> {
 }
 
 // @__NO_SIDE_EFFECTS__
-export function _superRefine<T>(fn: (arg: T, payload: $RefinementCtx<T>) => void | Promise<void>): checks.$ZodCheck<T> {
+export function _superRefine<T>(
+  fn: (arg: T, payload: $RefinementCtx<T>) => void | Promise<void>,
+  params?: string | $ZodCustomParams
+): checks.$ZodCheck<T> {
   const ch = _check<T>((payload) => {
     (payload as $RefinementCtx).addIssue = (issue) => {
       if (typeof issue === "string") {
@@ -1652,7 +1655,7 @@ export function _superRefine<T>(fn: (arg: T, payload: $RefinementCtx<T>) => void
     };
 
     return fn(payload.value, payload as $RefinementCtx<T>);
-  });
+  }, params);
   return ch;
 }
 

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1633,10 +1633,15 @@ export interface $RefinementCtx<T = unknown> extends schemas.ParsePayload<T> {
   addIssue(arg: string | $ZodSuperRefineIssue): void;
 }
 
+export interface $ZodSuperRefineParams {
+  /** If provided, the refinement runs only when this returns `true`. By default, it is skipped if prior parsing produced aborting issues. */
+  when?: ((payload: schemas.ParsePayload) => boolean) | undefined;
+}
+
 // @__NO_SIDE_EFFECTS__
 export function _superRefine<T>(
   fn: (arg: T, payload: $RefinementCtx<T>) => void | Promise<void>,
-  params?: string | $ZodCustomParams
+  params?: $ZodSuperRefineParams
 ): checks.$ZodCheck<T> {
   const ch = _check<T>((payload) => {
     (payload as $RefinementCtx).addIssue = (issue) => {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -13,7 +13,7 @@ export interface $ZodCheckDef {
   error?: errors.$ZodErrorMap<never> | undefined;
   /** If true, no later checks will be executed if this check fails. Default `false`. */
   abort?: boolean | undefined;
-  /** If provided, this check will only be executed if the function returns `true`. Defaults to `payload => z.util.isAborted(payload)`. */
+  /** If provided, the check runs only when this returns `true`. By default, it is skipped if prior parsing produced aborting issues. */
   when?: ((payload: schemas.ParsePayload) => boolean) | undefined;
 }
 

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1770,9 +1770,10 @@ export function refine<T>(
 // superRefine
 // @__NO_SIDE_EFFECTS__
 export function superRefine<T>(
-  fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>
+  fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>,
+  params?: core.$ZodSuperRefineParams
 ): core.$ZodCheck<T> {
-  return core._superRefine(fn);
+  return core._superRefine(fn, params);
 }
 
 // Re-export describe and meta from core


### PR DESCRIPTION
This PR adds the `params` object to `.superRefine` which allows using `when` parameter to run the superrefine validation even when the base schema fails, similar to how `.refine` works currently

See my issue about this: https://github.com/colinhacks/zod/issues/5739