### PR TITLE
docs: update z.custom examples for v4

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3080,17 +3080,26 @@ computeTrimmedLengthAsync("sandwich"); // => Promise<8>
 
 ## Custom
 
-You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for creating schemas for types that are not supported by Zod out of the box, such as template string literals.
+You can create a Zod schema for any TypeScript type by using `z.custom()`. This is useful for creating schemas for types that are not supported by Zod out of the box.
 
 ```ts
-const px = z.custom<`${number}px`>((val) => {
-  return typeof val === "string" ? /^\d+px$/.test(val) : false;
-});
+import type { Buffer } from "node:buffer";
 
-type px = z.infer<typeof px>; // `${number}px`
+const bufferSchema = z.custom<Buffer>((val) => Buffer.isBuffer(val));
 
-px.parse("42px"); // "42px"
-px.parse("42vw"); // throws;
+bufferSchema.parse(Buffer.from("hello")); // ✅
+bufferSchema.parse("hello"); // throws
+```
+
+You can also use `z.custom()` to validate more specific shapes, like a non-empty array:
+
+```ts
+const nonEmptyArray = z.custom<[string, ...string[]]>(
+  (val) => Array.isArray(val) && val.length > 0 && val.every((v) => typeof v === "string")
+);
+
+nonEmptyArray.parse(["a", "b"]); // ✅
+nonEmptyArray.parse([]); // throws
 ```
 
 If you don't provide a validation function, Zod will allow any value. This can be dangerous!


### PR DESCRIPTION
Closes #5605

The `z.custom` docs currently reference template string literals as an example use case, but since `z.templateLiteral` was introduced in v4, that example is misleading — it suggests you need `z.custom` for something Zod now handles natively.

This PR:
- Removes the "such as template string literals" mention from the description
- Replaces the `${number}px` template literal example with two examples that genuinely need `z.custom`: validating a Node.js `Buffer` and a non-empty typed array
- Keeps everything else (the "no validation function" warning, error customization docs) as-is

I ran into this while reading the docs and had to double-check whether `z.templateLiteral` or `z.custom` was the right approach for template strings. Figured it'd be worth clearing up for others too.

Happy to adjust anything based on feedback!