### PR TITLE
fix: replace .default with .prefault

### DIFF
--- a/packages/zod/src/v4/classic/tests/prefault.test.ts
+++ b/packages/zod/src/v4/classic/tests/prefault.test.ts
@@ -41,7 +41,7 @@ test("object schema with prefault should return shallow clone", () => {
     .object({
       a: z.string(),
     })
-    .default({ a: "x" });
+    .prefault({ a: "x" });
   const result1 = schema.parse(undefined);
   const result2 = schema.parse(undefined);
   expect(result1).not.toBe(result2);


### PR DESCRIPTION
The test intended to verify the behavior of `.prefault()`, but it was using `.default()` instead.

This PR updates the test to use `.prefault()` so it correctly tests the intended functionality.