### PR TITLE
chore: fix typo in resolution source

### DIFF
--- a/packages/resolution/src/index.cts
+++ b/packages/resolution/src/index.cts
@@ -29,7 +29,7 @@ if (success !== `{"success":true,"data":{"name":"John Doe"}}`) {
 const failure = JSON.stringify(schema.safeParse({ name: 123 }));
 if (
   failure !==
-  '{"success":false,"error":{"name":"ZodError","message":"[\\n  {\\n    \\"expected\\": \\"string\\",\\n    \\"code\\": \\"invalid_type\\",\\n    \\"path\\": [\\n      \\"name\\"\\n    ],\\n    \\"message\\": \\"Entrée invalide : string attendu, nombre reçu\\"\\n  }\\n]"}}'
+  '{"success":false,"error":{"name":"ZodError","message":"[\\n  {\\n    \\"expected\\": \\"string\\",\\n    \\"code\\": \\"invalid_type\\",\\n    \\"path\\": [\\n      \\"name\\"\\n    ],\\n    \\"message\\": \\"Entrée invalid : string attendu, nombre reçu\\"\\n  }\\n]"}}'
 ) {
   throw new Error();
 }

--- a/packages/resolution/src/index.mts
+++ b/packages/resolution/src/index.mts
@@ -29,7 +29,7 @@ if (success !== `{"success":true,"data":{"name":"John Doe"}}`) {
 const failure = JSON.stringify(schema.safeParse({ name: 123 }));
 if (
   failure !==
-  '{"success":false,"error":{"name":"ZodError","message":"[\\n  {\\n    \\"expected\\": \\"string\\",\\n    \\"code\\": \\"invalid_type\\",\\n    \\"path\\": [\\n      \\"name\\"\\n    ],\\n    \\"message\\": \\"Entrée invalide : string attendu, nombre reçu\\"\\n  }\\n]"}}'
+  '{"success":false,"error":{"name":"ZodError","message":"[\\n  {\\n    \\"expected\\": \\"string\\",\\n    \\"code\\": \\"invalid_type\\",\\n    \\"path\\": [\\n      \\"name\\"\\n    ],\\n    \\"message\\": \\"Entrée invalid : string attendu, nombre reçu\\"\\n  }\\n]"}}'
 ) {
   throw new Error();
 }

--- a/packages/resolution/src/index.ts
+++ b/packages/resolution/src/index.ts
@@ -29,7 +29,7 @@ if (success !== `{"success":true,"data":{"name":"John Doe"}}`) {
 const failure = JSON.stringify(schema.safeParse({ name: 123 }));
 if (
   failure !==
-  '{"success":false,"error":{"name":"ZodError","message":"[\\n  {\\n    \\"expected\\": \\"string\\",\\n    \\"code\\": \\"invalid_type\\",\\n    \\"path\\": [\\n      \\"name\\"\\n    ],\\n    \\"message\\": \\"Entrée invalide : string attendu, nombre reçu\\"\\n  }\\n]"}}'
+  '{"success":false,"error":{"name":"ZodError","message":"[\\n  {\\n    \\"expected\\": \\"string\\",\\n    \\"code\\": \\"invalid_type\\",\\n    \\"path\\": [\\n      \\"name\\"\\n    ],\\n    \\"message\\": \\"Entrée invalid : string attendu, nombre reçu\\"\\n  }\\n]"}}'
 ) {
   throw new Error();
 }


### PR DESCRIPTION
Fixed a typo (invalide -> invalid) in packages/resolution/src/index.*. Found using codespell.