### PR TITLE
ci(release): switch to npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,8 @@ jobs:
 
       - id: publish
         name: Publish to NPM
-        uses: JS-DevTools/npm-publish@v3
+        uses: JS-DevTools/npm-publish@v4
         with:
-          token: ${{ secrets.NPM_TOKEN }}
           # dry-run: true
           provenance: true
           package: ./packages/zod
@@ -64,9 +63,8 @@ jobs:
 
       - name: Publish canary
         if: ${{ !steps.publish.outputs.type }}
-        uses: JS-DevTools/npm-publish@v3
+        uses: JS-DevTools/npm-publish@v4
         with:
-          token: ${{ secrets.NPM_TOKEN }}
           dry-run: false
           provenance: true
           tag: canary


### PR DESCRIPTION
## Summary

- Bumps `JS-DevTools/npm-publish` from `v3` to `v4` in `.github/workflows/release.yml`.
- Drops `token: ${{ secrets.NPM_TOKEN }}` from both the stable and canary publish steps.

`v3` of the action requires a static token; `v4.1.0+` made the token optional and falls through to OIDC trusted publishing when one isn't provided. The workflow already sets `permissions.id-token: write`, and the trusted publisher for `zod` is now configured on npmjs.com, so this is the only change needed to switch over.

## Why

The canary publish step has been failing with `E404 'zod@…-canary.…' is not in this registry` on every run since Jan 25, 2026 (41 consecutive failures). The stable publish path looks healthy only because it's a no-op on commits without a version bump — every actual publish attempt this year has been the canary path, and it's been broken the whole time.

Root cause: the static `NPM_TOKEN` no longer has rights to publish under the `canary` dist-tag (and possibly more broadly). Trusted publishing eliminates the token entirely, so this both unblocks canary releases and removes a long-lived secret from the publish pipeline.

## Test plan

- [ ] Merge to `main`. The workflow only runs on push to `main` (gated on changes to `packages/zod/{package.json,src/**}` or `release.yml` itself); merging this PR will satisfy the third condition and trigger a run.
- [ ] Confirm the "Publish canary" step succeeds and a fresh `zod@canary` version lands on npm with provenance attestation.
- [ ] Next time a real version bump lands, confirm the stable "Publish to NPM" step also succeeds via OIDC.