### PR TITLE
base64 native parser only

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -194,33 +194,43 @@ test("email validations", () => {
 test("base64 validations", () => {
   const validBase64Strings = [
     "SGVsbG8gV29ybGQ=", // "Hello World"
+    "SGVsbG8gV29ybGQ", // "Hello World" with no padding
+    " SGVsbG8gV29ybGQ\n", // "Hello World" untrimmed
+    "SGVs bG8gV29ybGQ", // "Hello World" with a space in the middle
+    "   SG Vs b G8g V29 y bGQ   ", // "Hello World" with arbitrary spaces
+    "SGVs\nbG8g \fV29y \rbGQ ", // "Hello World" with chars that match /\s/ excluding \v no padding
+    "SGVs\nbG8g \fV29y \rbGQ =", // "Hello World" with chars that match /\s/ excluding \v and padding
+    "SGVsbG8gV29ybGQ", // Missing padding
     "VGhpcyBpcyBhbiBlbmNvZGVkIHN0cmluZw==", // "This is an encoded string"
+    "VGhpcyBpcyBhbiBlbmNvZGVkIHN0cmluZw", // Missing padding
     "TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcms=", // "Many hands make light work"
     "UGF0aWVuY2UgaXMgdGhlIGtleSB0byBzdWNjZXNz", // "Patience is the key to success"
     "QmFzZTY0IGVuY29kaW5nIGlzIGZ1bg==", // "Base64 encoding is fun"
     "MTIzNDU2Nzg5MA==", // "1234567890"
     "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo=", // "abcdefghijklmnopqrstuvwxyz"
     "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=", // "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo", // Missing padding
     "ISIkJSMmJyonKCk=", // "!\"#$%&'()*"
     "", // Empty string is technically a valid base64
   ];
 
   for (const str of validBase64Strings) {
-    expect(str + z.string().base64().safeParse(str).success).toBe(`${str}true`);
+    const escapedStr = JSON.stringify(str).slice(1, -1);
+    expect(escapedStr + z.string().base64().safeParse(str).success).toBe(`${escapedStr}true`);
   }
 
   const invalidBase64Strings = [
-    "12345", // Not padded correctly, not a multiple of 4 characters
-    "SGVsbG8gV29ybGQ", // Missing padding
-    "VGhpcyBpcyBhbiBlbmNvZGVkIHN0cmluZw", // Missing padding
+    "12345", // length % 4 === 1
+    "1 2345", // length % 4 === 1 check ignores whitespace
     "!UGF0aWVuY2UgaXMgdGhlIGtleSB0byBzdWNjZXNz", // Invalid character '!'
     "?QmFzZTY0IGVuY29kaW5nIGlzIGZ1bg==", // Invalid character '?'
     ".MTIzND2Nzg5MC4=", // Invalid character '.'
-    "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo", // Missing padding
+    "SGVsbG8gV29ybGQ\v", // "\v matches /\s/, but is not allowed by atob"
   ];
 
   for (const str of invalidBase64Strings) {
-    expect(str + z.string().base64().safeParse(str).success).toBe(`${str}false`);
+    const escapedStr = JSON.stringify(str).slice(1, -1);
+    expect(escapedStr + z.string().base64().safeParse(str).success).toBe(`${escapedStr}false`);
   }
 });
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -887,9 +887,7 @@ export const $ZodCIDRv6: core.$constructor<$ZodCIDRv6> = /*@__PURE__*/ core.$con
 //////////////////////////////   ZodBase64   //////////////////////////////
 export function isValidBase64(data: string): boolean {
   if (data === "") return true;
-  if (data.length % 4 !== 0) return false;
   try {
-    // @ts-ignore
     atob(data);
     return true;
   } catch {
@@ -1982,7 +1980,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
             })));
           }
         }
-        
+
         if (${id}.value === undefined) {
           if (${k} in input) {
             newResult[${k}] = undefined;
@@ -1990,7 +1988,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         } else {
           newResult[${k}] = ${id}.value;
         }
-        
+
       `);
         } else {
           doc.write(`
@@ -2000,7 +1998,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
             path: iss.path ? [${k}, ...iss.path] : [${k}]
           })));
         }
-        
+
         if (${id}.value === undefined) {
           if (${k} in input) {
             newResult[${k}] = undefined;
@@ -2008,7 +2006,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         } else {
           newResult[${k}] = ${id}.value;
         }
-        
+
       `);
         }
       }

--- a/packages/zod/src/v4/mini/tests/string.test.ts
+++ b/packages/zod/src/v4/mini/tests/string.test.ts
@@ -277,11 +277,13 @@ test("z.base64", () => {
   const a = z.base64();
   // valid base64
   expect(z.parse(a, "SGVsbG8gd29ybGQ=")).toEqual("SGVsbG8gd29ybGQ=");
+  expect(z.parse(a, "SGVs bG8g d29yb GQ=")).toEqual("SGVs bG8g d29yb GQ=");
+  expect(z.parse(a, "SGVsbG8gd29ybGQ")).toEqual("SGVsbG8gd29ybGQ");
   expect(z.parse(a, "U29tZSBvdGhlciBzdHJpbmc=")).toEqual("U29tZSBvdGhlciBzdHJpbmc=");
+  expect(z.parse(a, "U29tZSBvdGhlciBzdHJpbmc")).toEqual("U29tZSBvdGhlciBzdHJpbmc");
   // invalid base64
-  expect(() => z.parse(a, "SGVsbG8gd29ybGQ")).toThrow();
-  expect(() => z.parse(a, "U29tZSBvdGhlciBzdHJpbmc")).toThrow();
   expect(() => z.parse(a, "hello")).toThrow();
+  expect(() => z.parse(a, "SGVsbG8gd29ybGQ==")).toThrow(); // incorrect padding
   // wrong type
   expect(() => z.parse(a, 123)).toThrow();
 });


### PR DESCRIPTION
Hi!

I was looking through the code of the base64 parts and saw something a bit arbitrary there IMO.

There's a check to see if the base64 encoded string length divides by 4.

Looking at the comments and tests, it seemed like it was supposed to verify that the string had padding.

I have two issues with this approach.

The first one is that it doesn't actually do the work it was intended to do. `atob`, the function that parses the base64 string in order to validate it, ignores whitespace characters. This means I can pass `"123 "` and it passes the validation although the string is not padded correctly.

The second one is my opinion - I don't think that requiring padding (without a way to configure it) is actually beneficial to the developer. When I do input validation, what I'm worried about is 'will this crash my program later on?'. In this case, `atob` and its new implemention in `Unit8Array.fromBase64()` both allow unpadded base64 strings. So for me it doesn't make much sense to deny base64 strings that are valid for parsing in JS.

I can see how adding validations on top of what JS supports is beneficial in general, but for now, people can normalize the base64 strings instead of denying them. Later, we can add custom checks with options, but I think that the current state where there is not way to configure the parser, the behavior should match what JS accepts as valid.

At first I was trying to create a backwards compatible implementation and adding options and / or a whole new type (e.g base64js), but IMO it just made things look weird and sloppy. You can see my vibe coded attempt at https://github.com/drornir/zod/pull/1

In my opinion, it's debateble whether this is an API change or a bugfix. So I thought that instead of banging my head agaisnt the wall, I'll do the most minimal change and open this up to conversation.

As you can see from my [first attempt](https://github.com/drornir/zod/pull/1), I have more thoughts and ideas for follow up PR's if you're up for it :)


