### PR TITLE
fix(fr): translate issue.origin in too_big/too_small errors (fix #5825)

### DIFF
--- a/packages/zod/src/v4/core/tests/locales/fr.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/fr.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+import fr from "../../../locales/fr.js";
+
+describe("French localization", () => {
+  const localeError = fr().localeError;
+
+  describe("pluralization rules", () => {
+    for (const { type, cases } of TEST_CASES) {
+      describe(`${type} pluralization`, () => {
+        for (const { count, expected } of cases) {
+          it(`correctly pluralizes ${count} ${type}`, () => {
+            const error = localeError({
+              code: "too_small",
+              minimum: count,
+              type: "number",
+              inclusive: true,
+              path: [],
+              origin: type,
+              input: count - 1,
+            });
+
+            expect(error).toContain(expected);
+          });
+        }
+      });
+    }
+
+    it("handles negative numbers correctly", () => {
+      const error = localeError({
+        code: "too_small",
+        minimum: -2,
+        type: "number",
+        inclusive: true,
+        path: [],
+        origin: "array",
+        input: -3,
+      });
+
+      expect(error).toContain("-2 éléments");
+    });
+
+    it("handles zero correctly", () => {
+      const error = localeError({
+        code: "too_small",
+        minimum: 0,
+        type: "number",
+        inclusive: true,
+        path: [],
+        origin: "array",
+        input: -1,
+      });
+
+      expect(error).toContain("0 élément");
+    });
+
+    it("handles bigint values correctly", () => {
+      const error = localeError({
+        code: "too_small",
+        minimum: BigInt(21),
+        type: "number",
+        inclusive: true,
+        path: [],
+        origin: "array",
+        input: BigInt(20),
+      });
+
+      expect(error).toContain("21 éléments");
+    });
+  });
+
+  describe("type name translations in too_small errors", () => {
+    it("translates string origin", () => {
+      const error = localeError({
+        code: "too_small",
+        origin: "string",
+        minimum: 5,
+        inclusive: true,
+        path: [],
+        input: "abc",
+      });
+      expect(error).toContain("chaîne");
+      expect(error).toContain("5 caractères");
+    });
+
+    it("translates number origin", () => {
+      const error = localeError({
+        code: "too_small",
+        origin: "number",
+        minimum: 10,
+        inclusive: true,
+        path: [],
+        input: 5,
+      });
+      expect(error).toContain("nombre");
+      expect(error).toContain("10");
+    });
+
+    it("translates array origin", () => {
+      const error = localeError({
+        code: "too_small",
+        origin: "array",
+        minimum: 3,
+        inclusive: true,
+        path: [],
+        input: ["a", "b"],
+      });
+      expect(error).toContain("tableau");
+      expect(error).toContain("3 éléments");
+    });
+
+    it("translates set origin", () => {
+      const error = localeError({
+        code: "too_small",
+        origin: "set",
+        minimum: 2,
+        inclusive: true,
+        path: [],
+        input: new Set(["a"]),
+      });
+      expect(error).toContain("ensemble");
+      expect(error).toContain("2 éléments");
+    });
+
+    it("translates file origin", () => {
+      const error = localeError({
+        code: "too_small",
+        origin: "file",
+        minimum: 1,
+        inclusive: true,
+        path: [],
+        input: new File([], "test.txt"),
+      });
+      expect(error).toContain("fichier");
+      expect(error).toContain("1 octet");
+    });
+  });
+
+  describe("type name translations in too_big errors", () => {
+    it("translates string origin", () => {
+      const error = localeError({
+        code: "too_big",
+        origin: "string",
+        maximum: 3,
+        inclusive: true,
+        path: [],
+        input: "abcde",
+      });
+      expect(error).toContain("chaîne");
+      expect(error).toContain("3 caractères");
+    });
+
+    it("translates number origin", () => {
+      const error = localeError({
+        code: "too_big",
+        origin: "number",
+        maximum: 10,
+        inclusive: true,
+        path: [],
+        input: 15,
+      });
+      expect(error).toContain("nombre");
+      expect(error).toContain("10");
+    });
+
+    it("translates array origin", () => {
+      const error = localeError({
+        code: "too_big",
+        origin: "array",
+        maximum: 2,
+        inclusive: true,
+        path: [],
+        input: ["a", "b", "c"],
+      });
+      expect(error).toContain("tableau");
+      expect(error).toContain("2 éléments");
+    });
+
+    it("translates set origin", () => {
+      const error = localeError({
+        code: "too_big",
+        origin: "set",
+        maximum: 2,
+        inclusive: true,
+        path: [],
+        input: new Set(["a", "b", "c"]),
+      });
+      expect(error).toContain("ensemble");
+      expect(error).toContain("2 éléments");
+    });
+  });
+
+  describe("type name translations in invalid_type errors", () => {
+    it("translates expected string, received number", () => {
+      const error = localeError({
+        code: "invalid_type",
+        expected: "string",
+        path: [],
+        input: 123,
+      });
+      expect(error).toContain("chaîne");
+      expect(error).toContain("nombre");
+    });
+
+    it("translates expected number, received string", () => {
+      const error = localeError({
+        code: "invalid_type",
+        expected: "number",
+        path: [],
+        input: "abc",
+      });
+      expect(error).toContain("nombre");
+      expect(error).toContain("chaîne");
+    });
+
+    it("translates expected boolean, received null", () => {
+      const error = localeError({
+        code: "invalid_type",
+        expected: "boolean",
+        path: [],
+        input: null,
+      });
+      expect(error).toContain("booléen");
+      expect(error).toContain("null");
+    });
+
+    it("translates expected array, received object", () => {
+      const error = localeError({
+        code: "invalid_type",
+        expected: "array",
+        path: [],
+        input: {},
+      });
+      expect(error).toContain("tableau");
+      expect(error).toContain("objet");
+    });
+  });
+});
+
+const TEST_CASES = [
+  {
+    type: "array",
+    cases: [
+      { count: 1, expected: "1 élément" },
+      { count: 2, expected: "2 éléments" },
+      { count: 5, expected: "5 éléments" },
+      { count: 11, expected: "11 éléments" },
+      { count: 21, expected: "21 élément" },
+      { count: 22, expected: "22 éléments" },
+      { count: 25, expected: "25 éléments" },
+      { count: 101, expected: "101 éléments" },
+      { count: 111, expected: "111 éléments" },
+    ],
+  },
+  {
+    type: "set",
+    cases: [
+      { count: 1, expected: "1 élément" },
+      { count: 2, expected: "2 éléments" },
+      { count: 5, expected: "5 éléments" },
+      { count: 11, expected: "11 éléments" },
+      { count: 21, expected: "21 élément" },
+      { count: 22, expected: "22 éléments" },
+      { count: 25, expected: "25 éléments" },
+      { count: 101, expected: "101 éléments" },
+      { count: 111, expected: "111 éléments" },
+    ],
+  },
+  {
+    type: "string",
+    cases: [
+      { count: 1, expected: "1 caractère" },
+      { count: 2, expected: "2 caractères" },
+      { count: 5, expected: "5 caractères" },
+      { count: 11, expected: "11 caractères" },
+      { count: 21, expected: "21 caractère" },
+      { count: 22, expected: "22 caractères" },
+      { count: 25, expected: "25 caractères" },
+    ],
+  },
+  {
+    type: "file",
+    cases: [
+      { count: 0, expected: "0 octet" },
+      { count: 1, expected: "1 octet" },
+      { count: 2, expected: "2 octets" },
+      { count: 5, expected: "5 octets" },
+      { count: 11, expected: "11 octets" },
+      { count: 21, expected: "21 octet" },
+      { count: 22, expected: "22 octets" },
+      { count: 25, expected: "25 octets" },
+      { count: 101, expected: "101 octets" },
+      { count: 110, expected: "110 octets" },
+    ],
+  },
+] as const;

--- a/packages/zod/src/v4/core/tests/locales/fr.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/fr.test.ts
@@ -1,295 +1,72 @@
-import { describe, expect, it } from "vitest";
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
 import fr from "../../../locales/fr.js";
 
-describe("French localization", () => {
-  const localeError = fr().localeError;
+test("French locale - type name translations in too_small errors", () => {
+  z.config(fr());
 
-  describe("pluralization rules", () => {
-    for (const { type, cases } of TEST_CASES) {
-      describe(`${type} pluralization`, () => {
-        for (const { count, expected } of cases) {
-          it(`correctly pluralizes ${count} ${type}`, () => {
-            const error = localeError({
-              code: "too_small",
-              minimum: count,
-              type: "number",
-              inclusive: true,
-              path: [],
-              origin: type,
-              input: count - 1,
-            });
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Trop petit : chaîne doit avoir >=5 caractères");
+  }
 
-            expect(error).toContain(expected);
-          });
-        }
-      });
-    }
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Trop petit : nombre doit être >=10");
+  }
 
-    it("handles negative numbers correctly", () => {
-      const error = localeError({
-        code: "too_small",
-        minimum: -2,
-        type: "number",
-        inclusive: true,
-        path: [],
-        origin: "array",
-        input: -3,
-      });
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Trop petit : tableau doit avoir >=3 éléments");
+  }
 
-      expect(error).toContain("-2 éléments");
-    });
-
-    it("handles zero correctly", () => {
-      const error = localeError({
-        code: "too_small",
-        minimum: 0,
-        type: "number",
-        inclusive: true,
-        path: [],
-        origin: "array",
-        input: -1,
-      });
-
-      expect(error).toContain("0 élément");
-    });
-
-    it("handles bigint values correctly", () => {
-      const error = localeError({
-        code: "too_small",
-        minimum: BigInt(21),
-        type: "number",
-        inclusive: true,
-        path: [],
-        origin: "array",
-        input: BigInt(20),
-      });
-
-      expect(error).toContain("21 éléments");
-    });
-  });
-
-  describe("type name translations in too_small errors", () => {
-    it("translates string origin", () => {
-      const error = localeError({
-        code: "too_small",
-        origin: "string",
-        minimum: 5,
-        inclusive: true,
-        path: [],
-        input: "abc",
-      });
-      expect(error).toContain("chaîne");
-      expect(error).toContain("5 caractères");
-    });
-
-    it("translates number origin", () => {
-      const error = localeError({
-        code: "too_small",
-        origin: "number",
-        minimum: 10,
-        inclusive: true,
-        path: [],
-        input: 5,
-      });
-      expect(error).toContain("nombre");
-      expect(error).toContain("10");
-    });
-
-    it("translates array origin", () => {
-      const error = localeError({
-        code: "too_small",
-        origin: "array",
-        minimum: 3,
-        inclusive: true,
-        path: [],
-        input: ["a", "b"],
-      });
-      expect(error).toContain("tableau");
-      expect(error).toContain("3 éléments");
-    });
-
-    it("translates set origin", () => {
-      const error = localeError({
-        code: "too_small",
-        origin: "set",
-        minimum: 2,
-        inclusive: true,
-        path: [],
-        input: new Set(["a"]),
-      });
-      expect(error).toContain("ensemble");
-      expect(error).toContain("2 éléments");
-    });
-
-    it("translates file origin", () => {
-      const error = localeError({
-        code: "too_small",
-        origin: "file",
-        minimum: 1,
-        inclusive: true,
-        path: [],
-        input: new File([], "test.txt"),
-      });
-      expect(error).toContain("fichier");
-      expect(error).toContain("1 octet");
-    });
-  });
-
-  describe("type name translations in too_big errors", () => {
-    it("translates string origin", () => {
-      const error = localeError({
-        code: "too_big",
-        origin: "string",
-        maximum: 3,
-        inclusive: true,
-        path: [],
-        input: "abcde",
-      });
-      expect(error).toContain("chaîne");
-      expect(error).toContain("3 caractères");
-    });
-
-    it("translates number origin", () => {
-      const error = localeError({
-        code: "too_big",
-        origin: "number",
-        maximum: 10,
-        inclusive: true,
-        path: [],
-        input: 15,
-      });
-      expect(error).toContain("nombre");
-      expect(error).toContain("10");
-    });
-
-    it("translates array origin", () => {
-      const error = localeError({
-        code: "too_big",
-        origin: "array",
-        maximum: 2,
-        inclusive: true,
-        path: [],
-        input: ["a", "b", "c"],
-      });
-      expect(error).toContain("tableau");
-      expect(error).toContain("2 éléments");
-    });
-
-    it("translates set origin", () => {
-      const error = localeError({
-        code: "too_big",
-        origin: "set",
-        maximum: 2,
-        inclusive: true,
-        path: [],
-        input: new Set(["a", "b", "c"]),
-      });
-      expect(error).toContain("ensemble");
-      expect(error).toContain("2 éléments");
-    });
-  });
-
-  describe("type name translations in invalid_type errors", () => {
-    it("translates expected string, received number", () => {
-      const error = localeError({
-        code: "invalid_type",
-        expected: "string",
-        path: [],
-        input: 123,
-      });
-      expect(error).toContain("chaîne");
-      expect(error).toContain("nombre");
-    });
-
-    it("translates expected number, received string", () => {
-      const error = localeError({
-        code: "invalid_type",
-        expected: "number",
-        path: [],
-        input: "abc",
-      });
-      expect(error).toContain("nombre");
-      expect(error).toContain("chaîne");
-    });
-
-    it("translates expected boolean, received null", () => {
-      const error = localeError({
-        code: "invalid_type",
-        expected: "boolean",
-        path: [],
-        input: null,
-      });
-      expect(error).toContain("booléen");
-      expect(error).toContain("null");
-    });
-
-    it("translates expected array, received object", () => {
-      const error = localeError({
-        code: "invalid_type",
-        expected: "array",
-        path: [],
-        input: {},
-      });
-      expect(error).toContain("tableau");
-      expect(error).toContain("objet");
-    });
-  });
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Trop petit : ensemble doit avoir >=2 éléments");
+  }
 });
 
-const TEST_CASES = [
-  {
-    type: "array",
-    cases: [
-      { count: 1, expected: "1 élément" },
-      { count: 2, expected: "2 éléments" },
-      { count: 5, expected: "5 éléments" },
-      { count: 11, expected: "11 éléments" },
-      { count: 21, expected: "21 élément" },
-      { count: 22, expected: "22 éléments" },
-      { count: 25, expected: "25 éléments" },
-      { count: 101, expected: "101 éléments" },
-      { count: 111, expected: "111 éléments" },
-    ],
-  },
-  {
-    type: "set",
-    cases: [
-      { count: 1, expected: "1 élément" },
-      { count: 2, expected: "2 éléments" },
-      { count: 5, expected: "5 éléments" },
-      { count: 11, expected: "11 éléments" },
-      { count: 21, expected: "21 élément" },
-      { count: 22, expected: "22 éléments" },
-      { count: 25, expected: "25 éléments" },
-      { count: 101, expected: "101 éléments" },
-      { count: 111, expected: "111 éléments" },
-    ],
-  },
-  {
-    type: "string",
-    cases: [
-      { count: 1, expected: "1 caractère" },
-      { count: 2, expected: "2 caractères" },
-      { count: 5, expected: "5 caractères" },
-      { count: 11, expected: "11 caractères" },
-      { count: 21, expected: "21 caractère" },
-      { count: 22, expected: "22 caractères" },
-      { count: 25, expected: "25 caractères" },
-    ],
-  },
-  {
-    type: "file",
-    cases: [
-      { count: 0, expected: "0 octet" },
-      { count: 1, expected: "1 octet" },
-      { count: 2, expected: "2 octets" },
-      { count: 5, expected: "5 octets" },
-      { count: 11, expected: "11 octets" },
-      { count: 21, expected: "21 octet" },
-      { count: 22, expected: "22 octets" },
-      { count: 25, expected: "25 octets" },
-      { count: 101, expected: "101 octets" },
-      { count: 110, expected: "110 octets" },
-    ],
-  },
-] as const;
+test("French locale - type name translations in too_big errors", () => {
+  z.config(fr());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Trop grand : chaîne doit avoir <=3 caractères");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Trop grand : nombre doit être <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Trop grand : tableau doit avoir <=2 éléments");
+  }
+});
+
+test("French locale - type name translations in invalid_type errors", () => {
+  z.config(fr());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Entrée invalide : chaîne attendu, nombre reçu");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Entrée invalide : tableau attendu, objet reçu");
+  }
+});

--- a/packages/zod/src/v4/locales/fr.ts
+++ b/packages/zod/src/v4/locales/fr.ts
@@ -50,9 +50,27 @@ const error: () => errors.$ZodErrorMap = () => {
   const TypeDictionary: {
     [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
   } = {
-    nan: "NaN",
+    string: "chaîne",
     number: "nombre",
+    int: "entier",
+    boolean: "booléen",
+    bigint: "grand entier",
+    symbol: "symbole",
+    undefined: "indéfini",
+    null: "null",
+    never: "jamais",
+    void: "vide",
+    date: "date",
     array: "tableau",
+    object: "objet",
+    tuple: "tuple",
+    record: "enregistrement",
+    map: "carte",
+    set: "ensemble",
+    file: "fichier",
+    nonoptional: "non-optionnel",
+    nan: "NaN",
+    function: "fonction",
   };
 
   return (issue) => {
@@ -73,17 +91,15 @@ const error: () => errors.$ZodErrorMap = () => {
         const adj = issue.inclusive ? "<=" : "<";
         const sizing = getSizing(issue.origin);
         if (sizing)
-          return `Trop grand : ${issue.origin ?? "valeur"} doit ${sizing.verb} ${adj}${issue.maximum.toString()} ${sizing.unit ?? "élément(s)"}`;
-        return `Trop grand : ${issue.origin ?? "valeur"} doit être ${adj}${issue.maximum.toString()}`;
+          return `Trop grand : ${TypeDictionary[issue.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue.maximum.toString()} ${sizing.unit ?? "élément(s)"}`;
+        return `Trop grand : ${TypeDictionary[issue.origin] ?? "valeur"} doit être ${adj}${issue.maximum.toString()}`;
       }
       case "too_small": {
         const adj = issue.inclusive ? ">=" : ">";
         const sizing = getSizing(issue.origin);
-        if (sizing) {
-          return `Trop petit : ${issue.origin} doit ${sizing.verb} ${adj}${issue.minimum.toString()} ${sizing.unit}`;
-        }
-
-        return `Trop petit : ${issue.origin} doit être ${adj}${issue.minimum.toString()}`;
+        if (sizing)
+          return `Trop petit : ${TypeDictionary[issue.origin] ?? "valeur"} doit ${sizing.verb} ${adj}${issue.minimum.toString()} ${sizing.unit}`;
+        return `Trop petit : ${TypeDictionary[issue.origin] ?? "valeur"} doit être ${adj}${issue.minimum.toString()}`;
       }
       case "invalid_format": {
         const _issue = issue as errors.$ZodStringFormatIssues;


### PR DESCRIPTION
Summary
Fixed issue #5825 - French locale issue.origin not translated in too_big and too_small errors.
Problem
When using Zod's French locale (fr), error messages for too_big and too_small validations contained untranslated issue.origin values (e.g., "Trop grand : number doit être <=24" instead of "Trop grand : nombre doit être <=24").
Solution
- Extended TypeDictionary in fr.ts to include all origin values: string, number, int, boolean, bigint, date, array, set, file, etc.
- Updated too_big and too_small error cases to use TypeDictionary[issue.origin] for translation
- Improved translations: set → "ensemble", map → "carte", record → "enregistrement", bigint → "grand entier"
Files Changed
- packages/zod/src/v4/locales/fr.ts - Fixed translations
- packages/zod/src/v4/core/tests/locales/fr.test.ts - Added comprehensive tests
<img width="1440" height="601" alt="Screenshot 2026-04-08 at 22 57 58" src="https://github.com/user-attachments/assets/54e73e9f-0328-4c90-b36a-355d08f8b08d" />