### PR TITLE
fix(v4): clone Map and Set in shallowClone to prevent shared state

### DIFF
--- a/packages/zod/src/v4/classic/tests/default.test.ts
+++ b/packages/zod/src/v4/classic/tests/default.test.ts
@@ -332,6 +332,50 @@ test("defaulted array schema returns shallow clone", () => {
   expect(result1).toEqual(result2);
 });
 
+test("defaulted Map schema returns shallow clone", () => {
+  const schema = z.map(z.string(), z.number()).default(new Map([["a", 1]]));
+  const result1 = schema.parse(undefined);
+  const result2 = schema.parse(undefined);
+  expect(result1).not.toBe(result2);
+  expect(result1).toEqual(result2);
+});
+
+test("defaulted Set schema returns shallow clone", () => {
+  const schema = z.set(z.string()).default(new Set(["x"]));
+  const result1 = schema.parse(undefined);
+  const result2 = schema.parse(undefined);
+  expect(result1).not.toBe(result2);
+  expect(result1).toEqual(result2);
+});
+
+test("mutations on defaulted Map do not affect subsequent parses", () => {
+  const schema = z.map(z.string(), z.number()).default(new Map());
+  const result1 = schema.parse(undefined);
+  const result2 = schema.parse(undefined);
+  result1.set("key1", 1);
+  result2.set("key2", 2);
+  expect(result1.size).toBe(1);
+  expect(result1.get("key1")).toBe(1);
+  expect(result1.has("key2")).toBe(false);
+  expect(result2.size).toBe(1);
+  expect(result2.get("key2")).toBe(2);
+  expect(result2.has("key1")).toBe(false);
+});
+
+test("mutations on defaulted Set do not affect subsequent parses", () => {
+  const schema = z.set(z.string()).default(new Set());
+  const result1 = schema.parse(undefined);
+  const result2 = schema.parse(undefined);
+  result1.add("item1");
+  result2.add("item2");
+  expect(result1.size).toBe(1);
+  expect(result1.has("item1")).toBe(true);
+  expect(result1.has("item2")).toBe(false);
+  expect(result2.size).toBe(1);
+  expect(result2.has("item2")).toBe(true);
+  expect(result2.has("item1")).toBe(false);
+});
+
 test("direction-aware defaults", () => {
   const schema = z.string().default("hello");
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -407,6 +407,8 @@ export function isPlainObject(o: any): o is Record<PropertyKey, unknown> {
 export function shallowClone(o: any): any {
   if (isPlainObject(o)) return { ...o };
   if (Array.isArray(o)) return [...o];
+  if (o instanceof Map) return new Map(o);
+  if (o instanceof Set) return new Set(o);
   return o;
 }
 


### PR DESCRIPTION
## Problem

When using `.default()` with mutable values like `Map` or `Set`, every call to
`.parse(undefined)` returns the **same reference**. Mutations on one parse result
leak into subsequent parses:

```ts
const schema = z.map(z.string(), z.number()).default(new Map());

const result1 = schema.parse(undefined);
result1.set("key", 42);

const result2 = schema.parse(undefined);
console.log(result2.size); // 1 — should be 0
```

This already worked correctly for plain objects and arrays via shallowClone,
but Map and Set fell through to return o (same reference).

## Fix
Extended shallowClone in util.ts to cover Map and Set:

```ts
if (o instanceof Map) return new Map(o);
if (o instanceof Set) return new Set(o);
```

## Tests
Added four tests to default.test.ts:

shallow clone returns distinct instances for Map and Set
mutations on one parse result do not affect another (both directions)
Fixes #5826
