### PR TITLE
fix(v4): reject tuple holes before required defaults

### DIFF
--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -282,11 +282,10 @@ test("tuple result is dense when optional precedes a default", () => {
   expect(1 in out && 3 in out).toEqual(true);
 });
 
-test("tuple breaks and truncates on first absent-optional rejection", () => {
-  // An `.optional()` slot that rejects `undefined` (e.g. via a refine) past
-  // optStart must (a) swallow the issue, (b) truncate the result there, and
-  // (c) NOT materialize any later defaults — otherwise the parser would
-  // happily fill in slots after a slot it just decided was missing/invalid.
+test("tuple truncates absent optional rejections only when the output tail is optional", () => {
+  // An absent optional-output slot can only be swallowed when every later
+  // output slot is optional too. If a later default would make the output tail
+  // required, truncating would violate the tuple's output type.
   const refusesUndefined = z
     .string()
     .optional()
@@ -294,13 +293,15 @@ test("tuple breaks and truncates on first absent-optional rejection", () => {
 
   const trailingDefault = z.tuple([z.string(), refusesUndefined, z.string().default("d")]);
   const r1 = trailingDefault.safeParse(["alpha"]);
-  expect(r1.success).toBe(true);
-  expect(r1.data).toEqual(["alpha"]);
+  expect(r1.success).toBe(false);
+  expect(r1.error!.issues[0].path).toEqual([1]);
 
-  // Optional slots BEFORE the rejected one collapse away with the truncate
-  // (mirrors the trailing-trim behaviour for absent optionals).
+  // Optional slots BEFORE the rejected one still cannot hide a later required
+  // output slot.
   const beforeReject = z.tuple([z.string(), z.string().optional(), refusesUndefined, z.string().default("d")]);
-  expect(beforeReject.safeParse(["alpha"]).data).toEqual(["alpha"]);
+  const r2 = beforeReject.safeParse(["alpha"]);
+  expect(r2.success).toBe(false);
+  expect(r2.error!.issues[0].path).toEqual([2]);
 
   // No default after — truncate still applies, no spurious issue surfaces.
   const noTrailingDefault = z.tuple([z.string(), refusesUndefined]);
@@ -309,7 +310,7 @@ test("tuple breaks and truncates on first absent-optional rejection", () => {
   expect(r3.data).toEqual(["alpha"]);
 });
 
-test("tuple breaks on absent-optional rejection under async parse", async () => {
+test("tuple rejects absent optional before required output under async parse", async () => {
   const refusesUndefined = z
     .string()
     .optional()
@@ -317,8 +318,24 @@ test("tuple breaks on absent-optional rejection under async parse", async () => 
 
   const schema = z.tuple([z.string(), refusesUndefined, z.string().default("d")]);
   const r = await schema.safeParseAsync(["alpha"]);
-  expect(r.success).toBe(true);
-  expect(r.data).toEqual(["alpha"]);
+  expect(r.success).toBe(false);
+  expect(r.error!.issues[0].path).toEqual([1]);
+});
+
+test("tuple rejects absent exact optional before defaulted output", () => {
+  const schema = z.tuple([z.string(), z.string().exactOptional(), z.string().default("fallback")]);
+  expectTypeOf<typeof schema._output>().toEqualTypeOf<[string, string, string]>();
+
+  const missingExact = schema.safeParse(["alpha"]);
+  expect(missingExact.success).toBe(false);
+  expect(missingExact.error!.issues[0].path).toEqual([1]);
+
+  expect(schema.parse(["alpha", "bravo"])).toEqual(["alpha", "bravo", "fallback"]);
+  expect(schema.safeParse(["alpha", undefined]).success).toBe(false);
+
+  // With no later required output slot, exact optional still behaves like an
+  // omitted tuple tail and truncates cleanly.
+  expect(z.tuple([z.string(), z.string().exactOptional(), z.string().optional()]).parse(["alpha"])).toEqual(["alpha"]);
 });
 
 test("tuple preserves explicit undefined inside input even for optional-out schemas", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2677,8 +2677,8 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
     payload.value = [];
     const proms: Promise<any>[] = [];
 
-    const reversedIndex = [...items].reverse().findIndex((item) => item._zod.optin !== "optional");
-    const optStart = reversedIndex === -1 ? 0 : items.length - reversedIndex;
+    const optStart = getTupleOptStart(items, "optin");
+    const outputOptStart = getTupleOptStart(items, "optout");
 
     if (!def.rest) {
       if (input.length < optStart) {
@@ -2736,10 +2736,19 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       }
     }
 
-    if (proms.length) return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input));
-    return handleTupleResults(itemResults, payload, items, input);
+    if (proms.length) {
+      return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input, outputOptStart));
+    }
+    return handleTupleResults(itemResults, payload, items, input, outputOptStart);
   };
 });
+
+function getTupleOptStart(items: readonly $ZodType[], key: "optin" | "optout") {
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (items[i]._zod[key] !== "optional") return i + 1;
+  }
+  return 0;
+}
 
 function handleTupleResult(result: ParsePayload, final: ParsePayload<any[]>, index: number) {
   if (result.issues.length) {
@@ -2748,36 +2757,22 @@ function handleTupleResult(result: ParsePayload, final: ParsePayload<any[]>, ind
   final.value[index] = result.value;
 }
 
-// Post-processes the per-item results collected by the tuple parser.
-// `optStart` is intentionally NOT consulted here — it's an input-length
-// concern handled by the `too_small` precheck at the top of parse. This
-// step is purely about output shaping, which is governed by `optout`:
-// a `.default()` tail item sits inside the optStart region (its `optin`
-// is optional), but it must NOT be dropped or have its errors swallowed
-// because it materializes a defined value (`optout !== "optional"`).
 function handleTupleResults(
   itemResults: ParsePayload[],
   final: ParsePayload<any[]>,
   items: readonly $ZodType[],
-  input: unknown[]
+  input: unknown[],
+  outputOptStart: number
 ) {
-  const hasRequiredOutputAfter: boolean[] = new Array(items.length);
-  let hasRequiredOutput = false;
-  for (let i = items.length - 1; i >= 0; i--) {
-    hasRequiredOutputAfter[i] = hasRequiredOutput;
-    if (items[i]._zod.optout !== "optional") hasRequiredOutput = true;
-  }
-
   // Walk results in order. Mirror $ZodObject's swallow-on-absent-optional
-  // rule, but only when the remaining tuple output tail is optional too. If a
-  // later slot has required output (e.g. `.default()`), truncation would return
-  // a value that does not satisfy the tuple's output type.
+  // rule, but only after `outputOptStart`: the first index where the output
+  // tuple tail can be absent.
   for (let i = 0; i < items.length; i++) {
     const r = itemResults[i];
     const isOptionalOut = items[i]._zod.optout === "optional";
     const isPresent = i < input.length;
     if (r.issues.length) {
-      if (isOptionalOut && !isPresent && !hasRequiredOutputAfter[i]) {
+      if (isOptionalOut && !isPresent && i >= outputOptStart) {
         final.value.length = i;
         break;
       }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2769,10 +2769,9 @@ function handleTupleResults(
   // tuple tail can be absent.
   for (let i = 0; i < items.length; i++) {
     const r = itemResults[i];
-    const isOptionalOut = items[i]._zod.optout === "optional";
     const isPresent = i < input.length;
     if (r.issues.length) {
-      if (isOptionalOut && !isPresent && i >= optoutStart) {
+      if (!isPresent && i >= optoutStart) {
         final.value.length = i;
         break;
       }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2706,9 +2706,8 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
 
     // Run every item in parallel, collecting results into an indexed
     // array. The post-processing in `handleTupleResults` walks them in
-    // order so it can break on the first absent-optional error: once a
-    // slot rejects `undefined`, the tuple is malformed at that index and
-    // any later defaults must NOT fire.
+    // order so it can decide whether an absent optional-output error can
+    // truncate the tail or must be reported to preserve required output.
     const itemResults: ParsePayload[] = new Array(items.length);
     for (let i = 0; i < items.length; i++) {
       const r = items[i]._zod.run({ value: input[i], issues: [] }, ctx);
@@ -2762,17 +2761,23 @@ function handleTupleResults(
   items: readonly $ZodType[],
   input: unknown[]
 ) {
+  const hasRequiredOutputAfter: boolean[] = new Array(items.length);
+  let hasRequiredOutput = false;
+  for (let i = items.length - 1; i >= 0; i--) {
+    hasRequiredOutputAfter[i] = hasRequiredOutput;
+    if (items[i]._zod.optout !== "optional") hasRequiredOutput = true;
+  }
+
   // Walk results in order. Mirror $ZodObject's swallow-on-absent-optional
-  // rule, but for a tuple "absent" is a positional concept: once we
-  // swallow at index k, every later index is also absent-or-corrupted,
-  // so we truncate the result there and stop processing — including
-  // skipping any later defaults.
+  // rule, but only when the remaining tuple output tail is optional too. If a
+  // later slot has required output (e.g. `.default()`), truncation would return
+  // a value that does not satisfy the tuple's output type.
   for (let i = 0; i < items.length; i++) {
     const r = itemResults[i];
     const isOptionalOut = items[i]._zod.optout === "optional";
     const isPresent = i < input.length;
     if (r.issues.length) {
-      if (isOptionalOut && !isPresent) {
+      if (isOptionalOut && !isPresent && !hasRequiredOutputAfter[i]) {
         final.value.length = i;
         break;
       }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2677,14 +2677,14 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
     payload.value = [];
     const proms: Promise<any>[] = [];
 
-    const optStart = getTupleOptStart(items, "optin");
-    const outputOptStart = getTupleOptStart(items, "optout");
+    const optinStart = getTupleOptStart(items, "optin");
+    const optoutStart = getTupleOptStart(items, "optout");
 
     if (!def.rest) {
-      if (input.length < optStart) {
+      if (input.length < optinStart) {
         payload.issues.push({
           code: "too_small",
-          minimum: optStart,
+          minimum: optinStart,
           inclusive: true,
           input,
           inst,
@@ -2737,9 +2737,9 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
     }
 
     if (proms.length) {
-      return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input, outputOptStart));
+      return Promise.all(proms).then(() => handleTupleResults(itemResults, payload, items, input, optoutStart));
     }
-    return handleTupleResults(itemResults, payload, items, input, outputOptStart);
+    return handleTupleResults(itemResults, payload, items, input, optoutStart);
   };
 });
 
@@ -2762,17 +2762,17 @@ function handleTupleResults(
   final: ParsePayload<any[]>,
   items: readonly $ZodType[],
   input: unknown[],
-  outputOptStart: number
+  optoutStart: number
 ) {
   // Walk results in order. Mirror $ZodObject's swallow-on-absent-optional
-  // rule, but only after `outputOptStart`: the first index where the output
+  // rule, but only after `optoutStart`: the first index where the output
   // tuple tail can be absent.
   for (let i = 0; i < items.length; i++) {
     const r = itemResults[i];
     const isOptionalOut = items[i]._zod.optout === "optional";
     const isPresent = i < input.length;
     if (r.issues.length) {
-      if (isOptionalOut && !isPresent && i >= outputOptStart) {
+      if (isOptionalOut && !isPresent && i >= optoutStart) {
         final.value.length = i;
         break;
       }


### PR DESCRIPTION
## Summary
- Reject absent optional-output tuple slots when a later slot has required output, such as a defaulted element.
- Add regression coverage for `exactOptional()` before `.default()` plus refined optional async/sync parity.

## Test plan
- `pnpm vitest run packages/zod/src/v4/classic/tests/tuple.test.ts`
- `pnpm vitest run packages/zod/src/v4/classic/tests/optional.test.ts`