### PR TITLE
fix(v4): reject whitespace in z.base64() to close atob bypass

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -217,6 +217,16 @@ test("base64 validations", () => {
     "?QmFzZTY0IGVuY29kaW5nIGlzIGZ1bg==", // Invalid character '?'
     ".MTIzND2Nzg5MC4=", // Invalid character '.'
     "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo", // Missing padding
+    // Whitespace is not part of canonical base64 (RFC 4648 §3.3) — atob() strips
+    // whitespace internally before validating, so the length check alone would
+    // accept "123 " etc.
+    "123 ", // bypasses length-mod-4 via trailing whitespace
+    "SGVsbG8gV29ybGQ= ", // trailing space
+    " SGVsbG8gV29ybGQ=", // leading space
+    "SGVsbG8gV29ybGQ=\n", // trailing newline
+    "SGVs bG8gV29ybGQ=", // internal space
+    "SGVs\nbG8gV29ybGQ=", // internal newline
+    "SGVs\tbG8gV29ybGQ=", // internal tab
   ];
 
   for (const str of invalidBase64Strings) {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -887,6 +887,8 @@ export const $ZodCIDRv6: core.$constructor<$ZodCIDRv6> = /*@__PURE__*/ core.$con
 //////////////////////////////   ZodBase64   //////////////////////////////
 export function isValidBase64(data: string): boolean {
   if (data === "") return true;
+  // atob ignores whitespace, so reject it up front.
+  if (/\s/.test(data)) return false;
   if (data.length % 4 !== 0) return false;
   try {
     // @ts-ignore

--- a/packages/zod/src/v4/mini/tests/string.test.ts
+++ b/packages/zod/src/v4/mini/tests/string.test.ts
@@ -282,6 +282,11 @@ test("z.base64", () => {
   expect(() => z.parse(a, "SGVsbG8gd29ybGQ")).toThrow();
   expect(() => z.parse(a, "U29tZSBvdGhlciBzdHJpbmc")).toThrow();
   expect(() => z.parse(a, "hello")).toThrow();
+  // whitespace is not allowed (atob would otherwise strip it)
+  expect(() => z.parse(a, "123 ")).toThrow();
+  expect(() => z.parse(a, "SGVsbG8gd29ybGQ= ")).toThrow();
+  expect(() => z.parse(a, "SGVsbG8gd29ybGQ=\n")).toThrow();
+  expect(() => z.parse(a, "SGVs bG8gd29ybGQ=")).toThrow();
   // wrong type
   expect(() => z.parse(a, 123)).toThrow();
 });


### PR DESCRIPTION
## Summary

Closes the whitespace bypass in `isValidBase64()` raised in #5865. `atob()` strips ASCII whitespace before decoding, which lets strings like `"123 "` (length 4, mod-4 passes, `atob` strips and parses `"123"`) sneak past the existing length check. Fix: reject whitespace explicitly before the length check so the runtime matches the strict regex we already advertise via `bag.patterns` / `contentEncoding`.

## Why not just enforce `regexes.base64` at runtime?

That's what the validator originally did. It was replaced with the `atob`-based check specifically for perf on large inputs in #4386 (commit `ec7c89d9`), which also added the `big base64 and base64url` regression test in `packages/zod/src/v4/classic/tests/string.test.ts` that round-trips 10MB through `z.base64().parse()`. The `/\s/.test()` short-circuit is a single deterministic linear scan with no backtracking, so it fits inside that perf envelope without reintroducing the regex.

## Why keep the strict default at all?

Discussed in detail at https://github.com/colinhacks/zod/pull/5865#issuecomment-4337242184. Short version: zod's string formats are strict by default, the unpadded base64url niche is already served by `z.base64url()` / `z.jwt()`, and strict-vs-lenient is asymmetric — strict can be loosened later via opt-in (`z.base64({ padding: "optional" })`) non-breakingly, while lenient cannot be tightened without a breaking change.

## Test plan

- [x] `pnpm vitest run packages/zod/src/v4/classic/tests/string.test.ts -t "base64"` — passes
- [x] `pnpm vitest run packages/zod/src/v4` — 2640 tests passing
- [x] Full `pnpm vitest run` (via pre-push hook) — 3689 tests passing, no type errors
- [x] New invalid cases added in `packages/zod/src/v4/classic/tests/string.test.ts` covering the bypass (`"123 "`) plus leading/trailing/internal space, newline, and tab
- [x] Mini parity in `packages/zod/src/v4/mini/tests/string.test.ts`

Refs #5865.
