### PR TITLE
Fix strict object effects in intersections

### DIFF
--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -1,4 +1,4 @@
-import { expect, expectTypeOf, test } from "vitest";
+import { expect, expectTypeOf, test, vi } from "vitest";
 import type { util } from "zod/v4/core";
 
 import * as z from "zod/v4";
@@ -65,6 +65,82 @@ test("object intersection: strict + strict", () => {
       },
     ]
   `);
+});
+
+test("strict object intersection runs refinements after sibling keys are reconciled", () => {
+  const spy = vi.fn();
+  const alwaysFailingSuperRefine = (_data: unknown, ctx: z.RefinementCtx) => {
+    spy();
+    ctx.addIssue({
+      code: "custom",
+      message: "This check always fails",
+    });
+  };
+
+  const schema = z.intersection(
+    z.strictObject({ x: z.string() }).superRefine(alwaysFailingSuperRefine),
+    z.strictObject({ a: z.string() }).superRefine(alwaysFailingSuperRefine)
+  );
+
+  const result = schema.safeParse({ x: "test", a: "hello" });
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(result.error?.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "custom",
+        "message": "This check always fails",
+        "path": [],
+      },
+      {
+        "code": "custom",
+        "message": "This check always fails",
+        "path": [],
+      },
+    ]
+  `);
+});
+
+test("strict object intersection runs transforms after sibling keys are reconciled", () => {
+  const spy = vi.fn();
+  const transformFn = <T extends object>(data: T) => {
+    spy();
+    return { ...data, transformed: true };
+  };
+
+  const schema = z.intersection(
+    z.strictObject({ x: z.string() }).transform(transformFn),
+    z.strictObject({ a: z.string() }).transform(transformFn)
+  );
+
+  const result = schema.safeParse({ x: "test", a: "hello" });
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(result.data).toEqual({
+    x: "test",
+    a: "hello",
+    transformed: true,
+  });
+});
+
+test("nested strict object intersection applies defaults after sibling keys are reconciled", () => {
+  const inner = z.intersection(
+    z.strictObject({
+      x: z.string().default("X default"),
+      y: z.number(),
+    }),
+    z.strictObject({
+      z: z.boolean(),
+    })
+  );
+
+  const schema = z.intersection(inner, z.strictObject({ a: z.string() }));
+  const result = schema.safeParse({ y: 34, z: true, a: "hello" });
+
+  expect(result.data).toEqual({
+    x: "X default",
+    y: 34,
+    z: true,
+    a: "hello",
+  });
 });
 
 test("deep intersection", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -24,11 +24,14 @@ export interface ParseContext<T extends errors.$ZodIssueBase = never> {
   // readonly abortEarly?: boolean;
 }
 
+type IntersectionKeySet = ReadonlySet<string> | "all";
+
 /** @internal */
 export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> extends ParseContext<T> {
   readonly async?: boolean | undefined;
   readonly direction?: "forward" | "backward";
   readonly skipChecks?: boolean;
+  readonly intersectionKeySet?: IntersectionKeySet;
 }
 
 export interface ParsePayload<T = unknown> {
@@ -1852,7 +1855,7 @@ function handleCatchall(
   proms: Promise<any>[],
   input: any,
   payload: ParsePayload,
-  ctx: ParseContext,
+  ctx: ParseContextInternal,
   def: ReturnType<typeof normalizeDef>,
   inst: $ZodObject
 ) {
@@ -1868,6 +1871,7 @@ function handleCatchall(
     if (key === "__proto__") continue;
     if (keySet.has(key)) continue;
     if (t === "never") {
+      if (allowsIntersectionKey(ctx.intersectionKeySet, key)) continue;
       unrecognized.push(key);
       continue;
     }
@@ -2472,8 +2476,8 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
 
     inst._zod.parse = (payload, ctx) => {
       const input = payload.value;
-      const left = def.left._zod.run({ value: input, issues: [] }, ctx);
-      const right = def.right._zod.run({ value: input, issues: [] }, ctx);
+      const left = def.left._zod.run({ value: input, issues: [] }, extendIntersectionKeySet(ctx, def.right));
+      const right = def.right._zod.run({ value: input, issues: [] }, extendIntersectionKeySet(ctx, def.left));
       const async = left instanceof Promise || right instanceof Promise;
 
       if (async) {
@@ -2486,6 +2490,64 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
     };
   }
 );
+
+function allowsIntersectionKey(keySet: IntersectionKeySet | undefined, key: string): boolean {
+  return keySet === "all" || keySet?.has(key) === true;
+}
+
+function extendIntersectionKeySet(ctx: ParseContextInternal, schema: SomeType): ParseContextInternal {
+  const keySet = getIntersectionKeySet(schema);
+  if (!keySet) return ctx;
+
+  const merged = mergeIntersectionKeySets(ctx.intersectionKeySet, keySet);
+  return merged === ctx.intersectionKeySet ? ctx : { ...ctx, intersectionKeySet: merged };
+}
+
+function mergeIntersectionKeySets(left: IntersectionKeySet | undefined, right: IntersectionKeySet): IntersectionKeySet {
+  if (left === "all" || right === "all") return "all";
+  if (!left) return right;
+
+  const merged = new Set(left);
+  for (const key of right) merged.add(key);
+  return merged;
+}
+
+function getIntersectionKeySet(schema: SomeType, seen = new Set<SomeType>()): IntersectionKeySet | undefined {
+  if (seen.has(schema)) return undefined;
+  seen.add(schema);
+
+  const def = schema._zod.def as any;
+  switch (def.type) {
+    case "object": {
+      const catchall = def.catchall?._zod.def.type;
+      return catchall === "never" ? new Set(Object.keys(def.shape)) : "all";
+    }
+    case "intersection":
+      return mergeIntersectionKeySets(
+        getIntersectionKeySet(def.left, seen),
+        getIntersectionKeySet(def.right, seen) ?? new Set()
+      );
+    case "pipe":
+      return getIntersectionKeySet(def.in, seen);
+    case "readonly":
+    case "nullable":
+    case "optional":
+    case "nonoptional":
+    case "default":
+    case "prefault":
+    case "catch":
+    case "success":
+      return getIntersectionKeySet(def.innerType, seen);
+    case "lazy":
+      return getIntersectionKeySet((schema._zod as any).innerType, seen);
+    case "any":
+    case "unknown":
+    case "record":
+      return "all";
+    default:
+      return undefined;
+  }
+}
 
 function mergeValues(
   a: any,


### PR DESCRIPTION
## Summary
- Allow strict object intersections to reconcile keys accepted by sibling schemas before treating unknown keys as aborting issues.
- Add regressions for strict object intersections running refinements, transforms, and nested defaults.

Fixes #5663

## Test plan
- pnpm vitest run packages/zod/src/v4/classic/tests/intersection.test.ts
- pnpm dev --eval 'import * as z from "zod/v4"; const inner = z.intersection(z.strictObject({ x: z.string().default("X default"), y: z.number() }), z.strictObject({ z: z.boolean() })); const schema = z.intersection(inner, z.strictObject({ a: z.string() })); const result = schema.safeParse({ y: 34, z: true, a: "hello" }); if (!result.success || result.data.x !== "X default") process.exit(1);'
- pnpm biome check packages/zod/src/v4/core/schemas.ts packages/zod/src/v4/classic/tests/intersection.test.ts
- git push pre-push hook: pnpm test