### PR TITLE
fix(v4): apply util.Writeable in mini constructors and extend/safeExtend/partial/required

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1220,11 +1220,11 @@ export interface ZodObject<
   /** This is the default behavior. This method call is likely unnecessary. */
   strip(): ZodObject<Shape, core.$strip>;
 
-  extend<U extends core.$ZodLooseShape>(shape: U): ZodObject<util.Extend<Shape, U>, Config>;
+  extend<U extends core.$ZodLooseShape>(shape: U): ZodObject<util.Extend<Shape, util.Writeable<U>>, Config>;
 
   safeExtend<U extends core.$ZodLooseShape>(
     shape: SafeExtendShape<Shape, U> & Partial<Record<keyof Shape, core.SomeType>>
-  ): ZodObject<util.Extend<Shape, U>, Config>;
+  ): ZodObject<util.Extend<Shape, util.Writeable<U>>, Config>;
 
   /**
    * @deprecated Use [`A.extend(B.shape)`](https://zod.dev/api?id=extend) instead.
@@ -1241,7 +1241,7 @@ export interface ZodObject<
 
   partial(): ZodObject<
     {
-      [k in keyof Shape]: ZodOptional<Shape[k]>;
+      -readonly [k in keyof Shape]: ZodOptional<Shape[k]>;
     },
     Config
   >;
@@ -1249,7 +1249,7 @@ export interface ZodObject<
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
   ): ZodObject<
     {
-      [k in keyof Shape]: k extends keyof M
+      -readonly [k in keyof Shape]: k extends keyof M
         ? // Shape[k] extends OptionalInSchema
           //   ? Shape[k]
           //   :
@@ -1262,7 +1262,7 @@ export interface ZodObject<
   // required
   required(): ZodObject<
     {
-      [k in keyof Shape]: ZodNonOptional<Shape[k]>;
+      -readonly [k in keyof Shape]: ZodNonOptional<Shape[k]>;
     },
     Config
   >;
@@ -1270,7 +1270,7 @@ export interface ZodObject<
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
   ): ZodObject<
     {
-      [k in keyof Shape]: k extends keyof M ? ZodNonOptional<Shape[k]> : Shape[k];
+      -readonly [k in keyof Shape]: k extends keyof M ? ZodNonOptional<Shape[k]> : Shape[k];
     },
     Config
   >;

--- a/packages/zod/src/v4/classic/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/recursive-types.test.ts
@@ -153,6 +153,50 @@ test("pick and omit with getter", () => {
   expect(() => OmittedCategory.parse({ name: "test", subcategories: [] })).toThrow();
 });
 
+test("shape stays writeable through extend/safeExtend/partial/required", () => {
+  const Base = z.object({ name: z.string() });
+
+  const Extended = Base.extend({
+    get sub() {
+      return z.array(Extended);
+    },
+  });
+  type ExtendedShape = (typeof Extended)["shape"];
+  expectTypeOf<ExtendedShape>().toEqualTypeOf<{
+    name: z.ZodString;
+    sub: z.ZodArray<typeof Extended>;
+  }>();
+
+  const SafeExt = Base.safeExtend({ extra: z.string() } as const);
+  type SafeExtShape = (typeof SafeExt)["shape"];
+  expectTypeOf<SafeExtShape>().toEqualTypeOf<{
+    name: z.ZodString;
+    extra: z.ZodString;
+  }>();
+
+  const FromConst = Base.extend({ a: z.string(), b: z.number() } as const);
+  type FromConstShape = (typeof FromConst)["shape"];
+  expectTypeOf<FromConstShape>().toEqualTypeOf<{
+    name: z.ZodString;
+    a: z.ZodString;
+    b: z.ZodNumber;
+  }>();
+
+  const PartialExtended = Extended.partial();
+  type PartialShape = (typeof PartialExtended)["shape"];
+  expectTypeOf<PartialShape>().toEqualTypeOf<{
+    name: z.ZodOptional<z.ZodString>;
+    sub: z.ZodOptional<z.ZodArray<typeof Extended>>;
+  }>();
+
+  const RequiredExtended = Extended.required();
+  type RequiredShape = (typeof RequiredExtended)["shape"];
+  expectTypeOf<RequiredShape>().toEqualTypeOf<{
+    name: z.ZodNonOptional<z.ZodString>;
+    sub: z.ZodNonOptional<z.ZodArray<typeof Extended>>;
+  }>();
+});
+
 test("deferred self-recursion", () => {
   const Feature = z.object({
     title: z.string(),

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -854,7 +854,7 @@ export const ZodMiniObject: core.$constructor<ZodMiniObject> = /*@__PURE__*/ cor
 export function object<T extends core.$ZodLooseShape = Record<never, SomeType>>(
   shape?: T,
   params?: string | core.$ZodObjectParams
-): ZodMiniObject<T, core.$strip> {
+): ZodMiniObject<util.Writeable<T>, core.$strip> {
   const def: core.$ZodObjectDef = {
     type: "object",
     shape: shape ?? {},
@@ -868,7 +868,7 @@ export function object<T extends core.$ZodLooseShape = Record<never, SomeType>>(
 export function strictObject<T extends core.$ZodLooseShape>(
   shape: T,
   params?: string | core.$ZodObjectParams
-): ZodMiniObject<T, core.$strict> {
+): ZodMiniObject<util.Writeable<T>, core.$strict> {
   return new ZodMiniObject({
     type: "object",
     shape,
@@ -882,7 +882,7 @@ export function strictObject<T extends core.$ZodLooseShape>(
 export function looseObject<T extends core.$ZodLooseShape>(
   shape: T,
   params?: string | core.$ZodObjectParams
-): ZodMiniObject<T, core.$loose> {
+): ZodMiniObject<util.Writeable<T>, core.$loose> {
   return new ZodMiniObject({
     type: "object",
     shape,
@@ -896,7 +896,7 @@ export function looseObject<T extends core.$ZodLooseShape>(
 export function extend<T extends ZodMiniObject, U extends core.$ZodLooseShape>(
   schema: T,
   shape: U
-): ZodMiniObject<util.Extend<T["shape"], U>, T["_zod"]["config"]> {
+): ZodMiniObject<util.Extend<T["shape"], util.Writeable<U>>, T["_zod"]["config"]> {
   return util.extend(schema, shape);
 }
 
@@ -914,7 +914,7 @@ export type SafeExtendShape<Base extends core.$ZodShape, Ext extends core.$ZodLo
 export function safeExtend<T extends ZodMiniObject, U extends core.$ZodLooseShape>(
   schema: T,
   shape: SafeExtendShape<T["shape"], U>
-): ZodMiniObject<util.Extend<T["shape"], U>, T["_zod"]["config"]> {
+): ZodMiniObject<util.Extend<T["shape"], util.Writeable<U>>, T["_zod"]["config"]> {
   return util.safeExtend(schema, shape as any);
 }
 
@@ -951,7 +951,7 @@ export function partial<T extends ZodMiniObject>(
   schema: T
 ): ZodMiniObject<
   {
-    [k in keyof T["shape"]]: ZodMiniOptional<T["shape"][k]>;
+    -readonly [k in keyof T["shape"]]: ZodMiniOptional<T["shape"][k]>;
   },
   T["_zod"]["config"]
 >;
@@ -961,7 +961,7 @@ export function partial<T extends ZodMiniObject, M extends util.Mask<keyof T["sh
   mask: M & Record<Exclude<keyof M, keyof T["shape"]>, never>
 ): ZodMiniObject<
   {
-    [k in keyof T["shape"]]: k extends keyof M ? ZodMiniOptional<T["shape"][k]> : T["shape"][k];
+    -readonly [k in keyof T["shape"]]: k extends keyof M ? ZodMiniOptional<T["shape"][k]> : T["shape"][k];
   },
   T["_zod"]["config"]
 >;
@@ -986,7 +986,7 @@ export function required<T extends ZodMiniObject>(
   schema: T
 ): ZodMiniObject<
   {
-    [k in keyof T["shape"]]: ZodMiniNonOptional<T["shape"][k]>;
+    -readonly [k in keyof T["shape"]]: ZodMiniNonOptional<T["shape"][k]>;
   },
   T["_zod"]["config"]
 >;

--- a/packages/zod/src/v4/mini/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/mini/tests/recursive-types.test.ts
@@ -273,3 +273,53 @@ test("recursion compatibility", () => {
     },
   });
 });
+
+test("shape stays writeable through object/strictObject/looseObject/extend with getters", () => {
+  const Cat = z.object({
+    name: z.string(),
+    get sub(): z.ZodMiniArray<typeof Cat> {
+      return z.array(Cat);
+    },
+  });
+  type CatShape = (typeof Cat)["shape"];
+  expectTypeOf<CatShape>().toEqualTypeOf<{
+    name: z.ZodMiniString<string>;
+    sub: z.ZodMiniArray<typeof Cat>;
+  }>();
+
+  const StrictCat = z.strictObject({
+    name: z.string(),
+    get sub(): z.ZodMiniArray<typeof StrictCat> {
+      return z.array(StrictCat);
+    },
+  });
+  type StrictShape = (typeof StrictCat)["shape"];
+  expectTypeOf<StrictShape>().toEqualTypeOf<{
+    name: z.ZodMiniString<string>;
+    sub: z.ZodMiniArray<typeof StrictCat>;
+  }>();
+
+  const LooseCat = z.looseObject({
+    name: z.string(),
+    get sub(): z.ZodMiniArray<typeof LooseCat> {
+      return z.array(LooseCat);
+    },
+  });
+  type LooseShape = (typeof LooseCat)["shape"];
+  expectTypeOf<LooseShape>().toEqualTypeOf<{
+    name: z.ZodMiniString<string>;
+    sub: z.ZodMiniArray<typeof LooseCat>;
+  }>();
+
+  const Base = z.object({ name: z.string() });
+  const Extended = z.extend(Base, {
+    get sub(): z.ZodMiniArray<typeof Extended> {
+      return z.array(Extended);
+    },
+  });
+  type ExtendedShape = (typeof Extended)["shape"];
+  expectTypeOf<ExtendedShape>().toEqualTypeOf<{
+    name: z.ZodMiniString<string>;
+    sub: z.ZodMiniArray<typeof Extended>;
+  }>();
+});


### PR DESCRIPTION
## Summary

Follow-up to #5882. After fixing `strictObject`/`looseObject` in classic, audited the rest of the surface that takes (or constructs) a `$ZodLooseShape` and found four more places where `readonly` modifiers were leaking into the displayed shape. This brings classic and mini to parity.

## What was leaking, before

```ts
// classic
Base.extend({ get sub() { return z.array(Extended); } })
// ZodObject<{ name: ZodString; readonly sub: ZodArray<...>; }, $strip>
//                              ^^^^^^^^

Base.extend({ a: z.string(), b: z.number() } as const)
// ZodObject<{ name: ZodString; readonly a: ZodString; readonly b: ZodNumber; }, $strip>

Extended.partial()
// preserves readonly from Shape

// mini
zm.object({ name: zm.string(), get sub() {...} })
zm.strictObject({ name: zm.string(), get sub() {...} })
zm.looseObject({ name: zm.string(), get sub() {...} })
zm.extend(Base, { get sub() {...} })
// All four leak readonly — mini was missing Writeable everywhere.
```

## Changes

**Mini** (`packages/zod/src/v4/mini/schemas.ts`):
- `object`, `strictObject`, `looseObject` wrap `T` in `util.Writeable<T>` (mini was missing it on all three constructors).
- `extend`, `safeExtend` wrap `U` in `util.Writeable<U>`.
- `partial`, `required` use `-readonly` mapped types.

**Classic** (`packages/zod/src/v4/classic/schemas.ts`):
- `extend`, `safeExtend` wrap `U` in `util.Writeable<U>`.
- `partial`, `required` use `-readonly` mapped types.

## Why partial/required need `-readonly`

In normal flows the input `Shape` arrives prettified after this PR, so the modifier is defensive. But `partial()` and `required()` operate on a `Shape` from `._zod.config`, and if any future entry point introduces a readonly shape (e.g. someone reads `.shape` and pipes it manually), the inline mapped types `{ [k in keyof Shape]: ZodOptional<Shape[k]> }` would preserve readonly. The `-readonly` modifier costs nothing and closes that hole.

## Behavior unchanged

- `z.infer` output is identical — `$InferObjectOutput` already strips readonly via `-readonly`.
- No runtime behavior change.
- This is a display/shape-typing alignment fix only.

## Test plan

- [x] Added `expectTypeOf<(typeof X)["shape"]>` assertions in both `packages/zod/src/v4/classic/tests/recursive-types.test.ts` and `packages/zod/src/v4/mini/tests/recursive-types.test.ts`. Covers object/strictObject/looseObject with getters, extend/safeExtend, `as const` shapes, partial(), required().
- [x] `pnpm vitest run` — 333 files / 3741 tests passing
- [x] Confirmed via `tsc --noErrorTruncation` that hovers no longer surface `readonly` on any of the audited paths
- [x] Biome format/lint clean
