### PR TITLE
fix(fromJSONSchema): handle circular references in dereferenced schemas

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -26,6 +26,10 @@ interface ConversionContext {
   processing: Set<string>;
   rootSchema: JSONSchema.JSONSchema;
   registry: $ZodRegistry<any>;
+  /** Tracks already-converted schema objects by identity (for dereferenced schemas) */
+  schemaObjects: WeakMap<object, ZodType>;
+  /** Tracks schema objects currently being converted (cycle detection) */
+  processingSchemas: WeakSet<object>;
 }
 
 // Keys that are recognized and handled by the conversion logic
@@ -543,6 +547,23 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
     return schema ? z.any() : z.never();
   }
 
+  // Object-identity cycle detection for dereferenced schemas
+  const cached = ctx.schemaObjects.get(schema);
+  if (cached) return cached;
+
+  if (ctx.processingSchemas.has(schema)) {
+    // Circular reference by object identity — use lazy
+    return z.lazy(() => {
+      const resolved = ctx.schemaObjects.get(schema);
+      if (!resolved) {
+        throw new Error("Circular reference not resolved");
+      }
+      return resolved;
+    });
+  }
+
+  ctx.processingSchemas.add(schema);
+
   // Convert base schema first (ignoring composition keywords)
   let baseSchema = convertBaseSchema(schema, ctx);
   const hasExplicitType = schema.type || schema.enum !== undefined || schema.const !== undefined;
@@ -616,6 +637,9 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
     ctx.registry.add(baseSchema, extraMeta);
   }
 
+  ctx.schemaObjects.set(schema, baseSchema);
+  ctx.processingSchemas.delete(schema);
+
   return baseSchema;
 }
 
@@ -637,6 +661,8 @@ export function fromJSONSchema(schema: JSONSchema.JSONSchema | boolean, params?:
     processing: new Set(),
     rootSchema: schema,
     registry: params?.registry ?? globalRegistry,
+    schemaObjects: new WeakMap(),
+    processingSchemas: new WeakSet(),
   };
 
   return convertSchema(schema, ctx);

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -732,3 +732,94 @@ test("contentEncoding and contentMediaType are stored as metadata", () => {
   expect(meta?.contentEncoding).toBe("base64");
   expect(meta?.contentMediaType).toBe("image/png");
 });
+
+test("circular object reference (dereferenced schema)", () => {
+  // Simulates a fully-dereferenced JSON Schema where object identity creates cycles
+  const person: any = {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+    },
+    required: ["name"],
+  };
+  // Create circular reference: person.properties.bestFriend -> person
+  person.properties.bestFriend = person;
+
+  const schema = fromJSONSchema(person);
+  expect(schema.parse({ name: "Alice", bestFriend: { name: "Bob" } })).toEqual({
+    name: "Alice",
+    bestFriend: { name: "Bob" },
+  });
+  // Nested circular usage
+  expect(
+    schema.parse({
+      name: "Alice",
+      bestFriend: { name: "Bob", bestFriend: { name: "Charlie" } },
+    })
+  ).toEqual({
+    name: "Alice",
+    bestFriend: { name: "Bob", bestFriend: { name: "Charlie" } },
+  });
+});
+
+test("circular array reference (dereferenced schema)", () => {
+  const node: any = {
+    type: "object",
+    properties: {
+      value: { type: "number" },
+    },
+    required: ["value"],
+  };
+  // node.properties.children is an array of node (circular)
+  node.properties.children = {
+    type: "array",
+    items: node,
+  };
+
+  const schema = fromJSONSchema(node);
+  expect(
+    schema.parse({
+      value: 1,
+      children: [
+        { value: 2, children: [] },
+        { value: 3, children: [{ value: 4 }] },
+      ],
+    })
+  ).toEqual({
+    value: 1,
+    children: [
+      { value: 2, children: [] },
+      { value: 3, children: [{ value: 4 }] },
+    ],
+  });
+});
+
+test("mutual circular reference (dereferenced schema)", () => {
+  const parent: any = {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+    },
+    required: ["name"],
+  };
+  const child: any = {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      parent: parent,
+    },
+    required: ["name"],
+  };
+  parent.properties.children = { type: "array", items: child };
+
+  const schema = fromJSONSchema(parent);
+  expect(
+    schema.parse({
+      name: "Parent",
+      children: [{ name: "Child", parent: { name: "Parent" } }],
+    })
+  ).toEqual({
+    name: "Parent",
+    children: [{ name: "Child", parent: { name: "Parent" } }],
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #5675

`z.fromJSONSchema` crashes with "Maximum call stack size exceeded" when given a **dereferenced** JSON Schema that contains circular object references (e.g., a `Person` schema where `bestFriend` property references the same `Person` schema object).

The existing circular reference handling only tracks `$ref` string paths. When schemas are fully dereferenced (all `$ref` replaced with inline objects), the same schema object can appear at multiple positions. Without object-identity tracking, the converter recurses infinitely.

### Changes

- Added `WeakMap`/`WeakSet`-based object identity tracking to `ConversionContext` alongside the existing string-based `$ref` tracking
- When a schema object is encountered that is already being processed, it is wrapped in `z.lazy()` to break the cycle — matching the same pattern used for `$ref` cycles
- Added 3 tests covering: self-referencing objects, circular arrays, and mutual circular references

### Before
```ts
const person: any = { type: "object", properties: { name: { type: "string" } } };
person.properties.bestFriend = person; // circular by object identity

z.fromJSONSchema(person); // ❌ Maximum call stack size exceeded
```

### After
```ts
z.fromJSONSchema(person); // ✅ Works, circular ref resolved via z.lazy()
schema.parse({ name: "Alice", bestFriend: { name: "Bob" } }); // ✅
```

## Test plan

- [x] Added test for self-referencing circular object schema
- [x] Added test for circular array schema (node with children array of nodes)
- [x] Added test for mutual circular references (parent ↔ child)
- [x] All 3581 existing tests continue to pass
- [x] No type errors