### PR TITLE
Fix docs: replace .pick() with payload.issues in refine when example

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2356,9 +2356,11 @@ const schema = z
 
     // run if password & confirmPassword are valid
     when(payload) { // [!code ++]
-      return schema // [!code ++]
-        .pick({ password: true, confirmPassword: true }) // [!code ++]
-        .safeParse(payload.value).success; // [!code ++]
+      // no issues with `password` or `confirmPassword` // [!code ++]
+      return payload.issues.every((iss) => { // [!code ++]
+        const firstPathEl = iss.path?.[0]; // [!code ++]
+        return firstPathEl !== "password" && firstPathEl !== "confirmPassword"; // [!code ++]
+      }); // [!code ++]
     },  // [!code ++]
   });
 


### PR DESCRIPTION
## Problem

The **Zod (classic)** tab example for the `when` parameter in `.refine()` uses `.pick()` on a schema that contains refinements, which throws:

```
Error: .pick() cannot be used on object schemas containing refinements
```

Reported in #5805.

## Fix

Replace the `.pick()` + `.safeParse()` approach with `payload.issues.every()` — the same pattern already used in the **Zod Mini** tab.

Closes #5805