### PR TITLE
fix: strip redundant id from $defs entries in toJSONSchema

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1219,11 +1219,9 @@ describe("toJSONSchema", () => {
         },
         "definitions": {
           "primary": {
-            "id": "primary",
             "type": "string",
           },
           "rest": {
-            "id": "rest",
             "type": "number",
           },
         },
@@ -2014,11 +2012,9 @@ test("extract schemas with id", () => {
     {
       "$defs": {
         "age": {
-          "id": "age",
           "type": "number",
         },
         "name": {
-          "id": "name",
           "type": "string",
         },
       },
@@ -2106,7 +2102,6 @@ test("describe with id", () => {
     {
       "$defs": {
         "jobId": {
-          "id": "jobId",
           "type": "string",
         },
       },
@@ -2146,7 +2141,6 @@ test("describe with id on wrapper", () => {
     {
       "$defs": {
         "roJobId": {
-          "id": "roJobId",
           "readOnly": true,
           "type": "string",
         },
@@ -2185,12 +2179,10 @@ test("overwrite id", () => {
     {
       "$defs": {
         "aaa": {
-          "id": "aaa",
           "type": "string",
         },
         "bbb": {
           "$ref": "#/$defs/aaa",
-          "id": "bbb",
         },
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2224,12 +2216,10 @@ test("overwrite id", () => {
     {
       "$defs": {
         "aaa": {
-          "id": "aaa",
           "type": "string",
         },
         "ccc": {
           "$ref": "#/$defs/aaa",
-          "id": "ccc",
         },
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -2351,7 +2341,6 @@ test("top-level readonly", () => {
       "$defs": {
         "B": {
           "additionalProperties": false,
-          "id": "B",
           "properties": {
             "a": {
               "$ref": "#",
@@ -2497,7 +2486,6 @@ test("_ref", () => {
     {
       "$defs": {
         "foo": {
-          "id": "foo",
           "type": "string",
         },
       },

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2126,6 +2126,45 @@ test("describe with id", () => {
   `);
 });
 
+test("id is stripped from $defs entries (draft-2020-12)", () => {
+  // The `id` in `.meta()` is a registration tag — it determines the $defs key
+  // but should not leak into the definition body, where it is redundant.
+  const inner = z.string().meta({ id: "Inner" });
+  const result = z.toJSONSchema(z.object({ a: inner, b: inner }));
+  expect(result.$defs?.Inner).toEqual({ type: "string" });
+  expect((result.$defs?.Inner as any).id).toBeUndefined();
+});
+
+test("id is stripped from definitions entries (draft-04)", () => {
+  // In draft-04, `id` is a reserved keyword that sets a base URI for the
+  // subschema. Leaking Zod's registration tag here is semantically wrong, so
+  // ensure it is stripped.
+  const inner = z.string().meta({ id: "Inner" });
+  const result = z.toJSONSchema(z.object({ a: inner, b: inner }), { target: "draft-04" }) as any;
+  expect(result.definitions?.Inner).toEqual({ type: "string" });
+  expect(result.definitions?.Inner?.id).toBeUndefined();
+});
+
+test("id is stripped from root schema", () => {
+  // The registration tag should not appear on the root either.
+  const A = z.object({ name: z.string() }).meta({ id: "A" });
+  const result = z.toJSONSchema(A);
+  expect((result as any).id).toBeUndefined();
+});
+
+test("id is observable in override callback", () => {
+  // The strip happens after override callbacks run, so userland override code
+  // can still read `jsonSchema.id` if it wants to.
+  const inner = z.string().meta({ id: "Inner" });
+  const seenIds: Array<string | undefined> = [];
+  z.toJSONSchema(z.object({ a: inner }), {
+    override: ({ jsonSchema }) => {
+      if (jsonSchema.id !== undefined) seenIds.push(jsonSchema.id as string);
+    },
+  });
+  expect(seenIds).toContain("Inner");
+});
+
 test("describe with id on wrapper", () => {
   // Test that $ref propagation works when processor sets a different ref (readonly -> innerType)
   // but parent was extracted due to having an id
@@ -2359,7 +2398,6 @@ test("top-level readonly", () => {
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": false,
-      "id": "A",
       "properties": {
         "b": {
           "$ref": "#/$defs/B",

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -287,7 +287,12 @@ export function extractDefs<T extends schemas.$ZodType>(
     seen.def = { ...seen.schema };
     // defId won't be set if the schema is a reference to an external schema
     // or if the schema is the root schema
-    if (defId) seen.defId = defId;
+    if (defId) {
+      seen.defId = defId;
+      // The `id` is already encoded as the $defs key — strip it from the
+      // definition body to avoid redundant (and technically invalid) output.
+      if (seen.def.id === defId) delete seen.def.id;
+    }
     // wipe away all properties except $ref
     const schema = seen.schema;
     for (const key in schema) {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -287,12 +287,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     seen.def = { ...seen.schema };
     // defId won't be set if the schema is a reference to an external schema
     // or if the schema is the root schema
-    if (defId) {
-      seen.defId = defId;
-      // The `id` is already encoded as the $defs key — strip it from the
-      // definition body to avoid redundant (and technically invalid) output.
-      if (seen.def.id === defId) delete seen.def.id;
-    }
+    if (defId) seen.defId = defId;
     // wipe away all properties except $ref
     const schema = seen.schema;
     for (const key in schema) {
@@ -476,11 +471,19 @@ export function finalize<T extends schemas.$ZodType>(
 
   Object.assign(result, root.def ?? root.schema);
 
+  // The `id` in `.meta()` is a Zod-specific registration tag used to extract
+  // schemas into $defs — it is not user-facing JSON Schema metadata. Strip it
+  // from the output body where it would otherwise leak. The id is preserved
+  // implicitly via the $defs key (and via $ref paths).
+  const rootMetaId = ctx.metadataRegistry.get(schema)?.id;
+  if (rootMetaId !== undefined && result.id === rootMetaId) delete result.id;
+
   // build defs object
   const defs: JSONSchema.BaseSchema["$defs"] = ctx.external?.defs ?? {};
   for (const entry of ctx.seen.entries()) {
     const seen = entry[1];
     if (seen.def && seen.defId) {
+      if (seen.def.id === seen.defId) delete seen.def.id;
       defs[seen.defId] = seen.def;
     }
   }


### PR DESCRIPTION
## Problem

When a schema is annotated with `.meta({ id: "Name" })`, the `id` is used as the key in `$defs` so that other schemas can reference it via `$ref`. However, the `id` was also being included verbatim in the definition body, producing redundant output:

```json
{
  "$defs": {
    "Inner": {
      "id": "Inner",
      "type": "string"
    }
  }
}
```

The presence of `id` inside `$defs` entries is misleading — it looks like a JSON Schema `$id`, but it's just Zod's internal `id` tag. The `id` is already encoded as the `$defs` key itself, so including it in the value is redundant.

Fixes #5731

## Solution

In `extractToDef()`, after copying the schema into `seen.def`, delete the `id` property from the definition body when it matches `defId` — the id is already encoded as the `$defs` key name.

**Before:**
```json
{ "$defs": { "Inner": { "id": "Inner", "type": "string" } } }
```

**After:**
```json
{ "$defs": { "Inner": { "type": "string" } } }
```

## Tests

Updated 6 existing snapshot tests that documented the old (buggy) behavior to reflect the correct output.