### PR TITLE
fix(v4): type `safeParse` errors by input, not output (#5195)

### DIFF
--- a/packages/zod/src/v4/classic/compat.ts
+++ b/packages/zod/src/v4/classic/compat.ts
@@ -28,11 +28,11 @@ export const ZodIssueCode = {
 } as const;
 
 /** @deprecated Use `z.$ZodFlattenedError` */
-export type inferFlattenedErrors<T extends core.$ZodType, U = string> = core.$ZodFlattenedError<core.output<T>, U>;
+export type inferFlattenedErrors<T extends core.$ZodType, U = string> = core.$ZodFlattenedError<core.input<T>, U>;
 
 /** @deprecated Use `z.$ZodFormattedError` */
 export type inferFormattedError<T extends core.$ZodType<any, any>, U = string> = core.$ZodFormattedError<
-  core.output<T>,
+  core.input<T>,
   U
 >;
 

--- a/packages/zod/src/v4/classic/parse.ts
+++ b/packages/zod/src/v4/classic/parse.ts
@@ -1,7 +1,7 @@
 import * as core from "../core/index.js";
 import { type ZodError, ZodRealError } from "./errors.js";
 
-export type ZodSafeParseResult<T> = ZodSafeParseSuccess<T> | ZodSafeParseError<T>;
+export type ZodSafeParseResult<O, I = O> = ZodSafeParseSuccess<O> | ZodSafeParseError<I>;
 export type ZodSafeParseSuccess<T> = { success: true; data: T; error?: never };
 export type ZodSafeParseError<T> = { success: false; data?: never; error: ZodError<T> };
 
@@ -24,13 +24,15 @@ export const safeParse: <T extends core.$ZodType>(
   value: unknown,
   _ctx?: core.ParseContext<core.$ZodIssue>
   // _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
-) => ZodSafeParseResult<core.output<T>> = /* @__PURE__ */ core._safeParse(ZodRealError) as any;
+) => ZodSafeParseResult<core.output<T>, core.input<T>> = /* @__PURE__ */ core._safeParse(ZodRealError) as any;
 
 export const safeParseAsync: <T extends core.$ZodType>(
   schema: T,
   value: unknown,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => Promise<ZodSafeParseResult<core.output<T>>> = /* @__PURE__ */ core._safeParseAsync(ZodRealError) as any;
+) => Promise<ZodSafeParseResult<core.output<T>, core.input<T>>> = /* @__PURE__ */ core._safeParseAsync(
+  ZodRealError
+) as any;
 
 // Codec functions
 export const encode: <T extends core.$ZodType>(
@@ -61,22 +63,26 @@ export const safeEncode: <T extends core.$ZodType>(
   schema: T,
   value: core.output<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => ZodSafeParseResult<core.input<T>> = /* @__PURE__ */ core._safeEncode(ZodRealError) as any;
+) => ZodSafeParseResult<core.input<T>, core.output<T>> = /* @__PURE__ */ core._safeEncode(ZodRealError) as any;
 
 export const safeDecode: <T extends core.$ZodType>(
   schema: T,
   value: core.input<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => ZodSafeParseResult<core.output<T>> = /* @__PURE__ */ core._safeDecode(ZodRealError) as any;
+) => ZodSafeParseResult<core.output<T>, core.input<T>> = /* @__PURE__ */ core._safeDecode(ZodRealError) as any;
 
 export const safeEncodeAsync: <T extends core.$ZodType>(
   schema: T,
   value: core.output<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => Promise<ZodSafeParseResult<core.input<T>>> = /* @__PURE__ */ core._safeEncodeAsync(ZodRealError) as any;
+) => Promise<ZodSafeParseResult<core.input<T>, core.output<T>>> = /* @__PURE__ */ core._safeEncodeAsync(
+  ZodRealError
+) as any;
 
 export const safeDecodeAsync: <T extends core.$ZodType>(
   schema: T,
   value: core.input<T>,
   _ctx?: core.ParseContext<core.$ZodIssue>
-) => Promise<ZodSafeParseResult<core.output<T>>> = /* @__PURE__ */ core._safeDecodeAsync(ZodRealError) as any;
+) => Promise<ZodSafeParseResult<core.output<T>, core.input<T>>> = /* @__PURE__ */ core._safeDecodeAsync(
+  ZodRealError
+) as any;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -114,16 +114,19 @@ export interface ZodType<
 
   // parsing
   parse(data: unknown, params?: core.ParseContext<core.$ZodIssue>): core.output<this>;
-  safeParse(data: unknown, params?: core.ParseContext<core.$ZodIssue>): parse.ZodSafeParseResult<core.output<this>>;
+  safeParse(
+    data: unknown,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): parse.ZodSafeParseResult<core.output<this>, core.input<this>>;
   parseAsync(data: unknown, params?: core.ParseContext<core.$ZodIssue>): Promise<core.output<this>>;
   safeParseAsync(
     data: unknown,
     params?: core.ParseContext<core.$ZodIssue>
-  ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
+  ): Promise<parse.ZodSafeParseResult<core.output<this>, core.input<this>>>;
   spa: (
     data: unknown,
     params?: core.ParseContext<core.$ZodIssue>
-  ) => Promise<parse.ZodSafeParseResult<core.output<this>>>;
+  ) => Promise<parse.ZodSafeParseResult<core.output<this>, core.input<this>>>;
 
   // encoding/decoding
   encode(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>): core.input<this>;
@@ -133,19 +136,19 @@ export interface ZodType<
   safeEncode(
     data: core.output<this>,
     params?: core.ParseContext<core.$ZodIssue>
-  ): parse.ZodSafeParseResult<core.input<this>>;
+  ): parse.ZodSafeParseResult<core.input<this>, core.output<this>>;
   safeDecode(
     data: core.input<this>,
     params?: core.ParseContext<core.$ZodIssue>
-  ): parse.ZodSafeParseResult<core.output<this>>;
+  ): parse.ZodSafeParseResult<core.output<this>, core.input<this>>;
   safeEncodeAsync(
     data: core.output<this>,
     params?: core.ParseContext<core.$ZodIssue>
-  ): Promise<parse.ZodSafeParseResult<core.input<this>>>;
+  ): Promise<parse.ZodSafeParseResult<core.input<this>, core.output<this>>>;
   safeDecodeAsync(
     data: core.input<this>,
     params?: core.ParseContext<core.$ZodIssue>
-  ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
+  ): Promise<parse.ZodSafeParseResult<core.output<this>, core.input<this>>>;
 
   // refinements
   refine<Ch extends (arg: core.output<this>) => unknown | Promise<unknown>>(

--- a/packages/zod/src/v4/classic/tests/safeparse-error-input.test.ts
+++ b/packages/zod/src/v4/classic/tests/safeparse-error-input.test.ts
@@ -1,0 +1,70 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as z from "zod/v4";
+
+// Regression test for #5195: errors must be keyed by input, not output.
+test("safeParse error tree is keyed by input type for pipe (#5195)", () => {
+  type A = { a: number };
+  type B = { b: string };
+
+  const pipe = z.object({ a: z.number().max(9) }).pipe(z.transform<A, B>(({ a }) => ({ b: a.toString() })));
+
+  const result = pipe.safeParse({ a: 10 });
+  if (result.success) throw new Error("expected validation failure");
+
+  const tree = z.treeifyError(result.error);
+  expect(tree.properties?.a?.errors[0]).toMatch(/9|max/i);
+
+  expectTypeOf(tree.properties?.a).not.toBeNever();
+  // @ts-expect-error 'b' is on the output type — must not appear on the error tree
+  tree.properties?.b;
+});
+
+test("safeParseAsync error tree is keyed by input type for pipe", async () => {
+  type A = { a: number };
+  type B = { b: string };
+
+  const pipe = z.object({ a: z.number().max(9) }).pipe(z.transform<A, B>(({ a }) => ({ b: a.toString() })));
+
+  const result = await pipe.safeParseAsync({ a: 10 });
+  if (result.success) throw new Error("expected validation failure");
+
+  const tree = z.treeifyError(result.error);
+  expect(tree.properties?.a?.errors[0]).toMatch(/9|max/i);
+  // @ts-expect-error 'b' is on the output type — must not appear on the error tree
+  tree.properties?.b;
+});
+
+test("safeDecode error tree is keyed by codec input (the value being validated)", () => {
+  const codec = z.codec(z.object({ raw: z.string().min(2) }), z.object({ parsed: z.number() }), {
+    decode: ({ raw }) => ({ parsed: Number(raw) }),
+    encode: ({ parsed }) => ({ raw: String(parsed) }),
+  });
+
+  const result = codec.safeDecode({ raw: "x" });
+  if (result.success) throw new Error("expected validation failure");
+
+  const tree = z.treeifyError(result.error);
+  expect(tree.properties?.raw?.errors[0]).toMatch(/2|small/i);
+  // @ts-expect-error 'parsed' is on the codec output — must not appear on the decode error tree
+  tree.properties?.parsed;
+});
+
+test("safeEncode error tree is keyed by codec output (the value being validated in reverse)", () => {
+  const codec = z.codec(z.object({ raw: z.string() }), z.object({ parsed: z.number().max(9) }), {
+    decode: ({ raw }) => ({ parsed: Number(raw) }),
+    encode: ({ parsed }) => ({ raw: String(parsed) }),
+  });
+
+  const result = codec.safeEncode({ parsed: 100 });
+  if (result.success) throw new Error("expected validation failure");
+
+  const tree = z.treeifyError(result.error);
+  expect(tree.properties?.parsed?.errors[0]).toMatch(/9|max/i);
+  // @ts-expect-error 'raw' is on the codec input — must not appear on the encode error tree
+  tree.properties?.raw;
+});
+
+test("ZodSafeParseResult one-arg form is backward-compatible", () => {
+  const _: z.ZodSafeParseResult<string> = z.string().safeParse("ok");
+  void _;
+});

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -54,7 +54,7 @@ export type $SafeParse = <T extends schemas.$ZodType>(
   schema: T,
   value: unknown,
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
-) => util.SafeParseResult<core.output<T>>;
+) => util.SafeParseResult<core.output<T>, core.input<T>>;
 
 export const _safeParse: (_Err: $ZodErrorClass) => $SafeParse = (_Err) => (schema, value, _ctx) => {
   const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
@@ -76,7 +76,7 @@ export type $SafeParseAsync = <T extends schemas.$ZodType>(
   schema: T,
   value: unknown,
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
-) => Promise<util.SafeParseResult<core.output<T>>>;
+) => Promise<util.SafeParseResult<core.output<T>, core.input<T>>>;
 
 export const _safeParseAsync: (_Err: $ZodErrorClass) => $SafeParseAsync = (_Err) => async (schema, value, _ctx) => {
   const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
@@ -148,7 +148,7 @@ export type $SafeEncode = <T extends schemas.$ZodType>(
   schema: T,
   value: core.output<T>,
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
-) => util.SafeParseResult<core.input<T>>;
+) => util.SafeParseResult<core.input<T>, core.output<T>>;
 
 export const _safeEncode: (_Err: $ZodErrorClass) => $SafeEncode = (_Err) => (schema, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, direction: "backward" as const } : { direction: "backward" as const };
@@ -161,7 +161,7 @@ export type $SafeDecode = <T extends schemas.$ZodType>(
   schema: T,
   value: core.input<T>,
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
-) => util.SafeParseResult<core.output<T>>;
+) => util.SafeParseResult<core.output<T>, core.input<T>>;
 
 export const _safeDecode: (_Err: $ZodErrorClass) => $SafeDecode = (_Err) => (schema, value, _ctx) => {
   return _safeParse(_Err)(schema, value, _ctx);
@@ -173,7 +173,7 @@ export type $SafeEncodeAsync = <T extends schemas.$ZodType>(
   schema: T,
   value: core.output<T>,
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
-) => Promise<util.SafeParseResult<core.input<T>>>;
+) => Promise<util.SafeParseResult<core.input<T>, core.output<T>>>;
 
 export const _safeEncodeAsync: (_Err: $ZodErrorClass) => $SafeEncodeAsync = (_Err) => async (schema, value, _ctx) => {
   const ctx = _ctx ? { ..._ctx, direction: "backward" as const } : { direction: "backward" as const };
@@ -186,7 +186,7 @@ export type $SafeDecodeAsync = <T extends schemas.$ZodType>(
   schema: T,
   value: core.input<T>,
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
-) => Promise<util.SafeParseResult<core.output<T>>>;
+) => Promise<util.SafeParseResult<core.output<T>, core.input<T>>>;
 
 export const _safeDecodeAsync: (_Err: $ZodErrorClass) => $SafeDecodeAsync = (_Err) => async (schema, value, _ctx) => {
   return _safeParseAsync(_Err)(schema, value, _ctx);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -177,7 +177,7 @@ export type PrimitiveArray = Array<Primitive>;
 export type HasSize = { size: number };
 export type HasLength = { length: number }; // string | Array<unknown> | Set<unknown> | File;
 export type Numeric = number | bigint | Date;
-export type SafeParseResult<T> = SafeParseSuccess<T> | SafeParseError<T>;
+export type SafeParseResult<O, I = O> = SafeParseSuccess<O> | SafeParseError<I>;
 export type SafeParseSuccess<T> = { success: true; data: T; error?: never };
 export type SafeParseError<T> = {
   success: false;

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -28,12 +28,15 @@ export interface ZodMiniType<
   def: Internals["def"];
 
   parse(data: unknown, params?: core.ParseContext<core.$ZodIssue>): core.output<this>;
-  safeParse(data: unknown, params?: core.ParseContext<core.$ZodIssue>): util.SafeParseResult<core.output<this>>;
+  safeParse(
+    data: unknown,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): util.SafeParseResult<core.output<this>, core.input<this>>;
   parseAsync(data: unknown, params?: core.ParseContext<core.$ZodIssue>): Promise<core.output<this>>;
   safeParseAsync(
     data: unknown,
     params?: core.ParseContext<core.$ZodIssue>
-  ): Promise<util.SafeParseResult<core.output<this>>>;
+  ): Promise<util.SafeParseResult<core.output<this>, core.input<this>>>;
   apply<T>(fn: (schema: this) => T): T;
 }
 


### PR DESCRIPTION
Fixes #5195. Related ecosystem evidence: [`nicoespeon/zod-v3-to-v4#30`](https://github.com/nicoespeon/zod-v3-to-v4/issues/30) and [`#35`](https://github.com/nicoespeon/zod-v3-to-v4/pull/35) — the official v3→v4 migration tool had to drop v3's input generic when rewriting `SafeParseReturnType<I, O>` to `ZodSafeParseResult<O>`, and explicitly flagged this issue as the upstream gap.

Discussion seed in https://github.com/colinhacks/zod/issues/5195#issuecomment-4359672000. Opening the PR for concrete review surface; happy to close it if the maintainer would rather keep the current shape.

## Problem

When a schema's input differs from its output (pipe / transform / codec), `safeParse(...).error` is currently typed as `ZodError<output>` even though the issues it carries are paths in the **input** space (validation runs there). `z.treeifyError(result.error)` therefore infers a tree keyed by output properties that don't exist at runtime, while the input-keyed properties that DO exist are flagged as type errors.

OP's reproduction:

```ts
type A = { a: number };
type B = { b: string };
const pipe = z.object({ a: z.number().max(9) })
  .pipe(z.transform<A, B>(({ a }) => ({ b: a.toString() })));

const errors = pipe.safeParse({ a: 10 })?.error;
if (errors) {
  z.treeifyError(errors).properties?.a; // ← flagged as a type error, but real
  z.treeifyError(errors).properties?.b; // ← accepted, but does not exist at runtime
}
```

The maintainer-suggested workaround `z.treeifyError<unknown>(errors)` is fine for one-off code but doesn't scale into codemods or library APIs that need typed error trees per schema.

## Fix

Generalise the success/error split so error carries the **input** generic, defaulting to the output for backward compatibility:

```ts
// before
export type SafeParseResult<T> = SafeParseSuccess<T> | SafeParseError<T>;

// after
export type SafeParseResult<O, I = O> = SafeParseSuccess<O> | SafeParseError<I>;
```

Then thread `core.input<this>` through:

- `safeParse` / `safeParseAsync` / `spa` overloads on `ZodType` (classic) and `ZodMiniType` (mini)
- `safeEncode` / `safeDecode` (and async variants) — error keyed by the value being parsed
- `inferFlattenedErrors` / `inferFormattedError` v3-compat aliases so `error.flatten()` / `error.format()` typings agree

The two-generic shape mirrors v3's `SafeParseReturnType<I, O>` exactly, which v4 collapsed. Codecs and migrations that used to work in v3 keep working with the same intent.

## Backward compatibility

- `ZodSafeParseResult<X>` (single arg) defaults to `<X, X>` — identical typing for the 98% of schemas where `input === output`.
- `result.success` / `result.data` typings unchanged.
- `result.error` typing only changes for pipe / transform / codec schemas, where the previous typing was unsound: any user code that relied on it was already broken at runtime (the OP's reproduction is exactly that case).

## Tests

- `packages/zod/src/v4/classic/tests/safeparse-error-input.test.ts` — locks in the OP reproduction (tree keyed by input, output keys rejected) and verifies the one-arg form still types correctly for simple schemas.
- Existing `inferFlattenedErrors` test in `error.test.ts` now compiles cleanly (it was already asserting the correct runtime shape — only the inferred type was lying).

## Local results

```
Test Files  1 failed | 338 passed (339)
     Tests  1 failed | 3792 passed (3793)
Type Errors no errors
```

The single failing test (`src/v4/classic/tests/datetime.test.ts > redos checker`) is **not** caused by this PR. It's a `recheck` library bug on Windows that fires for every contributor on Windows, regardless of branch — `recheck`'s jar resolution uses a forward-slash regex that no-ops on backslash paths. This is independent of `safeParse` typings and is fixed by **#5919**. Same test passes on Linux CI today.

Diff stats: 7 files, +62 / -25 (most of which is overload signatures gaining a second generic).

## Note about CI

CI on this PR will also show a red `Test with TypeScript latest` job, also unrelated to this change: it's the repo-wide `baseUrl` deprecation that surfaces under TS 6 since [`e58ea4d`](https://github.com/colinhacks/zod/commit/e58ea4d91b1dfe8194b73508203213cbc7e9c936). Every PR opened since that commit fails the same way. **#5921** (small workflow patch) addresses it; once that lands the noise on this PR will go away.

Sanity-checked locally on TS 6.0.3 with #5919 + #5921 patches applied: full suite green, `safeparse-error-input.test.ts` passes, `inferFlattenedErrors` test passes, no type errors anywhere in the repo.