### PR TITLE
fix(docs): heading anchor links now include the hash so it doesnt scoll all the way up, follows navbar logic

### DIFF
--- a/packages/docs/components/heading.tsx
+++ b/packages/docs/components/heading.tsx
@@ -19,23 +19,23 @@ export function Heading<T extends Types = "h1">({ as, className, ...props }: Hea
       <Link
         data-card=""
         // href={`#${props.id}`}
-        href={`?id=${props.id}`}
+        href={`?id=${props.id}#${props.id}`}
         // onclick="event.preventDefault(); history.pushState(null, '', '?asdf=qwer');"
         className="peer"
-        // shallow={true}
-        // onClick={(e) => {
-        //   // function __handleScroll(){
-        //   // if id query parameter is present, scroll to the element with that id
-        //   const params = new URLSearchParams(window.location.search);
-        //   console.dir(params, { depth: null });
-        //   const id = params.get("id");
-        //   console.dir(params, { depth: null });
-        //   if (id) {
-        //     console.dir(document.getElementById(id), { depth: null });
-        //     document.getElementById(id)?.scrollIntoView();
-        //   }
-        //   // }
-        // }}
+      // shallow={true}
+      // onClick={(e) => {
+      //   // function __handleScroll(){
+      //   // if id query parameter is present, scroll to the element with that id
+      //   const params = new URLSearchParams(window.location.search);
+      //   console.dir(params, { depth: null });
+      //   const id = params.get("id");
+      //   console.dir(params, { depth: null });
+      //   if (id) {
+      //     console.dir(document.getElementById(id), { depth: null });
+      //     document.getElementById(id)?.scrollIntoView();
+      //   }
+      //   // }
+      // }}
       >
         {props.children}
       </Link>


### PR DESCRIPTION
Fixes #5788

## Problem
Clicking a heading (e.g. "Coercion") on a docs page like `/api` sets the
URL to `?id=coercion`. Clicking the same heading a second time causes the
page to jump to the top instead of staying at the section.

This happens because the `<Link>` only sets a query param (`?id=coercion`).
When the URL hasn't changed, Next.js treats it as a no-op navigation —
no scroll happens, and the page snaps to top via scroll restoration.

The right-side TOC nav already uses `?id=coercion#coercion` (both query
param and hash), which works reliably on every click.

## Fix
Add the hash to the heading anchor href to match what the TOC nav already does:

- Before: `?id=${props.id}`
- After:  `?id=${props.id}#${props.id}`

This means every click is always a real URL change (the hash is always
present), and the browser's native anchor scrolling handles positioning
correctly and idempotently.