### PR TITLE
fix: apply key transforms in record with enum/literal keys

### DIFF
--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -630,3 +630,29 @@ test("numeric string keys", () => {
   );
   expect(transformedSchema.parse({ 5: "five", 10: "ten" })).toEqual({ 10: "five", 20: "ten" });
 });
+
+test("record with literal key transform applies key transformation", () => {
+  // When a record has finite key values (literal/enum) and a key transform,
+  // the output keys should be transformed (consistent with partialRecord)
+  const schema = z.record(
+    z.literal("a").transform(() => "b" as const),
+    z.string()
+  );
+  expect(schema.parse({ a: "hello" })).toEqual({ b: "hello" });
+});
+
+test("record with enum key transform applies key transformation", () => {
+  const schema = z.record(
+    z.enum(["x", "y"]).transform((k) => k.toUpperCase()),
+    z.number()
+  );
+  expect(schema.parse({ x: 1, y: 2 })).toEqual({ X: 1, Y: 2 });
+});
+
+test("record key transform is consistent with partialRecord", () => {
+  const keySchema = z.literal("a").transform(() => "b" as const);
+
+  const recordResult = z.record(keySchema, z.string()).parse({ a: "hello" });
+  const partialResult = z.partialRecord(keySchema, z.string()).parse({ a: "hello" });
+  expect(recordResult).toEqual(partialResult);
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2777,6 +2777,14 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       for (const key of values) {
         if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
           recordKeys.add(typeof key === "number" ? key.toString() : key);
+
+          // Run key through the key schema to apply any transforms
+          const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
+          if (keyResult instanceof Promise) {
+            throw new Error("Async schemas not supported in object keys currently");
+          }
+          const outputKey = keyResult.issues.length === 0 ? (keyResult.value as PropertyKey) : key;
+
           const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
 
           if (result instanceof Promise) {
@@ -2785,14 +2793,14 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
                 if (result.issues.length) {
                   payload.issues.push(...util.prefixIssues(key, result.issues));
                 }
-                payload.value[key] = result.value;
+                payload.value[outputKey] = result.value;
               })
             );
           } else {
             if (result.issues.length) {
               payload.issues.push(...util.prefixIssues(key, result.issues));
             }
-            payload.value[key] = result.value;
+            payload.value[outputKey] = result.value;
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixes #5296

`z.record()` with a key schema that has known finite values (enum/literal) and a `.transform()` does not apply the key transformation. The output contains the original keys instead of the transformed ones.

This was inconsistent with `z.partialRecord()`, which correctly applies key transforms.

### Before

```ts
const schema = z.record(
  z.literal("a").transform(() => "b" as const),
  z.string()
);
schema.parse({ a: "hello" }); // { a: "hello" } — key NOT transformed
```

### After

```ts
schema.parse({ a: "hello" }); // { b: "hello" } — key transformed correctly
```

### Root cause

When a record's key schema has known finite values (via `_zod.values`), the parser takes a fast path that iterates those values directly and looks them up in the input object. This fast path never ran the key through `def.keyType._zod.run()`, so any transforms on the key schema were silently ignored.

`z.partialRecord()` worked correctly because it sets `_zod.values = undefined`, forcing the general code path that does run keys through the key schema.

### Fix

Run each key through `def.keyType._zod.run()` in the fast path and use the transformed value (`keyResult.value`) as the output key.

## Test plan

- [x] Added test for record with literal key transform
- [x] Added test for record with enum key transform
- [x] Added test verifying record/partialRecord consistency
- [x] All 3577 existing tests pass
- [x] No type errors