### PR TITLE
docs: add Zod AOT to ecosystem page

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -310,6 +310,12 @@ const zodUtilities: ZodResource[] = [
     description: "Comprehensive validation for Iranian data structures (National Code, Bank Cards, Sheba, Crypto, etc) with smart metadata extraction (Bank Names, Logos). Zero dependencies.",
     slug: "Reza-kh80/zod-ir",
   },
+  {
+    name: "Zod AOT",
+    url: "https://github.com/wakita181009/zod-aot",
+    description: "Compile Zod schemas into zero-overhead validation functions at build time. 2-64x faster validation with no code changes.",
+    slug: "wakita181009/zod-aot",
+  },
 ];
 
 export {


### PR DESCRIPTION
## Summary 
 
- Add [Zod AOT](https://github.com/wakita181009/zod-aot) to the Zod Utilities section of the ecosystem page

## What is Zod AOT?
 
Zod AOT compiles Zod schemas into zero-overhead validation functions at build time.

- **2-64x faster** validation with no code changes required
- Supports Zod 4 (`zod@^4`)
- Integrates with all major bundlers (Vite, webpack, esbuild, Rollup, Rolldown, rspack, Bun) via unplugin
- `compile()` returns a full Zod schema, so it works seamlessly with any library that accepts Zod schemas (e.g. `@hono/zod-validator`) 
- CLI also available for non-bundler workflows 
 
### Benchmark highlights 

| Schema | Zod v4 | zod-aot | Speedup |
|---|---|---|---|
| Simple string | 1.2M ops/s | 2.1M ops/s | **1.8x** | 
| Medium object (valid) | 480K ops/s | 2.4M ops/s | **5x** |
| Medium object (invalid) | 210K ops/s | 4.8M ops/s | **23x** |
| Large nested object (100 fields) | 12K ops/s | 780K ops/s | **64x** |
| Discriminated union (5 variants) | 320K ops/s | 3.2M ops/s | **10x** | 

## Related

- Blog post: [I Made Zod 64x Faster by Compiling Schemas at Build Time](https://dev.to/wakita181009/i-made-zod-64x-faster-by-compiling-schemas-at-build-time-3e1a) 
- [Benchmarks source](https://github.com/wakita181009/zod-aot/tree/main/benchmarks)
