### PR TITLE
docs: fix unmergable typo in changelog

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3,11 +3,11 @@ title: Defining schemas
 description: "Complete API reference for all Zod schema types, methods, and validation features"
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
-import { Callout } from "fumadocs-ui/components/callout"
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Callout } from "fumadocs-ui/components/callout";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-To validate data, you must first define a *schema*. Schemas represent *types*, from simple primitive values to complex nested objects and arrays. 
+To validate data, you must first define a _schema_. Schemas represent _types_, from simple primitive values to complex nested objects and arrays.
 
 ## Primitives
 
@@ -24,16 +24,15 @@ z.undefined();
 z.null();
 ```
 
-
 ### Coercion
 
 To coerce input data to the appropriate type, use `z.coerce` instead:
 
 ```ts
-z.coerce.string();    // String(input)
-z.coerce.number();    // Number(input)
-z.coerce.boolean();   // Boolean(input)
-z.coerce.bigint();    // BigInt(input)
+z.coerce.string(); // String(input)
+z.coerce.number(); // Number(input)
+z.coerce.boolean(); // Boolean(input)
+z.coerce.bigint(); // BigInt(input)
 ```
 
 The coerced variant of these schemas attempts to convert the input value to the appropriate type.
@@ -41,10 +40,10 @@ The coerced variant of these schemas attempts to convert the input value to the 
 ```ts
 const schema = z.coerce.string();
 
-schema.parse("tuna");    // => "tuna"
-schema.parse(42);        // => "42"
-schema.parse(true);      // => "true"
-schema.parse(null);      // => "null"
+schema.parse("tuna"); // => "tuna"
+schema.parse(42); // => "42"
+schema.parse(true); // => "true"
+schema.parse(null); // => "null"
 ```
 
 The input type of these coerced schemas is `unknown` by default. To specify a more specific input type, pass a generic parameter:
@@ -60,54 +59,52 @@ type BInput = z.input<typeof B>; // => number
 <Accordions type="single">
 <Accordion title="How coercion works in Zod">
   
-  Zod coerces all inputs using the built-in constructors. 
+  Zod coerces all inputs using the built-in constructors.
 
-  | Zod API                  | Coercion                   |
-  |--------------------------|----------------------------|
-  | `z.coerce.string()`      | `String(value)`            |
-  | `z.coerce.number()`      | `Number(value)`            |
-  | `z.coerce.boolean()`     | `Boolean(value)`           |
-  | `z.coerce.bigint()`      | `BigInt(value)`            |
-  | `z.coerce.date()`        | `new Date(value)`          |
+| Zod API              | Coercion          |
+| -------------------- | ----------------- |
+| `z.coerce.string()`  | `String(value)`   |
+| `z.coerce.number()`  | `Number(value)`   |
+| `z.coerce.boolean()` | `Boolean(value)`  |
+| `z.coerce.bigint()`  | `BigInt(value)`   |
+| `z.coerce.date()`    | `new Date(value)` |
 
-  Boolean coercion with `z.coerce.boolean()` may not work how you expect. Any [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) value is coerced to `true`, and any [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) value is coerced to `false`.
+Boolean coercion with `z.coerce.boolean()` may not work how you expect. Any [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) value is coerced to `true`, and any [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) value is coerced to `false`.
 
-  ```ts
-  const schema = z.coerce.boolean(); // Boolean(input)
+```ts
+const schema = z.coerce.boolean(); // Boolean(input)
 
-  schema.parse("tuna"); // => true
-  schema.parse("true"); // => true
-  schema.parse("false"); // => true
-  schema.parse(1); // => true
-  schema.parse([]); // => true
+schema.parse("tuna"); // => true
+schema.parse("true"); // => true
+schema.parse("false"); // => true
+schema.parse(1); // => true
+schema.parse([]); // => true
 
-  schema.parse(0); // => false
-  schema.parse(""); // => false
-  schema.parse(undefined); // => false
-  schema.parse(null); // => false
-  ```
+schema.parse(0); // => false
+schema.parse(""); // => false
+schema.parse(undefined); // => false
+schema.parse(null); // => false
+```
 
-  For total control over coercion logic, consider using [`z.transform()`](#transforms) or [`z.pipe()`](#pipes).
+For total control over coercion logic, consider using [`z.transform()`](#transforms) or [`z.pipe()`](#pipes).
 
 </Accordion>
 <Accordion title="Customizing the input type">
   
   By default the _input_ type of any `z.coerce` schema is `unknown`. In some cases, it may be preferable for the input type to be more specific. You can specify the input type with a generic parameter.
 
-  ```ts
-  const regularCoerce = z.coerce.string();
-  type RegularInput = z.input<typeof regularCoerce>; // => unknown
-  type RegularOutput = z.output<typeof regularCoerce>; // => string
+```ts
+const regularCoerce = z.coerce.string();
+type RegularInput = z.input<typeof regularCoerce>; // => unknown
+type RegularOutput = z.output<typeof regularCoerce>; // => string
 
-  const customInput = z.coerce.string<string>();
-  type CustomInput = z.input<typeof customInput>; // => string
-  type CustomOutput = z.output<typeof customInput>; // => string
-  ```
+const customInput = z.coerce.string<string>();
+type CustomInput = z.input<typeof customInput>; // => string
+type CustomOutput = z.output<typeof customInput>; // => string
+```
 
 </Accordion>
 </Accordions>
-
-
 
 ## Literals
 
@@ -152,23 +149,15 @@ colors.values; // => Set<"red" | "green" | "blue">
 </Tab>
 </Tabs>
 
-
-
 ## Strings
 
-{/* Zod provides a handful of built-in string validation and transform APIs.
+{/\* Zod provides a handful of built-in string validation and transform APIs.
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.string().startsWith("fourscore")
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-z.string().check(z.startsWith("fourscore"))
-```
-</Tab>
+  <Tab value="Zod">```ts z.string().startsWith("fourscore") ```</Tab>
+  <Tab value="Zod Mini">
+    ```ts z.string().check(z.startsWith("fourscore")) ```
+  </Tab>
 </Tabs>
 
 All of the APIs documented below support the `error` parameter for customizing the error message.
@@ -185,57 +174,38 @@ z.string().check(z.startsWith("fourscore", {error: "Nice try, buddy"}))
 ```
 </Tab></Tabs> */}
 
-
 Zod provides a handful of built-in string validation and transform APIs. To perform some common string validations:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.string().max(5);
-z.string().min(5);
-z.string().length(5);
-z.string().regex(/^[a-z]+$/);
-z.string().startsWith("aaa");
-z.string().endsWith("zzz");
-z.string().includes("---");
-z.string().uppercase();
-z.string().lowercase();
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-z.string().check(z.maxLength(5));
-z.string().check(z.minLength(5));
-z.string().check(z.length(5));
-z.string().check(z.regex(/^[a-z]+$/));
-z.string().check(z.startsWith("aaa"));
-z.string().check(z.endsWith("zzz"));
-z.string().check(z.includes("---"));
-z.string().check(z.uppercase());
-z.string().check(z.lowercase());
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts z.string().max(5); z.string().min(5); z.string().length(5);
+    z.string().regex(/^[a-z]+$/); z.string().startsWith("aaa");
+    z.string().endsWith("zzz"); z.string().includes("---");
+    z.string().uppercase(); z.string().lowercase(); ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts z.string().check(z.maxLength(5)); z.string().check(z.minLength(5));
+    z.string().check(z.length(5)); z.string().check(z.regex(/^[a-z]+$/));
+    z.string().check(z.startsWith("aaa")); z.string().check(z.endsWith("zzz"));
+    z.string().check(z.includes("---")); z.string().check(z.uppercase());
+    z.string().check(z.lowercase()); ```
+  </Tab>
 </Tabs>
 
 To perform some simple string transforms:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.string().trim(); // trim whitespace
-z.string().toLowerCase(); // toLowerCase
-z.string().toUpperCase(); // toUpperCase
-z.string().normalize(); // normalize unicode characters
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-z.string().check(z.trim()); // trim whitespace
-z.string().check(z.toLowerCase()); // toLowerCase
-z.string().check(z.toUpperCase()); // toUpperCase
-z.string().check(z.normalize()); // normalize unicode characters
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts z.string().trim(); // trim whitespace z.string().toLowerCase(); //
+    toLowerCase z.string().toUpperCase(); // toUpperCase z.string().normalize();
+    // normalize unicode characters ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts z.string().check(z.trim()); // trim whitespace
+    z.string().check(z.toLowerCase()); // toLowerCase
+    z.string().check(z.toUpperCase()); // toUpperCase
+    z.string().check(z.normalize()); // normalize unicode characters ```
+  </Tab>
 </Tabs>
 
 ## String formats
@@ -246,9 +216,9 @@ To validate against some common string formats:
 z.email();
 z.uuid();
 z.url();
-z.httpUrl();       // http or https URLs only
+z.httpUrl(); // http or https URLs only
 z.hostname();
-z.emoji();         // validates a single emoji character
+z.emoji(); // validates a single emoji character
 z.base64();
 z.base64url();
 z.hex();
@@ -260,9 +230,9 @@ z.ulid();
 z.ipv4();
 z.ipv6();
 z.mac();
-z.cidrv4();        // ipv4 CIDR block
-z.cidrv6();        // ipv6 CIDR block
-z.hash("sha256");  // or "sha1", "sha384", "sha512", "md5"
+z.cidrv4(); // ipv4 CIDR block
+z.cidrv6(); // ipv6 CIDR block
+z.hash("sha256"); // or "sha1", "sha384", "sha512", "md5"
 z.iso.date();
 z.iso.time();
 z.iso.datetime();
@@ -280,7 +250,7 @@ z.email();
 By default, Zod uses a comparatively strict email regex designed to validate normal email addresses containing common characters. It's roughly equivalent to the rules enforced by Gmail. To learn more about this regex, refer to [this post](https://colinhacks.com/essays/reasonable-email-regex).
 
 ```ts
-/^(?!\.)(?!.*\.\.)([a-z0-9_'+\-\.]*)[a-z0-9_+-]@([a-z0-9][a-z0-9\-]*\.)+[a-z]{2,}$/i
+/^(?!\.)(?!.*\.\.)([a-z0-9_'+\-\.]*)[a-z0-9_+-]@([a-z0-9][a-z0-9\-]*\.)+[a-z]{2,}$/i;
 ```
 
 To customize the email validation behavior, you can pass a custom regular expression to the `pattern` param.
@@ -345,7 +315,7 @@ schema.parse("http://localhost"); // ✅
 schema.parse("mailto:noreply@zod.dev"); // ✅
 ```
 
-As you can see this is quite permissive. Internally this uses the `new URL()` constructor to validate inputs; this behavior may differ across platforms and runtimes but it's the mostly rigorous way to validate URIs/URLs on any given JS runtime/engine. 
+As you can see this is quite permissive. Internally this uses the `new URL()` constructor to validate inputs; this behavior may differ across platforms and runtimes but it's the mostly rigorous way to validate URIs/URLs on any given JS runtime/engine.
 
 To validate the hostname against a specific regex:
 
@@ -368,24 +338,25 @@ schema.parse("http://example.com"); // ❌
 <Callout>
   **Web URLs** — In many cases, you'll want to validate Web URLs specifically. Here's the recommended schema for doing so:
 
-  ```ts
-  const httpUrl = z.url({
-    protocol: /^https?$/,
-    hostname: z.regexes.domain
-  });
-  ```
+```ts
+const httpUrl = z.url({
+  protocol: /^https?$/,
+  hostname: z.regexes.domain,
+});
+```
 
-  This restricts the protocol to `http`/`https` and ensures the hostname is a valid domain name with the `z.regexes.domain` regular expression:
+This restricts the protocol to `http`/`https` and ensures the hostname is a valid domain name with the `z.regexes.domain` regular expression:
 
-  ```ts
-  /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
-  ```
+```ts
+/^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+```
+
 </Callout>
 
 To normalize URLs, use the `normalize` flag. This will overwrite the input value with the [normalized URL](https://chatgpt.com/share/6881547f-bebc-800f-9093-f5981e277c2c) returned by `new URL()`.
 
 ```ts
-new URL("HTTP://ExAmPle.com:80/./a/../b?X=1#f oo").href
+new URL("HTTP://ExAmPle.com:80/./a/../b?X=1#f oo").href;
 // => "http://example.com/b?X=1#f%20oo"
 ```
 
@@ -414,11 +385,11 @@ const datetime = z.iso.datetime({ offset: true });
 datetime.parse("2020-01-01T06:15:00+02:00"); // ✅
 
 // basic offsets not allowed
-datetime.parse("2020-01-01T06:15:00+02");    // ❌
-datetime.parse("2020-01-01T06:15:00+0200");  // ❌
+datetime.parse("2020-01-01T06:15:00+02"); // ❌
+datetime.parse("2020-01-01T06:15:00+0200"); // ❌
 
 // Z is still supported
-datetime.parse("2020-01-01T06:15:00Z"); // ✅ 
+datetime.parse("2020-01-01T06:15:00Z"); // ✅
 ```
 
 To allow unqualified (timezone-less) datetimes:
@@ -488,10 +459,10 @@ Use the `precision` parameter to constrain the allowable decimal precision.
 
 ```ts
 z.iso.time({ precision: -1 }); // HH:MM (minute precision)
-z.iso.time({ precision: 0 });  // HH:MM:SS (second precision)
-z.iso.time({ precision: 1 });  // HH:MM:SS.s (decisecond precision)
-z.iso.time({ precision: 2 });  // HH:MM:SS.ss (centisecond precision)
-z.iso.time({ precision: 3 });  // HH:MM:SS.sss (millisecond precision)
+z.iso.time({ precision: 0 }); // HH:MM:SS (second precision)
+z.iso.time({ precision: 1 }); // HH:MM:SS.s (decisecond precision)
+z.iso.time({ precision: 2 }); // HH:MM:SS.ss (centisecond precision)
+z.iso.time({ precision: 3 }); // HH:MM:SS.sss (millisecond precision)
 ```
 
 ### IP addresses
@@ -521,11 +492,11 @@ cidrv6.parse("2001:db8::/32"); // ✅
 Validate standard 48-bit MAC address [IEEE 802](https://en.wikipedia.org/wiki/MAC_address).
 
 ```ts
-const mac = z.mac(); 
-mac.parse("00:1A:2B:3C:4D:5E");  // ✅
-mac.parse("00-1a-2b-3c-4d-5e");  // ❌ colon-delimited by default
-mac.parse("001A:2B3C:4D5E");     // ❌ standard formats only
-mac.parse("00:1A:2b:3C:4d:5E");  // ❌ no mixed case
+const mac = z.mac();
+mac.parse("00:1A:2B:3C:4D:5E"); // ✅
+mac.parse("00-1a-2b-3c-4d-5e"); // ❌ colon-delimited by default
+mac.parse("001A:2B3C:4D5E"); // ❌ standard formats only
+mac.parse("00:1A:2b:3C:4d:5E"); // ❌ no mixed case
 
 // custom delimiter
 const dashMac = z.mac({ delimiter: "-" });
@@ -556,21 +527,21 @@ z.hash("sha512");
 By default, `z.hash()` expects hexadecimal encoding, as is conventional. You can specify a different encoding with the `enc` parameter:
 
 ```ts
-z.hash("sha256", { enc: "hex" });       // default
-z.hash("sha256", { enc: "base64" });    // base64 encoding
+z.hash("sha256", { enc: "hex" }); // default
+z.hash("sha256", { enc: "base64" }); // base64 encoding
 z.hash("sha256", { enc: "base64url" }); // base64url encoding (no padding)
 ```
 
 <Accordions>
 <Accordion title="Expected lengths and padding">
 
-| Algorithm / Encoding | `"hex"`  | `"base64"`  | `"base64url"`  |
-|-----------|-----------|--------------|-----------------|
-| `"md5"`   | 32        | 24 (22 + "==") | 22              |
-| `"sha1"`  | 40        | 28 (27 + "=")  | 27              |
-| `"sha256"`| 64        | 44 (43 + "=")  | 43              |
-| `"sha384"`| 96        | 64 (no padding)| 64              |
-| `"sha512"`| 128       | 88 (86 + "==") | 86              |
+| Algorithm / Encoding | `"hex"` | `"base64"`      | `"base64url"` |
+| -------------------- | ------- | --------------- | ------------- |
+| `"md5"`              | 32      | 24 (22 + "==")  | 22            |
+| `"sha1"`             | 40      | 28 (27 + "=")   | 27            |
+| `"sha256"`           | 64      | 44 (43 + "=")   | 43            |
+| `"sha384"`           | 96      | 64 (no padding) | 64            |
+| `"sha512"`           | 128     | 88 (86 + "==")  | 86            |
 
 </Accordion>
 </Accordions>
@@ -580,7 +551,7 @@ z.hash("sha256", { enc: "base64url" }); // base64url encoding (no padding)
 To define your own string formats:
 
 ```ts
-const coolId = z.stringFormat("cool-id", ()=>{
+const coolId = z.stringFormat("cool-id", () => {
   // arbitrary validation here
   return val.length === 100 && val.startsWith("cool-");
 });
@@ -610,26 +581,26 @@ myFormat.parse("invalid input!");
 To define a template literal schema:
 
 ```ts
-const schema = z.templateLiteral([ "hello, ", z.string(), "!" ]);
+const schema = z.templateLiteral(["hello, ", z.string(), "!"]);
 // `hello, ${string}!`
 ```
 
 The `z.templateLiteral` API can handle any number of string literals (e.g. `"hello"`) and schemas. Any schema with an inferred type that's assignable to `string | number | bigint | boolean | null | undefined` can be passed.
 
 ```ts
-z.templateLiteral([ "hi there" ]);
+z.templateLiteral(["hi there"]);
 // `hi there`
 
-z.templateLiteral([ "email: ", z.string() ]);
+z.templateLiteral(["email: ", z.string()]);
 // `email: ${string}`
 
-z.templateLiteral([ "high", z.literal(5) ]);
+z.templateLiteral(["high", z.literal(5)]);
 // `high5`
 
-z.templateLiteral([ z.nullable(z.literal("grassy")) ]);
+z.templateLiteral([z.nullable(z.literal("grassy"))]);
 // `grassy` | `null`
 
-z.templateLiteral([ z.number(), z.enum(["px", "em", "rem"]) ]);
+z.templateLiteral([z.number(), z.enum(["px", "em", "rem"])]);
 // `${number}px` | `${number}em` | `${number}rem`
 ```
 
@@ -640,47 +611,35 @@ Use `z.number()` to validate numbers. It allows any finite number.
 ```ts
 const schema = z.number();
 
-schema.parse(3.14);      // ✅
-schema.parse(NaN);       // ❌
-schema.parse(Infinity);  // ❌
+schema.parse(3.14); // ✅
+schema.parse(NaN); // ❌
+schema.parse(Infinity); // ❌
 ```
 
 Zod implements a handful of number-specific validations:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.number().gt(5);
-z.number().gte(5);                     // alias .min(5)
-z.number().lt(5);
-z.number().lte(5);                     // alias .max(5)
-z.number().positive();                 // alias .gt(0)
-z.number().nonnegative();    
-z.number().negative(); 
-z.number().nonpositive(); 
-z.number().multipleOf(5);              // alias .step(5)
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-z.number().check(z.gt(5));
-z.number().check(z.gte(5));            // alias .minimum(5)
-z.number().check(z.lt(5));
-z.number().check(z.lte(5));            // alias .maximum(5)
-z.number().check(z.positive());        // alias .gt(0)
-z.number().check(z.nonnegative()); 
-z.number().check(z.negative()); 
-z.number().check(z.nonpositive()); 
-z.number().check(z.multipleOf(5));     // alias .step(5)
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts z.number().gt(5); z.number().gte(5); // alias .min(5)
+    z.number().lt(5); z.number().lte(5); // alias .max(5) z.number().positive();
+    // alias .gt(0) z.number().nonnegative(); z.number().negative();
+    z.number().nonpositive(); z.number().multipleOf(5); // alias .step(5) ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts z.number().check(z.gt(5)); z.number().check(z.gte(5)); // alias
+    .minimum(5) z.number().check(z.lt(5)); z.number().check(z.lte(5)); // alias
+    .maximum(5) z.number().check(z.positive()); // alias .gt(0)
+    z.number().check(z.nonnegative()); z.number().check(z.negative());
+    z.number().check(z.nonpositive()); z.number().check(z.multipleOf(5)); //
+    alias .step(5) ```
+  </Tab>
 </Tabs>
 
 If (for some reason) you want to validate `NaN`, use `z.nan()`.
 
 ```ts
-z.nan().parse(NaN);              // ✅
-z.nan().parse("anything else");  // ❌
+z.nan().parse(NaN); // ✅
+z.nan().parse("anything else"); // ❌
 ```
 
 ## Integers
@@ -688,8 +647,8 @@ z.nan().parse("anything else");  // ❌
 To validate integers:
 
 ```ts
-z.int();     // restricts to safe integer range
-z.int32();   // restrict to int32 range
+z.int(); // restricts to safe integer range
+z.int32(); // restrict to int32 range
 ```
 
 ## BigInts
@@ -754,7 +713,7 @@ To customize the error message:
 
 ```ts
 z.date({
-  error: issue => issue.input === undefined ? "Required" : "Invalid date"
+  error: (issue) => (issue.input === undefined ? "Required" : "Invalid date"),
 });
 ```
 
@@ -775,7 +734,7 @@ z.date().check(z.maximum(new Date(), { error: "Too young!" }));
 </Tab>
 </Tabs>
 
-<div id="zod-enums" style={{height:"0px" }} /> 
+<div id="zod-enums" style={{ height: "0px" }} />
 
 ## Enums
 
@@ -791,32 +750,33 @@ FishEnum.parse("Swordfish"); // => ❌
 <Callout>
   Careful — If you declare your string array as a variable, Zod won't be able to properly infer the exact values of each element.
 
-  ```ts
-  const fish = ["Salmon", "Tuna", "Trout"];
-  
-  const FishEnum = z.enum(fish);
-  type FishEnum = z.infer<typeof FishEnum>; // string
-  ```
+```ts
+const fish = ["Salmon", "Tuna", "Trout"];
 
-  To fix this, always pass the array directly into the `z.enum()` function, or use [`as const`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions).
+const FishEnum = z.enum(fish);
+type FishEnum = z.infer<typeof FishEnum>; // string
+```
 
-  ```ts
-  const fish = ["Salmon", "Tuna", "Trout"] as const;
+To fix this, always pass the array directly into the `z.enum()` function, or use [`as const`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions).
 
-  const FishEnum = z.enum(fish);
-  type FishEnum = z.infer<typeof FishEnum>; // "Salmon" | "Tuna" | "Trout"
-  ```
+```ts
+const fish = ["Salmon", "Tuna", "Trout"] as const;
+
+const FishEnum = z.enum(fish);
+type FishEnum = z.infer<typeof FishEnum>; // "Salmon" | "Tuna" | "Trout"
+```
+
 </Callout>
 
-Enum-like object literals (`{ [key: string]: string | number }`) are supported. 
+Enum-like object literals (`{ [key: string]: string | number }`) are supported.
 
 ```ts
 const Fish = {
   Salmon: 0,
-  Tuna: 1
-} as const
+  Tuna: 1,
+} as const;
 
-const FishEnum = z.enum(Fish)
+const FishEnum = z.enum(Fish);
 FishEnum.parse(Fish.Salmon); // => ✅
 FishEnum.parse(0); // => ✅
 FishEnum.parse(2); // => ❌
@@ -827,7 +787,7 @@ You can also pass in an externally-declared TypeScript enum.
 ```ts
 enum Fish {
   Salmon = 0,
-  Tuna = 1
+  Tuna = 1,
 }
 
 const FishEnum = z.enum(Fish);
@@ -837,9 +797,10 @@ FishEnum.parse(2); // => ❌
 ```
 
 <Callout>
-**Zod 4** — This replaces the `z.nativeEnum()` API in Zod 3. 
+**Zod 4** — This replaces the `z.nativeEnum()` API in Zod 3.
 
-Note that using TypeScript's `enum` keyword is [not recommended](https://www.totaltypescript.com/why-i-dont-like-typescript-enums). 
+Note that using TypeScript's `enum` keyword is [not recommended](https://www.totaltypescript.com/why-i-dont-like-typescript-enums).
+
 </Callout>
 
 ```ts
@@ -863,7 +824,8 @@ const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);
 
 FishEnum.enum;
 // => { Salmon: "Salmon", Tuna: "Tuna", Trout: "Trout" }
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -871,7 +833,8 @@ const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);
 
 FishEnum.def.entries;
 // => { Salmon: "Salmon", Tuna: "Tuna", Trout: "Trout" }
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -880,18 +843,11 @@ FishEnum.def.entries;
 To create a new enum schema, excluding certain values:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);
-const TunaOnly = FishEnum.exclude(["Salmon", "Trout"]);
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-// no equivalent
- 
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]); const TunaOnly =
+    FishEnum.exclude(["Salmon", "Trout"]); ```
+  </Tab>
+  <Tab value="Zod Mini">```ts // no equivalent ```</Tab>
 </Tabs>
 
 ### `.extract()`
@@ -899,18 +855,11 @@ const TunaOnly = FishEnum.exclude(["Salmon", "Trout"]);
 To create a new enum schema, extracting certain values:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]);
-const SalmonAndTroutOnly = FishEnum.extract(["Salmon", "Trout"]);
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-// no equivalent
- 
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts const FishEnum = z.enum(["Salmon", "Tuna", "Trout"]); const
+    SalmonAndTroutOnly = FishEnum.extract(["Salmon", "Trout"]); ```
+  </Tab>
+  <Tab value="Zod Mini">```ts // no equivalent ```</Tab>
 </Tabs>
 
 ## Stringbools [#stringbool]
@@ -922,19 +871,19 @@ In some cases (e.g. parsing environment variables) it's valuable to parse certai
 ```ts
 const strbool = z.stringbool();
 
-strbool.parse("true")         // => true
-strbool.parse("1")            // => true
-strbool.parse("yes")          // => true
-strbool.parse("on")           // => true
-strbool.parse("y")            // => true
-strbool.parse("enabled")      // => true
+strbool.parse("true"); // => true
+strbool.parse("1"); // => true
+strbool.parse("yes"); // => true
+strbool.parse("on"); // => true
+strbool.parse("y"); // => true
+strbool.parse("enabled"); // => true
 
-strbool.parse("false");       // => false
-strbool.parse("0");           // => false
-strbool.parse("no");          // => false
-strbool.parse("off");         // => false
-strbool.parse("n");           // => false
-strbool.parse("disabled");    // => false
+strbool.parse("false"); // => false
+strbool.parse("0"); // => false
+strbool.parse("no"); // => false
+strbool.parse("off"); // => false
+strbool.parse("n"); // => false
+strbool.parse("disabled"); // => false
 
 strbool.parse(/* anything else */); // ZodError<[{ code: "invalid_value" }]>
 ```
@@ -949,30 +898,23 @@ z.stringbool({
 });
 ```
 
-By default the schema is *case-insensitive*; all inputs are converted to lowercase before comparison to the `truthy`/`falsy` values. To make it case-sensitive:
+By default the schema is _case-insensitive_; all inputs are converted to lowercase before comparison to the `truthy`/`falsy` values. To make it case-sensitive:
 
 ```ts
 z.stringbool({
-  case: "sensitive"
+  case: "sensitive",
 });
 ```
 
-
 ## Optionals
 
-To make a schema *optional* (that is, to allow `undefined` inputs).
+To make a schema _optional_ (that is, to allow `undefined` inputs).
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.optional(z.literal("yoda")); // or z.literal("yoda").optional()
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-z.optional(z.literal("yoda"));
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts z.optional(z.literal("yoda")); // or z.literal("yoda").optional() ```
+  </Tab>
+  <Tab value="Zod Mini">```ts z.optional(z.literal("yoda")); ```</Tab>
 </Tabs>
 
 This returns a `ZodOptional` instance that wraps the original schema. To extract the inner schema:
@@ -992,19 +934,15 @@ optionalYoda.def.innerType; // ZodMiniLiteral<"yoda">
 
 ## Nullables
 
-To make a schema *nullable* (that is, to allow `null` inputs).
+To make a schema _nullable_ (that is, to allow `null` inputs).
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.nullable(z.literal("yoda")); // or z.literal("yoda").nullable()
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-const nullableYoda = z.nullable(z.literal("yoda"));
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts z.nullable(z.literal("yoda")); // or z.literal("yoda").nullable() ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts const nullableYoda = z.nullable(z.literal("yoda")); ```
+  </Tab>
 </Tabs>
 
 This returns a `ZodNullable` instance that wraps the original schema. To extract the inner schema:
@@ -1024,19 +962,15 @@ nullableYoda.def.innerType; // ZodMiniLiteral<"yoda">
 
 ## Nullish
 
-To make a schema *nullish* (both optional and nullable):
+To make a schema _nullish_ (both optional and nullable):
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-const nullishYoda = z.nullish(z.literal("yoda"));
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-const nullishYoda = z.nullish(z.literal("yoda"));
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts const nullishYoda = z.nullish(z.literal("yoda")); ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts const nullishYoda = z.nullish(z.literal("yoda")); ```
+  </Tab>
 </Tabs>
 
 Refer to the TypeScript manual for more about the concept of [nullish](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing).
@@ -1064,15 +998,16 @@ z.never(); // inferred type: `never`
 To define an object type:
 
 ```ts z.object
-  // all properties are required by default
-  const Person = z.object({
-    name: z.string(),
-    age: z.number(),
-  });
+// all properties are required by default
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+});
 
-  type Person = z.infer<typeof Person>;
-  // => { name: string; age: number; }
-  ```
+type Person = z.infer<typeof Person>;
+// => { name: string; age: number; }
+```
+
 By default, all properties are required. To make certain properties optional:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
@@ -1084,7 +1019,8 @@ const Dog = z.object({
 });
 
 Dog.parse({ name: "Yeller" }); // ✅
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts z.object
@@ -1094,13 +1030,12 @@ const Dog = z.object({
 });
 
 Dog.parse({ name: "Yeller" }); // ✅
-```
+````
+
 </Tab>
 </Tabs>
 
-
-
-By default, unrecognized keys are *stripped* from the parsed result:
+By default, unrecognized keys are _stripped_ from the parsed result:
 
 ```ts z.object
 Dog.parse({ name: "Yeller", extraKey: true });
@@ -1109,7 +1044,7 @@ Dog.parse({ name: "Yeller", extraKey: true });
 
 ### `z.strictObject`
 
-To define a *strict* schema that throws an error when unknown keys are found:
+To define a _strict_ schema that throws an error when unknown keys are found:
 
 ```ts z.object
 const StrictDog = z.strictObject({
@@ -1122,7 +1057,7 @@ StrictDog.parse({ name: "Yeller", extraKey: true });
 
 ### `z.looseObject`
 
-To define a *loose* schema that allows unknown keys to pass through:
+To define a _loose_ schema that allows unknown keys to pass through:
 
 ```ts z.object
 const LooseDog = z.looseObject({
@@ -1135,7 +1070,7 @@ LooseDog.parse({ name: "Yeller", extraKey: true });
 
 ### `.catchall()`
 
-To define a *catchall schema* that will be used to validate any unrecognized keys:
+To define a _catchall schema_ that will be used to validate any unrecognized keys:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -1147,7 +1082,8 @@ const DogWithStrings = z.object({
 
 DogWithStrings.parse({ name: "Yeller", extraKey: "extraValue" }); // ✅
 DogWithStrings.parse({ name: "Yeller", extraKey: 42 }); // ❌
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts z.object
@@ -1161,10 +1097,10 @@ const DogWithStrings = z.catchall(
 
 DogWithStrings.parse({ name: "Yeller", extraKey: "extraValue" }); // ✅
 DogWithStrings.parse({ name: "Yeller", extraKey: 42 }); // ❌
-```
+````
+
 </Tab>
 </Tabs>
-
 
 ### `.shape`
 
@@ -1231,7 +1167,8 @@ This API can be used to overwrite existing fields! Be careful with this power! I
 **Alternative: spread syntax** — You can alternatively avoid `.extend()` altogether by creating a new object schema entirely. This makes the strictness level of the resulting schema visually obvious.
 
 ```ts
-const DogWithBreed = z.object({ // or z.strictObject() or z.looseObject()...
+const DogWithBreed = z.object({
+  // or z.strictObject() or z.looseObject()...
   ...Dog.shape,
   breed: z.string(),
 });
@@ -1253,7 +1190,7 @@ This approach has a few advantages:
 2. The same syntax works in Zod and Zod Mini
 3. It's more `tsc`-efficient — the `.extend()` method can be expensive on large schemas, and due to [a TypeScript limitation](https://github.com/microsoft/TypeScript/pull/61505) it gets quadratically more expensive when calls are chained
 4. If you wish, you can change the strictness level of the resulting schema by using `z.strictObject()` or `z.looseObject()`
-</Callout>
+   </Callout>
 
 ### `.safeExtend()`
 
@@ -1263,7 +1200,7 @@ The `.safeExtend()` method works similarly to `.extend()`, but it won't let you 
 z.object({ a: z.string() }).safeExtend({ a: z.string().min(5) }); // ✅
 z.object({ a: z.string() }).safeExtend({ a: z.any() }); // ✅
 z.object({ a: z.string() }).safeExtend({ a: z.number() });
-//                                       ^  ❌ ZodNumber is not assignable 
+//                                       ^  ❌ ZodNumber is not assignable
 ```
 
 Use `.safeExtend()` to extend schemas that contain refinements. (Regular `.extend()` will throw an error when used on schemas with refinements.)
@@ -1278,9 +1215,10 @@ const Base = z.object({
 
 // Extended inherits the refinements of Base
 const Extended = Base.safeExtend({
-  a: z.string().min(10)
+a: z.string().min(10)
 });
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -1293,7 +1231,8 @@ const Base = z.object({
 const Extended = z.safeExtend(Base, {
   a: z.string().min(10)
 });
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -1311,8 +1250,8 @@ const Recipe = z.object({
 });
 // { title: string; description?: string | undefined; ingredients: string[] }
 ```
-To pick certain keys:
 
+To pick certain keys:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -1326,7 +1265,6 @@ const JustTheTitle = z.pick(Recipe, { title: true });
 ```
 </Tab>
 </Tabs>
-
 
 ### `.omit()`
 
@@ -1345,11 +1283,9 @@ const RecipeNoId = z.omit(Recipe, { id: true });
 </Tab>
 </Tabs>
 
-
 ### `.partial()`
 
 For convenience, Zod provides a dedicated API for making some or all properties optional, inspired by the built-in TypeScript utility type [`Partial`](https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype).
-
 
 To make all fields optional:
 
@@ -1391,7 +1327,7 @@ const RecipeOptionalIngredients = z.partial(Recipe, {
 
 ### `.required()`
 
-Zod provides an API for making some or all properties *required*, inspired by TypeScript's [`Required`](https://www.typescriptlang.org/docs/handbook/utility-types.html#requiredtype) utility type.
+Zod provides an API for making some or all properties _required_, inspired by TypeScript's [`Required`](https://www.typescriptlang.org/docs/handbook/utility-types.html#requiredtype) utility type.
 
 To make all properties required:
 
@@ -1427,8 +1363,6 @@ const RecipeRequiredDescription = z.required(Recipe, {description: true});
 </Tab>
 </Tabs>
 
-
-
 ## Recursive objects
 
 To define a self-referential type, use a [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get) on the key. This lets JavaScript resolve the cyclical schema at runtime.
@@ -1436,34 +1370,35 @@ To define a self-referential type, use a [getter](https://developer.mozilla.org/
 ```ts
 const Category = z.object({
   name: z.string(),
-  get subcategories(){
-    return z.array(Category)
-  }
+  get subcategories() {
+    return z.array(Category);
+  },
 });
 
 type Category = z.infer<typeof Category>;
 // { name: string; subcategories: Category[] }
 ```
 
-<Callout type="warn"> 
-  Though recursive schemas are supported, passing cyclical data into Zod will cause an infinite loop.
+<Callout type="warn">
+  Though recursive schemas are supported, passing cyclical data into Zod will
+  cause an infinite loop.
 </Callout>
 
-You can also represent *mutually recursive types*:
+You can also represent _mutually recursive types_:
 
 ```ts
 const User = z.object({
   email: z.email(),
-  get posts(){
-    return z.array(Post)
-  }
+  get posts() {
+    return z.array(Post);
+  },
 });
 
 const Post = z.object({
   title: z.string(),
-  get author(){
-    return User
-  }
+  get author() {
+    return User;
+  },
 });
 ```
 
@@ -1497,9 +1432,10 @@ const Activity = z.object({
 });
 ```
 
-{/* Some general rules of thumb for avoiding circularity  */}
+{/* Some general rules of thumb for avoiding circularity */}
 
-{/* 
+{/\*
+
 <Accordions>
   <Accordion title="Resolving type errors in recursive schemas">
     Recursive type inference can by mysterious. TypeScript is capable of it in certain limited scenarios. Depending on what you're trying to do, you may encounter errors like this:
@@ -1508,8 +1444,8 @@ const Activity = z.object({
     export const Activity = z.object({
       name: z.string(),
       get children() {
-        // ^ ❌ 'children' implicitly has return type 'any' because it does not 
-        // have a return type annotation and is referenced directly or indirectly 
+        // ^ ❌ 'children' implicitly has return type 'any' because it does not
+        // have a return type annotation and is referenced directly or indirectly
         // in one of its return expressions.ts(7023)
 
         return z.optional(z.array(Activity)); //.optional();
@@ -1519,8 +1455,8 @@ const Activity = z.object({
 
     Here are a couple rules of thumb:
 
-    ### Object types only 
-    
+    ### Object types only
+
     Generally speaking, recursive inference only works with object types that are referencing each other. TypeScript has special handling for resolving getter-based recursive objects, which is what Zod relies on. If you try to add non-object types into the mix, you'll likely encounter errors.
 
     ```ts
@@ -1534,19 +1470,19 @@ const Activity = z.object({
     const ActivityArray = z.array(Activity);
     ```
 
-    Sometimes you can get around this limitation by defining 
+    Sometimes you can get around this limitation by defining
 
 
     ### Avoid nesting function calls
-    
+
     Functions like `z.array()` and `z.optional()` accept Zod schemas, so when you use them TypeScript will do some type-checking on their inputs to make sure they are valid. But type checking is the enemy of recursive type inference—it's hard for TypeScript to *check* and *infer* types at the same time. Methods do not have this problem, so prefer methods over functions when possible (sorry Zod Mini users).
 
     ```ts
     const Activity = z.object({
       name: z.string(),
       get subactivities() {
-        // ^ ❌ 'subactivities' implicitly has return type 'any' because it does not 
-        // have a return type annotation and is referenced directly or indirectly 
+        // ^ ❌ 'subactivities' implicitly has return type 'any' because it does not
+        // have a return type annotation and is referenced directly or indirectly
         // in one of its return expressions.ts(7023)
 
         return z.union([z.null(), Activity]);
@@ -1555,7 +1491,7 @@ const Activity = z.object({
     ```
 
     ### Fall back to type annotations on your getters
-    
+
     When in doubt, you can generally sidestep these issues with some carefully deployed type annotations on your getters. Due to the limitations described above, this is particularly necessary when using Zod Mini.
 
     ```ts
@@ -1577,16 +1513,10 @@ const Activity = z.object({
 To define an array schema:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-const stringArray = z.array(z.string()); // or z.string().array()
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-const stringArray = z.array(z.string());
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts const stringArray = z.array(z.string()); // or z.string().array() ```
+  </Tab>
+  <Tab value="Zod Mini">```ts const stringArray = z.array(z.string()); ```</Tab>
 </Tabs>
 
 To access the inner schema for an element of the array.
@@ -1607,20 +1537,17 @@ stringArray.def.element; // => string schema
 Zod implements a number of array-specific validations:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.array(z.string()).min(5); // must contain 5 or more items
-z.array(z.string()).max(5); // must contain 5 or fewer items
-z.array(z.string()).length(5); // must contain 5 items exactly
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-z.array(z.string()).check(z.minLength(5)); // must contain 5 or more items
-z.array(z.string()).check(z.maxLength(5)); // must contain 5 or fewer items
-z.array(z.string()).check(z.length(5)); // must contain 5 items exactly
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts z.array(z.string()).min(5); // must contain 5 or more items
+    z.array(z.string()).max(5); // must contain 5 or fewer items
+    z.array(z.string()).length(5); // must contain 5 items exactly ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts z.array(z.string()).check(z.minLength(5)); // must contain 5 or more
+    items z.array(z.string()).check(z.maxLength(5)); // must contain 5 or fewer
+    items z.array(z.string()).check(z.length(5)); // must contain 5 items
+    exactly ```
+  </Tab>
 </Tabs>
 
 {/* Unlike `.nonempty()` these methods do not change the inferred type. */}
@@ -1630,11 +1557,7 @@ z.array(z.string()).check(z.length(5)); // must contain 5 items exactly
 Unlike arrays, tuples are typically fixed-length arrays that specify different schemas for each index.
 
 ```ts
-const MyTuple = z.tuple([
-  z.string(),
-  z.number(),
-  z.boolean()
-]);
+const MyTuple = z.tuple([z.string(), z.number(), z.boolean()]);
 
 type MyTuple = z.infer<typeof MyTuple>;
 // [string, number, boolean]
@@ -1662,21 +1585,17 @@ stringOrNumber.parse(14); // passes
 To extract the internal option schemas:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-stringOrNumber.options; // [ZodString, ZodNumber]
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-stringOrNumber.def.options; // [ZodString, ZodNumber]
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts stringOrNumber.options; // [ZodString, ZodNumber] ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts stringOrNumber.def.options; // [ZodString, ZodNumber] ```
+  </Tab>
 </Tabs>
 
-{/* For convenience, you can also use the [`.or` method](#or):
+{/\* For convenience, you can also use the [`.or` method](#or):
 
-```ts
+````ts
 const stringOrNumber = z.string().or(z.number());
 ``` */}
 
@@ -1694,7 +1613,7 @@ console.log(optionalUrl.safeParse(null).success); // true
 console.log(optionalUrl.safeParse("").success); // true
 console.log(optionalUrl.safeParse("https://zod.dev").success); // true
 console.log(optionalUrl.safeParse("not a valid url").success); // false
-```
+````
 
 <br/> */}
 
@@ -1706,8 +1625,8 @@ An exclusive union (XOR) is a union where exactly one option must match. Unlike 
 const schema = z.xor([z.string(), z.number()]);
 
 schema.parse("hello"); // ✅ passes
-schema.parse(42);      // ✅ passes
-schema.parse(true);    // ❌ fails (zero matches)
+schema.parse(42); // ✅ passes
+schema.parse(true); // ❌ fails (zero matches)
 ```
 
 This is useful when you want to ensure mutual exclusivity between options:
@@ -1729,7 +1648,6 @@ const overlapping = z.xor([z.string(), z.any()]);
 overlapping.parse("hello"); // ❌ fails (matches both string and any)
 ```
 
-
 ## Discriminated unions
 
 A [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) is a special kind of union in which a) all the options are object schemas that b) share a particular key (the "discriminator"). Based on the value of the discriminator key, TypeScript is able to "narrow" the type signature as you'd expect.
@@ -1739,8 +1657,8 @@ type MyResult =
   | { status: "success"; data: string }
   | { status: "failed"; error: string };
 
-function handleResult(result: MyResult){
-  if(result.status === "success"){
+function handleResult(result: MyResult) {
+  if (result.status === "success") {
     result.data; // string
   } else {
     result.error; // string
@@ -1748,10 +1666,9 @@ function handleResult(result: MyResult){
 }
 ```
 
-You could represent it with a regular `z.union()`. But regular unions are *naive*—they check the input against each option in order and return the first one that passes. This can be slow for large unions.
+You could represent it with a regular `z.union()`. But regular unions are _naive_—they check the input against each option in order and return the first one that passes. This can be slow for large unions.
 
-So Zod provides a `z.discriminatedUnion()` API that uses a *discriminator key* to make parsing more efficient.
-
+So Zod provides a `z.discriminatedUnion()` API that uses a _discriminator key_ to make parsing more efficient.
 
 ```ts
 const MyResult = z.discriminatedUnion("status", [
@@ -1760,48 +1677,49 @@ const MyResult = z.discriminatedUnion("status", [
 ]);
 ```
 
-Each option should be an *object schema* whose discriminator prop (`status` in the example above) corresponds to some literal value or set of values, usually `z.enum()`, `z.literal()`, `z.null()`, or `z.undefined()`.
+Each option should be an _object schema_ whose discriminator prop (`status` in the example above) corresponds to some literal value or set of values, usually `z.enum()`, `z.literal()`, `z.null()`, or `z.undefined()`.
 
-{/* 
+{/\*
+
 <Callout>
   In Zod 3, you were required to specify the discriminator key as the first argument. This is no longer necessary, as Zod can now automatically detect the discriminator key.
 
-  ```ts
-  const MyResult = z.discriminatedUnion("status", [
-    z.object({ status: z.literal("success"), data: z.string() }),
-    z.object({ status: z.literal("failed"), error: z.string() }),
-  ]);
-  ```
+```ts
+const MyResult = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("success"), data: z.string() }),
+  z.object({ status: z.literal("failed"), error: z.string() }),
+]);
+```
 
-  If Zod can't find a discriminator key, it will throw an error at schema creation time.
+If Zod can't find a discriminator key, it will throw an error at schema creation time.
+
 </Callout> */}
 
 <Accordions type="single">
 <Accordion title="Nesting discriminated unions">
 
-  For advanced use cases, discriminated unions can be nested. Zod will figure out the optimal parsing strategy to leverage the discriminators at each level.
+For advanced use cases, discriminated unions can be nested. Zod will figure out the optimal parsing strategy to leverage the discriminators at each level.
 
-  ```ts
-  const BaseError = { status: z.literal("failed"), message: z.string() };
-  const MyErrors = z.discriminatedUnion("code", [
-    z.object({ ...BaseError, code: z.literal(400) }),
-    z.object({ ...BaseError, code: z.literal(401) }),
-    z.object({ ...BaseError, code: z.literal(500) }),
-  ]);
+```ts
+const BaseError = { status: z.literal("failed"), message: z.string() };
+const MyErrors = z.discriminatedUnion("code", [
+  z.object({ ...BaseError, code: z.literal(400) }),
+  z.object({ ...BaseError, code: z.literal(401) }),
+  z.object({ ...BaseError, code: z.literal(500) }),
+]);
 
-  const MyResult = z.discriminatedUnion("status", [
-    z.object({ status: z.literal("success"), data: z.string() }),
-    MyErrors
-  ]);
-  ```
+const MyResult = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("success"), data: z.string() }),
+  MyErrors,
+]);
+```
 
 </Accordion>
 </Accordions>
 
-
 ## Intersections
 
-Intersection types (`A & B`) represent a logical "AND". 
+Intersection types (`A & B`) represent a logical "AND".
 
 ```ts
 const a = z.union([z.number(), z.string()]);
@@ -1811,7 +1729,7 @@ const c = z.intersection(a, b);
 type c = z.infer<typeof c>; // => number
 ```
 
-This can be useful for intersecting two object types. 
+This can be useful for intersecting two object types.
 
 ```ts
 const Person = z.object({ name: z.string() });
@@ -1826,7 +1744,10 @@ type EmployedPerson = z.infer<typeof EmployedPerson>;
 ```
 
 <Callout type="warn">
-  When merging object schemas, prefer [`A.extend(B)`](#extend) over intersections. Using `.extend()` will give you a new object schema, whereas `z.intersection(A, B)` returns a `ZodIntersection` instance which lacks common object methods like `pick` and `omit`.
+  When merging object schemas, prefer [`A.extend(B)`](#extend) over
+  intersections. Using `.extend()` will give you a new object schema, whereas
+  `z.intersection(A, B)` returns a `ZodIntersection` instance which lacks common
+  object methods like `pick` and `omit`.
 </Callout>
 
 ## Records
@@ -1865,45 +1786,44 @@ const Person = z.record(Keys, z.string());
 
 ```ts
 const numberKeys = z.record(z.number(), z.string());
-numberKeys.parse({ 
+numberKeys.parse({
   1: "one", // ✅
   2: "two", // ✅
   "1.5": "one", // ✅
   "-3": "two", // ✅
-  abc: "one" // ❌
+  abc: "one", // ❌
 });
 
 // further validation is also supported
 const intKeys = z.record(z.int().step(1).min(0).max(10), z.string());
-intKeys.parse({ 
+intKeys.parse({
   0: "zero", // ✅
   1: "one", // ✅
   2: "two", // ✅
   12: "twelve", // ❌
-  abc: "one" // ❌
+  abc: "one", // ❌
 });
 ```
 
 ### `z.partialRecord`
 
-
 <Callout>
   **Zod 4** — In Zod 4, if you pass a `z.enum` as the first argument to `z.record()`, Zod will exhaustively check that all enum values exist in the input as keys. This behavior agrees with TypeScript:
 
-  ```ts
-  type MyRecord = Record<"a" | "b", string>;
-  const myRecord: MyRecord = { a: "foo", b: "bar" }; // ✅
-  const myRecord: MyRecord = { a: "foo" }; // ❌ missing required key `b`
-  ```
+```ts
+type MyRecord = Record<"a" | "b", string>;
+const myRecord: MyRecord = { a: "foo", b: "bar" }; // ✅
+const myRecord: MyRecord = { a: "foo" }; // ❌ missing required key `b`
+```
 
-  In Zod 3, exhaustiveness was not checked. To replicate the old behavior, use `z.partialRecord()`.
+In Zod 3, exhaustiveness was not checked. To replicate the old behavior, use `z.partialRecord()`.
 
 </Callout>
 
-If you want a *partial* record type, use `z.partialRecord()`. This skips the special exhaustiveness checks Zod normally runs with `z.enum()` and `z.literal()` key schemas.
+If you want a _partial_ record type, use `z.partialRecord()`. This skips the special exhaustiveness checks Zod normally runs with `z.enum()` and `z.literal()` key schemas.
 
 ```ts
-const Keys = z.enum(["id", "name", "email"]).or(z.never()); 
+const Keys = z.enum(["id", "name", "email"]).or(z.never());
 const Person = z.partialRecord(Keys, z.string());
 // { id?: string; name?: string; email?: string }
 ```
@@ -1920,13 +1840,12 @@ const schema = z
 type schema = z.infer<typeof schema>;
 // => { name: string } & Record<string, string>
 
-schema.parse({ 
+schema.parse({
   name: "John",
-  home_phone: "+12345678900",     // validated as phone number
-  work_phone: "+12345678900",     // validated as phone number
+  home_phone: "+12345678900", // validated as phone number
+  work_phone: "+12345678900", // validated as phone number
 });
 ```
-
 
 ## Maps
 
@@ -1956,20 +1875,16 @@ NumberSet.parse(mySet);
 Set schemas can be further constrained with the following utility methods.
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.set(z.string()).min(5); // must contain 5 or more items
-z.set(z.string()).max(5); // must contain 5 or fewer items
-z.set(z.string()).size(5); // must contain 5 items exactly
-```
-</Tab>
-<Tab value='Zod Mini'>
-```ts
-z.set(z.string()).check(z.minSize(5)); // must contain 5 or more items
-z.set(z.string()).check(z.maxSize(5)); // must contain 5 or fewer items
-z.set(z.string()).check(z.size(5)); // must contain 5 items exactly
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts z.set(z.string()).min(5); // must contain 5 or more items
+    z.set(z.string()).max(5); // must contain 5 or fewer items
+    z.set(z.string()).size(5); // must contain 5 items exactly ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts z.set(z.string()).check(z.minSize(5)); // must contain 5 or more items
+    z.set(z.string()).check(z.maxSize(5)); // must contain 5 or fewer items
+    z.set(z.string()).check(z.size(5)); // must contain 5 items exactly ```
+  </Tab>
 </Tabs>
 
 ## Files
@@ -1985,7 +1900,8 @@ fileSchema.min(10_000); // minimum .size (bytes)
 fileSchema.max(1_000_000); // maximum .size (bytes)
 fileSchema.mime("image/png"); // MIME type
 fileSchema.mime(["image/png", "image/jpeg"]); // multiple MIME types
-```
+
+````
 
 </Tab>
 <Tab value='Zod Mini'>
@@ -1998,14 +1914,17 @@ fileSchema.check(
   z.mime("image/png"), // MIME type
   z.mime(["image/png", "image/jpeg"]); // multiple MIME types
 )
-```
+````
+
 </Tab>
 </Tabs>
 
 ## Promises
 
 <Callout type="warn">
-  **Deprecated** — `z.promise()` is deprecated in Zod 4. There are vanishingly few valid uses cases for a `Promise` schema. If you suspect a value might be a `Promise`, simply `await` it before parsing it with Zod.
+  **Deprecated** — `z.promise()` is deprecated in Zod 4. There are vanishingly
+  few valid uses cases for a `Promise` schema. If you suspect a value might be a
+  `Promise`, simply `await` it before parsing it with Zod.
 </Callout>
 
 <Accordions type="single"><Accordion title="See z.promise() documentation">
@@ -2057,9 +1976,11 @@ TestSchema.parse("whatever"); // ❌
 To validate a particular property of a class instance against a Zod schema:
 
 ```ts
-const blobSchema = z.instanceof(URL).check(
-  z.property("protocol", z.literal("https:" as string, "Only HTTPS allowed"))
-);
+const blobSchema = z
+  .instanceof(URL)
+  .check(
+    z.property("protocol", z.literal("https:" as string, "Only HTTPS allowed")),
+  );
 
 blobSchema.parse(new URL("https://example.com")); // ✅
 blobSchema.parse(new URL("http://example.com")); // ❌
@@ -2068,9 +1989,7 @@ blobSchema.parse(new URL("http://example.com")); // ❌
 The `z.property()` API works with any data type (but it's most useful when used in conjunction with `z.instanceof()`).
 
 ```ts
-const blobSchema = z.string().check(
-  z.property("length", z.number().min(10))
-);
+const blobSchema = z.string().check(z.property("length", z.number().min(10)));
 
 blobSchema.parse("hello there!"); // ✅
 blobSchema.parse("hello."); // ❌
@@ -2078,15 +1997,16 @@ blobSchema.parse("hello."); // ❌
 
 ## Refinements
 
-Every Zod schema stores an array of *refinements*. Refinements are a way to perform custom validation that Zod doesn't provide a native API for.
+Every Zod schema stores an array of _refinements_. Refinements are a way to perform custom validation that Zod doesn't provide a native API for.
 
 ### `.refine()`
 
-{/* <Callout>
-  Checks do not (in fact, cannot) change the inferred type of the schema.
+{/\* <Callout>
+Checks do not (in fact, cannot) change the inferred type of the schema.
+
 </Callout>
 
-### `.refine()` */}
+### `.refine()` \*/}
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -2102,10 +2022,11 @@ const myString = z.string().check(z.refine((val) => val.length <= 255));
 </Tabs>
 
 <Callout type="warn">
-  Refinement functions should never throw. Instead they should return a falsy value to signal failure. Thrown errors are not caught by Zod.
+  Refinement functions should never throw. Instead they should return a falsy
+  value to signal failure. Thrown errors are not caught by Zod.
 </Callout>
 
-#### `error` 
+#### `error`
 
 To customize the error message:
 
@@ -2126,9 +2047,9 @@ const myString = z.string().check(
 </Tab>
 </Tabs>
 
-#### `abort` 
+#### `abort`
 
-By default, validation issues from checks are considered *continuable*; that is, Zod will execute *all* checks in sequence, even if one of them causes a validation error. This is usually desirable, as it means Zod can surface as many errors as possible in one go.
+By default, validation issues from checks are considered _continuable_; that is, Zod will execute _all_ checks in sequence, even if one of them causes a validation error. This is usually desirable, as it means Zod can surface as many errors as possible in one go.
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -2136,15 +2057,15 @@ By default, validation issues from checks are considered *continuable*; that is,
 const myString = z.string()
   .refine((val) => val.length > 8, { error: "Too short!" })
   .refine((val) => val === val.toLowerCase(), { error: "Must be lowercase" });
-  
 
 const result = myString.safeParse("OH NO");
 result.error?.issues;
-/* [
-  { "code": "custom", "message": "Too short!" },
-  { "code": "custom", "message": "Must be lowercase" }
-] */
-```
+/_ [
+{ "code": "custom", "message": "Too short!" },
+{ "code": "custom", "message": "Must be lowercase" }
+] _/
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2159,12 +2080,12 @@ result.error?.issues;
   { "code": "custom", "message": "Too short!" },
   { "code": "custom", "message": "Must be lowercase" }
 ] */
-```
+````
+
 </Tab>
 </Tabs>
 
-
-To mark a particular refinement as *non-continuable*, use the `abort` parameter. Validation will terminate if the check fails.
+To mark a particular refinement as _non-continuable_, use the `abort` parameter. Validation will terminate if the check fails.
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -2173,11 +2094,11 @@ const myString = z.string()
   .refine((val) => val.length > 8, { error: "Too short!", abort: true })
   .refine((val) => val === val.toLowerCase(), { error: "Must be lowercase", abort: true });
 
-
 const result = myString.safeParse("OH NO");
 result.error?.issues;
 // => [{ "code": "custom", "message": "Too short!" }]
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2189,7 +2110,8 @@ const myString = z.string().check(
 const result = z.safeParse(myString, "OH NO");
 result.error?.issues;
 // [ { "code": "custom", "message": "Too short!" }]
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -2225,7 +2147,6 @@ const passwordForm = z
 ```
 </Tab>
 </Tabs>
-
 
 This will set the `path` parameter in the associated issue:
 
@@ -2282,13 +2203,13 @@ const userId = z.string().refine(async (id) => {
 
 #### `when`
 
-> **Note** — This is a power user feature and can absolutely be abused in ways that will increase the probability of uncaught errors originating from inside your refinements. 
+> **Note** — This is a power user feature and can absolutely be abused in ways that will increase the probability of uncaught errors originating from inside your refinements.
 
-By default, refinements don't run if any *non-continuable* issues have already been encountered. Zod is careful to ensure the type signature of the value is correct before passing it into any refinement functions.
+By default, refinements don't run if any _non-continuable_ issues have already been encountered. Zod is careful to ensure the type signature of the value is correct before passing it into any refinement functions.
 
 ```ts
 const schema = z.string().refine((val) => {
-  return val.length > 8
+  return val.length > 8;
 });
 
 schema.parse(1234); // invalid_type: refinement won't be executed
@@ -2311,11 +2232,12 @@ const schema = z
   });
 
 schema.parse({
-  password: "asdf",
-  confirmPassword: "asdf",
-  anotherField: 1234 // ❌ this error will prevent the password check from running
+password: "asdf",
+confirmPassword: "asdf",
+anotherField: 1234 // ❌ this error will prevent the password check from running
 });
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2335,7 +2257,8 @@ schema.parse({
   confirmPassword: "asdf",
   anotherField: 1234 // ❌ this error will prevent the password check from running
 });
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -2360,14 +2283,16 @@ const schema = z
         .pick({ password: true, confirmPassword: true }) // [!code ++]
         .safeParse(payload.value).success; // [!code ++]
     },  // [!code ++]
-  });
+
+});
 
 schema.parse({
-  password: "asdf",
-  confirmPassword: "asdf",
-  anotherField: 1234 // ❌ this error will not prevent the password check from running
+password: "asdf",
+confirmPassword: "asdf",
+anotherField: 1234 // ❌ this error will not prevent the password check from running
 });
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2394,13 +2319,12 @@ schema.parse({
   confirmPassword: "asdf",
   anotherField: 1234 // ❌ this error will prevent the password check from running
 });
-```
+````
+
 </Tab>
 </Tabs>
 
-
 ### `.superRefine()`
-    
 
 The regular `.refine` API only generates a single issue with a `"custom"` error code, but `.superRefine()` makes it possible to create multiple issues using any of Zod's [internal issue types](https://github.com/colinhacks/zod/blob/main/packages/zod/src/v4/core/errors.ts).
 
@@ -2419,17 +2343,16 @@ const UniqueStringArray = z.array(z.string()).superRefine((val, ctx) => {
     });
   }
 
-  if (val.length !== new Set(val).size) {
-    ctx.addIssue({
-      code: "custom",
-      message: `No duplicates allowed.`,
-      input: val,
-    });
-  }
+if (val.length !== new Set(val).size) {
+ctx.addIssue({
+code: "custom",
+message: `No duplicates allowed.`,
+input: val,
+});
+}
 });
 
-
-```
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2455,14 +2378,17 @@ const UniqueStringArray = z.array(z.string()).check(
     }
   })
 );
-```
+````
+
 </Tab>
 </Tabs>
 
 ### `.check()`
 
 <Callout>
-**Note** — The `.check()` API is a more low-level API that's generally more complex than `.superRefine()`. It can be faster in performance-sensitive code paths, but it's also more verbose.
+  **Note** — The `.check()` API is a more low-level API that's generally more
+  complex than `.superRefine()`. It can be faster in performance-sensitive code
+  paths, but it's also more verbose.
 </Callout>
 
 <Accordions>
@@ -2485,17 +2411,18 @@ const UniqueStringArray = z.array(z.string()).check((ctx) => {
     });
   }
 
-  // create multiple issues in one refinement
-  if (ctx.value.length !== new Set(ctx.value).size) {
-    ctx.issues.push({
-      code: "custom",
-      message: `No duplicates allowed.`,
-      input: ctx.value,
-      continue: true // make this issue continuable (default: false)
-    });
-  }
+// create multiple issues in one refinement
+if (ctx.value.length !== new Set(ctx.value).size) {
+ctx.issues.push({
+code: "custom",
+message: `No duplicates allowed.`,
+input: ctx.value,
+continue: true // make this issue continuable (default: false)
 });
-```
+}
+});
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2522,7 +2449,8 @@ const UniqueStringArray = z.array(z.string()).check((ctx) => {
     });
   }
 });
-```
+````
+
 </Tab>
 </Tabs>
 </Accordion>
@@ -2532,20 +2460,20 @@ const UniqueStringArray = z.array(z.string()).check((ctx) => {
 
 > **New** — Introduced in Zod 4.1. Refer to the dedicated [Codecs](/codecs) page for more information.
 
-Codecs are a special kind of schema that implement *bidirectional transformations* between two other schemas.
+Codecs are a special kind of schema that implement _bidirectional transformations_ between two other schemas.
 
 ```ts
 const stringToDate = z.codec(
-  z.iso.datetime(),  // input schema: ISO date string
-  z.date(),          // output schema: Date object
+  z.iso.datetime(), // input schema: ISO date string
+  z.date(), // output schema: Date object
   {
     decode: (isoString) => new Date(isoString), // ISO string → Date
-    encode: (date) => date.toISOString(),       // Date → ISO string
-  }
+    encode: (date) => date.toISOString(), // Date → ISO string
+  },
 );
 ```
 
-A regular `.parse()` operations performs the *forward transform*. It calls the codec's `decode` function.
+A regular `.parse()` operations performs the _forward transform_. It calls the codec's `decode` function.
 
 ```ts
 stringToDate.parse("2024-01-15T10:30:00.000Z"); // => Date
@@ -2557,7 +2485,7 @@ You can alternatively use the top-level `z.decode()` function. Unlike `.parse()`
 z.decode(stringToDate, "2024-01-15T10:30:00.000Z"); // => Date
 ```
 
-To perform the *reverse transform*, use the inverse: `z.encode()`.
+To perform the _reverse transform_, use the inverse: `z.encode()`.
 
 ```ts
 z.encode(stringToDate, new Date("2024-01-15")); // => "2024-01-15T00:00:00.000Z"
@@ -2593,17 +2521,18 @@ Schemas can be chained together into "pipes". Pipes are primarily useful when us
 const stringToLength = z.string().pipe(z.transform(val => val.length));
 
 stringToLength.parse("hello"); // => 5
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 const stringToLength = z.pipe(z.string(), z.transform(val => val.length));
 
 z.parse(stringToLength, "hello"); // => 5
-```
+````
+
 </Tab>
 </Tabs>
-
 
 ## Transforms
 
@@ -2619,7 +2548,8 @@ const castToString = z.transform((val) => String(val));
 castToString.parse("asdf"); // => "asdf"
 castToString.parse(123); // => "123"
 castToString.parse(true); // => "true"
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2628,7 +2558,8 @@ const castToString = z.transform((val) => String(val));
 z.parse(castToString, "asdf"); // => "asdf"
 z.parse(castToString, 123); // => "123"
 z.parse(castToString, true); // => "true"
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -2636,7 +2567,7 @@ z.parse(castToString, true); // => "true"
   Transform functions should never throw. Thrown errors are not caught by Zod.
 </Callout>
 
-{/* The output type of the schema is inferred from the transform function:
+{/\* The output type of the schema is inferred from the transform function:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -2644,17 +2575,18 @@ z.parse(castToString, true); // => "true"
 const castToString = z.transform((val) => String(val));
 
 type CastToString = z.infer<typeof castToString>; // string
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 const castToString = z.transform((val) => String(val));
 
 type CastToString = z.infer<typeof castToString>; // string
-```
+````
+
 </Tab>
 </Tabs> */}
-
 
 To perform validation logic inside a transform, use `ctx`. To report a validation issue, push a new issue onto `ctx.issues` (similar to the [`.check()`](#check) API).
 
@@ -2679,21 +2611,22 @@ const coercedInt = z.transform((val, ctx) => {
 
 Most commonly, transforms are used in conjunction with [Pipes](#pipes). This combination is useful for performing some initial validation, then transforming the parsed data into another form.
 
-
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
 ```ts
 const stringToLength = z.string().pipe(z.transform(val => val.length));
 
 stringToLength.parse("hello"); // => 5
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 const stringToLength = z.pipe(z.string(), z.transform(val => val.length));
 
 z.parse(stringToLength, "hello"); // => 5
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -2727,7 +2660,8 @@ const idToUser = z
   });
 
 const user = await idToUser.parseAsync("abc123");
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2735,19 +2669,21 @@ const idToUser = z.pipe(
   z.string(),
   z.transform(async (id) => {
     // fetch user from database
-    return db.getUserById(id); 
+    return db.getUserById(id);
   }));
 
 const user = await idToUser.parse("abc123");
-```
+````
+
 </Tab>
 </Tabs>
 
 <Callout>
-  If you use async transforms, you must use a `.parseAsync` or `.safeParseAsync` when parsing data! Otherwise Zod will throw an error.
+  If you use async transforms, you must use a `.parseAsync` or `.safeParseAsync`
+  when parsing data! Otherwise Zod will throw an error.
 </Callout>
 
-### `.preprocess()` 
+### `.preprocess()`
 
 Piping a transform into another schema is another common pattern, so Zod provides a convenience `z.preprocess()` function.
 
@@ -2770,14 +2706,16 @@ To set a default value for a schema:
 const defaultTuna = z.string().default("tuna");
 
 defaultTuna.parse(undefined); // => "tuna"
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 const defaultTuna = z._default(z.string(), "tuna");
 
 defaultTuna.parse(undefined); // => "tuna"
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -2788,10 +2726,11 @@ Alternatively, you can pass a function which will be re-executed whenever a defa
 ```ts
 const randomDefault = z.number().default(Math.random);
 
-randomDefault.parse(undefined);    // => 0.4413456736055323
-randomDefault.parse(undefined);    // => 0.1871840107401901
-randomDefault.parse(undefined);    // => 0.7223408162401552
-```
+randomDefault.parse(undefined); // => 0.4413456736055323
+randomDefault.parse(undefined); // => 0.1871840107401901
+randomDefault.parse(undefined); // => 0.7223408162401552
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2800,24 +2739,29 @@ const randomDefault = z._default(z.number(), Math.random);
 z.parse(randomDefault, undefined); // => 0.4413456736055323
 z.parse(randomDefault, undefined); // => 0.1871840107401901
 z.parse(randomDefault, undefined); // => 0.7223408162401552
-```
+````
+
 </Tab>
 </Tabs>
 
-
 ## Prefaults
 
-In Zod, setting a *default* value will short-circuit the parsing process. If the input is `undefined`, the default value is eagerly returned. As such, the default value must be assignable to the *output type* of the schema.
+In Zod, setting a _default_ value will short-circuit the parsing process. If the input is `undefined`, the default value is eagerly returned. As such, the default value must be assignable to the _output type_ of the schema.
 
 ```ts
-const schema = z.string().transform(val => val.length).default(0);
+const schema = z
+  .string()
+  .transform((val) => val.length)
+  .default(0);
 schema.parse(undefined); // => 0
 ```
 
-Sometimes, it's useful to define a *prefault* ("pre-parse default") value. If the input is `undefined`, the prefault value will be parsed instead. The parsing process is *not* short circuited. As such, the prefault value must be assignable to the *input type* of the schema.
+Sometimes, it's useful to define a _prefault_ ("pre-parse default") value. If the input is `undefined`, the prefault value will be parsed instead. The parsing process is _not_ short circuited. As such, the prefault value must be assignable to the _input type_ of the schema.
 
 ```ts
-z.string().transform(val => val.length).prefault("tuna");
+z.string()
+  .transform((val) => val.length)
+  .prefault("tuna");
 schema.parse(undefined); // => 4
 ```
 
@@ -2842,7 +2786,8 @@ const numberWithCatch = z.number().catch(42);
 
 numberWithCatch.parse(5); // => 5
 numberWithCatch.parse("tuna"); // => 42
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2850,10 +2795,10 @@ const numberWithCatch = z.catch(z.number(), 42);
 
 numberWithCatch.parse(5); // => 5
 numberWithCatch.parse("tuna"); // => 42
-```
+````
+
 </Tab>
 </Tabs>
-
 
 Alternatively, you can pass a function which will be re-executed whenever a catch value needs to be generated.
 
@@ -2868,7 +2813,8 @@ const numberWithRandomCatch = z.number().catch((ctx) => {
 numberWithRandomCatch.parse("sup"); // => 0.4413456736055323
 numberWithRandomCatch.parse("sup"); // => 0.1871840107401901
 numberWithRandomCatch.parse("sup"); // => 0.7223408162401552
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -2881,7 +2827,8 @@ const numberWithRandomCatch = z.catch(z.number(), (ctx) => {
 z.parse(numberWithRandomCatch, "sup"); // => 0.4413456736055323
 z.parse(numberWithRandomCatch, "sup"); // => 0.1871840107401901
 z.parse(numberWithRandomCatch, "sup"); // => 0.7223408162401552
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -2897,7 +2844,7 @@ const pluto: Dog = { name: "pluto" };
 const simba: Cat = pluto; // works fine
 ```
 
-In some cases, it can be desirable to simulate [nominal typing](https://en.wikipedia.org/wiki/Nominal_type_system) inside TypeScript. This can be achieved with *branded types* (also known as "opaque types").
+In some cases, it can be desirable to simulate [nominal typing](https://en.wikipedia.org/wiki/Nominal_type_system) inside TypeScript. This can be achieved with _branded types_ (also known as "opaque types").
 
 ```ts
 const Cat = z.object({ name: z.string() }).brand<"Cat">();
@@ -2921,7 +2868,7 @@ With this brand, any plain (unbranded) data structures are no longer assignable 
 
 > Note that branded types do not affect the runtime result of `.parse`. It is a static-only construct.
 
-By default, only the *output type* is branded. 
+By default, only the _output type_ is branded.
 
 ```ts
 const USD = z.string().brand<"USD">();
@@ -3013,17 +2960,15 @@ This is a convenience API that returns the following union schema:
 ```ts
 const jsonSchema = z.lazy(() => {
   return z.union([
-    z.string(params), 
-    z.number(), 
-    z.boolean(), 
-    z.null(), 
-    z.array(jsonSchema), 
-    z.record(z.string(), jsonSchema)
+    z.string(params),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonSchema),
+    z.record(z.string(), jsonSchema),
   ]);
 });
 ```
-
-
 
 ## Functions
 
@@ -3032,7 +2977,7 @@ Zod provides a `z.function()` utility for defining Zod-validated functions. This
 ```ts
 const MyFunction = z.function({
   input: [z.string()], // parameters (must be an array or a ZodTuple)
-  output: z.number()  // return type
+  output: z.number(), // return type
 });
 
 type MyFunction = z.infer<typeof MyFunction>;
@@ -3067,12 +3012,11 @@ const MyFunction = z.function({
 const computeTrimmedLength = MyFunction.implement((input) => input.trim.length);
 ```
 
-
 Use the `.implementAsync()` method to create an async function.
 
 ```ts
 const computeTrimmedLengthAsync = MyFunction.implementAsync(
-  async (input) => input.trim().length
+  async (input) => input.trim().length,
 );
 
 computeTrimmedLengthAsync("sandwich"); // => Promise<8>
@@ -3119,14 +3063,15 @@ function setCommonNumberChecks<T extends z.ZodNumber>(schema: T) {
 }
 
 const schema = z.number()
-  .apply(setCommonNumberChecks)
-  .nullable();
+.apply(setCommonNumberChecks)
+.nullable();
 
-schema.parse(0);  // => 0
+schema.parse(0); // => 0
 schema.parse(-1); // ❌ throws
 schema.parse(101); // ❌ throws
 schema.parse(null); // => null
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -3142,6 +3087,7 @@ z.parse(schema, 0);   // => 0
 z.parse(schema, -1);  // ❌ throws
 z.parse(schema, 101); // ❌ throws
 z.parse(schema, null); // => null
-```
+````
+
 </Tab>
 </Tabs>

--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -3,7 +3,7 @@ title: Basic usage
 description: "Basic usage guide covering schema definition, parsing data, error handling, and type inference"
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { Callout } from "fumadocs-ui/components/callout";
 
 This page will walk you through the basics of creating schemas, parsing data, and using inferred types. For complete documentation on Zod's schema API, refer to [Defining schemas](/api).
@@ -15,32 +15,34 @@ Before you can do anything else, you need to define a schema. For the purposes o
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
 ```ts
-import * as z from "zod"; 
+import * as z from "zod";
 
-const Player = z.object({ 
-  username: z.string(),
-  xp: z.number()
+const Player = z.object({
+username: z.string(),
+xp: z.number()
 });
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 import * as z from "zod/mini"
 
-const Player = z.object({ 
+const Player = z.object({
   username: z.string(),
   xp: z.number()
 });
-```
+````
+
 </Tab>
 </Tabs>
 
 ## Parsing data
 
-Given any Zod schema, use `.parse` to validate an input. If it's valid, Zod returns a strongly-typed *deep clone* of the input. 
+Given any Zod schema, use `.parse` to validate an input. If it's valid, Zod returns a strongly-typed _deep clone_ of the input.
 
 ```ts
-Player.parse({ username: "billie", xp: 100 }); 
+Player.parse({ username: "billie", xp: 100 });
 // => returns { username: "billie", xp: 100 }
 ```
 
@@ -48,8 +50,9 @@ Player.parse({ username: "billie", xp: 100 });
 **Note** — If your schema uses certain asynchronous APIs like `async` [refinements](/api#refinements) or [transforms](/api#transforms), you'll need to use the `.parseAsync()` method instead.
 
 ```ts
-await Player.parseAsync({ username: "billie", xp: 100 }); 
+await Player.parseAsync({ username: "billie", xp: 100 });
 ```
+
 </Callout>
 
 ## Handling errors
@@ -114,9 +117,9 @@ To avoid a `try/catch` block, you can use the `.safeParse()` method to get back 
 ```ts
 const result = Player.safeParse({ username: 42, xp: "100" });
 if (!result.success) {
-  result.error;   // ZodError instance
+  result.error; // ZodError instance
 } else {
-  result.data;    // { username: string; xp: number }
+  result.data; // { username: string; xp: number }
 }
 ```
 
@@ -126,6 +129,7 @@ if (!result.success) {
 ```ts
 await schema.safeParseAsync("hello");
 ```
+
 </Callout>
 
 ## Inferring types
@@ -133,9 +137,9 @@ await schema.safeParseAsync("hello");
 Zod infers a static type from your schema definitions. You can extract this type with the `z.infer<>` utility and use it however you like.
 
 ```ts
-const Player = z.object({ 
+const Player = z.object({
   username: z.string(),
-  xp: z.number()
+  xp: z.number(),
 });
 
 // extract the inferred type

--- a/packages/docs/content/blog/clerk-fellowship.mdx
+++ b/packages/docs/content/blog/clerk-fellowship.mdx
@@ -60,5 +60,3 @@ This fellowship is a way to bridge that gap. All-in-all, I'm beyond excited to h
 > I encourage other companies to try similar things! There is no shortage of invaluable libraries with full-time (or nearly full-time) maintainers who are forgoing a regular income to build free tools. ArkType, Valibot, and tRPC come to mind.
 
 So if you're building an app sometime soon, be smart—validate your `Request` bodies (or, uh, Server Action arguments?) and don't roll your own auth.
-
-

--- a/packages/docs/content/codecs.mdx
+++ b/packages/docs/content/codecs.mdx
@@ -3,12 +3,12 @@ title: Codecs
 description: "Bidirectional transformations with encode and decode"
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 import { ThemedImage } from "@/components/themed-image";
 
 > ✨ **New** — Introduced in `zod@4.1`
 
-All Zod schemas can process inputs in both the forward and backward direction: 
+All Zod schemas can process inputs in both the forward and backward direction:
 
 - **Forward**: `Input` to `Output`
   - `.parse()`
@@ -23,13 +23,14 @@ In most cases, this is a distinction without a difference. The input and output 
 ```ts
 const schema = z.string();
 
-type Input = z.input<typeof schema>;    // string
-type Output = z.output<typeof schema>;  // string
+type Input = z.input<typeof schema>; // string
+type Output = z.output<typeof schema>; // string
 
-schema.parse("asdf");   // => "asdf"
-schema.decode("asdf");  // => "asdf"
-schema.encode("asdf");  // => "asdf"
-```
+schema.parse("asdf"); // => "asdf"
+schema.decode("asdf"); // => "asdf"
+schema.encode("asdf"); // => "asdf"
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -41,21 +42,21 @@ type Output = z.output<typeof schema>;  // string
 z.parse(schema, "asdf");   // => "asdf"
 z.decode(schema, "asdf");  // => "asdf"
 z.encode(schema, "asdf");  // => "asdf"
-```
+````
+
 </Tab>
 </Tabs>
 
-
-However, some schema types cause the input and output types to diverge, notably `z.codec()`. Codecs are a special type of schema that defines a *bi-directional transformation* between two other schemas.
+However, some schema types cause the input and output types to diverge, notably `z.codec()`. Codecs are a special type of schema that defines a _bi-directional transformation_ between two other schemas.
 
 ```ts
 const stringToDate = z.codec(
-  z.iso.datetime(),  // input schema: ISO date string
-  z.date(),          // output schema: Date object
+  z.iso.datetime(), // input schema: ISO date string
+  z.date(), // output schema: Date object
   {
     decode: (isoString) => new Date(isoString), // ISO string → Date
-    encode: (date) => date.toISOString(),       // Date → ISO string
-  }
+    encode: (date) => date.toISOString(), // Date → ISO string
+  },
 );
 ```
 
@@ -69,7 +70,8 @@ stringToDate.decode("2024-01-15T10:30:00.000Z")
 
 stringToDate.encode(new Date("2024-01-15T10:30:00.000Z"))
 // => string
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -78,18 +80,19 @@ z.decode(stringToDate, "2024-01-15T10:30:00.000Z")
 
 z.encode(stringToDate, new Date("2024-01-15T10:30:00.000Z"))
 // => string
-```
+````
+
 </Tab>
 </Tabs>
 
-> **Note** —There's nothing special about the directions or terminology here. Instead of *encoding* with an `A -> B` codec, you could instead *decode* with a `B -> A` codec. The use of the terms "decode" and "encode" is just a convention.
+> **Note** —There's nothing special about the directions or terminology here. Instead of _encoding_ with an `A -> B` codec, you could instead _decode_ with a `B -> A` codec. The use of the terms "decode" and "encode" is just a convention.
 
 This is particularly useful when parsing data at a network boundary. You can share a single Zod schema between your client and server, then use this single schema to convert between a network-friendly format (say, JSON) and a richer JavaScript representation.
 
-<ThemedImage 
-  lightSrc="/codecs/codecs-network-light.svg" 
-  darkSrc="/codecs/codecs-network-dark.svg" 
-  alt="Codecs encoding and decoding data across a network boundary" 
+<ThemedImage
+  lightSrc="/codecs/codecs-network-light.svg"
+  darkSrc="/codecs/codecs-network-dark.svg"
+  alt="Codecs encoding and decoding data across a network boundary"
 />
 
 ### Composability
@@ -99,38 +102,37 @@ This is particularly useful when parsing data at a network boundary. You can sha
 Codecs are a schema like any other. You can nest them inside objects, arrays, pipes, etc. There are no rules on where you can use them!
 
 ```ts
-const payloadSchema = z.object({ 
-  startDate: stringToDate 
+const payloadSchema = z.object({
+  startDate: stringToDate,
 });
 
 payloadSchema.decode({
-  startDate: "2024-01-15T10:30:00.000Z"
+  startDate: "2024-01-15T10:30:00.000Z",
 }); // => { startDate: Date }
 ```
 
-
 ### Type-safe inputs
 
-While `.parse()` and `.decode()` behave identically at *runtime*, they have different type signatures. The `.parse()` method accepts `unknown` as input, and returns a value that matches the schema's inferred *output type*. By contrast, the `z.decode()` and `z.encode()` functions have *strongly-typed inputs*. 
+While `.parse()` and `.decode()` behave identically at _runtime_, they have different type signatures. The `.parse()` method accepts `unknown` as input, and returns a value that matches the schema's inferred _output type_. By contrast, the `z.decode()` and `z.encode()` functions have _strongly-typed inputs_.
 
 ```ts
-stringToDate.parse(12345); 
+stringToDate.parse(12345);
 // no complaints from TypeScript (fails at runtime)
 
-stringToDate.decode(12345); 
+stringToDate.decode(12345);
 // ❌ TypeScript error: Argument of type 'number' is not assignable to parameter of type 'string'.
 
-stringToDate.encode(12345); 
+stringToDate.encode(12345);
 // ❌ TypeScript error: Argument of type 'number' is not assignable to parameter of type 'Date'.
 ```
 
-Why the difference? Encoding and decoding imply *transformation*. In many cases, the inputs to these methods are already strongly typed in application code, so z.decode/z.encode accept strongly typed inputs to surface mistakes at compile time.
+Why the difference? Encoding and decoding imply _transformation_. In many cases, the inputs to these methods are already strongly typed in application code, so z.decode/z.encode accept strongly typed inputs to surface mistakes at compile time.
 Here's a diagram demonstrating the differences between the type signatures for `parse()`, `decode()`, and `encode()`.
 
-<ThemedImage 
-  lightSrc="/codecs/codecs-light.png" 
-  darkSrc="/codecs/codecs-dark.png" 
-  alt="Codec directionality diagram showing bidirectional transformation between input and output schemas" 
+<ThemedImage
+  lightSrc="/codecs/codecs-light.png"
+  darkSrc="/codecs/codecs-dark.png"
+  alt="Codec directionality diagram showing bidirectional transformation between input and output schemas"
 />
 
 ### Async and safe variants
@@ -147,22 +149,22 @@ const asyncCodec = z.codec(z.string(), z.number(), {
 As with regular `parse()`, there are "safe" and "async" variants of `decode()` and `encode()`.
 
 ```ts
-stringToDate.decode("2024-01-15T10:30:00.000Z"); 
+stringToDate.decode("2024-01-15T10:30:00.000Z");
 // => Date
 
-stringToDate.decodeAsync("2024-01-15T10:30:00.000Z"); 
+stringToDate.decodeAsync("2024-01-15T10:30:00.000Z");
 // => Promise<Date>
 
-stringToDate.safeDecode("2024-01-15T10:30:00.000Z"); 
+stringToDate.safeDecode("2024-01-15T10:30:00.000Z");
 // => { success: true, data: Date } | { success: false, error: ZodError }
 
-stringToDate.safeDecodeAsync("2024-01-15T10:30:00.000Z"); 
+stringToDate.safeDecodeAsync("2024-01-15T10:30:00.000Z");
 // => Promise<{ success: true, data: Date } | { success: false, error: ZodError }>
 ```
 
 ## How encoding works
 
-There are some subtleties to how certain Zod schemas "reverse" their parse behavior. 
+There are some subtleties to how certain Zod schemas "reverse" their parse behavior.
 
 ### Codecs
 
@@ -170,34 +172,36 @@ This one is fairly self-explanatory. Codecs encapsulate a bi-directional transfo
 
 ```ts
 const stringToDate = z.codec(
-  z.iso.datetime(),  // input schema: ISO date string
-  z.date(),          // output schema: Date object
+  z.iso.datetime(), // input schema: ISO date string
+  z.date(), // output schema: Date object
   {
     decode: (isoString) => new Date(isoString), // ISO string → Date
-    encode: (date) => date.toISOString(),       // Date → ISO string
-  }
+    encode: (date) => date.toISOString(), // Date → ISO string
+  },
 );
 
-stringToDate.decode("2024-01-15T10:30:00.000Z"); 
+stringToDate.decode("2024-01-15T10:30:00.000Z");
 // => Date
 
-stringToDate.encode(new Date("2024-01-15")); 
+stringToDate.encode(new Date("2024-01-15"));
 // => string
 ```
 
-
 ### Pipes
 
-> **Fun fact** — Codecs are actually implemented internally as *subclass* of pipes that have been augmented with "interstitial" transform logic. 
+> **Fun fact** — Codecs are actually implemented internally as _subclass_ of pipes that have been augmented with "interstitial" transform logic.
 
 During regular decoding, a `ZodPipe<A, B>` schema will first parse the data with `A`, then pass it into `B`. As you might expect, during encoding, the data is first encoded with `B`, then passed into `A`.
 
 ### Refinements
 
-All checks (`.refine()`, `.min()`, `.max()`, etc.) are still executed in both directions. 
+All checks (`.refine()`, `.min()`, `.max()`, etc.) are still executed in both directions.
 
 ```ts
-const schema = stringToDate.refine((date) => date.getFullYear() >= 2000, "Must be this millennium");
+const schema = stringToDate.refine(
+  (date) => date.getFullYear() >= 2000,
+  "Must be this millennium",
+);
 
 schema.encode(new Date("2000-01-01"));
 // => Date
@@ -228,18 +232,19 @@ schema.encode("  hello  ");
 
 ### Defaults and prefaults
 
-Defaults and prefaults are only applied in the "forward" direction. 
+Defaults and prefaults are only applied in the "forward" direction.
+
 ```ts
 const stringWithDefault = z.string().default("hello");
 
-stringWithDefault.decode(undefined); 
+stringWithDefault.decode(undefined);
 // => "hello"
 
-stringWithDefault.encode(undefined); 
+stringWithDefault.encode(undefined);
 // => ZodError: Expected string, received undefined
 ```
 
-When you attach a default value to a schema, the input becomes optional (`| undefined`) but the output does not. As such, `undefined` is not a valid input to `z.encode()` and defaults/prefaults will not be applied. 
+When you attach a default value to a schema, the input becomes optional (`| undefined`) but the output does not. As such, `undefined` is not a valid input to `z.encode()` and defaults/prefaults will not be applied.
 
 ### Catch
 
@@ -248,60 +253,60 @@ Similarly, `.catch()` is only applied in the "forward" direction.
 ```ts
 const stringWithCatch = z.string().catch("hello");
 
-stringWithCatch.decode(1234); 
+stringWithCatch.decode(1234);
 // => "hello"
 
-stringWithCatch.encode(1234); 
+stringWithCatch.encode(1234);
 // => ZodError: Expected string, received number
 ```
 
 ### Stringbool
 
-> **Note** — [Stringbool](/api#stringbool) pre-dates the introduction of codecs in Zod. It has since been internally re-implemented as a codec. 
+> **Note** — [Stringbool](/api#stringbool) pre-dates the introduction of codecs in Zod. It has since been internally re-implemented as a codec.
 
 The `z.stringbool()` API converts string values (`"true"`, `"false"`, `"yes"`, `"no"`, etc.) into `boolean`. By default, it will convert `true` to `"true"` and `false` to `"false"` during `z.encode()`.
 
 ```ts
 const stringbool = z.stringbool();
 
-stringbool.decode("true");  // => true
+stringbool.decode("true"); // => true
 stringbool.decode("false"); // => false
 
-stringbool.encode(true);    // => "true"
-stringbool.encode(false);   // => "false"
+stringbool.encode(true); // => "true"
+stringbool.encode(false); // => "false"
 ```
 
-If you specify a custom set of `truthy` and `falsy` values, the *first element in the array* will be used instead.
+If you specify a custom set of `truthy` and `falsy` values, the _first element in the array_ will be used instead.
 
 ```ts
 const stringbool = z.stringbool({ truthy: ["yes", "y"], falsy: ["no", "n"] });
 
-stringbool.encode(true);    // => "yes"
-stringbool.encode(false);   // => "no"
+stringbool.encode(true); // => "yes"
+stringbool.encode(false); // => "no"
 ```
 
 ### Transforms
 
-⚠️ — The `.transform()` API implements a *unidirectional* transformation. If any `.transform()` exists anywhere in your schema, attempting a `z.encode()` operation will throw a *runtime error* (not a `ZodError`). 
+⚠️ — The `.transform()` API implements a _unidirectional_ transformation. If any `.transform()` exists anywhere in your schema, attempting a `z.encode()` operation will throw a _runtime error_ (not a `ZodError`).
 
 ```ts
-const schema = z.string().transform(val => val.length);
+const schema = z.string().transform((val) => val.length);
 
-schema.encode(1234); 
+schema.encode(1234);
 // ❌ Error: Encountered unidirectional transform during encode: ZodTransform
 ```
 
-{/* ### Success
+{/\* ### Success
 
 `ZodSuccess` is also strictly unidirectional, and will throw an error if encountered during an encode operation.
 
-```ts
+````ts
 const successSchema = z.success(z.string());
 
-z.decode(successSchema, "hello"); 
+z.decode(successSchema, "hello");
 // => true
 
-z.encode(successSchema, true);    
+z.encode(successSchema, true);
 // ❌ Error: Encountered unidirectional transform during encode: ZodSuccess
 ``` */}
 
@@ -310,7 +315,7 @@ z.encode(successSchema, true);
 
 Below are implementations for a bunch of commonly-needed codecs. For the sake of customizability, these are not included as first-class APIs in Zod itself. Instead, you should copy/paste them into your project and modify them as needed.
 
-> **Note** — All of these codec implementations have been tested for correctness. 
+> **Note** — All of these codec implementations have been tested for correctness.
 
 ### `stringToNumber`
 
@@ -324,7 +329,7 @@ const stringToNumber = z.codec(z.string().regex(z.regexes.number), z.number(), {
 
 stringToNumber.decode("42.5");  // => 42.5
 stringToNumber.encode(42.5);    // => "42.5"
-```
+````
 
 ### `stringToInt`
 
@@ -336,8 +341,8 @@ const stringToInt = z.codec(z.string().regex(z.regexes.integer), z.int(), {
   encode: (num) => num.toString(),
 });
 
-stringToInt.decode("42");  // => 42
-stringToInt.encode(42);    // => "42"
+stringToInt.decode("42"); // => 42
+stringToInt.encode(42); // => "42"
 ```
 
 ### `stringToBigInt`
@@ -350,8 +355,8 @@ const stringToBigInt = z.codec(z.string(), z.bigint(), {
   encode: (bigint) => bigint.toString(),
 });
 
-stringToBigInt.decode("12345");  // => 12345n
-stringToBigInt.encode(12345n);   // => "12345"
+stringToBigInt.decode("12345"); // => 12345n
+stringToBigInt.encode(12345n); // => "12345"
 ```
 
 ### `numberToBigInt`
@@ -364,8 +369,8 @@ const numberToBigInt = z.codec(z.int(), z.bigint(), {
   encode: (bigint) => Number(bigint),
 });
 
-numberToBigInt.decode(42);   // => 42n
-numberToBigInt.encode(42n);  // => 42
+numberToBigInt.decode(42); // => 42n
+numberToBigInt.encode(42n); // => 42
 ```
 
 ### `isoDatetimeToDate`
@@ -378,8 +383,8 @@ const isoDatetimeToDate = z.codec(z.iso.datetime(), z.date(), {
   encode: (date) => date.toISOString(),
 });
 
-isoDatetimeToDate.decode("2024-01-15T10:30:00.000Z");  // => Date object
-isoDatetimeToDate.encode(new Date("2024-01-15"));       // => "2024-01-15T00:00:00.000Z"
+isoDatetimeToDate.decode("2024-01-15T10:30:00.000Z"); // => Date object
+isoDatetimeToDate.encode(new Date("2024-01-15")); // => "2024-01-15T00:00:00.000Z"
 ```
 
 ### `epochSecondsToDate`
@@ -392,8 +397,8 @@ const epochSecondsToDate = z.codec(z.int().min(0), z.date(), {
   encode: (date) => Math.floor(date.getTime() / 1000),
 });
 
-epochSecondsToDate.decode(1705314600);  // => Date object
-epochSecondsToDate.encode(new Date());  // => Unix timestamp in seconds
+epochSecondsToDate.decode(1705314600); // => Date object
+epochSecondsToDate.encode(new Date()); // => Unix timestamp in seconds
 ```
 
 ### `epochMillisToDate`
@@ -406,8 +411,8 @@ const epochMillisToDate = z.codec(z.int().min(0), z.date(), {
   encode: (date) => date.getTime(),
 });
 
-epochMillisToDate.decode(1705314600000);  // => Date object
-epochMillisToDate.encode(new Date());     // => Unix timestamp in milliseconds
+epochMillisToDate.decode(1705314600000); // => Date object
+epochMillisToDate.encode(new Date()); // => Unix timestamp in milliseconds
 ```
 
 ### `json(schema)`
@@ -439,13 +444,13 @@ Usage example with a specific schema:
 ```ts
 const jsonToObject = jsonCodec(z.object({ name: z.string(), age: z.number() }));
 
-jsonToObject.decode('{"name":"Alice","age":30}');  
+jsonToObject.decode('{"name":"Alice","age":30}');
 // => { name: "Alice", age: 30 }
 
-jsonToObject.encode({ name: "Bob", age: 25 });     
+jsonToObject.encode({ name: "Bob", age: 25 });
 // => '{"name":"Bob","age":25}'
 
-jsonToObject.decode('~~invalid~~'); 
+jsonToObject.decode("~~invalid~~");
 // ZodError: [
 //   {
 //     "code": "invalid_format",
@@ -466,8 +471,8 @@ const utf8ToBytes = z.codec(z.string(), z.instanceof(Uint8Array), {
   encode: (bytes) => new TextDecoder().decode(bytes),
 });
 
-utf8ToBytes.decode("Hello, 世界!");  // => Uint8Array
-utf8ToBytes.encode(bytes);          // => "Hello, 世界!"
+utf8ToBytes.decode("Hello, 世界!"); // => Uint8Array
+utf8ToBytes.encode(bytes); // => "Hello, 世界!"
 ```
 
 ### `bytesToUtf8`
@@ -480,8 +485,8 @@ const bytesToUtf8 = z.codec(z.instanceof(Uint8Array), z.string(), {
   encode: (str) => new TextEncoder().encode(str),
 });
 
-bytesToUtf8.decode(bytes);          // => "Hello, 世界!"
-bytesToUtf8.encode("Hello, 世界!");  // => Uint8Array
+bytesToUtf8.decode(bytes); // => "Hello, 世界!"
+bytesToUtf8.encode("Hello, 世界!"); // => Uint8Array
 ```
 
 ### `base64ToBytes`
@@ -494,8 +499,8 @@ const base64ToBytes = z.codec(z.base64(), z.instanceof(Uint8Array), {
   encode: (bytes) => z.util.uint8ArrayToBase64(bytes),
 });
 
-base64ToBytes.decode("SGVsbG8=");  // => Uint8Array([72, 101, 108, 108, 111])
-base64ToBytes.encode(bytes);       // => "SGVsbG8="
+base64ToBytes.decode("SGVsbG8="); // => Uint8Array([72, 101, 108, 108, 111])
+base64ToBytes.encode(bytes); // => "SGVsbG8="
 ```
 
 ### `base64urlToBytes`
@@ -508,8 +513,8 @@ const base64urlToBytes = z.codec(z.base64url(), z.instanceof(Uint8Array), {
   encode: (bytes) => z.util.uint8ArrayToBase64url(bytes),
 });
 
-base64urlToBytes.decode("SGVsbG8");  // => Uint8Array([72, 101, 108, 108, 111])
-base64urlToBytes.encode(bytes);      // => "SGVsbG8"
+base64urlToBytes.decode("SGVsbG8"); // => Uint8Array([72, 101, 108, 108, 111])
+base64urlToBytes.encode(bytes); // => "SGVsbG8"
 ```
 
 ### `hexToBytes`
@@ -522,8 +527,8 @@ const hexToBytes = z.codec(z.hex(), z.instanceof(Uint8Array), {
   encode: (bytes) => z.util.uint8ArrayToHex(bytes),
 });
 
-hexToBytes.decode("48656c6c6f");     // => Uint8Array([72, 101, 108, 108, 111])
-hexToBytes.encode(bytes);            // => "48656c6c6f"
+hexToBytes.decode("48656c6c6f"); // => Uint8Array([72, 101, 108, 108, 111])
+hexToBytes.encode(bytes); // => "48656c6c6f"
 ```
 
 ### `stringToURL`
@@ -536,8 +541,8 @@ const stringToURL = z.codec(z.url(), z.instanceof(URL), {
   encode: (url) => url.href,
 });
 
-stringToURL.decode("https://example.com/path");  // => URL object
-stringToURL.encode(new URL("https://example.com"));  // => "https://example.com/"
+stringToURL.decode("https://example.com/path"); // => URL object
+stringToURL.encode(new URL("https://example.com")); // => "https://example.com/"
 ```
 
 ### `stringToHttpURL`
@@ -550,8 +555,8 @@ const stringToHttpURL = z.codec(z.httpUrl(), z.instanceof(URL), {
   encode: (url) => url.href,
 });
 
-stringToHttpURL.decode("https://api.example.com/v1");  // => URL object
-stringToHttpURL.encode(url);                           // => "https://api.example.com/v1"
+stringToHttpURL.decode("https://api.example.com/v1"); // => URL object
+stringToHttpURL.encode(url); // => "https://api.example.com/v1"
 ```
 
 ### `uriComponent`
@@ -564,6 +569,6 @@ const uriComponent = z.codec(z.string(), z.string(), {
   encode: (decodedString) => encodeURIComponent(decodedString),
 });
 
-uriComponent.decode("Hello%20World%21");  // => "Hello World!"
-uriComponent.encode("Hello World!");      // => "Hello%20World!"
+uriComponent.decode("Hello%20World%21"); // => "Hello World!"
+uriComponent.encode("Hello World!"); // => "Hello%20World!"
 ```

--- a/packages/docs/content/ecosystem.mdx
+++ b/packages/docs/content/ecosystem.mdx
@@ -23,36 +23,29 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [Fixing TypeScript's Blindspot: Runtime Typechecking](https://www.youtube.com/watch?v=rY_XqfSHock) by [@jherr](https://x.com/jherr)
 - [Validate Environment Variables With Zod](https://catalins.tech/validate-environment-variables-with-zod/) by [@catalinmpit](https://x.com/catalinmpit)
 
-
 ## API Libraries
 
 <ApiLibraries />
-
 
 ## Form Integrations
 
 <FormIntegrations />
 
-
 ## Zod to X
 
 <ZodToX />
-
 
 ## X to Zod
 
 <XToZod />
 
-
 ## Mocking Libraries
 
 <MockingLibraries />
 
-
 ## Powered by Zod
 
 <PoweredByZod />
-
 
 ## Zod Utilities
 

--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -3,7 +3,7 @@ title: Customizing errors
 description: "Guide to customizing validation error messages and error handling patterns"
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
 {/* ## `$ZodError` */}
 
@@ -13,7 +13,6 @@ In Zod, validation errors are surfaced as instances of the `z.core.$ZodError` cl
 
 Instances of `$ZodError` contain an `.issues` array. Each issue contains a human-readable `message` and additional structured metadata about the issue.
 
-
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
 ```ts
@@ -22,14 +21,15 @@ import * as z from "zod";
 const result = z.string().safeParse(12); // { success: false, error: ZodError }
 result.error.issues;
 // [
-//   {
-//     expected: 'string',
-//     code: 'invalid_type',
-//     path: [],
-//     message: 'Invalid input: expected string, received number'
-//   }
+// {
+// expected: 'string',
+// code: 'invalid_type',
+// path: [],
+// message: 'Invalid input: expected string, received number'
+// }
 // ]
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -45,7 +45,7 @@ result.error.issues;
 //     message: 'Invalid input'
 //   }
 // ]
-```
+````
 
 </Tab>
 </Tabs>
@@ -53,7 +53,6 @@ result.error.issues;
 {/* ## Customization */}
 
 Every issue contains a `message` property with a human-readable error message. Error messages can be customized in a number of ways.
-
 
 ## The `error` param
 
@@ -82,28 +81,18 @@ z.string("Not a string!").parse(12);
 All `z` functions and schema methods accept custom errors.
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
-<Tab value="Zod">
-```ts
-z.string("Bad!");
-z.string().min(5, "Too short!");
-z.uuid("Bad UUID!");
-z.iso.date("Bad date!");
-z.array(z.string(), "Not an array!");
-z.array(z.string()).min(5, "Too few items!");
-z.set(z.string(), "Bad set!");
-```
-</Tab>
-<Tab value="Zod Mini">
-```ts
-z.string("Bad!");
-z.string().check(z.minLength(5, "Too short!"));
-z.uuid("Bad UUID!");
-z.iso.date("Bad date!");
-z.array(z.string(), "Bad array!");
-z.array(z.string()).check(z.minLength(5, "Too few items!"));
-z.set(z.string(), "Bad set!");
-```
-</Tab>
+  <Tab value="Zod">
+    ```ts z.string("Bad!"); z.string().min(5, "Too short!"); z.uuid("Bad
+    UUID!"); z.iso.date("Bad date!"); z.array(z.string(), "Not an array!");
+    z.array(z.string()).min(5, "Too few items!"); z.set(z.string(), "Bad set!");
+    ```
+  </Tab>
+  <Tab value="Zod Mini">
+    ```ts z.string("Bad!"); z.string().check(z.minLength(5, "Too short!"));
+    z.uuid("Bad UUID!"); z.iso.date("Bad date!"); z.array(z.string(), "Bad
+    array!"); z.array(z.string()).check(z.minLength(5, "Too few items!"));
+    z.set(z.string(), "Bad set!"); ```
+  </Tab>
 </Tabs>
 
 If you prefer, you can pass a params object with an `error` parameter instead.
@@ -134,22 +123,23 @@ z.set(z.string(), { error: "Bad set!" });
 </Tab>
 </Tabs>
 
-
 The `error` param optionally accepts a function. An error customization function is known as an **error map** in Zod terminology. The error map will run at parse time if a validation error occurs.
 
 ```ts
-z.string({ error: ()=>`[${Date.now()}]: Validation failure.` });
+z.string({ error: () => `[${Date.now()}]: Validation failure.` });
 ```
 
 <Callout>
-**Note** — In Zod v3, there were separate params for `message` (a string) and `errorMap` (a function). These have been unified in Zod 4 as `error`.
+  **Note** — In Zod v3, there were separate params for `message` (a string) and
+  `errorMap` (a function). These have been unified in Zod 4 as `error`.
 </Callout>
 
 The error map receives a context object you can use to customize the error message based on the validation issue.
 
 ```ts
 z.string({
-  error: (iss) => iss.input === undefined ? "Field is required." : "Invalid input."
+  error: (iss) =>
+    iss.input === undefined ? "Field is required." : "Invalid input.",
 });
 ```
 
@@ -197,17 +187,17 @@ z.int64({
 
 ## Per-parse error customization
 
-To customize errors on a *per-parse* basis, pass an error map into the parse method:
+To customize errors on a _per-parse_ basis, pass an error map into the parse method:
 
 ```ts
 const schema = z.string();
 
 schema.parse(12, {
-  error: iss => "per-parse custom error"
+  error: (iss) => "per-parse custom error",
 });
 ```
 
-This has *lower precedence* than any schema-level custom messages.
+This has _lower precedence_ than any schema-level custom messages.
 
 ```ts
 const schema = z.string({ error: "highest priority" });
@@ -233,7 +223,7 @@ const result = schema.safeParse(12, {
       return `minimum is ${iss.minimum}`;
     }
     // ...
-  }
+  },
 });
 ```
 
@@ -243,8 +233,8 @@ By default, Zod does not include input data in issues. This is to prevent uninte
 
 ```ts
 z.string().parse(12, {
-  reportInput: true
-})
+  reportInput: true,
+});
 
 // ZodError: [
 //   {
@@ -269,7 +259,7 @@ z.config({
 });
 ```
 
-Global error messages have *lower precedence* than schema-level or per-parse error messages.
+Global error messages have _lower precedence_ than schema-level or per-parse error messages.
 
 The `iss` object is a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) of all possible issue types. Use the `code` property to discriminate between them.
 
@@ -302,7 +292,8 @@ import * as z from "zod";
 import { en } from "zod/locales"
 
 z.config(en());
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -310,7 +301,8 @@ import * as z from "zod/mini"
 import { en } from "zod/locales";
 
 z.config(en());
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -322,7 +314,7 @@ import * as z from "zod";
 async function loadLocale(locale: string) {
   const { default: locale } = await import(`zod/v4/locales/${locale}.js`);
   z.config(locale());
-};
+}
 
 await loadLocale("fr");
 ```
@@ -335,14 +327,16 @@ For convenience, all locales are exported as `z.locales` from `"zod"`. In some b
 import * as z from "zod";
 
 z.config(z.locales.en());
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 import * as z from "zod/mini"
 
 z.config(z.locales.en());
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -398,34 +392,34 @@ The following locales are available:
 - `zhTW` — Traditional Chinese
 - `yo` — Yorùbá
 
-
 ## Error precedence
 
-Below is a quick reference for determining error precedence: if multiple error customizations have been defined, which one takes priority? From *highest to lowest* priority:
+Below is a quick reference for determining error precedence: if multiple error customizations have been defined, which one takes priority? From _highest to lowest_ priority:
 
 1. **Schema-level error** — Any error message "hard coded" into a schema definition.
 
-  ```ts
-  z.string("Not a string!");
-  ```
+```ts
+z.string("Not a string!");
+```
 
 2. **Per-parse error** — A custom error map passed into the `.parse()` method.
 
-  ```ts
-  z.string().parse(12, {
-    error: (iss) => "My custom error"
-  });
-  ```
+```ts
+z.string().parse(12, {
+  error: (iss) => "My custom error",
+});
+```
 
 3. **Global error map** — A custom error map passed into `z.config()`.
 
-  ```ts
-  z.config({
-    customError: (iss) => "My custom error"
-  });
-  ```
+```ts
+z.config({
+  customError: (iss) => "My custom error",
+});
+```
 
 4. **Locale error map** — A custom error map passed into `z.config()`.
 
-  ```ts
-  z.config(z.locales.en());
+```ts
+z.config(z.locales.en());
+```

--- a/packages/docs/content/error-formatting.mdx
+++ b/packages/docs/content/error-formatting.mdx
@@ -4,7 +4,7 @@ description: "Utilities for formatting and displaying Zod errors"
 ---
 
 import { Callout } from "fumadocs-ui/components/callout";
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 Zod emphasizes _completeness_ and _correctness_ in its error reporting. In many cases, it's helpful to convert the `$ZodError` to a more useful format. Zod provides some utilities for this.
 
@@ -31,31 +31,29 @@ const result = schema.safeParse({
 result.error!.issues;
 [
   {
-    expected: 'string',
-    code: 'invalid_type',
-    path: [ 'username' ],
-    message: 'Invalid input: expected string, received number'
+    expected: "string",
+    code: "invalid_type",
+    path: ["username"],
+    message: "Invalid input: expected string, received number",
   },
   {
-    expected: 'number',
-    code: 'invalid_type',
-    path: [ 'favoriteNumbers', 1 ],
-    message: 'Invalid input: expected number, received string'
+    expected: "number",
+    code: "invalid_type",
+    path: ["favoriteNumbers", 1],
+    message: "Invalid input: expected number, received string",
   },
   {
-    code: 'unrecognized_keys',
-    keys: [ 'extraKey' ],
+    code: "unrecognized_keys",
+    keys: ["extraKey"],
     path: [],
-    message: 'Unrecognized key: "extraKey"'
-  }
+    message: 'Unrecognized key: "extraKey"',
+  },
 ];
 ```
-
 
 ## `z.treeifyError()`
 
 To convert ("treeify") this error into a nested object, use `z.treeifyError()`.
-
 
 ```ts
 const tree = z.treeifyError(result.error);
@@ -108,7 +106,6 @@ This returns the following string:
   → at favoriteNumbers[1]
 ```
 
-
 ## `z.formatError()`
 
 <Callout type="warn">
@@ -151,7 +148,7 @@ This returns the following string:
 
 ## `z.flattenError()`
 
-While `z.treeifyError()` is useful for traversing a potentially complex nested structure, the majority of schemas are *flat*—just one level deep. In this case, use `z.flattenError()` to retrieve a clean, shallow error object.
+While `z.treeifyError()` is useful for traversing a potentially complex nested structure, the majority of schemas are _flat_—just one level deep. In this case, use `z.flattenError()` to retrieve a clean, shallow error object.
 
 ```ts
 const flattened = z.flattenError(result.error);

--- a/packages/docs/content/index.mdx
+++ b/packages/docs/content/index.mdx
@@ -4,37 +4,79 @@ mode: "center"
 description: "Introduction to Zod - TypeScript-first schema validation library with static type inference"
 ---
 
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
-import { Tabs } from 'fumadocs-ui/components/tabs';
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
+import { Tabs } from "fumadocs-ui/components/tabs";
 
-import { Featured } from '../components/featured';
-import { Platinum } from '../components/platinum';
-import { Gold } from '../components/gold';
-import { Silver } from '../components/silver';
-import { Bronze } from '../components/bronze';
-import { HeroLogo } from '../components/hero-logo';
-
+import { Featured } from "../components/featured";
+import { Platinum } from "../components/platinum";
+import { Gold } from "../components/gold";
+import { Silver } from "../components/silver";
+import { Bronze } from "../components/bronze";
+import { HeroLogo } from "../components/hero-logo";
 
 <div className="flex flex-col items-stretch text-center">
   <HeroLogo />
   <h1 className="text-3xl font-bold">Zod</h1>
-  <p className="mt-2 mb-1">TypeScript-first schema validation with static type inference<br/>by <a href="https://x.com/colinhacks">@colinhacks</a> </p>
-  <br/>
-  <div  className="flex flex-row flex-wrap justify-center gap-1 py-2">
-    <a className="border-none" href="https://github.com/colinhacks/zod/actions?query=branch%3Amain">
-      <img className="h-[20px] m-0!" src="https://github.com/colinhacks/zod/actions/workflows/test.yml/badge.svg?event=push&branch=main" alt="Zod CI status" />
+  <p className="mt-2 mb-1">
+    TypeScript-first schema validation with static type inference
+    <br />
+    by <a href="https://x.com/colinhacks">@colinhacks</a>{" "}
+  </p>
+  <br />
+  <div className="flex flex-row flex-wrap justify-center gap-1 py-2">
+    <a
+      className="border-none"
+      href="https://github.com/colinhacks/zod/actions?query=branch%3Amain"
+    >
+      <img
+        className="h-[20px] m-0!"
+        src="https://github.com/colinhacks/zod/actions/workflows/test.yml/badge.svg?event=push&branch=main"
+        alt="Zod CI status"
+      />
     </a>
-    <a className="border-none" href="https://twitter.com/colinhacks" rel="nofollow">
-      <img  className="h-[20px] m-0!" src="https://img.shields.io/badge/created%20by-@colinhacks-4BBAAB.svg" alt="Created by Colin McDonnell" />
+    <a
+      className="border-none"
+      href="https://twitter.com/colinhacks"
+      rel="nofollow"
+    >
+      <img
+        className="h-[20px] m-0!"
+        src="https://img.shields.io/badge/created%20by-@colinhacks-4BBAAB.svg"
+        alt="Created by Colin McDonnell"
+      />
     </a>
-    <a className="border-none" href="https://opensource.org/licenses/MIT" rel="nofollow">
-      <img  className="h-[20px] m-0!" src="https://img.shields.io/github/license/colinhacks/zod" alt="License" />
+    <a
+      className="border-none"
+      href="https://opensource.org/licenses/MIT"
+      rel="nofollow"
+    >
+      <img
+        className="h-[20px] m-0!"
+        src="https://img.shields.io/github/license/colinhacks/zod"
+        alt="License"
+      />
     </a>
-    <a className="border-none" href="https://www.npmjs.com/package/zod" rel="nofollow">
-      <img  className="h-[20px] m-0!" src="https://img.shields.io/npm/dw/zod.svg" alt="npm" />
+    <a
+      className="border-none"
+      href="https://www.npmjs.com/package/zod"
+      rel="nofollow"
+    >
+      <img
+        className="h-[20px] m-0!"
+        src="https://img.shields.io/npm/dw/zod.svg"
+        alt="npm"
+      />
     </a>
-    <a className="border-none" href="https://github.com/colinhacks/zod" rel="nofollow">
-      <img  className="h-[20px] m-0!" src="https://img.shields.io/github/stars/colinhacks/zod" alt="stars" />
+    <a
+      className="border-none"
+      href="https://github.com/colinhacks/zod"
+      rel="nofollow"
+    >
+      <img
+        className="h-[20px] m-0!"
+        src="https://img.shields.io/github/stars/colinhacks/zod"
+        alt="stars"
+      />
     </a>
   </div>
   <div className="flex flex-row justify-center gap-1">
@@ -49,10 +91,11 @@ import { HeroLogo } from '../components/hero-logo';
   </div>
 </div>
 
-<br/>
+<br />
 
-{/* <ParamField path="param" type="string">
-  An example of a parameter field
+{/\* <ParamField path="param" type="string">
+An example of a parameter field
+
 </ParamField>
 
 <ParamField query="filter" type="string" default="none" required>
@@ -65,24 +108,33 @@ import { HeroLogo } from '../components/hero-logo';
 
 <div className="mt-5 font-gray-100 mx-auto text-center pt-12">
   <span className="">
-    Zod 4 is now stable! Read the <a rel="noopener noreferrer" href="/v4" alt="zod 4 release notes">release notes here</a>.
+    Zod 4 is now stable! Read the{" "}
+    <a rel="noopener noreferrer" href="/v4" alt="zod 4 release notes">
+      release notes here
+    </a>
+    .
   </span>
 </div>
 
-<br /><br /><br />
+<br />
+<br />
+<br />
 
-<Featured data={{
-  name: "Jazz",
-  link: "https://jazz.tools/?utm_source=zod",
-  lightImage: "https://raw.githubusercontent.com/garden-co/jazz/938f6767e46cdfded60e50d99bf3b533f4809c68/homepage/homepage/public/Zod%20sponsor%20message.png",
-  
-  darkImage: "https://raw.githubusercontent.com/garden-co/jazz/938f6767e46cdfded60e50d99bf3b533f4809c68/homepage/homepage/public/Zod%20sponsor%20message.png",
-}} />
+<Featured
+  data={{
+    name: "Jazz",
+    link: "https://jazz.tools/?utm_source=zod",
+    lightImage:
+      "https://raw.githubusercontent.com/garden-co/jazz/938f6767e46cdfded60e50d99bf3b533f4809c68/homepage/homepage/public/Zod%20sponsor%20message.png",
 
+    darkImage:
+      "https://raw.githubusercontent.com/garden-co/jazz/938f6767e46cdfded60e50d99bf3b533f4809c68/homepage/homepage/public/Zod%20sponsor%20message.png",
+  }}
+/>
 
 ## Introduction
 
-Zod is a TypeScript-first validation library. Using Zod, you can define *schemas* you can use to validate data, from a simple `string` to a complex nested object.
+Zod is a TypeScript-first validation library. Using Zod, you can define _schemas_ you can use to validate data, from a simple `string` to a complex nested object.
 
 ```ts
 import * as z from "zod";
@@ -92,7 +144,9 @@ const User = z.object({
 });
 
 // some untrusted data...
-const input = { /* stuff */ };
+const input = {
+  /* stuff */
+};
 
 // the parsed result is validated and type safe!
 const data = User.parse(input);
@@ -112,9 +166,7 @@ console.log(data.name);
 - Built-in JSON Schema conversion
 - Extensive ecosystem
 
-
 ## Installation
-
 
 ```sh
 npm install zod
@@ -126,12 +178,12 @@ Zod provides an MCP server that can be used by agents to search Zod's docs. To a
 
 ## Requirements
 
-Zod is tested against *TypeScript v5.5* and later. Older versions may work but are not officially supported.
+Zod is tested against _TypeScript v5.5_ and later. Older versions may work but are not officially supported.
 
 ### `"strict"`
 
 You must enable `strict` mode in your `tsconfig.json`. This is a best practice for all TypeScript projects.
-  
+
 ```ts
 // tsconfig.json
 {
@@ -142,7 +194,6 @@ You must enable `strict` mode in your `tsconfig.json`. This is a best practice f
   }
 }
 ```
-
 
 ## Ecosystem
 
@@ -166,28 +217,26 @@ I also contribute to the following projects, which I'd like to highlight:
 
 Sponsorship at any level is appreciated and encouraged. If you built a paid product using Zod, consider one of the [corporate tiers](https://github.com/sponsors/colinhacks).
 
-
 ### Platinum
 
 <Platinum />
 
-<br/>
+<br />
 
 ### Gold
 
 <Gold />
 
-<br/>
+<br />
 
 ### Silver
 
 <Silver />
 
-<br/>
+<br />
 
 ### Bronze
 
 <Bronze />
 
 <br />
-

--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -3,19 +3,25 @@ title: "JSON Schema"
 description: "How to convert Zod schemas to JSON Schema"
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
-import { Callout } from "fumadocs-ui/components/callout"
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Callout } from "fumadocs-ui/components/callout";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-<Callout icon={'💎'}>
-  **New** — Zod 4 introduces a new feature: native [JSON Schema](https://json-schema.org/) conversion. JSON Schema is a standard for describing the structure of JSON (with JSON). It's widely used in [OpenAPI](https://www.openapis.org/) definitions and defining [structured outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat) for AI.
+<Callout icon={"💎"}>
+  **New** — Zod 4 introduces a new feature: native [JSON
+  Schema](https://json-schema.org/) conversion. JSON Schema is a standard for
+  describing the structure of JSON (with JSON). It's widely used in
+  [OpenAPI](https://www.openapis.org/) definitions and defining [structured
+  outputs](https://platform.openai.com/docs/guides/structured-outputs?api-mode=chat)
+  for AI.
 </Callout>
-
 
 ## `z.fromJSONSchema()`
 
 <Callout type="warn">
-  **Experimental** — The `z.fromJSONSchema()` function is experimental and is not considered part of Zod's stable API. It is likely to undergo implementation changes in future releases.
+  **Experimental** — The `z.fromJSONSchema()` function is experimental and is
+  not considered part of Zod's stable API. It is likely to undergo
+  implementation changes in future releases.
 </Callout>
 
 Zod provides `z.fromJSONSchema()` to convert a JSON Schema into a Zod schema.
@@ -35,7 +41,6 @@ const jsonSchema = {
 const zodSchema = z.fromJSONSchema(jsonSchema);
 ```
 
-
 ## `z.toJSONSchema()`
 
 To convert a Zod schema to JSON Schema, use the `z.toJSONSchema()` function.
@@ -48,7 +53,7 @@ const schema = z.object({
   age: z.number(),
 });
 
-z.toJSONSchema(schema)
+z.toJSONSchema(schema);
 // => {
 //   type: 'object',
 //   properties: { name: { type: 'string' }, age: { type: 'number' } },
@@ -73,13 +78,12 @@ z.nan(); // ❌
 z.custom(); // ❌
 ```
 
-
 A second argument can be used to customize the conversion logic.
 
 ```ts
 z.toJSONSchema(schema, {
   // ...params
-})
+});
 ```
 
 Below is a quick reference for each supported parameter. Each one is explained in more detail below.
@@ -101,7 +105,7 @@ interface ToJSONSchemaParams {
     | ({} & string)
     | undefined;
 
-  /** A registry used to look up metadata for each schema. 
+  /** A registry used to look up metadata for each schema.
    * Any schema with an `id` property will be extracted as a $def. */
   metadata?: $ZodRegistry<Record<string, any>>;
 
@@ -130,22 +134,25 @@ interface ToJSONSchemaParams {
 
 ### `io`
 
-Some schema types have different input and output types, e.g. `ZodPipe`, `ZodDefault`, and coerced primitives. By default, the result of `z.toJSONSchema` represents the *output type*; use `"io": "input"` to extract the input type instead.
+Some schema types have different input and output types, e.g. `ZodPipe`, `ZodDefault`, and coerced primitives. By default, the result of `z.toJSONSchema` represents the _output type_; use `"io": "input"` to extract the input type instead.
 
 ```ts
-const mySchema = z.string().transform(val => val.length).pipe(z.number());
+const mySchema = z
+  .string()
+  .transform((val) => val.length)
+  .pipe(z.number());
 // ZodPipe
 
-const jsonSchema = z.toJSONSchema(mySchema); 
+const jsonSchema = z.toJSONSchema(mySchema);
 // => { type: "number" }
 
-const jsonSchema = z.toJSONSchema(mySchema, { io: "input" }); 
+const jsonSchema = z.toJSONSchema(mySchema, { io: "input" });
 // => { type: "string" }
 ```
 
 ### `target`
 
-To set the target JSON Schema version, use the `target` parameter. By default, Zod will target Draft 2020-12.   
+To set the target JSON Schema version, use the `target` parameter. By default, Zod will target Draft 2020-12.
 
 ```ts
 z.toJSONSchema(schema, { target: "draft-07" });
@@ -158,7 +165,7 @@ z.toJSONSchema(schema, { target: "openapi-3.0" });
 
 > If you haven't already, read through the [Metadata and registries](/metadata) page for context on storing metadata in Zod.
 
-In Zod, metadata is stored in registries. Zod exports a global registry `z.globalRegistry` that can be used to store common metadata fields like `id`, `title`, `description`, and `examples`. 
+In Zod, metadata is stored in registries. Zod exports a global registry `z.globalRegistry` that can be used to store common metadata fields like `id`, `title`, `description`, and `examples`.
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -166,36 +173,38 @@ In Zod, metadata is stored in registries. Zod exports a global registry `z.globa
 import * as z from "zod";
 
 // `.meta()` is a convenience method for registering a schema in `z.globalRegistry`
-const emailSchema = z.string().meta({ 
-  title: "Email address",
-  description: "Your email address",
+const emailSchema = z.string().meta({
+title: "Email address",
+description: "Your email address",
 });
 
 z.toJSONSchema(emailSchema);
-// => { type: "string", title: "Email address", description: "Your email address", ... } 
-```
+// => { type: "string", title: "Email address", description: "Your email address", ... }
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 import * as z from "zod";
 
 // `.meta()` is a convenience method for registering a schema in `z.globalRegistry`
-const emailSchema = z.string().register(z.globalRegistry, { 
+const emailSchema = z.string().register(z.globalRegistry, {
   title: "Email address",
   description: "Your email address",
 });
 
 z.toJSONSchema(emailSchema);
-// => { type: "string", title: "Email address", description: "Your email address", ... } 
-```
+// => { type: "string", title: "Email address", description: "Your email address", ... }
+````
+
 </Tab>
 </Tabs>
 
-All metadata fields get copied into the resulting JSON Schema. 
+All metadata fields get copied into the resulting JSON Schema.
 
 ```ts
 const schema = z.string().meta({
-  whatever: 1234
+  whatever: 1234,
 });
 
 z.toJSONSchema(schema);
@@ -204,7 +213,7 @@ z.toJSONSchema(schema);
 
 ### `unrepresentable`
 
-The following APIs are not representable in JSON Schema. By default, Zod will throw an error if they are encountered. It is unsound to attempt a conversion to JSON Schema; you should modify your schemas  as they have no equivalent in JSON. An error will be thrown if any of these are encountered.
+The following APIs are not representable in JSON Schema. By default, Zod will throw an error if they are encountered. It is unsound to attempt a conversion to JSON Schema; you should modify your schemas as they have no equivalent in JSON. An error will be thrown if any of these are encountered.
 
 ```ts
 z.bigint(); // ❌
@@ -220,7 +229,7 @@ z.nan(); // ❌
 z.custom(); // ❌
 ```
 
-By default, Zod will throw an error if any of these are encountered. 
+By default, Zod will throw an error if any of these are encountered.
 
 ```ts
 z.toJSONSchema(z.bigint());
@@ -233,9 +242,10 @@ You can change this behavior by setting the `unrepresentable` option to `"any"`.
 z.toJSONSchema(z.bigint(), { unrepresentable: "any" });
 // => {}
 ```
+
 ### `cycles`
 
-How to handle cycles. If a cycle is encountered as `z.toJSONSchema()` traverses the schema, it will be represented using `$ref`. 
+How to handle cycles. If a cycle is encountered as `z.toJSONSchema()` traverses the schema, it will be represented using `$ref`.
 
 ```ts
 const User = z.object({
@@ -261,10 +271,9 @@ z.toJSONSchema(User, { cycles: "throw" });
 // => throws Error
 ```
 
-
 ### `reused`
 
-How to handle schemas that occur multiple times in the same schema. By default, Zod will inline these schemas. 
+How to handle schemas that occur multiple times in the same schema. By default, Zod will inline these schemas.
 
 ```ts
 const name = z.string();
@@ -276,9 +285,9 @@ const User = z.object({
 z.toJSONSchema(User);
 // => {
 //   type: 'object',
-//   properties: { 
-//     firstName: { type: 'string' }, 
-//     lastName: { type: 'string' } 
+//   properties: {
+//     firstName: { type: 'string' },
+//     lastName: { type: 'string' }
 //   },
 //   required: [ 'firstName', 'lastName' ],
 //   additionalProperties: false,
@@ -303,20 +312,20 @@ z.toJSONSchema(User, { reused: "ref" });
 
 ### `override`
 
-To define some custom override logic, use `override`. The provided callback has access to the original Zod schema and the default JSON Schema. *This function should directly modify `ctx.jsonSchema`.*
-
+To define some custom override logic, use `override`. The provided callback has access to the original Zod schema and the default JSON Schema. _This function should directly modify `ctx.jsonSchema`._
 
 ```ts
-const mySchema = /* ... */
-z.toJSONSchema(mySchema, {
-  override: (ctx)=>{
-    ctx.zodSchema; // the original Zod schema
-    ctx.jsonSchema; // the default JSON Schema
+const mySchema =
+  /* ... */
+  z.toJSONSchema(mySchema, {
+    override: (ctx) => {
+      ctx.zodSchema; // the original Zod schema
+      ctx.jsonSchema; // the default JSON Schema
 
-    // directly modify
-    ctx.jsonSchema.whatever = "sup";
-  }
-});
+      // directly modify
+      ctx.jsonSchema.whatever = "sup";
+    },
+  });
 ```
 
 Note that unrepresentable types will throw an `Error` before this function is called. If you are trying to define custom behavior for an unrepresentable type, you'll need to set the `unrepresentable: "any"` alongside `override`.
@@ -327,14 +336,13 @@ const result = z.toJSONSchema(z.date(), {
   unrepresentable: "any",
   override: (ctx) => {
     const def = ctx.zodSchema._zod.def;
-    if(def.type ==="date"){
+    if (def.type === "date") {
       ctx.jsonSchema.type = "string";
       ctx.jsonSchema.format = "date-time";
     }
   },
 });
 ```
-
 
 ## Conversion
 
@@ -405,7 +413,7 @@ const schema = z.object({
   age: z.number(),
 });
 
-z.toJSONSchema(schema)
+z.toJSONSchema(schema);
 // => {
 //   type: 'object',
 //   properties: { name: { type: 'string' }, age: { type: 'number' } },
@@ -432,11 +440,10 @@ z.toJSONSchema(schema, { io: "input" });
 // }
 ```
 
-By contrast: 
+By contrast:
 
-- `z.looseObject()` will *never* set `additionalProperties: false`
-- `z.strictObject()` will *always* set `additionalProperties: false`
-
+- `z.looseObject()` will _never_ set `additionalProperties: false`
+- `z.strictObject()` will _always_ set `additionalProperties: false`
 
 ### File schemas
 
@@ -450,7 +457,10 @@ z.file();
 Size and MIME checks are also represented:
 
 ```ts
-z.file().min(1).max(1024 * 1024).mime("image/png");
+z.file()
+  .min(1)
+  .max(1024 * 1024)
+  .mime("image/png");
 // => {
 //   type: "string",
 //   format: "binary",
@@ -460,7 +470,6 @@ z.file().min(1).max(1024 * 1024).mime("image/png");
 //   maxLength: 1048576,
 // }
 ```
-
 
 ### Nullability
 
@@ -487,44 +496,41 @@ z.optional(z.string());
 // => { type: "string" }
 ```
 
-{/* ### Pipes
+{/\* ### Pipes
 
-Pipes contain an input and an output schema. Zod uses the *output schema* for JSON Schema conversion. */}
-
-
-
+Pipes contain an input and an output schema. Zod uses the _output schema_ for JSON Schema conversion. \*/}
 
 ## Registries
 
-Passing a schema into `z.toJSONSchema()` will return a *self-contained* JSON Schema. 
+Passing a schema into `z.toJSONSchema()` will return a _self-contained_ JSON Schema.
 
-In other cases, you may have a set of Zod schemas you'd like to represent using multiple interlinked JSON Schemas, perhaps to write to `.json` files and serve from a web server. 
+In other cases, you may have a set of Zod schemas you'd like to represent using multiple interlinked JSON Schemas, perhaps to write to `.json` files and serve from a web server.
 
 ```ts
 import * as z from "zod";
 
 const User = z.object({
   name: z.string(),
-  get posts(){
+  get posts() {
     return z.array(Post);
-  }
+  },
 });
 
 const Post = z.object({
   title: z.string(),
   content: z.string(),
-  get author(){
+  get author() {
     return User;
-  }
+  },
 });
 
-z.globalRegistry.add(User, {id: "User"});
-z.globalRegistry.add(Post, {id: "Post"});
+z.globalRegistry.add(User, { id: "User" });
+z.globalRegistry.add(Post, { id: "Post" });
 ```
 
-To achieve this, you can pass a [registry](/metadata#registries) into `z.toJSONSchema()`. 
+To achieve this, you can pass a [registry](/metadata#registries) into `z.toJSONSchema()`.
 
-> **Important** — All schemas should have a registered `id` property in the registry! Any schemas without an `id` will be ignored. 
+> **Important** — All schemas should have a registered `id` property in the registry! Any schemas without an `id` will be ignored.
 
 ```ts
 z.toJSONSchema(z.globalRegistry);
@@ -559,7 +565,7 @@ By default, the `$ref` URIs are simple relative paths like `"User"`. To make the
 
 ```ts
 z.toJSONSchema(z.globalRegistry, {
-  uri: (id) => `https://example.com/${id}.json`
+  uri: (id) => `https://example.com/${id}.json`,
 });
 // => {
 //   schemas: {

--- a/packages/docs/content/library-authors.mdx
+++ b/packages/docs/content/library-authors.mdx
@@ -3,7 +3,7 @@ title: For library authors
 description: "Guidelines and best practices for library authors integrating with Zod"
 ---
 
-import { Callout } from "fumadocs-ui/components/callout"
+import { Callout } from "fumadocs-ui/components/callout";
 
 <Callout title="Update — July 10th, 2025">
 Zod `4.0.0` has been released on `npm`. This completes the incremental rollout process described below. To add support, bump your peer dependency to include `zod@^4.0.0`:
@@ -18,19 +18,18 @@ Zod `4.0.0` has been released on `npm`. This completes the incremental rollout p
 ```
 
 If you'd already implemented Zod 4 support according to the best practices described below (e.g. using the `"zod/v4/core"` subpath), then no other code changes should be necessary. This should not require a major version bump in your library.
+
 </Callout>
- 
 
-This page is primarily intended for consumption by *library authors* who are building tooling on top of Zod. 
-
+This page is primarily intended for consumption by _library authors_ who are building tooling on top of Zod.
 
 > If you are a library author and think this page should include some additional guidance, please open an issue!
 
 ## Do I need to depend on Zod?
 
-First things first, make sure you need to depend on Zod at all. 
+First things first, make sure you need to depend on Zod at all.
 
-If you're building a library that accepts user-defined schemas to perform black-box validation, you may not need to integrate with Zod specifically. Instead look into [Standard Schema](https://standardschema.dev/). It's a shared interface implemented by most popular validation libraries in the TypeScript ecosystem (see the [full list](https://standardschema.dev/#what-schema-libraries-implement-the-spec)), including Zod. 
+If you're building a library that accepts user-defined schemas to perform black-box validation, you may not need to integrate with Zod specifically. Instead look into [Standard Schema](https://standardschema.dev/). It's a shared interface implemented by most popular validation libraries in the TypeScript ecosystem (see the [full list](https://standardschema.dev/#what-schema-libraries-implement-the-spec)), including Zod.
 
 This spec works great if you accept user-defined schemas and treat them like "black box" validators. Given any compliant library, you can extract inferred input/output types, validate inputs, and get back a standardized error.
 
@@ -67,7 +66,7 @@ During development, you need to meet your own peer dependency requirement, to do
 
 ## How to support Zod 4?
 
-To support Zod 4, update the minimum version for your `"zod"` peer dependency to `^3.25.0 || ^4.0.0`. 
+To support Zod 4, update the minimum version for your `"zod"` peer dependency to `^3.25.0 || ^4.0.0`.
 
 ```json
 // package.json
@@ -87,18 +86,17 @@ import * as z4 from "zod/v4/core";
 
 Import from these subpaths only. Think of them like "permalinks" to their respective Zod versions. These will remain available forever.
 
-- `"zod/v3"` for Zod 3 ✅ 
+- `"zod/v3"` for Zod 3 ✅
 - `"zod/v4/core"` for the Zod 4 Core package ✅
 
 You generally shouldn't be importing from any other paths. The Zod Core library is a shared library that undergirds both Zod 4 Classic and Zod 4 Mini. It's generally a bad idea to implement any functionality that is specific to one or the other. Do not import from these subpaths:
 
-- `"zod"` — ❌ In 3.x releases, this exports Zod 3. In 4.x releases, this will export Zod 4. Use the permalinks instead. 
+- `"zod"` — ❌ In 3.x releases, this exports Zod 3. In 4.x releases, this will export Zod 4. Use the permalinks instead.
 - `"zod/v4"` and `"zod/v4/mini"`— ❌ These subpaths are the homes of Zod 4 Classic and Mini, respectively. If you want your library to work with both Zod and Zod Mini, you should build against the base classes defined in `"zod/v4/core"`. If you reference classes from the `"zod/v4"` module, your library will not work with Zod Mini, and vice versa. This is extremely discouraged. Use `"zod/v4/core"` instead, which exports the `$`-prefixed subclasses that are extended by Zod Classic and Zod Mini. The internals of the classic & mini subclasses are identical; they only differ in which helper methods they implement.
-
 
 ## Do I need to publish a new major version?
 
-No, you should not need to publish a new major version of your library to support Zod 4 (unless you are dropping support for Zod 3, which isn't recommended). 
+No, you should not need to publish a new major version of your library to support Zod 4 (unless you are dropping support for Zod 3, which isn't recommended).
 
 You will need to bump your peer dependency to `^3.25.0`, thus your users will need to `npm upgrade zod`. But there were no breaking changes made to Zod 3 between `zod@3.24` and `zod@3.25`; in fact, there were no code changes whatsoever. As code changes will be required on the part of your users, I do not believe this constitutes a breaking change. I recommend against publishing a new major version.
 
@@ -134,21 +132,23 @@ if ("_zod" in schema) {
 
 ## How to support Zod and Zod Mini simultaneously?
 
-Your library code should only import from `"zod/v4/core"`. This sub-package defines the interfaces, classes, and utilities that are shared between Zod and Zod Mini. 
+Your library code should only import from `"zod/v4/core"`. This sub-package defines the interfaces, classes, and utilities that are shared between Zod and Zod Mini.
 
 ```ts
 // library code
 import * as z4 from "zod/v4/core";
 
-export function acceptObjectSchema<T extends z4.$ZodObject>(schema: T){
+export function acceptObjectSchema<T extends z4.$ZodObject>(schema: T) {
   // parse data
-  z4.parse(schema, { /* somedata */});
+  z4.parse(schema, {
+    /* somedata */
+  });
   // inspect internals
   schema._zod.def.shape;
 }
 ```
 
-By building against the shared base interfaces, you can reliably support both sub-packages simultaneously. This function can accept both Zod and Zod Mini schemas. 
+By building against the shared base interfaces, you can reliably support both sub-packages simultaneously. This function can accept both Zod and Zod Mini schemas.
 
 ```ts
 // user code
@@ -160,14 +160,14 @@ acceptObjectSchema(z.object({ name: z.string() }));
 
 // Zod 4 Mini
 import * as zm from "zod/mini";
-acceptObjectSchema(zm.object({ name: zm.string() }))
+acceptObjectSchema(zm.object({ name: zm.string() }));
 ```
 
 Refer to the [Zod Core](/packages/core) page for more information on the contents of the core sub-library.
 
-{/* ### Future proofing
+{/\* ### Future proofing
 
-To future-proof your library, your code should always allow for new schema and check classes to be added in the future. The addition of a new schema type is *not* considered a breaking change. 
+To future-proof your library, your code should always allow for new schema and check classes to be added in the future. The addition of a new schema type is _not_ considered a breaking change.
 
 One common pattern when introspecting Zod schemas is to write a switch statement over the set of first-party schema types:
 
@@ -183,13 +183,13 @@ switch (def.type) {
     break;
   default:
     console.warn(`Unknown schema type: ${def.type}`);
-    // reasonable fallback behavior
+  // reasonable fallback behavior
 }
 ```
 
 To future-proof this code, your `default` case should probably not throw an error. Instead, it should print an informative error and fall back to some reasonable behavior. If instead you `throw` an error in the default case, your library will be unusable if/when new schemas types are added in the future. Best to print a warning and treat it as a "no-op" (or some other reasonable fallback behavior). The same applies to unrecognized check types, string formats, etc.
 
- */}
+\*/}
 
 ## How to accept user-defined schemas?
 
@@ -205,7 +205,7 @@ function inferSchema<T>(schema: z4.$ZodType<T>) {
 }
 ```
 
-This approach is incorrect, and limits TypeScript's ability to properly infer the argument. No matter what you pass in, the type of `schema` will be an instance of `$ZodType`. 
+This approach is incorrect, and limits TypeScript's ability to properly infer the argument. No matter what you pass in, the type of `schema` will be an instance of `$ZodType`.
 
 ```ts
 inferSchema(z.string());
@@ -226,7 +226,6 @@ inferSchema(z.string());
 To constrain the input schema to a specific subclass:
 
 ```ts
-
 import * as z4 from "zod/v4/core";
 
 // only accepts object schemas
@@ -238,7 +237,6 @@ function inferSchema<T extends z4.$ZodObject>(schema: T) {
 To constrain the inferred output type of the input schema:
 
 ```ts
-
 import * as z4 from "zod/v4/core";
 
 // only accepts string schemas
@@ -246,17 +244,20 @@ function inferSchema<T extends z4.$ZodType<string>>(schema: T) {
   return schema;
 }
 
-inferSchema(z.string()); // ✅ 
+inferSchema(z.string()); // ✅
 
-inferSchema(z.number()); 
-// ❌ The types of '_zod.output' are incompatible between these types. 
+inferSchema(z.number());
+// ❌ The types of '_zod.output' are incompatible between these types.
 // // Type 'number' is not assignable to type 'string'
 ```
 
 To parse data with the schema, use the top-level `z4.parse`/`z4.safeParse`/`z4.parseAsync`/`z4.safeParseAsync` functions. The `z4.$ZodType` subclass has no methods on it. The usual parsing methods are implemented by Zod and Zod Mini, but are not available in Zod Core.
 
 ```ts
-function parseData<T extends z4.$ZodType>(data: unknown, schema: T): z4.output<T> {
+function parseData<T extends z4.$ZodType>(
+  data: unknown,
+  schema: T,
+): z4.output<T> {
   return z.parse(schema, data);
 }
 

--- a/packages/docs/content/metadata.mdx
+++ b/packages/docs/content/metadata.mdx
@@ -3,16 +3,16 @@ title: "Metadata and registries"
 description: "Attaching and manipulatinvg metadata on Zod schemas"
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
-import { Callout } from "fumadocs-ui/components/callout"
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Callout } from "fumadocs-ui/components/callout";
 
 {/* > Zod 4+ provides native `.toJSONSChema()` functionality that leverages registries to generate idiomatic JSON Schema from Zod. Refer to the [JSON SChema docs](/json-schema) page for more information. */}
 
-It's often useful to associate a schema with some additional *metadata* for documentation, code generation, AI structured outputs, form validation, and other purposes.
+It's often useful to associate a schema with some additional _metadata_ for documentation, code generation, AI structured outputs, form validation, and other purposes.
 
 ## Registries
 
-Metadata in Zod is handled via *registries*. Registries are collections of schemas, each associated with some *strongly-typed* metadata. To create a simple registry:
+Metadata in Zod is handled via _registries_. Registries are collections of schemas, each associated with some _strongly-typed_ metadata. To create a simple registry:
 
 ```ts
 import * as z from "zod";
@@ -25,7 +25,7 @@ To register, lookup, and remove schemas from this registry:
 ```ts
 const mySchema = z.string();
 
-myRegistry.add(mySchema, { description: "A cool schema!"});
+myRegistry.add(mySchema, { description: "A cool schema!" });
 myRegistry.has(mySchema); // => true
 myRegistry.get(mySchema); // => { description: "A cool schema!" }
 myRegistry.remove(mySchema);
@@ -39,8 +39,7 @@ myRegistry.add(mySchema, { description: "A cool schema!" }); // ✅
 myRegistry.add(mySchema, { description: 123 }); // ❌
 ```
 
-> **Special handling for `id`** —  Zod registries treat the `id` property specially. An `Error` will be thrown if multiple schemas are registered with the same `id` value. This is true for all registries, including the global registry.
-
+> **Special handling for `id`** — Zod registries treat the `id` property specially. An `Error` will be thrown if multiple schemas are registered with the same `id` value. This is true for all registries, including the global registry.
 
 ### `.register()`
 
@@ -61,7 +60,7 @@ This lets you define metadata "inline" in your schemas.
 const mySchema = z.object({
   name: z.string().register(myRegistry, { description: "The user's name" }),
   age: z.number().register(myRegistry, { description: "The user's age" }),
-})
+});
 ```
 
 <Callout>
@@ -73,8 +72,8 @@ const myRegistry = z.registry();
 myRegistry.add(z.string());
 myRegistry.add(z.number());
 ```
-</Callout>
 
+</Callout>
 
 ## Metadata
 
@@ -84,8 +83,8 @@ For convenience, Zod provides a global registry (`z.globalRegistry`) that can be
 
 ```ts
 export interface GlobalMeta {
-  id?: string ;
-  title?: string ;
+  id?: string;
+  title?: string;
   description?: string;
   deprecated?: boolean;
   [k: string]: unknown;
@@ -97,15 +96,15 @@ To register some metadata in `z.globalRegistry` for a schema:
 ```ts
 import * as z from "zod";
 
-const emailSchema = z.email().register(z.globalRegistry, { 
+const emailSchema = z.email().register(z.globalRegistry, {
   id: "email_address",
   title: "Email address",
   description: "Your email address",
-  examples: ["first.last@example.com"]
+  examples: ["first.last@example.com"],
 });
 ```
 
-To globally augment the `GlobalMeta` interface, use [*declaration merging*](https://www.typescriptlang.org/docs/handbook/declaration-merging.html). Add the following anywhere in your codebase. Creating a `zod.d.ts` file in your project root is a common convention.
+To globally augment the `GlobalMeta` interface, use [_declaration merging_](https://www.typescriptlang.org/docs/handbook/declaration-merging.html). Add the following anywhere in your codebase. Creating a `zod.d.ts` file in your project root is a common convention.
 
 ```ts
 declare module "zod" {
@@ -116,12 +115,12 @@ declare module "zod" {
 }
 
 // forces TypeScript to consider the file a module
-export {}
+export {};
 ```
 
 ### `.meta()`
 
-For a more convenient approach, use the `.meta()` method to register a schema in `z.globalRegistry`. 
+For a more convenient approach, use the `.meta()` method to register a schema in `z.globalRegistry`.
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -146,32 +145,31 @@ const emailSchema = z.email().check(
 </Tab>
 </Tabs>
 
-Calling `.meta()` without an argument will *retrieve* the metadata for a schema.
-
+Calling `.meta()` without an argument will _retrieve_ the metadata for a schema.
 
 ```ts
 emailSchema.meta();
 // => { id: "email_address", title: "Email address", ... }
 ```
 
-Metadata is associated with a *specific schema instance.* This is important to keep in mind, especially since Zod methods are immutable—they always return a new instance.
+Metadata is associated with a _specific schema instance._ This is important to keep in mind, especially since Zod methods are immutable—they always return a new instance.
 
 ```ts
 const A = z.string().meta({ description: "A cool string" });
 A.meta(); // => { description: "A cool string" }
 
-const B = A.refine(_ => true);
+const B = A.refine((_) => true);
 B.meta(); // => undefined
 ```
 
 ### `.describe()`
 
 <Callout>
-The `.describe()` method still exists for compatibility with Zod 3, but `.meta()` is now the recommended approach.
+  The `.describe()` method still exists for compatibility with Zod 3, but
+  `.meta()` is now the recommended approach.
 </Callout>
 
 The `.describe()` method is a shorthand for registering a schema in `z.globalRegistry` with just a `description` field.
-
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
@@ -181,7 +179,8 @@ emailSchema.describe("An email address");
 
 // equivalent to
 emailSchema.meta({ description: "An email address" });
-```
+
+````
 </Tab>
 <Tab value="Zod Mini">
 ```ts
@@ -189,14 +188,14 @@ const emailSchema = z.email().check(z.describe("An email address"));
 
 // equivalent to
 z.email().check(z.meta({ description: "An email address" }));
-```
+````
+
 </Tab>
 </Tabs>
 
 ## Custom registries
 
 You've already seen a simple example of a custom registry:
-
 
 ```ts
 import * as z from "zod";
@@ -208,7 +207,7 @@ Let's look at some more advanced patterns.
 
 ### Referencing inferred types
 
-It's often valuable for the metadata type to reference the *inferred type* of a schema. For instance, you may want an `examples` field to contain examples of the schema's output.
+It's often valuable for the metadata type to reference the _inferred type_ of a schema. For instance, you may want an `examples` field to contain examples of the schema's output.
 
 ```ts
 import * as z from "zod";
@@ -232,6 +231,6 @@ import * as z from "zod";
 const myRegistry = z.registry<{ description: string }, z.ZodString>();
 
 myRegistry.add(z.string(), { description: "A number" }); // ✅
-myRegistry.add(z.number(), { description: "A number" }); // ❌ 
-//             ^ 'ZodNumber' is not assignable to parameter of type 'ZodString' 
+myRegistry.add(z.number(), { description: "A number" }); // ❌
+//             ^ 'ZodNumber' is not assignable to parameter of type 'ZodString'
 ```

--- a/packages/docs/content/packages/core.mdx
+++ b/packages/docs/content/packages/core.mdx
@@ -3,8 +3,8 @@ title: Zod Core
 description: "Zod Core package - minimal core functionality for custom implementations"
 ---
 
-import { Callout } from "fumadocs-ui/components/callout"
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Callout } from "fumadocs-ui/components/callout";
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
 This sub-package exports the core classes and utilities that are consumed by Zod and Zod Mini. It is not intended to be used directly; instead it's designed to be extended by other packages. It implements:
 
@@ -43,7 +43,9 @@ The base class for all Zod schemas is `$ZodType`. It accepts two generic paramet
 
 ```ts
 export class $ZodType<Output = unknown, Input = unknown> {
-  _zod: { /* internals */}
+  _zod: {
+    /* internals */
+  };
 }
 ```
 
@@ -161,20 +163,21 @@ export type $ZodTypes =
       - $ZodCustom
 
       ```
+
 </Accordion>
 </Accordions>
 
 ## Internals
 
-All `zod/v4/core` subclasses only contain a single property: `_zod`. This property is an object containing the schemas *internals*. The goal is to make `zod/v4/core` as extensible and unopinionated as possible. Other libraries can "build their own Zod" on top of these classes without `zod/v4/core` cluttering up the interface. Refer to the implementations of `zod` and `zod/mini` for examples of how to extend these classes. 
+All `zod/v4/core` subclasses only contain a single property: `_zod`. This property is an object containing the schemas _internals_. The goal is to make `zod/v4/core` as extensible and unopinionated as possible. Other libraries can "build their own Zod" on top of these classes without `zod/v4/core` cluttering up the interface. Refer to the implementations of `zod` and `zod/mini` for examples of how to extend these classes.
 
 The `_zod` internals property contains some notable properties:
 
-- `.def` — The schema's *definition*: this is the object you pass into the class's constructor to create an instance. It completely describes the schema, and it's JSON-serializable.
+- `.def` — The schema's _definition_: this is the object you pass into the class's constructor to create an instance. It completely describes the schema, and it's JSON-serializable.
   - `.def.type` — A string representing the schema's type, e.g. `"string"`, `"object"`, `"array"`, etc.
-  - `.def.checks` — An array of *checks* that are executed by the schema after parsing.
-- `.input` — A virtual property that "stores" the schema's *inferred input type*.
-- `.output` — A virtual property that "stores" the schema's *inferred output type*.
+  - `.def.checks` — An array of _checks_ that are executed by the schema after parsing.
+- `.input` — A virtual property that "stores" the schema's _inferred input type_.
+- `.output` — A virtual property that "stores" the schema's _inferred output type_.
 - `.run()` — The schema's internal parser implementation.
 
 If you are implementing a tool (say, a code generator) that must traverse Zod schemas, you can cast any schema to `$ZodTypes` and use the `def` property to discriminate between these classes.
@@ -196,7 +199,7 @@ export function walk(_schema: z.$ZodType) {
 }
 ```
 
-There are a number of subclasses of `$ZodString` that implement various *string formats*. These are exported as `z.$ZodStringFormatTypes`.
+There are a number of subclasses of `$ZodString` that implement various _string formats_. These are exported as `z.$ZodStringFormatTypes`.
 
 ```ts
 export type $ZodStringFormatTypes =
@@ -222,11 +225,10 @@ export type $ZodStringFormatTypes =
   | $ZodBase64
   | $ZodBase64URL
   | $ZodE164
-  | $ZodJWT
+  | $ZodJWT;
 ```
 
-
-## Parsing 
+## Parsing
 
 As the Zod Core schema classes have no methods, there are top-level functions for parsing data.
 
@@ -240,10 +242,9 @@ await z.parseAsync(schema, "hello");
 await z.safeParseAsync(schema, "hello");
 ```
 
-
 ## Checks
 
-Every Zod schema contains an array of *checks*. These perform post-parsing refinements (and occasionally mutations) that *do not affect* the inferred type.
+Every Zod schema contains an array of _checks_. These perform post-parsing refinements (and occasionally mutations) that _do not affect_ the inferred type.
 
 ```ts
 const schema = z.string().check(z.email()).check(z.min(5));
@@ -257,13 +258,15 @@ The base class for all Zod checks is `$ZodCheck`. It accepts a single generic pa
 
 ```ts
 export class $ZodCheck<in T = unknown> {
-  _zod: { /* internals */}
+  _zod: {
+    /* internals */
+  };
 }
 ```
 
 The `_zod` internals property contains some notable properties:
 
-- `.def` — The check's *definition*: this is the object you pass into the class's constructor to create the check. It completely describes the check, and it's JSON-serializable.
+- `.def` — The check's _definition_: this is the object you pass into the class's constructor to create the check. It completely describes the check, and it's JSON-serializable.
   - `.def.check` — A string representing the check's type, e.g. `"min_length"`, `"less_than"`, `"string_format"`, etc.
 - `.check()` — Contains the check's validation logic.
 
@@ -285,9 +288,8 @@ export type $ZodChecks =
   | $ZodCheckProperty
   | $ZodCheckMimeType
   | $ZodCheckOverwrite
-  | $ZodCheckStringFormat
+  | $ZodCheckStringFormat;
 ```
-
 
 You can use the `._zod.def.check` property to discriminate between these classes.
 
@@ -303,8 +305,7 @@ switch (def.check) {
 }
 ```
 
-
-As with schema types, there are a number of subclasses of `$ZodCheckStringFormat` that implement various *string formats*. 
+As with schema types, there are a number of subclasses of `$ZodCheckStringFormat` that implement various _string formats_.
 
 ```ts
 export type $ZodStringFormatChecks =
@@ -339,7 +340,6 @@ export type $ZodStringFormatChecks =
   | $ZodJWT;
 ```
 
-
 Use a nested `switch` to discriminate between the different string format checks.
 
 ```ts
@@ -358,35 +358,35 @@ switch (def.check) {
       switch (formatCheckDef.format) {
         case "email":
         case "url":
-          // do stuff
+        // do stuff
       }
     }
     break;
 }
 ```
 
-You'll notice some of these string format *checks* overlap with the string format *types* above. That's because these classes implement both the `$ZodCheck` and `$ZodType` interfaces. That is, they can be used as either a check or a type. In these cases, both `._zod.parse` (the schema parser) and `._zod.check` (the check validation) are executed during parsing. In effect, the instance is prepended to its own `checks` array (though it won't actually exist in `._zod.def.checks`).
+You'll notice some of these string format _checks_ overlap with the string format _types_ above. That's because these classes implement both the `$ZodCheck` and `$ZodType` interfaces. That is, they can be used as either a check or a type. In these cases, both `._zod.parse` (the schema parser) and `._zod.check` (the check validation) are executed during parsing. In effect, the instance is prepended to its own `checks` array (though it won't actually exist in `._zod.def.checks`).
 
 ```ts
 // as a type
 z.email().parse("user@example.com");
 
 // as a check
-z.string().check(z.email()).parse("user@example.com")
+z.string().check(z.email()).parse("user@example.com");
 ```
 
 ## Errors
 
 The base class for all errors in Zod is `$ZodError`.
 
-> For performance reasons, `$ZodError` *does not* extend the built-in `Error` class! So using `instanceof Error` will return `false`.
+> For performance reasons, `$ZodError` _does not_ extend the built-in `Error` class! So using `instanceof Error` will return `false`.
 
 - The `zod` package implements a subclass of `$ZodError` called `ZodError` with some additional convenience methods.
 - The `zod/mini` sub-package directly uses `$ZodError`
 
 ```ts
 export class $ZodError<T = unknown> implements Error {
- public issues: $ZodIssue[];
+  public issues: $ZodIssue[];
 }
 ```
 
@@ -418,12 +418,11 @@ export type $ZodIssue =
   | $ZodIssueInvalidElement
   | $ZodIssueInvalidValue
   | $ZodIssueCustom;
-  ```
+```
 
 For details on each type, refer to [the implementation](https://github.com/colinhacks/zod/blob/main/packages/zod/src/v4/core/errors.ts).
 
-
-{/* ## Best practices
+{/\* ## Best practices
 
 If you're reading this page, you're likely trying to build some kind of tool or library on top of Zod. This section breaks down some best practices for doing so.
 
@@ -435,7 +434,6 @@ Zod implements the [Standard Schema](https://standardschema.dev/) specification,
 
 If your tool accepts Zod schemas from a consumer/user, you should add `"zod/v4/core"` to `peerDependencies`. This lets your users "bring their own Zod". Be as flexible as possible with the version range. For example, if your tool is compatible with `zod/v4/core`, you can use the following. This allows your users to bring any version of `zod/v4/core`, avoiding accidental duplicate installs.
 
-
 ```json
 {
   "peerDependencies": {
@@ -446,7 +444,7 @@ If your tool accepts Zod schemas from a consumer/user, you should add `"zod/v4/c
 
 Since package managers generally won't install your own `peerDependencies`, you'll need to add `zod/v4/core` to your `devDependencies` as well. As new versions of `zod/v4/core` are released, you can update your `devDependencies` to match the latest version. This is important for testing and development purposes.
 
-```json
+````json
 {
   "peerDependencies": {
     "zod": "*"
@@ -457,3 +455,4 @@ Since package managers generally won't install your own `peerDependencies`, you'
 }
 ``` */}
 
+````

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -3,11 +3,13 @@ title: Zod Mini
 description: "Zod Mini - a tree-shakable Zod"
 ---
 
-import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
-import { Callout } from 'fumadocs-ui/components/callout';
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Callout } from "fumadocs-ui/components/callout";
 
 <Callout type="info">
-  **Note** — The docs for Zod Mini are interleaved with the regular Zod docs via tabbed code blocks. This page is designed to explain why Zod Mini exists, when to use it, and some key differences from regular Zod.
+  **Note** — The docs for Zod Mini are interleaved with the regular Zod docs via
+  tabbed code blocks. This page is designed to explain why Zod Mini exists, when
+  to use it, and some key differences from regular Zod.
 </Callout>
 
 Zod Mini variant was introduced with the release of Zod 4. To try it:
@@ -22,7 +24,7 @@ To import it:
 import * as z from "zod/mini";
 ```
 
-Zod Mini implements the exact same functionality as `zod`, but using a *functional*, *tree-shakable* API. If you're coming from `zod`, this means you generally will use *functions* in place of methods.
+Zod Mini implements the exact same functionality as `zod`, but using a _functional_, _tree-shakable_ API. If you're coming from `zod`, this means you generally will use _functions_ in place of methods.
 
 ```ts
 // regular Zod
@@ -34,13 +36,13 @@ const mySchema = z.nullable(z.optional(z.string()));
 
 ## Tree-shaking
 
-Tree-shaking is a technique used by modern bundlers to remove unused code from the final bundle. It's also referred to as *dead-code elimination*.
+Tree-shaking is a technique used by modern bundlers to remove unused code from the final bundle. It's also referred to as _dead-code elimination_.
 
 In regular Zod, schemas provide a range of convenience methods to perform some common operations (e.g. `.min()` on string schemas). Bundlers are generally not able to remove ("treeshake") unused method implementations from your bundle, but they are able to remove unused top-level functions. As such, the API of Zod Mini uses more functions than methods.
 
 ```ts
 // regular Zod
-z.string().min(5).max(10).trim()
+z.string().min(5).max(10).trim();
 
 // Zod Mini
 z.string().check(z.minLength(5), z.maxLength(10), z.trim());
@@ -49,15 +51,15 @@ z.string().check(z.minLength(5), z.maxLength(10), z.trim());
 To give a general idea about the bundle size reduction, consider this simple script:
 
 ```ts
-z.boolean().parse(true)
+z.boolean().parse(true);
 ```
 
 Bundling this with Zod and Zod Mini results in the following bundle sizes. Zod Mini results in a 64% reduction.
 
-| Package | Bundle size (gzip) |
-|---------|-------------|
-| Zod Mini | `2.12kb` |
-| Zod | `5.91kb` |
+| Package  | Bundle size (gzip) |
+| -------- | ------------------ |
+| Zod Mini | `2.12kb`           |
+| Zod      | `5.91kb`           |
 
 With a marginally more complex schema that involves object types:
 
@@ -71,16 +73,16 @@ schema.parse({
 });
 ```
 
-| Package | Bundle size (gzip) |
-|---------|-------------|
-| Zod Mini | `4.0kb` |
-| Zod | `13.1kb` |
+| Package  | Bundle size (gzip) |
+| -------- | ------------------ |
+| Zod Mini | `4.0kb`            |
+| Zod      | `13.1kb`           |
 
 This gives you a sense of the bundle sizes involved. Look closely at these numbers and run your own benchmarks to determine if using Zod Mini is worth it for your use case.
 
 ## When (not) to use Zod Mini
 
-In general you should probably use regular Zod unless you have uncommonly strict constraints around bundle size. Many developers massively overestimate the importance of bundle size to application performance. In practice, bundle size on the scale of Zod (`5-10kb` typically) is only a meaningful concern when optimizing front-end bundles for a user base with slow mobile network connections in rural or developing areas. 
+In general you should probably use regular Zod unless you have uncommonly strict constraints around bundle size. Many developers massively overestimate the importance of bundle size to application performance. In practice, bundle size on the scale of Zod (`5-10kb` typically) is only a meaningful concern when optimizing front-end bundles for a user base with slow mobile network connections in rural or developing areas.
 
 Let's run through some considerations:
 
@@ -92,16 +94,16 @@ The API of Zod Mini is more verbose and less discoverable. The methods in Zod's 
 
 If you are using Zod on the backend, bundle size on the scale of Zod is not meaningful. This is true even in resource-constrained environments like Lambda. [This post](https://medium.com/@adtanasa/size-is-almost-all-that-matters-for-optimizing-aws-lambda-cold-starts-cad54f65cbb) benchmarks cold start times with bundles of various sizes. Here is a subset of the results:
 
-| Bundle size | Lambda cold start time |
-|-------------|----------------|
-| `1kb` | `171ms` |
+| Bundle size                           | Lambda cold start time   |
+| ------------------------------------- | ------------------------ |
+| `1kb`                                 | `171ms`                  |
 | `17kb` (size of gzipped non-Mini Zod) | `171.6ms` (interpolated) |
-| `128kb` | `176ms` |
-| `256kb` | `182ms` |
-| `512kb` | `279ms` |
-| `1mb` | `557ms` |
+| `128kb`                               | `176ms`                  |
+| `256kb`                               | `182ms`                  |
+| `512kb`                               | `279ms`                  |
+| `1mb`                                 | `557ms`                  |
 
-The minimum cold start time for a negligible `1kb` bundle is `171ms`. The next bundle size tested is `128kb`, which added only `5ms`. When gzipped, the bundle size for the entirely of regular Zod is roughly `17kb`, which would correspond to a `0.6ms` increase in startup time. 
+The minimum cold start time for a negligible `1kb` bundle is `171ms`. The next bundle size tested is `128kb`, which added only `5ms`. When gzipped, the bundle size for the entirely of regular Zod is roughly `17kb`, which would correspond to a `0.6ms` increase in startup time.
 
 ### Internet speed
 
@@ -111,20 +113,19 @@ Generally, the round trip time to the server (`100-200ms`) will dwarf the time r
 
 All Zod Mini schemas extend the `z.ZodMiniType` base class, which in turn extends `z.core.$ZodType` from [`zod/v4/core`](/packages/core). While this class implements far fewer methods than `ZodType` in `zod`, some particularly useful methods remain.
 
-
 ### `.parse`
 
 This is an obvious one. All Zod Mini schemas implement the same parsing methods as `zod`.
 
 ```ts
-import * as z from "zod/mini"
+import * as z from "zod/mini";
 
 const mySchema = z.string();
 
-mySchema.parse('asdf')
-await mySchema.parseAsync('asdf')
-mySchema.safeParse('asdf')
-await mySchema.safeParseAsync('asdf')
+mySchema.parse("asdf");
+await mySchema.parseAsync("asdf");
+mySchema.safeParse("asdf");
+await mySchema.safeParseAsync("asdf");
 ```
 
 ### `.check()`
@@ -137,20 +138,20 @@ import * as z from "zod";
 z.string()
   .min(5)
   .max(10)
-  .refine(val => val.includes("@"))
-  .trim()
+  .refine((val) => val.includes("@"))
+  .trim();
 ```
 
 In Zod Mini such methods aren't implemented. Instead you pass these checks into schemas using the `.check()` method:
 
 ```ts
-import * as z from "zod/mini"
+import * as z from "zod/mini";
 
 z.string().check(
-  z.minLength(5), 
+  z.minLength(5),
   z.maxLength(10),
-  z.refine(val => val.includes("@")),
-  z.trim()
+  z.refine((val) => val.includes("@")),
+  z.trim(),
 );
 ```
 
@@ -182,11 +183,11 @@ z.property(key, schema);
 z.mime(value);
 
 // custom checks
-z.refine()
-z.check()   // replaces .superRefine()
+z.refine();
+z.check(); // replaces .superRefine()
 
 // mutations (these do not change the inferred types)
-z.overwrite(value => newValue);
+z.overwrite((value) => newValue);
 z.normalize();
 z.trim();
 z.toLowerCase();
@@ -202,28 +203,27 @@ z.describe("...");
 For registering a schema in a [registry](/metadata#registries).
 
 ```ts
-const myReg = z.registry<{title: string}>();
+const myReg = z.registry<{ title: string }>();
 
 z.string().register(myReg, { title: "My cool string schema" });
 ```
 
 ### `.brand()`
 
-For *branding* a schema. Refer to the [Branded types](/api#branded-types) docs for more information.
+For _branding_ a schema. Refer to the [Branded types](/api#branded-types) docs for more information.
 
 ```ts
-import * as z from "zod/mini"
+import * as z from "zod/mini";
 
 const USD = z.string().brand("USD");
 ```
-
 
 ### `.clone(def)`
 
 Returns an identical clone of the current schema using the provided `def`.
 
 ```ts
-const mySchema = z.string()
+const mySchema = z.string();
 
 mySchema.clone(mySchema._zod.def);
 ```
@@ -235,7 +235,7 @@ While regular Zod automatically loads the English (`en`) locale, Zod Mini does n
 This means, by default the `message` property of all issues will simply read `"Invalid input"`. To load the English locale:
 
 ```ts
-import * as z from "zod/mini"
+import * as z from "zod/mini";
 
 z.config(z.locales.en());
 ```

--- a/packages/docs/content/packages/zod.mdx
+++ b/packages/docs/content/packages/zod.mdx
@@ -3,7 +3,7 @@ title: Zod
 description: "Internals and structure of the Zod library"
 ---
 
-The `zod/v4` package is the "flagship" library of the Zod ecosystem. It strikes a balance between developer experience and bundle size that's ideal for the vast majority of applications. 
+The `zod/v4` package is the "flagship" library of the Zod ecosystem. It strikes a balance between developer experience and bundle size that's ideal for the vast majority of applications.
 
 > If you have uncommonly strict constraints around bundle size, consider [Zod Mini](/packages/mini).
 
@@ -22,10 +22,7 @@ const schema = z.object({
 The API relies on methods to provide a concise, chainable, autocomplete-friendly way to define complex types.
 
 ```ts
-z.string()
-  .min(5)
-  .max(10)
-  .toLowerCase();
+z.string().min(5).max(10).toLowerCase();
 ```
 
 All schemas extend the `z.ZodType` base class, which in turn extends `z.$ZodType` from [`zod/v4/core`](/packages/core). All instance of `ZodType` implement the following methods:
@@ -40,7 +37,6 @@ mySchema.parse(data);
 mySchema.safeParse(data);
 mySchema.parseAsync(data);
 mySchema.safeParseAsync(data);
-
 
 // refinements
 mySchema.refine(refinementFunc);

--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -6,7 +6,7 @@ description: "Complete changelog and migration guide for upgrading from Zod 3 to
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
 
-This migration guide aims to list the breaking changes in Zod 4 in order of highest to lowest impact. To learn more about the performance enhancements and new features of Zod 4, read the [introductory post](/v4). 
+This migration guide aims to list the breaking changes in Zod 4 in order of highest to lowest impact. To learn more about the performance enhancements and new features of Zod 4, read the [introductory post](/v4).
 
 {/* To give the ecosystem time to migrate, Zod 4 will initially be published alongside Zod v3.25. To use Zod 4, upgrade to `zod@3.25.0` or later: */}
 
@@ -14,9 +14,9 @@ This migration guide aims to list the breaking changes in Zod 4 in order of high
 npm install zod@^4.0.0
 ```
 
-{/* Zod 4 is available at the `"/v4"` subpath:
+{/\* Zod 4 is available at the `"/v4"` subpath:
 
-```ts
+````ts
 import * as z from "zod";
 ``` */}
 
@@ -27,12 +27,12 @@ Many of Zod's behaviors and APIs have been made more intuitive and cohesive. The
 </Callout>
 
 <Callout>
-**Unofficial codemod** — A community-maintained codemod [`zod-v3-to-v4`](https://github.com/nicoespeon/zod-v3-to-v4) is available. 
+**Unofficial codemod** — A community-maintained codemod [`zod-v3-to-v4`](https://github.com/nicoespeon/zod-v3-to-v4) is available.
 </Callout>
 
 ## Error customization
 
-Zod 4 standardizes the APIs for error customization under a single, unified `error` param. Previously Zod's error customization APIs were fragmented and inconsistent. This is cleaned up in Zod 4. 
+Zod 4 standardizes the APIs for error customization under a single, unified `error` param. Previously Zod's error customization APIs were fragmented and inconsistent. This is cleaned up in Zod 4.
 
 ### deprecates `message` parameter
 
@@ -42,7 +42,8 @@ Replaces `message` param with `error`. The old `message` parameter is still supp
 <Tab value="Zod 4">
 ```ts
 z.string().min(5, { error: "Too short." });
-```
+````
+
 </Tab>
 <Tab value="Zod 3">
 ```ts
@@ -53,9 +54,9 @@ z.string().min(5, { message: "Too short." });
 
 ### drops `invalid_type_error` and `required_error`
 
-The `invalid_type_error` / `required_error` params have been dropped. These were hastily added years ago as a way to customize errors that was less verbose than `errorMap`. They came with all sorts of footguns (they can't be used in conjunction with `errorMap`) and do not align with Zod's actual issue codes (there is no `required` issue code). 
+The `invalid_type_error` / `required_error` params have been dropped. These were hastily added years ago as a way to customize errors that was less verbose than `errorMap`. They came with all sorts of footguns (they can't be used in conjunction with `errorMap`) and do not align with Zod's actual issue codes (there is no `required` issue code).
 
-These can now be cleanly represented with the new `error` parameter. 
+These can now be cleanly represented with the new `error` parameter.
 
 <Tabs groupId="error-type" items={["Zod 4", "Zod 3"]} persist>
 <Tab value="Zod 4">
@@ -79,7 +80,7 @@ z.string({
 
 ### drops `errorMap`
 
-This is renamed to `error`. 
+This is renamed to `error`.
 
 Error maps can also now return a plain `string` (instead of `{message: string}`). They can also return `undefined`, which tells Zod to yield control to the next error map in the chain.
 
@@ -109,16 +110,16 @@ z.string({
 </Tab>
 </Tabs>
 
-{/* ## `.safeParse()` 
+{/\* ## `.safeParse()`
 
-For performance reasons, the errors returned by `.safeParse()` and `.safeParseAsync()` no longer extend `Error`. 
+For performance reasons, the errors returned by `.safeParse()` and `.safeParseAsync()` no longer extend `Error`.
 
 ```ts
-const result = z.string().safeParse(12); 
+const result = z.string().safeParse(12);
 result.error! instanceof Error; // => false
 ```
 
-It is very slow to instantiate `Error` instances in JavaScript, as the initialization process snapshots the call stack. In the case of Zod's "safe" parse methods, it's expected that you will handle errors at the point of parsing, so instantiating a true `Error` object adds little value anyway. 
+It is very slow to instantiate `Error` instances in JavaScript, as the initialization process snapshots the call stack. In the case of Zod's "safe" parse methods, it's expected that you will handle errors at the point of parsing, so instantiating a true `Error` object adds little value anyway.
 
 > Pro tip: prefer `.safeParse()` over `try/catch` in performance-sensitive code.
 
@@ -131,11 +132,14 @@ try {
   console.log(err instanceof Error); // => true
 }
 ```
- */}
+
+\*/}
 
 ## `ZodError`
-{/* 
-### changes to `.message` 
+
+{/\*
+
+### changes to `.message`
 
 Previously the `.message` property on `ZodError` was a JSON.stringified copy of the `.issues` array. This was redundant, confusing, and a bit of an abuse of the `.message` property. Also due to the [`Error` prototype changes](#safeparse) (and inconsistencies in how Node.js logs `Error` subclasses vs other objects) the logging of a multi-line `.message` property got a lot uglier:
 
@@ -152,7 +156,6 @@ ZodError {
     ']'
 }
 ```
-
 
 For these reasons, the `.message` property is left empty and the `.issues` array is marked as enumerable. This keeps error logging consistent and pretty:
 
@@ -172,16 +175,16 @@ ZodError {
 }
 ```
 
-Vitest uses special handling for `Error` subclasses that ignores enumerable properties.  */}
+Vitest uses special handling for `Error` subclasses that ignores enumerable properties. \*/}
 
 ### updates issue formats
 
-The issue formats have been dramatically streamlined. 
+The issue formats have been dramatically streamlined.
 
 ```ts
 import * as z from "zod"; // v4
 
-type IssueFormats = 
+type IssueFormats =
   | z.core.$ZodIssueInvalidType
   | z.core.$ZodIssueTooBig
   | z.core.$ZodIssueTooSmall
@@ -190,7 +193,7 @@ type IssueFormats =
   | z.core.$ZodIssueUnrecognizedKeys
   | z.core.$ZodIssueInvalidValue
   | z.core.$ZodIssueInvalidUnion
-  | z.core.$ZodIssueInvalidKey // new: used for z.record/z.map 
+  | z.core.$ZodIssueInvalidKey // new: used for z.record/z.map
   | z.core.$ZodIssueInvalidElement // new: used for z.map/z.set
   | z.core.$ZodIssueCustom;
 ```
@@ -202,7 +205,7 @@ import * as z from "zod"; // v3
 
 export type IssueFormats =
   | z.ZodInvalidTypeIssue // ♻️ renamed to z.core.$ZodIssueInvalidType
-  | z.ZodTooBigIssue  // ♻️ renamed to z.core.$ZodIssueTooBig
+  | z.ZodTooBigIssue // ♻️ renamed to z.core.$ZodIssueTooBig
   | z.ZodTooSmallIssue // ♻️ renamed to z.core.$ZodIssueTooSmall
   | z.ZodInvalidStringIssue // ♻️ z.core.$ZodIssueInvalidStringFormat
   | z.ZodNotMultipleOfIssue // ♻️ renamed to z.core.$ZodIssueNotMultipleOf
@@ -216,7 +219,7 @@ export type IssueFormats =
   | z.ZodInvalidReturnTypeIssue // ❌ z.function throws ZodError directly
   | z.ZodInvalidDateIssue // ❌ merged into invalid_type
   | z.ZodInvalidIntersectionTypesIssue // ❌ removed (throws regular Error)
-  | z.ZodNotFiniteIssue // ❌ infinite values no longer accepted (invalid_type)
+  | z.ZodNotFiniteIssue; // ❌ infinite values no longer accepted (invalid_type)
 ```
 
 While certain Zod 4 issue types have been merged, dropped, and modified, each issue remains structurally similar to Zod 3 counterpart (identical, in most cases). All issues still conform to the same base interface as Zod 3, so most common error handling logic will work without modification.
@@ -232,7 +235,7 @@ export interface $ZodIssueBase {
 
 ### changes error map precedence
 
-The error map precedence has been changed to be more consistent. Specifically, an error map passed into `.parse()` *no longer* takes precedence over a schema-level error map.
+The error map precedence has been changed to be more consistent. Specifically, an error map passed into `.parse()` _no longer_ takes precedence over a schema-level error map.
 
 ```ts
 const mySchema = z.string({ error: () => "Schema-level error" });
@@ -244,15 +247,15 @@ mySchema.parse(12, { error: () => "Contextual error" }); // => "Contextual error
 mySchema.parse(12, { error: () => "Contextual error" }); // => "Schema-level error"
 ```
 
-### deprecates `.format()` 
+### deprecates `.format()`
 
-The `.format()` method on `ZodError` has been deprecated. Instead use the top-level `z.treeifyError()` function. Read the [Formatting errors docs](/error-formatting) for more information. 
+The `.format()` method on `ZodError` has been deprecated. Instead use the top-level `z.treeifyError()` function. Read the [Formatting errors docs](/error-formatting) for more information.
 
 ### deprecates `.flatten()`
 
-The `.flatten()` method on `ZodError` has also been deprecated. Instead use the top-level `z.treeifyError()` function. Read the [Formatting errors docs](/error-formatting) for more information. 
+The `.flatten()` method on `ZodError` has also been deprecated. Instead use the top-level `z.treeifyError()` function. Read the [Formatting errors docs](/error-formatting) for more information.
 
-### drops `.formErrors` 
+### drops `.formErrors`
 
 This API was identical to `.flatten()`. It exists for historical reasons and isn't documented.
 
@@ -261,16 +264,16 @@ This API was identical to `.flatten()`. It exists for historical reasons and isn
 Directly push to `err.issues` array instead, if necessary.
 
 ```ts
-myError.issues.push({ 
+myError.issues.push({
   // new issue
 });
 ```
 
-{/* ## `.and()` dropped
+{/\* ## `.and()` dropped
 
-The `.and()` method on `ZodType` has been dropped in favor of `z.intersection(A, B)`. Not only is this method rarely used, there are few good reasons to use intersections at all. The `.and()` API prevented bundlers from treeshaking `ZodIntersection`, a fairly large and complex class. 
+The `.and()` method on `ZodType` has been dropped in favor of `z.intersection(A, B)`. Not only is this method rarely used, there are few good reasons to use intersections at all. The `.and()` API prevented bundlers from treeshaking `ZodIntersection`, a fairly large and complex class.
 
-```ts
+````ts
 z.object({ a: z.string() }).and(z.object({ b: z.number() })); // ❌
 
 // use z.intersection
@@ -318,13 +321,13 @@ z.iso.date();
 z.iso.time();
 z.iso.datetime();
 z.iso.duration();
-```
+````
 
 The method forms (`z.string().email()`) still exist and work as before, but are now deprecated.
 
 ```ts
 z.string().email(); // ❌ deprecated
-z.email(); // ✅ 
+z.email(); // ✅
 ```
 
 ### stricter `.uuid()`
@@ -336,37 +339,37 @@ z.uuid(); // RFC 9562/4122 compliant UUID
 z.guid(); // any 8-4-4-4-12 hex pattern
 ```
 
-### no padding in `.base64url()` 
+### no padding in `.base64url()`
 
-Padding is no longer allowed in `z.base64url()` (formerly `z.string().base64url()`). Generally it's desirable for base64url strings to be unpadded and URL-safe. 
+Padding is no longer allowed in `z.base64url()` (formerly `z.string().base64url()`). Generally it's desirable for base64url strings to be unpadded and URL-safe.
 
-### drops `z.string().ip()` 
+### drops `z.string().ip()`
 
 This has been replaced with separate `.ipv4()` and `.ipv6()` methods. Use `z.union()` to combine them if you need to accept both.
 
 ```ts
-z.string().ip() // ❌
-z.ipv4() // ✅
-z.ipv6() // ✅
+z.string().ip(); // ❌
+z.ipv4(); // ✅
+z.ipv6(); // ✅
 ```
 
 ### updates `z.string().ipv6()`
 
 Validation now happens using the `new URL()` constructor, which is far more robust than the old regular expression approach. Some invalid values that passed validation previously may now fail.
 
-### drops `z.string().cidr()` 
+### drops `z.string().cidr()`
 
 Similarly, this has been replaced with separate `.cidrv4()` and `.cidrv6()` methods. Use `z.union()` to combine them if you need to accept both.
 
 ```ts
-z.string().cidr() // ❌
-z.cidrv4() // ✅
-z.cidrv6() // ✅
+z.string().cidr(); // ❌
+z.cidrv4(); // ✅
+z.cidrv6(); // ✅
 ```
 
 ## `z.coerce` updates
 
-The input type of all `z.coerce` schemas is now `unknown`. 
+The input type of all `z.coerce` schemas is now `unknown`.
 
 ```ts
 const schema = z.coerce.string();
@@ -378,35 +381,37 @@ type schemaInput = z.input<typeof schema>;
 
 ## `.default()` updates
 
-The application of `.default()` has changed in a subtle way. If the input is `undefined`, `ZodDefault` short-circuits the parsing process and returns the default value. The default value must be assignable to the *output type*.
+The application of `.default()` has changed in a subtle way. If the input is `undefined`, `ZodDefault` short-circuits the parsing process and returns the default value. The default value must be assignable to the _output type_.
 
 ```ts
-const schema = z.string()
-  .transform(val => val.length)
+const schema = z
+  .string()
+  .transform((val) => val.length)
   .default(0); // should be a number
 schema.parse(undefined); // => 0
 ```
 
-In Zod 3, `.default()` expected a value that matched the *input type*. `ZodDefault` would parse the default value, instead of short-circuiting. As such, the default value must be assignable to the *input type* of the schema.
+In Zod 3, `.default()` expected a value that matched the _input type_. `ZodDefault` would parse the default value, instead of short-circuiting. As such, the default value must be assignable to the _input type_ of the schema.
 
 ```ts
 // Zod 3
-const schema = z.string()
-  .transform(val => val.length)
+const schema = z
+  .string()
+  .transform((val) => val.length)
   .default("tuna");
 schema.parse(undefined); // => 4
 ```
 
-To replicate the old behavior, Zod implements a new `.prefault()` API. This is short for "pre-parse default". 
+To replicate the old behavior, Zod implements a new `.prefault()` API. This is short for "pre-parse default".
 
 ```ts
 // Zod 3
-const schema = z.string()
-  .transform(val => val.length)
+const schema = z
+  .string()
+  .transform((val) => val.length)
   .prefault("tuna");
 schema.parse(undefined); // => 4
 ```
-
 
 ## `z.object()`
 
@@ -459,7 +464,7 @@ The `z.unknown()` and `z.any()` types are no longer marked as "key optional" in 
 ```ts
 const mySchema = z.object({
   a: z.any(),
-  b: z.unknown()
+  b: z.unknown(),
 });
 // Zod 3: { a?: any; b?: unknown };
 // Zod 4: { a: any; b: unknown };
@@ -516,7 +521,7 @@ This now behaves identically to `z.array().min(1)`. The inferred type does not c
 ```ts
 const NonEmpty = z.array(z.string()).nonempty();
 
-type NonEmpty = z.infer<typeof NonEmpty>; 
+type NonEmpty = z.infer<typeof NonEmpty>;
 // Zod 3: [string, ...string[]]
 // Zod 4: string[]
 ```
@@ -550,9 +555,10 @@ const myFunction = z.function({
 });
 
 myFunction.implement((input) => {
-  return `Hello ${input.name}, you are ${input.age} years old.`;
+return `Hello ${input.name}, you are ${input.age} years old.`;
 });
-```
+
+````
 </Tab>
 <Tab value="Zod 3">
 ```ts
@@ -566,7 +572,8 @@ const myFunction = z.function()
 myFunction.implement((input) => {
   return `Hello ${input.name}, you are ${input.age} years old.`;
 });
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -574,7 +581,7 @@ If you have a desperate need for a Zod schema with a function type, consider [th
 
 ### adds `.implementAsync()`
 
-To define an async function, use `implementAsync()` instead of `implement()`. 
+To define an async function, use `implementAsync()` instead of `implement()`.
 
 ```ts
 myFunction.implementAsync(async (input) => {
@@ -590,10 +597,10 @@ In Zod 3, passing a [type predicate](https://www.typescriptlang.org/docs/handboo
 
 ```ts
 const mySchema = z.unknown().refine((val): val is string => {
-  return typeof val === "string"
+  return typeof val === "string";
 });
 
-type MySchema = z.infer<typeof mySchema>; 
+type MySchema = z.infer<typeof mySchema>;
 // Zod 3: `string`
 // Zod 4: still `unknown`
 ```
@@ -610,20 +617,20 @@ z.string().superRefine((val, ctx) => {
 
 ### drops function as second argument
 
-The following horrifying overload has been removed. 
+The following horrifying overload has been removed.
 
 ```ts
 const longString = z.string().refine(
   (val) => val.length > 10,
-  (val) => ({ message: `${val} is not more than 10 characters` })
+  (val) => ({ message: `${val} is not more than 10 characters` }),
 );
 ```
 
-{/* ## `.superRefine()` deprecated
+{/\* ## `.superRefine()` deprecated
 
 The `.superRefine()` method has been deprecated in favor of `.check()`. The `.check()` method provides the same functionality with a cleaner API. The `.check()` method is also available on Zod and Zod Mini schemas.
 
-```ts
+````ts
 const UniqueStringArray = z.array(z.string()).check((ctx) => {
   if (ctx.value.length > 3) {
     ctx.issues.push({
@@ -651,7 +658,7 @@ const UniqueStringArray = z.array(z.string()).check((ctx) => {
 
 The undocumented convenience methods `z.ostring()`, `z.onumber()`, etc. have been removed. These were shorthand methods for defining optional string schemas.
 
-## `z.literal()` 
+## `z.literal()`
 
 ### drops `symbol` support
 
@@ -662,14 +669,14 @@ Symbols aren't considered literal values, nor can they be simply compared with `
 Previously all Zod classes defined a static `.create()` method. These are now implemented as standalone factory functions.
 
 ```ts
-z.ZodString.create(); // ❌ 
-```
+z.ZodString.create(); // ❌
+````
 
 ## `z.record()`
 
 ### drops single argument usage
 
-Before, `z.record()` could be used with a single argument. This is no longer supported. 
+Before, `z.record()` could be used with a single argument. This is no longer supported.
 
 ```ts
 // Zod 3
@@ -685,7 +692,7 @@ z.record(z.string(), z.string()); // ✅
 Records have gotten a lot smarter. In Zod 3, passing an enum into `z.record()` as a key schema would result in a partial type
 
 ```ts
-const myRecord = z.record(z.enum(["a", "b", "c"]), z.number()); 
+const myRecord = z.record(z.enum(["a", "b", "c"]), z.number());
 // { a?: number; b?: number; c?: number; }
 ```
 
@@ -705,37 +712,15 @@ const myRecord = z.partialRecord(z.enum(["a", "b", "c"]), z.number());
 
 ## `z.intersection()`
 
-
 ### throws `Error` on merge conflict
 
-Zod intersection parses the input against two schemas, then attempts to merge the results. In Zod 3, when the results were unmergeable, Zod threw a `ZodError` with a special `"invalid_intersection_types"` issue. 
+Zod intersection parses the input against two schemas, then attempts to merge the results. In Zod 3, when the results were unmergeable, Zod threw a `ZodError` with a special `"invalid_intersection_types"` issue.
 
-In Zod 4, this will throw a regular `Error` instead. The existence of unmergeable results indicates a structural problem with the schema: an intersection of two incompatible types. Thus, a regular error is more appropriate than a validation error. 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+In Zod 4, this will throw a regular `Error` instead. The existence of unmergeable results indicates a structural problem with the schema: an intersection of two incompatible types. Thus, a regular error is more appropriate than a validation error.
 
 ## Internal changes
 
-> The typical user of Zod can likely ignore everything below this line. These changes do not impact the user-facing `z` APIs. 
+> The typical user of Zod can likely ignore everything below this line. These changes do not impact the user-facing `z` APIs.
 
 There are too many internal changes to list here, but some may be relevant to regular users who are (intentionally or not) relying on certain implementation details. These changes will be of particular interest to library authors building tools on top of Zod.
 
@@ -760,17 +745,16 @@ The second generic `Def` has been entirely removed. Instead the base class now o
 ```ts
 function inferSchema<T extends z.ZodType>(schema: T): T {
   return schema;
-};
+}
 
 inferSchema(z.string()); // z.ZodString
 ```
 
 The need for `z.ZodTypeAny` has been eliminated; just use `z.ZodType` instead.
 
-
 ### adds `z.core`
 
-Many utility functions and types have been moved to the new `zod/v4/core` sub-package, to facilitate code sharing between Zod and Zod Mini. 
+Many utility functions and types have been moved to the new `zod/v4/core` sub-package, to facilitate code sharing between Zod and Zod Mini.
 
 ```ts
 import * as z from "zod/v4/core";
@@ -780,7 +764,7 @@ function handleError(iss: z.$ZodError) {
 }
 ```
 
-For convenience, the contents of `zod/v4/core` are also re-exported from `zod` and `zod/mini` under the `z.core` namespace. 
+For convenience, the contents of `zod/v4/core` are also re-exported from `zod` and `zod/mini` under the `z.core` namespace.
 
 ```ts
 import * as z from "zod";
@@ -796,24 +780,18 @@ Refer to the [Zod Core](/packages/core) docs for more information on the content
 
 The `._def` property is now moved to `._zod.def`. The structure of all internal defs is subject to change; this is relevant to library authors but won't be comprehensively documented here.
 
-
 ### drops `ZodEffects`
 
-This doesn't affect the user-facing APIs, but it's an internal change worth highlighting. It's part of a larger restructure of how Zod handles *refinements*. 
+This doesn't affect the user-facing APIs, but it's an internal change worth highlighting. It's part of a larger restructure of how Zod handles _refinements_.
 
-Previously both refinements and transformations lived inside a wrapper class called `ZodEffects`. That means adding either one to a schema would wrap the original schema in a `ZodEffects` instance. In Zod 4, refinements now live inside the schemas themselves. More accurately, each schema contains an array of "checks"; the concept of a "check" is new in Zod 4 and generalizes the concept of a refinement to include potentially side-effectful transforms like `z.toLowerCase()`. 
+Previously both refinements and transformations lived inside a wrapper class called `ZodEffects`. That means adding either one to a schema would wrap the original schema in a `ZodEffects` instance. In Zod 4, refinements now live inside the schemas themselves. More accurately, each schema contains an array of "checks"; the concept of a "check" is new in Zod 4 and generalizes the concept of a refinement to include potentially side-effectful transforms like `z.toLowerCase()`.
 
 This is particularly apparent in the Zod Mini API, which heavily relies on the `.check()` method to compose various validations together.
 
 ```ts
 import * as z from "zod/mini";
 
-z.string().check(
-  z.minLength(10),
-  z.maxLength(100),
-  z.toLowerCase(),
-  z.trim(),
-);
+z.string().check(z.minLength(10), z.maxLength(100), z.toLowerCase(), z.trim());
 ```
 
 ### adds `ZodTransform`
@@ -823,7 +801,7 @@ Meanwhile, transforms have been moved into a dedicated `ZodTransform` class. Thi
 ```ts
 import * as z from "zod";
 
-const schema = z.transform(input => String(input));
+const schema = z.transform((input) => String(input));
 
 schema.parse(12); // => "12"
 ```
@@ -831,7 +809,7 @@ schema.parse(12); // => "12"
 This is primarily used in conjunction with `ZodPipe`. The `.transform()` method now returns an instance of `ZodPipe`.
 
 ```ts
-z.string().transform(val => val); // ZodPipe<ZodString, ZodTransform>
+z.string().transform((val) => val); // ZodPipe<ZodString, ZodTransform>
 ```
 
 ### drops `ZodPreprocess`
@@ -839,30 +817,28 @@ z.string().transform(val => val); // ZodPipe<ZodString, ZodTransform>
 As with `.transform()`, the `z.preprocess()` function now returns a `ZodPipe` instance instead of a dedicated `ZodPreprocess` instance.
 
 ```ts
-z.preprocess(val => val, z.string()); // ZodPipe<ZodTransform, ZodString>
+z.preprocess((val) => val, z.string()); // ZodPipe<ZodTransform, ZodString>
 ```
 
 ### drops `ZodBranded`
 
 Branding is now handled with a direct modification to the inferred type, instead of a dedicated `ZodBranded` class. The user-facing APIs remain the same.
 
+{/\* - Dropping support for ES5
 
-{/* - Dropping support for ES5
-  - Zod relies on `Set` internally */}
+- Zod relies on `Set` internally \*/}
 
 {/* - `z.keyof` now returns `ZodEnum` instead of `ZodLiteral` */}
 
+{/\* ## Changed: `.refine()`
 
-
-{/* ## Changed: `.refine()`
-
-The `.refine()` method used to accept a function as the second argument. 
+The `.refine()` method used to accept a function as the second argument.
 
 ```ts
 // no longer supported
 const longString = z.string().refine(
   (val) => val.length > 10,
-  (val) => ({ message: `${val} is not more than 10 characters` })
+  (val) => ({ message: `${val} is not more than 10 characters` }),
 );
 ```
 
@@ -876,7 +852,7 @@ const longString = z.string().refine((val) => val.length > 10, {
  */}
 
 
-{/* 
+{/*
 - No support for `null` or `undefined` in `z.literal`
   - `z.literal(null)`
   - `z.literal(undefined)`
@@ -903,3 +879,4 @@ const longString = z.string().refine((val) => val.length > 10, {
   - ZodEnum and ZodNativeEnum are merged
   - `.Values` and `.Enum` are removed. Use `.enum` instead.
   - `.options` is removed */}
+```

--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -708,9 +708,9 @@ const myRecord = z.partialRecord(z.enum(["a", "b", "c"]), z.number());
 
 ### throws `Error` on merge conflict
 
-Zod intersection parses the input against two schemas, then attempts to merge the results. In Zod 3, when the results were unmergable, Zod threw a `ZodError` with a special `"invalid_intersection_types"` issue. 
+Zod intersection parses the input against two schemas, then attempts to merge the results. In Zod 3, when the results were unmergeable, Zod threw a `ZodError` with a special `"invalid_intersection_types"` issue. 
 
-In Zod 4, this will throw a regular `Error` instead. The existence of unmergable results indicates a structural problem with the schema: an intersection of two incompatible types. Thus, a regular error is more appropriate than a validation error. 
+In Zod 4, this will throw a regular `Error` instead. The existence of unmergeable results indicates a structural problem with the schema: an intersection of two incompatible types. Thus, a regular error is more appropriate than a validation error. 
 
 
 

--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -5,36 +5,40 @@ description: "Zod 4 release notes and new features including performance improve
 
 import { Callout } from "fumadocs-ui/components/callout";
 import { Tabs, Tab } from "fumadocs-ui/components/tabs";
-import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
+import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
 
-After a year of active development: Zod 4 is now stable! It's faster, slimmer, more `tsc`-efficient, and implements some long-requested features. 
+After a year of active development: Zod 4 is now stable! It's faster, slimmer, more `tsc`-efficient, and implements some long-requested features.
 
-<Callout icon="❤️"> 
-Huge thanks to [Clerk](https://go.clerk.com/zod-clerk), who supported my work on Zod 4 through their extremely generous [OSS Fellowship](https://clerk.com/blog/zod-fellowship). They were an amazing partner throughout the (much longer than anticipated!) development process.
+<Callout icon="❤️">
+  Huge thanks to [Clerk](https://go.clerk.com/zod-clerk), who supported my work
+  on Zod 4 through their extremely generous [OSS
+  Fellowship](https://clerk.com/blog/zod-fellowship). They were an amazing
+  partner throughout the (much longer than anticipated!) development process.
 </Callout>
 
-## Versioning 
+## Versioning
 
-{/* <Callout> 
-  **Update** — `zod@4.0.0` has now been published to npm. To upgrad
+{/\* <Callout>
+**Update** — `zod@4.0.0` has now been published to npm. To upgrad
+
 </Callout> */}
 
 {/* To simplify the migration process both for users and Zod's ecosystem of associated libraries, Zod 4 will initially published alongside Zod 3 as part of the `zod@3.25` release. Despite the version number, it is considered stable and ready for production use. */}
 
-To upgrade: 
+To upgrade:
 
 ```
 npm install zod@^4.0.0
 ```
 
-
-{/* Down the road, when there's broad support for Zod 4, we'll publish `zod@4.0.0` on npm. At this point, Zod 4 will be exported from the package root (`"zod"`). The `"zod/v4"` subpath will remain available. For a detailed writeup on the reasons for this versioning scheme, refer to [this issue](https://github.com/colinhacks/zod/issues/4371).  */}
+{/* Down the road, when there's broad support for Zod 4, we'll publish `zod@4.0.0` on npm. At this point, Zod 4 will be exported from the package root (`"zod"`). The `"zod/v4"` subpath will remain available. For a detailed writeup on the reasons for this versioning scheme, refer to [this issue](https://github.com/colinhacks/zod/issues/4371). */}
 
 For a complete list of breaking changes, refer to the [Migration guide](/v4/changelog). This post focuses on new features & enhancements.
 
-{/* A number of popular ecosystem packages have Zod 4 support ready or nearly ready. Track the following pull requests for updates:
+{/\* A number of popular ecosystem packages have Zod 4 support ready or nearly ready. Track the following pull requests for updates:
+
 - [`drizzle-zod#4478`](https://github.com/drizzle-team/drizzle-orm/pull/4478)
-- [`@hono/zod-validator#1173`](https://github.com/honojs/middleware/pull/1173) */}
+- [`@hono/zod-validator#1173`](https://github.com/honojs/middleware/pull/1173) \*/}
 
 ## Why a new major version?
 
@@ -48,7 +52,7 @@ For a scannable breakdown of what's new, see the table of contents. Click on any
 
 You can run these benchmarks yourself in the Zod repo:
 
-```sh 
+```sh
 $ git clone git@github.com:colinhacks/zod.git
 $ cd zod
 $ git switch v4
@@ -99,7 +103,7 @@ summary for z.array() parsing
 
 ### 6.5x faster object parsing
 
-This runs the [Moltar validation library benchmark](https://moltar.github.io/typescript-runtime-type-benchmarks/). 
+This runs the [Moltar validation library benchmark](https://moltar.github.io/typescript-runtime-type-benchmarks/).
 
 ```sh
 $ pnpm bench object-moltar
@@ -137,16 +141,17 @@ export const B = A.extend({
 });
 ```
 
-Compiling this file with `tsc --extendedDiagnostics` using `"zod/v3"` results in >25000 type instantiations. With `"zod/v4"` it only results in ~175. 
+Compiling this file with `tsc --extendedDiagnostics` using `"zod/v3"` results in >25000 type instantiations. With `"zod/v4"` it only results in ~175.
 
 <Callout>
 
-The Zod repo contains a `tsc` benchmarking playground. Try this for yourself using the compiler benchmarks in `packages/tsc`. The exact numbers may change as the implementation evolves. 
+The Zod repo contains a `tsc` benchmarking playground. Try this for yourself using the compiler benchmarks in `packages/tsc`. The exact numbers may change as the implementation evolves.
 
 ```sh
 $ cd packages/tsc
 $ pnpm bench object-with-extend
 ```
+
 </Callout>
 
 More importantly, Zod 4 has redesigned and simplified the generics of `ZodObject` and other schema classes to avoid some pernicious "instantiation explosions". For instance, chaining `.extend()` and `.omit()` repeatedly—something that previously caused compiler issues:
@@ -273,18 +278,18 @@ const schema = z.boolean();
 schema.parse(true);
 ```
 
-It's about as simple as it gets when it comes to validation. That's intentional; it's a good way to measure the *core bundle size*—the code that will end up in the bundle even in simple cases. We'll bundle this with `rollup` using both Zod 3 and Zod 4 and compare the final bundles. 
+It's about as simple as it gets when it comes to validation. That's intentional; it's a good way to measure the _core bundle size_—the code that will end up in the bundle even in simple cases. We'll bundle this with `rollup` using both Zod 3 and Zod 4 and compare the final bundles.
 
 | Package | Bundle (gzip) |
-|---------|--------------|
-| Zod 3   | `12.47kb`      |
-| Zod 4   | `5.36kb`       |
+| ------- | ------------- |
+| Zod 3   | `12.47kb`     |
+| Zod 4   | `5.36kb`      |
 
 The core bundle is ~57% smaller in Zod 4 (2.3x). That's good! But we can do a lot better.
 
 ## Introducing Zod Mini
 
-Zod's method-heavy API is fundamentally difficult to tree-shake. Even our simple `z.boolean()` script pulls in the implementations of a bunch of methods we didn't use, like `.optional()`, `.array()`, etc. Writing slimmer implementations can only get you so far. That's where Zod Mini comes in. 
+Zod's method-heavy API is fundamentally difficult to tree-shake. Even our simple `z.boolean()` script pulls in the implementations of a bunch of methods we didn't use, like `.optional()`, `.array()`, etc. Writing slimmer implementations can only get you so far. That's where Zod Mini comes in.
 
 ```sh
 npm install zod@^4.0.0
@@ -301,8 +306,9 @@ z.optional(z.string());
 
 z.union([z.string(), z.number()]);
 
-z.extend(z.object({ /* ... */ }), { age: z.number() });
-```
+z.extend(z.object({/* ... */}), { age: z.number() });
+
+````
 </Tab>
 <Tab value="Zod">
 ```ts
@@ -313,7 +319,8 @@ z.string().optional();
 z.string().or(z.number());
 
 z.object({ /* ... */ }).extend({ age: z.number() });
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -336,11 +343,12 @@ There's also a general-purpose `.check()` method used to add refinements.
 import * as z from "zod/mini";
 
 z.array(z.number()).check(
-  z.minLength(5), 
-  z.maxLength(10),
-  z.refine(arr => arr.includes(5))
+z.minLength(5),
+z.maxLength(10),
+z.refine(arr => arr.includes(5))
 );
-```
+
+````
 </Tab>
 <Tab value="Zod">
 ```ts
@@ -350,7 +358,8 @@ z.array(z.number())
   .min(5)
   .max(10)
   .refine(arr => arr.includes(5));
-```
+````
+
 </Tab>
 </Tabs>
 
@@ -388,15 +397,14 @@ z.property(key, schema); // for object schemas; check `input[key]` against `sche
 z.mime(value); // for file schemas (see below)
 
 // overwrites (these *do not* change the inferred type!)
-z.overwrite(value => newValue);
+z.overwrite((value) => newValue);
 z.normalize();
 z.trim();
 z.toLowerCase();
 z.toUpperCase();
 ```
 
-
-This more functional API makes it easier for bundlers to tree-shake the APIs you don't use. While regular Zod is still recommended for the majority of use cases, any projects with uncommonly strict bundle size constraints should consider Zod Mini.  
+This more functional API makes it easier for bundlers to tree-shake the APIs you don't use. While regular Zod is still recommended for the majority of use cases, any projects with uncommonly strict bundle size constraints should consider Zod Mini.
 
 ### 6.6x reduction in core bundle size
 
@@ -411,11 +419,11 @@ schema.parse(false);
 
 When we build this with `rollup`, the gzipped bundle size is `1.88kb`. That's an 85% (6.6x) reduction in core bundle size compared to `zod@3`.
 
-| Package   | Bundle (gzip) |
-|-----------|--------------|
-| Zod 3     |  `12.47kb`      |
-| Zod 4 (regular)     | `5.36kb`       |
-| Zod 4 (mini) | `1.88kb`       |
+| Package         | Bundle (gzip) |
+| --------------- | ------------- |
+| Zod 3           | `12.47kb`     |
+| Zod 4 (regular) | `5.36kb`      |
+| Zod 4 (mini)    | `1.88kb`      |
 
 Learn more on the dedicated [`zod/mini`](/packages/mini) docs page. Complete API details are mixed into existing documentation pages; code blocks contain separate tabs for `"Zod"` and `"Zod Mini"` wherever their APIs diverge.
 
@@ -429,7 +437,7 @@ import * as z from "zod";
 const myRegistry = z.registry<{ title: string; description: string }>();
 ```
 
-To add schemas to your registry: 
+To add schemas to your registry:
 
 ```ts
 const emailSchema = z.string().email();
@@ -444,7 +452,10 @@ Alternatively, you can use the `.register()` method on a schema for convenience:
 {/* > Unlike all other Zod methods, `.register()` is *not* immutable, it returns the original schema. */}
 
 ```ts
-emailSchema.register(myRegistry, { title: "Email address", description: "..." })
+emailSchema.register(myRegistry, {
+  title: "Email address",
+  description: "...",
+});
 // => returns emailSchema
 ```
 
@@ -453,12 +464,12 @@ emailSchema.register(myRegistry, { title: "Email address", description: "..." })
 Zod also exports a global registry `z.globalRegistry` that accepts some common JSON Schema-compatible metadata:
 
 ```ts
-z.globalRegistry.add(z.string(), { 
+z.globalRegistry.add(z.string(), {
   id: "email_address",
   title: "Email address",
   description: "Provide your email",
   examples: ["naomie@example.com"],
-  extraKey: "Additional properties are also allowed"
+  extraKey: "Additional properties are also allowed",
 });
 ```
 
@@ -469,7 +480,7 @@ To conveniently add a schema to `z.globalRegistry`, use the `.meta()` method.
 {/* > Unlike `.register()`, `.meta()` *is* immutable; it returns a new instance (a clone of the original schema). */}
 
 ```ts
-z.string().meta({ 
+z.string().meta({
   id: "email_address",
   title: "Email address",
   description: "Provide your email",
@@ -487,6 +498,7 @@ z.string().describe("An email address");
 // equivalent to
 z.string().meta({ description: "An email address" });
 ```
+
 </Callout>
 
 ## JSON Schema conversion
@@ -496,7 +508,7 @@ Zod 4 introduces first-party JSON Schema conversion via `z.toJSONSchema()`.
 ```ts
 import * as z from "zod";
 
-const mySchema = z.object({name: z.string(), points: z.number()});
+const mySchema = z.object({ name: z.string(), points: z.number() });
 
 z.toJSONSchema(mySchema);
 // => {
@@ -528,7 +540,6 @@ z.toJSONSchema(mySchema);
 //   },
 //   required: [ 'firstName', 'lastName', 'age' ]
 // }
-
 ```
 
 Refer to the [JSON Schema docs](/json-schema) for information on customizing the generated JSON Schema.
@@ -540,37 +551,37 @@ This was an unexpected one. After years of trying to crack this problem, I final
 ```ts
 const Category = z.object({
   name: z.string(),
-  get subcategories(){
-    return z.array(Category)
-  }
+  get subcategories() {
+    return z.array(Category);
+  },
 });
 
 type Category = z.infer<typeof Category>;
 // { name: string; subcategories: Category[] }
 ```
 
-You can also represent *mutually recursive types*:
+You can also represent _mutually recursive types_:
 
 ```ts
 const User = z.object({
   email: z.email(),
-  get posts(){
-    return z.array(Post)
-  }
+  get posts() {
+    return z.array(Post);
+  },
 });
 
 const Post = z.object({
   title: z.string(),
-  get author(){
-    return User
-  }
+  get author() {
+    return User;
+  },
 });
 ```
 
-Unlike the Zod 3 pattern for recursive types, there's no type casting required. The resulting schemas are plain `ZodObject` instances and have the full set of methods available. 
+Unlike the Zod 3 pattern for recursive types, there's no type casting required. The resulting schemas are plain `ZodObject` instances and have the full set of methods available.
 
 ```ts
-Post.pick({ title: true })
+Post.pick({ title: true });
 Post.partial();
 Post.extend({ publishDate: z.date() });
 ```
@@ -589,7 +600,7 @@ fileSchema.mime(["image/png"]); // MIME type
 
 ## Internationalization
 
-Zod 4 introduces a new `locales` API for globally translating error messages into different languages. 
+Zod 4 introduces a new `locales` API for globally translating error messages into different languages.
 
 ```ts
 import * as z from "zod";
@@ -602,32 +613,32 @@ See the full list of supported locales in [Customizing errors](/error-customizat
 
 ## Error pretty-printing
 
-The popularity of the [`zod-validation-error`](https://www.npmjs.com/package/zod-validation-error) package demonstrates that there's significant demand for an official API for pretty-printing errors. If you are using that package currently, by all means continue using it. 
+The popularity of the [`zod-validation-error`](https://www.npmjs.com/package/zod-validation-error) package demonstrates that there's significant demand for an official API for pretty-printing errors. If you are using that package currently, by all means continue using it.
 
 Zod now implements a top-level `z.prettifyError` function for converting a `ZodError` to a user-friendly formatted string.
 
 ```ts
 const myError = new z.ZodError([
   {
-    code: 'unrecognized_keys',
-    keys: [ 'extraField' ],
+    code: "unrecognized_keys",
+    keys: ["extraField"],
     path: [],
-    message: 'Unrecognized key: "extraField"'
+    message: 'Unrecognized key: "extraField"',
   },
   {
-    expected: 'string',
-    code: 'invalid_type',
-    path: [ 'username' ],
-    message: 'Invalid input: expected string, received number'
+    expected: "string",
+    code: "invalid_type",
+    path: ["username"],
+    message: "Invalid input: expected string, received number",
   },
   {
-    origin: 'number',
-    code: 'too_small',
+    origin: "number",
+    code: "too_small",
     minimum: 0,
     inclusive: true,
-    path: [ 'favoriteNumbers', 1 ],
-    message: 'Too small: expected number to be >=0'
-  }
+    path: ["favoriteNumbers", 1],
+    message: "Too small: expected number to be >=0",
+  },
 ]);
 
 z.prettifyError(myError);
@@ -694,7 +705,6 @@ z.email({ pattern: z.regexes.unicodeEmail });
 
 Zod 4 implements `z.templateLiteral()`. Template literal types are perhaps the biggest feature of TypeScript's type system that wasn't previously representable.
 
-
 ```ts
 const hello = z.templateLiteral(["hello, ", z.string()]);
 // `hello, ${string}`
@@ -703,11 +713,7 @@ const cssUnits = z.enum(["px", "em", "rem", "%"]);
 const css = z.templateLiteral([z.number(), cssUnits]);
 // `${number}px` | `${number}em` | `${number}rem` | `${number}%`
 
-const email = z.templateLiteral([
-  z.string().min(1),
-  "@",
-  z.string().max(64),
-]);
+const email = z.templateLiteral([z.string().min(1), "@", z.string().max(64)]);
 // `${string}@${string}` (the min/max refinements are enforced!)
 ```
 
@@ -720,18 +726,18 @@ Read the [template literal docs](/api#template-literals) for more info.
 New numeric "formats" have been added for representing fixed-width integer and float types. These return a `ZodNumber` instance with proper inclusive minimum/maximum constraints already added.
 
 ```ts
-z.int();      // [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]
-z.float32();  // [-3.4028234663852886e38, 3.4028234663852886e38]
-z.float64();  // [-1.7976931348623157e308, 1.7976931348623157e308]
-z.int32();    // [-2147483648, 2147483647]
-z.uint32();   // [0, 4294967295]
+z.int(); // [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER]
+z.float32(); // [-3.4028234663852886e38, 3.4028234663852886e38]
+z.float64(); // [-1.7976931348623157e308, 1.7976931348623157e308]
+z.int32(); // [-2147483648, 2147483647]
+z.uint32(); // [0, 4294967295]
 ```
 
 Similarly the following `bigint` numeric formats have also been added. These integer types exceed what can be safely represented by a `number` in JavaScript, so these return a `ZodBigInt` instance with the proper inclusive minimum/maximum constraints already added.
 
 ```ts
-z.int64();    // [-9223372036854775808n, 9223372036854775807n]
-z.uint64();   // [0n, 18446744073709551615n]
+z.int64(); // [-9223372036854775808n, 9223372036854775807n]
+z.uint64(); // [0n, 18446744073709551615n]
 ```
 
 ## Stringbool
@@ -743,19 +749,19 @@ This is still a good API, and its behavior aligns with the other `z.coerce` APIs
 ```ts
 const strbool = z.stringbool();
 
-strbool.parse("true")         // => true
-strbool.parse("1")            // => true
-strbool.parse("yes")          // => true
-strbool.parse("on")           // => true
-strbool.parse("y")            // => true
-strbool.parse("enabled")      // => true
+strbool.parse("true"); // => true
+strbool.parse("1"); // => true
+strbool.parse("yes"); // => true
+strbool.parse("on"); // => true
+strbool.parse("y"); // => true
+strbool.parse("enabled"); // => true
 
-strbool.parse("false");       // => false
-strbool.parse("0");           // => false
-strbool.parse("no");          // => false
-strbool.parse("off");         // => false
-strbool.parse("n");           // => false
-strbool.parse("disabled");    // => false
+strbool.parse("false"); // => false
+strbool.parse("0"); // => false
+strbool.parse("no"); // => false
+strbool.parse("off"); // => false
+strbool.parse("n"); // => false
+strbool.parse("disabled"); // => false
 
 strbool.parse(/* anything else */); // ZodError<[{ code: "invalid_value" }]>
 ```
@@ -765,15 +771,15 @@ To customize the truthy and falsy values:
 ```ts
 z.stringbool({
   truthy: ["yes", "true"],
-  falsy: ["no", "false"]
-})
+  falsy: ["no", "false"],
+});
 ```
 
 Refer to the [`z.stringbool()` docs](/api#stringbool) for more information.
 
 ## Simplified error customization
 
-The majority of breaking changes in Zod 4 involve the *error customization* APIs. They were a bit of a mess in Zod 3; Zod 4 makes things significantly more elegant, to the point where I think it's worth highlighting here. 
+The majority of breaking changes in Zod 4 involve the _error customization_ APIs. They were a bit of a mess in Zod 3; Zod 4 makes things significantly more elegant, to the point where I think it's worth highlighting here.
 
 Long story short, there is now a single, unified `error` parameter for customizing errors, replacing the following APIs:
 
@@ -788,22 +794,22 @@ Replace `invalid_type_error` and `required_error` with `error` (function syntax)
 
 ```diff
 // Zod 3
-- z.string({ 
--   required_error: "This field is required" 
--   invalid_type_error: "Not a string", 
+- z.string({
+-   required_error: "This field is required"
+-   invalid_type_error: "Not a string",
 - });
 
-// Zod 4 
-+ z.string({ error: (issue) => issue.input === undefined ? 
+// Zod 4
++ z.string({ error: (issue) => issue.input === undefined ?
 +  "This field is required" :
-+  "Not a string" 
++  "Not a string"
 + });
 ```
 
 Replace `errorMap` with `error` (function syntax):
 
 ```diff
-// Zod 3 
+// Zod 3
 - z.string({
 -   errorMap: (issue, ctx) => {
 -     if (issue.code === "too_small") {
@@ -834,31 +840,34 @@ const MyResult = z.discriminatedUnion("status", [
   // union discriminator
   z.object({ status: z.union([z.literal("bbb"), z.literal("ccc")]) }),
   // pipe discriminator
-  z.object({ status: z.literal("fail").transform(val => val.toUpperCase()) }),
+  z.object({ status: z.literal("fail").transform((val) => val.toUpperCase()) }),
 ]);
 ```
 
-Perhaps most importantly, discriminated unions now *compose*—you can use one discriminated union as a member of another.
+Perhaps most importantly, discriminated unions now _compose_—you can use one discriminated union as a member of another.
 
 ```ts
-const BaseError = z.object({ status: z.literal("failed"), message: z.string() });
+const BaseError = z.object({
+  status: z.literal("failed"),
+  message: z.string(),
+});
 
 const MyResult = z.discriminatedUnion("status", [
   z.object({ status: z.literal("success"), data: z.string() }),
   z.discriminatedUnion("code", [
     BaseError.extend({ code: z.literal(400) }),
     BaseError.extend({ code: z.literal(401) }),
-    BaseError.extend({ code: z.literal(500) })
-  ])
+    BaseError.extend({ code: z.literal(500) }),
+  ]),
 ]);
 ```
 
 ## Multiple values in `z.literal()`
 
-The `z.literal()` API now optionally supports multiple values. 
+The `z.literal()` API now optionally supports multiple values.
 
 ```ts
-const httpCodes = z.literal([ 200, 201, 202, 204, 206, 207, 208, 226 ]);
+const httpCodes = z.literal([200, 201, 202, 204, 206, 207, 208, 226]);
 
 // previously in Zod 3:
 const httpCodes = z.union([
@@ -869,7 +878,7 @@ const httpCodes = z.union([
   z.literal(206),
   z.literal(207),
   z.literal(208),
-  z.literal(226)
+  z.literal(226),
 ]);
 ```
 
@@ -879,7 +888,7 @@ In Zod 3, they were stored in a `ZodEffects` class that wrapped the original sch
 
 ```ts
 z.string()
-  .refine(val => val.includes("@"))
+  .refine((val) => val.includes("@"))
   .min(5);
 // ^ ❌ Property 'min' does not exist on type ZodEffects<ZodString, string, string>
 ```
@@ -888,23 +897,25 @@ In Zod 4, refinements are stored inside the schemas themselves, so the code abov
 
 ```ts
 z.string()
-  .refine(val => val.includes("@"))
+  .refine((val) => val.includes("@"))
   .min(5); // ✅
 ```
 
 ### `.overwrite()`
 
-The `.transform()` method is extremely useful, but it has one major downside: the output type is no longer *introspectable* at runtime. The transform function is a black box that can return anything. This means (among other things) there's no sound way to convert the schema to JSON Schema.
+The `.transform()` method is extremely useful, but it has one major downside: the output type is no longer _introspectable_ at runtime. The transform function is a black box that can return anything. This means (among other things) there's no sound way to convert the schema to JSON Schema.
 
 ```ts
-const Squared = z.number().transform(val => val ** 2);
+const Squared = z.number().transform((val) => val ** 2);
 // => ZodPipe<ZodNumber, ZodTransform>
 ```
 
-Zod 4 introduces a new `.overwrite()` method for representing transforms that *don't change the inferred type*. Unlike `.transform()`, this method returns an instance of the original class. The overwrite function is stored as a refinement, so it doesn't (and can't) modify the inferred type.
+Zod 4 introduces a new `.overwrite()` method for representing transforms that _don't change the inferred type_. Unlike `.transform()`, this method returns an instance of the original class. The overwrite function is stored as a refinement, so it doesn't (and can't) modify the inferred type.
 
 ```ts
-z.number().overwrite(val => val ** 2).max(100);
+z.number()
+  .overwrite((val) => val ** 2)
+  .max(100);
 // => ZodNumber
 ```
 
@@ -912,16 +923,15 @@ z.number().overwrite(val => val ** 2).max(100);
 
 ## An extensible foundation: `zod/v4/core`
 
-While this will not be relevant to the majority of Zod users, it's worth highlighting. The addition of Zod Mini necessitated the creation of a shared sub-package `zod/v4/core` which contains the core functionality shared between Zod and Zod Mini. 
+While this will not be relevant to the majority of Zod users, it's worth highlighting. The addition of Zod Mini necessitated the creation of a shared sub-package `zod/v4/core` which contains the core functionality shared between Zod and Zod Mini.
 
 I was resistant to this at first, but now I see it as one of Zod 4's most important features. It lets Zod level up from a simple library to a fast validation "substrate" that can be sprinkled into other libraries.
 
 If you're building a schema library, refer to the implementations of Zod and Zod Mini to see how to build on top of the foundation `zod/v4/core` provides. Don't hesitate to get in touch in GitHub discussions or via [X](https://x.com/colinhacks)/[Bluesky](https://bsky.app/profile/colinhacks.com) for help or feedback.
 
-
 ## Wrapping up
 
-I'm planning to write up a series of additional posts explaining the design process behind some major features like Zod Mini. I'll update this section as those get posted. 
+I'm planning to write up a series of additional posts explaining the design process behind some major features like Zod Mini. I'll update this section as those get posted.
 
 For library authors, there is now a dedicated [For library authors](/library-authors) guide that describes the best practices for building on top of Zod. It answers common questions about how to support Zod 3 & Zod 4 (including Mini) simultaneously.
 

--- a/packages/docs/content/v4/versioning.mdx
+++ b/packages/docs/content/v4/versioning.mdx
@@ -3,9 +3,7 @@ title: Versioning
 description: "Versioning strategy and compatibility information for Zod 4"
 ---
 
-
 import { Callout } from "fumadocs-ui/components/callout";
-
 
 ### **Update — July 8th, 2025**
 
@@ -17,15 +15,13 @@ To upgrade to Zod 4:
 npm install zod@^4.0.0
 ```
 
-If you are using Zod 4, your existing imports (`"zod/v4"` and `"zod/v4-mini"`) will continue to work forever. However, after upgrading, you can *optionally* rewrite your imports as follows:
+If you are using Zod 4, your existing imports (`"zod/v4"` and `"zod/v4-mini"`) will continue to work forever. However, after upgrading, you can _optionally_ rewrite your imports as follows:
 
-
-|                | Before   | After     |
-|----------------|-----------------|-------------|
-| Zod 4          | `"zod/v4"`      | `"zod"`     |
-| Zod 4 Mini     | `"zod/v4-mini"` | `"zod/mini"`|
-| Zod 3          | `"zod"`         | `"zod/v3"`  |
-
+|            | Before          | After        |
+| ---------- | --------------- | ------------ |
+| Zod 4      | `"zod/v4"`      | `"zod"`      |
+| Zod 4 Mini | `"zod/v4-mini"` | `"zod/mini"` |
+| Zod 3      | `"zod"`         | `"zod/v3"`   |
 
 **Library authors** — if you've already implemented Zod 4 support according to the best practices outlined in the [Library authors](/library-authors) guide, bump your peer dependency to include `zod@^4.0.0`:
 
@@ -38,7 +34,7 @@ If you are using Zod 4, your existing imports (`"zod/v4"` and `"zod/v4-mini"`) w
 }
 ```
 
-*There should be no other code changes necessary.* No code changes were made between the latest `3.25.x` release and `4.0.0`. This does not require a major version bump.
+_There should be no other code changes necessary._ No code changes were made between the latest `3.25.x` release and `4.0.0`. This does not require a major version bump.
 
 <details>
 <summary><strong>Some notes on subpath versioning</strong></summary>
@@ -46,6 +42,7 @@ If you are using Zod 4, your existing imports (`"zod/v4"` and `"zod/v4-mini"`) w
 Ultimately, the subpath versioning scheme was a necessary evil to force the ecosystem to upgrade in a non-breaking way. If I'd published `zod@4.0.0` out of the gate, most libraries would have naively bumped their peer dependencies, forcing a "version bump avalanche" across the ecosystem.
 
 As it stands, there is now [broad support](https://x.com/colinhacks/status/1932323805705482339) for Zod 4 across the ecosystem. No migration process is totally painless, but it seems like the "version avalanche" I'd feared didn't happen. By and large, libraries have been able to support Zod 3 and Zod 4 simultaneously: Hono, LangChain, React Hook Form, etc. Several ecosystem maintainers reached out to me specifically to indicate how convenient it was to incrementally add support for Zod 4 (something that would typically require a major version bump). Long story short: this approach worked great! Few other libraries are subject to the same constraints as Zod, but I strongly encourage other libraries with large associated ecosystems to consider a similar approach.
+
 </details>
 
 ## Versioning in Zod 4
@@ -54,10 +51,10 @@ This is a writeup of Zod 4's approach to versioning, with the goal of making it 
 
 The general approach:
 
-- Zod 4 will not initially be published as `zod@4.0.0` on npm. Instead it will be exported at a subpath (`"zod/v4"`) alongside `zod@3.25.0` 
+- Zod 4 will not initially be published as `zod@4.0.0` on npm. Instead it will be exported at a subpath (`"zod/v4"`) alongside `zod@3.25.0`
 - Despite this, Zod 4 is considered stable and production-ready
 - Zod 3 will continue to be exported from the package root (`"zod"`) as well as a new subpath `"zod/v3"`. It will continue to receive bug fixes & stability improvements.
- 
+
 > This approach is analogous to how Golang handles major version changes: https://go.dev/doc/modules/major-version
 
 Sometime later:
@@ -66,25 +63,24 @@ Sometime later:
 - At this point `zod@4.0.0` will get published to npm
 - The `"zod/v4"` subpath will remain available forever
 
-## Why? 
+## Why?
 
 Zod occupies a unique place in the ecosystem. Many libraries/frameworks in the ecosystem accept user-defined Zod schemas. This means their user-facing API is strongly coupled to Zod and its various classes/interfaces/utilities. For these libraries/frameworks, a breaking change to Zod necessarily causes a breaking change for their users. A Zod 3 `ZodType` is not assignable to a Zod 4 `ZodType`.
 
-
-### Why can't libraries just support v3 and v4 simultaneously? 
+### Why can't libraries just support v3 and v4 simultaneously?
 
 Unfortunately the limitations of peerDependencies (and inconsistencies between package managers) make it extremely difficult to elegantly support two major versions of one library simultaneously.
 
-If I naively published `zod@4.0.0` to npm, the vast majority of the libraries in Zod's ecosystem would need to publish a new major version to properly support Zod 4, include some high-profile libraries like the AI SDK. It would trigger a "version bump avalanche" across the ecosystem and generally create a huge amount of frustration and work. 
-  
+If I naively published `zod@4.0.0` to npm, the vast majority of the libraries in Zod's ecosystem would need to publish a new major version to properly support Zod 4, include some high-profile libraries like the AI SDK. It would trigger a "version bump avalanche" across the ecosystem and generally create a huge amount of frustration and work.
+
 With subpath versioning, we solve this problem. it provides a straightforward way for libraries to support Zod 3 and Zod 4 (including Zod Mini) simultaneously. They can continue defining a single peerDependency on `"zod"`; no need for more arcane solutions like npm aliases, optional peer dependencies, a `"zod-compat"` package, or other such hacks.
 
 Libraries will need to bump the minimum version of their `"zod"` peer dependency to `zod@^3.25.0`. They can then reference both Zod 3 and Zod 4 in their implementation:
 
-  ```ts 
-  import * as z3 from "zod/v3"
-  import * as z4 from "zod/v4"
-  ```
+```ts
+import * as z3 from "zod/v3";
+import * as z4 from "zod/v4";
+```
 
 Later, once there's broad support for v4, we'll bump the major version on `npm` and start exporting Zod 4 from the package root, completing the transition. (This has now happened—see the note at the top of this page.)
 
@@ -96,11 +92,11 @@ While it may seem unorthodox (at least for people who don't use Go!), this is th
 
 A deeper dive into why peer dependencies don't work in this situation.
 
-Imagine you're a library trying to build a function `acceptSchema` that accepts a Zod schema. You want to be able to accept Zod 3 or Zod 4 schemas.  In this hypothetical, I'm imagine Zod 4 was published as `zod@4` on npm, no subpaths. Here are your options:
+Imagine you're a library trying to build a function `acceptSchema` that accepts a Zod schema. You want to be able to accept Zod 3 or Zod 4 schemas. In this hypothetical, I'm imagine Zod 4 was published as `zod@4` on npm, no subpaths. Here are your options:
 
-1. Install both zod@3 and zod@4 as `dependencies` simultaneously using npm aliases. This works but you end up including your own copies of both Zod 3 and Zod 4. You have no guarantee that your user's Zod schemas are instances of the same z.ZodType class you're pulling from dependencies (`instanceof` checks will probably fail). 
+1. Install both zod@3 and zod@4 as `dependencies` simultaneously using npm aliases. This works but you end up including your own copies of both Zod 3 and Zod 4. You have no guarantee that your user's Zod schemas are instances of the same z.ZodType class you're pulling from dependencies (`instanceof` checks will probably fail).
 
-2. Use a peer dependency that spans multiple major versions:  `"zod@>=3.0.0"` …but when developing a library you’d still need to pick a version to develop against. Usually you'd install this as a dev dependency. The onus is on you to painstakingly ensure your code works, character-for-character,  across both versions. This is impossible in the case of Zod 3 & Zod 4 because a number of very fundamental classes have simplified/different generics.
+2. Use a peer dependency that spans multiple major versions: `"zod@>=3.0.0"` …but when developing a library you’d still need to pick a version to develop against. Usually you'd install this as a dev dependency. The onus is on you to painstakingly ensure your code works, character-for-character, across both versions. This is impossible in the case of Zod 3 & Zod 4 because a number of very fundamental classes have simplified/different generics.
 
 3. Optional peer dependencies. i just couldn't find a straight answer about how to reliably determine which peer dep is installed at runtime across all platforms. Many answers online will say "use dynamic imports in a try/catch to check it a package exists". Those folks are assuming you're on the backend because no frontend bundlers have no affordance for this. They'll fail when you try to bundle a dependency that isn't installed. Obviuosly it doesn't matter if you're inside a try/catch during a build step. Also: since we're talking about multiple versions of the same library, you'd need to use npm aliases to differentiate the two versions in your `package.json`. Versions of npm as recent as v10 cannot handle the combination of peer dependencies + npm aliases.
 


### PR DESCRIPTION
Fixes a minor typo in the v4 changelog: 'unmergable' -> 'unmergeable'.