### PR TITLE
fix(ci): support TypeScript 6+ build and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,20 @@ jobs:
       - uses: pnpm/action-setup@v4
       - run: pnpm install
       - run: pnpm add typescript@${{ matrix.typescript }} -w
+      - name: Patch for TypeScript 6+ (zshy hardcodes deprecated moduleResolution=node10)
+        run: |
+          TS_MAJOR=$(npx tsc --version | awk '{print $2}' | cut -d. -f1)
+          if [ "$TS_MAJOR" -ge 6 ]; then
+            pnpm add typescript@${{ matrix.typescript }} --filter @zod/resolution --filter @zod/integration
+            node -e "
+              const fs = require('fs');
+              const p = '.configs/tsconfig.base.json';
+              const c = JSON.parse(fs.readFileSync(p, 'utf8'));
+              c.compilerOptions.ignoreDeprecations = '6.0';
+              fs.writeFileSync(p, JSON.stringify(c, null, 2) + '\n');
+            "
+            echo 'Patched tsconfig and updated subpackage TypeScript for TS6+'
+          fi
       - run: pnpm build
       - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all

--- a/packages/zod/src/v3/tests/all-errors.test.ts
+++ b/packages/zod/src/v3/tests/all-errors.test.ts
@@ -16,7 +16,7 @@ type TestFormErrors = z.inferFlattenedErrors<typeof Test>;
 test("default flattened errors type inference", () => {
   type TestTypeErrors = {
     formErrors: string[];
-    fieldErrors: { [P in keyof z.TypeOf<typeof Test>]?: string[] | undefined };
+    fieldErrors: { [P in keyof z.TypeOf<typeof Test>]?: string[] };
   };
 
   util.assertEqual<z.inferFlattenedErrors<typeof Test>, TestTypeErrors>(true);
@@ -28,7 +28,7 @@ test("custom flattened errors type inference", () => {
   type TestTypeErrors = {
     formErrors: ErrorType[];
     fieldErrors: {
-      [P in keyof z.TypeOf<typeof Test>]?: ErrorType[] | undefined;
+      [P in keyof z.TypeOf<typeof Test>]?: ErrorType[];
     };
   };
 
@@ -40,7 +40,7 @@ test("custom flattened errors type inference", () => {
 test("form errors type inference", () => {
   type TestTypeErrors = {
     formErrors: string[];
-    fieldErrors: { [P in keyof z.TypeOf<typeof Test>]?: string[] | undefined };
+    fieldErrors: { [P in keyof z.TypeOf<typeof Test>]?: string[] };
   };
 
   util.assertEqual<z.inferFlattenedErrors<typeof Test>, TestTypeErrors>(true);

--- a/packages/zod/src/v3/tests/object.test.ts
+++ b/packages/zod/src/v3/tests/object.test.ts
@@ -212,9 +212,9 @@ test("inferred merged object type with optional properties", async () => {
     .object({ a: z.string(), b: z.string().optional() })
     .merge(z.object({ a: z.string().optional(), b: z.string() }));
   type Merged = z.infer<typeof Merged>;
-  util.assertEqual<Merged, { a?: string; b: string }>(true);
+  util.assertEqual<Merged, { a?: string | undefined; b: string }>(true);
   // todo
-  // util.assertEqual<Merged, { a?: string; b: string }>(true);
+  // util.assertEqual<Merged, { a?: string | undefined; b: string }>(true);
 });
 
 test("inferred unioned object type with optional properties", async () => {
@@ -223,7 +223,7 @@ test("inferred unioned object type with optional properties", async () => {
     z.object({ a: z.string().optional(), b: z.string() }),
   ]);
   type Unioned = z.infer<typeof Unioned>;
-  util.assertEqual<Unioned, { a: string; b?: string } | { a?: string; b: string }>(true);
+  util.assertEqual<Unioned, { a: string; b?: string | undefined } | { a?: string | undefined; b: string }>(true);
 });
 
 test("inferred enum type", async () => {
@@ -245,13 +245,13 @@ test("inferred enum type", async () => {
 test("inferred partial object type with optional properties", async () => {
   const Partial = z.object({ a: z.string(), b: z.string().optional() }).partial();
   type Partial = z.infer<typeof Partial>;
-  util.assertEqual<Partial, { a?: string; b?: string }>(true);
+  util.assertEqual<Partial, { a?: string | undefined; b?: string | undefined }>(true);
 });
 
 test("inferred picked object type with optional properties", async () => {
   const Picked = z.object({ a: z.string(), b: z.string().optional() }).pick({ b: true });
   type Picked = z.infer<typeof Picked>;
-  util.assertEqual<Picked, { b?: string }>(true);
+  util.assertEqual<Picked, { b?: string | undefined }>(true);
 });
 
 test("inferred type for unknown/any keys", () => {

--- a/packages/zod/src/v3/tests/partials.test.ts
+++ b/packages/zod/src/v3/tests/partials.test.ts
@@ -21,7 +21,7 @@ test("shallow inference", () => {
     name?: string | undefined;
     age?: number | undefined;
     outer?: { inner: string } | undefined;
-    array?: { asdf: string }[];
+    array?: { asdf: string }[] | undefined;
   };
   util.assertEqual<shallow, correct>(true);
 });
@@ -41,7 +41,7 @@ test("deep partial inference", () => {
   asdf.parse("asdf");
   type deep = z.infer<typeof deep>;
   type correct = {
-    array?: { asdf?: string }[];
+    array?: { asdf?: string | undefined }[] | undefined;
     name?: string | undefined;
     age?: number | undefined;
     outer?: { inner?: string | undefined } | undefined;
@@ -118,7 +118,7 @@ test("deep partial inference", () => {
           asdf?: string | undefined;
         }[]
       | undefined;
-    tuple?: [{ value?: string }] | undefined;
+    tuple?: [{ value?: string | undefined }] | undefined;
   };
   util.assertEqual<expected, partialed>(true);
 });

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -247,7 +247,7 @@ test("z.tuple", () => {
   const b = z.tuple([z.string(), z.number(), z.optional(z.string())], z.boolean());
   type b = z.output<typeof b>;
 
-  expectTypeOf<b>().toEqualTypeOf<[string, number, string?, ...boolean[]]>();
+  expectTypeOf<b>().toEqualTypeOf<[string, number, (string | undefined)?, ...boolean[]]>();
   const datas = [
     ["hello", 123],
     ["hello", 123, "world"],
@@ -265,7 +265,7 @@ test("z.tuple", () => {
   const cArgs = [z.string(), z.number(), z.optional(z.string())] as const;
   const c = z.tuple(cArgs, z.boolean());
   type c = z.output<typeof c>;
-  expectTypeOf<c>().toEqualTypeOf<[string, number, string?, ...boolean[]]>();
+  expectTypeOf<c>().toEqualTypeOf<[string, number, (string | undefined)?, ...boolean[]]>();
   // type c = z.output<typeof c>;
 });
 

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -232,8 +232,8 @@ test("inferred merged object type with optional properties", async () => {
     .object({ a: z.string(), b: z.string().optional() })
     .merge(z.object({ a: z.string().optional(), b: z.string() }));
   type Merged = z.infer<typeof Merged>;
-  expectTypeOf<Merged>().toEqualTypeOf<{ a?: string; b: string }>();
-  expectTypeOf<Merged>().toEqualTypeOf<{ a?: string; b: string }>();
+  expectTypeOf<Merged>().toEqualTypeOf<{ a?: string | undefined; b: string }>();
+  expectTypeOf<Merged>().toEqualTypeOf<{ a?: string | undefined; b: string }>();
 });
 
 test("inferred unioned object type with optional properties", async () => {
@@ -242,7 +242,9 @@ test("inferred unioned object type with optional properties", async () => {
     z.object({ a: z.string().optional(), b: z.string() }),
   ]);
   type Unioned = z.infer<typeof Unioned>;
-  expectTypeOf<Unioned>().toEqualTypeOf<{ a: string; b?: string } | { a?: string; b: string }>();
+  expectTypeOf<Unioned>().toEqualTypeOf<
+    { a: string; b?: string | undefined } | { a?: string | undefined; b: string }
+  >();
 });
 
 test("inferred enum type", async () => {
@@ -279,13 +281,13 @@ test("z.keyof returns enum", () => {
 test("inferred partial object type with optional properties", async () => {
   const Partial = z.object({ a: z.string(), b: z.string().optional() }).partial();
   type Partial = z.infer<typeof Partial>;
-  expectTypeOf<Partial>().toEqualTypeOf<{ a?: string; b?: string }>();
+  expectTypeOf<Partial>().toEqualTypeOf<{ a?: string | undefined; b?: string | undefined }>();
 });
 
 test("inferred picked object type with optional properties", async () => {
   const Picked = z.object({ a: z.string(), b: z.string().optional() }).pick({ b: true });
   type Picked = z.infer<typeof Picked>;
-  expectTypeOf<Picked>().toEqualTypeOf<{ b?: string }>();
+  expectTypeOf<Picked>().toEqualTypeOf<{ b?: string | undefined }>();
 });
 
 test("inferred type for unknown/any keys", () => {

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -107,7 +107,9 @@ test("async validation", async () => {
 
 test("tuple with optional elements", () => {
   const myTuple = z.tuple([z.string(), z.number().optional(), z.string().optional()]).rest(z.boolean());
-  expectTypeOf<typeof myTuple._output>().toEqualTypeOf<[string, number?, string?, ...boolean[]]>();
+  expectTypeOf<typeof myTuple._output>().toEqualTypeOf<
+    [string, (number | undefined)?, (string | undefined)?, ...boolean[]]
+  >();
 
   const goodData = [["asdf"], ["asdf", 1234], ["asdf", 1234, "asdf"], ["asdf", 1234, "asdf", true, false, true]];
   for (const data of goodData) {
@@ -149,7 +151,9 @@ test("tuple with optional elements followed by required", () => {
 
 test("tuple with all optional elements", () => {
   const allOptionalTuple = z.tuple([z.string().optional(), z.number().optional(), z.boolean().optional()]);
-  expectTypeOf<typeof allOptionalTuple._output>().toEqualTypeOf<[string?, number?, boolean?]>();
+  expectTypeOf<typeof allOptionalTuple._output>().toEqualTypeOf<
+    [(string | undefined)?, (number | undefined)?, (boolean | undefined)?]
+  >();
 
   // Empty array should be valid (all items optional)
   expect(allOptionalTuple.parse([])).toEqual([]);

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -247,7 +247,7 @@ test("z.tuple", () => {
   const b = z.tuple([z.string(), z.number(), z.optional(z.string())], z.boolean());
   type b = z.output<typeof b>;
 
-  expectTypeOf<b>().toEqualTypeOf<[string, number, string?, ...boolean[]]>();
+  expectTypeOf<b>().toEqualTypeOf<[string, number, (string | undefined)?, ...boolean[]]>();
   const datas = [
     ["hello", 123],
     ["hello", 123, "world"],
@@ -265,7 +265,7 @@ test("z.tuple", () => {
   const cArgs = [z.string(), z.number(), z.optional(z.string())] as const;
   const c = z.tuple(cArgs, z.boolean());
   type c = z.output<typeof c>;
-  expectTypeOf<c>().toEqualTypeOf<[string, number, string?, ...boolean[]]>();
+  expectTypeOf<c>().toEqualTypeOf<[string, number, (string | undefined)?, ...boolean[]]>();
 });
 
 test("z.record", () => {

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -17,7 +17,7 @@ test("z.object", () => {
   expectTypeOf<a>().toEqualTypeOf<{
     name: string;
     age: number;
-    points?: number;
+    points?: number | undefined;
     "test?": boolean;
   }>();
   expect(z.parse(a, { name: "john", age: 30, "test?": true })).toEqual({
@@ -109,7 +109,7 @@ test("z.extend", () => {
   expectTypeOf<ExtendedUser>().toEqualTypeOf<{
     name: string;
     age: number;
-    email?: string;
+    email?: string | undefined;
     isAdmin: boolean;
   }>();
   expect(extendedSchema).toBeDefined();
@@ -120,7 +120,7 @@ test("z.safeExtend", () => {
   const extended = z.safeExtend(userSchema, { name: z.string() });
   expect(z.safeParse(extended, { name: "John", age: 30 }).success).toBe(true);
   type Extended = z.infer<typeof extended>;
-  expectTypeOf<Extended>().toEqualTypeOf<{ name: string; age: number; email?: string }>();
+  expectTypeOf<Extended>().toEqualTypeOf<{ name: string; age: number; email?: string | undefined }>();
   // @ts-expect-error
   z.safeExtend(userSchema, { name: z.number() });
 });
@@ -128,7 +128,7 @@ test("z.safeExtend", () => {
 test("z.pick", () => {
   const pickedSchema = z.pick(userSchema, { name: true, email: true });
   type PickedUser = z.infer<typeof pickedSchema>;
-  expectTypeOf<PickedUser>().toEqualTypeOf<{ name: string; email?: string }>();
+  expectTypeOf<PickedUser>().toEqualTypeOf<{ name: string; email?: string | undefined }>();
   expect(pickedSchema).toBeDefined();
   expect(z.safeParse(pickedSchema, { name: "John", email: "john@example.com" }).success).toBe(true);
 });
@@ -149,9 +149,9 @@ test("z.partial", () => {
   const partialSchema = z.partial(userSchema);
   type PartialUser = z.infer<typeof partialSchema>;
   expectTypeOf<PartialUser>().toEqualTypeOf<{
-    name?: string;
-    age?: number;
-    email?: string;
+    name?: string | undefined;
+    age?: number | undefined;
+    email?: string | undefined;
   }>();
   expect(z.safeParse(partialSchema, { name: "John" }).success).toBe(true);
 });
@@ -160,9 +160,9 @@ test("z.partial with mask", () => {
   const partialSchemaWithMask = z.partial(userSchema, { name: true });
   type PartialUserWithMask = z.infer<typeof partialSchemaWithMask>;
   expectTypeOf<PartialUserWithMask>().toEqualTypeOf<{
-    name?: string;
+    name?: string | undefined;
     age: number;
-    email?: string;
+    email?: string | undefined;
   }>();
   expect(z.safeParse(partialSchemaWithMask, { age: 30 }).success).toBe(true);
   expect(z.safeParse(partialSchemaWithMask, { name: "John" }).success).toBe(false);

--- a/packages/zod/src/v4/mini/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/mini/tests/recursive-types.test.ts
@@ -33,7 +33,7 @@ test("recursion with z.lazy", () => {
   type Category = z.infer<typeof Category>;
   interface _Category {
     name: string;
-    subcategories?: _Category[];
+    subcategories?: _Category[] | undefined;
   }
   expectTypeOf<Category>().toEqualTypeOf<_Category>();
 });


### PR DESCRIPTION
## Summary

- Patch `tsconfig.base.json` with `ignoreDeprecations=6.0` in CI when TypeScript >= 6
- Align subpackage TypeScript versions (resolution, integration) to avoid version mismatches
- Update test type assertions for TS6 `exactOptionalPropertyTypes` changes

## Problem

`zshy` hardcodes `moduleResolution=node10` for CJS builds, which triggers **TS5107** in TypeScript 6+. Additionally, TS6 now distinguishes `{ a?: T }` from `{ a?: T | undefined
}`, breaking type assertions in 9 test files.

This affects all open PRs — the "Test with TypeScript latest" job fails across the board.

## Approach

**CI workflow:** Detect the installed TypeScript major version. When >= 6:
1. Update TypeScript in subpackages that pin their own version
2. Inject `ignoreDeprecations: "6.0"` into `tsconfig.base.json`

**Tests:** Add explicit `| undefined` to optional properties and tuple elements in expected types, matching what zod's type inference actually produces.
