### PR TITLE
fix(toJSONSchema): emit falsy prefault values as defaults

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2560,6 +2560,33 @@ test("defaults/prefaults", () => {
   `);
 });
 
+test("falsy prefault values are emitted as defaults", () => {
+  // https://github.com/colinhacks/zod/issues/5824
+  expect(z.boolean().prefault(false).toJSONSchema({ io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": false,
+      "type": "boolean",
+    }
+  `);
+
+  expect(z.number().prefault(0).toJSONSchema({ io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": 0,
+      "type": "number",
+    }
+  `);
+
+  expect(z.string().prefault("").toJSONSchema({ io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": "",
+      "type": "string",
+    }
+  `);
+});
+
 test("input type", () => {
   const schema = z.object({
     a: z.string(),

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -205,7 +205,7 @@ export function process<T extends schemas.$ZodType>(
   }
 
   // set prefault as default
-  if (ctx.io === "input" && result.schema._prefault) result.schema.default ??= result.schema._prefault;
+  if (ctx.io === "input" && "_prefault" in result.schema) result.schema.default ??= result.schema._prefault;
   delete result.schema._prefault;
 
   // pulling fresh from ctx.seen in case it was overwritten


### PR DESCRIPTION
Closes #5824.

The previous truthy check on \`result.schema._prefault\` skipped prefaults whose value was \`false\`, \`0\` or \`\"\"\`, so they were never propagated to the JSON Schema \`default\`. The reporter included the suggested patch in the issue body.

\`\`\`ts
z.boolean().prefault(false).toJSONSchema({ io: \"input\" })
// before: { type: \"boolean\" }
// after:  { default: false, type: \"boolean\" }
\`\`\`

Switched to an \`in\` check so any explicitly set prefault is emitted. \`_prefault\` is only set in the prefault processor (\`json._prefault = JSON.parse(JSON.stringify(def.defaultValue))\`), so the property is never \`undefined\` when present, and the \`??=\` keeps the existing precedence over an inherited \`default\`.

Added a regression test in \`to-json-schema.test.ts\` covering \`false\`, \`0\` and \`\"\"\` prefaults. Verified it fails on \`main\` and passes with the fix. Full \`to-json-schema\` + \`to-json-schema-methods\` suites both green (322/322).

Note: the unrelated \`datetime > redos checker\` flake (#5743) is failing on \`main\` on Node 24 and is not affected by this change.