### PR TITLE
fix(docs): add custom not-found page with theme-aware styling

### DIFF
--- a/packages/docs/app/not-found.tsx
+++ b/packages/docs/app/not-found.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Page not found",
+};
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center min-h-[60vh] text-center px-4">
+      <h1
+        className="text-8xl font-bold tracking-tight"
+        style={{ color: "var(--color-fd-primary)" }}
+      >
+        404
+      </h1>
+      <p
+        className="mt-4 text-xl"
+        style={{ color: "var(--color-fd-foreground)" }}
+      >
+        This page could not be found.
+      </p>
+      <Link
+        href="/"
+        className="mt-6 inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors"
+        style={{
+          backgroundColor: "var(--color-fd-muted)",
+          color: "var(--color-fd-foreground)",
+        }}
+      >
+        ← Back to home
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #5778 — the 404 page on zod.dev has broken styling in light mode because the default Next.js error page uses a hardcoded black background that ignores the Fumadocs theme.

## Changes

- Add `packages/docs/app/not-found.tsx` with theme-aware styling using Fumadocs CSS variables

## What this fixes

1. **Light mode background** — uses `var(--color-fd-primary)` and `var(--color-fd-foreground)` instead of hardcoded black
2. **Centered 404 message** — `flex` centering on the content area
3. **Readable text** — theme-aware colors work in both light and dark modes
4. **Concise page title** — "Page not found" instead of "404: This page could not be found"