### PR TITLE
fix(email): reject addresses longer than 254 chars (RFC 5321)

### DIFF
--- a/packages/zod/src/v4/classic/tests/string-formats.test.ts
+++ b/packages/zod/src/v4/classic/tests/string-formats.test.ts
@@ -30,6 +30,25 @@ test("string format methods", () => {
   expect(e.safeParse("EMAIL@EXAMPLE.COM").success).toBe(false); // Negative
 });
 
+test("z.email() rejects addresses longer than 254 characters (RFC 5321)", () => {
+  const schema = z.email();
+  // "@example.com" = 12 chars; fill the remaining budget with the local part
+  const domain = "@example.com";
+  const addr254 = "a".repeat(254 - domain.length) + domain; // exactly 254
+  const addr255 = "a".repeat(255 - domain.length) + domain; // exactly 255
+
+  expect(addr254.length).toBe(254);
+  expect(addr255.length).toBe(255);
+
+  expect(schema.safeParse(addr254).success).toBe(true);
+
+  const result = schema.safeParse(addr255);
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues[0].code).toBe("too_big");
+  }
+});
+
 test("z.stringFormat", () => {
   const ccRegex = /^(?:\d{14,19}|\d{4}(?: \d{3,6}){2,4}|\d{4}(?:-\d{3,6}){2,4})$/u;
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -449,11 +449,30 @@ export interface $ZodEmail extends $ZodType {
   _zod: $ZodEmailInternals;
 }
 
+// RFC 5321 §4.5.3.1.3 limits the maximum total email address length to 254 chars.
+const EMAIL_MAX_LENGTH = 254;
+
 export const $ZodEmail: core.$constructor<$ZodEmail> = /*@__PURE__*/ core.$constructor(
   "$ZodEmail",
   (inst, def): void => {
     def.pattern ??= regexes.email;
     $ZodStringFormat.init(inst, def);
+    const patternCheck = inst._zod.check!;
+    inst._zod.check = (payload) => {
+      if (payload.value.length > EMAIL_MAX_LENGTH) {
+        payload.issues.push({
+          origin: "string",
+          code: "too_big",
+          maximum: EMAIL_MAX_LENGTH,
+          inclusive: true,
+          input: payload.value,
+          inst,
+          continue: !def.abort,
+        });
+        return;
+      }
+      patternCheck(payload);
+    };
   }
 );
 


### PR DESCRIPTION
## Problem

`z.email()` accepts email addresses of any length. RFC 5321 §4.5.3.1.3 caps the maximum total length at **254 characters**, but a purely regex-based check can't enforce this efficiently.

```ts
const schema = z.email();
const tooLong = "a".repeat(243) + "@example.com"; // 255 chars
schema.parse(tooLong); // currently passes — should fail
```

## Fix

Add an explicit length guard at the top of `$ZodEmail`'s check function. If the input exceeds 254 characters the check pushes a `too_big` issue and returns early — the regex never runs, keeping this path fast.

```ts
inst._zod.check = (payload) => {
  if (payload.value.length > 254) {
    payload.issues.push({
      origin: "string",
      code: "too_big",
      maximum: 254,
      inclusive: true,
      input: payload.value,
      inst,
      continue: !def.abort,
    });
    return;
  }
  patternCheck(payload);
};
```

The `too_big` code gives callers a structured way to distinguish this failure from a format error.

## Test

A new test in `string-formats.test.ts` verifies that a 254-char address passes and a 255-char address returns `{ code: "too_big" }`.

## References

- RFC 5321 §4.5.3.1.3: https://datatracker.ietf.org/doc/html/rfc5321#section-4.5.3.1.3
- Closes #5878