### PR TITLE
docs: add documentation for .or() method

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1674,11 +1674,22 @@ stringOrNumber.def.options; // [ZodString, ZodNumber]
 </Tab>
 </Tabs>
 
-{/* For convenience, you can also use the [`.or` method](#or):
+### `.or()`
+
+For convenience, you can use the `.or()` method as shorthand for `z.union()`:
 
 ```ts
-const stringOrNumber = z.string().or(z.number());
-``` */}
+// These are equivalent:
+const stringOrNumber1 = z.union([z.string(), z.number()]);
+const stringOrNumber2 = z.string().or(z.number());
+```
+
+This is particularly useful when chaining:
+
+```ts
+const schema = z.string().url().or(z.string().email());
+// Accepts either a valid URL or email
+```
 
 {/* **Optional string validation:**
 


### PR DESCRIPTION
## Related to #5798

Adds documentation for the `.or()` method which was also missing from the API reference (similar to `.and()` in #5802).

### Changes
- Uncommented and expanded the `.or()` documentation
- Added practical examples showing chaining usage
- Placed in the Unions section where it belongs

### Context  
The `.or()` method exists as a convenience wrapper for `z.union()` but was commented out in the docs. This PR makes it visible and adds clearer examples.

**Location in code:** [`packages/zod/src/v4/classic/schemas.ts#L226`](https://github.com/colinhacks/zod/blob/main/packages/zod/src/v4/classic/schemas.ts#L226)