### PR TITLE
fix: cascade inner field defaults through .default({}) on objects

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1924,6 +1924,19 @@ export function _default<T extends core.SomeType>(
   innerType: T,
   defaultValue: util.NoUndefined<core.output<T>> | (() => util.NoUndefined<core.output<T>>)
 ): ZodDefault<T> {
+  // Cascade inner defaults: when the inner type is an object schema and
+  // the default is a static plain object, parse it through the inner schema
+  // so nested field-level defaults are applied at definition time.
+  if (
+    typeof defaultValue !== "function" &&
+    util.isPlainObject(defaultValue) &&
+    (innerType as any)._zod?.def?.type === "object"
+  ) {
+    const result = (innerType as any)._zod.run({ value: { ...defaultValue }, issues: [] }, { async: false });
+    if (!(result instanceof Promise) && result.issues.length === 0) {
+      defaultValue = result.value;
+    }
+  }
   return new ZodDefault({
     type: "default",
     innerType: innerType as any as core.$ZodType,

--- a/packages/zod/src/v4/classic/tests/default.test.ts
+++ b/packages/zod/src/v4/classic/tests/default.test.ts
@@ -363,3 +363,60 @@ test("direction-aware defaults", () => {
     }
   `);
 });
+
+test("default({}) cascades inner field defaults", () => {
+  const inner = z.object({
+    name: z.string().default("untitled"),
+    count: z.number().default(0),
+  });
+  const schema = inner.default({} as z.output<typeof inner>);
+
+  // parse(undefined) should equal parse({})
+  expect(schema.parse(undefined)).toEqual({ name: "untitled", count: 0 });
+  expect(schema.parse({})).toEqual({ name: "untitled", count: 0 });
+  expect(schema.parse(undefined)).toEqual(schema.parse({}));
+});
+
+test("nested objects with cascading defaults", () => {
+  const revenue = z.object({
+    users: z.number().default(1000),
+    price: z.number().default(29),
+  });
+  const costs = z.object({
+    team_size: z.number().default(5),
+    salary: z.number().default(10_000),
+  });
+  const outer = z.object({
+    revenue: revenue.default({} as z.output<typeof revenue>),
+    costs: costs.default({} as z.output<typeof costs>),
+  });
+  const config = outer.default({} as z.output<typeof outer>);
+
+  expect(config.parse(undefined)).toEqual({
+    revenue: { users: 1000, price: 29 },
+    costs: { team_size: 5, salary: 10_000 },
+  });
+});
+
+test("default({}) with partial override preserves explicit values", () => {
+  const inner = z.object({
+    a: z.string().default("alpha"),
+    b: z.string().default("beta"),
+  });
+  const schema = inner.default({ a: "custom" } as z.output<typeof inner>);
+
+  // Explicit value in default should be kept, missing field should get inner default
+  expect(schema.parse(undefined)).toEqual({ a: "custom", b: "beta" });
+});
+
+test("default({}) returns distinct shallow clones", () => {
+  const inner = z.object({
+    items: z.array(z.string()).default([]),
+  });
+  const schema = inner.default({} as z.output<typeof inner>);
+
+  const r1 = schema.parse(undefined);
+  const r2 = schema.parse(undefined);
+  expect(r1).toEqual(r2);
+  expect(r1).not.toBe(r2);
+});

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1454,6 +1454,19 @@ export function _default<T extends schemas.$ZodObject>(
   innerType: T,
   defaultValue: util.NoUndefined<core.output<T>> | (() => util.NoUndefined<core.output<T>>)
 ): schemas.$ZodDefault<T> {
+  // Cascade inner defaults: when the inner type is an object schema and
+  // the default is a static plain object, parse it through the inner schema
+  // so nested field-level defaults are applied at definition time.
+  if (
+    typeof defaultValue !== "function" &&
+    util.isPlainObject(defaultValue) &&
+    (innerType as any)._zod?.def?.type === "object"
+  ) {
+    const result = (innerType as any)._zod.run({ value: { ...defaultValue }, issues: [] }, { async: false });
+    if (!(result instanceof Promise) && result.issues.length === 0) {
+      defaultValue = result.value;
+    }
+  }
   return new Class({
     type: "default",
     innerType,

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1446,6 +1446,19 @@ export function _default<T extends SomeType>(
   innerType: T,
   defaultValue: util.NoUndefined<core.output<T>> | (() => util.NoUndefined<core.output<T>>)
 ): ZodMiniDefault<T> {
+  // Cascade inner defaults: when the inner type is an object schema and
+  // the default is a static plain object, parse it through the inner schema
+  // so nested field-level defaults are applied at definition time.
+  if (
+    typeof defaultValue !== "function" &&
+    util.isPlainObject(defaultValue) &&
+    (innerType as any)._zod?.def?.type === "object"
+  ) {
+    const result = (innerType as any)._zod.run({ value: { ...defaultValue }, issues: [] }, { async: false });
+    if (!(result instanceof Promise) && result.issues.length === 0) {
+      defaultValue = result.value;
+    }
+  }
   return new ZodMiniDefault({
     type: "default",
     innerType: innerType as any as core.$ZodType,


### PR DESCRIPTION
## Summary

Fixes #5764

When `.default({})` is called on an object schema, the default value is now parsed through the inner schema **at definition time** so that nested field-level defaults are applied. This ensures the invariant:

```
schema.default(d).parse(undefined) === schema.parse(d)
```

holds for object schemas, matching user expectations and Zod v4's own direction on defaults.

### Before

```ts
const schema = z.object({
  name: z.string().default("untitled"),
  count: z.number().default(0),
}).default({});

schema.parse(undefined); // => {} ❌
```

### After

```ts
schema.parse(undefined); // => { name: "untitled", count: 0 } ✅
```

## Approach

In the `_default()` factory (classic, mini, and core), when the inner type is an object schema and the default is a static plain object (not a function), run it through the inner schema's parse at definition time. This:

- Has **zero runtime overhead** — the short-circuit optimization in `$ZodDefault.parse` is preserved
- Handles **deeply nested** objects recursively (inner defaults are already resolved when outer `.default({})` is called)
- Silently falls back to the original default if parsing fails (e.g., invalid default)

### Files changed

- `packages/zod/src/v4/classic/schemas.ts` — classic `_default()` factory
- `packages/zod/src/v4/mini/schemas.ts` — mini `_default()` factory
- `packages/zod/src/v4/core/api.ts` — core `_default()` factory
- `packages/zod/src/v4/classic/tests/default.test.ts` — 4 new test cases

## Test plan

- [x] Existing `default.test.ts` tests still pass (20/20)
- [x] New tests cover: basic cascading, deeply nested objects, partial overrides, shallow clone identity
- [x] Full test suite passes (3583 tests, 0 type errors)
- [x] Format and lint checks pass