### PR TITLE
test: increase timeout for redos checker in datetime.test.ts

### DIFF
--- a/packages/zod/src/v4/classic/tests/datetime.test.ts
+++ b/packages/zod/src/v4/classic/tests/datetime.test.ts
@@ -299,4 +299,4 @@ test("redos checker", () => {
     const result = checkSync(schema._zod.pattern.source, "");
     if (result.status !== "safe") throw Error("ReDoS issue");
   }
-});
+}, 10000);


### PR DESCRIPTION
This PR increases the timeout for the `redos checker` test case in `src/v4/classic/tests/datetime.test.ts` to 10s.

#### Why?
As documented in #5743 (and previously discussed in #5365), this test is hitting the 5s limit on node 24.12.0 (LTS). This provides a buffer for the `recheck` library's execution on newer V8 engines.

#### Verified on
- Node 22 (Pass)
- Node 24 (Pass)

Closes #5743 