### PR TITLE
fix(v4): clarify infinite number errors

### DIFF
--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -22,7 +22,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -34,9 +34,9 @@ test("Infinity validation", () => {
       {
         "expected": "number",
         "code": "invalid_type",
-        "received": "Infinity",
+        "received": "-Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received -Infinity"
       }
     ]],
       "success": false,
@@ -208,7 +208,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -220,9 +220,9 @@ test(".finite() validation", () => {
       {
         "expected": "number",
         "code": "invalid_type",
-        "received": "Infinity",
+        "received": "-Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received -Infinity"
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1131,7 +1131,7 @@ export const $ZodNumber: core.$constructor<$ZodNumber> = /*@__PURE__*/ core.$con
         ? Number.isNaN(input)
           ? "NaN"
           : !Number.isFinite(input)
-            ? "Infinity"
+            ? String(input)
             : undefined
         : undefined;
 

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -58,15 +58,11 @@ const error: () => errors.$ZodErrorMap = () => {
     // All other type names omitted - they fall back to raw values via ?? operator
   };
 
-  function getTypeName(type: errors.$ZodInvalidTypeExpected): string {
-    return TypeDictionary[type] ?? type;
-  }
-
-  function getReceivedTypeName(receivedType: errors.$ZodInvalidTypeExpected, input: unknown): string {
-    if (receivedType === "number" && typeof input === "number" && !Number.isFinite(input)) {
+  function getTypeName(type: errors.$ZodInvalidTypeExpected, input?: unknown): string {
+    if (type === "number" && typeof input === "number" && !Number.isFinite(input)) {
       return String(input);
     }
-    return getTypeName(receivedType);
+    return TypeDictionary[type] ?? type;
   }
 
   return (issue) => {
@@ -74,7 +70,7 @@ const error: () => errors.$ZodErrorMap = () => {
       case "invalid_type": {
         const expected = getTypeName(issue.expected);
         const receivedType = util.parsedType(issue.input);
-        const received = getReceivedTypeName(receivedType, issue.input);
+        const received = getTypeName(receivedType, issue.input);
         return `Invalid input: expected ${expected}, received ${received}`;
       }
 

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -58,12 +58,23 @@ const error: () => errors.$ZodErrorMap = () => {
     // All other type names omitted - they fall back to raw values via ?? operator
   };
 
+  function getTypeName(type: errors.$ZodInvalidTypeExpected): string {
+    return TypeDictionary[type] ?? type;
+  }
+
+  function getReceivedTypeName(receivedType: errors.$ZodInvalidTypeExpected, input: unknown): string {
+    if (receivedType === "number" && typeof input === "number" && !Number.isFinite(input)) {
+      return String(input);
+    }
+    return getTypeName(receivedType);
+  }
+
   return (issue) => {
     switch (issue.code) {
       case "invalid_type": {
-        const expected = TypeDictionary[issue.expected] ?? issue.expected;
+        const expected = getTypeName(issue.expected);
         const receivedType = util.parsedType(issue.input);
-        const received = TypeDictionary[receivedType] ?? receivedType;
+        const received = getReceivedTypeName(receivedType, issue.input);
         return `Invalid input: expected ${expected}, received ${received}`;
       }
 


### PR DESCRIPTION
## Summary
- Show `Infinity` and `-Infinity` in the default English invalid type message for non-finite numbers.
- Preserve the sign of `-Infinity` in number invalid type issue metadata.

Closes #5697

## Test plan
- `pnpm vitest run packages/zod/src/v4/classic/tests/number.test.ts packages/zod/src/v4/core/tests/locales/en.test.ts`