### PR TITLE
fix(core): honour `jitless` config in `allowsEval` probe

### DIFF
--- a/packages/zod/src/v4/classic/tests/jitless-allows-eval.test.ts
+++ b/packages/zod/src/v4/classic/tests/jitless-allows-eval.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+import * as z from "zod/v4";
+import * as core from "zod/v4/core";
+
+const { allowsEval } = core.util;
+
+// Regression test for the CSP feature-probe issue (#4461, #5414):
+// `allowsEval` used to always invoke `new Function("")` even when the
+// user had opted into `z.config({ jitless: true })`, producing a
+// `securitypolicyviolation` report on strict-CSP pages (no 'unsafe-eval')
+// that Chrome DevTools surfaces as an Issue.
+//
+// The fix: when `globalConfig.jitless` is true, `allowsEval.value`
+// returns `false` without triggering the probe. This test lives in its
+// own file because vitest isolates ESM graphs per file, so the cached
+// `allowsEval.value` is fresh and is never accessed before the config
+// mutation below.
+
+test("globalConfig.jitless=true short-circuits the allowsEval probe", () => {
+  // Set BEFORE first access to allowsEval.value — the getter is memoised
+  // via `cached()`, so the contract is "configure at app entry".
+  z.config({ jitless: true });
+
+  // Sanity: config is wired
+  expect(core.globalConfig.jitless).toBe(true);
+
+  // Spy: if the probe were still attempted, `new Function("")` would be
+  // called. Swap the global `Function` constructor with a throwing stub
+  // and verify the stub is NEVER invoked.
+  const origFunction = globalThis.Function;
+  let probeAttempted = false;
+  // @ts-expect-error assigning a stub to the Function global for the test
+  globalThis.Function = function StubFunction(..._args: unknown[]): never {
+    probeAttempted = true;
+    throw new Error("allowsEval probe should have been skipped under jitless=true");
+  };
+
+  try {
+    expect(allowsEval.value).toBe(false);
+    expect(probeAttempted).toBe(false);
+  } finally {
+    globalThis.Function = origFunction;
+    // Restore config so other test files in the same worker see default
+    delete core.globalConfig.jitless;
+  }
+});

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -362,13 +362,8 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
 }
 
 export const allowsEval: { value: boolean } = cached(() => {
-  // Users on strict Content-Security-Policy environments (no `unsafe-eval`)
-  // can opt out of the JIT fast-path with `z.config({ jitless: true })`.
-  // Honouring it here — before the `new Function("")` probe — prevents a
-  // one-shot `securitypolicyviolation` report at the probe site, which
-  // Chrome's DevTools surfaces as an Issue even though the error is caught.
-  // Callers must set `jitless` at application entry, before any schema is
-  // parsed, since this getter is memoised via `cached()`.
+  // Skip the probe under `jitless`: strict CSPs report the caught `new Function`
+  // as a `securitypolicyviolation` even though the throw is swallowed.
   if (globalConfig.jitless) {
     return false;
   }

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1,4 +1,5 @@
 import type * as checks from "./checks.js";
+import { globalConfig } from "./core.js";
 import type { $ZodConfig } from "./core.js";
 import type * as errors from "./errors.js";
 import type * as schemas from "./schemas.js";
@@ -361,6 +362,17 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
 }
 
 export const allowsEval: { value: boolean } = cached(() => {
+  // Users on strict Content-Security-Policy environments (no `unsafe-eval`)
+  // can opt out of the JIT fast-path with `z.config({ jitless: true })`.
+  // Honouring it here — before the `new Function("")` probe — prevents a
+  // one-shot `securitypolicyviolation` report at the probe site, which
+  // Chrome's DevTools surfaces as an Issue even though the error is caught.
+  // Callers must set `jitless` at application entry, before any schema is
+  // parsed, since this getter is memoised via `cached()`.
+  if (globalConfig.jitless) {
+    return false;
+  }
+
   // @ts-ignore
   if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
     return false;


### PR DESCRIPTION
## Summary

Makes `z.config({ jitless: true })` actually silence the Chrome DevTools "Content Security Policy of your site blocks the use of 'eval' in JavaScript" issue on strict-CSP pages, by short-circuiting the `new Function("")` feature probe inside `allowsEval`.

Closes #4461.
Closes #5414.

## Problem

`util.allowsEval` feature-probes for `new Function()` support so the JIT fast-path in `schemas.ts` can be enabled opportunistically. The probe is wrapped in `try/catch`, so it never throws at runtime — **but browsers still log the caught attempt as a `securitypolicyviolation`**, which Chrome surfaces as a Developer Tools Issue:

> Content Security Policy of your site blocks the use of 'eval' in JavaScript

Users on strict CSPs (`script-src` without `'unsafe-eval'`) have flagged this in production error monitors (Datadog, Sentry) — see #5414 where @zbauman3 reported *"literally thousands of errors"* from a single Zod v4 upgrade. The maintainer's documented workaround was:

> ```ts
> z.config({ jitless: true })
> ```

But this doesn't actually help today, because `allowsEval` is memoised via `cached()` and runs lazily on first `.value` access, regardless of whether the user set `jitless` first. Users reported back that setting `jitless` did nothing for the CSP violation, and the thread has stalled.

## Fix

`allowsEval` now consults `globalConfig.jitless` **before** attempting the probe. When `jitless === true`, it returns `false` without invoking `new Function` at all — no CSP violation is ever generated.

```ts
export const allowsEval: { value: boolean } = cached(() => {
  if (globalConfig.jitless) {
    return false;                          // NEW: skip probe entirely
  }
  // @ts-ignore
  if (typeof navigator !== "undefined" && navigator?.userAgent?.includes("Cloudflare")) {
    return false;
  }
  try {
    const F = Function;
    new F("");
    return true;
  } catch (_) {
    return false;
  }
});
```

The change is **minimal, additive, and strictly more restrictive** when opted into. The existing `jit = !core.globalConfig.jitless` gate at `schemas.ts:2025` already routes `jitless=true` users onto the slow path; the probe was just dead weight on their page loads.

## API / behaviour

- **Default unchanged**: when `jitless` is `undefined` (its default), `allowsEval` probes exactly as before — no behaviour shift for the 99% of users who never touch config.
- **Opt-in, safer**: when `jitless=true`, Zod never calls `new Function("")`. Users on strict CSPs now have a clean devtools console.
- **Contract (should be documented)**: `z.config({ jitless: true })` must be called at application entry, before any schema is parsed, because `allowsEval.value` is memoised via `cached()` on first access. Same contract the `jitless` option already implies — this PR doesn't change it.
- **No runtime cost** to users who don't set `jitless` (one extra `if (undefined)` branch on first probe).

## Tests

Added `packages/zod/src/v4/classic/tests/jitless-allows-eval.test.ts`. It:

1. Calls `z.config({ jitless: true })` at the top of the test.
2. Swaps `globalThis.Function` with a stub that throws if invoked.
3. Asserts `util.allowsEval.value === false`.
4. Asserts the stub was **never called** (the probe really did short-circuit).

The test lives in its own file because vitest isolates ESM graphs per file, so the cached `allowsEval.value` is guaranteed fresh and is never accessed before the config mutation. A `finally` block restores `globalThis.Function` and clears the config flag so other test files in the same worker see the default.

```
✓ src/v4/classic/tests/jitless-allows-eval.test.ts (1 test) 2ms
✓ [TS] src/v4/classic/tests/jitless-allows-eval.test.ts (1 test)
Test Files  2 passed (2)
     Tests  2 passed (2)
Type Errors no errors
```

## Regression check

Ran the full suite locally (`pnpm test`). All existing tests pass **except** `src/v4/classic/tests/datetime.test.ts > redos checker`, which times out at 5000ms → 13800ms on my Windows/pnpm combo when run under parallel-file concurrency. Isolated run (`pnpm test packages/zod/src/v4/classic/tests/datetime.test.ts`) passes cleanly in 11.5s / 28 tests. The failure is environmental (ReDoS-check regex timing on a slower machine) and completely unrelated to `util.ts` — same test passes on `main` without this branch. CI on GitHub Actions (Linux) should be clean.

## Scope / risk

- Single file of production change: `packages/zod/src/v4/core/util.ts` (+12 lines, new runtime import + early return).
- One new test file: `packages/zod/src/v4/classic/tests/jitless-allows-eval.test.ts` (+46 lines).
- No change to public API surface. `$ZodConfig.jitless` already exists on `main` and is documented at `core.ts:129`.
- No dependency changes, no bundler-config changes, no type signature changes.

Happy to iterate on the test style, the comment wording, or split the changelog/docs note into a separate PR if preferred.