### PR TITLE
fix(v4): apply util.Writeable<T> in strictObject/looseObject for shape display parity

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1301,7 +1301,7 @@ export function object<T extends core.$ZodLooseShape = Partial<Record<never, cor
 export function strictObject<T extends core.$ZodLooseShape>(
   shape: T,
   params?: string | core.$ZodObjectParams
-): ZodObject<T, core.$strict> {
+): ZodObject<util.Writeable<T>, core.$strict> {
   return new ZodObject({
     type: "object",
     shape,
@@ -1315,7 +1315,7 @@ export function strictObject<T extends core.$ZodLooseShape>(
 export function looseObject<T extends core.$ZodLooseShape>(
   shape: T,
   params?: string | core.$ZodObjectParams
-): ZodObject<T, core.$loose> {
+): ZodObject<util.Writeable<T>, core.$loose> {
   return new ZodObject({
     type: "object",
     shape,

--- a/packages/zod/src/v4/classic/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/recursive-types.test.ts
@@ -135,6 +135,11 @@ test("pick and omit with getter", () => {
   }
   expectTypeOf<Category>().toEqualTypeOf<_Category>();
 
+  // Shape should not surface `readonly` modifiers from getter-defined keys.
+  // object/strictObject/looseObject all pass shape through util.Writeable<T>.
+  type Shape = (typeof Category)["shape"];
+  expectTypeOf<Shape>().toEqualTypeOf<{ name: z.ZodString; subcategories: z.ZodArray<typeof Category> }>();
+
   const PickedCategory = Category.pick({ name: true });
   const OmittedCategory = Category.omit({ subcategories: true });
 


### PR DESCRIPTION
## Summary

\`z.object()\` already wraps its shape in \`util.Writeable<T>\` to strip \`readonly\` modifiers from the displayed shape (e.g. for getter-defined keys used in recursive schemas, or shapes built from \`as const\`). \`z.strictObject()\` and \`z.looseObject()\` were missed and surface \`readonly\` modifiers in tooltips for identical input. This commit aligns them.

The wrapped form does not change runtime behavior or \`z.infer\` output — \`$InferObjectOutput\` already strips \`readonly\` via the \`-readonly\` mapped-type modifier. This is a display/shape-typing alignment fix.

Adds an \`expectTypeOf\` assertion on \`(typeof Category)["shape"]\` in the recursive-types tests to guard against future drift.

### Before

\`\`\`ts
const Cat = z.strictObject({
  name: z.string(),
  get sub() { return z.array(Cat); },
});
// hover: ZodObject<{ name: ZodString; readonly sub: ZodArray<...>; }, $strict>
//                                     ^^^^^^^^
\`\`\`

### After

\`\`\`ts
// hover: ZodObject<{ name: ZodString; sub: ZodArray<...>; }, $strict>
\`\`\`

### Notes on the related PR #5811

The reverse change was proposed in #5811 (remove \`Writeable<T>\` from \`z.object()\`) on the theory that it caused tooltips to display \`util.Writeable<T>\` literally. That doesn't reproduce in any TS version I tested (5.5–6.0); \`Writeable<T>\` is the standard \"Prettify\" mapped-type pattern (\`{ -readonly [K in keyof T]: T[K] } & {}\`), which TS expands inline. The reporter on #5810 also noted they couldn't reproduce outside their local environment. Going with the symmetric fix instead.

## Test plan

- [x] \`pnpm vitest run\` — 323 files / 3661 tests passing
- [x] Confirmed the new \`expectTypeOf<Shape>\` assertion fails when \`Writeable<T>\` is reverted on \`strictObject\`
- [x] Biome format/lint clean