### PR TITLE
fix(types): preserve concrete shape type in z.object() return type

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1286,7 +1286,7 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
 export function object<T extends core.$ZodLooseShape = Partial<Record<never, core.SomeType>>>(
   shape?: T,
   params?: string | core.$ZodObjectParams
-): ZodObject<util.Writeable<T>, core.$strip> {
+): ZodObject<T, core.$strip> {
   const def: core.$ZodObjectDef = {
     type: "object",
     shape: shape ?? {},


### PR DESCRIPTION
## Problem

`z.object()` widens its return type to `ZodObject<util.Writeable<T>, core.$strip>`
in the language server (VSCode / Cursor), losing all field-level type information.
`strictObject()` and `looseObject()` are unaffected and infer correctly.

Fixes #5810.

## Root Cause

The return type annotation on `object()` used `util.Writeable<T>`:
```ts
): ZodObject<util.Writeable<T>, core.$strip>
```

`Writeable<T>` is a mapped type (`{ -readonly [P in keyof T]: T[P] } & {}`) that
strips `readonly` modifiers. As a side effect, TypeScript cannot resolve it back to
the original concrete `T`, so the language server shows the widened form instead of
the full shape.

## Fix

One-line change — use `T` directly, consistent with `strictObject()` and
`looseObject()`:
```ts
): ZodObject<T, core.$strip>
```

## Verification
```ts
const schema = z.object({
  id: z.string(),
  source: z.enum(["OpenLibrary", "Wikidata"]),
});
// Before: ZodObject<util.Writeable<T>, core.$strip>  
// After:  ZodObject<{ id: ZodString; source: ZodEnum<...> }, $strip>  
```

## CI Note

The CI failure on this PR is pre-existing and unrelated to this change — it is
a `moduleResolution=node10` deprecation error triggered by the "TypeScript latest"
job and exists on `main` as well.