### PR TITLE
docs: clarify stringFormat usage with z.coerce.string()

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -588,6 +588,15 @@ const coolId = z.stringFormat("cool-id", ()=>{
 // a regex is also accepted
 z.stringFormat("cool-id", /^cool-[a-z0-9]{95}$/);
 ```
+> ⚠️ **Note**
+> `z.stringFormat()` is not chainable on `z.string()` or `z.coerce.string()`.
+> To use it with coercion, combine it via `.pipe()`:
+>
+> ```ts
+> z.coerce.string().pipe(
+>   z.stringFormat("cool-id", /^cool-[a-z0-9]{95}$/)
+> );
+> ```
 
 This schema will produce `"invalid_format"` issues, which are more descriptive than the `"custom"` errors produced by refinements or `z.custom()`.
 


### PR DESCRIPTION
This PR adds a clarification to the `z.stringFormat()` documentation to explain that it is not chainable on `z.string()` or `z.coerce.string()`.

It also includes an example demonstrating the correct usage with `.pipe()` when combining `z.coerce.string()` and `z.stringFormat()`.

This helps prevent confusion and improves developer experience when working with custom string formats.

Fixes #5815