### PR TITLE
Add strictRecord and strip record extras by default

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1853,13 +1853,15 @@ const AnyObject = z.record(Keys, z.unknown());
 // Record<string | number | symbol, unknown>
 ```
 
-To create an object schemas containing keys defined by an enum:
+To create an object schema containing keys defined by an enum:
 
 ```ts
 const Keys = z.enum(["id", "name", "email"]);
 const Person = z.record(Keys, z.string());
 // { id: string; name: string; email: string }
 ```
+
+By default, keys that don't match the key schema are stripped from the parsed result.
 
 Zod supports numeric keys inside records in a way that closely mirrors TypeScript itself. A `number` schema, when used as a record key, will validate that the key is a valid "numeric string". Additional numerical constraints (min, max, step, etc.) will also be validated.
 
@@ -1870,7 +1872,7 @@ numberKeys.parse({
   2: "two", // ✅
   "1.5": "one", // ✅
   "-3": "two", // ✅
-  abc: "one" // ❌
+  abc: "one" // stripped
 });
 
 // further validation is also supported
@@ -1879,8 +1881,8 @@ intKeys.parse({
   0: "zero", // ✅
   1: "one", // ✅
   2: "two", // ✅
-  12: "twelve", // ❌
-  abc: "one" // ❌
+  12: "twelve", // stripped
+  abc: "one" // stripped
 });
 ```
 
@@ -1908,9 +1910,25 @@ const Person = z.partialRecord(Keys, z.string());
 // { id?: string; name?: string; email?: string }
 ```
 
+### `z.strictRecord`
+
+Use `z.strictRecord()` to error on keys that don't match the key schema.
+
+```ts
+const Keys = z.enum(["id", "name", "email"]);
+const Person = z.strictRecord(Keys, z.string());
+
+Person.parse({
+  id: "123",
+  name: "Ada",
+  email: "ada@example.com",
+  extra: "unknown", // ❌ unrecognized key
+});
+```
+
 ### `z.looseRecord`
 
-By default, `z.record()` errors on keys that don't match the key schema. Use `z.looseRecord()` to pass through non-matching keys unchanged. This is particularly useful when combined with intersections to model multiple pattern properties:
+Use `z.looseRecord()` to pass through keys that don't match the key schema unchanged. This is particularly useful when combined with intersections to model multiple pattern properties:
 
 ```ts
 const schema = z

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1861,7 +1861,7 @@ const Person = z.record(Keys, z.string());
 // { id: string; name: string; email: string }
 ```
 
-By default, keys that don't match the key schema are stripped from the parsed result.
+By default, properties whose keys don't match the key schema are stripped from the parsed result. Values for matching keys are still parsed against the value schema.
 
 Zod supports numeric keys inside records in a way that closely mirrors TypeScript itself. A `number` schema, when used as a record key, will validate that the key is a valid "numeric string". Additional numerical constraints (min, max, step, etc.) will also be validated.
 

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -392,7 +392,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
 
         // Case A: No properties (pure record)
         if (Object.keys(shape).length === 0) {
-          zodSchema = z.record(keySchema, valueSchema);
+          zodSchema = z.strictRecord(keySchema, valueSchema);
           break;
         }
 

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1735,6 +1735,7 @@ export function record<Key extends core.$ZodRecordKey, Value extends core.SomeTy
       type: "record",
       keyType: string() as any,
       valueType: keyType as any as core.$ZodType,
+      mode: "strip",
       ...util.normalizeParams(valueType as string | core.$ZodRecordParams | undefined),
     }) as any;
   }
@@ -1742,6 +1743,7 @@ export function record<Key extends core.$ZodRecordKey, Value extends core.SomeTy
     type: "record",
     keyType,
     valueType: valueType as any as core.$ZodType,
+    mode: "strip",
     ...util.normalizeParams(params),
   }) as any;
 }
@@ -1757,6 +1759,21 @@ export function partialRecord<Key extends core.$ZodRecordKey, Value extends core
     type: "record",
     keyType: k,
     valueType: valueType as any,
+    mode: "strip",
+    ...util.normalizeParams(params),
+  }) as any;
+}
+
+export function strictRecord<Key extends core.$ZodRecordKey, Value extends core.SomeType>(
+  keyType: Key,
+  valueType: Value,
+  params?: string | core.$ZodRecordParams
+): ZodRecord<Key, Value> {
+  return new ZodRecord({
+    type: "record",
+    keyType,
+    valueType: valueType as any as core.$ZodType,
+    mode: "strict",
     ...util.normalizeParams(params),
   }) as any;
 }

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -295,8 +295,15 @@ test("z.record", () => {
   });
   // missing keys
   expect(() => z.parse(c, { a: "hello", b: "world" })).toThrow();
-  // extra keys
-  expect(() => z.parse(c, { a: "hello", b: "world", c: "world", d: "world" })).toThrow();
+  // extra keys are stripped
+  expect(z.parse(c, { a: "hello", b: "world", c: "world", d: "world" })).toEqual({
+    a: "hello",
+    b: "world",
+    c: "world",
+  });
+
+  const strictC = z.strictRecord(z.enum(["a", "b", "c"]), z.string());
+  expect(() => z.parse(strictC, { a: "hello", b: "world", c: "world", d: "world" })).toThrow();
 
   // partial enum
   const d = z.record(z.enum(["a", "b"]).or(z.never()), z.string());

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -8,6 +8,9 @@ test("type inference", () => {
   const recordWithEnumKeys = z.record(z.enum(["Tuna", "Salmon"]), z.string());
   type recordWithEnumKeys = z.infer<typeof recordWithEnumKeys>;
 
+  const strictRecordWithEnumKeys = z.strictRecord(z.enum(["Tuna", "Salmon"]), z.string());
+  type strictRecordWithEnumKeys = z.infer<typeof strictRecordWithEnumKeys>;
+
   const recordWithLiteralKey = z.record(z.literal(["Tuna", "Salmon", 21]), z.string());
   type recordWithLiteralKey = z.infer<typeof recordWithLiteralKey>;
 
@@ -27,6 +30,7 @@ test("type inference", () => {
 
   expectTypeOf<booleanRecord>().toEqualTypeOf<Record<string, boolean>>();
   expectTypeOf<recordWithEnumKeys>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
+  expectTypeOf<strictRecordWithEnumKeys>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
   expectTypeOf<recordWithLiteralKey>().toEqualTypeOf<Record<"Tuna" | "Salmon" | 21, string>>();
   expectTypeOf<recordWithLiteralUnionKeys>().toEqualTypeOf<Record<"Tuna" | "Salmon" | 21, string>>();
   expectTypeOf<recordWithTypescriptEnum>().toEqualTypeOf<Record<Enum, string>>();
@@ -44,21 +48,10 @@ test("enum exhaustiveness", () => {
     Salmon: "asdf",
   });
 
-  expect(schema.safeParse({ Tuna: "asdf", Salmon: "asdf", Trout: "asdf" })).toMatchInlineSnapshot(`
-    {
-      "error": [ZodError: [
-      {
-        "code": "unrecognized_keys",
-        "keys": [
-          "Trout"
-        ],
-        "path": [],
-        "message": "Unrecognized key: \\"Trout\\""
-      }
-    ]],
-      "success": false,
-    }
-  `);
+  expect(schema.parse({ Tuna: "asdf", Salmon: "asdf", Trout: "asdf" })).toEqual({
+    Tuna: "asdf",
+    Salmon: "asdf",
+  });
   expect(schema.safeParse({ Tuna: "asdf" })).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
@@ -76,21 +69,9 @@ test("enum exhaustiveness", () => {
   `);
 });
 
-test("typescript enum exhaustiveness", () => {
-  enum BigFish {
-    Tuna = 0,
-    Salmon = "Shark",
-  }
-
-  const schema = z.record(z.enum(BigFish), z.string());
-  const value = {
-    [BigFish.Tuna]: "asdf",
-    [BigFish.Salmon]: "asdf",
-  };
-
-  expect(schema.parse(value)).toEqual(value);
-
-  expect(schema.safeParse({ [BigFish.Tuna]: "asdf", [BigFish.Salmon]: "asdf", Trout: "asdf" })).toMatchInlineSnapshot(`
+test("strictRecord rejects unrecognized enum keys", () => {
+  const schema = z.strictRecord(z.enum(["Tuna", "Salmon"]), z.string());
+  expect(schema.safeParse({ Tuna: "asdf", Salmon: "asdf", Trout: "asdf" })).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
       {
@@ -105,6 +86,33 @@ test("typescript enum exhaustiveness", () => {
       "success": false,
     }
   `);
+  expect(schema.safeParse({ Tuna: "asdf" }).success).toBe(false);
+});
+
+test("looseRecord passes through unrecognized enum keys", () => {
+  const schema = z.looseRecord(z.enum(["Tuna", "Salmon"]), z.string());
+  expect(schema.parse({ Tuna: "asdf", Salmon: "asdf", Trout: 123 })).toEqual({
+    Tuna: "asdf",
+    Salmon: "asdf",
+    Trout: 123,
+  });
+});
+
+test("typescript enum exhaustiveness", () => {
+  enum BigFish {
+    Tuna = 0,
+    Salmon = "Shark",
+  }
+
+  const schema = z.record(z.enum(BigFish), z.string());
+  const value = {
+    [BigFish.Tuna]: "asdf",
+    [BigFish.Salmon]: "asdf",
+  };
+
+  expect(schema.parse(value)).toEqual(value);
+
+  expect(schema.parse({ [BigFish.Tuna]: "asdf", [BigFish.Salmon]: "asdf", Trout: "asdf" })).toEqual(value);
   expect(schema.safeParse({ [BigFish.Tuna]: "asdf" })).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
@@ -145,21 +153,11 @@ test("literal exhaustiveness", () => {
     21: "asdf",
   });
 
-  expect(schema.safeParse({ Tuna: "asdf", Salmon: "asdf", 21: "asdf", Trout: "asdf" })).toMatchInlineSnapshot(`
-    {
-      "error": [ZodError: [
-      {
-        "code": "unrecognized_keys",
-        "keys": [
-          "Trout"
-        ],
-        "path": [],
-        "message": "Unrecognized key: \\"Trout\\""
-      }
-    ]],
-      "success": false,
-    }
-  `);
+  expect(schema.parse({ Tuna: "asdf", Salmon: "asdf", 21: "asdf", Trout: "asdf" })).toEqual({
+    Tuna: "asdf",
+    Salmon: "asdf",
+    21: "asdf",
+  });
   expect(schema.safeParse({ Tuna: "asdf" })).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
@@ -192,21 +190,10 @@ test("pipe exhaustiveness", () => {
     Salmon: "asdf",
   });
 
-  expect(schema.safeParse({ Tuna: "asdf", Salmon: "asdf", Trout: "asdf" })).toMatchInlineSnapshot(`
-    {
-      "error": [ZodError: [
-      {
-        "code": "unrecognized_keys",
-        "keys": [
-          "Trout"
-        ],
-        "path": [],
-        "message": "Unrecognized key: \\"Trout\\""
-      }
-    ]],
-      "success": false,
-    }
-  `);
+  expect(schema.parse({ Tuna: "asdf", Salmon: "asdf", Trout: "asdf" })).toEqual({
+    Tuna: "asdf",
+    Salmon: "asdf",
+  });
   expect(schema.safeParse({ Tuna: "asdf" })).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
@@ -232,21 +219,11 @@ test("union exhaustiveness", () => {
     21: "asdf",
   });
 
-  expect(schema.safeParse({ Tuna: "asdf", Salmon: "asdf", 21: "asdf", Trout: "asdf" })).toMatchInlineSnapshot(`
-    {
-      "error": [ZodError: [
-      {
-        "code": "unrecognized_keys",
-        "keys": [
-          "Trout"
-        ],
-        "path": [],
-        "message": "Unrecognized key: \\"Trout\\""
-      }
-    ]],
-      "success": false,
-    }
-  `);
+  expect(schema.parse({ Tuna: "asdf", Salmon: "asdf", 21: "asdf", Trout: "asdf" })).toEqual({
+    Tuna: "asdf",
+    Salmon: "asdf",
+    21: "asdf",
+  });
   expect(schema.safeParse({ Tuna: "asdf" })).toMatchInlineSnapshot(`
     {
       "error": [ZodError: [
@@ -518,34 +495,8 @@ test("partialRecord with z.literal([key, ...])", () => {
   expect(schema.parse({ id: "1" })).toEqual({ id: "1" });
   expect(schema.parse({ name: "n", email: "e@example.com" })).toEqual({ name: "n", email: "e@example.com" });
 
-  // Should fail with unrecognized key, error checked via inline snapshot
-  expect(schema.safeParse({ foo: "bar" })).toMatchInlineSnapshot(`
-    {
-      "error": [ZodError: [
-      {
-        "code": "invalid_key",
-        "origin": "record",
-        "issues": [
-          {
-            "code": "invalid_value",
-            "values": [
-              "id",
-              "name",
-              "email"
-            ],
-            "path": [],
-            "message": "Invalid option: expected one of \\"id\\"|\\"name\\"|\\"email\\""
-          }
-        ],
-        "path": [
-          "foo"
-        ],
-        "message": "Invalid key in record"
-      }
-    ]],
-      "success": false,
-    }
-  `);
+  // Should strip unrecognized keys
+  expect(schema.parse({ foo: "bar" })).toEqual({});
 });
 
 test("partialRecord with numeric literal keys", () => {
@@ -559,8 +510,8 @@ test("partialRecord with numeric literal keys", () => {
   expect(schema.parse({ 1: "one" })).toEqual({ 1: "one" });
   expect(schema.parse({ 2: "two", 3: "three" })).toEqual({ 2: "two", 3: "three" });
 
-  // Should fail with unrecognized key
-  expect(schema.safeParse({ 4: "four" }).success).toBe(false);
+  // Should strip unrecognized keys
+  expect(schema.parse({ 4: "four" })).toEqual({});
 });
 
 test("partialRecord with union of string and numeric literal keys", () => {
@@ -575,9 +526,53 @@ test("partialRecord with union of string and numeric literal keys", () => {
   expect(schema.parse({ a: "1", 2: "4" })).toEqual({ a: "1", 2: "4" });
   expect(schema.parse({ a: "a", b: "b", 1: "1", 2: "2" })).toEqual({ a: "a", b: "b", 1: "1", 2: "2" });
 
-  // Should fail with unrecognized key
-  expect(schema.safeParse({ d: "d" }).success).toBe(false);
-  expect(schema.safeParse({ 4: "4" }).success).toBe(false);
+  // Should strip unrecognized keys
+  expect(schema.parse({ d: "d" })).toEqual({});
+  expect(schema.parse({ 4: "4" })).toEqual({});
+});
+
+test("record strips non-matching keys", () => {
+  const schema = z.record(z.string().regex(/^S_/), z.string());
+
+  // Keys matching pattern are validated
+  expect(schema.parse({ S_name: "John" })).toEqual({ S_name: "John" });
+  expect(() => schema.parse({ S_name: 123 })).toThrow(); // wrong value type
+
+  // Keys not matching pattern are stripped
+  expect(schema.parse({ S_name: "John", other: "value" })).toEqual({ S_name: "John" });
+  expect(schema.parse({ S_name: "John", count: 123 })).toEqual({ S_name: "John" });
+  expect(schema.parse({ other: "value" })).toEqual({});
+});
+
+test("strictRecord rejects non-matching keys", () => {
+  const schema = z.strictRecord(z.string().regex(/^S_/), z.string());
+
+  expect(schema.parse({ S_name: "John" })).toEqual({ S_name: "John" });
+  expect(schema.safeParse({ S_name: "John", other: "value" })).toMatchInlineSnapshot(`
+    {
+      "error": [ZodError: [
+      {
+        "code": "invalid_key",
+        "origin": "record",
+        "issues": [
+          {
+            "origin": "string",
+            "code": "invalid_format",
+            "format": "regex",
+            "pattern": "/^S_/",
+            "path": [],
+            "message": "Invalid string: must match pattern /^S_/"
+          }
+        ],
+        "path": [
+          "other"
+        ],
+        "message": "Invalid key in record"
+      }
+    ]],
+      "success": false,
+    }
+  `);
 });
 
 test("looseRecord passes through non-matching keys", () => {
@@ -676,13 +671,17 @@ test("numeric string keys", () => {
   expect(schema.parse({ 1: 100, 2: 200 })).toEqual({ 1: 100, 2: 200 });
   expect(schema.parse({ "1.5": 100, "-3": 200 })).toEqual({ "1.5": 100, "-3": 200 });
 
-  // Non-numeric keys fail
-  expect(schema.safeParse({ abc: 100 }).success).toBe(false);
+  // Non-numeric keys are stripped
+  expect(schema.parse({ abc: 100 })).toEqual({});
 
   // Integer constraint is respected
   const intSchema = z.record(z.number().int(), z.number());
   expect(intSchema.parse({ 1: 100 })).toEqual({ 1: 100 });
-  expect(intSchema.safeParse({ "1.5": 100 }).success).toBe(false);
+  expect(intSchema.parse({ "1.5": 100 })).toEqual({});
+
+  // strictRecord keeps the old invalid-key behavior
+  const strictIntSchema = z.strictRecord(z.number().int(), z.number());
+  expect(strictIntSchema.safeParse({ "1.5": 100 }).success).toBe(false);
 
   // Transforms on numeric keys work
   const transformedSchema = z.record(

--- a/packages/zod/src/v4/classic/tests/to-json-schema-methods.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema-methods.test.ts
@@ -274,6 +274,10 @@ describe("toJSONSchema method", () => {
       expectMethodMatch(z.record(z.string(), z.number()));
     });
 
+    test("strict record", () => {
+      expectMethodMatch(z.strictRecord(z.string(), z.number()));
+    });
+
     test("union", () => {
       expectMethodMatch(z.union([z.string(), z.number()]));
     });

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2810,8 +2810,8 @@ export interface $ZodRecordDef<Key extends $ZodRecordKey = $ZodRecordKey, Value 
   type: "record";
   keyType: Key;
   valueType: Value;
-  /** @default "strict" - errors on keys not matching keyType. "loose" passes through non-matching keys unchanged. */
-  mode?: "strict" | "loose";
+  /** @default "strip" - removes keys not matching keyType. "strict" errors. "loose" passes through unchanged. */
+  mode?: "strict" | "strip" | "loose";
 }
 
 // export type $InferZodRecordOutput<
@@ -2886,6 +2886,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
 
     const proms: Promise<any>[] = [];
 
+    const mode = def.mode ?? "strip";
     const values = def.keyType._zod.values;
     if (values) {
       payload.value = {};
@@ -2930,10 +2931,15 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       }
 
       let unrecognized!: string[];
-      for (const key in input) {
+      for (const key of Object.keys(input)) {
+        if (key === "__proto__") continue;
         if (!recordKeys.has(key)) {
-          unrecognized = unrecognized ?? [];
-          unrecognized.push(key);
+          if (mode === "loose") {
+            payload.value[key] = input[key];
+          } else if (mode === "strict") {
+            unrecognized = unrecognized ?? [];
+            unrecognized.push(key);
+          }
         }
       }
       if (unrecognized && unrecognized.length > 0) {
@@ -2970,11 +2976,10 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
         }
 
         if (keyResult.issues.length) {
-          if (def.mode === "loose") {
+          if (mode === "loose") {
             // Pass through unchanged
             payload.value[key] = input[key];
-          } else {
-            // Default "strict" behavior: error on invalid key
+          } else if (mode === "strict") {
             payload.issues.push({
               code: "invalid_key",
               origin: "record",

--- a/packages/zod/src/v4/core/tests/locales/el.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/el.test.ts
@@ -115,7 +115,7 @@ test("Greek locale - other error cases", () => {
   }
 
   // Test invalid_key with record (only "map" | "record" produce invalid_key)
-  const recordSchema = z.record(z.number(), z.string());
+  const recordSchema = z.strictRecord(z.number(), z.string());
   const recordResult = recordSchema.safeParse({ notANumber: "value" });
   expect(recordResult.success).toBe(false);
   if (!recordResult.success) {

--- a/packages/zod/src/v4/core/tests/locales/he.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/he.test.ts
@@ -229,7 +229,7 @@ describe("Hebrew localization", () => {
     });
 
     test("invalid_key in object", () => {
-      const schema = z.record(z.number(), z.string());
+      const schema = z.strictRecord(z.number(), z.string());
       const result = schema.safeParse({ notANumber: "value" });
       expect(result.success).toBe(false);
       if (!result.success) {

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1189,6 +1189,7 @@ export function record<Key extends core.$ZodRecordKey, Value extends SomeType>(
       type: "record",
       keyType: string() as any,
       valueType: keyType as any as core.$ZodType,
+      mode: "strip",
       ...util.normalizeParams(valueType as string | core.$ZodRecordParams | undefined),
     }) as any;
   }
@@ -1196,6 +1197,7 @@ export function record<Key extends core.$ZodRecordKey, Value extends SomeType>(
     type: "record",
     keyType,
     valueType: valueType as any as core.$ZodType,
+    mode: "strip",
     ...util.normalizeParams(params),
   }) as any;
 }
@@ -1211,6 +1213,21 @@ export function partialRecord<Key extends core.$ZodRecordKey, Value extends Some
     type: "record",
     keyType: k,
     valueType: valueType as any,
+    mode: "strip",
+    ...util.normalizeParams(params),
+  }) as any;
+}
+
+export function strictRecord<Key extends core.$ZodRecordKey, Value extends SomeType>(
+  keyType: Key,
+  valueType: Value,
+  params?: string | core.$ZodRecordParams
+): ZodMiniRecord<Key, Value> {
+  return new ZodMiniRecord({
+    type: "record",
+    keyType,
+    valueType: valueType as any as core.$ZodType,
+    mode: "strict",
     ...util.normalizeParams(params),
   }) as any;
 }

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -313,8 +313,15 @@ test("z.record", () => {
   });
   // missing keys
   expect(() => z.parse(c, { a: "hello", b: "world" })).toThrow();
-  // extra keys
-  expect(() => z.parse(c, { a: "hello", b: "world", c: "world", d: "world" })).toThrow();
+  // extra keys are stripped
+  expect(z.parse(c, { a: "hello", b: "world", c: "world", d: "world" })).toEqual({
+    a: "hello",
+    b: "world",
+    c: "world",
+  });
+
+  const strictC = z.strictRecord(z.enum(["a", "b", "c"]), z.string());
+  expect(() => z.parse(strictC, { a: "hello", b: "world", c: "world", d: "world" })).toThrow();
 
   // literal union keys
   const d = z.record(z.union([z.literal("a"), z.literal(0)]), z.string());


### PR DESCRIPTION
Make `z.record()` and `z.partialRecord()` strip properties whose keys do not match the key schema by default, matching `z.object()`'s default strip behavior. This also makes records easier to compose in intersections: a record branch can validate the keys it understands without rejecting unrelated properties owned by another branch.

Add `z.strictRecord()` for the previous invalid-key behavior in Classic and Mini, and update finite-key `z.looseRecord()` so unrecognized keys pass through consistently. JSON Schema import keeps strict `propertyNames` behavior by producing `z.strictRecord()`.

Validated with the focused record/JSON Schema tests and the full pre-push `pnpm test` suite.

Fixes #5666.
Fixes #2200.