### PR TITLE
fix: add null-checks in toJSONSchema process() and isTransforming()

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -141,6 +141,11 @@ export function process<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   _params: ProcessParams = { path: [], schemaPath: [] }
 ): JSONSchema.BaseSchema {
+  // Guard against undefined or non-Zod schema inputs. This can happen when
+  // recordProcessor passes def.valueType which may be undefined for some
+  // schemas generated from JSON Schema → Zod conversion.
+  if (!schema || !schema._zod) return {};
+
   const def = schema._zod.def as schemas.$ZodTypes["_zod"]["def"];
 
   // check for schema in seens
@@ -521,6 +526,10 @@ function isTransforming(
     seen: Set<schemas.$ZodType>;
   }
 ): boolean {
+  // Guard against undefined or non-Zod schema inputs. Recursive calls from
+  // record/map/set types may pass def.valueType which can be undefined.
+  if (!_schema || !(_schema as any)._zod) return false;
+
   const ctx = _ctx ?? { seen: new Set() };
 
   if (ctx.seen.has(_schema)) return false;


### PR DESCRIPTION
## Summary

Adds null-guards to `process()` and `isTransforming()` in `v4/core/to-json-schema.ts` to prevent crashes when these functions receive `undefined` or non-Zod schema inputs.

## Problem

Both functions access `schema._zod.def` without checking if the input is defined:

- `recordProcessor` in `json-schema-processors.ts` calls `process(def.valueType, ...)` — but `def.valueType` can be `undefined` for record schemas generated from JSON Schema → Zod conversion
- `isTransforming()` recursively processes `def.valueType` for record/map/set types without checking if it's defined

This crashes with:
```
TypeError: Cannot read properties of undefined (reading '_zod')
    at process (v4/core/to-json-schema.js:33)
```

## Fix

Simple early-return guards at the entry of both functions:

```typescript
// process() — return empty schema for undefined inputs
if (!schema || !schema._zod) return {};

// isTransforming() — undefined schemas are not transforming
if (!_schema || !(_schema as any)._zod) return false;
```

These are safe defaults — an undefined schema has no JSON Schema representation (empty object) and is not transforming (false).

## Impact

This bug blocks the entire MCP (Model Context Protocol) tool listing for any project using Zod v4 schemas generated from JSON Schema conversion. Specifically:

1. `@modelcontextprotocol/sdk` calls `toJSONSchema` to serialize tool parameter schemas for `tools/list`
2. `@payloadcms/plugin-mcp` uses `json-schema-to-zod` to convert collection JSON Schemas → Zod schemas
3. Some generated record schemas have `undefined` `valueType` in their `_zod.def`
4. `tools/list` → `toJsonSchemaCompat()` → `toJSONSchema()` → `process(undefined)` → crash

The `tools/list` response fails completely, making all MCP tools inaccessible.

## Related Issues

- Fixes #5821
- Related to #5129 (reported same crash on v4.0.17, closed but fix not present in v4.3.6)