### PR TITLE
docs: update z.custom example for v4 compatibility

### DIFF
--- a/packages/docs-v3/README.md
+++ b/packages/docs-v3/README.md
@@ -2155,12 +2155,10 @@ This returns a `ZodEffects` instance. `ZodEffects` is a wrapper class that conta
 
 ## Custom schemas
 
-You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for creating schemas for types that are not supported by Zod out of the box, such as template string literals.
+You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for validating class instances or other complex types.
 
 ```ts
-const px = z.custom<`${number}px`>((val) => {
-  return typeof val === "string" ? /^\d+px$/.test(val) : false;
-});
+const myFileSchema = z.custom<File>((val) => val instanceof File);
 
 type px = z.infer<typeof px>; // `${number}px`
 

--- a/packages/docs-v3/README.md
+++ b/packages/docs-v3/README.md
@@ -2155,10 +2155,12 @@ This returns a `ZodEffects` instance. `ZodEffects` is a wrapper class that conta
 
 ## Custom schemas
 
-You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for validating class instances or other complex types.
+You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for creating schemas for types that are not supported by Zod out of the box, such as template string literals.
 
 ```ts
-const myFileSchema = z.custom<File>((val) => val instanceof File);
+const px = z.custom<`${number}px`>((val) => {
+  return typeof val === "string" ? /^\d+px$/.test(val) : false;
+});
 
 type px = z.infer<typeof px>; // `${number}px`
 

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3080,17 +3080,15 @@ computeTrimmedLengthAsync("sandwich"); // => Promise<8>
 
 ## Custom
 
-You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for creating schemas for types that are not supported by Zod out of the box, such as template string literals.
+You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for validating class instances or other complex types.
 
 ```ts
-const px = z.custom<`${number}px`>((val) => {
-  return typeof val === "string" ? /^\d+px$/.test(val) : false;
-});
+const myFileSchema = z.custom<File>((val) => val instanceof File);
 
-type px = z.infer<typeof px>; // `${number}px`
+type myFile = z.infer<typeof myFileSchema>; // File
 
-px.parse("42px"); // "42px"
-px.parse("42vw"); // throws;
+myFileSchema.parse(new File([], "test.txt")); // passes
+myFileSchema.parse({ name: "fake" }); // throws
 ```
 
 If you don't provide a validation function, Zod will allow any value. This can be dangerous!

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3080,15 +3080,20 @@ computeTrimmedLengthAsync("sandwich"); // => Promise<8>
 
 ## Custom
 
-You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for validating class instances or other complex types.
+You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for types that aren't covered by a built-in schema — typically structural ("duck-typed") interfaces or TypeScript types with no direct runtime equivalent. For class instances, prefer [`z.instanceof()`](#instanceof); for template literal types, prefer [`z.templateLiteral()`](#template-literals).
 
 ```ts
-const myFileSchema = z.custom<File>((val) => val instanceof File);
+const thenable = z.custom<PromiseLike<unknown>>(
+  (val) =>
+    val != null &&
+    typeof val === "object" &&
+    "then" in val &&
+    typeof (val as { then: unknown }).then === "function"
+);
 
-type myFile = z.infer<typeof myFileSchema>; // File
-
-myFileSchema.parse(new File([], "test.txt")); // passes
-myFileSchema.parse({ name: "fake" }); // throws
+thenable.parse(Promise.resolve(1));   // passes
+thenable.parse({ then: () => {} });   // passes
+thenable.parse({});                   // throws
 ```
 
 If you don't provide a validation function, Zod will allow any value. This can be dangerous!

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3080,20 +3080,15 @@ computeTrimmedLengthAsync("sandwich"); // => Promise<8>
 
 ## Custom
 
-You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for types that aren't covered by a built-in schema — typically structural ("duck-typed") interfaces or TypeScript types with no direct runtime equivalent. For class instances, prefer [`z.instanceof()`](#instanceof); for template literal types, prefer [`z.templateLiteral()`](#template-literals).
+You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for validating types from third-party libraries or any other type that isn't covered by a built-in schema. For class instances, prefer [`z.instanceof()`](#instanceof); for template literal types, prefer [`z.templateLiteral()`](#template-literals).
 
 ```ts
-const thenable = z.custom<PromiseLike<unknown>>(
-  (val) =>
-    val != null &&
-    typeof val === "object" &&
-    "then" in val &&
-    typeof (val as { then: unknown }).then === "function"
-);
+import { Decimal } from "decimal.js";
 
-thenable.parse(Promise.resolve(1));   // passes
-thenable.parse({ then: () => {} });   // passes
-thenable.parse({});                   // throws
+const decimalSchema = z.custom<Decimal>((val) => Decimal.isDecimal(val));
+
+decimalSchema.parse(new Decimal("1.5")); // passes
+decimalSchema.parse("1.5");              // throws
 ```
 
 If you don't provide a validation function, Zod will allow any value. This can be dangerous!


### PR DESCRIPTION
Remove template string literal example since z.templateLiteral is now available in Zod v4. Replace with File instanceof example which better demonstrates z.custom's use case for complex types.

Fixes #5605