### PR TITLE
Add support for `window.ZOD_NO_EVAL`

### DIFF
--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -369,6 +369,12 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
 }
 
 export const allowsEval: { value: boolean } = cached(() => {
+  // trying to feature detect can cause a CSP error, so this provides a way for users opt-out globally,
+  // before the library is loaded
+  if (typeof window !== "undefined" && (window as any).ZOD_NO_EVAL === true) {
+    return false;
+  }
+
   // @ts-ignore
   if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
     return false;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -369,7 +369,7 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
 }
 
 export const allowsEval: { value: boolean } = cached(() => {
-  // trying to feature detect can cause a CSP error, so this provides a way for users opt-out globally,
+  // trying to feature detect can cause a CSP error, so this provides a way for users to opt out globally,
   // before the library is loaded
   if (typeof window !== "undefined" && (window as any).ZOD_NO_EVAL === true) {
     return false;


### PR DESCRIPTION
We made this patch locally and thought might as well open a PR.

Opting out using `z.config` is tricky given it has to run before any schemas are loaded. Setting a global variable on `window` can be done quite easily when building the app html, before the main app js is loaded that contains zod.

An alternative approach could be a `window.ZOD_CONFIG` object that is mixed into `globalConfig` in `packages/zod/src/v4/core/config.ts`. Happy to switch to that if you like?

Ref https://github.com/colinhacks/zod/issues/4461