### PR TITLE
Preserve merged values in nested intersections

### DIFF
--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -67,6 +67,29 @@ test("object intersection: strict + strict", () => {
   `);
 });
 
+test("nested strict object intersection preserves merged value with defaults", () => {
+  const inner = z.intersection(
+    z.strictObject({
+      x: z.string().default("X default"),
+      y: z.number(),
+    }),
+    z.strictObject({
+      z: z.boolean(),
+    })
+  );
+
+  const schema = z.intersection(inner, z.strictObject({ a: z.string() }));
+  type Schema = z.output<typeof schema>;
+  expectTypeOf<Schema>().toEqualTypeOf<{ x: string; y: number } & { z: boolean } & { a: string }>();
+
+  expect(schema.parse({ y: 34, z: true, a: "hello" })).toEqual({
+    x: "X default",
+    y: 34,
+    z: true,
+    a: "hello",
+  });
+});
+
 test("deep intersection", () => {
   const Animal = z.object({
     properties: z.object({

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2579,11 +2579,10 @@ function handleIntersectionResults(result: ParsePayload, left: ParsePayload, rig
     result.issues.push({ ...unrecIssue, keys: bothKeys });
   }
 
-  if (util.aborted(result)) return result;
-
   const merged = mergeValues(left.value, right.value);
 
   if (!merged.valid) {
+    if (util.aborted(result)) return result;
     throw new Error(`Unmergable intersection. Error path: ` + `${JSON.stringify(merged.mergeErrorPath)}`);
   }
 


### PR DESCRIPTION
## Summary
- Preserve a valid merged intersection output even when validation issues remain on the payload.
- Add a regression for nested strict object intersections preserving defaults from an inner intersection.

Refs #5663

## Test plan
- pnpm vitest run packages/zod/src/v4/classic/tests/intersection.test.ts
- pnpm dev --eval 'import * as z from "zod/v4"; const inner = z.intersection(z.strictObject({ x: z.string().default("X default"), y: z.number() }), z.strictObject({ z: z.boolean() })); const schema = z.intersection(inner, z.strictObject({ a: z.string() })); const result = schema.safeParse({ y: 34, z: true, a: "hello" }); if (!result.success || result.data.x !== "X default") process.exit(1);'
- pnpm biome check packages/zod/src/v4/core/schemas.ts packages/zod/src/v4/classic/tests/intersection.test.ts
- git push pre-push hook: pnpm test