### PR TITLE
test(v4): add locale tests for all 50 supported locales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ packages/tsc-perf
 tsconfig.vitest-temp.json
 *.tgz
 
-.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ packages/tsc-perf
 tsconfig.vitest-temp.json
 *.tgz
 
+.claude/

--- a/packages/zod/src/v4/core/tests/locales/LOCALE_TESTS.md
+++ b/packages/zod/src/v4/core/tests/locales/LOCALE_TESTS.md
@@ -1,0 +1,109 @@
+# Locale Tests
+
+## Purpose
+
+These tests verify that each Zod v4 locale produces the correct translated error messages for every supported error code. They act as a **contract** between the locale implementation and the expected user-facing output — catching regressions, translation drift, and formatting bugs.
+
+## What Is Tested
+
+Each locale test file covers four groups of assertions:
+
+| Group                 | Zod schema patterns                                                                               | Error codes exercised                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `too_small errors`    | `z.string().min()`, `z.number().min()`, `z.array().min()`, `z.set().min()`                        | `too_small`                                                                                |
+| `too_big errors`      | `z.string().max()`, `z.number().max()`, `z.array().max()`                                         | `too_big`                                                                                  |
+| `invalid_type errors` | `z.string()`, `z.number()`, `z.boolean()`, `z.array()` parsed with wrong types                    | `invalid_type`                                                                             |
+| `other error cases`   | `z.enum()`, `.multipleOf()`, `.strict()`, `z.union()`, `.regex()`, `.startsWith()`, `.endsWith()` | `invalid_value`, `not_multiple_of`, `unrecognized_keys`, `invalid_union`, `invalid_format` |
+
+## Why This Implementation
+
+### Static string assertions
+
+Each test calls `safeParse()` on an intentionally invalid input and asserts the exact translated message string using `toBe()`. This approach:
+
+- **Catches subtle translation bugs** — a wrong word, missing space, or swapped order fails immediately.
+- **Is self-documenting** — reading the test shows exactly what message users will see.
+- **Is zero-dependency** — no mocking, no fixtures, just the real locale function running against the real Zod error pipeline.
+
+### `safeParse` + success guard pattern
+
+```ts
+const result = z.string().min(5).safeParse("abc");
+expect(result.success).toBe(false);
+if (!result.success) {
+  expect(result.error.issues[0].message).toBe("...");
+}
+```
+
+The explicit `success: false` check before accessing `.error` ensures TypeScript narrowing works correctly and that the test fails with a clear message if the schema unexpectedly succeeds.
+
+### One file per locale
+
+Each locale gets its own isolated test file (`ar.test.ts`, `de.test.ts`, etc.) rather than a single parameterized suite. This keeps failures easy to locate, allows locale-specific edge cases (e.g. plural forms, RTL separators), and makes it straightforward to add or skip tests for a single locale.
+
+### Coverage scope
+
+Tests cover the most commonly triggered error codes across all types. Locale-specific edge cases (e.g. plural forms for `unrecognized_keys`, RTL punctuation in Arabic, gendered adjectives in Slavic locales) are included wherever the locale source differentiates them.
+
+## Locales Covered (50 total)
+
+| Code    | Language                   |
+| ------- | -------------------------- |
+| `ar`    | Arabic                     |
+| `az`    | Azerbaijani                |
+| `be`    | Belarusian                 |
+| `bg`    | Bulgarian                  |
+| `ca`    | Catalan                    |
+| `cs`    | Czech                      |
+| `da`    | Danish                     |
+| `de`    | German                     |
+| `en`    | English                    |
+| `eo`    | Esperanto                  |
+| `es`    | Spanish                    |
+| `fa`    | Persian (Farsi)            |
+| `fi`    | Finnish                    |
+| `fr`    | French                     |
+| `fr-CA` | French (Canada)            |
+| `he`    | Hebrew                     |
+| `hr`    | Croatian                   |
+| `hu`    | Hungarian                  |
+| `hy`    | Armenian                   |
+| `id`    | Indonesian                 |
+| `is`    | Icelandic                  |
+| `it`    | Italian                    |
+| `ja`    | Japanese                   |
+| `ka`    | Georgian                   |
+| `kh`    | Khmer (Cambodia)           |
+| `km`    | Khmer                      |
+| `ko`    | Korean                     |
+| `lt`    | Lithuanian                 |
+| `mk`    | Macedonian                 |
+| `ms`    | Malay                      |
+| `nl`    | Dutch                      |
+| `no`    | Norwegian                  |
+| `ota`   | Ottoman Turkish            |
+| `pl`    | Polish                     |
+| `ps`    | Pashto                     |
+| `pt`    | Portuguese                 |
+| `ru`    | Russian                    |
+| `sl`    | Slovenian                  |
+| `sv`    | Swedish                    |
+| `ta`    | Tamil                      |
+| `th`    | Thai                       |
+| `tr`    | Turkish                    |
+| `ua`    | Ukrainian (alternate code) |
+| `uk`    | Ukrainian                  |
+| `ur`    | Urdu                       |
+| `uz`    | Uzbek                      |
+| `vi`    | Vietnamese                 |
+| `yo`    | Yoruba                     |
+| `zh-CN` | Chinese (Simplified)       |
+| `zh-TW` | Chinese (Traditional)      |
+
+## Adding Tests for a New Locale
+
+1. Create `packages/zod/src/v4/core/tests/locales/<code>.test.ts`
+2. Import the locale: `import xx from "../../../locales/<code>.js"`
+3. Copy the four test group structure from an existing file (e.g. `de.test.ts`)
+4. Trace each message through the locale source file (`packages/zod/src/v4/locales/<code>.ts`) to derive the expected string — do not guess
+5. Pay attention to: TypeDictionary overrides, plural forms in `unrecognized_keys`, locale-specific separators in `joinValues`, and sizing unit/verb for string/array/set

--- a/packages/zod/src/v4/core/tests/locales/ar.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ar.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ar from "../../../locales/ar.js";
+
+test("Arabic locale - too_small errors", () => {
+  z.config(ar());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("أصغر من اللازم: يفترض لـ string أن يكون >= 5 حرف");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("أصغر من اللازم: يفترض لـ number أن يكون >= 10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("أصغر من اللازم: يفترض لـ array أن يكون >= 3 عنصر");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("أصغر من اللازم: يفترض لـ set أن يكون >= 2 عنصر");
+  }
+});
+
+test("Arabic locale - too_big errors", () => {
+  z.config(ar());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe(" أكبر من اللازم: يفترض أن تكون string <= 3 حرف");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("أكبر من اللازم: يفترض أن تكون number <= 10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe(" أكبر من اللازم: يفترض أن تكون array <= 2 عنصر");
+  }
+});
+
+test("Arabic locale - invalid_type errors", () => {
+  z.config(ar());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("مدخلات غير مقبولة: يفترض إدخال string، ولكن تم إدخال number");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("مدخلات غير مقبولة: يفترض إدخال number، ولكن تم إدخال string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("مدخلات غير مقبولة: يفترض إدخال boolean، ولكن تم إدخال null");
+  }
+});
+
+test("Arabic locale - other error cases", () => {
+  z.config(ar());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('اختيار غير مقبول: يتوقع انتقاء أحد هذه الخيارات: "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("رقم غير مقبول: يجب أن يكون من مضاعفات 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('معرف غريب: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('معرفات غريبة: "b"، "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("مدخل غير مقبول");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("نَص غير مقبول: يجب أن يطابق النمط /^[a-z]+$/");
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('نَص غير مقبول: يجب أن ينتهي بـ "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/az.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/az.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import az from "../../../locales/az.js";
+
+test("Azerbaijani locale - too_small errors", () => {
+  z.config(az());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Çox kiçik: gözlənilən string >=5 simvol");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Çox kiçik: gözlənilən number >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Çox kiçik: gözlənilən array >=3 element");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Çox kiçik: gözlənilən set >=2 element");
+  }
+});
+
+test("Azerbaijani locale - too_big errors", () => {
+  z.config(az());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Çox böyük: gözlənilən string <=3 simvol");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Çox böyük: gözlənilən number <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Çox böyük: gözlənilən array <=2 element");
+  }
+});
+
+test("Azerbaijani locale - invalid_type errors", () => {
+  z.config(az());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Yanlış dəyər: gözlənilən string, daxil olan number");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Yanlış dəyər: gözlənilən number, daxil olan string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Yanlış dəyər: gözlənilən boolean, daxil olan null");
+  }
+});
+
+test("Azerbaijani locale - other error cases", () => {
+  z.config(az());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Yanlış seçim: aşağıdakılardan biri olmalıdır: "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Yanlış ədəd: 3 ilə bölünə bilən olmalıdır");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Tanınmayan açar: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Tanınmayan açarlar: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Yanlış dəyər");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Yanlış mətn: /^[a-z]+$/ şablonuna uyğun olmalıdır");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Yanlış mətn: "hello" ilə başlamalıdır');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Yanlış mətn: "world" ilə bitməlidir');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/bg.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/bg.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import bg from "../../../locales/bg.js";
+
+test("Bulgarian locale - too_small errors", () => {
+  z.config(bg());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Твърде малко: очаква се string да съдържа >=5 символа");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Твърде малко: очаква се number да бъде >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Твърде малко: очаква се array да съдържа >=3 елемента");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Твърде малко: очаква се set да съдържа >=2 елемента");
+  }
+});
+
+test("Bulgarian locale - too_big errors", () => {
+  z.config(bg());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Твърде голямо: очаква се string да съдържа <=3 символа");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Твърде голямо: очаква се number да бъде <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Твърде голямо: очаква се array да съдържа <=2 елемента");
+  }
+});
+
+test("Bulgarian locale - invalid_type errors", () => {
+  z.config(bg());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Невалиден вход: очакван string, получен число");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Невалиден вход: очакван число, получен string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Невалиден вход: очакван boolean, получен null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Невалиден вход: очакван масив, получен object");
+  }
+});
+
+test("Bulgarian locale - other error cases", () => {
+  z.config(bg());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Невалидна опция: очаквано едно от "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Невалидно число: трябва да бъде кратно на 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Неразпознат ключ: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Неразпознати ключове: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Невалиден вход");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Невалиден низ: трябва да съвпада с /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Невалиден низ: трябва да започва с "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Невалиден низ: трябва да завършва с "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ca.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ca.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ca from "../../../locales/ca.js";
+
+test("Catalan locale - too_small errors", () => {
+  z.config(ca());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe(
+      "Massa petit: s'esperava que string contingués com a mínim 5 caràcters"
+    );
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Massa petit: s'esperava que number fos com a mínim 10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe(
+      "Massa petit: s'esperava que array contingués com a mínim 3 elements"
+    );
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Massa petit: s'esperava que set contingués com a mínim 2 elements");
+  }
+});
+
+test("Catalan locale - too_big errors", () => {
+  z.config(ca());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe(
+      "Massa gran: s'esperava que string contingués com a màxim 3 caràcters"
+    );
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Massa gran: s'esperava que number fos com a màxim 10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe(
+      "Massa gran: s'esperava que array contingués com a màxim 2 elements"
+    );
+  }
+});
+
+test("Catalan locale - invalid_type errors", () => {
+  z.config(ca());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Tipus invàlid: s'esperava string, s'ha rebut number");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Tipus invàlid: s'esperava number, s'ha rebut string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Tipus invàlid: s'esperava boolean, s'ha rebut null");
+  }
+});
+
+test("Catalan locale - other error cases", () => {
+  z.config(ca());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Opció invàlida: s\'esperava una de "a" o "b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Número invàlid: ha de ser múltiple de 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Clau no reconeguda: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Claus no reconegudas: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Entrada invàlida");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Format invàlid: ha de coincidir amb el patró /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Format invàlid: ha de començar amb "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Format invàlid: ha d\'acabar amb "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/cs.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/cs.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import cs from "../../../locales/cs.js";
+
+test("Czech locale - too_small errors", () => {
+  z.config(cs());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Hodnota je příliš malá: string musí mít >=5 znaků");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Hodnota je příliš malá: number musí být >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Hodnota je příliš malá: array musí mít >=3 prvků");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Hodnota je příliš malá: set musí mít >=2 prvků");
+  }
+});
+
+test("Czech locale - too_big errors", () => {
+  z.config(cs());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Hodnota je příliš velká: string musí mít <=3 znaků");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Hodnota je příliš velká: number musí být <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Hodnota je příliš velká: array musí mít <=2 prvků");
+  }
+});
+
+test("Czech locale - invalid_type errors", () => {
+  z.config(cs());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Neplatný vstup: očekáváno řetězec, obdrženo číslo");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Neplatný vstup: očekáváno číslo, obdrženo řetězec");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Neplatný vstup: očekáváno boolean, obdrženo null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Neplatný vstup: očekáváno pole, obdrženo object");
+  }
+});
+
+test("Czech locale - other error cases", () => {
+  z.config(cs());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Neplatná možnost: očekávána jedna z hodnot "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Neplatné číslo: musí být násobkem 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Neznámé klíče: "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Neplatný vstup");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Neplatný řetězec: musí odpovídat vzoru /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Neplatný řetězec: musí začínat na "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Neplatný řetězec: musí končit na "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/da.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/da.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import da from "../../../locales/da.js";
+
+test("Danish locale - too_small errors", () => {
+  z.config(da());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("For lille: forventede streng havde >= 5 tegn");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("For lille: forventede tal havde >= 10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("For lille: forventede liste indeholdt >= 3 elementer");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("For lille: forventede sæt indeholdt >= 2 elementer");
+  }
+});
+
+test("Danish locale - too_big errors", () => {
+  z.config(da());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("For stor: forventede streng havde <= 3 tegn");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("For stor: forventede tal havde <= 10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("For stor: forventede liste indeholdt <= 2 elementer");
+  }
+});
+
+test("Danish locale - invalid_type errors", () => {
+  z.config(da());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Ugyldigt input: forventede streng, fik tal");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Ugyldigt input: forventede tal, fik streng");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Ugyldigt input: forventede boolean, fik null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Ugyldigt input: forventede liste, fik objekt");
+  }
+});
+
+test("Danish locale - other error cases", () => {
+  z.config(da());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Ugyldigt valg: forventede en af følgende "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Ugyldigt tal: skal være deleligt med 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Ukendt nøgle: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Ukendte nøgler: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Ugyldigt input: matcher ingen af de tilladte typer");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Ugyldig streng: skal matche mønsteret /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Ugyldig streng: skal starte med "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Ugyldig streng: skal ende med "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/de.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/de.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import de from "../../../locales/de.js";
+
+test("German locale - too_small errors", () => {
+  z.config(de());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Zu klein: erwartet, dass string >=5 Zeichen hat");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Zu klein: erwartet, dass number >=10 ist");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Zu klein: erwartet, dass array >=3 Elemente hat");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Zu klein: erwartet, dass set >=2 Elemente hat");
+  }
+});
+
+test("German locale - too_big errors", () => {
+  z.config(de());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Zu groß: erwartet, dass string <=3 Zeichen hat");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Zu groß: erwartet, dass number <=10 ist");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Zu groß: erwartet, dass array <=2 Elemente hat");
+  }
+});
+
+test("German locale - invalid_type errors", () => {
+  z.config(de());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Ungültige Eingabe: erwartet string, erhalten Zahl");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Ungültige Eingabe: erwartet Zahl, erhalten string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Ungültige Eingabe: erwartet boolean, erhalten null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Ungültige Eingabe: erwartet Array, erhalten object");
+  }
+});
+
+test("German locale - other error cases", () => {
+  z.config(de());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Ungültige Option: erwartet eine von "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Ungültige Zahl: muss ein Vielfaches von 3 sein");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Unbekannter Schlüssel: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Unbekannte Schlüssel: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Ungültige Eingabe");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Ungültiger String: muss dem Muster /^[a-z]+$/ entsprechen");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Ungültiger String: muss mit "hello" beginnen');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Ungültiger String: muss mit "world" enden');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/eo.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/eo.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import eo from "../../../locales/eo.js";
+
+test("Esperanto locale - too_small errors", () => {
+  z.config(eo());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Tro malgranda: atendiĝis ke string havu >=5 karaktrojn");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Tro malgranda: atendiĝis ke number estu >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Tro malgranda: atendiĝis ke array havu >=3 elementojn");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Tro malgranda: atendiĝis ke set havu >=2 elementojn");
+  }
+});
+
+test("Esperanto locale - too_big errors", () => {
+  z.config(eo());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Tro granda: atendiĝis ke string havu <=3 karaktrojn");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Tro granda: atendiĝis ke number havu <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Tro granda: atendiĝis ke array havu <=2 elementojn");
+  }
+});
+
+test("Esperanto locale - invalid_type errors", () => {
+  z.config(eo());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Nevalida enigo: atendiĝis string, riceviĝis nombro");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Nevalida enigo: atendiĝis nombro, riceviĝis string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Nevalida enigo: atendiĝis boolean, riceviĝis senvalora");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Nevalida enigo: atendiĝis tabelo, riceviĝis object");
+  }
+});
+
+test("Esperanto locale - other error cases", () => {
+  z.config(eo());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Nevalida opcio: atendiĝis unu el "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Nevalida nombro: devas esti oblo de 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Nekonata ŝlosilo: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Nekonataj ŝlosiloj: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Nevalida enigo");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Nevalida karaktraro: devas kongrui kun la modelo /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Nevalida karaktraro: devas komenciĝi per "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Nevalida karaktraro: devas finiĝi per "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/fa.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/fa.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import fa from "../../../locales/fa.js";
+
+test("Persian locale - too_small errors", () => {
+  z.config(fa());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("خیلی کوچک: string باید >=5 کاراکتر باشد");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("خیلی کوچک: number باید >=10 باشد");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("خیلی کوچک: array باید >=3 آیتم باشد");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("خیلی کوچک: set باید >=2 آیتم باشد");
+  }
+});
+
+test("Persian locale - too_big errors", () => {
+  z.config(fa());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("خیلی بزرگ: string باید <=3 کاراکتر باشد");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("خیلی بزرگ: number باید <=10 باشد");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("خیلی بزرگ: array باید <=2 آیتم باشد");
+  }
+});
+
+test("Persian locale - invalid_type errors", () => {
+  z.config(fa());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ورودی نامعتبر: می‌بایست string می‌بود، عدد دریافت شد");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ورودی نامعتبر: می‌بایست عدد می‌بود، string دریافت شد");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("ورودی نامعتبر: می‌بایست boolean می‌بود، null دریافت شد");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ورودی نامعتبر: می‌بایست آرایه می‌بود، object دریافت شد");
+  }
+});
+
+test("Persian locale - other error cases", () => {
+  z.config(fa());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('گزینه نامعتبر: می‌بایست یکی از "a"|"b" می‌بود');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("عدد نامعتبر: باید مضرب 3 باشد");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('کلید ناشناس: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('کلیدهای ناشناس: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("ورودی نامعتبر");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("رشته نامعتبر: باید با الگوی /^[a-z]+$/ مطابقت داشته باشد");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('رشته نامعتبر: باید با "hello" شروع شود');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('رشته نامعتبر: باید با "world" تمام شود');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/fi.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/fi.test.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import fi from "../../../locales/fi.js";
+
+test("Finnish locale - too_small errors", () => {
+  z.config(fi());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Liian pieni: merkkijonon täytyy olla >=5 merkkiä");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Liian pieni: luvun täytyy olla >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Liian pieni: listan täytyy olla >=3 alkiota");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Liian pieni: joukon täytyy olla >=2 alkiota");
+  }
+});
+
+test("Finnish locale - too_big errors", () => {
+  z.config(fi());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Liian suuri: merkkijonon täytyy olla <=3 merkkiä");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Liian suuri: luvun täytyy olla <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Liian suuri: listan täytyy olla <=2 alkiota");
+  }
+});
+
+test("Finnish locale - invalid_type errors", () => {
+  z.config(fi());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Virheellinen tyyppi: odotettiin string, oli number");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Virheellinen tyyppi: odotettiin number, oli string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Virheellinen tyyppi: odotettiin boolean, oli null");
+  }
+});
+
+test("Finnish locale - other error cases", () => {
+  z.config(fi());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Virheellinen valinta: täytyy olla yksi seuraavista: "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Virheellinen luku: täytyy olla luvun 3 monikerta");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Tuntematon avain: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Tuntemattomat avaimet: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Virheellinen unioni");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe(
+      "Virheellinen syöte: täytyy vastata säännöllistä lauseketta /^[a-z]+$/"
+    );
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Virheellinen syöte: täytyy alkaa "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Virheellinen syöte: täytyy loppua "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/fr-CA.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/fr-CA.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import frCA from "../../../locales/fr-CA.js";
+
+test("French (Canada) locale - too_small errors", () => {
+  z.config(frCA());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Trop petit : attendu que string ait ≥5 caractères");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Trop petit : attendu que number soit ≥10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Trop petit : attendu que array ait ≥3 éléments");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Trop petit : attendu que set ait ≥2 éléments");
+  }
+});
+
+test("French (Canada) locale - too_big errors", () => {
+  z.config(frCA());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Trop grand : attendu que string ait ≤3 caractères");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Trop grand : attendu que number soit ≤10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Trop grand : attendu que array ait ≤2 éléments");
+  }
+});
+
+test("French (Canada) locale - invalid_type errors", () => {
+  z.config(frCA());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Entrée invalide : attendu string, reçu number");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Entrée invalide : attendu number, reçu string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Entrée invalide : attendu boolean, reçu null");
+  }
+});
+
+test("French (Canada) locale - other error cases", () => {
+  z.config(frCA());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Option invalide : attendu l\'une des valeurs suivantes "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Nombre invalide : doit être un multiple de 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Clé non reconnue : "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Clés non reconnues : "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Entrée invalide");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Chaîne invalide : doit correspondre au motif /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Chaîne invalide : doit commencer par "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Chaîne invalide : doit se terminer par "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/fr.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/fr.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import fr from "../../../locales/fr.js";
+
+test("French locale - too_small errors", () => {
+  z.config(fr());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Trop petit : string doit avoir >=5 caractères");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Trop petit : number doit être >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Trop petit : array doit avoir >=3 éléments");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Trop petit : set doit avoir >=2 éléments");
+  }
+});
+
+test("French locale - too_big errors", () => {
+  z.config(fr());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Trop grand : string doit avoir <=3 caractères");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Trop grand : number doit être <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Trop grand : array doit avoir <=2 éléments");
+  }
+});
+
+test("French locale - invalid_type errors", () => {
+  z.config(fr());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Entrée invalide : string attendu, nombre reçu");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Entrée invalide : nombre attendu, string reçu");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Entrée invalide : boolean attendu, null reçu");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Entrée invalide : tableau attendu, object reçu");
+  }
+});
+
+test("French locale - other error cases", () => {
+  z.config(fr());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Option invalide : une valeur parmi "a"|"b" attendue');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Nombre invalide : doit être un multiple de 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Clé non reconnue : "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Clés non reconnues : "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Entrée invalide");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Chaîne invalide : doit correspondre au modèle /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Chaîne invalide : doit commencer par "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Chaîne invalide : doit se terminer par "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/hu.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/hu.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import hu from "../../../locales/hu.js";
+
+test("Hungarian locale - too_small errors", () => {
+  z.config(hu());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe(
+      "Túl kicsi: a bemeneti érték string mérete túl kicsi >=5 karakter"
+    );
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Túl kicsi: a bemeneti érték number túl kicsi >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Túl kicsi: a bemeneti érték array mérete túl kicsi >=3 elem");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Túl kicsi: a bemeneti érték set mérete túl kicsi >=2 elem");
+  }
+});
+
+test("Hungarian locale - too_big errors", () => {
+  z.config(hu());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Túl nagy: string mérete túl nagy <=3 karakter");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Túl nagy: a bemeneti érték number túl nagy: <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Túl nagy: array mérete túl nagy <=2 elem");
+  }
+});
+
+test("Hungarian locale - invalid_type errors", () => {
+  z.config(hu());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Érvénytelen bemenet: a várt érték string, a kapott érték szám");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Érvénytelen bemenet: a várt érték szám, a kapott érték string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe(
+      "Érvénytelen bemenet: a várt érték boolean, a kapott érték null"
+    );
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Érvénytelen bemenet: a várt érték tömb, a kapott érték object");
+  }
+});
+
+test("Hungarian locale - other error cases", () => {
+  z.config(hu());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Érvénytelen opció: valamelyik érték várt "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Érvénytelen szám: 3 többszörösének kell lennie");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Ismeretlen kulcs: "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Érvénytelen bemenet");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Érvénytelen string: /^[a-z]+$/ mintának kell megfelelnie");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Érvénytelen string: "hello" értékkel kell kezdődnie');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Érvénytelen string: "world" értékkel kell végződnie');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/hy.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/hy.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import hy from "../../../locales/hy.js";
+
+test("Armenian locale - too_small errors", () => {
+  z.config(hy());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe(
+      "Չափազանց փոքր արժեք․ սպասվում է, որ stringը կունենա >=5 նշաններ"
+    );
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Չափազանց փոքր արժեք․ սպասվում է, որ numberը լինի >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Չափազանց փոքր արժեք․ սպասվում է, որ arrayը կունենա >=3 տարրեր");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Չափազանց փոքր արժեք․ սպասվում է, որ setը կունենա >=2 տարրեր");
+  }
+});
+
+test("Armenian locale - too_big errors", () => {
+  z.config(hy());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Չափազանց մեծ արժեք․ սպասվում է, որ stringը կունենա <=3 նշաններ");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Չափազանց մեծ արժեք․ սպասվում է, որ numberը լինի <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Չափազանց մեծ արժեք․ սպասվում է, որ arrayը կունենա <=2 տարրեր");
+  }
+});
+
+test("Armenian locale - invalid_type errors", () => {
+  z.config(hy());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Սխալ մուտքագրում․ սպասվում էր string, ստացվել է թիվ");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Սխալ մուտքագրում․ սպասվում էր թիվ, ստացվել է string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Սխալ մուտքագրում․ սպասվում էր boolean, ստացվել է null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Սխալ մուտքագրում․ սպասվում էր զանգված, ստացվել է object");
+  }
+});
+
+test("Armenian locale - other error cases", () => {
+  z.config(hy());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Սխալ տարբերակ․ սպասվում էր հետևյալներից մեկը՝ "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Սխալ թիվ․ պետք է բազմապատիկ լինի 3-ի");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Չճանաչված բանալի. "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Չճանաչված բանալիներ. "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Սխալ մուտքագրում");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Սխալ տող․ պետք է համապատասխանի /^[a-z]+$/ ձևաչափին");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Սխալ տող․ պետք է սկսվի "hello"-ով');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Սխալ տող․ պետք է ավարտվի "world"-ով');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/id.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/id.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import id from "../../../locales/id.js";
+
+test("Indonesian locale - too_small errors", () => {
+  z.config(id());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Terlalu kecil: diharapkan string memiliki >=5 karakter");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Terlalu kecil: diharapkan number menjadi >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Terlalu kecil: diharapkan array memiliki >=3 item");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Terlalu kecil: diharapkan set memiliki >=2 item");
+  }
+});
+
+test("Indonesian locale - too_big errors", () => {
+  z.config(id());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Terlalu besar: diharapkan string memiliki <=3 karakter");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Terlalu besar: diharapkan number menjadi <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Terlalu besar: diharapkan array memiliki <=2 item");
+  }
+});
+
+test("Indonesian locale - invalid_type errors", () => {
+  z.config(id());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Input tidak valid: diharapkan string, diterima number");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Input tidak valid: diharapkan number, diterima string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Input tidak valid: diharapkan boolean, diterima null");
+  }
+});
+
+test("Indonesian locale - other error cases", () => {
+  z.config(id());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Pilihan tidak valid: diharapkan salah satu dari "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Angka tidak valid: harus kelipatan dari 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Kunci tidak dikenali : "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Input tidak valid");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("String tidak valid: harus sesuai pola /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('String tidak valid: harus dimulai dengan "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('String tidak valid: harus berakhir dengan "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/is.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/is.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import is from "../../../locales/is.js";
+
+test("Icelandic locale - too_small errors", () => {
+  z.config(is());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Of lítið: gert er ráð fyrir að string hafi >=5 stafi");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Of lítið: gert er ráð fyrir að number sé >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Of lítið: gert er ráð fyrir að array hafi >=3 hluti");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Of lítið: gert er ráð fyrir að set hafi >=2 hluti");
+  }
+});
+
+test("Icelandic locale - too_big errors", () => {
+  z.config(is());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Of stórt: gert er ráð fyrir að string hafi <=3 stafi");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Of stórt: gert er ráð fyrir að number sé <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Of stórt: gert er ráð fyrir að array hafi <=2 hluti");
+  }
+});
+
+test("Icelandic locale - invalid_type errors", () => {
+  z.config(is());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Rangt gildi: Þú slóst inn númer þar sem á að vera string");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Rangt gildi: Þú slóst inn string þar sem á að vera númer");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Rangt gildi: Þú slóst inn null þar sem á að vera boolean");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Rangt gildi: Þú slóst inn object þar sem á að vera fylki");
+  }
+});
+
+test("Icelandic locale - other error cases", () => {
+  z.config(is());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Ógilt val: má vera eitt af eftirfarandi "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Röng tala: verður að vera margfeldi af 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Óþekkt ur lykill: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Óþekkt ir lyklar: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Rangt gildi");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Ógildur strengur: verður að fylgja mynstri /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Ógildur strengur: verður að byrja á "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Ógildur strengur: verður að enda á "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/it.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/it.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import it from "../../../locales/it.js";
+
+test("Italian locale - too_small errors", () => {
+  z.config(it());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Troppo piccolo: string deve avere >=5 caratteri");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Troppo piccolo: number deve essere >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Troppo piccolo: array deve avere >=3 elementi");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Troppo piccolo: set deve avere >=2 elementi");
+  }
+});
+
+test("Italian locale - too_big errors", () => {
+  z.config(it());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Troppo grande: string deve avere <=3 caratteri");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Troppo grande: number deve essere <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Troppo grande: array deve avere <=2 elementi");
+  }
+});
+
+test("Italian locale - invalid_type errors", () => {
+  z.config(it());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Input non valido: atteso string, ricevuto numero");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Input non valido: atteso numero, ricevuto string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Input non valido: atteso boolean, ricevuto null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Input non valido: atteso vettore, ricevuto object");
+  }
+});
+
+test("Italian locale - other error cases", () => {
+  z.config(it());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Opzione non valida: atteso uno tra "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Numero non valido: deve essere un multiplo di 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Chiave non riconosciuta: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Chiavi non riconosciute: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Input non valido");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Stringa non valida: deve corrispondere al pattern /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Stringa non valida: deve iniziare con "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Stringa non valida: deve terminare con "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ja.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ja.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ja from "../../../locales/ja.js";
+
+test("Japanese locale - too_small errors", () => {
+  z.config(ja());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("小さすぎる値: stringは5文字以上である必要があります");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("小さすぎる値: numberは10以上である必要があります");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("小さすぎる値: arrayは3要素以上である必要があります");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("小さすぎる値: setは2要素以上である必要があります");
+  }
+});
+
+test("Japanese locale - too_big errors", () => {
+  z.config(ja());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("大きすぎる値: stringは3文字以下である必要があります");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("大きすぎる値: numberは10以下である必要があります");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("大きすぎる値: arrayは2要素以下である必要があります");
+  }
+});
+
+test("Japanese locale - invalid_type errors", () => {
+  z.config(ja());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("無効な入力: stringが期待されましたが、数値が入力されました");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("無効な入力: 数値が期待されましたが、stringが入力されました");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("無効な入力: booleanが期待されましたが、nullが入力されました");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("無効な入力: 配列が期待されましたが、objectが入力されました");
+  }
+});
+
+test("Japanese locale - other error cases", () => {
+  z.config(ja());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('無効な選択: "a"、"b"のいずれかである必要があります');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("無効な数値: 3の倍数である必要があります");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('認識されていないキー: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('認識されていないキー群: "b"、"c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("無効な入力");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("無効な文字列: パターン/^[a-z]+$/に一致する必要があります");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('無効な文字列: "hello"で始まる必要があります');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('無効な文字列: "world"で終わる必要があります');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ka.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ka.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ka from "../../../locales/ka.js";
+
+test("Georgian locale - too_small errors", () => {
+  z.config(ka());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ზედმეტად პატარა: მოსალოდნელი string უნდა შეიცავდეს >=5 სიმბოლო");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ზედმეტად პატარა: მოსალოდნელი number იყოს >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ზედმეტად პატარა: მოსალოდნელი array უნდა შეიცავდეს >=3 ელემენტი");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("ზედმეტად პატარა: მოსალოდნელი set უნდა შეიცავდეს >=2 ელემენტი");
+  }
+});
+
+test("Georgian locale - too_big errors", () => {
+  z.config(ka());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ზედმეტად დიდი: მოსალოდნელი string უნდა შეიცავდეს <=3 სიმბოლო");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ზედმეტად დიდი: მოსალოდნელი number იყოს <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ზედმეტად დიდი: მოსალოდნელი array უნდა შეიცავდეს <=2 ელემენტი");
+  }
+});
+
+test("Georgian locale - invalid_type errors", () => {
+  z.config(ka());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("არასწორი შეყვანა: მოსალოდნელი ველი, მიღებული რიცხვი");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("არასწორი შეყვანა: მოსალოდნელი რიცხვი, მიღებული ველი");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("არასწორი შეყვანა: მოსალოდნელი ბულეანი, მიღებული null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("არასწორი შეყვანა: მოსალოდნელი მასივი, მიღებული object");
+  }
+});
+
+test("Georgian locale - other error cases", () => {
+  z.config(ka());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('არასწორი ვარიანტი: მოსალოდნელია ერთ-ერთი "a"|"b"-დან');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("არასწორი რიცხვი: უნდა იყოს 3-ის ჯერადი");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('უცნობი გასაღები: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('უცნობი გასაღებები: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("არასწორი შეყვანა");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("არასწორი ველი: უნდა შეესაბამებოდეს შაბლონს /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('არასწორი ველი: უნდა იწყებოდეს "hello"-ით');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('არასწორი ველი: უნდა მთავრდებოდეს "world"-ით');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/kh.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/kh.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import kh from "../../../locales/kh.js";
+
+test("Khmer (kh alias) locale - too_small errors", () => {
+  z.config(kh());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("តូចពេក៖ ត្រូវការ string >= 5 តួអក្សរ");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("តូចពេក៖ ត្រូវការ number >= 10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("តូចពេក៖ ត្រូវការ array >= 3 ធាតុ");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("តូចពេក៖ ត្រូវការ set >= 2 ធាតុ");
+  }
+});
+
+test("Khmer (kh alias) locale - too_big errors", () => {
+  z.config(kh());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ធំពេក៖ ត្រូវការ string <= 3 តួអក្សរ");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ធំពេក៖ ត្រូវការ number <= 10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ធំពេក៖ ត្រូវការ array <= 2 ធាតុ");
+  }
+});
+
+test("Khmer (kh alias) locale - invalid_type errors", () => {
+  z.config(kh());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ string ប៉ុន្តែទទួលបាន លេខ");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ លេខ ប៉ុន្តែទទួលបាន string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ boolean ប៉ុន្តែទទួលបាន គ្មានតម្លៃ (null)");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ អារេ (Array) ប៉ុន្តែទទួលបាន object");
+  }
+});
+
+test("Khmer (kh alias) locale - other error cases", () => {
+  z.config(kh());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('ជម្រើសមិនត្រឹមត្រូវ៖ ត្រូវជាមួយក្នុងចំណោម "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("លេខមិនត្រឹមត្រូវ៖ ត្រូវតែជាពហុគុណនៃ 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('រកឃើញសោមិនស្គាល់៖ "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("ទិន្នន័យមិនត្រឹមត្រូវ");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("ខ្សែអក្សរមិនត្រឹមត្រូវ៖ ត្រូវតែផ្គូផ្គងនឹងទម្រង់ដែលបានកំណត់ /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('ខ្សែអក្សរមិនត្រឹមត្រូវ៖ ត្រូវចាប់ផ្តើមដោយ "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('ខ្សែអក្សរមិនត្រឹមត្រូវ៖ ត្រូវបញ្ចប់ដោយ "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/km.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/km.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import km from "../../../locales/km.js";
+
+test("Khmer locale - too_small errors", () => {
+  z.config(km());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("តូចពេក៖ ត្រូវការ string >= 5 តួអក្សរ");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("តូចពេក៖ ត្រូវការ number >= 10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("តូចពេក៖ ត្រូវការ array >= 3 ធាតុ");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("តូចពេក៖ ត្រូវការ set >= 2 ធាតុ");
+  }
+});
+
+test("Khmer locale - too_big errors", () => {
+  z.config(km());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ធំពេក៖ ត្រូវការ string <= 3 តួអក្សរ");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ធំពេក៖ ត្រូវការ number <= 10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ធំពេក៖ ត្រូវការ array <= 2 ធាតុ");
+  }
+});
+
+test("Khmer locale - invalid_type errors", () => {
+  z.config(km());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ string ប៉ុន្តែទទួលបាន លេខ");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ លេខ ប៉ុន្តែទទួលបាន string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ boolean ប៉ុន្តែទទួលបាន គ្មានតម្លៃ (null)");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ អារេ (Array) ប៉ុន្តែទទួលបាន object");
+  }
+});
+
+test("Khmer locale - other error cases", () => {
+  z.config(km());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('ជម្រើសមិនត្រឹមត្រូវ៖ ត្រូវជាមួយក្នុងចំណោម "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("លេខមិនត្រឹមត្រូវ៖ ត្រូវតែជាពហុគុណនៃ 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('រកឃើញសោមិនស្គាល់៖ "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("ទិន្នន័យមិនត្រឹមត្រូវ");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("ខ្សែអក្សរមិនត្រឹមត្រូវ៖ ត្រូវតែផ្គូផ្គងនឹងទម្រង់ដែលបានកំណត់ /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('ខ្សែអក្សរមិនត្រឹមត្រូវ៖ ត្រូវចាប់ផ្តើមដោយ "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('ខ្សែអក្សរមិនត្រឹមត្រូវ៖ ត្រូវបញ្ចប់ដោយ "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ko.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ko.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ko from "../../../locales/ko.js";
+
+test("Korean locale - too_small errors", () => {
+  z.config(ko());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("string이 너무 작습니다: 5문자 이상이어야 합니다");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("number이 너무 작습니다: 10 이상이어야 합니다");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("array이 너무 작습니다: 3개 이상이어야 합니다");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("set이 너무 작습니다: 2개 이상이어야 합니다");
+  }
+});
+
+test("Korean locale - too_big errors", () => {
+  z.config(ko());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("string이 너무 큽니다: 3문자 이하여야 합니다");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("number이 너무 큽니다: 10 이하여야 합니다");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("array이 너무 큽니다: 2개 이하여야 합니다");
+  }
+});
+
+test("Korean locale - invalid_type errors", () => {
+  z.config(ko());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("잘못된 입력: 예상 타입은 string, 받은 타입은 number입니다");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("잘못된 입력: 예상 타입은 number, 받은 타입은 string입니다");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("잘못된 입력: 예상 타입은 boolean, 받은 타입은 null입니다");
+  }
+});
+
+test("Korean locale - other error cases", () => {
+  z.config(ko());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('잘못된 옵션: "a"또는 "b" 중 하나여야 합니다');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("잘못된 숫자: 3의 배수여야 합니다");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('인식할 수 없는 키: "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("잘못된 입력");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("잘못된 문자열: 정규식 /^[a-z]+$/ 패턴과 일치해야 합니다");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('잘못된 문자열: "hello"(으)로 시작해야 합니다');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('잘못된 문자열: "world"(으)로 끝나야 합니다');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/lt.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/lt.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import lt from "../../../locales/lt.js";
+
+test("Lithuanian locale - too_small errors", () => {
+  z.config(lt());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Eilutė turi būti ne trumpesnė kaip 5 simboliai");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Skaičius turi būti ne mažesnis kaip 10 undefined");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Masyvas turi turėti ne mažiau kaip 3 elementus");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Set turi turėti ne mažiau kaip 2 elementus");
+  }
+});
+
+test("Lithuanian locale - too_big errors", () => {
+  z.config(lt());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Eilutė turi būti ne ilgesnė kaip 3 simboliai");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Skaičius turi būti ne didesnis kaip 10 undefined");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Masyvas turi turėti ne daugiau kaip 2 elementus");
+  }
+});
+
+test("Lithuanian locale - invalid_type errors", () => {
+  z.config(lt());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Gautas tipas skaičius, o tikėtasi - eilutė");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Gautas tipas eilutė, o tikėtasi - skaičius");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Gautas tipas nulinė reikšmė, o tikėtasi - loginė reikšmė");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Gautas tipas objektas, o tikėtasi - masyvas");
+  }
+});
+
+test("Lithuanian locale - other error cases", () => {
+  z.config(lt());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Privalo būti vienas iš "a"|"b" pasirinkimų');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Skaičius privalo būti 3 kartotinis.");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Neatpažintas raktas: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Neatpažinti raktai: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Klaidinga įvestis");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Eilutė privalo atitikti /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Eilutė privalo prasidėti "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Eilutė privalo pasibaigti "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/mk.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/mk.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import mk from "../../../locales/mk.js";
+
+test("Macedonian locale - too_small errors", () => {
+  z.config(mk());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Премногу мал: се очекува string да има >=5 знаци");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Премногу мал: се очекува number да биде >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Премногу мал: се очекува array да има >=3 ставки");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Премногу мал: се очекува set да има >=2 ставки");
+  }
+});
+
+test("Macedonian locale - too_big errors", () => {
+  z.config(mk());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Премногу голем: се очекува string да има <=3 знаци");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Премногу голем: се очекува number да биде <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Премногу голем: се очекува array да има <=2 ставки");
+  }
+});
+
+test("Macedonian locale - invalid_type errors", () => {
+  z.config(mk());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Грешен внес: се очекува string, примено број");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Грешен внес: се очекува број, примено string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Грешен внес: се очекува boolean, примено null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Грешен внес: се очекува низа, примено object");
+  }
+});
+
+test("Macedonian locale - other error cases", () => {
+  z.config(mk());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Грешана опција: се очекува една "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Грешен број: мора да биде делив со 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Непрепознаен клуч: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Непрепознаени клучеви: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Грешен внес");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Неважечка низа: мора да одгоара на патернот /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Неважечка низа: мора да започнува со "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Неважечка низа: мора да завршува со "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ms.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ms.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ms from "../../../locales/ms.js";
+
+test("Malay locale - too_small errors", () => {
+  z.config(ms());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Terlalu kecil: dijangka string mempunyai >=5 aksara");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Terlalu kecil: dijangka number adalah >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Terlalu kecil: dijangka array mempunyai >=3 elemen");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Terlalu kecil: dijangka set mempunyai >=2 elemen");
+  }
+});
+
+test("Malay locale - too_big errors", () => {
+  z.config(ms());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Terlalu besar: dijangka string mempunyai <=3 aksara");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Terlalu besar: dijangka number adalah <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Terlalu besar: dijangka array mempunyai <=2 elemen");
+  }
+});
+
+test("Malay locale - invalid_type errors", () => {
+  z.config(ms());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Input tidak sah: dijangka string, diterima nombor");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Input tidak sah: dijangka nombor, diterima string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Input tidak sah: dijangka boolean, diterima null");
+  }
+});
+
+test("Malay locale - other error cases", () => {
+  z.config(ms());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Pilihan tidak sah: dijangka salah satu daripada "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Nombor tidak sah: perlu gandaan 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Kunci tidak dikenali: "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Input tidak sah");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("String tidak sah: mesti sepadan dengan corak /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('String tidak sah: mesti bermula dengan "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('String tidak sah: mesti berakhir dengan "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/no.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/no.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import no from "../../../locales/no.js";
+
+test("Norwegian locale - too_small errors", () => {
+  z.config(no());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("For lite(n): forventet string til å ha >=5 tegn");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("For lite(n): forventet number til å ha >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("For lite(n): forventet array til å ha >=3 elementer");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("For lite(n): forventet set til å ha >=2 elementer");
+  }
+});
+
+test("Norwegian locale - too_big errors", () => {
+  z.config(no());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("For stor(t): forventet string til å ha <=3 tegn");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("For stor(t): forventet number til å ha <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("For stor(t): forventet array til å ha <=2 elementer");
+  }
+});
+
+test("Norwegian locale - invalid_type errors", () => {
+  z.config(no());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Ugyldig input: forventet string, fikk tall");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Ugyldig input: forventet tall, fikk string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Ugyldig input: forventet boolean, fikk null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Ugyldig input: forventet liste, fikk object");
+  }
+});
+
+test("Norwegian locale - other error cases", () => {
+  z.config(no());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Ugyldig valg: forventet en av "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Ugyldig tall: må være et multiplum av 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Ukjent nøkkel: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Ukjente nøkler: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Ugyldig input");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Ugyldig streng: må matche mønsteret /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Ugyldig streng: må starte med "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Ugyldig streng: må ende med "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ota.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ota.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ota from "../../../locales/ota.js";
+
+test("Ottoman Turkish locale - too_small errors", () => {
+  z.config(ota());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Fazla küçük: string, >=5 harf sahip olmalıydı.");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Fazla küçük: number, >=10 olmalıydı.");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Fazla küçük: array, >=3 unsur sahip olmalıydı.");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Fazla küçük: set, >=2 unsur sahip olmalıydı.");
+  }
+});
+
+test("Ottoman Turkish locale - too_big errors", () => {
+  z.config(ota());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Fazla büyük: string, <=3 harf sahip olmalıydı.");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Fazla büyük: number, <=10 olmalıydı.");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Fazla büyük: array, <=2 unsur sahip olmalıydı.");
+  }
+});
+
+test("Ottoman Turkish locale - invalid_type errors", () => {
+  z.config(ota());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Fâsit giren: umulan string, alınan numara");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Fâsit giren: umulan numara, alınan string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Fâsit giren: umulan boolean, alınan gayb");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Fâsit giren: umulan saf, alınan object");
+  }
+});
+
+test("Ottoman Turkish locale - other error cases", () => {
+  z.config(ota());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Fâsit tercih: mûteberler "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Fâsit sayı: 3 katı olmalıydı.");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Tanınmayan anahtar : "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Giren tanınamadı.");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Fâsit metin: /^[a-z]+$/ nakşına uymalı.");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Fâsit metin: "hello" ile başlamalı.');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Fâsit metin: "world" ile bitmeli.');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/pl.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/pl.test.ts
@@ -1,0 +1,141 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import pl from "../../../locales/pl.js";
+
+test("Polish locale - too_small errors", () => {
+  z.config(pl());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Za mała wartość: oczekiwano, że string będzie mieć >=5 znaków");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Zbyt mał(y/a/e): oczekiwano, że number będzie wynosić >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Za mała wartość: oczekiwano, że array będzie mieć >=3 elementów");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Za mała wartość: oczekiwano, że set będzie mieć >=2 elementów");
+  }
+});
+
+test("Polish locale - too_big errors", () => {
+  z.config(pl());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Za duża wartość: oczekiwano, że string będzie mieć <=3 znaków");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Zbyt duż(y/a/e): oczekiwano, że number będzie wynosić <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Za duża wartość: oczekiwano, że array będzie mieć <=2 elementów");
+  }
+});
+
+test("Polish locale - invalid_type errors", () => {
+  z.config(pl());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe(
+      "Nieprawidłowe dane wejściowe: oczekiwano string, otrzymano liczba"
+    );
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe(
+      "Nieprawidłowe dane wejściowe: oczekiwano liczba, otrzymano string"
+    );
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe(
+      "Nieprawidłowe dane wejściowe: oczekiwano boolean, otrzymano null"
+    );
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe(
+      "Nieprawidłowe dane wejściowe: oczekiwano tablica, otrzymano object"
+    );
+  }
+});
+
+test("Polish locale - other error cases", () => {
+  z.config(pl());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Nieprawidłowa opcja: oczekiwano jednej z wartości "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Nieprawidłowa liczba: musi być wielokrotnością 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Nierozpoznane klucze: "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Nieprawidłowe dane wejściowe");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Nieprawidłowy ciąg znaków: musi odpowiadać wzorcowi /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Nieprawidłowy ciąg znaków: musi zaczynać się od "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Nieprawidłowy ciąg znaków: musi kończyć się na "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ps.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ps.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ps from "../../../locales/ps.js";
+
+test("Pashto locale - too_small errors", () => {
+  z.config(ps());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ډیر کوچنی: string باید >=5 توکي ولري");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ډیر کوچنی: number باید >=10 وي");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ډیر کوچنی: array باید >=3 توکي ولري");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("ډیر کوچنی: set باید >=2 توکي ولري");
+  }
+});
+
+test("Pashto locale - too_big errors", () => {
+  z.config(ps());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ډیر لوی: string باید <=3 توکي ولري");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ډیر لوی: number باید <=10 وي");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ډیر لوی: array باید <=2 توکي ولري");
+  }
+});
+
+test("Pashto locale - invalid_type errors", () => {
+  z.config(ps());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ناسم ورودي: باید string وای, مګر عدد ترلاسه شو");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ناسم ورودي: باید عدد وای, مګر string ترلاسه شو");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("ناسم ورودي: باید boolean وای, مګر null ترلاسه شو");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ناسم ورودي: باید ارې وای, مګر object ترلاسه شو");
+  }
+});
+
+test("Pashto locale - other error cases", () => {
+  z.config(ps());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('ناسم انتخاب: باید یو له "a"|"b" څخه وای');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("ناسم عدد: باید د 3 مضرب وي");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('ناسم کلیډ: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('ناسم کلیډونه: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("ناسمه ورودي");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("ناسم متن: باید د /^[a-z]+$/ سره مطابقت ولري");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('ناسم متن: باید د "hello" سره پیل شي');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('ناسم متن: باید د "world" سره پای ته ورسيږي');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/pt.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/pt.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import pt from "../../../locales/pt.js";
+
+test("Portuguese locale - too_small errors", () => {
+  z.config(pt());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Muito pequeno: esperado que string tivesse >=5 caracteres");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Muito pequeno: esperado que number fosse >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Muito pequeno: esperado que array tivesse >=3 itens");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Muito pequeno: esperado que set tivesse >=2 itens");
+  }
+});
+
+test("Portuguese locale - too_big errors", () => {
+  z.config(pt());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Muito grande: esperado que string tivesse <=3 caracteres");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Muito grande: esperado que number fosse <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Muito grande: esperado que array tivesse <=2 itens");
+  }
+});
+
+test("Portuguese locale - invalid_type errors", () => {
+  z.config(pt());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Tipo inválido: esperado string, recebido número");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Tipo inválido: esperado número, recebido string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Tipo inválido: esperado boolean, recebido nulo");
+  }
+});
+
+test("Portuguese locale - other error cases", () => {
+  z.config(pt());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Opção inválida: esperada uma das "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Número inválido: deve ser múltiplo de 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Chave desconhecida: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Chaves desconhecidas: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Entrada inválida");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Texto inválido: deve corresponder ao padrão /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Texto inválido: deve começar com "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Texto inválido: deve terminar com "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/sl.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/sl.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import sl from "../../../locales/sl.js";
+
+test("Slovenian locale - too_small errors", () => {
+  z.config(sl());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Premajhno: pričakovano, da bo string imelo >=5 znakov");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Premajhno: pričakovano, da bo number >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Premajhno: pričakovano, da bo array imelo >=3 elementov");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Premajhno: pričakovano, da bo set imelo >=2 elementov");
+  }
+});
+
+test("Slovenian locale - too_big errors", () => {
+  z.config(sl());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Preveliko: pričakovano, da bo string imelo <=3 znakov");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Preveliko: pričakovano, da bo number <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Preveliko: pričakovano, da bo array imelo <=2 elementov");
+  }
+});
+
+test("Slovenian locale - invalid_type errors", () => {
+  z.config(sl());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Neveljaven vnos: pričakovano string, prejeto število");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Neveljaven vnos: pričakovano število, prejeto string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Neveljaven vnos: pričakovano boolean, prejeto null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Neveljaven vnos: pričakovano tabela, prejeto object");
+  }
+});
+
+test("Slovenian locale - other error cases", () => {
+  z.config(sl());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Neveljavna možnost: pričakovano eno izmed "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Neveljavno število: mora biti večkratnik 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Neprepoznan ključ: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Neprepoznani ključi: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Neveljaven vnos");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Neveljaven niz: mora ustrezati vzorcu /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Neveljaven niz: mora se začeti z "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Neveljaven niz: mora se končati z "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/sv.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/sv.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import sv from "../../../locales/sv.js";
+
+test("Swedish locale - too_small errors", () => {
+  z.config(sv());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("För lite(t): förväntade string att ha >=5 tecken");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("För lite(t): förväntade number att ha >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("För lite(t): förväntade array att ha >=3 objekt");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("För lite(t): förväntade set att ha >=2 objekt");
+  }
+});
+
+test("Swedish locale - too_big errors", () => {
+  z.config(sv());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("För stor(t): förväntade string att ha <=3 tecken");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("För stor(t): förväntat number att ha <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("För stor(t): förväntade array att ha <=2 objekt");
+  }
+});
+
+test("Swedish locale - invalid_type errors", () => {
+  z.config(sv());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Ogiltig inmatning: förväntat string, fick antal");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Ogiltig inmatning: förväntat antal, fick string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Ogiltig inmatning: förväntat boolean, fick null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Ogiltig inmatning: förväntat lista, fick object");
+  }
+});
+
+test("Swedish locale - other error cases", () => {
+  z.config(sv());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Ogiltigt val: förväntade en av "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Ogiltigt tal: måste vara en multipel av 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Okänd nyckel: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Okända nycklar: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Ogiltig input");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe('Ogiltig sträng: måste matcha mönstret "/^[a-z]+$/"');
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Ogiltig sträng: måste börja med "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Ogiltig sträng: måste sluta med "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ta.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ta.test.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ta from "../../../locales/ta.js";
+
+test("Tamil locale - too_small errors", () => {
+  z.config(ta());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe(
+      "மிகச் சிறியது: எதிர்பார்க்கப்பட்டது string >=5 எழுத்துக்கள் ஆக இருக்க வேண்டும்"
+    );
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("மிகச் சிறியது: எதிர்பார்க்கப்பட்டது number >=10 ஆக இருக்க வேண்டும்");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("மிகச் சிறியது: எதிர்பார்க்கப்பட்டது array >=3 உறுப்புகள் ஆக இருக்க வேண்டும்");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("மிகச் சிறியது: எதிர்பார்க்கப்பட்டது set >=2 உறுப்புகள் ஆக இருக்க வேண்டும்");
+  }
+});
+
+test("Tamil locale - too_big errors", () => {
+  z.config(ta());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe(
+      "மிக பெரியது: எதிர்பார்க்கப்பட்டது string <=3 எழுத்துக்கள் ஆக இருக்க வேண்டும்"
+    );
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("மிக பெரியது: எதிர்பார்க்கப்பட்டது number <=10 ஆக இருக்க வேண்டும்");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("மிக பெரியது: எதிர்பார்க்கப்பட்டது array <=2 உறுப்புகள் ஆக இருக்க வேண்டும்");
+  }
+});
+
+test("Tamil locale - invalid_type errors", () => {
+  z.config(ta());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("தவறான உள்ளீடு: எதிர்பார்க்கப்பட்டது string, பெறப்பட்டது எண்");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("தவறான உள்ளீடு: எதிர்பார்க்கப்பட்டது எண், பெறப்பட்டது string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("தவறான உள்ளீடு: எதிர்பார்க்கப்பட்டது boolean, பெறப்பட்டது வெறுமை");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("தவறான உள்ளீடு: எதிர்பார்க்கப்பட்டது அணி, பெறப்பட்டது object");
+  }
+});
+
+test("Tamil locale - other error cases", () => {
+  z.config(ta());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('தவறான விருப்பம்: எதிர்பார்க்கப்பட்டது "a"|"b" இல் ஒன்று');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("தவறான எண்: 3 இன் பலமாக இருக்க வேண்டும்");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('அடையாளம் தெரியாத விசை: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('அடையாளம் தெரியாத விசைகள்: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("தவறான உள்ளீடு");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("தவறான சரம்: /^[a-z]+$/ முறைபாட்டுடன் பொருந்த வேண்டும்");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('தவறான சரம்: "hello" இல் தொடங்க வேண்டும்');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('தவறான சரம்: "world" இல் முடிவடைய வேண்டும்');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/th.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/th.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import th from "../../../locales/th.js";
+
+test("Thai locale - too_small errors", () => {
+  z.config(th());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("น้อยกว่ากำหนด: string ควรมีอย่างน้อย 5 ตัวอักษร");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("น้อยกว่ากำหนด: number ควรมีอย่างน้อย 10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("น้อยกว่ากำหนด: array ควรมีอย่างน้อย 3 รายการ");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("น้อยกว่ากำหนด: set ควรมีอย่างน้อย 2 รายการ");
+  }
+});
+
+test("Thai locale - too_big errors", () => {
+  z.config(th());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("เกินกำหนด: string ควรมีไม่เกิน 3 ตัวอักษร");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("เกินกำหนด: number ควรมีไม่เกิน 10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("เกินกำหนด: array ควรมีไม่เกิน 2 รายการ");
+  }
+});
+
+test("Thai locale - invalid_type errors", () => {
+  z.config(th());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("ประเภทข้อมูลไม่ถูกต้อง: ควรเป็น string แต่ได้รับ ตัวเลข");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("ประเภทข้อมูลไม่ถูกต้อง: ควรเป็น ตัวเลข แต่ได้รับ string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("ประเภทข้อมูลไม่ถูกต้อง: ควรเป็น boolean แต่ได้รับ ไม่มีค่า (null)");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("ประเภทข้อมูลไม่ถูกต้อง: ควรเป็น อาร์เรย์ (Array) แต่ได้รับ object");
+  }
+});
+
+test("Thai locale - other error cases", () => {
+  z.config(th());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('ตัวเลือกไม่ถูกต้อง: ควรเป็นหนึ่งใน "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("ตัวเลขไม่ถูกต้อง: ต้องเป็นจำนวนที่หารด้วย 3 ได้ลงตัว");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('พบคีย์ที่ไม่รู้จัก: "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("ข้อมูลไม่ถูกต้อง: ไม่ตรงกับรูปแบบยูเนียนที่กำหนดไว้");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("รูปแบบไม่ถูกต้อง: ต้องตรงกับรูปแบบที่กำหนด /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('รูปแบบไม่ถูกต้อง: ข้อความต้องขึ้นต้นด้วย "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('รูปแบบไม่ถูกต้อง: ข้อความต้องลงท้ายด้วย "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ua.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ua.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ua from "../../../locales/ua.js";
+
+test("Ukrainian (ua alias) locale - too_small errors", () => {
+  z.config(ua());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Занадто мале: очікується, що string матиме >=5 символів");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Занадто мале: очікується, що number буде >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Занадто мале: очікується, що array матиме >=3 елементів");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Занадто мале: очікується, що set матиме >=2 елементів");
+  }
+});
+
+test("Ukrainian (ua alias) locale - too_big errors", () => {
+  z.config(ua());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Занадто велике: очікується, що string матиме <=3 символів");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Занадто велике: очікується, що number буде <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Занадто велике: очікується, що array матиме <=2 елементів");
+  }
+});
+
+test("Ukrainian (ua alias) locale - invalid_type errors", () => {
+  z.config(ua());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Неправильні вхідні дані: очікується string, отримано число");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Неправильні вхідні дані: очікується число, отримано string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Неправильні вхідні дані: очікується boolean, отримано null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Неправильні вхідні дані: очікується масив, отримано object");
+  }
+});
+
+test("Ukrainian (ua alias) locale - other error cases", () => {
+  z.config(ua());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Неправильна опція: очікується одне з "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Неправильне число: повинно бути кратним 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Нерозпізнаний ключ: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Нерозпізнаний ключі: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Неправильні вхідні дані");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Неправильний рядок: повинен відповідати шаблону /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Неправильний рядок: повинен починатися з "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Неправильний рядок: повинен закінчуватися на "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/uk.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/uk.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import uk from "../../../locales/uk.js";
+
+test("Ukrainian locale - too_small errors", () => {
+  z.config(uk());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Занадто мале: очікується, що string матиме >=5 символів");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Занадто мале: очікується, що number буде >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Занадто мале: очікується, що array матиме >=3 елементів");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Занадто мале: очікується, що set матиме >=2 елементів");
+  }
+});
+
+test("Ukrainian locale - too_big errors", () => {
+  z.config(uk());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Занадто велике: очікується, що string матиме <=3 символів");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Занадто велике: очікується, що number буде <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Занадто велике: очікується, що array матиме <=2 елементів");
+  }
+});
+
+test("Ukrainian locale - invalid_type errors", () => {
+  z.config(uk());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Неправильні вхідні дані: очікується string, отримано число");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Неправильні вхідні дані: очікується число, отримано string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Неправильні вхідні дані: очікується boolean, отримано null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Неправильні вхідні дані: очікується масив, отримано object");
+  }
+});
+
+test("Ukrainian locale - other error cases", () => {
+  z.config(uk());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Неправильна опція: очікується одне з "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Неправильне число: повинно бути кратним 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Нерозпізнаний ключ: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('Нерозпізнаний ключі: "b", "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Неправильні вхідні дані");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Неправильний рядок: повинен відповідати шаблону /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Неправильний рядок: повинен починатися з "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Неправильний рядок: повинен закінчуватися на "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/ur.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/ur.test.ts
@@ -1,0 +1,139 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import ur from "../../../locales/ur.js";
+
+test("Urdu locale - too_small errors", () => {
+  z.config(ur());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("بہت چھوٹا: string کے >=5 حروف ہونے متوقع تھے");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("بہت چھوٹا: number کا >=10 ہونا متوقع تھا");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("بہت چھوٹا: array کے >=3 آئٹمز ہونے متوقع تھے");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("بہت چھوٹا: set کے >=2 آئٹمز ہونے متوقع تھے");
+  }
+});
+
+test("Urdu locale - too_big errors", () => {
+  z.config(ur());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("بہت بڑا: string کے <=3 حروف ہونے متوقع تھے");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("بہت بڑا: number کا <=10 ہونا متوقع تھا");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("بہت بڑا: array کے <=2 آئٹمز ہونے متوقع تھے");
+  }
+});
+
+test("Urdu locale - invalid_type errors", () => {
+  z.config(ur());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("غلط ان پٹ: string متوقع تھا، نمبر موصول ہوا");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("غلط ان پٹ: نمبر متوقع تھا، string موصول ہوا");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("غلط ان پٹ: boolean متوقع تھا، نل موصول ہوا");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("غلط ان پٹ: آرے متوقع تھا، object موصول ہوا");
+  }
+});
+
+test("Urdu locale - other error cases", () => {
+  z.config(ur());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('غلط آپشن: "a"|"b" میں سے ایک متوقع تھا');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("غلط نمبر: 3 کا مضاعف ہونا چاہیے");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('غیر تسلیم شدہ کی: "b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('غیر تسلیم شدہ کیز: "b"، "c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("غلط ان پٹ");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("غلط سٹرنگ: پیٹرن /^[a-z]+$/ سے میچ ہونا چاہیے");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('غلط سٹرنگ: "hello" سے شروع ہونا چاہیے');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('غلط سٹرنگ: "world" پر ختم ہونا چاہیے');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/vi.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/vi.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import vi from "../../../locales/vi.js";
+
+test("Vietnamese locale - too_small errors", () => {
+  z.config(vi());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Quá nhỏ: mong đợi string có >=5 ký tự");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Quá nhỏ: mong đợi number >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Quá nhỏ: mong đợi array có >=3 phần tử");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Quá nhỏ: mong đợi set có >=2 phần tử");
+  }
+});
+
+test("Vietnamese locale - too_big errors", () => {
+  z.config(vi());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Quá lớn: mong đợi string có <=3 ký tự");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Quá lớn: mong đợi number <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Quá lớn: mong đợi array có <=2 phần tử");
+  }
+});
+
+test("Vietnamese locale - invalid_type errors", () => {
+  z.config(vi());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Đầu vào không hợp lệ: mong đợi string, nhận được số");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Đầu vào không hợp lệ: mong đợi số, nhận được string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Đầu vào không hợp lệ: mong đợi boolean, nhận được null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Đầu vào không hợp lệ: mong đợi mảng, nhận được object");
+  }
+});
+
+test("Vietnamese locale - other error cases", () => {
+  z.config(vi());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Tùy chọn không hợp lệ: mong đợi một trong các giá trị "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Số không hợp lệ: phải là bội số của 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Khóa không được nhận dạng: "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Đầu vào không hợp lệ");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Chuỗi không hợp lệ: phải khớp với mẫu /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Chuỗi không hợp lệ: phải bắt đầu bằng "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Chuỗi không hợp lệ: phải kết thúc bằng "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/yo.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/yo.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import yo from "../../../locales/yo.js";
+
+test("Yoruba locale - too_small errors", () => {
+  z.config(yo());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Kéré ju: a ní láti jẹ́ pé string ní >=5 àmi");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Kéré ju: a ní láti jẹ́ >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Kéré ju: a ní láti jẹ́ pé array ní >=3 nkan");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("Kéré ju: a ní láti jẹ́ pé set ní >=2 nkan");
+  }
+});
+
+test("Yoruba locale - too_big errors", () => {
+  z.config(yo());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Tó pọ̀ jù: a ní láti jẹ́ pé string ní <=3 àmi");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Tó pọ̀ jù: a ní láti jẹ́ <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Tó pọ̀ jù: a ní láti jẹ́ pé array ní <=2 nkan");
+  }
+});
+
+test("Yoruba locale - invalid_type errors", () => {
+  z.config(yo());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("Ìbáwọlé aṣìṣe: a ní láti fi string, àmọ̀ a rí nọ́mbà");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("Ìbáwọlé aṣìṣe: a ní láti fi nọ́mbà, àmọ̀ a rí string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("Ìbáwọlé aṣìṣe: a ní láti fi boolean, àmọ̀ a rí null");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("Ìbáwọlé aṣìṣe: a ní láti fi akopọ, àmọ̀ a rí object");
+  }
+});
+
+test("Yoruba locale - other error cases", () => {
+  z.config(yo());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('Àṣàyàn aṣìṣe: yan ọ̀kan lára "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("Nọ́mbà aṣìṣe: gbọ́dọ̀ jẹ́ èyà pípín ti 3");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('Bọtìnì àìmọ̀: "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("Ìbáwọlé aṣìṣe");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("Ọ̀rọ̀ aṣìṣe: gbọ́dọ̀ bá àpẹẹrẹ mu /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('Ọ̀rọ̀ aṣìṣe: gbọ́dọ̀ bẹ̀rẹ̀ pẹ̀lú "hello"');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('Ọ̀rọ̀ aṣìṣe: gbọ́dọ̀ parí pẹ̀lú "world"');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/zh-CN.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/zh-CN.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import zhCN from "../../../locales/zh-CN.js";
+
+test("Chinese (Simplified) locale - too_small errors", () => {
+  z.config(zhCN());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("数值过小：期望 string >=5 字符");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("数值过小：期望 number >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("数值过小：期望 array >=3 项");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("数值过小：期望 set >=2 项");
+  }
+});
+
+test("Chinese (Simplified) locale - too_big errors", () => {
+  z.config(zhCN());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("数值过大：期望 string <=3 字符");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("数值过大：期望 number <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("数值过大：期望 array <=2 项");
+  }
+});
+
+test("Chinese (Simplified) locale - invalid_type errors", () => {
+  z.config(zhCN());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("无效输入：期望 string，实际接收 数字");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("无效输入：期望 数字，实际接收 string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("无效输入：期望 boolean，实际接收 空值(null)");
+  }
+
+  const arrayResult = z.array(z.string()).safeParse({});
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("无效输入：期望 数组，实际接收 object");
+  }
+});
+
+test("Chinese (Simplified) locale - other error cases", () => {
+  z.config(zhCN());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('无效选项：期望以下之一 "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("无效数字：必须是 3 的倍数");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('出现未知的键(key): "b"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("无效输入");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("无效字符串：必须满足正则表达式 /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('无效字符串：必须以 "hello" 开头');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('无效字符串：必须以 "world" 结尾');
+  }
+});

--- a/packages/zod/src/v4/core/tests/locales/zh-TW.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/zh-TW.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "vitest";
+import { z } from "../../../../index.js";
+import zhTW from "../../../locales/zh-TW.js";
+
+test("Chinese (Traditional) locale - too_small errors", () => {
+  z.config(zhTW());
+
+  const stringResult = z.string().min(5).safeParse("abc");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("數值過小：預期 string 應為 >=5 字元");
+  }
+
+  const numberResult = z.number().min(10).safeParse(5);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("數值過小：預期 number 應為 >=10");
+  }
+
+  const arrayResult = z.array(z.string()).min(3).safeParse(["a", "b"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("數值過小：預期 array 應為 >=3 項目");
+  }
+
+  const setResult = z
+    .set(z.string())
+    .min(2)
+    .safeParse(new Set(["a"]));
+  expect(setResult.success).toBe(false);
+  if (!setResult.success) {
+    expect(setResult.error.issues[0].message).toBe("數值過小：預期 set 應為 >=2 項目");
+  }
+});
+
+test("Chinese (Traditional) locale - too_big errors", () => {
+  z.config(zhTW());
+
+  const stringResult = z.string().max(3).safeParse("abcde");
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("數值過大：預期 string 應為 <=3 字元");
+  }
+
+  const numberResult = z.number().max(10).safeParse(15);
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("數值過大：預期 number 應為 <=10");
+  }
+
+  const arrayResult = z.array(z.string()).max(2).safeParse(["a", "b", "c"]);
+  expect(arrayResult.success).toBe(false);
+  if (!arrayResult.success) {
+    expect(arrayResult.error.issues[0].message).toBe("數值過大：預期 array 應為 <=2 項目");
+  }
+});
+
+test("Chinese (Traditional) locale - invalid_type errors", () => {
+  z.config(zhTW());
+
+  const stringResult = z.string().safeParse(123);
+  expect(stringResult.success).toBe(false);
+  if (!stringResult.success) {
+    expect(stringResult.error.issues[0].message).toBe("無效的輸入值：預期為 string，但收到 number");
+  }
+
+  const numberResult = z.number().safeParse("abc");
+  expect(numberResult.success).toBe(false);
+  if (!numberResult.success) {
+    expect(numberResult.error.issues[0].message).toBe("無效的輸入值：預期為 number，但收到 string");
+  }
+
+  const booleanResult = z.boolean().safeParse(null);
+  expect(booleanResult.success).toBe(false);
+  if (!booleanResult.success) {
+    expect(booleanResult.error.issues[0].message).toBe("無效的輸入值：預期為 boolean，但收到 null");
+  }
+});
+
+test("Chinese (Traditional) locale - other error cases", () => {
+  z.config(zhTW());
+
+  const enumResult = z.enum(["a", "b"]).safeParse("c");
+  expect(enumResult.success).toBe(false);
+  if (!enumResult.success) {
+    expect(enumResult.error.issues[0].message).toBe('無效的選項：預期為以下其中之一 "a"|"b"');
+  }
+
+  const multipleResult = z.number().multipleOf(3).safeParse(10);
+  expect(multipleResult.success).toBe(false);
+  if (!multipleResult.success) {
+    expect(multipleResult.error.issues[0].message).toBe("無效的數字：必須為 3 的倍數");
+  }
+
+  const strictResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "extra" });
+  expect(strictResult.success).toBe(false);
+  if (!strictResult.success) {
+    expect(strictResult.error.issues[0].message).toBe('無法識別的鍵值："b"');
+  }
+
+  const strictMultiResult = z.object({ a: z.string() }).strict().safeParse({ a: "test", b: "x", c: "y" });
+  expect(strictMultiResult.success).toBe(false);
+  if (!strictMultiResult.success) {
+    expect(strictMultiResult.error.issues[0].message).toBe('無法識別的鍵值們："b"、"c"');
+  }
+
+  const unionResult = z.union([z.string(), z.number()]).safeParse(true);
+  expect(unionResult.success).toBe(false);
+  if (!unionResult.success) {
+    expect(unionResult.error.issues[0].message).toBe("無效的輸入值");
+  }
+
+  const regexResult = z
+    .string()
+    .regex(/^[a-z]+$/)
+    .safeParse("ABC123");
+  expect(regexResult.success).toBe(false);
+  if (!regexResult.success) {
+    expect(regexResult.error.issues[0].message).toBe("無效的字串：必須符合格式 /^[a-z]+$/");
+  }
+
+  const startsWithResult = z.string().startsWith("hello").safeParse("world");
+  expect(startsWithResult.success).toBe(false);
+  if (!startsWithResult.success) {
+    expect(startsWithResult.error.issues[0].message).toBe('無效的字串：必須以 "hello" 開頭');
+  }
+
+  const endsWithResult = z.string().endsWith("world").safeParse("hello");
+  expect(endsWithResult.success).toBe(false);
+  if (!endsWithResult.success) {
+    expect(endsWithResult.error.issues[0].message).toBe('無效的字串：必須以 "world" 結尾');
+  }
+});


### PR DESCRIPTION
## Summary

- Adds error message assertion tests for every locale in `packages/zod/src/v4/locales/` (50 locales total)
- Each test file covers `too_small`, `too_big`, `invalid_type`, `invalid_value`, `not_multiple_of`, `unrecognized_keys`, `invalid_union`, and `invalid_format` error codes
- Adds `LOCALE_TESTS.md` documenting the test approach, design decisions, and a guide for adding tests for new locales

## Test plan

- [ ] All 50 locale test files pass in CI
- [ ] Each expected message was traced directly from the locale source file (no guessing)
- [ ] Locale-specific edge cases covered: plural forms (`unrecognized_keys`), RTL separators (Arabic), gendered adjectives (Slavic locales), `TypeDictionary` overrides per locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)