### PR TITLE
docs: fix self-referencing schema in refine when() example

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2344,19 +2344,20 @@ An error on `anotherField` will prevent the password confirmation check from exe
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
 ```ts
-const schema = z
-  .object({
-    password: z.string().min(8),
-    confirmPassword: z.string(),
-    anotherField: z.string(),
-  })
+const baseSchema = z.object({
+  password: z.string().min(8),
+  confirmPassword: z.string(),
+  anotherField: z.string(),
+});
+
+const schema = baseSchema
   .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords do not match",
     path: ["confirmPassword"],
 
     // run if password & confirmPassword are valid
     when(payload) { // [!code ++]
-      return schema // [!code ++]
+      return baseSchema // [!code ++]
         .pick({ password: true, confirmPassword: true }) // [!code ++]
         .safeParse(payload.value).success; // [!code ++]
     },  // [!code ++]


### PR DESCRIPTION
## Problem

The docs example for the `when` parameter in `.refine()` has a self-reference bug:

```typescript
const schema = z.object({...}).refine({
  when(payload) {
    return schema.pick({...}) // ReferenceError: schema is not initialized
  }
})
```

Two issues:
1. `schema` is accessed during its own initialization (temporal dead zone)
2. `.pick()` on a schema with refinements throws in Zod v4 (refinements are not carried over)

Users copying this example get runtime errors.

## Solution

Extract the base object schema into a separate variable:

```typescript
const baseSchema = z.object({...});

const schema = baseSchema.refine({
  when(payload) {
    return baseSchema.pick({...}).safeParse(payload.value).success;
  }
})
```

This resolves both the self-reference and the `.pick()` on refined schema issues.

## Changes

- `packages/docs/content/api.mdx` -- Updated the Zod tab example in the refine `when` section

Closes #5805
Relates to #5755