### PR TITLE
fix(json-schema): use $defs instead of definitions for openapi-3.0 target

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1157,6 +1157,45 @@ describe("toJSONSchema", () => {
     `);
   });
 
+  test("recursive schema openapi-3.0 uses $defs", () => {
+    const Recursive: z.ZodType = z.lazy(() => z.object({ child: Recursive.optional() }));
+    const Schema = z.object({ data: Recursive });
+    const jsonSchema = z.toJSONSchema(Schema, { target: "openapi-3.0" });
+    // OpenAPI 3.0 should not use "definitions" — it is a Swagger 2.0 / JSON Schema
+    // Draft 4 concept not recognized by OpenAPI 3.0 Schema Objects.
+    expect(jsonSchema).not.toHaveProperty("definitions");
+    expect(jsonSchema).toHaveProperty("$defs");
+    expect(jsonSchema).toMatchInlineSnapshot(`
+      {
+        "$defs": {
+          "__schema0": {
+            "additionalProperties": false,
+            "properties": {
+              "child": {
+                "allOf": [
+                  {
+                    "$ref": "#/$defs/__schema0",
+                  },
+                ],
+              },
+            },
+            "type": "object",
+          },
+        },
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "$ref": "#/$defs/__schema0",
+          },
+        },
+        "required": [
+          "data",
+        ],
+        "type": "object",
+      }
+    `);
+  });
+
   test("tuple draft-7", () => {
     const schema = z.tuple([z.string(), z.number()]);
     expect(z.toJSONSchema(schema, { target: "draft-7", io: "input" })).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -650,7 +650,7 @@ export function toJSONSchema(
     }
 
     if (Object.keys(defs).length > 0) {
-      const defsSegment = ctx.target === "draft-2020-12" ? "$defs" : "definitions";
+      const defsSegment = ctx.target === "draft-04" || ctx.target === "draft-07" ? "definitions" : "$defs";
       schemas.__shared = {
         [defsSegment]: defs,
       };

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -247,7 +247,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     // e.g. lazy
 
     // external is configured
-    const defsSegment = ctx.target === "draft-2020-12" ? "$defs" : "definitions";
+    const defsSegment = ctx.target === "draft-04" || ctx.target === "draft-07" ? "definitions" : "$defs";
     if (ctx.external) {
       const externalId = ctx.external.registry.get(entry[0])?.id; // ?? "__shared";// `__schema${ctx.counter++}`;
 
@@ -484,10 +484,10 @@ export function finalize<T extends schemas.$ZodType>(
   if (ctx.external) {
   } else {
     if (Object.keys(defs).length > 0) {
-      if (ctx.target === "draft-2020-12") {
-        result.$defs = defs;
-      } else {
+      if (ctx.target === "draft-04" || ctx.target === "draft-07") {
         result.definitions = defs;
+      } else {
+        result.$defs = defs;
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Fixes `toJSONSchema()` with `target: "openapi-3.0"` to use `$defs` and `#/$defs/` refs instead of `definitions` and `#/definitions/` for recursive schemas.

## Root cause

The `defsSegment` logic in `to-json-schema.ts` and `json-schema-processors.ts` used a binary choice: `$defs` for `draft-2020-12`, `definitions` for everything else. This meant `openapi-3.0` was getting `definitions` — a Swagger 2.0 / JSON Schema Draft 4 concept that is not a recognized keyword in OpenAPI 3.0 Schema Objects.

For a recursive schema like:

```ts
const Recursive = z.lazy(() => z.object({ child: Recursive.optional() }));
const Schema = z.object({ data: Recursive });
z.toJSONSchema(Schema, { target: "openapi-3.0" });
```

The output contained `"$ref": "#/definitions/__schema0"` and a `"definitions"` key, which broke tools like Redoc that strictly validate against the OAS 3.0 spec.

## Fix

Inverted the condition: `definitions` is now only used for `draft-04` and `draft-07`, while everything else (including `openapi-3.0` and `draft-2020-12`) uses `$defs`. This is forward-compatible since OpenAPI 3.1 adopted JSON Schema 2020-12's `$defs` convention.

Changed in three places:
1. `to-json-schema.ts` line 250 — `makeURI` ref path segment
2. `to-json-schema.ts` lines 486-491 — `finalize` defs key placement
3. `json-schema-processors.ts` line 653 — registry `toJSONSchema` defs segment

## Tests

Added a new test `"recursive schema openapi-3.0 uses $defs"` that verifies:
- The output does NOT have a `definitions` key
- The output DOES have a `$defs` key
- Refs use `#/$defs/` prefix
- Full inline snapshot of expected output

All 3577 existing tests pass.

## Related issue

Closes #5693