### PR TITLE
fix(v4): skip __proto__ key in object catchall

### DIFF
--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -1,4 +1,4 @@
-import { expect, expectTypeOf, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 import * as z from "zod/v4";
 import * as core from "zod/v4/core";
 
@@ -668,4 +668,50 @@ test("safeExtend() on object with refinements should not throw", () => {
     .refine(() => true);
 
   expect(() => schema.safeExtend({ b: z.string() })).not.toThrow();
+});
+
+// __proto__ in input must not replace the prototype of the parsed object via
+// the assignment setter on the result {}.
+// https://github.com/colinhacks/zod/security/advisories/GHSA-r34p-xfmx-58wv
+// https://github.com/colinhacks/zod/security/advisories/GHSA-84jv-fqfx-wxhr
+describe("__proto__ in object catchall paths", () => {
+  const protoInput = () => JSON.parse('{"__proto__":{"isAdmin":true},"name":"alice"}');
+
+  test("looseObject drops __proto__ and preserves Object.prototype", () => {
+    const schema = z.looseObject({ name: z.string() });
+    const parsed = schema.parse(protoInput());
+    expect(Object.keys(parsed)).toEqual(["name"]);
+    expect((parsed as any).isAdmin).toBeUndefined();
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  });
+
+  test("passthrough drops __proto__", () => {
+    const schema = z.object({ name: z.string() }).passthrough();
+    const parsed = schema.parse(protoInput());
+    expect((parsed as any).isAdmin).toBeUndefined();
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  });
+
+  test("catchall(unknown) drops __proto__", () => {
+    const schema = z.object({ name: z.string() }).catchall(z.unknown());
+    const parsed = schema.parse(protoInput());
+    expect((parsed as any).isAdmin).toBeUndefined();
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  });
+
+  test("safeParseAsync + jitless drops __proto__", async () => {
+    const schema = z.looseObject({ name: z.string() });
+    const result = await schema.safeParseAsync(protoInput(), { jitless: true } as any);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as any).isAdmin).toBeUndefined();
+      expect(Object.getPrototypeOf(result.data)).toBe(Object.prototype);
+    }
+  });
+
+  test("strict does not surface __proto__ as unrecognized", () => {
+    const schema = z.object({ name: z.string() }).strict();
+    const result = schema.safeParse(protoInput());
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1845,12 +1845,14 @@ function handleCatchall(
   inst: $ZodObject
 ) {
   const unrecognized: string[] = [];
-  // iterate over input keys
   const keySet = def.keySet;
   const _catchall = def.catchall!._zod;
   const t = _catchall.def.type;
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
+    // skip __proto__ so it can't replace the result prototype via the
+    // assignment setter on the plain {} we build into
+    if (key === "__proto__") continue;
     if (keySet.has(key)) continue;
     if (t === "never") {
       unrecognized.push(key);


### PR DESCRIPTION
## Summary

In `handleCatchall()`, an unrecognized `__proto__` key in the input is currently assigned directly to a fresh `{}` result object via `(final.value)[key] = result.value`. Because that goes through the `__proto__` setter on a plain object, the assignment **replaces the prototype of the parsed result**, giving the validated object attacker-controlled inherited properties. `Object.prototype` itself is not affected.

PoC on `4.3.6`:

```ts
const schema = z.looseObject({ name: z.string() });
const input = JSON.parse('{"__proto__":{"isAdmin":true},"name":"alice"}');
const parsed = schema.parse(input);
parsed.isAdmin // true  ← inherited from injected prototype
```

Same shape reproduces with `passthrough()` and `catchall(...)`, sync/async, and `{ jitless: true }` (the JIT fastpass falls through to the same `handleCatchall` for unknown keys).

## Fix

One-line guard in the catchall loop:

```ts
for (const key in input) {
  if (key === "__proto__") continue;
  ...
}
```

Mirrors the existing `__proto__` skip in `$ZodRecord` (`schemas.ts:2867`) and the v3 object-assembly guard at `parseUtil.ts:144`. Deliberately conservative — `for..in` iteration of input is preserved, so behavior for any input *other than* one with a `__proto__` own key is unchanged. Inherited prototype-chain enumeration (the separate concern in GHSA-9hmj-h52h-mxcf) is not addressed here; that's a narrower attack model and a noisier behavior change worth handling separately.

Reported in:

- GHSA-r34p-xfmx-58wv (critical)
- GHSA-84jv-fqfx-wxhr

## Test plan

- [x] 5 new tests in `object.test.ts` covering `looseObject` / `passthrough` / `catchall(unknown)` / `safeParseAsync` + `{ jitless: true }` / `strict()`, asserting `Object.getPrototypeOf(parsed) === Object.prototype` and that the injected key is not visible on the result.
- [x] `pnpm vitest run` — 3753 passed across 333 files, no regressions.