### PR TITLE
fix(v4): break circular import between classic schemas and iso (#5275)

### DIFF
--- a/packages/treeshake/tests/no-circular-imports.test.ts
+++ b/packages/treeshake/tests/no-circular-imports.test.ts
@@ -1,0 +1,40 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import commonjs from "@rollup/plugin-commonjs";
+import resolvePlugin from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import { rollup } from "rollup";
+import { expect, test } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(HERE, "..");
+const ZOD_SRC = resolve(PKG_ROOT, "../zod/src");
+
+const ENTRIES = ["zod-full.ts", "zod-string.ts", "zod-mini-full.ts"];
+
+async function circularWarningsFor(entry: string): Promise<string[]> {
+  const warnings: string[] = [];
+  const zodSrc = ZOD_SRC.replace(/\\/g, "/");
+  await rollup({
+    input: resolve(PKG_ROOT, entry),
+    plugins: [
+      resolvePlugin({ exportConditions: ["@zod/source", "default"] }),
+      commonjs(),
+      typescript({ tsconfig: false }),
+    ],
+    onwarn(warning) {
+      if (warning.code !== "CIRCULAR_DEPENDENCY") return;
+      const ids = (warning.ids ?? []).map((id) => id.replace(/\\/g, "/"));
+      if (ids.some((id) => id.includes(zodSrc))) warnings.push(ids.join(" -> "));
+    },
+  });
+  return warnings;
+}
+
+test.concurrent.each(ENTRIES)(
+  "rollup reports no circular deps in zod source for %s (regression: #5275)",
+  async (entry) => {
+    const warnings = await circularWarningsFor(entry);
+    expect(warnings).toEqual([]);
+  }
+);

--- a/packages/treeshake/vitest.config.ts
+++ b/packages/treeshake/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineProject } from "vitest/config";
+
+export default defineProject({
+  resolve: {
+    conditions: ["@zod/source", "default"],
+  },
+  test: {
+    include: ["tests/**/*.test.ts"],
+    testTimeout: 60000,
+  },
+});

--- a/packages/treeshake/vitest.config.ts
+++ b/packages/treeshake/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineProject({
   },
   test: {
     include: ["tests/**/*.test.ts"],
-    testTimeout: 60000,
+    testTimeout: 180000,
   },
 });

--- a/packages/zod/src/v4/classic/iso.ts
+++ b/packages/zod/src/v4/classic/iso.ts
@@ -1,89 +1,19 @@
 import * as core from "../core/index.js";
-import * as schemas from "./schemas.js";
+import { ZodISODate, ZodISODateTime, ZodISODuration, ZodISOTime } from "./schemas.js";
 
-//////////////////////////////////////////////
-//////////////////////////////////////////////
-//////////                          //////////
-//////////      ZodISODateTime      //////////
-//////////                          //////////
-//////////////////////////////////////////////
-//////////////////////////////////////////////
-
-export interface ZodISODateTime extends schemas.ZodStringFormat {
-  _zod: core.$ZodISODateTimeInternals;
-}
-export const ZodISODateTime: core.$constructor<ZodISODateTime> = /*@__PURE__*/ core.$constructor(
-  "ZodISODateTime",
-  (inst, def) => {
-    core.$ZodISODateTime.init(inst, def);
-    schemas.ZodStringFormat.init(inst, def);
-  }
-);
+export { ZodISODate, ZodISODateTime, ZodISODuration, ZodISOTime } from "./schemas.js";
 
 export function datetime(params?: string | core.$ZodISODateTimeParams): ZodISODateTime {
   return core._isoDateTime(ZodISODateTime, params);
 }
 
-//////////////////////////////////////////
-//////////////////////////////////////////
-//////////                      //////////
-//////////      ZodISODate      //////////
-//////////                      //////////
-//////////////////////////////////////////
-//////////////////////////////////////////
-
-export interface ZodISODate extends schemas.ZodStringFormat {
-  _zod: core.$ZodISODateInternals;
-}
-export const ZodISODate: core.$constructor<ZodISODate> = /*@__PURE__*/ core.$constructor("ZodISODate", (inst, def) => {
-  core.$ZodISODate.init(inst, def);
-  schemas.ZodStringFormat.init(inst, def);
-});
-
 export function date(params?: string | core.$ZodISODateParams): ZodISODate {
   return core._isoDate(ZodISODate, params);
 }
 
-// ZodISOTime
-
-//////////////////////////////////////////
-//////////////////////////////////////////
-//////////                      //////////
-//////////      ZodISOTime      //////////
-//////////                      //////////
-//////////////////////////////////////////
-//////////////////////////////////////////
-
-export interface ZodISOTime extends schemas.ZodStringFormat {
-  _zod: core.$ZodISOTimeInternals;
-}
-export const ZodISOTime: core.$constructor<ZodISOTime> = /*@__PURE__*/ core.$constructor("ZodISOTime", (inst, def) => {
-  core.$ZodISOTime.init(inst, def);
-  schemas.ZodStringFormat.init(inst, def);
-});
-
 export function time(params?: string | core.$ZodISOTimeParams): ZodISOTime {
   return core._isoTime(ZodISOTime, params);
 }
-
-//////////////////////////////////////////////
-//////////////////////////////////////////////
-//////////                          //////////
-//////////      ZodISODuration      //////////
-//////////                          //////////
-//////////////////////////////////////////////
-//////////////////////////////////////////////
-
-export interface ZodISODuration extends schemas.ZodStringFormat {
-  _zod: core.$ZodISODurationInternals;
-}
-export const ZodISODuration: core.$constructor<ZodISODuration> = /*@__PURE__*/ core.$constructor(
-  "ZodISODuration",
-  (inst, def) => {
-    core.$ZodISODuration.init(inst, def);
-    schemas.ZodStringFormat.init(inst, def);
-  }
-);
 
 export function duration(params?: string | core.$ZodISODurationParams): ZodISODuration {
   return core._isoDuration(ZodISODuration, params);

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -5,7 +5,6 @@ import type { StandardSchemaWithJSONProps } from "../core/standard-schema.js";
 import { createStandardJSONSchemaMethod, createToJSONSchemaMethod } from "../core/to-json-schema.js";
 
 import * as checks from "./checks.js";
-import * as iso from "./iso.js";
 import * as parse from "./parse.js";
 
 // Lazy-bind builder methods.
@@ -559,10 +558,10 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   inst.e164 = (params) => inst.check(core._e164(ZodE164, params));
 
   // iso
-  inst.datetime = (params) => inst.check(iso.datetime(params as any));
-  inst.date = (params) => inst.check(iso.date(params as any));
-  inst.time = (params) => inst.check(iso.time(params as any));
-  inst.duration = (params) => inst.check(iso.duration(params as any));
+  inst.datetime = (params) => inst.check(core._isoDateTime(ZodISODateTime, params as any));
+  inst.date = (params) => inst.check(core._isoDate(ZodISODate, params as any));
+  inst.time = (params) => inst.check(core._isoTime(ZodISOTime, params as any));
+  inst.duration = (params) => inst.check(core._isoDuration(ZodISODuration, params as any));
 });
 
 export function string(params?: string | core.$ZodStringParams): ZodString;
@@ -579,6 +578,72 @@ export const ZodStringFormat: core.$constructor<ZodStringFormat> = /*@__PURE__*/
   (inst, def) => {
     core.$ZodStringFormat.init(inst, def);
     _ZodString.init(inst, def);
+  }
+);
+
+//////////////////////////////////////////////
+//////////////////////////////////////////////
+//////////                          //////////
+//////////      ZodISODateTime      //////////
+//////////                          //////////
+//////////////////////////////////////////////
+//////////////////////////////////////////////
+export interface ZodISODateTime extends ZodStringFormat {
+  _zod: core.$ZodISODateTimeInternals;
+}
+export const ZodISODateTime: core.$constructor<ZodISODateTime> = /*@__PURE__*/ core.$constructor(
+  "ZodISODateTime",
+  (inst, def) => {
+    core.$ZodISODateTime.init(inst, def);
+    ZodStringFormat.init(inst, def);
+  }
+);
+
+//////////////////////////////////////////
+//////////////////////////////////////////
+//////////                      //////////
+//////////      ZodISODate      //////////
+//////////                      //////////
+//////////////////////////////////////////
+//////////////////////////////////////////
+export interface ZodISODate extends ZodStringFormat {
+  _zod: core.$ZodISODateInternals;
+}
+export const ZodISODate: core.$constructor<ZodISODate> = /*@__PURE__*/ core.$constructor("ZodISODate", (inst, def) => {
+  core.$ZodISODate.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+//////////////////////////////////////////
+//////////////////////////////////////////
+//////////                      //////////
+//////////      ZodISOTime      //////////
+//////////                      //////////
+//////////////////////////////////////////
+//////////////////////////////////////////
+export interface ZodISOTime extends ZodStringFormat {
+  _zod: core.$ZodISOTimeInternals;
+}
+export const ZodISOTime: core.$constructor<ZodISOTime> = /*@__PURE__*/ core.$constructor("ZodISOTime", (inst, def) => {
+  core.$ZodISOTime.init(inst, def);
+  ZodStringFormat.init(inst, def);
+});
+
+//////////////////////////////////////////////
+//////////////////////////////////////////////
+//////////                          //////////
+//////////      ZodISODuration      //////////
+//////////                          //////////
+//////////////////////////////////////////////
+//////////////////////////////////////////////
+export interface ZodISODuration extends ZodStringFormat {
+  _zod: core.$ZodISODurationInternals;
+}
+export const ZodISODuration: core.$constructor<ZodISODuration> = /*@__PURE__*/ core.$constructor(
+  "ZodISODuration",
+  (inst, def) => {
+    core.$ZodISODuration.init(inst, def);
+    ZodStringFormat.init(inst, def);
   }
 );
 

--- a/packages/zod/src/v4/classic/tests/no-circular-imports.test.ts
+++ b/packages/zod/src/v4/classic/tests/no-circular-imports.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function listSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    if (name === "tests" || name === "node_modules") continue;
+    const p = resolve(dir, name);
+    if (statSync(p).isDirectory()) out.push(...listSourceFiles(p));
+    else if (p.endsWith(".ts") && !p.endsWith(".d.ts")) out.push(p);
+  }
+  return out;
+}
+
+function relativeImports(file: string): string[] {
+  const src = readFileSync(file, "utf-8");
+  const re = /(?:^|\n)\s*(?:import|export)[^"';\n]*from\s+["'](\.[^"']+)["']/g;
+  const dir = dirname(file);
+  const targets: string[] = [];
+  for (const m of src.matchAll(re)) {
+    targets.push(resolve(dir, m[1]!.replace(/\.js$/, ".ts")));
+  }
+  return targets;
+}
+
+function findCycles(graph: Map<string, string[]>): string[][] {
+  const cycles: string[][] = [];
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  const visited = new Set<string>();
+  const seenCycles = new Set<string>();
+
+  function dfs(node: string) {
+    if (onStack.has(node)) {
+      const i = stack.indexOf(node);
+      const cycle = stack.slice(i).concat(node);
+      const key = [...cycle].sort().join("|");
+      if (!seenCycles.has(key)) {
+        seenCycles.add(key);
+        cycles.push(cycle);
+      }
+      return;
+    }
+    if (visited.has(node)) return;
+    visited.add(node);
+    onStack.add(node);
+    stack.push(node);
+    for (const next of graph.get(node) ?? []) dfs(next);
+    stack.pop();
+    onStack.delete(node);
+  }
+
+  for (const n of graph.keys()) dfs(n);
+  return cycles;
+}
+
+test("v4/classic has no circular imports (regression: #5275)", () => {
+  const files = listSourceFiles(ROOT);
+  const fileSet = new Set(files);
+  const graph = new Map(files.map((f) => [f, relativeImports(f).filter((t) => fileSet.has(t))]));
+  const cycles = findCycles(graph).map((c) => c.map((p) => relative(ROOT, p)));
+  expect(cycles).toEqual([]);
+});


### PR DESCRIPTION
Closes #5275.

## Summary

`packages/zod/src/v4/classic/schemas.ts` imported `./iso.js` to forward the deprecated `ZodString.{datetime,date,time,duration}` proxies; `./iso.js` imported back from `./schemas.js` to extend `ZodStringFormat`. Rollup (and any bundler that reports cycles) flagged this two-way dependency, which is what kachkaev opened the issue about and what other consumers (instantsearch.js etc.) hit downstream.

## Fix

Move the `ZodISODateTime / ZodISODate / ZodISOTime / ZodISODuration` class definitions into `schemas.ts` next to their `ZodStringFormat` base, and have the deprecated `ZodString` proxies call the underlying `core._iso*` builders directly. `iso.ts` becomes a thin namespace facade that re-exports the classes from `schemas.ts` and exposes the `z.iso.{datetime,date,time,duration}` builder functions.

Public API is unchanged. All of `z.iso.datetime()`, `z.iso.ZodISODateTime`, top-level `ZodISODateTime`, and `z.string().datetime()` keep their existing shape and behaviour. The dependency between `schemas.ts` and `iso.ts` is now strictly one-way (`iso → schemas`), so the cycle is gone in both directions.

`packages/zod/src/v4/mini/iso.ts` was already cycle-free (`mini/schemas.ts` doesn't import `mini/iso.ts`), so nothing to change there.

## Regression tests

The issue author asked for "a test or some configuration to avoid circular dependencies in the future". This PR adds two complementary checks:

1. **`packages/zod/src/v4/classic/tests/no-circular-imports.test.ts`** — fast static analysis. Walks the `v4/classic` source tree, parses relative `import`/`export … from "./…"` statements, builds the import graph and runs DFS to detect cycles. ~50 lines, zero dependencies, runs in milliseconds. Catches any future cycle anywhere in `v4/classic`. Verified locally: when `import * as iso from "./iso.js"` is reintroduced into `schemas.ts`, the test fails with the exact cycle path.

2. **`packages/treeshake/tests/no-circular-imports.test.ts`** — bundles three zod entries (`zod-full.ts`, `zod-string.ts`, `zod-mini-full.ts`) via rollup's programmatic API (concurrently) and asserts that no `CIRCULAR_DEPENDENCY` warning involves zod source files. Mirrors the exact rollup pass that originally surfaced the issue, so it catches cross-tree cycles (e.g. `classic ↔ core ↔ mini`) that the static check above doesn't.

### Note on the rollup-based test (test 2)

This test runs rollup three times for real — it adds **~35s** to `pnpm test` end-to-end (rollup is CPU-bound on TS parsing, so `test.concurrent` only buys back ~5s vs sequential). The static-analysis test (test 1) already covers the regression scope of #5275 and runs in milliseconds.

Happy to drop test 2 if the cost isn't worth it for the project's CI budget — it's contained to a single new file plus a `vitest.config.ts` in the previously-untested `packages/treeshake` package, both trivial to remove. Or it can be moved to a separate non-default suite if you'd prefer to keep the bundler-level guarantee but off the hot path.

## Changes

- `packages/zod/src/v4/classic/schemas.ts` — drop the `import * as iso` line; inline the `ZodISO*` class definitions; deprecated string proxies call `core._iso*` directly.
- `packages/zod/src/v4/classic/iso.ts` — reduced to ~20 lines; re-exports classes from `schemas.ts` and defines the four `z.iso.*` builder functions.
- `packages/zod/src/v4/classic/tests/no-circular-imports.test.ts` — static-analysis cycle detector (test 1).
- `packages/treeshake/tests/no-circular-imports.test.ts` + `packages/treeshake/vitest.config.ts` — rollup-based cycle detector (test 2; see note above).

## Test plan

- [x] `pnpm vitest run iso string to-json-schema` — 612/612 passing locally.
- [x] `pnpm vitest run --project zod` — 3785/3786 passing (the one failure is the unrelated `recheck-jar` Windows env issue from #5919, not from this PR).
- [x] Verified test 1 actually fails when the cycle is reintroduced.
- [x] Full suite on CI.

