### PR TITLE
Tighten discriminated union option typing

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1617,7 +1617,7 @@ export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /
 );
 
 export function discriminatedUnion<
-  Types extends readonly [core.$ZodTypeDiscriminable, ...core.$ZodTypeDiscriminable[]],
+  Types extends readonly [core.$ZodTypeDiscriminable<Disc>, ...core.$ZodTypeDiscriminable<Disc>[]],
   Disc extends string,
 >(
   discriminator: Disc,

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -264,6 +264,9 @@ test("valid discriminator value, invalid data", () => {
 });
 
 test("wrong schema - missing discriminator", () => {
+  // @ts-expect-error missing discriminator property
+  z.discriminatedUnion("type", [z.object({ value: z.string() })]);
+
   try {
     z.discriminatedUnion("type", [
       z.object({ type: z.literal("a"), a: z.string() }),

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1207,17 +1207,19 @@ export function _xor<const T extends readonly schemas.$ZodObject[]>(
 }
 
 // ZodDiscriminatedUnion
-export interface $ZodTypeDiscriminableInternals extends schemas.$ZodTypeInternals {
+export interface $ZodTypeDiscriminableInternals<Disc extends string = string>
+  extends schemas.$ZodTypeInternals<unknown, { [K in Disc]?: unknown }> {
   propValues: util.PropValues;
 }
 
-export interface $ZodTypeDiscriminable extends schemas.$ZodType {
-  _zod: $ZodTypeDiscriminableInternals;
+export interface $ZodTypeDiscriminable<Disc extends string = string> extends schemas.$ZodType {
+  _zod: $ZodTypeDiscriminableInternals<Disc>;
 }
+
 export type $ZodDiscriminatedUnionParams = TypeParams<schemas.$ZodDiscriminatedUnion, "options" | "discriminator">;
 // @__NO_SIDE_EFFECTS__
 export function _discriminatedUnion<
-  Types extends [$ZodTypeDiscriminable, ...$ZodTypeDiscriminable[]],
+  Types extends [$ZodTypeDiscriminable<Disc>, ...$ZodTypeDiscriminable<Disc>[]],
   Disc extends string,
 >(
   Class: util.SchemaClass<schemas.$ZodDiscriminatedUnion>,

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1083,7 +1083,7 @@ export const ZodMiniDiscriminatedUnion: core.$constructor<ZodMiniDiscriminatedUn
 
 // @__NO_SIDE_EFFECTS__
 export function discriminatedUnion<
-  Types extends readonly [core.$ZodTypeDiscriminable, ...core.$ZodTypeDiscriminable[]],
+  Types extends readonly [core.$ZodTypeDiscriminable<Disc>, ...core.$ZodTypeDiscriminable<Disc>[]],
   Disc extends string,
 >(
   discriminator: Disc,

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -247,6 +247,11 @@ test("z.union([]) / z.xor([]) / z.discriminatedUnion(_, []) construct and reject
   }
 });
 
+test("z.discriminatedUnion rejects object options missing the discriminator at type level", () => {
+  // @ts-expect-error missing discriminator property
+  z.discriminatedUnion("type", [z.object({ value: z.string() })]);
+});
+
 test("z.intersection", () => {
   const a = z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() }));
   expect(z.parse(a, { a: "hello", b: 123 })).toEqual({ a: "hello", b: 123 });


### PR DESCRIPTION
## Summary
- Tightens the v4 discriminated union option constraint so options must have the selected discriminator key in their input type.
- Adds classic and mini type coverage for object options that define other keys but omit the discriminator.

## Test plan
- pnpm vitest run packages/zod/src/v4/classic/tests/discriminated-unions.test.ts packages/zod/src/v4/mini/tests/index.test.ts packages/zod/src/v4/classic/tests/recursive-types.test.ts packages/zod/src/v4/mini/tests/recursive-types.test.ts packages/zod/src/v4/classic/tests/template-literal.test.ts
- pnpm exec tsc -p packages/zod/tsconfig.test.json --noEmit --pretty false

Fixes #5775.