### PR TITLE
Fix: correct multipleOf validation for floating point values

### DIFF
--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -1352,12 +1352,12 @@ export type ZodNumberCheck =
 
 // https://stackoverflow.com/questions/3966484/why-does-modulus-operator-return-fractional-number-in-javascript/31711034#31711034
 function floatSafeRemainder(val: number, step: number) {
-  const valDecCount = (val.toString().split(".")[1] || "").length;
-  const stepDecCount = (step.toString().split(".")[1] || "").length;
-  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
-  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
-  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
-  return (valInt % stepInt) / 10 ** decCount;
+  const ratio = val / step;
+  const roundedRatio = Math.round(ratio);
+  // Use a relative epsilon scaled to the magnitude of the result
+  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
+  if (Math.abs(ratio - roundedRatio) < tolerance) return 0;
+  return ratio - roundedRatio;
 }
 
 export interface ZodNumberDef extends ZodTypeDef {

--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -169,6 +169,20 @@ test(".multipleOf() with scientific notation (multi-digit exponents)", () => {
   expect(schema15.parse(3e-15)).toEqual(3e-15);
 });
 
+test(".multipleOf() with small floats / scientific notation (#5792)", () => {
+  const schema = z.number().multipleOf(1e-7);
+
+  // Valid multiples (integer * 1e-7)
+  expect(schema.safeParse(0).success).toBe(true);
+  expect(schema.safeParse(1e-7).success).toBe(true);
+  expect(schema.safeParse(2e-7).success).toBe(true);
+  expect(schema.safeParse(3e-7).success).toBe(true);
+
+  // Invalid — 2.5 and 1.5 are not integers
+  expect(schema.safeParse(2.5e-7).success).toBe(false);
+  expect(schema.safeParse(1.5e-7).success).toBe(false);
+});
+
 test(".step() validation", () => {
   const schemaPointOne = z.number().step(0.1);
   const schemaPointZeroZeroZeroOne = z.number().step(0.0001);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -245,20 +245,12 @@ export function cleanRegex(source: string): string {
 }
 
 export function floatSafeRemainder(val: number, step: number): number {
-  const valDecCount = (val.toString().split(".")[1] || "").length;
-  const stepString = step.toString();
-  let stepDecCount = (stepString.split(".")[1] || "").length;
-  if (stepDecCount === 0 && /\d?e-\d+/.test(stepString)) {
-    const match = stepString.match(/\d?e-(\d+)/);
-    if (match?.[1]) {
-      stepDecCount = Number.parseInt(match[1]);
-    }
-  }
-
-  const decCount = valDecCount > stepDecCount ? valDecCount : stepDecCount;
-  const valInt = Number.parseInt(val.toFixed(decCount).replace(".", ""));
-  const stepInt = Number.parseInt(step.toFixed(decCount).replace(".", ""));
-  return (valInt % stepInt) / 10 ** decCount;
+  const ratio = val / step;
+  const roundedRatio = Math.round(ratio);
+  // Use a relative epsilon scaled to the magnitude of the result
+  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
+  if (Math.abs(ratio - roundedRatio) < tolerance) return 0;
+  return ratio - roundedRatio;
 }
 
 const EVALUATING = Symbol("evaluating");


### PR DESCRIPTION
## Problem

`z.number().multipleOf(1e-7).safeParse(2.5e-7)` incorrectly returns success. The value `2.5e-7` is **not** an integer multiple of `1e-7` (since `2.5e-7 / 1e-7 = 2.5`), yet validation passes.

### Root Cause

The `floatSafeRemainder` function parses `.toString()` representations to count decimal places. When values use scientific notation (e.g. `2.5e-7`), `split('.')` gives misleading results (`"5e-7"` with length 3), leading to incorrect integer conversions and a false pass.

## Solution

Replace the string-manipulation-based approach with a tolerance-based ratio comparison:

```ts
const ratio = val / step;
const roundedRatio = Math.round(ratio);
const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
if (Math.abs(ratio - roundedRatio) < tolerance) return 0;
```

This checks whether `val / step` is close to an integer, which is the mathematical definition of "multiple of". The tolerance uses `Number.EPSILON` scaled to the ratio magnitude to correctly handle IEEE 754 representation limits at any scale.

## Changes

- **`packages/zod/src/v4/core/util.ts`** — Rewrote `floatSafeRemainder`
- **`packages/zod/src/v3/types.ts`** — Same fix for v3 backward compatibility
- **`packages/zod/src/v4/classic/tests/number.test.ts`** — Added regression test for #5792

## Test Results

All **3577 tests pass** across 323 test files with 0 type errors.

Closes #5792