### PR TITLE
docs: add validex to Powered by Zod ecosystem section

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -270,7 +270,13 @@ const poweredByZodProjects: ZodResource[] = [
     url: "https://github.com/endel/zodgres",
     description: "Postgres.js + Zod: Database collections with static type inference and automatic migrations",
     slug: "endel/zodgres",
-  }
+  },
+  {
+    name: "validex",
+    url: "https://github.com/chiptoma/validex",
+    description: "25 tree-shakeable validation rules for common fields (email, phone, password, etc.) with structured error codes, i18n, and framework adapters.",
+    slug: "chiptoma/validex",
+  },
 ];
 
 const zodUtilities: ZodResource[] = [


### PR DESCRIPTION
validex provides 25 typed validation rules built on Zod 4 for common fields like email, phone, password, username, IBAN, and more. Each rule returns a standard Zod schema and includes structured error codes, three-tier config merging, i18n support with a CLI, and framework adapters for Nuxt and Fastify.

- npm: @validex/core
- GitHub: https://github.com/chiptoma/validex