### PR TITLE
feat: implement type narrowing in z.string().startsWith() and z.string().endsWith()

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -153,6 +153,68 @@ export interface ZodType<
 export interface _ZodType<out Internals extends core.$ZodTypeInternals = core.$ZodTypeInternals>
   extends ZodType<any, any, Internals> {}
 
+type _ZodStringWithOutput<
+  Schema extends _ZodString,
+  Output extends string,
+  Input = Schema["_zod"]["input"],
+  HasStartsWith extends boolean = _ZodStringHasStartsWith<Schema>,
+  HasEndsWith extends boolean = _ZodStringHasEndsWith<Schema>,
+> = util.Omit<Schema, keyof ZodType | "startsWith" | "endsWith"> &
+  ZodType<
+    Output,
+    Input,
+    util.Omit<Schema["_zod"], "output" | "input"> &
+      core.$ZodTypeInternals<Output, Input> &
+      (HasStartsWith extends true ? { _zodStartsWith: true } : {}) &
+      (HasEndsWith extends true ? { _zodEndsWith: true } : {})
+  > &
+  (HasEndsWith extends true
+    ? {
+        startsWith<Prefix extends string>(
+          value: Prefix,
+          params?: string | core.$ZodCheckStartsWithParams
+        ): _ZodStringWithOutput<Schema, _ZodStringWithBrands<string, Output>, Input, true, true>;
+      }
+    : {}) & {
+    startsWith<Prefix extends string>(
+      value: Prefix,
+      params?: string | core.$ZodCheckStartsWithParams
+    ): _ZodStringWithOutput<Schema, _ZodStringStartsWithOutput<Output, Prefix>, Input, true, HasEndsWith>;
+  } & (HasStartsWith extends true
+    ? {
+        endsWith<Suffix extends string>(
+          value: Suffix,
+          params?: string | core.$ZodCheckEndsWithParams
+        ): _ZodStringWithOutput<Schema, _ZodStringWithBrands<string, Output>, Input, true, true>;
+      }
+    : {}) & {
+    endsWith<Suffix extends string>(
+      value: Suffix,
+      params?: string | core.$ZodCheckEndsWithParams
+    ): _ZodStringWithOutput<Schema, _ZodStringEndsWithOutput<Output, Suffix>, Input, HasStartsWith, true>;
+  };
+
+type _ZodStringHasStartsWith<Schema extends _ZodString> = Schema["_zod"] extends { _zodStartsWith: true }
+  ? true
+  : false;
+type _ZodStringHasEndsWith<Schema extends _ZodString> = Schema["_zod"] extends { _zodEndsWith: true } ? true : false;
+
+type _ZodStringBrandRecord<Output extends string> = Output extends { [core.$brand]: infer BrandRecord }
+  ? BrandRecord
+  : never;
+
+type _ZodStringWithBrands<Base extends string, Output extends string> = [_ZodStringBrandRecord<Output>] extends [never]
+  ? Base
+  : Base & { [core.$brand]: _ZodStringBrandRecord<Output> };
+
+type _ZodStringStartsWithOutput<Output extends string, Prefix extends string> = string extends Output
+  ? `${Prefix}${string}`
+  : Output & `${Prefix}${string}`;
+
+type _ZodStringEndsWithOutput<Output extends string, Suffix extends string> = string extends Output
+  ? `${string}${Suffix}`
+  : Output & `${string}${Suffix}`;
+
 export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$constructor("ZodType", (inst, def) => {
   core.$ZodType.init(inst, def);
   Object.assign(inst["~standard"], {
@@ -268,8 +330,26 @@ export interface _ZodString<T extends core.$ZodStringInternals<unknown> = core.$
   // miscellaneous checks
   regex(regex: RegExp, params?: string | core.$ZodCheckRegexParams): this;
   includes(value: string, params?: string | core.$ZodCheckIncludesParams): this;
-  startsWith(value: string, params?: string | core.$ZodCheckStartsWithParams): this;
-  endsWith(value: string, params?: string | core.$ZodCheckEndsWithParams): this;
+  startsWith<Prefix extends string>(
+    value: Prefix,
+    params?: string | core.$ZodCheckStartsWithParams
+  ): _ZodStringWithOutput<
+    this,
+    _ZodStringStartsWithOutput<core.output<this> & string, Prefix>,
+    core.input<this>,
+    true,
+    _ZodStringHasEndsWith<this>
+  >;
+  endsWith<Suffix extends string>(
+    value: Suffix,
+    params?: string | core.$ZodCheckEndsWithParams
+  ): _ZodStringWithOutput<
+    this,
+    _ZodStringEndsWithOutput<core.output<this> & string, Suffix>,
+    core.input<this>,
+    _ZodStringHasStartsWith<this>,
+    true
+  >;
   min(minLength: number, params?: string | core.$ZodCheckMinLengthParams): this;
   max(maxLength: number, params?: string | core.$ZodCheckMaxLengthParams): this;
   length(len: number, params?: string | core.$ZodCheckLengthEqualsParams): this;
@@ -300,8 +380,36 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
   // validations
   inst.regex = (...args) => inst.check(checks.regex(...args));
   inst.includes = (...args) => inst.check(checks.includes(...args));
-  inst.startsWith = (...args) => inst.check(checks.startsWith(...args));
-  inst.endsWith = (...args) => inst.check(checks.endsWith(...args));
+  function startsWith<Prefix extends string>(
+    this: typeof inst,
+    value: Prefix,
+    params?: string | core.$ZodCheckStartsWithParams
+  ): _ZodStringWithOutput<
+    typeof inst,
+    _ZodStringStartsWithOutput<core.output<typeof inst> & string, Prefix>,
+    core.input<typeof inst>,
+    true,
+    _ZodStringHasEndsWith<typeof inst>
+  >;
+  function startsWith(this: typeof inst, value: string, params?: string | core.$ZodCheckStartsWithParams) {
+    return inst.check(checks.startsWith(value, params));
+  }
+  function endsWith<Suffix extends string>(
+    this: typeof inst,
+    value: Suffix,
+    params?: string | core.$ZodCheckEndsWithParams
+  ): _ZodStringWithOutput<
+    typeof inst,
+    _ZodStringEndsWithOutput<core.output<typeof inst> & string, Suffix>,
+    core.input<typeof inst>,
+    _ZodStringHasStartsWith<typeof inst>,
+    true
+  >;
+  function endsWith(this: typeof inst, value: string, params?: string | core.$ZodCheckEndsWithParams) {
+    return inst.check(checks.endsWith(value, params));
+  }
+  inst.startsWith = startsWith;
+  inst.endsWith = endsWith;
   inst.min = (...args) => inst.check(checks.minLength(...args));
   inst.max = (...args) => inst.check(checks.maxLength(...args));
   inst.length = (...args) => inst.check(checks.length(...args));

--- a/packages/zod/src/v4/classic/tests/assignability.test.ts
+++ b/packages/zod/src/v4/classic/tests/assignability.test.ts
@@ -6,6 +6,18 @@ test("assignability", () => {
   // $ZodString
   z.string() satisfies z.core.$ZodString;
   z.string() satisfies z.ZodString;
+  z.string().startsWith("hello") satisfies z.core.$ZodString;
+  z.string().startsWith("hello") satisfies z.ZodString;
+  z.string().endsWith("world") satisfies z.core.$ZodString;
+  z.string().endsWith("world") satisfies z.ZodString;
+  z.string().startsWith("hello").endsWith("world") satisfies z.core.$ZodString;
+  z.string().startsWith("hello").endsWith("world") satisfies z.ZodString;
+  z.string().endsWith("world").startsWith("hello") satisfies z.core.$ZodString;
+  z.string().endsWith("world").startsWith("hello") satisfies z.ZodString;
+  z.string().startsWith("hello").includes("loworl") satisfies z.core.$ZodString;
+  z.string().startsWith("hello").includes("loworl") satisfies z.ZodString;
+  z.string().endsWith("world").includes("loworl") satisfies z.core.$ZodString;
+  z.string().endsWith("world").includes("loworl") satisfies z.ZodString;
 
   // $ZodNumber
   z.number() satisfies z.core.$ZodNumber;

--- a/packages/zod/src/v4/classic/tests/brand.test.ts
+++ b/packages/zod/src/v4/classic/tests/brand.test.ts
@@ -104,3 +104,25 @@ test("brand direction: inout", () => {
   expectTypeOf<Input>().toEqualTypeOf<string & z.$brand<"A">>();
   expectTypeOf<Output>().toEqualTypeOf<string & z.$brand<"A">>();
 });
+
+test("startsWith/endsWith preserve brand direction", () => {
+  const outputBranded = z.string().brand<"A">().startsWith("hello");
+  const inputBranded = z.string().brand<"A", "in">().endsWith("world");
+  const inoutBranded = z.string().brand<"A", "inout">().startsWith("hello");
+
+  type outputBrandedInput = z.input<typeof outputBranded>;
+  type outputBrandedOutput = z.output<typeof outputBranded>;
+  type inputBrandedInput = z.input<typeof inputBranded>;
+  type inputBrandedOutput = z.output<typeof inputBranded>;
+  type inoutBrandedInput = z.input<typeof inoutBranded>;
+  type inoutBrandedOutput = z.output<typeof inoutBranded>;
+
+  expectTypeOf<outputBrandedInput>().toEqualTypeOf<string>();
+  expectTypeOf<outputBrandedOutput>().toEqualTypeOf<`hello${string}` & z.$brand<"A">>();
+
+  expectTypeOf<inputBrandedInput>().toEqualTypeOf<string & z.$brand<"A">>();
+  expectTypeOf<inputBrandedOutput>().toEqualTypeOf<`${string}world`>();
+
+  expectTypeOf<inoutBrandedInput>().toEqualTypeOf<string & z.$brand<"A">>();
+  expectTypeOf<inoutBrandedOutput>().toEqualTypeOf<`hello${string}` & z.$brand<"A">>();
+});

--- a/packages/zod/src/v4/classic/tests/coerce.test.ts
+++ b/packages/zod/src/v4/classic/tests/coerce.test.ts
@@ -158,3 +158,18 @@ test("override input type", () => {
   type output = z.infer<typeof a>;
   expectTypeOf<output>().toEqualTypeOf<string>();
 });
+
+test("string coercion preserves input type after startsWith/endsWith", () => {
+  const prefixed = z.coerce.string().startsWith("hello");
+  const suffixed = z.coerce.string<number>().endsWith("world");
+
+  type prefixedInput = z.input<typeof prefixed>;
+  type prefixedOutput = z.output<typeof prefixed>;
+  type suffixedInput = z.input<typeof suffixed>;
+  type suffixedOutput = z.output<typeof suffixed>;
+
+  expectTypeOf<prefixedInput>().toEqualTypeOf<unknown>();
+  expectTypeOf<prefixedOutput>().toEqualTypeOf<`hello${string}`>();
+  expectTypeOf<suffixedInput>().toEqualTypeOf<number>();
+  expectTypeOf<suffixedOutput>().toEqualTypeOf<`${string}world`>();
+});

--- a/packages/zod/src/v4/classic/tests/template-literal.test.ts
+++ b/packages/zod/src/v4/classic/tests/template-literal.test.ts
@@ -55,6 +55,12 @@ const stringLen5 = z.templateLiteral(["", z.string().length(5)]);
 const stringMin5Max10 = z.templateLiteral(["", z.string().min(5).max(10)]);
 const stringStartsWithMax5 = z.templateLiteral(["", z.string().startsWith("hello").max(5)]);
 const brandedString = z.templateLiteral(["", z.string().min(1).brand("myBrand")]);
+const dynamicPrefix = "hello" as string;
+const dynamicSuffix = "world" as string;
+const dynamicStringStartsWith = z.templateLiteral(["", z.string().startsWith(dynamicPrefix)]);
+const dynamicStringEndsWith = z.templateLiteral(["", z.string().endsWith(dynamicSuffix)]);
+const chainedStringStartsEnds = z.string().startsWith("hello").endsWith("world");
+const chainedStringEndsStarts = z.string().endsWith("world").startsWith("hello");
 // const anything = z.templateLiteral(["", z.any()]);
 
 const url = z.templateLiteral(["https://", z.string().regex(/\w+/), ".", z.enum(["com", "net"])]);
@@ -142,8 +148,12 @@ test("template literal type inference", () => {
   expectTypeOf<z.infer<typeof ulid>>().toEqualTypeOf<string>();
   expectTypeOf<z.infer<typeof uuid>>().toEqualTypeOf<string>();
   expectTypeOf<z.infer<typeof stringAToZ>>().toEqualTypeOf<string>();
-  expectTypeOf<z.infer<typeof stringStartsWith>>().toEqualTypeOf<string>();
-  expectTypeOf<z.infer<typeof stringEndsWith>>().toEqualTypeOf<string>();
+  expectTypeOf<z.infer<typeof stringStartsWith>>().toEqualTypeOf<`hello${string}`>();
+  expectTypeOf<z.infer<typeof stringEndsWith>>().toEqualTypeOf<`${string}world`>();
+  expectTypeOf<z.infer<typeof dynamicStringStartsWith>>().toEqualTypeOf<string>();
+  expectTypeOf<z.infer<typeof dynamicStringEndsWith>>().toEqualTypeOf<string>();
+  expectTypeOf<z.infer<typeof chainedStringStartsEnds>>().toEqualTypeOf<string>();
+  expectTypeOf<z.infer<typeof chainedStringEndsStarts>>().toEqualTypeOf<string>();
   expectTypeOf<z.infer<typeof stringMax5>>().toEqualTypeOf<string>();
   expectTypeOf<z.infer<typeof stringMin5>>().toEqualTypeOf<string>();
   expectTypeOf<z.infer<typeof stringLen5>>().toEqualTypeOf<string>();


### PR DESCRIPTION
Related to #1747

The fix has previously been attempted 4 years ago in:
- #1730 - had reservations related to ZodString readability
- #1751 - got closed as stale

Unlike #1730, this PR does not modify `ZodString`, and is instead adding `_ZodStringWithOutput` helper.
Unlike #1751, this PR includes tests and does not use type assertions.

That one required quite a lot of gymnastics to get green and it is not the prettiest PR I've ever made, but hey, it works!

Alternatives considered: making `.startsWith` and `.endsWith` proxy to `.templateLiteral`. Abandoned as `.startsWith` and `.endsWith` may overlap.