### PR TITLE
Defer strict object keys in intersections

### DIFF
--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -1,4 +1,4 @@
-import { expect, expectTypeOf, test } from "vitest";
+import { expect, expectTypeOf, test, vi } from "vitest";
 import type { util } from "zod/v4/core";
 
 import * as z from "zod/v4";
@@ -65,6 +65,116 @@ test("object intersection: strict + strict", () => {
       },
     ]
   `);
+});
+
+test("strict object intersection runs checks after unrecognized keys are reconciled", () => {
+  const spy = vi.fn();
+  const alwaysFailingCheck = (payload: z.core.ParsePayload) => {
+    spy();
+    payload.issues.push({
+      code: "custom",
+      input: payload.value,
+      message: "This check always fails",
+    });
+  };
+
+  const schema = z.intersection(
+    z.strictObject({ x: z.string() }).check(alwaysFailingCheck),
+    z.strictObject({ a: z.string() }).check(alwaysFailingCheck)
+  );
+
+  const result = schema.safeParse({ x: "test", a: "hello" });
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(result.error?.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "custom",
+        "message": "This check always fails",
+        "path": [],
+      },
+      {
+        "code": "custom",
+        "message": "This check always fails",
+        "path": [],
+      },
+    ]
+  `);
+});
+
+test("strict object intersection runs superRefine after unrecognized keys are reconciled", () => {
+  const spy = vi.fn();
+  const alwaysFailingSuperRefine = (_data: unknown, ctx: z.RefinementCtx) => {
+    spy();
+    ctx.addIssue({
+      code: "custom",
+      message: "This check always fails",
+    });
+  };
+
+  const schema = z.intersection(
+    z.strictObject({ x: z.string() }).superRefine(alwaysFailingSuperRefine),
+    z.strictObject({ a: z.string() }).superRefine(alwaysFailingSuperRefine)
+  );
+
+  const result = schema.safeParse({ x: "test", a: "hello" });
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(result.error?.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "custom",
+        "message": "This check always fails",
+        "path": [],
+      },
+      {
+        "code": "custom",
+        "message": "This check always fails",
+        "path": [],
+      },
+    ]
+  `);
+});
+
+test("strict object intersection runs transforms after unrecognized keys are reconciled", () => {
+  const spy = vi.fn();
+  const transformFn = <T extends object>(data: T) => {
+    spy();
+    return { ...data, transformed: true };
+  };
+
+  const schema = z.intersection(
+    z.strictObject({ x: z.string() }).transform(transformFn),
+    z.strictObject({ a: z.string() }).transform(transformFn)
+  );
+
+  expect(schema.parse({ x: "test", a: "hello" })).toEqual({
+    x: "test",
+    a: "hello",
+    transformed: true,
+  });
+  expect(spy).toHaveBeenCalledTimes(2);
+});
+
+test("nested strict object intersection preserves merged value with defaults", () => {
+  const inner = z.intersection(
+    z.strictObject({
+      x: z.string().default("X default"),
+      y: z.number(),
+    }),
+    z.strictObject({
+      z: z.boolean(),
+    })
+  );
+
+  const schema = z.intersection(inner, z.strictObject({ a: z.string() }));
+  type Schema = z.output<typeof schema>;
+  expectTypeOf<Schema>().toEqualTypeOf<{ x: string; y: number } & { z: boolean } & { a: string }>();
+
+  expect(schema.parse({ y: 34, z: true, a: "hello" })).toEqual({
+    x: "X default",
+    y: 34,
+    z: true,
+    a: "hello",
+  });
 });
 
 test("deep intersection", () => {

--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -51,20 +51,8 @@ test("object intersection: strict + strict", () => {
   // Keys recognized by either side should work
   expect(C.parse({ a: "foo", b: "bar" })).toEqual({ a: "foo", b: "bar" });
 
-  // Keys unrecognized by BOTH sides should error
-  const result = C.safeParse({ a: "foo", b: "bar", c: "extra" });
-  expect(result.error?.issues).toMatchInlineSnapshot(`
-    [
-      {
-        "code": "unrecognized_keys",
-        "keys": [
-          "c",
-        ],
-        "message": "Unrecognized key: "c"",
-        "path": [],
-      },
-    ]
-  `);
+  // Extra keys are stripped under the intersection's loosened object parsing
+  expect(C.parse({ a: "foo", b: "bar", c: "extra" })).toEqual({ a: "foo", b: "bar" });
 });
 
 test("strict object intersection runs checks after unrecognized keys are reconciled", () => {

--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -55,6 +55,28 @@ test("object intersection: strict + strict", () => {
   expect(C.parse({ a: "foo", b: "bar", c: "extra" })).toEqual({ a: "foo", b: "bar" });
 });
 
+test("strict object can be composed with a refined object", () => {
+  const intersection = z
+    .object({ key1: z.boolean() })
+    .strict()
+    .and(z.object({ key2: z.boolean() }).refine(({ key2 }) => key2));
+
+  expect(intersection.parse({ key1: true, key2: true })).toEqual({
+    key1: true,
+    key2: true,
+  });
+
+  const merged = z
+    .object({ key1: z.boolean() })
+    .strict()
+    .merge(z.object({ key2: z.boolean() }).refine(({ key2 }) => key2));
+
+  expect(merged.parse({ key1: true, key2: true })).toEqual({
+    key1: true,
+    key2: true,
+  });
+});
+
 test("strict object intersection runs checks after unrecognized keys are reconciled", () => {
   const spy = vi.fn();
   const alwaysFailingCheck = (payload: z.core.ParsePayload) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -29,7 +29,7 @@ export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> ex
   readonly async?: boolean | undefined;
   readonly direction?: "forward" | "backward";
   readonly skipChecks?: boolean;
-  readonly deferUnrecognizedKeys?: boolean;
+  readonly loosen?: boolean;
 }
 
 export interface ParsePayload<T = unknown> {
@@ -1889,7 +1889,7 @@ function handleCatchall(
       input,
       inst,
     };
-    if (ctx.deferUnrecognizedKeys) {
+    if (ctx.loosen) {
       payload.deferredUnrecognizedKeys ??= [];
       payload.deferredUnrecognizedKeys.push(issue);
     } else {
@@ -2480,7 +2480,7 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
 
     inst._zod.parse = (payload, ctx) => {
       const input = payload.value;
-      const intersectCtx = { ...ctx, deferUnrecognizedKeys: true };
+      const intersectCtx = { ...ctx, loosen: true };
       const left = def.left._zod.run({ value: input, issues: [] }, intersectCtx);
       const right = def.right._zod.run({ value: input, issues: [] }, intersectCtx);
       const async = left instanceof Promise || right instanceof Promise;
@@ -2591,7 +2591,7 @@ function handleIntersectionResults(
   const bothKeys = [...unrecKeys].filter(([, f]) => f.l && f.r).map(([k]) => k);
   if (bothKeys.length && unrecIssue) {
     const issue = { ...unrecIssue, keys: bothKeys };
-    if (ctx.deferUnrecognizedKeys) {
+    if (ctx.loosen) {
       result.deferredUnrecognizedKeys ??= [];
       result.deferredUnrecognizedKeys.push(issue);
     } else {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1869,6 +1869,7 @@ function handleCatchall(
     if (key === "__proto__") continue;
     if (keySet.has(key)) continue;
     if (t === "never") {
+      if (ctx.loosen) continue;
       unrecognized.push(key);
       continue;
     }
@@ -1887,7 +1888,6 @@ function handleCatchall(
       keys: unrecognized,
       input,
       inst,
-      continue: ctx.loosen ? true : undefined,
     });
   }
 
@@ -2481,11 +2481,11 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
 
       if (async) {
         return Promise.all([left, right]).then(([left, right]) => {
-          return handleIntersectionResults(payload, left, right, ctx);
+          return handleIntersectionResults(payload, left, right);
         });
       }
 
-      return handleIntersectionResults(payload, left, right, ctx);
+      return handleIntersectionResults(payload, left, right);
     };
   }
 );
@@ -2548,12 +2548,7 @@ function mergeValues(
   return { valid: false, mergeErrorPath: [] };
 }
 
-function handleIntersectionResults(
-  result: ParsePayload,
-  left: ParsePayload,
-  right: ParsePayload,
-  ctx: ParseContextInternal
-): ParsePayload {
+function handleIntersectionResults(result: ParsePayload, left: ParsePayload, right: ParsePayload): ParsePayload {
   // Track which side(s) report each key as unrecognized
   const unrecKeys = new Map<string, { l?: true; r?: true }>();
   let unrecIssue: errors.$ZodRawIssue | undefined;
@@ -2584,13 +2579,7 @@ function handleIntersectionResults(
   // Report only keys unrecognized by BOTH sides
   const bothKeys = [...unrecKeys].filter(([, f]) => f.l && f.r).map(([k]) => k);
   if (bothKeys.length && unrecIssue) {
-    const issue = { ...unrecIssue, keys: bothKeys };
-    if (ctx.loosen) {
-      issue.continue = true;
-    } else {
-      delete issue.continue;
-    }
-    result.issues.push(issue);
+    result.issues.push({ ...unrecIssue, keys: bothKeys });
   }
 
   const merged = mergeValues(left.value, right.value);
@@ -4038,18 +4027,12 @@ export const $ZodPipe: core.$constructor<$ZodPipe> = /*@__PURE__*/ core.$constru
 });
 
 function handlePipeResult(left: ParsePayload, next: $ZodType, ctx: ParseContextInternal) {
-  if (left.issues.length && !allowsContinuablePipeIssues(left, ctx)) {
+  if (left.issues.length) {
     // prevent further checks
     left.aborted = true;
     return left;
   }
   return next._zod.run({ value: left.value, issues: left.issues }, ctx);
-}
-
-function allowsContinuablePipeIssues(left: ParsePayload, ctx: ParseContextInternal): boolean {
-  return (
-    ctx.loosen === true && left.issues.every((issue) => issue.code === "unrecognized_keys" && issue.continue === true)
-  );
 }
 
 ////////////////////////////////////////////

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -35,7 +35,6 @@ export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> ex
 export interface ParsePayload<T = unknown> {
   value: T;
   issues: errors.$ZodRawIssue[];
-  deferredUnrecognizedKeys?: errors.$ZodRawIssue[];
   /** A way to mark a whole payload as aborted. Used in codecs/pipes. */
   aborted?: boolean;
 }
@@ -1883,18 +1882,13 @@ function handleCatchall(
   }
 
   if (unrecognized.length) {
-    const issue: errors.$ZodRawIssue = {
+    payload.issues.push({
       code: "unrecognized_keys",
       keys: unrecognized,
       input,
       inst,
-    };
-    if (ctx.loosen) {
-      payload.deferredUnrecognizedKeys ??= [];
-      payload.deferredUnrecognizedKeys.push(issue);
-    } else {
-      payload.issues.push(issue);
-    }
+      continue: ctx.loosen ? true : undefined,
+    });
   }
 
   if (!proms.length) return payload;
@@ -2564,7 +2558,7 @@ function handleIntersectionResults(
   const unrecKeys = new Map<string, { l?: true; r?: true }>();
   let unrecIssue: errors.$ZodRawIssue | undefined;
 
-  for (const iss of left.issues.concat(left.deferredUnrecognizedKeys ?? [])) {
+  for (const iss of left.issues) {
     if (iss.code === "unrecognized_keys") {
       unrecIssue ??= iss;
       for (const k of iss.keys) {
@@ -2576,7 +2570,7 @@ function handleIntersectionResults(
     }
   }
 
-  for (const iss of right.issues.concat(right.deferredUnrecognizedKeys ?? [])) {
+  for (const iss of right.issues) {
     if (iss.code === "unrecognized_keys") {
       for (const k of iss.keys) {
         if (!unrecKeys.has(k)) unrecKeys.set(k, {});
@@ -2592,11 +2586,11 @@ function handleIntersectionResults(
   if (bothKeys.length && unrecIssue) {
     const issue = { ...unrecIssue, keys: bothKeys };
     if (ctx.loosen) {
-      result.deferredUnrecognizedKeys ??= [];
-      result.deferredUnrecognizedKeys.push(issue);
+      issue.continue = true;
     } else {
-      result.issues.push(issue);
+      delete issue.continue;
     }
+    result.issues.push(issue);
   }
 
   const merged = mergeValues(left.value, right.value);
@@ -4044,14 +4038,18 @@ export const $ZodPipe: core.$constructor<$ZodPipe> = /*@__PURE__*/ core.$constru
 });
 
 function handlePipeResult(left: ParsePayload, next: $ZodType, ctx: ParseContextInternal) {
-  if (left.issues.length) {
+  if (left.issues.length && !allowsContinuablePipeIssues(left, ctx)) {
     // prevent further checks
     left.aborted = true;
     return left;
   }
-  const payload: ParsePayload = { value: left.value, issues: left.issues };
-  if (left.deferredUnrecognizedKeys) payload.deferredUnrecognizedKeys = left.deferredUnrecognizedKeys;
-  return next._zod.run(payload, ctx);
+  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
+}
+
+function allowsContinuablePipeIssues(left: ParsePayload, ctx: ParseContextInternal): boolean {
+  return (
+    ctx.loosen === true && left.issues.every((issue) => issue.code === "unrecognized_keys" && issue.continue === true)
+  );
 }
 
 ////////////////////////////////////////////

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -29,11 +29,13 @@ export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> ex
   readonly async?: boolean | undefined;
   readonly direction?: "forward" | "backward";
   readonly skipChecks?: boolean;
+  readonly deferUnrecognizedKeys?: boolean;
 }
 
 export interface ParsePayload<T = unknown> {
   value: T;
   issues: errors.$ZodRawIssue[];
+  deferredUnrecognizedKeys?: errors.$ZodRawIssue[];
   /** A way to mark a whole payload as aborted. Used in codecs/pipes. */
   aborted?: boolean;
 }
@@ -1852,7 +1854,7 @@ function handleCatchall(
   proms: Promise<any>[],
   input: any,
   payload: ParsePayload,
-  ctx: ParseContext,
+  ctx: ParseContextInternal,
   def: ReturnType<typeof normalizeDef>,
   inst: $ZodObject
 ) {
@@ -1881,12 +1883,18 @@ function handleCatchall(
   }
 
   if (unrecognized.length) {
-    payload.issues.push({
+    const issue: errors.$ZodRawIssue = {
       code: "unrecognized_keys",
       keys: unrecognized,
       input,
       inst,
-    });
+    };
+    if (ctx.deferUnrecognizedKeys) {
+      payload.deferredUnrecognizedKeys ??= [];
+      payload.deferredUnrecognizedKeys.push(issue);
+    } else {
+      payload.issues.push(issue);
+    }
   }
 
   if (!proms.length) return payload;
@@ -2472,17 +2480,18 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
 
     inst._zod.parse = (payload, ctx) => {
       const input = payload.value;
-      const left = def.left._zod.run({ value: input, issues: [] }, ctx);
-      const right = def.right._zod.run({ value: input, issues: [] }, ctx);
+      const intersectCtx = { ...ctx, deferUnrecognizedKeys: true };
+      const left = def.left._zod.run({ value: input, issues: [] }, intersectCtx);
+      const right = def.right._zod.run({ value: input, issues: [] }, intersectCtx);
       const async = left instanceof Promise || right instanceof Promise;
 
       if (async) {
         return Promise.all([left, right]).then(([left, right]) => {
-          return handleIntersectionResults(payload, left, right);
+          return handleIntersectionResults(payload, left, right, ctx);
         });
       }
 
-      return handleIntersectionResults(payload, left, right);
+      return handleIntersectionResults(payload, left, right, ctx);
     };
   }
 );
@@ -2545,12 +2554,17 @@ function mergeValues(
   return { valid: false, mergeErrorPath: [] };
 }
 
-function handleIntersectionResults(result: ParsePayload, left: ParsePayload, right: ParsePayload): ParsePayload {
+function handleIntersectionResults(
+  result: ParsePayload,
+  left: ParsePayload,
+  right: ParsePayload,
+  ctx: ParseContextInternal
+): ParsePayload {
   // Track which side(s) report each key as unrecognized
   const unrecKeys = new Map<string, { l?: true; r?: true }>();
   let unrecIssue: errors.$ZodRawIssue | undefined;
 
-  for (const iss of left.issues) {
+  for (const iss of left.issues.concat(left.deferredUnrecognizedKeys ?? [])) {
     if (iss.code === "unrecognized_keys") {
       unrecIssue ??= iss;
       for (const k of iss.keys) {
@@ -2562,7 +2576,7 @@ function handleIntersectionResults(result: ParsePayload, left: ParsePayload, rig
     }
   }
 
-  for (const iss of right.issues) {
+  for (const iss of right.issues.concat(right.deferredUnrecognizedKeys ?? [])) {
     if (iss.code === "unrecognized_keys") {
       for (const k of iss.keys) {
         if (!unrecKeys.has(k)) unrecKeys.set(k, {});
@@ -2576,14 +2590,19 @@ function handleIntersectionResults(result: ParsePayload, left: ParsePayload, rig
   // Report only keys unrecognized by BOTH sides
   const bothKeys = [...unrecKeys].filter(([, f]) => f.l && f.r).map(([k]) => k);
   if (bothKeys.length && unrecIssue) {
-    result.issues.push({ ...unrecIssue, keys: bothKeys });
+    const issue = { ...unrecIssue, keys: bothKeys };
+    if (ctx.deferUnrecognizedKeys) {
+      result.deferredUnrecognizedKeys ??= [];
+      result.deferredUnrecognizedKeys.push(issue);
+    } else {
+      result.issues.push(issue);
+    }
   }
-
-  if (util.aborted(result)) return result;
 
   const merged = mergeValues(left.value, right.value);
 
   if (!merged.valid) {
+    if (util.aborted(result)) return result;
     throw new Error(`Unmergable intersection. Error path: ` + `${JSON.stringify(merged.mergeErrorPath)}`);
   }
 
@@ -4030,7 +4049,9 @@ function handlePipeResult(left: ParsePayload, next: $ZodType, ctx: ParseContextI
     left.aborted = true;
     return left;
   }
-  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
+  const payload: ParsePayload = { value: left.value, issues: left.issues };
+  if (left.deferredUnrecognizedKeys) payload.deferredUnrecognizedKeys = left.deferredUnrecognizedKeys;
+  return next._zod.run(payload, ctx);
 }
 
 ////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- Defer strict object `unrecognized_keys` issues while parsing intersection operands so sibling schemas can reconcile keys before checks and transforms run.
- Preserve deferred key metadata through pipes so transformed strict object operands still produce their output before intersection reconciliation.
- Add regressions for strict intersections with checks, superRefine, transforms, nested defaults, and strict/refined object composition.

Fixes #5663
Fixes #4017
Fixes #2200

## Test plan
- pnpm vitest run packages/zod/src/v4/classic/tests/intersection.test.ts
- pnpm vitest run packages/zod/src/v4/classic/tests/object.test.ts packages/zod/src/v4/classic/tests/pipe.test.ts packages/zod/src/v4/classic/tests/transform.test.ts
- pnpm dev --eval '<original issue repro cases>'
- pnpm biome check packages/zod/src/v4/core/schemas.ts packages/zod/src/v4/classic/tests/intersection.test.ts
- git push pre-push hook: pnpm test