### PR TITLE
feat: add `when` param support to `superRefine`

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -94,7 +94,8 @@ export interface ZodType<
     params?: string | core.$ZodCustomParams
   ): Ch extends (arg: any) => arg is infer R ? this & ZodType<R, core.input<this>> : this;
   superRefine(
-    refinement: (arg: core.output<this>, ctx: core.$RefinementCtx<core.output<this>>) => void | Promise<void>
+    refinement: (arg: core.output<this>, ctx: core.$RefinementCtx<core.output<this>>) => void | Promise<void>,
+    params?: core.$ZodSuperRefineParams
   ): this;
   overwrite(fn: (x: core.output<this>) => core.output<this>): this;
 
@@ -210,7 +211,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
 
   // refinements
   inst.refine = (check, params) => inst.check(refine(check, params)) as never;
-  inst.superRefine = (refinement) => inst.check(superRefine(refinement));
+  inst.superRefine = (refinement, params) => inst.check(superRefine(refinement, params));
   inst.overwrite = (fn) => inst.check(checks.overwrite(fn));
 
   // wrappers
@@ -2321,9 +2322,10 @@ export function refine<T>(
 
 // superRefine
 export function superRefine<T>(
-  fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>
+  fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>,
+  params?: core.$ZodSuperRefineParams
 ): core.$ZodCheck<T> {
-  return core._superRefine(fn);
+  return core._superRefine(fn, params);
 }
 
 // Re-export describe and meta from core

--- a/packages/zod/src/v4/classic/tests/refine.test.ts
+++ b/packages/zod/src/v4/classic/tests/refine.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, expectTypeOf, test } from "vitest";
 import * as z from "zod/v4";
+import type { ParsePayload } from "zod/v4/core";
 
 describe("basic refinement functionality", () => {
   test("should create a new schema instance when refining", () => {
@@ -460,33 +461,47 @@ describe("type refinement with type guards", () => {
   // });
 });
 
-test("when", () => {
-  const schema = z
-    .strictObject({
-      password: z.string().min(8),
-      confirmPassword: z.string(),
-      other: z.string(),
-    })
-    .refine(
-      (data) => {
-        // console.log("running check...");
-        // console.log(data);
-        // console.log(data.password);
-        return data.password === data.confirmPassword;
-      },
-      {
+describe("when", () => {
+  const baseSchema = z.strictObject({
+    password: z.string().min(8),
+    confirmPassword: z.string(),
+    other: z.string(),
+  });
+  const whenFn = (payload: ParsePayload): boolean => {
+    if (payload.value === undefined) return false;
+    if (payload.value === null) return false;
+    // no issues with confirmPassword or password
+    return payload.issues.every((iss) => iss.path?.[0] !== "confirmPassword" && iss.path?.[0] !== "password");
+  };
+
+  test.for([
+    [
+      "refine",
+      baseSchema.refine((data) => data.password === data.confirmPassword, {
         message: "Passwords do not match",
         path: ["confirmPassword"],
-        when(payload) {
-          if (payload.value === undefined) return false;
-          if (payload.value === null) return false;
-          // no issues with confirmPassword or password
-          return payload.issues.every((iss) => iss.path?.[0] !== "confirmPassword" && iss.path?.[0] !== "password");
+        when: whenFn,
+      }),
+    ],
+    [
+      "superRefine",
+      baseSchema.superRefine(
+        (data, ctx) => {
+          if (data.password !== data.confirmPassword) {
+            ctx.addIssue({
+              code: "custom",
+              message: "Passwords do not match",
+              path: ["confirmPassword"],
+            });
+          }
         },
-      }
-    );
-
-  expect(schema.safeParse(undefined)).toMatchInlineSnapshot(`
+        {
+          when: whenFn,
+        }
+      ),
+    ],
+  ] as const)("%s", ([_, schema]) => {
+    expect(schema.safeParse(undefined)).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
       {
@@ -499,7 +514,7 @@ test("when", () => {
       "success": false,
     }
   `);
-  expect(schema.safeParse(null)).toMatchInlineSnapshot(`
+    expect(schema.safeParse(null)).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
       {
@@ -512,13 +527,13 @@ test("when", () => {
       "success": false,
     }
   `);
-  expect(
-    schema.safeParse({
-      password: "asdf",
-      confirmPassword: "asdfg",
-      other: "qwer",
-    })
-  ).toMatchInlineSnapshot(`
+    expect(
+      schema.safeParse({
+        password: "asdf",
+        confirmPassword: "asdfg",
+        other: "qwer",
+      })
+    ).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
       {
@@ -536,13 +551,13 @@ test("when", () => {
     }
   `);
 
-  expect(
-    schema.safeParse({
-      password: "asdf",
-      confirmPassword: "asdfg",
-      other: 1234,
-    })
-  ).toMatchInlineSnapshot(`
+    expect(
+      schema.safeParse({
+        password: "asdf",
+        confirmPassword: "asdfg",
+        other: 1234,
+      })
+    ).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
       {
@@ -567,4 +582,30 @@ test("when", () => {
       "success": false,
     }
   `);
+
+    expect(
+      schema.safeParse({
+        password: "password1",
+        confirmPassword: "password2",
+        other: 1234,
+      })
+    ).toMatchObject({
+      success: false,
+      error: {
+        issues: [
+          {
+            code: "invalid_type",
+            expected: "string",
+            path: ["other"],
+            message: "Invalid input: expected string, received number",
+          },
+          {
+            code: "custom",
+            path: ["confirmPassword"],
+            message: "Passwords do not match",
+          },
+        ],
+      },
+    });
+  });
 });

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1633,8 +1633,12 @@ export interface $RefinementCtx<T = unknown> extends schemas.ParsePayload<T> {
   addIssue(arg: string | $ZodSuperRefineIssue): void;
 }
 
+export type $ZodSuperRefineParams = Pick<$ZodCustomParams, "when">;
 // @__NO_SIDE_EFFECTS__
-export function _superRefine<T>(fn: (arg: T, payload: $RefinementCtx<T>) => void | Promise<void>): checks.$ZodCheck<T> {
+export function _superRefine<T>(
+  fn: (arg: T, payload: $RefinementCtx<T>) => void | Promise<void>,
+  _params?: $ZodSuperRefineParams
+): checks.$ZodCheck<T> {
   const ch = _check<T>((payload) => {
     (payload as $RefinementCtx).addIssue = (issue) => {
       if (typeof issue === "string") {
@@ -1653,6 +1657,7 @@ export function _superRefine<T>(fn: (arg: T, payload: $RefinementCtx<T>) => void
 
     return fn(payload.value, payload as $RefinementCtx<T>);
   });
+  if (_params?.when) ch._zod.def.when = _params.when;
   return ch;
 }
 

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1770,9 +1770,10 @@ export function refine<T>(
 // superRefine
 // @__NO_SIDE_EFFECTS__
 export function superRefine<T>(
-  fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>
+  fn: (arg: T, payload: core.$RefinementCtx<T>) => void | Promise<void>,
+  params?: core.$ZodSuperRefineParams
 ): core.$ZodCheck<T> {
-  return core._superRefine(fn);
+  return core._superRefine(fn, params);
 }
 
 // Re-export describe and meta from core


### PR DESCRIPTION
Closes #5197

`superRefine` now accepts an optional `when` callback parameter (matching the existing `refine` API), allowing conditional execution of `superRefine` checks based on the validation payload.