### PR TITLE
fix(docs): silence TS 6 `baseUrl` deprecation in docs tsconfig

### DIFF
--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "target": "ESNext",
     "lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
## Summary

Fixes the intermittent `pnpm test` failure on the `Test with TypeScript 6` and `Test with TypeScript latest` CI jobs, caused by a `baseUrl` deprecation in `packages/docs/tsconfig.json` that vitest 4.x surfaces as an unhandled source error.

## Problem

Under TypeScript 6, `"baseUrl": "."` emits a deprecation:

```
TypeCheckError: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations" "6.0"' to silence this error.
 ❯ packages/docs/tsconfig.test.json:3:3
```

Vitest 4.x's typecheck integration catches the warning and re-emits it as an "Unhandled Source Error", which fails the test runner with exit 1 even when every test passes (`Tests 3791 passed (3791)`, `Type Errors no errors`, `Errors 1 error`). Whether the error is caught vs. dropped depends on worker timing, so different PRs see different outcomes for the same underlying state — same TypeScript version (6.0.3), same vitest (4.1.5):

| PR | TS-latest job |
|---|---|
| #5914 (2026-04-30) | pass |
| #5915 (2026-04-30) | fail |
| #5919 (2026-05-01) | fail |

## Why the existing CI patch doesn't cover this

Commit 4e29983 (`fix ci with "ignoreDeprecations": "6.0" in TypeScript 7`) already adds a `jq` step to the workflow that injects `ignoreDeprecations: "6.0"` into `.configs/tsconfig.base.json` for the TS 6 / latest matrix entries. That patch handles `packages/zod`'s typechecks fine.

But `packages/docs/tsconfig.json` is **standalone** — it doesn't `extends` `.configs/tsconfig.base.json` — so the workflow's `jq` patch never reaches it, and `packages/docs/tsconfig.test.json` (which extends the docs tsconfig) keeps surfacing the deprecation under TS 6+.

## Fix

One line: add `"ignoreDeprecations": "6.0"` to `packages/docs/tsconfig.json`. This is the documented mitigation in the deprecation message itself, and is the same value the workflow's `jq` step injects elsewhere.

```diff
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
```

## Verification

Reproduced locally with TS 6.0.3 + vitest 4.1.5. Before the fix, the unhandled error appears on most runs but not all (consistent with the cross-PR pattern above). After the fix, three consecutive `pnpm test` runs all complete without the error:

```
=== run 1 ===
 Test Files  336 passed (337) [redos test from #5919 unrelated]
      Tests  3788 passed (3789)
Type Errors  no errors
=== run 2 === (same)
=== run 3 === (same)
```

No `Errors 1 error` line in any run. The `1 failed` is the unrelated Windows-only `redos checker` flake that PR #5919 fixes; it is not caused by this PR.

## Scope

- 1 file touched: `packages/docs/tsconfig.json` (+1 line).
- Zero runtime / library code changes.
- No new dependencies, no workflow changes.
- Strictly more permissive on TS 6+: silences a future-removal warning that has no behavioural effect today. On TS 5.5 the option is a no-op.

## Alternative considered

Extending the workflow's `jq` step to also patch `packages/docs/tsconfig.json` would work but spreads the same workaround across two places and ties unrelated jobs together. Setting it in the source file is one line and self-documenting. Happy to switch to the workflow approach if preferred.