### PR TITLE
Fix: CVE-2026-6991: tighten cuid regex and reject SQL special chars

### DIFF
--- a/packages/zod/src/v3/tests/string.test.ts
+++ b/packages/zod/src/v3/tests/string.test.ts
@@ -386,7 +386,17 @@ test("bad nanoid", () => {
 
 test("cuid", () => {
   const cuid = z.string().cuid();
+  // Valid CUID (lowercase c, alphanumeric only)
   cuid.parse("ckopqwooh000001la8mbi2im9");
+
+  // Invalid: SQL special characters should be rejected
+  expect(() => cuid.parse("ckopqwooh000001la8mbi2im9'")).toThrow();
+  expect(() => cuid.parse('ckopqwooh000001la8mbi2im9"')).toThrow();
+  expect(() => cuid.parse("ckopqwooh000001la8mbi2im9;")).toThrow();
+
+  // Invalid: uppercase C should be rejected
+  expect(() => cuid.parse("Ckopqwooh000001la8mbi2im9")).toThrow();
+
   const result = cuid.safeParse("cifjhdsfhsd-invalid-cuid");
   expect(result.success).toEqual(false);
   if (!result.success) {

--- a/packages/zod/src/v3/tests/string.test.ts
+++ b/packages/zod/src/v3/tests/string.test.ts
@@ -386,10 +386,9 @@ test("bad nanoid", () => {
 
 test("cuid", () => {
   const cuid = z.string().cuid();
-  // Valid CUID (lowercase c, alphanumeric only)
   cuid.parse("ckopqwooh000001la8mbi2im9");
 
-  // Invalid: SQL special characters should be rejected
+  // Invalid: special characters should be rejected
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9'")).toThrow();
   expect(() => cuid.parse('ckopqwooh000001la8mbi2im9"')).toThrow();
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9;")).toThrow();

--- a/packages/zod/src/v3/tests/string.test.ts
+++ b/packages/zod/src/v3/tests/string.test.ts
@@ -387,13 +387,9 @@ test("bad nanoid", () => {
 test("cuid", () => {
   const cuid = z.string().cuid();
   cuid.parse("ckopqwooh000001la8mbi2im9");
-
-  // Invalid: special characters should be rejected
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9'")).toThrow();
   expect(() => cuid.parse('ckopqwooh000001la8mbi2im9"')).toThrow();
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9;")).toThrow();
-
-  // Invalid: uppercase C should be rejected
   expect(() => cuid.parse("Ckopqwooh000001la8mbi2im9")).toThrow();
 
   const result = cuid.safeParse("cifjhdsfhsd-invalid-cuid");

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -591,7 +591,7 @@ export interface ZodStringDef extends ZodTypeDef {
   coerce: boolean;
 }
 
-const cuidRegex = /^c[^\s-]{8,}$/i;
+const cuidRegex = /^c[0-9a-z]{8,}$/;
 const cuid2Regex = /^[0-9a-z]+$/;
 const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
 // const uuidRegex =

--- a/packages/zod/src/v4/classic/tests/continuability.test.ts
+++ b/packages/zod/src/v4/classic/tests/continuability.test.ts
@@ -274,7 +274,7 @@ test("continuability", () => {
         "message": "Invalid cuid",
         "origin": "string",
         "path": [],
-        "pattern": "/^[c][0-9a-z]{8,}$/",
+        "pattern": "/^c[0-9a-z]{8,}$/",
       },
       {
         "code": "custom",

--- a/packages/zod/src/v4/classic/tests/continuability.test.ts
+++ b/packages/zod/src/v4/classic/tests/continuability.test.ts
@@ -274,7 +274,7 @@ test("continuability", () => {
         "message": "Invalid cuid",
         "origin": "string",
         "path": [],
-        "pattern": "/^[cC][^\\s-]{8,}$/",
+        "pattern": "/^[c][0-9a-z]{8,}$/",
       },
       {
         "code": "custom",

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -606,10 +606,25 @@ test("bad guid", () => {
 
 test("cuid", () => {
   const cuid = z.string().cuid();
+  // Valid CUIDs (lowercase c, alphanumeric only)
   cuid.parse("ckopqwooh000001la8mbi2im9");
-  const result = cuid.safeParse("cifjhdsfhsd-invalid-cuid");
-  expect(result).toMatchObject({ success: false });
+  cuid.parse("cixs7y0c0000f7x3b1z6m3w6r");
 
+  // Invalid: too short
+  expect(() => cuid.parse("abc")).toThrow();
+
+  // Invalid: SQL special characters should be rejected
+  expect(() => cuid.parse("ckopqwooh000001la8mbi2im9'")).toThrow();
+  expect(() => cuid.parse('ckopqwooh000001la8mbi2im9"')).toThrow();
+  expect(() => cuid.parse("ckopqwooh000001la8mbi2im9;")).toThrow();
+  expect(() => cuid.parse("ckopqwooh000001la8mbi2im9\\")).toThrow();
+
+  // Invalid: uppercase C should be rejected (CUID spec uses lowercase c)
+  expect(() => cuid.parse("Ckopqwooh000001la8mbi2im9")).toThrow();
+
+  // Verify error message
+  const result = cuid.safeParse("invalid-cuid");
+  expect(result).toMatchObject({ success: false });
   expect(result.error!.issues[0].message).toEqual("Invalid cuid");
   expect(result.error).toMatchInlineSnapshot(`
     [ZodError: [
@@ -617,7 +632,7 @@ test("cuid", () => {
         "origin": "string",
         "code": "invalid_format",
         "format": "cuid",
-        "pattern": "/^[cC][^\\\\s-]{8,}$/",
+        "pattern": "/^[c][0-9a-z]{8,}$/",
         "path": [],
         "message": "Invalid cuid"
       }

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -608,20 +608,13 @@ test("cuid", () => {
   const cuid = z.string().cuid();
   cuid.parse("ckopqwooh000001la8mbi2im9");
   cuid.parse("cixs7y0c0000f7x3b1z6m3w6r");
-
-  // Invalid: too short
   expect(() => cuid.parse("abc")).toThrow();
-
-  // Invalid: special characters should be rejected
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9'")).toThrow();
   expect(() => cuid.parse('ckopqwooh000001la8mbi2im9"')).toThrow();
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9;")).toThrow();
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9\\")).toThrow();
-
-  // Invalid: uppercase C should be rejected
   expect(() => cuid.parse("Ckopqwooh000001la8mbi2im9")).toThrow();
 
-  // Verify error message
   const result = cuid.safeParse("invalid-cuid");
   expect(result).toMatchObject({ success: false });
   expect(result.error!.issues[0].message).toEqual("Invalid cuid");

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -606,20 +606,19 @@ test("bad guid", () => {
 
 test("cuid", () => {
   const cuid = z.string().cuid();
-  // Valid CUIDs (lowercase c, alphanumeric only)
   cuid.parse("ckopqwooh000001la8mbi2im9");
   cuid.parse("cixs7y0c0000f7x3b1z6m3w6r");
 
   // Invalid: too short
   expect(() => cuid.parse("abc")).toThrow();
 
-  // Invalid: SQL special characters should be rejected
+  // Invalid: special characters should be rejected
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9'")).toThrow();
   expect(() => cuid.parse('ckopqwooh000001la8mbi2im9"')).toThrow();
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9;")).toThrow();
   expect(() => cuid.parse("ckopqwooh000001la8mbi2im9\\")).toThrow();
 
-  // Invalid: uppercase C should be rejected (CUID spec uses lowercase c)
+  // Invalid: uppercase C should be rejected
   expect(() => cuid.parse("Ckopqwooh000001la8mbi2im9")).toThrow();
 
   // Verify error message
@@ -632,7 +631,7 @@ test("cuid", () => {
         "origin": "string",
         "code": "invalid_format",
         "format": "cuid",
-        "pattern": "/^[c][0-9a-z]{8,}$/",
+        "pattern": "/^c[0-9a-z]{8,}$/",
         "path": [],
         "message": "Invalid cuid"
       }

--- a/packages/zod/src/v4/classic/tests/template-literal.test.ts
+++ b/packages/zod/src/v4/classic/tests/template-literal.test.ts
@@ -555,8 +555,8 @@ test("regexes", () => {
   expect(optionalNumber._zod.pattern.source).toMatchInlineSnapshot(`"^(-?\\d+(?:\\.\\d+)?)?$"`);
   expect(nullishBruh._zod.pattern.source).toMatchInlineSnapshot(`"^(((bruh)|null))?$"`);
   expect(nullishString._zod.pattern.source).toMatchInlineSnapshot(`"^(([\\s\\S]{0,}|null))?$"`);
-  expect(cuid._zod.pattern.source).toMatchInlineSnapshot(`"^[cC][^\\s-]{8,}$"`);
-  expect(cuidZZZ._zod.pattern.source).toMatchInlineSnapshot(`"^[cC][^\\s-]{8,}ZZZ$"`);
+  expect(cuid._zod.pattern.source).toMatchInlineSnapshot(`"^[c][0-9a-z]{8,}$"`);
+  expect(cuidZZZ._zod.pattern.source).toMatchInlineSnapshot(`"^[c][0-9a-z]{8,}ZZZ$"`);
   expect(cuid2._zod.pattern.source).toMatchInlineSnapshot(`"^[0-9a-z]+$"`);
   expect(datetime._zod.pattern.source).toMatchInlineSnapshot(
     `"^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"`
@@ -717,7 +717,7 @@ test("template literal parsing - failure - issue format", () => {
       {
         "code": "invalid_format",
         "format": "template_literal",
-        "pattern": "^[cC][^\\\\s-]{8,}ZZZ$",
+        "pattern": "^[c][0-9a-z]{8,}ZZZ$",
         "path": [],
         "message": "Invalid input"
       }

--- a/packages/zod/src/v4/classic/tests/template-literal.test.ts
+++ b/packages/zod/src/v4/classic/tests/template-literal.test.ts
@@ -555,8 +555,8 @@ test("regexes", () => {
   expect(optionalNumber._zod.pattern.source).toMatchInlineSnapshot(`"^(-?\\d+(?:\\.\\d+)?)?$"`);
   expect(nullishBruh._zod.pattern.source).toMatchInlineSnapshot(`"^(((bruh)|null))?$"`);
   expect(nullishString._zod.pattern.source).toMatchInlineSnapshot(`"^(([\\s\\S]{0,}|null))?$"`);
-  expect(cuid._zod.pattern.source).toMatchInlineSnapshot(`"^[c][0-9a-z]{8,}$"`);
-  expect(cuidZZZ._zod.pattern.source).toMatchInlineSnapshot(`"^[c][0-9a-z]{8,}ZZZ$"`);
+  expect(cuid._zod.pattern.source).toMatchInlineSnapshot(`"^c[0-9a-z]{8,}$"`);
+  expect(cuidZZZ._zod.pattern.source).toMatchInlineSnapshot(`"^c[0-9a-z]{8,}ZZZ$"`);
   expect(cuid2._zod.pattern.source).toMatchInlineSnapshot(`"^[0-9a-z]+$"`);
   expect(datetime._zod.pattern.source).toMatchInlineSnapshot(
     `"^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$"`
@@ -717,7 +717,7 @@ test("template literal parsing - failure - issue format", () => {
       {
         "code": "invalid_format",
         "format": "template_literal",
-        "pattern": "^[c][0-9a-z]{8,}ZZZ$",
+        "pattern": "^c[0-9a-z]{8,}ZZZ$",
         "path": [],
         "message": "Invalid input"
       }

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -212,7 +212,7 @@ describe("toJSONSchema", () => {
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "cuid",
-        "pattern": "^[c][0-9a-z]{8,}$",
+        "pattern": "^c[0-9a-z]{8,}$",
         "type": "string",
       }
     `);

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -212,7 +212,7 @@ describe("toJSONSchema", () => {
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "cuid",
-        "pattern": "^[cC][^\\s-]{8,}$",
+        "pattern": "^[c][0-9a-z]{8,}$",
         "type": "string",
       }
     `);

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -1,6 +1,6 @@
 import * as util from "./util.js";
 
-export const cuid: RegExp = /^[cC][^\s-]{8,}$/;
+export const cuid: RegExp = /^[c][0-9a-z]{8,}$/;
 export const cuid2: RegExp = /^[0-9a-z]+$/;
 export const ulid: RegExp = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
 export const xid: RegExp = /^[0-9a-vA-V]{20}$/;

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -1,6 +1,6 @@
 import * as util from "./util.js";
 
-export const cuid: RegExp = /^[c][0-9a-z]{8,}$/;
+export const cuid: RegExp = /^c[0-9a-z]{8,}$/;
 export const cuid2: RegExp = /^[0-9a-z]+$/;
 export const ulid: RegExp = /^[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{26}$/;
 export const xid: RegExp = /^[0-9a-vA-V]{20}$/;

--- a/packages/zod/src/v4/mini/tests/string.test.ts
+++ b/packages/zod/src/v4/mini/tests/string.test.ts
@@ -181,17 +181,11 @@ test("z.cuid", () => {
   const a = z.cuid();
   expect(z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r")).toEqual("cixs7y0c0000f7x3b1z6m3w6r");
   expect(z.parse(a, "ckopqwooh000001la8mbi2im9")).toEqual("ckopqwooh000001la8mbi2im9");
-
-  // Invalid: too short
   expect(() => z.parse(a, "abc")).toThrow();
-
-  // Invalid: special characters should be rejected
   expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r'")).toThrow();
   expect(() => z.parse(a, 'cixs7y0c0000f7x3b1z6m3w6r"')).toThrow();
   expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r;")).toThrow();
   expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r\\")).toThrow();
-
-  // Invalid: uppercase C should be rejected
   expect(() => z.parse(a, "Cixs7y0c0000f7x3b1z6m3w6r")).toThrow();
 });
 

--- a/packages/zod/src/v4/mini/tests/string.test.ts
+++ b/packages/zod/src/v4/mini/tests/string.test.ts
@@ -179,8 +179,21 @@ test("z.nanoid", () => {
 
 test("z.cuid", () => {
   const a = z.cuid();
+  // Valid CUIDs (lowercase c, alphanumeric only)
   expect(z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r")).toEqual("cixs7y0c0000f7x3b1z6m3w6r");
+  expect(z.parse(a, "ckopqwooh000001la8mbi2im9")).toEqual("ckopqwooh000001la8mbi2im9");
+
+  // Invalid: too short
   expect(() => z.parse(a, "abc")).toThrow();
+
+  // Invalid: SQL special characters should be rejected
+  expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r'")).toThrow();
+  expect(() => z.parse(a, 'cixs7y0c0000f7x3b1z6m3w6r"')).toThrow();
+  expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r;")).toThrow();
+  expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r\\")).toThrow();
+
+  // Invalid: uppercase C should be rejected (CUID spec uses lowercase c)
+  expect(() => z.parse(a, "Cixs7y0c0000f7x3b1z6m3w6r")).toThrow();
 });
 
 test("z.cuid2", () => {

--- a/packages/zod/src/v4/mini/tests/string.test.ts
+++ b/packages/zod/src/v4/mini/tests/string.test.ts
@@ -179,20 +179,19 @@ test("z.nanoid", () => {
 
 test("z.cuid", () => {
   const a = z.cuid();
-  // Valid CUIDs (lowercase c, alphanumeric only)
   expect(z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r")).toEqual("cixs7y0c0000f7x3b1z6m3w6r");
   expect(z.parse(a, "ckopqwooh000001la8mbi2im9")).toEqual("ckopqwooh000001la8mbi2im9");
 
   // Invalid: too short
   expect(() => z.parse(a, "abc")).toThrow();
 
-  // Invalid: SQL special characters should be rejected
+  // Invalid: special characters should be rejected
   expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r'")).toThrow();
   expect(() => z.parse(a, 'cixs7y0c0000f7x3b1z6m3w6r"')).toThrow();
   expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r;")).toThrow();
   expect(() => z.parse(a, "cixs7y0c0000f7x3b1z6m3w6r\\")).toThrow();
 
-  // Invalid: uppercase C should be rejected (CUID spec uses lowercase c)
+  // Invalid: uppercase C should be rejected
   expect(() => z.parse(a, "Cixs7y0c0000f7x3b1z6m3w6r")).toThrow();
 });
 


### PR DESCRIPTION
## Summary
Fixes CVE-2026-6991, a vulnerability in Zod ≤4.3.6 where the CUID validation regex was too permissive, allowing SQL special characters to pass validation.

## Root Cause
The original regex `/^[cC][^\s-]{8,}$/` (v4) and `/^c[^\s-]{8,}$/i` (v3) accepted **any character except whitespace and hyphens**. This meant strings containing SQL metacharacters like `'`, `"`, `;`, `\` could be validated as "valid CUIDs", creating a potential SQL injection risk if applications use these values in queries without proper escaping.

## Changes
### 1. Tightened regex (v4 & v3)
- **v4** `packages/zod/src/v4/core/regexes.ts`:
  ```diff
  - export const cuid: RegExp = /^[cC][^\s-]{8,}$/;
  + export const cuid: RegExp = /^[c][0-9a-z]{8,}$/;
  ```
- **v3** `packages/zod/src/v3/types.ts`:
  ```diff
  - const cuidRegex = /^c[^\s-]{8,}$/i;
  + const cuidRegex = /^c[0-9a-z]{8,}$/;
  ```
- Now only allows **lowercase `c`** (per CUID spec) followed by **alphanumeric characters only**.

### 2. Added regression tests
- `packages/zod/src/v4/classic/tests/string.test.ts`
- `packages/zod/src/v4/mini/tests/string.test.ts`
- `packages/zod/src/v3/tests/string.test.ts`
- New test cases: SQL special chars, uppercase `C` rejection, short strings.

### 3. Updated snapshots
All snapshot references to the old pattern updated:
- `continuability.test.ts`
- `template-literal.test.ts`
- `to-json-schema.test.ts`

## Testing
- ✅ Full test suite passes: **327 test files, 3681 tests, 0 type errors**
- ✅ CUID-specific tests confirm:
  - Valid CUIDs (`ckopqwooh000001la8mbi2im9`) pass
  - SQL special chars (`'`, `"`, `;`, `\`) are rejected
  - Uppercase `C` is rejected (spec compliance)

## Security Impact
- Eliminates CVE-2026-6991 by ensuring CUID validation rejects strings with SQL special characters.
- Aligns with CUID specification (lowercase `c` only, alphanumeric charset).

## References
- CVE: https://www.cve.org/CVERecord?id=CVE-2026-6991
- VulDB: https://vuldb.com/vuln/359543

