### PR TITLE
chore: Add fullproduct.dev to ecosystem documentation

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -270,6 +270,12 @@ const poweredByZodProjects: ZodResource[] = [
     url: "https://github.com/endel/zodgres",
     description: "Postgres.js + Zod: Database collections with static type inference and automatic migrations",
     slug: "endel/zodgres",
+  },
+  {
+    name: "fullproduct.dev",
+    url: "https://fullproduct.dev?via=zod-v4-docs",
+    description: "Zod powered Universal App Starterkit using schemas as the single source of truth",
+    slug: "FullProduct-dev/green-stack-starter-demo",
   }
 ];
 

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -274,7 +274,7 @@ const poweredByZodProjects: ZodResource[] = [
   {
     name: "fullproduct.dev",
     url: "https://fullproduct.dev?via=zod-v4-docs",
-    description: "Zod powered Universal App Starterkit using schemas as the single source of truth",
+    description: "Zod powered Universal Expo + Next.js App Starterkit using schemas as the single source of truth",
     slug: "FullProduct-dev/green-stack-starter-demo",
   }
 ];

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -274,7 +274,7 @@ const poweredByZodProjects: ZodResource[] = [
   {
     name: "fullproduct.dev",
     url: "https://fullproduct.dev?via=zod-v4-docs",
-    description: "Zod powered Universal Expo + Next.js App Starterkit using schemas as the single source of truth",
+    description: "Zod & TS-first approach to building Universal Expo + Next.js apps using schemas as the single source of truth",
     slug: "FullProduct-dev/green-stack-starter-demo",
   }
 ];


### PR DESCRIPTION
Took a while, but we finally added support for Zod V4 in [fullproduct.dev](https://fullproduct.dev):

### What it is:

- Universal Starterkit (Expo + Next) with a unique _"schemas as single sources of truth"_ system built into it.

### What it does:

- Expand Zod V3 schemas with a powerful metadata and introspection API (to be updated for V4's own metadata API)
- Transform zod component prop schemas to Interactive MDX docs Nextra
- Scaffold out an auto-generated graphql schema (+ queries) from your back-end resolvers Zod input and output schemas
- Plugins to create DB models from Zod schemas to e.g. Mongoose Models
- `useFormState()` hook to further keep things in sync

## References

- V3 PR that got merged into V3 docs: #4131
- How Zod is used as the core for Single Sources of Truth: https://fullproduct.dev/docs/single-sources-of-truth