### PR TITLE
fix(v4): propagate inner-schema `optin` through `pipe(transform, …)` (#5917)

### DIFF
--- a/packages/zod/src/v4/classic/tests/preprocess-inner-optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess-inner-optional.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "vitest";
+import * as z from "zod/v4";
+
+// Regression tests for #5917.
+
+// OP's first case: `.optional()` outside preprocess. Worked before, must keep working.
+test("optional outside z.preprocess accepts missing key", () => {
+  const schema = z.object({
+    optionalNumber: z.preprocess((v) => v, z.number()).optional(),
+  });
+  expect(schema.safeParse({}).success).toBe(true);
+});
+
+// OP's second case: `.optional()` inside preprocess. Regressed in v4.4.0 → main bug.
+test("optional inside z.preprocess accepts missing key (#5917 main bug)", () => {
+  const schema = z.object({
+    optionalNumber: z.preprocess((v) => v, z.number().optional()),
+  });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(true);
+});
+
+// Before the fix the failure mode was a specific error message — keep it pinned
+// so we know what to look for if the pipe optin logic regresses again.
+test("optional inside z.preprocess no longer reports `expected nonoptional`", () => {
+  const schema = z.object({
+    optionalNumber: z.preprocess((v) => v, z.number().optional()),
+  });
+  const result = schema.safeParse({});
+  if (!result.success) {
+    throw new Error(JSON.stringify(result.error.issues));
+  }
+});
+
+// Both placements should produce the same parsed shape for present values too.
+test("both placements parse a present value identically", () => {
+  const inside = z.object({ n: z.preprocess((v) => v, z.number().optional()) });
+  const outside = z.object({ n: z.preprocess((v) => v, z.number()).optional() });
+  expect(inside.safeParse({ n: 7 })).toEqual(outside.safeParse({ n: 7 }));
+});
+
+// Sanity: removing `.optional()` entirely must still reject missing keys.
+test("z.preprocess without optional rejects missing keys", () => {
+  const schema = z.object({
+    requiredNumber: z.preprocess((v) => v, z.number()),
+  });
+  expect(schema.safeParse({}).success).toBe(false);
+});
+
+// Sanity: regular `pipe(realSchema, transform)` (NOT preprocess) keeps the old
+// left-side optin behaviour — only the transform-on-the-left case shifts.
+test("pipe with a real schema on the left keeps left-side optin", () => {
+  const schema = z.object({
+    s: z.string().pipe(z.transform((v) => v.toUpperCase())),
+  });
+  expect(schema.safeParse({}).success).toBe(false);
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4003,7 +4003,11 @@ export interface $ZodPipe<A extends SomeType = $ZodType, B extends SomeType = $Z
 export const $ZodPipe: core.$constructor<$ZodPipe> = /*@__PURE__*/ core.$constructor("$ZodPipe", (inst, def) => {
   $ZodType.init(inst, def);
   util.defineLazy(inst._zod, "values", () => def.in._zod.values);
-  util.defineLazy(inst._zod, "optin", () => def.in._zod.optin);
+  // For `z.preprocess(fn, schema)` (pipe with transform on the left),
+  // optin must come from the right-side schema — see #5917.
+  util.defineLazy(inst._zod, "optin", () =>
+    def.in._zod.def.type === "transform" ? def.out._zod.optin : def.in._zod.optin
+  );
   util.defineLazy(inst._zod, "optout", () => def.out._zod.optout);
   util.defineLazy(inst._zod, "propValues", () => def.in._zod.propValues);
 


### PR DESCRIPTION
Fixes #5917. Same family as #5002 (fixed in v4.0.13 via `362eb33`), now affecting the inner-`.optional()` placement under `z.preprocess`.

## Problem

Since v4.4.0, the position of `.optional()` inside `z.preprocess` matters:

```ts
// Outside — works (v4.3.6 and v4.4.0+)
z.object({
  optionalNumber: z.preprocess((v) => v, z.number()).optional(),
}).safeParse({}); // success: true

// Inside — works pre-v4.4.0, fails on main
z.object({
  optionalNumber: z.preprocess((v) => v, z.number().optional()),
}).safeParse({}); // success: false  ← regression
// → "Invalid input: expected nonoptional, received undefined"
```

`z.preprocess(fn, schema)` desugars to `pipe(transform(fn), schema)`. `$ZodPipe` reads its input optionality from the **left** side:

```ts
util.defineLazy(inst._zod, "optin", () => def.in._zod.optin);
```

The left side is a `$ZodTransform`, which has no `optin` (transforms accept any value, including `undefined`). So the pipe reports `optin === undefined` → required → the parent object rejects the missing key before ever invoking the inner schema.

## Fix

When the left side of a pipe is a transform, defer `optin` to the right side. The transform is input-transparent (it passes through whatever it receives), so the schema downstream is what decides whether `undefined` is a valid input.

```diff
- util.defineLazy(inst._zod, "optin", () => def.in._zod.optin);
+ util.defineLazy(inst._zod, "optin", () =>
+   def.in._zod.def.type === "transform" ? def.out._zod.optin : def.in._zod.optin
+ );
```

Surgical: the special case fires only on `transform → schema` pipes (the `z.preprocess` shape). Ordinary `pipe(realSchema, …)` keeps its existing left-side-driven `optin` — so e.g. `z.string().pipe(z.number())` continues to be required as before.

## Tests

`packages/zod/src/v4/classic/tests/preprocess-inner-optional.test.ts` covers:

1. `.optional()` outside preprocess — accepts missing key (was already passing, locked in as non-regression).
2. `.optional()` inside preprocess — accepts missing key (the main bug from #5917).
3. The exact "expected nonoptional" failure mode no longer fires.
4. Both placements parse a present value identically.
5. `z.preprocess` without `.optional()` still rejects missing keys.
6. `pipe(realSchema, transform)` keeps its left-side-driven `optin` (non-regression for ordinary pipes).

Local results:

```
Test Files  338 passed (339)   [redos checker is the unrelated Windows flake — fixed by #5919]
     Tests  3794 passed (3795)
Type Errors no errors
```

## Note about CI

The `Test with TypeScript latest` job will likely show red because of the repo-wide `baseUrl` deprecation surfacing under TS 6 — every PR opened since `e58ea4d` fails the same way; **#5921** addresses it.