### PR TITLE
ci: silence `baseUrl` deprecation in docs tsconfig under TS 6+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,14 @@ jobs:
       - uses: pnpm/action-setup@v4
       - run: pnpm install
       - run: pnpm add typescript@${{ matrix.typescript }} -w
+      # baseUrl in packages/docs/tsconfig.json is deprecated under TS 6
+      # and vitest's typecheck integration surfaces it as an unhandled
+      # error; TS 5.5 rejects "6.0", so inject only on newer matrix entries.
+      - if: matrix.typescript != '5.5'
+        run: |
+          TSCONFIG=packages/docs/tsconfig.json
+          jq '.compilerOptions.ignoreDeprecations = "6.0"' "$TSCONFIG" > "$TSCONFIG.tmp"
+          mv "$TSCONFIG.tmp" "$TSCONFIG"
       - run: pnpm build
       - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all


### PR DESCRIPTION
## Summary

Fixes the `pnpm test` job under `Test with TypeScript latest` (currently TS 6.0.3), which has been failing on every PR opened since e58ea4d (yesterday) with:

```
TypeCheckError: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations" "6.0"' to silence this error.
 ❯ packages/docs/tsconfig.test.json:3:3

Test Files  339 passed (339)
     Tests  3791 passed (3791)
Type Errors  no errors
     Errors  1 error    ← exit 1 here
```

All tests pass; the failure is a vitest-side classification of a TS deprecation as an unhandled error.

## Root cause

Commit e58ea4d ("docs: test Zod Mini tab code heights", 2026-04-30) added a brand-new `packages/docs/tsconfig.test.json`. That file `extends` `packages/docs/tsconfig.json`, which has carried `"baseUrl": "."` since long before TS deprecated it. Before e58ea4d, the docs package had no vitest typecheck setup, so the deprecation never reached `pnpm test`. After e58ea4d it does, and vitest 4.x's `typecheck.checker: "tsc"` re-emits TS source errors as test-runner unhandled errors → exit 1.

This explains the recent CI breakage: PR #5914 (opened 2026-04-30 18:50 UTC, before the e58ea4d landed at 19:12 UTC) passes; PRs opened or rerun after that point fail. Same TypeScript 6.0.3, same vitest 4.1.5 — only the new docs tsconfig differs.

## Why a source-level fix doesn't work

Tried first; closed PR #5920. Three things ruled out:

1. **`"ignoreDeprecations": "6.0"` in source** — TS 5.5 rejects with `TS5103: Invalid value for '--ignoreDeprecations'` and breaks the `Test with TypeScript 5.5` job.
2. **`"ignoreDeprecations": "5.0"` in source** — accepted by TS 5.5, but TS 6 still emits the `baseUrl` deprecation under it (the deprecation message specifically demands `"6.0"`).
3. **Removing `baseUrl` outright** — breaks Next.js asset imports in `app/layout.config.tsx`: `Cannot find module '@/public/logo/logo.png'`. Removing it would require touching unrelated runtime code.

So the fix has to be **TS-version-conditional**, which means workflow logic.

## Fix

Add a single matrix-conditional `jq` step before `pnpm build`, injecting `ignoreDeprecations: "6.0"` into `packages/docs/tsconfig.json` only when the matrix typescript value is not `5.5`. This mirrors the pattern already used in the repo (e.g. on the `fix-tests-ci` branch's commit 4e29983) for the same kind of TS-version delta on `.configs/tsconfig.base.json`.

```yaml
- if: matrix.typescript != '5.5'
  run: |
    TSCONFIG=packages/docs/tsconfig.json
    jq '.compilerOptions.ignoreDeprecations = "6.0"' "$TSCONFIG" > "$TSCONFIG.tmp"
    mv "$TSCONFIG.tmp" "$TSCONFIG"
```

The patched file is only used for the duration of the CI run; nothing in source changes.

## Verification

Reproduced and validated locally with TS 6.0.3 + vitest 4.1.5. Before the patch, the unhandled error appears on most runs; after applying the same `jq` transform manually, three consecutive `pnpm test` invocations all complete without `Errors 1 error`. TS 5.5 path is unchanged (the conditional skips the patch).

## Scope

- 1 file touched: `.github/workflows/test.yml` (+8 lines).
- Strictly additive: no existing step removed, no matrix entry changed.
- No source / runtime / library-code changes.
- The `jq` binary is already available on `ubuntu-latest` runners.

## Alternative considered

The `fix-tests-ci` branch's commit 4e29983 already adds a similar `jq` step plus a `typescript: "6"` matrix entry and `fail-fast: false`, but it patches `.configs/tsconfig.base.json` (not the docs one) and isn't merged yet. If that branch lands first, the same `jq` invocation can be folded into its block; the deltas don't conflict. Happy to defer or rebase if preferred.