### PR TITLE
fix: discriminatedUnion encode() with codec discriminator

### DIFF
--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -659,3 +659,29 @@ test("def", () => {
   expect(schema.def.discriminator).toEqual("type");
   expect(schema.def.unionFallback).toEqual(true);
 });
+
+test("encode with codec discriminator", () => {
+  const codec1 = z.codec(z.literal(1), z.literal("one"), {
+    decode: () => "one" as const,
+    encode: () => 1 as const,
+  });
+
+  const codec2 = z.codec(z.literal(2), z.literal("two"), {
+    decode: () => "two" as const,
+    encode: () => 2 as const,
+  });
+
+  const schema = z.discriminatedUnion("type", [
+    z.object({ type: codec1, value: z.string() }),
+    z.object({ type: codec2, value: z.number() }),
+  ]);
+
+  // decode (forward) should work
+  const decoded = schema.decode({ type: 1, value: "hello" });
+  expect(decoded).toEqual({ type: "one", value: "hello" });
+
+  // encode (backward) should also work — the discriminator values differ
+  // between forward (1, 2) and backward ("one", "two") directions
+  const encoded = z.encode(schema, { type: "one", value: "hello" });
+  expect(encoded).toEqual({ type: 1, value: "hello" });
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2347,7 +2347,11 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
         return opt._zod.run(payload, ctx) as any;
       }
 
-      if (def.unionFallback) {
+      // Fall back to union matching when the fast discriminator path fails:
+      // - explicitly enabled via unionFallback, or
+      // - during backward direction (encode), since codec-based discriminators
+      //   have different values in forward vs backward directions
+      if (def.unionFallback || ctx.direction === "backward") {
         return _super(payload, ctx);
       }
 


### PR DESCRIPTION
## Summary

Fixes #5593

When the discriminator field is a `ZodCodec`, `encode()` fails with "No matching discriminator" because the fast discriminator map only contains forward (decode) values while the encode input has backward (output) values.

### Before

```ts
const codec1 = z.codec(z.literal(1), z.literal("one"), {
  decode: () => "one" as const,
  encode: () => 1 as const,
});
const schema = z.discriminatedUnion("type", [
  z.object({ type: codec1, value: z.string() }),
  // ...
]);
z.encode(schema, { type: "one", value: "hello" }); // ❌ "No matching discriminator"
```

### After

```ts
z.encode(schema, { type: "one", value: "hello" }); // ✅ { type: 1, value: "hello" }
```

## Approach

The discriminator map is precomputed from forward `propValues` — for codecs, these are the input schema values (`1`, `2`). During `encode()`, the discriminator comes from the output schema (`"one"`, `"two"`), so the fast-path lookup misses.

Rather than building a second backward discriminator map (which adds complexity and may not generalize to all codec patterns), this fix falls back to the union matching path when the fast discriminator lookup fails in backward direction. This is the same path that `unionFallback: true` already uses.

### Files changed

- `packages/zod/src/v4/core/schemas.ts` — 3-line change in `$ZodDiscriminatedUnion.parse`
- `packages/zod/src/v4/classic/tests/discriminated-unions.test.ts` — new test case

## Test plan

- [x] New test: encode with codec discriminator passes
- [x] All existing discriminated union tests pass (23/23)
- [x] Full test suite passes (3577 tests, 0 type errors)
- [x] Format and lint checks pass