### PR TITLE
docs: add documentation for .and() method

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1829,6 +1829,27 @@ type EmployedPerson = z.infer<typeof EmployedPerson>;
   When merging object schemas, prefer [`A.extend(B)`](#extend) over intersections. Using `.extend()` will give you a new object schema, whereas `z.intersection(A, B)` returns a `ZodIntersection` instance which lacks common object methods like `pick` and `omit`.
 </Callout>
 
+### `.and()`
+
+For convenience, you can use the `.and()` method as shorthand for `z.intersection()`:
+
+```ts
+const Person = z.object({ name: z.string() });
+const Employee = z.object({ role: z.string() });
+
+// These are equivalent:
+const EmployedPerson1 = z.intersection(Person, Employee);
+const EmployedPerson2 = Person.and(Employee);
+```
+
+This is particularly useful when chaining with other methods:
+
+```ts
+const schema = z
+  .object({ name: z.string() })
+  .and(z.looseRecord(z.string().regex(/_phone$/), z.e164()));
+```
+
 ## Records
 
 Record schemas are used to validate types such as `Record<string, string>`.


### PR DESCRIPTION
## Fixes #5798

Adds documentation for the `.and()` method which was missing from the API reference.

### Changes
- Added dedicated section after Intersections explaining `.and()` usage
- Included code examples showing it's a shorthand for `z.intersection()`
- Demonstrated practical usage when chaining with other methods

### Context
The `.and()` method exists in the codebase as a convenience wrapper for `z.intersection()` but wasn't documented. It's already used in examples (like in the looseObject docs) but users had no reference documentation for it.

**Location in code:** [`packages/zod/src/v4/classic/schemas.ts#L224`](https://github.com/colinhacks/zod/blob/c7805073fef5b6b8857307c3d4b3597a70613bc2/packages/zod/src/v4/classic/schemas.ts#L224)