### PR TITLE
fix: distinguish ZodCoerced* types from non-coerced via phantom brand

### DIFF
--- a/packages/zod/src/v4/classic/coerce.ts
+++ b/packages/zod/src/v4/classic/coerce.ts
@@ -1,27 +1,37 @@
 import * as core from "../core/index.js";
 import * as schemas from "./schemas.js";
 
-export interface ZodCoercedString<T = unknown> extends schemas._ZodString<core.$ZodStringInternals<T>> {}
+export interface ZodCoercedString<T = unknown> extends schemas._ZodString<core.$ZodStringInternals<T>> {
+  readonly "~coerced": true;
+}
 export function string<T = unknown>(params?: string | core.$ZodStringParams): ZodCoercedString<T> {
   return core._coercedString(schemas.ZodString, params) as any;
 }
 
-export interface ZodCoercedNumber<T = unknown> extends schemas._ZodNumber<core.$ZodNumberInternals<T>> {}
+export interface ZodCoercedNumber<T = unknown> extends schemas._ZodNumber<core.$ZodNumberInternals<T>> {
+  readonly "~coerced": true;
+}
 export function number<T = unknown>(params?: string | core.$ZodNumberParams): ZodCoercedNumber<T> {
   return core._coercedNumber(schemas.ZodNumber, params) as ZodCoercedNumber<T>;
 }
 
-export interface ZodCoercedBoolean<T = unknown> extends schemas._ZodBoolean<core.$ZodBooleanInternals<T>> {}
+export interface ZodCoercedBoolean<T = unknown> extends schemas._ZodBoolean<core.$ZodBooleanInternals<T>> {
+  readonly "~coerced": true;
+}
 export function boolean<T = unknown>(params?: string | core.$ZodBooleanParams): ZodCoercedBoolean<T> {
   return core._coercedBoolean(schemas.ZodBoolean, params) as ZodCoercedBoolean<T>;
 }
 
-export interface ZodCoercedBigInt<T = unknown> extends schemas._ZodBigInt<core.$ZodBigIntInternals<T>> {}
+export interface ZodCoercedBigInt<T = unknown> extends schemas._ZodBigInt<core.$ZodBigIntInternals<T>> {
+  readonly "~coerced": true;
+}
 export function bigint<T = unknown>(params?: string | core.$ZodBigIntParams): ZodCoercedBigInt<T> {
   return core._coercedBigint(schemas.ZodBigInt, params) as ZodCoercedBigInt<T>;
 }
 
-export interface ZodCoercedDate<T = unknown> extends schemas._ZodDate<core.$ZodDateInternals<T>> {}
+export interface ZodCoercedDate<T = unknown> extends schemas._ZodDate<core.$ZodDateInternals<T>> {
+  readonly "~coerced": true;
+}
 export function date<T = unknown>(params?: string | core.$ZodDateParams): ZodCoercedDate<T> {
   return core._coercedDate(schemas.ZodDate, params) as ZodCoercedDate<T>;
 }

--- a/packages/zod/src/v4/classic/tests/coerce.test.ts
+++ b/packages/zod/src/v4/classic/tests/coerce.test.ts
@@ -158,3 +158,14 @@ test("override input type", () => {
   type output = z.infer<typeof a>;
   expectTypeOf<output>().toEqualTypeOf<string>();
 });
+
+test("coerced types are not assignable from non-coerced", () => {
+  // ZodNumber should NOT be assignable to ZodCoercedNumber
+  // This prevents passing z.number() where z.coerce.number() is expected,
+  // which would fail at runtime since non-coerced schemas don't coerce input.
+  expectTypeOf(z.number()).not.toMatchTypeOf<z.ZodCoercedNumber>();
+  expectTypeOf(z.string()).not.toMatchTypeOf<z.ZodCoercedString>();
+  expectTypeOf(z.boolean()).not.toMatchTypeOf<z.ZodCoercedBoolean>();
+  expectTypeOf(z.bigint()).not.toMatchTypeOf<z.ZodCoercedBigInt>();
+  expectTypeOf(z.date()).not.toMatchTypeOf<z.ZodCoercedDate>();
+});


### PR DESCRIPTION
## Summary

Fixes #5692

`ZodCoercedNumber` and `ZodNumber` (and all other coerced/non-coerced pairs) were structurally identical at the TypeScript type level. This allowed passing `z.number()` where `z.coerce.number()` is expected — compiles fine but crashes at runtime:

```ts
function sample(schema: z.ZodCoercedNumber) {
  return schema.parse("123"); // expects coercion
}
sample(z.number()); // No type error, but fails at runtime!
```

### Fix

Add a `readonly "~coerced": true` phantom brand property to all 5 `ZodCoerced*` interfaces (`ZodCoercedString`, `ZodCoercedNumber`, `ZodCoercedBoolean`, `ZodCoercedBigInt`, `ZodCoercedDate`). This follows the same naming convention as the existing `~standard` property.

With the phantom brand:
- `ZodNumber` is **not** assignable to `ZodCoercedNumber` (missing `~coerced` — prevents the bug)
- Runtime behavior is completely unchanged (phantom properties don't exist at runtime)

### After

```ts
sample(z.number());        // TS error: Property '~coerced' is missing
sample(z.coerce.number()); // OK
```

## Test plan

- [x] Added type-level test verifying all 5 non-coerced types are NOT assignable to their coerced counterparts
- [x] All 3577 existing tests pass
- [x] No type errors