### PR TITLE
Tighten preprocess return types

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2642,8 +2642,45 @@ export function json(params?: string | core.$ZodCustomParams): ZodJSONSchema {
 
 // preprocess
 
+type _IsUnknown<T> = util.IsAny<T> extends true
+  ? false
+  : unknown extends T
+    ? [T] extends [unknown]
+      ? true
+      : false
+    : false;
+type _IsExactlyVoid<T> = [void] extends [T] ? ([T] extends [void] ? true : false) : false;
+type _AllTrue<T> = false extends T ? false : true;
+type _IsPreprocessAssignableTo<A, B> = util.IsAny<A> extends true
+  ? true
+  : _IsUnknown<A> extends true
+    ? true
+    : [A] extends [B]
+      ? true
+      : keyof A extends never
+        ? [B] extends [A]
+          ? true
+          : false
+        : A extends readonly (infer AElement)[]
+          ? B extends readonly (infer BElement)[]
+            ? _IsPreprocessAssignableTo<AElement, BElement>
+            : false
+          : B extends object
+            ? A extends object
+              ? _AllTrue<
+                  { [K in keyof B]-?: K extends keyof A ? _IsPreprocessAssignableTo<A[K], B[K]> : false }[keyof B]
+                >
+              : false
+            : false;
+type _IsPreprocessAssignable<A, U extends core.SomeType> = _IsPreprocessAssignableTo<Awaited<A>, core.input<U>>;
+type _PreprocessReturn<A, U extends core.SomeType> = _IsExactlyVoid<Awaited<A>> extends true
+  ? A
+  : _IsPreprocessAssignable<A, U> extends true
+    ? A
+    : never;
+
 export function preprocess<A, U extends core.SomeType, B = unknown>(
-  fn: (arg: B, ctx: core.$RefinementCtx) => A,
+  fn: (arg: B, ctx: core.$RefinementCtx) => _PreprocessReturn<A, U>,
   schema: U
 ): ZodPipe<ZodTransform<A, B>, U> {
   return pipe(transform(fn as any), schema as any) as any;

--- a/packages/zod/src/v4/classic/tests/preprocess.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess.test.ts
@@ -24,6 +24,33 @@ test("async preprocess", async () => {
   `);
 });
 
+test("preprocess return type checking", () => {
+  const stringArray = z.string().array();
+  const numberSchema = z.number();
+  const objectSchema = z.object({ value: z.string() });
+  const stringWithDefault = z.string().default("x");
+
+  z.preprocess((val) => String(val), z.string());
+  z.preprocess((data) => [data], stringArray);
+  z.preprocess((data) => ({ value: data }), objectSchema);
+  z.preprocess(() => undefined, stringWithDefault);
+  z.preprocess<unknown[], typeof stringArray>((data) => [data], stringArray);
+  z.preprocess<number, typeof numberSchema, string>((val) => val.length, numberSchema);
+
+  // @ts-expect-error return type is not compatible with schema input
+  z.preprocess(() => 4, z.string());
+  // @ts-expect-error async return type is not compatible with schema input
+  z.preprocess(async () => 4, z.string());
+  // @ts-expect-error union includes a value not compatible with schema input
+  z.preprocess(() => (Math.random() ? "x" : 4), z.string());
+  // @ts-expect-error array element union includes a value not compatible with schema input
+  z.preprocess(() => [] as (string | number)[], stringArray);
+  // @ts-expect-error object property is not compatible with schema input
+  z.preprocess(() => ({ value: 4 }), objectSchema);
+  // @ts-expect-error undefined is not compatible with schema input
+  z.preprocess(() => undefined, z.string());
+});
+
 test("ctx.addIssue accepts string", () => {
   const schema = z.preprocess((_, ctx) => {
     ctx.addIssue("bad stuff");


### PR DESCRIPTION
Adds a type-level compatibility check for `z.preprocess()` callback returns so clear mismatches are caught before the value reaches the target schema, while preserving the existing `<A, U, B>` generic shape and validation-boundary patterns like `unknown`, `unknown[]`, object wrappers, `void`, and `z.NEVER`.

Covers the regression reported in #5733 with focused type assertions for sync, async, union, array, object, and default-schema cases.

Validated with `pnpm exec tsc -p packages/zod/tsconfig.test.json --noEmit --extendedDiagnostics` and `pnpm vitest run packages/zod/src/v4/classic/tests/preprocess.test.ts`.