### PR TITLE
Drop `z.undefined()`'s `optin`/`optout = "optional"`

### DIFF
--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -41,14 +41,14 @@ test("optionality", () => {
   // z.undefined should NOT be optional
   const f = z.undefined();
   expect(f._zod.optin).toEqual("optional");
-  expect(f._zod.optout).toEqual("optional");
+  expect(f._zod.optout).toEqual(undefined);
   expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
   // z.union should be optional if any of the types are optional
   const g = z.union([z.string(), z.undefined()]);
   expect(g._zod.optin).toEqual("optional");
-  expect(g._zod.optout).toEqual("optional");
+  expect(g._zod.optout).toEqual(undefined);
   expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof g._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -40,14 +40,14 @@ test("optionality", () => {
 
   // z.undefined should NOT be optional
   const f = z.undefined();
-  expect(f._zod.optin).toEqual("optional");
+  expect(f._zod.optin).toEqual(undefined);
   expect(f._zod.optout).toEqual(undefined);
   expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
   // z.union should be optional if any of the types are optional
   const g = z.union([z.string(), z.undefined()]);
-  expect(g._zod.optin).toEqual("optional");
+  expect(g._zod.optin).toEqual(undefined);
   expect(g._zod.optout).toEqual(undefined);
   expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof g._zod.optout>().toEqualTypeOf<"optional" | undefined>();

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1358,7 +1358,6 @@ export const $ZodUndefined: core.$constructor<$ZodUndefined> = /*@__PURE__*/ cor
     $ZodType.init(inst, def);
     inst._zod.pattern = regexes.undefined;
     inst._zod.values = new Set([undefined]);
-    inst._zod.optin = "optional";
 
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1359,7 +1359,6 @@ export const $ZodUndefined: core.$constructor<$ZodUndefined> = /*@__PURE__*/ cor
     inst._zod.pattern = regexes.undefined;
     inst._zod.values = new Set([undefined]);
     inst._zod.optin = "optional";
-    inst._zod.optout = "optional";
 
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;


### PR DESCRIPTION
> _Note: this PR description was drafted with AI assistance._

Drops the `inst._zod.optin = "optional"` / `inst._zod.optout = "optional"` assignments in `$ZodUndefined`.

These were bundled into #4769 alongside the `.catch()` JSON-schema fix from #4768 without separate justification. The test added in the same commit literally has `// z.undefined should NOT be optional` directly above an assertion saying it is. The comment was the principled position; the assignments snapshotted whatever the runtime values happened to be after the patch.

`optout` is read by the object parser's absent-key error-swallow path (#5589) and the tuple parser's `optStart`. Marking `z.undefined()` as optout-optional conflates "value type is `undefined`" with "key may be absent in inferred output," which is upstream of the confusion threading through #5654 and #5661. `optin` rides along on the input side — `z.object({ a: z.undefined() })` infers as `{ a: undefined }` (required key) under strict semantics, and the JSON-schema `required` array should agree.

Inference doesn't move. `$ZodUndefinedInternals` doesn't promote `optin`/`optout` to required fields, so neither `z.object({ a: z.undefined() })` nor `z.union([z.string(), z.undefined()])` ever extended `OptionalOutSchema`/`OptionalInSchema` structurally. Only the runtime values were disagreeing with the type.

Test changes: four runtime-value assertion flips in `optional.test.ts` for the `z.undefined()` and `z.union([z.string(), z.undefined()])` blocks. `expectTypeOf` lines unchanged. 3,763/3,763 pass.
