### PR TITLE
fix(transform): type standalone z.transform() ctx as $RefinementCtx

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1814,7 +1814,7 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
 );
 
 export function transform<I = unknown, O = I>(
-  fn: (input: I, ctx: core.ParsePayload) => O
+  fn: (input: I, ctx: core.$RefinementCtx<I>) => O
 ): ZodTransform<Awaited<O>, I> {
   return new ZodTransform({
     type: "transform",

--- a/packages/zod/src/v4/classic/tests/transform.test.ts
+++ b/packages/zod/src/v4/classic/tests/transform.test.ts
@@ -359,3 +359,33 @@ test("encode error", () => {
     `[ZodEncodeError: Encountered unidirectional transform during encode: ZodTransform]`
   );
 });
+
+test("standalone z.transform ctx.addIssue", () => {
+  const schema = z.transform((input: string, ctx) => {
+    if (input.length < 3) {
+      ctx.addIssue({
+        code: "custom",
+        message: "too short",
+      });
+    }
+    return input.toUpperCase();
+  });
+
+  const good = schema.safeParse("hello");
+  expect(good.success).toBe(true);
+  if (good.success) {
+    expect(good.data).toBe("HELLO");
+  }
+
+  const bad = schema.safeParse("hi");
+  expect(bad.success).toBe(false);
+});
+
+test("standalone z.transform ctx.addIssue type check", () => {
+  // Verify that ctx.addIssue is available in the type system
+  const _schema = z.transform((_input: string, ctx) => {
+    // This should compile without errors — ctx.addIssue should be typed
+    expectTypeOf(ctx.addIssue).toBeFunction();
+    return _input;
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the type of the `ctx` parameter in the standalone `z.transform()` factory function to include `addIssue()`.

## Root cause

The standalone `z.transform((input, ctx) => ...)` factory function typed `ctx` as `ParsePayload`, which only includes `value`, `issues`, and `aborted`. However, at runtime, the classic `ZodTransform` constructor mutates the payload to attach `addIssue()` before invoking the callback — so `ctx.addIssue(...)` works at runtime but TypeScript doesn't see it.

The chained `.transform()` method on `ZodType` already correctly types `ctx` as `$RefinementCtx` (which extends `ParsePayload` with `addIssue`). The standalone factory was just missed.

## Fix

Changed the `ctx` parameter type from `core.ParsePayload` to `core.$RefinementCtx<I>` in the standalone `transform()` function signature.

## Tests

Added two tests:
- Runtime test: standalone `z.transform()` with `ctx.addIssue()` correctly surfaces validation errors
- Type test: verifies `ctx.addIssue` is typed as a function via `expectTypeOf`

## Related issue

Closes #5678