### PR TITLE
feat(v4): add z.script() for unicode script validation

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -389,6 +389,7 @@ export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> 
   ): this;
   /** @deprecated Use `z.iso.duration()` instead. */
   duration(params?: string | core.$ZodCheckISODurationParams): this;
+  script(name: string, params?: string | core.$ZodCheckScriptParams): this;
 }
 
 export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$constructor("ZodString", (inst, def) => {
@@ -418,6 +419,7 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   inst.cidrv4 = (params) => inst.check(core._cidrv4(ZodCIDRv4, params));
   inst.cidrv6 = (params) => inst.check(core._cidrv6(ZodCIDRv6, params));
   inst.e164 = (params) => inst.check(core._e164(ZodE164, params));
+  inst.script = (name, params) => inst.check(core._script(ZodScript, name, params));
 
   // iso
   inst.datetime = (params) => inst.check(iso.datetime(params as any));
@@ -535,6 +537,18 @@ export const ZodEmoji: core.$constructor<ZodEmoji> = /*@__PURE__*/ core.$constru
 
 export function emoji(params?: string | core.$ZodEmojiParams): ZodEmoji {
   return core._emoji(ZodEmoji, params);
+}
+
+// ZodScript
+export interface ZodScript extends ZodStringFormat<"script"> {
+  _zod: core.$ZodScriptInternals;
+}
+export const ZodScript: core.$constructor<ZodScript> = /*@__PURE__*/ core.$constructor("ZodScript", (inst, def) => {
+  core.$ZodScript.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+export function script(name: string, params?: string | core.$ZodScriptParams): ZodScript {
+  return core._script(ZodScript, name, params);
 }
 
 // ZodNanoID

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -507,6 +507,31 @@ test("emoji validations", () => {
   expect(() => emoji.parse("stuff😀")).toThrow();
 });
 
+test("script validations", () => {
+  const arabic = z.script("Arabic");
+  arabic.parse("مرحبا");
+  arabic.parse("عالم");
+  arabic.parse("أمين");
+  expect(() => arabic.parse("hello")).toThrow();
+  expect(() => arabic.parse("مرحبا123")).toThrow();
+
+  const latin = z.script("Latin");
+  latin.parse("hello");
+  expect(() => latin.parse("مرحبا")).toThrow();
+
+  const cyrillic = z.string().script("Cyrillic");
+  cyrillic.parse("привет");
+  expect(() => cyrillic.parse("hello")).toThrow();
+
+  expect(() => z.script("NotAScript")).toThrow(SyntaxError);
+
+  const result = arabic.safeParse("hello");
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues[0].code).toBe("invalid_format");
+  }
+});
+
 test("nanoid", () => {
   const nanoid = z.string().nanoid("custom error");
   nanoid.parse("lfNZluvAxMkf7Q8C5H-QS");

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -519,9 +519,12 @@ test("script validations", () => {
   latin.parse("hello");
   expect(() => latin.parse("مرحبا")).toThrow();
 
-  const cyrillic = z.string().script("Cyrillic");
+  const cyrillic = z.script("Cyrillic");
   cyrillic.parse("привет");
   expect(() => cyrillic.parse("hello")).toThrow();
+
+  // method form is equivalent to the standalone factory
+  expect(() => z.string().script("Cyrillic").parse("hello")).toThrow();
 
   expect(() => z.script("NotAScript")).toThrow(SyntaxError);
 

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -228,6 +228,25 @@ export function _emoji<T extends schemas.$ZodEmoji>(
   });
 }
 
+// Script
+export type $ZodScriptParams = StringFormatParams<schemas.$ZodScript, "name" | "when">;
+export type $ZodCheckScriptParams = CheckStringFormatParams<schemas.$ZodScript, "name" | "when">;
+// @__NO_SIDE_EFFECTS__
+export function _script<T extends schemas.$ZodScript>(
+  Class: util.SchemaClass<T>,
+  name: string,
+  params?: string | Omit<$ZodScriptParams, "name"> | Omit<$ZodCheckScriptParams, "name">
+): T {
+  return new Class({
+    type: "string",
+    format: "script",
+    check: "string_format",
+    abort: false,
+    name,
+    ...util.normalizeParams(params),
+  });
+}
+
 // NanoID
 export type $ZodNanoIDParams = StringFormatParams<schemas.$ZodNanoID, "when">;
 export type $ZodCheckNanoIDParams = CheckStringFormatParams<schemas.$ZodNanoID, "when">;

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -183,3 +183,7 @@ export const sha384_base64url: RegExp = /*@__PURE__*/ fixedBase64url(64);
 export const sha512_hex: RegExp = /^[0-9a-fA-F]{128}$/;
 export const sha512_base64: RegExp = /*@__PURE__*/ fixedBase64(86, "==");
 export const sha512_base64url: RegExp = /*@__PURE__*/ fixedBase64url(86);
+
+export function script(name: string): RegExp {
+  return new RegExp(`^\\p{Script=${name}}+$`, "u");
+}

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -567,6 +567,25 @@ export const $ZodEmoji: core.$constructor<$ZodEmoji> = /*@__PURE__*/ core.$const
   }
 );
 
+//////////////////////////////   ZodScript   //////////////////////////////
+
+export interface $ZodScriptDef extends $ZodStringFormatDef<"script"> {
+  name: string;
+}
+export interface $ZodScriptInternals extends $ZodStringFormatInternals<"script"> {
+  def: $ZodScriptDef;
+}
+export interface $ZodScript extends $ZodType {
+  _zod: $ZodScriptInternals;
+}
+export const $ZodScript: core.$constructor<$ZodScript> = /*@__PURE__*/ core.$constructor(
+  "$ZodScript",
+  (inst, def): void => {
+    def.pattern ??= regexes.script(def.name);
+    $ZodStringFormat.init(inst, def);
+  }
+);
+
 //////////////////////////////   ZodNanoID   //////////////////////////////
 
 export interface $ZodNanoIDDef extends $ZodStringFormatDef<"nanoid"> {}
@@ -4566,4 +4585,5 @@ export type $ZodStringFormatTypes =
   | $ZodJWT
   | $ZodCustomStringFormat<"hex">
   | $ZodCustomStringFormat<util.HashFormat>
-  | $ZodCustomStringFormat<"hostname">;
+  | $ZodCustomStringFormat<"hostname">
+  | $ZodScript;

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -227,6 +227,23 @@ export function emoji(params?: string | core.$ZodEmojiParams): ZodMiniEmoji {
   return core._emoji(ZodMiniEmoji, params);
 }
 
+// ZodMiniScript
+export interface ZodMiniScript extends _ZodMiniString<core.$ZodScriptInternals> {
+  // _zod: core.$ZodScriptInternals;
+}
+export const ZodMiniScript: core.$constructor<ZodMiniScript> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniScript",
+  (inst, def) => {
+    core.$ZodScript.init(inst, def);
+    ZodMiniStringFormat.init(inst, def);
+  }
+);
+
+// @__NO_SIDE_EFFECTS__
+export function script(name: string, params?: string | core.$ZodScriptParams): ZodMiniScript {
+  return core._script(ZodMiniScript, name, params);
+}
+
 // ZodMiniNanoID
 export interface ZodMiniNanoID extends _ZodMiniString<core.$ZodNanoIDInternals> {
   // _zod: core.$ZodNanoIDInternals;


### PR DESCRIPTION
Will eventually close #5804 

This PR adds z.script(name) which validates that every character in the string belong to the given unicode script, using the \p{Script=lang} property escape built into the JS engine

### Expected behavior:

z.script("Arabic").parse("حفلة");   // passes
z.script("Latin").parse("hello");    // passes
z.script("Cyrillic").parse("привет"); // passes

z.string().script("Cyrillic") // the method form also available and passed the tests

z.script("NotAScript") // throws syntax error at Schema creation; The JS Engine rejects unknowin script identifiers.

### Notes:
 
 - Invalid script names fail fast at schema creation time (not parse time) => the JS engine rejects unknown \p{Script=...} identifiers immediately
  
- Strict by design: spaces, punctuation, and diacritics outside the script's own code points will fail (suitable for validating individual words/tokens, not full sentences) => Support can be extended with Script_Extensions instead of Script `^\p{Script_Extensions=Arabic}+$`
 
 - Script names are the official Unicode identifiers (Old_Persian, Linear_B..etc) => casing matters

  - New scripts are supported automatically as Node.js/V8 updates their ICU Unicode tables => nothing to maintain in Zod

### Motivation:
Making zod even more accessible worldwide! :D

## Important:

Named aliases (z.arabic(), z.latin(), etc.) are intentionally left out each would be a one-liner in classic/schemas.ts, but picking which of the 150+ Unicode scripts deserve a named helper is an arbitrary call.
z.script("Arabic") is already readable, and the escape hatch is there if we want to ship named aliases later.


Reference Issue: #5804