### PR TITLE
fix(v4): avoid recursive core pipe metadata types

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2295,9 +2295,16 @@ export interface ZodPipe<A extends core.SomeType = core.$ZodType, B extends core
   extends _ZodType<core.$ZodPipeInternals<A, B>>,
     core.$ZodPipe<A, B> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodPipeInternals<A, B> & {
+    values: A["_zod"]["values"];
+    optin: A["_zod"]["optin"];
+    optout: B["_zod"]["optout"];
+    propValues: A["_zod"]["propValues"];
+  };
   in: A;
   out: B;
 }
+
 export const ZodPipe: core.$constructor<ZodPipe> = /*@__PURE__*/ core.$constructor("ZodPipe", (inst, def) => {
   core.$ZodPipe.init(inst, def);
   ZodType.init(inst, def);
@@ -2325,7 +2332,12 @@ export interface ZodCodec<A extends core.SomeType = core.$ZodType, B extends cor
   extends ZodPipe<A, B>,
     core.$ZodCodec<A, B> {
   "~standard": ZodStandardSchemaWithJSON<this>;
-  _zod: core.$ZodCodecInternals<A, B>;
+  _zod: core.$ZodCodecInternals<A, B> & {
+    values: A["_zod"]["values"];
+    optin: A["_zod"]["optin"];
+    optout: B["_zod"]["optout"];
+    propValues: A["_zod"]["propValues"];
+  };
   def: core.$ZodCodecDef<A, B>;
 }
 export const ZodCodec: core.$constructor<ZodCodec> = /*@__PURE__*/ core.$constructor("ZodCodec", (inst, def) => {

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -101,6 +101,7 @@ test("pipe optionality inside objects", () => {
       .string()
       .transform((val) => (Math.random() ? val : undefined))
       .pipe(z.string().default("asdf")),
+    f: z.string().optional().pipe(z.string()).pipe(z.string()),
   });
 
   type SchemaIn = z.input<typeof schema>;
@@ -110,6 +111,7 @@ test("pipe optionality inside objects", () => {
     c?: string | undefined;
     d: string;
     e: string;
+    f?: string | undefined;
   }>();
 
   type SchemaOut = z.output<typeof schema>;
@@ -119,6 +121,7 @@ test("pipe optionality inside objects", () => {
     c: string;
     d?: string | undefined;
     e: string;
+    f: string;
   }>();
 });
 

--- a/packages/zod/src/v4/classic/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/recursive-types.test.ts
@@ -587,6 +587,13 @@ export type RecursiveA = z.ZodUnion<
   ]
 >;
 
+test("recursive core pipe type", () => {
+  type RecursiveCorePipe = z.core.$ZodPipe<RecursiveCorePipeBar, z.core.$ZodTransform>;
+  type RecursiveCorePipeBar = z.core.$ZodString | RecursiveCorePipe;
+
+  expectTypeOf<RecursiveCorePipe>().toMatchTypeOf<z.core.$ZodPipe>();
+});
+
 test("recursive type with `id` meta", () => {
   const AType = z.object({
     type: z.literal("a"),

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3990,10 +3990,10 @@ export interface $ZodPipeInternals<A extends SomeType = $ZodType, B extends Some
   extends $ZodTypeInternals<core.output<B>, core.input<A>> {
   def: $ZodPipeDef<A, B>;
   isst: never;
-  values: A["_zod"]["values"];
-  optin: A["_zod"]["optin"];
-  optout: B["_zod"]["optout"];
-  propValues: A["_zod"]["propValues"];
+  values?: util.PrimitiveSet | undefined;
+  optin?: "optional" | undefined;
+  optout?: "optional" | undefined;
+  propValues?: util.PropValues | undefined;
 }
 
 export interface $ZodPipe<A extends SomeType = $ZodType, B extends SomeType = $ZodType> extends $ZodType {
@@ -4046,13 +4046,8 @@ export interface $ZodCodecDef<A extends SomeType = $ZodType, B extends SomeType 
 }
 
 export interface $ZodCodecInternals<A extends SomeType = $ZodType, B extends SomeType = $ZodType>
-  extends $ZodTypeInternals<core.output<B>, core.input<A>> {
+  extends $ZodPipeInternals<A, B> {
   def: $ZodCodecDef<A, B>;
-  isst: never;
-  values: A["_zod"]["values"];
-  optin: A["_zod"]["optin"];
-  optout: B["_zod"]["optout"];
-  propValues: A["_zod"]["propValues"];
 }
 
 export interface $ZodCodec<A extends SomeType = $ZodType, B extends SomeType = $ZodType> extends $ZodType {

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1600,8 +1600,14 @@ export function nan(params?: string | core.$ZodNaNParams): ZodMiniNaN {
 // ZodMiniPipe
 export interface ZodMiniPipe<A extends SomeType = core.$ZodType, B extends SomeType = core.$ZodType>
   extends _ZodMiniType<core.$ZodPipeInternals<A, B>> {
-  // _zod: core.$ZodPipeInternals<A, B>;
+  _zod: core.$ZodPipeInternals<A, B> & {
+    values: A["_zod"]["values"];
+    optin: A["_zod"]["optin"];
+    optout: B["_zod"]["optout"];
+    propValues: A["_zod"]["propValues"];
+  };
 }
+
 export const ZodMiniPipe: core.$constructor<ZodMiniPipe> = /*@__PURE__*/ core.$constructor(
   "ZodMiniPipe",
   (inst, def) => {
@@ -1626,7 +1632,12 @@ export function pipe<
 export interface ZodMiniCodec<A extends SomeType = core.$ZodType, B extends SomeType = core.$ZodType>
   extends ZodMiniPipe<A, B>,
     core.$ZodCodec<A, B> {
-  _zod: core.$ZodCodecInternals<A, B>;
+  _zod: core.$ZodCodecInternals<A, B> & {
+    values: A["_zod"]["values"];
+    optin: A["_zod"]["optin"];
+    optout: B["_zod"]["optout"];
+    propValues: A["_zod"]["propValues"];
+  };
   def: core.$ZodCodecDef<A, B>;
 }
 export const ZodMiniCodec: core.$constructor<ZodMiniCodec> = /*@__PURE__*/ core.$constructor(


### PR DESCRIPTION
## Summary
- Fixes #4611 by broadening core pipe/codec metadata internals so recursive `$ZodPipe` aliases do not force TypeScript into infinite instantiation.
- Preserves precise bubbled metadata on concrete classic/mini `ZodPipe` and `ZodCodec` types, with coverage for nested pipe optionality.

## Test plan
- `pnpm test`