### PR TITLE
fix(v4): resolve stack overflow in toJSONSchema for recursive lazy with describe

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2988,3 +2988,18 @@ test("cycle detection - mutual recursion", () => {
     Set the \`cycles\` parameter to \`"ref"\` to resolve cyclical schemas with defs.]
   `);
 });
+
+test("recursive lazy with describe does not stack overflow", () => {
+  const NodeSchema: z.ZodType = z.lazy(() =>
+    z
+      .object({
+        value: z.string().describe("node value"),
+        children: z.array(NodeSchema.describe("child node")).optional().describe("child list"),
+      })
+      .describe("tree node")
+  );
+
+  const result = z.toJSONSchema(NodeSchema, { cycles: "ref", reused: "ref" });
+  expect(result).toBeDefined();
+  expect(result.$defs).toBeDefined();
+});

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -556,15 +556,7 @@ export const optionalProcessor: Processor<schemas.$ZodOptional> = (schema, ctx, 
 };
 
 export const lazyProcessor: Processor<schemas.$ZodLazy> = (schema, ctx, _json, params) => {
-  // For clones of lazy schemas (e.g. via .describe()/.meta()), walk up to the
-  // root lazy and reuse its cached innerType. Each clone would otherwise
-  // re-evaluate the getter, producing new schema objects per recursion level
-  // and causing a stack overflow on recursive schemas.
-  let root = schema as schemas.$ZodLazy;
-  while (root._zod.parent && (root._zod.parent as schemas.$ZodType)._zod.def.type === "lazy") {
-    root = root._zod.parent as schemas.$ZodLazy;
-  }
-  const innerType = root._zod.innerType;
+  const innerType = (schema as schemas.$ZodLazy)._zod.innerType;
   process(innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = innerType;

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -556,7 +556,15 @@ export const optionalProcessor: Processor<schemas.$ZodOptional> = (schema, ctx, 
 };
 
 export const lazyProcessor: Processor<schemas.$ZodLazy> = (schema, ctx, _json, params) => {
-  const innerType = (schema as schemas.$ZodLazy)._zod.innerType;
+  // For clones of lazy schemas (e.g. via .describe()/.meta()), walk up to the
+  // root lazy and reuse its cached innerType. Each clone would otherwise
+  // re-evaluate the getter, producing new schema objects per recursion level
+  // and causing a stack overflow on recursive schemas.
+  let root = schema as schemas.$ZodLazy;
+  while (root._zod.parent && (root._zod.parent as schemas.$ZodType)._zod.def.type === "lazy") {
+    root = root._zod.parent as schemas.$ZodLazy;
+  }
+  const innerType = root._zod.innerType;
   process(innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = innerType;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4402,14 +4402,14 @@ export interface $ZodLazy<T extends SomeType = $ZodType> extends $ZodType {
 export const $ZodLazy: core.$constructor<$ZodLazy> = /*@__PURE__*/ core.$constructor("$ZodLazy", (inst, def) => {
   $ZodType.init(inst, def);
 
-  // let _innerType!: any;
-  // util.defineLazy(def, "getter", () => {
-  //   if (!_innerType) {
-  //     _innerType = def.getter();
-  //   }
-  //   return () => _innerType;
-  // });
-  util.defineLazy(inst._zod, "innerType", () => def.getter() as $ZodType);
+  // Cache the resolved inner type on the shared `def` so all clones of this
+  // lazy (e.g. via `.describe()`/`.meta()`) share the same inner instance,
+  // preserving identity for cycle detection on recursive schemas.
+  util.defineLazy(inst._zod, "innerType", () => {
+    const d = def as $ZodLazyDef & { _cachedInner?: $ZodType };
+    if (!d._cachedInner) d._cachedInner = def.getter() as $ZodType;
+    return d._cachedInner;
+  });
   util.defineLazy(inst._zod, "pattern", () => inst._zod.innerType?._zod?.pattern);
   util.defineLazy(inst._zod, "propValues", () => inst._zod.innerType?._zod?.propValues);
   util.defineLazy(inst._zod, "optin", () => inst._zod.innerType?._zod?.optin ?? undefined);


### PR DESCRIPTION
Fixes #5777

When `.describe()` or `.meta()` is used on branches inside a recursive `z.lazy()` schema, `toJSONSchema()` hits a stack overflow. The root cause is that each described clone of a lazy schema re-evaluates the getter function, creating fresh schema instances at every recursion level — none of which are in the `seen` cache.

The fix walks the parent chain in `lazyProcessor` to find the root lazy schema and reuses its cached `innerType`. This ensures all clones of the same recursive lazy share one set of resolved inner schemas, so the `seen` check stops recursion as expected.

Added a test with a recursive tree schema where every branch uses `.describe()` to verify the fix.