### PR TITLE
fix: Handle `z.union([])` and `z.xor([])`

### DIFF
--- a/packages/zod/src/v4/classic/tests/union.test.ts
+++ b/packages/zod/src/v4/classic/tests/union.test.ts
@@ -217,3 +217,57 @@ test("z.xor() type inference", () => {
   type Result = z.infer<typeof schema>;
   expectTypeOf<Result>().toEqualTypeOf<string | number | boolean>();
 });
+
+test("z.union([]) constructs and rejects all input", () => {
+  const schema = z.union([]);
+  expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<never>();
+  const result = schema.safeParse("anything");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "invalid_union",
+          "errors": [],
+          "message": "Invalid input",
+          "path": [],
+        },
+      ]
+    `);
+  }
+});
+
+test("z.xor([]) constructs and rejects all input", () => {
+  const schema = z.xor([]);
+  expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<never>();
+  const result = schema.safeParse("anything");
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "invalid_union",
+          "errors": [],
+          "message": "Invalid input",
+          "path": [],
+        },
+      ]
+    `);
+  }
+});
+
+test("z.discriminatedUnion with empty options constructs and rejects", () => {
+  const schema = z.discriminatedUnion("type", [] as any);
+  const nonObject = schema.safeParse("nope");
+  expect(nonObject.success).toEqual(false);
+  if (!nonObject.success) {
+    expect(nonObject.error.issues[0].code).toBe("invalid_type");
+  }
+  const obj = schema.safeParse({ type: "x" });
+  expect(obj.success).toEqual(false);
+  if (!obj.success) {
+    expect(obj.error.issues[0].code).toBe("invalid_union");
+    expect((obj.error.issues[0] as any).errors).toEqual([]);
+    expect((obj.error.issues[0] as any).options).toEqual([]);
+  }
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2146,11 +2146,10 @@ export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$const
     return undefined;
   });
 
-  const single = def.options.length === 1;
-  const first = def.options[0]._zod.run;
+  const first = def.options.length === 1 ? def.options[0]._zod.run : null;
 
   inst._zod.parse = (payload, ctx) => {
-    if (single) {
+    if (first) {
       return first(payload, ctx);
     }
     let async = false;
@@ -2226,11 +2225,10 @@ export const $ZodXor: core.$constructor<$ZodXor> = /*@__PURE__*/ core.$construct
   $ZodUnion.init(inst, def);
   def.inclusive = false;
 
-  const single = def.options.length === 1;
-  const first = def.options[0]._zod.run;
+  const first = def.options.length === 1 ? def.options[0]._zod.run : null;
 
   inst._zod.parse = (payload, ctx) => {
-    if (single) {
+    if (first) {
       return first(payload, ctx);
     }
     let async = false;

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -228,6 +228,25 @@ test("z.union", () => {
   expect(() => z.parse(a, true)).toThrow();
 });
 
+test("z.union([]) / z.xor([]) / z.discriminatedUnion(_, []) construct and reject all input", () => {
+  for (const schema of [z.union([]), z.xor([])]) {
+    const r = schema.safeParse("anything");
+    expect(r.success).toEqual(false);
+    if (!r.success) {
+      expect(r.error.issues[0].code).toBe("invalid_union");
+      expect((r.error.issues[0] as any).errors).toEqual([]);
+    }
+  }
+  const disc = z.discriminatedUnion("type", [] as any);
+  const r = disc.safeParse({ type: "x" });
+  expect(r.success).toEqual(false);
+  if (!r.success) {
+    expect(r.error.issues[0].code).toBe("invalid_union");
+    expect((r.error.issues[0] as any).errors).toEqual([]);
+    expect((r.error.issues[0] as any).options).toEqual([]);
+  }
+});
+
 test("z.intersection", () => {
   const a = z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() }));
   expect(z.parse(a, { a: "hello", b: 123 })).toEqual({ a: "hello", b: 123 });


### PR DESCRIPTION
The types already resolve to `never`, but `parse` would throw.

Think it makes sense to treat as `never` when parsing?

Fixes https://github.com/colinhacks/zod/issues/5868