### PR TITLE
Make z.preprocess defer optionality to inner schema

### DIFF
--- a/packages/docs/content/packages/core.mdx
+++ b/packages/docs/content/packages/core.mdx
@@ -84,7 +84,7 @@ export type $ZodTypes =
   | $ZodNonOptional
   | $ZodReadonly
   | $ZodNaN
-  | $ZodPipe // $ZodCodec extends this
+  | $ZodPipe // $ZodCodec and $ZodPreprocess extend this
   | $ZodSuccess
   | $ZodCatch
   | $ZodFile;
@@ -156,6 +156,7 @@ export type $ZodTypes =
       - $ZodNaN
       - $ZodPipe
           - $ZodCodec
+          - $ZodPreprocess
       - $ZodReadonly
       - $ZodTemplateLiteral
       - $ZodCustom

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2361,6 +2361,72 @@ export function invertCodec<A extends core.SomeType, B extends core.SomeType>(co
   }) as any;
 }
 
+// ZodPreprocess
+// Subtype of ZodPipe whose `optin`/`optout`/`values`/`propValues` defer to B
+// (the inner schema) instead of A. The `def.in` slot holds a permissive
+// pass-through schema (z.unknown()) so no input-side validation runs.
+export interface ZodPreprocess<B extends core.SomeType = core.$ZodType>
+  extends ZodPipe<core.$ZodType, B>,
+    core.$ZodPreprocess<B> {
+  "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodPreprocessInternals<B>;
+  def: core.$ZodPreprocessDef<B>;
+}
+export const ZodPreprocess: core.$constructor<ZodPreprocess> = /*@__PURE__*/ core.$constructor(
+  "ZodPreprocess",
+  (inst, def) => {
+    ZodPipe.init(inst, def);
+    core.$ZodPreprocess.init(inst, def);
+
+    // Override parse so the user-supplied transform receives a payload with
+    // `addIssue` attached (mirroring classic ZodTransform behavior).
+    inst._zod.parse = (payload, ctx) => {
+      if (ctx.direction === "backward") {
+        throw new core.$ZodEncodeError(inst.constructor.name);
+      }
+
+      (payload as core.$RefinementCtx).addIssue = (issue) => {
+        if (typeof issue === "string") {
+          payload.issues.push(core.util.issue(issue, payload.value, def));
+        } else {
+          // for Zod 3 backwards compatibility
+          const _issue = issue as any;
+
+          if (_issue.fatal) _issue.continue = false;
+          _issue.code ??= "custom";
+          _issue.input ??= payload.value;
+          _issue.inst ??= inst;
+          payload.issues.push(core.util.issue(_issue));
+        }
+      };
+
+      const _out = def.transform(payload.value, payload);
+      if (ctx.async) {
+        const output = _out instanceof Promise ? _out : Promise.resolve(_out);
+        return output.then((output) => {
+          payload.value = output;
+          return handlePreprocessResult(payload, def.out, ctx);
+        });
+      }
+
+      if (_out instanceof Promise) {
+        throw new core.$ZodAsyncError();
+      }
+
+      payload.value = _out;
+      return handlePreprocessResult(payload, def.out, ctx);
+    };
+  }
+);
+
+function handlePreprocessResult(left: core.ParsePayload, next: core.$ZodType, ctx: core.ParseContextInternal) {
+  if (left.issues.length) {
+    left.aborted = true;
+    return left;
+  }
+  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
+}
+
 // ZodReadonly
 export interface ZodReadonly<T extends core.SomeType = core.$ZodType>
   extends _ZodType<core.$ZodReadonlyInternals<T>>,
@@ -2645,6 +2711,11 @@ export function json(params?: string | core.$ZodCustomParams): ZodJSONSchema {
 export function preprocess<A, U extends core.SomeType, B = unknown>(
   fn: (arg: B, ctx: core.$RefinementCtx) => A,
   schema: U
-): ZodPipe<ZodTransform<A, B>, U> {
-  return pipe(transform(fn as any), schema as any) as any;
+): ZodPreprocess<U> {
+  return new ZodPreprocess({
+    type: "pipe",
+    in: unknown() as any as core.$ZodType,
+    out: schema as any as core.$ZodType,
+    transform: fn as any,
+  }) as any;
 }

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2362,11 +2362,6 @@ export function invertCodec<A extends core.SomeType, B extends core.SomeType>(co
 }
 
 // ZodPreprocess
-// Subtype of ZodPipe whose `optin`/`optout` defer to B (the inner schema)
-// instead of A. Runtime structure is identical to `pipe(transform(fn),
-// schema)` — `def.in` is a real ZodTransform and the parse function is
-// inherited from ZodPipe unchanged. The override is purely a static
-// metadata override so object containers see B's presence semantics.
 export interface ZodPreprocess<B extends core.SomeType = core.$ZodType>
   extends ZodPipe<core.$ZodTransform, B>,
     core.$ZodPreprocess<B> {

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2362,11 +2362,13 @@ export function invertCodec<A extends core.SomeType, B extends core.SomeType>(co
 }
 
 // ZodPreprocess
-// Subtype of ZodPipe whose `optin`/`optout`/`values`/`propValues` defer to B
-// (the inner schema) instead of A. The `def.in` slot holds a permissive
-// pass-through schema (z.unknown()) so no input-side validation runs.
+// Subtype of ZodPipe whose `optin`/`optout` defer to B (the inner schema)
+// instead of A. Runtime structure is identical to `pipe(transform(fn),
+// schema)` — `def.in` is a real ZodTransform and the parse function is
+// inherited from ZodPipe unchanged. The override is purely a static
+// metadata override so object containers see B's presence semantics.
 export interface ZodPreprocess<B extends core.SomeType = core.$ZodType>
-  extends ZodPipe<core.$ZodType, B>,
+  extends ZodPipe<core.$ZodTransform, B>,
     core.$ZodPreprocess<B> {
   "~standard": ZodStandardSchemaWithJSON<this>;
   _zod: core.$ZodPreprocessInternals<B>;
@@ -2377,55 +2379,8 @@ export const ZodPreprocess: core.$constructor<ZodPreprocess> = /*@__PURE__*/ cor
   (inst, def) => {
     ZodPipe.init(inst, def);
     core.$ZodPreprocess.init(inst, def);
-
-    // Override parse so the user-supplied transform receives a payload with
-    // `addIssue` attached (mirroring classic ZodTransform behavior).
-    inst._zod.parse = (payload, ctx) => {
-      if (ctx.direction === "backward") {
-        throw new core.$ZodEncodeError(inst.constructor.name);
-      }
-
-      (payload as core.$RefinementCtx).addIssue = (issue) => {
-        if (typeof issue === "string") {
-          payload.issues.push(core.util.issue(issue, payload.value, def));
-        } else {
-          // for Zod 3 backwards compatibility
-          const _issue = issue as any;
-
-          if (_issue.fatal) _issue.continue = false;
-          _issue.code ??= "custom";
-          _issue.input ??= payload.value;
-          _issue.inst ??= inst;
-          payload.issues.push(core.util.issue(_issue));
-        }
-      };
-
-      const _out = def.transform(payload.value, payload);
-      if (ctx.async) {
-        const output = _out instanceof Promise ? _out : Promise.resolve(_out);
-        return output.then((output) => {
-          payload.value = output;
-          return handlePreprocessResult(payload, def.out, ctx);
-        });
-      }
-
-      if (_out instanceof Promise) {
-        throw new core.$ZodAsyncError();
-      }
-
-      payload.value = _out;
-      return handlePreprocessResult(payload, def.out, ctx);
-    };
   }
 );
-
-function handlePreprocessResult(left: core.ParsePayload, next: core.$ZodType, ctx: core.ParseContextInternal) {
-  if (left.issues.length) {
-    left.aborted = true;
-    return left;
-  }
-  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
-}
 
 // ZodReadonly
 export interface ZodReadonly<T extends core.SomeType = core.$ZodType>
@@ -2714,8 +2669,7 @@ export function preprocess<A, U extends core.SomeType, B = unknown>(
 ): ZodPreprocess<U> {
   return new ZodPreprocess({
     type: "pipe",
-    in: unknown() as any as core.$ZodType,
+    in: transform(fn as any) as any as core.$ZodTransform,
     out: schema as any as core.$ZodType,
-    transform: fn as any,
   }) as any;
 }

--- a/packages/zod/src/v4/classic/tests/assignability.test.ts
+++ b/packages/zod/src/v4/classic/tests/assignability.test.ts
@@ -143,6 +143,12 @@ test("assignability", () => {
   z.unknown().pipe(z.number()) satisfies z.core.$ZodPipe;
   z.unknown().pipe(z.number()) satisfies z.ZodPipe;
 
+  // $ZodPreprocess (structural subtype of $ZodPipe with A pinned to $ZodType)
+  z.preprocess((v) => v, z.number()) satisfies z.core.$ZodPreprocess;
+  z.preprocess((v) => v, z.number()) satisfies z.ZodPreprocess;
+  z.preprocess((v) => v, z.number()) satisfies z.core.$ZodPipe<z.core.$ZodType, z.ZodNumber>;
+  z.preprocess((v) => v, z.number()) satisfies z.ZodPipe<z.core.$ZodType, z.ZodNumber>;
+
   // $ZodSuccess
   z.success(z.string()) satisfies z.core.$ZodSuccess;
   z.success(z.string()) satisfies z.ZodSuccess;

--- a/packages/zod/src/v4/classic/tests/assignability.test.ts
+++ b/packages/zod/src/v4/classic/tests/assignability.test.ts
@@ -143,11 +143,11 @@ test("assignability", () => {
   z.unknown().pipe(z.number()) satisfies z.core.$ZodPipe;
   z.unknown().pipe(z.number()) satisfies z.ZodPipe;
 
-  // $ZodPreprocess (structural subtype of $ZodPipe with A pinned to $ZodType)
+  // $ZodPreprocess (structural subtype of $ZodPipe<$ZodTransform, B>)
   z.preprocess((v) => v, z.number()) satisfies z.core.$ZodPreprocess;
   z.preprocess((v) => v, z.number()) satisfies z.ZodPreprocess;
-  z.preprocess((v) => v, z.number()) satisfies z.core.$ZodPipe<z.core.$ZodType, z.ZodNumber>;
-  z.preprocess((v) => v, z.number()) satisfies z.ZodPipe<z.core.$ZodType, z.ZodNumber>;
+  z.preprocess((v) => v, z.number()) satisfies z.core.$ZodPipe<z.core.$ZodTransform, z.ZodNumber>;
+  z.preprocess((v) => v, z.number()) satisfies z.ZodPipe<z.core.$ZodTransform, z.ZodNumber>;
 
   // $ZodSuccess
   z.success(z.string()) satisfies z.core.$ZodSuccess;

--- a/packages/zod/src/v4/classic/tests/assignability.test.ts
+++ b/packages/zod/src/v4/classic/tests/assignability.test.ts
@@ -143,7 +143,7 @@ test("assignability", () => {
   z.unknown().pipe(z.number()) satisfies z.core.$ZodPipe;
   z.unknown().pipe(z.number()) satisfies z.ZodPipe;
 
-  // $ZodPreprocess (structural subtype of $ZodPipe<$ZodTransform, B>)
+  // $ZodPreprocess
   z.preprocess((v) => v, z.number()) satisfies z.core.$ZodPreprocess;
   z.preprocess((v) => v, z.number()) satisfies z.ZodPreprocess;
   z.preprocess((v) => v, z.number()) satisfies z.core.$ZodPipe<z.core.$ZodTransform, z.ZodNumber>;

--- a/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
@@ -1,10 +1,7 @@
 import { expectTypeOf, test } from "vitest";
 import * as z from "zod/v4";
 
-// These are pure type-level checks. They run no assertions, so the value of
-// the test is in the `expectTypeOf` calls — failures surface as type errors.
-
-test("ZodPreprocess<B> is assignable to ZodPipe<$ZodTransform, B>", () => {
+test("ZodPreprocess<B> assignable to ZodPipe<$ZodTransform, B>", () => {
   const pre = z.preprocess((v) => v, z.string().optional());
   const _asPipe: z.ZodPipe<z.core.$ZodTransform, z.ZodOptional<z.ZodString>> = pre;
   const _asCorePipe: z.core.$ZodPipe<z.core.$ZodTransform, z.ZodOptional<z.ZodString>> = pre;
@@ -12,20 +9,17 @@ test("ZodPreprocess<B> is assignable to ZodPipe<$ZodTransform, B>", () => {
   expectTypeOf(_asCorePipe).toMatchTypeOf<z.core.$ZodPipe>();
 });
 
-test("ZodPreprocess narrows optin/optout to B's values", () => {
+test("ZodPreprocess optin/optout defer to B", () => {
   const optionalInside = z.preprocess((v) => v, z.string().optional());
   expectTypeOf<(typeof optionalInside)["_zod"]["optin"]>().toEqualTypeOf<"optional">();
   expectTypeOf<(typeof optionalInside)["_zod"]["optout"]>().toEqualTypeOf<"optional">();
 
-  // Schemas with no explicit optin/optout (e.g. ZodString) inherit
-  // `optin?: "optional" | undefined` from $ZodTypeInternals, so the field
-  // surfaces as `"optional" | undefined` after the override.
   const required = z.preprocess((v) => v, z.string());
   expectTypeOf<(typeof required)["_zod"]["optin"]>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<(typeof required)["_zod"]["optout"]>().toEqualTypeOf<"optional" | undefined>();
 });
 
-test("ZodPreprocess output/input inference unchanged from a plain pipe", () => {
+test("ZodPreprocess input/output inference", () => {
   const pre = z.preprocess((v) => v, z.number().optional());
   expectTypeOf<z.output<typeof pre>>().toEqualTypeOf<number | undefined>();
   expectTypeOf<z.input<typeof pre>>().toEqualTypeOf<unknown>();

--- a/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
@@ -4,10 +4,10 @@ import * as z from "zod/v4";
 // These are pure type-level checks. They run no assertions, so the value of
 // the test is in the `expectTypeOf` calls — failures surface as type errors.
 
-test("ZodPreprocess<B> is assignable to ZodPipe<$ZodType, B>", () => {
+test("ZodPreprocess<B> is assignable to ZodPipe<$ZodTransform, B>", () => {
   const pre = z.preprocess((v) => v, z.string().optional());
-  const _asPipe: z.ZodPipe<z.core.$ZodType, z.ZodOptional<z.ZodString>> = pre;
-  const _asCorePipe: z.core.$ZodPipe<z.core.$ZodType, z.ZodOptional<z.ZodString>> = pre;
+  const _asPipe: z.ZodPipe<z.core.$ZodTransform, z.ZodOptional<z.ZodString>> = pre;
+  const _asCorePipe: z.core.$ZodPipe<z.core.$ZodTransform, z.ZodOptional<z.ZodString>> = pre;
   expectTypeOf(_asPipe).toMatchTypeOf<z.ZodPipe>();
   expectTypeOf(_asCorePipe).toMatchTypeOf<z.core.$ZodPipe>();
 });

--- a/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
@@ -1,0 +1,32 @@
+import { expectTypeOf, test } from "vitest";
+import * as z from "zod/v4";
+
+// These are pure type-level checks. They run no assertions, so the value of
+// the test is in the `expectTypeOf` calls — failures surface as type errors.
+
+test("ZodPreprocess<B> is assignable to ZodPipe<$ZodType, B>", () => {
+  const pre = z.preprocess((v) => v, z.string().optional());
+  const _asPipe: z.ZodPipe<z.core.$ZodType, z.ZodOptional<z.ZodString>> = pre;
+  const _asCorePipe: z.core.$ZodPipe<z.core.$ZodType, z.ZodOptional<z.ZodString>> = pre;
+  expectTypeOf(_asPipe).toMatchTypeOf<z.ZodPipe>();
+  expectTypeOf(_asCorePipe).toMatchTypeOf<z.core.$ZodPipe>();
+});
+
+test("ZodPreprocess narrows optin/optout to B's values", () => {
+  const optionalInside = z.preprocess((v) => v, z.string().optional());
+  expectTypeOf<(typeof optionalInside)["_zod"]["optin"]>().toEqualTypeOf<"optional">();
+  expectTypeOf<(typeof optionalInside)["_zod"]["optout"]>().toEqualTypeOf<"optional">();
+
+  // Schemas with no explicit optin/optout (e.g. ZodString) inherit
+  // `optin?: "optional" | undefined` from $ZodTypeInternals, so the field
+  // surfaces as `"optional" | undefined` after the override.
+  const required = z.preprocess((v) => v, z.string());
+  expectTypeOf<(typeof required)["_zod"]["optin"]>().toEqualTypeOf<"optional" | undefined>();
+  expectTypeOf<(typeof required)["_zod"]["optout"]>().toEqualTypeOf<"optional" | undefined>();
+});
+
+test("ZodPreprocess output/input inference unchanged from a plain pipe", () => {
+  const pre = z.preprocess((v) => v, z.number().optional());
+  expectTypeOf<z.output<typeof pre>>().toEqualTypeOf<number | undefined>();
+  expectTypeOf<z.input<typeof pre>>().toEqualTypeOf<unknown>();
+});

--- a/packages/zod/src/v4/classic/tests/preprocess.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess.test.ts
@@ -302,3 +302,29 @@ test("preprocess is a structural subtype of ZodPipe", () => {
   expect(schema).toBeInstanceOf(z.ZodPreprocess);
   expect(schema._zod.def.type).toBe("pipe");
 });
+
+// Preprocess `fn` can map any input to a B-accepted value, so `values` and
+// `propValues` (which describe the *input* set) must not be inherited from B.
+// Otherwise the discriminated-union disc map and record-key enumerator
+// short-circuit on B's literal set before the preprocess fn ever runs.
+test("preprocess does not propagate values/propValues from inner schema", () => {
+  const inner = z.preprocess((v) => v, z.literal("test"));
+  expect(inner._zod.values).toBeUndefined();
+  expect(inner._zod.propValues).toBeUndefined();
+});
+
+test("preprocess as discriminator throws at construction (no propValues to inherit)", () => {
+  const schema = z.discriminatedUnion("kind", [
+    z.object({ kind: z.preprocess((v: any) => String(v).toUpperCase(), z.literal("A")), a: z.string() }),
+    z.object({ kind: z.preprocess((v: any) => String(v).toUpperCase(), z.literal("B")), b: z.number() }),
+  ]);
+  expect(() => schema.parse({ kind: "a", a: "x" })).toThrow(/Invalid discriminated union option/);
+});
+
+test("preprocess as record key does not restrict accepted keys", () => {
+  const schema = z.record(
+    z.preprocess((v: any) => String(v).toLowerCase(), z.enum(["a", "b"])),
+    z.string()
+  );
+  expect(schema.safeParse({ A: "x", B: "y" })).toEqual({ success: true, data: { a: "x", b: "y" } });
+});

--- a/packages/zod/src/v4/classic/tests/preprocess.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess.test.ts
@@ -280,3 +280,25 @@ test("perform transform with non-fatal issues", () => {
     ]]
   `);
 });
+
+// https://github.com/colinhacks/zod/issues/5917
+test("optional propagates through preprocess inside object", () => {
+  const outer = z.object({ x: z.preprocess((v) => v, z.number()).optional() });
+  const inner = z.object({ x: z.preprocess((v) => v, z.number().optional()) });
+
+  expect(outer.safeParse({}).success).toBe(true);
+  expect(inner.safeParse({}).success).toBe(true);
+
+  expect(outer.safeParse({ x: 1 })).toEqual({ success: true, data: { x: 1 } });
+  expect(inner.safeParse({ x: 1 })).toEqual({ success: true, data: { x: 1 } });
+
+  expect(inner._zod.def.shape.x._zod.optin).toBe("optional");
+  expect(inner._zod.def.shape.x._zod.optout).toBe("optional");
+});
+
+test("preprocess is a structural subtype of ZodPipe", () => {
+  const schema = z.preprocess((v) => v, z.string());
+  expect(schema).toBeInstanceOf(z.ZodPipe);
+  expect(schema).toBeInstanceOf(z.ZodPreprocess);
+  expect(schema._zod.def.type).toBe("pipe");
+});

--- a/packages/zod/src/v4/classic/tests/preprocess.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess.test.ts
@@ -303,10 +303,6 @@ test("preprocess is a structural subtype of ZodPipe", () => {
   expect(schema._zod.def.type).toBe("pipe");
 });
 
-// Preprocess `fn` can map any input to a B-accepted value, so `values` and
-// `propValues` (which describe the *input* set) must not be inherited from B.
-// Otherwise the discriminated-union disc map and record-key enumerator
-// short-circuit on B's literal set before the preprocess fn ever runs.
 test("preprocess does not propagate values/propValues from inner schema", () => {
   const inner = z.preprocess((v) => v, z.literal("test"));
   expect(inner._zod.values).toBeUndefined();

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2896,6 +2896,31 @@ test("use output type for preprocess", () => {
   `);
 });
 
+test("strip output-side examples from input JSON schema for codec", () => {
+  // Codec is implicitly transforming (decode/encode), so examples attached
+  // to the codec describe the OUTPUT representation and must not leak into
+  // the INPUT JSON schema.
+  const codec = z
+    .codec(z.string(), z.number(), { decode: (s) => Number(s), encode: (n) => String(n) })
+    .meta({ examples: [42] });
+
+  expect(z.toJSONSchema(codec, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+    }
+  `);
+  expect(z.toJSONSchema(codec, { io: "output" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "examples": [
+        42,
+      ],
+      "type": "number",
+    }
+  `);
+});
+
 // test("isTransforming", () => {
 //   const tx = z.core.isTransforming;
 //   expect(tx(z.string())).toEqual(false);

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2897,9 +2897,6 @@ test("use output type for preprocess", () => {
 });
 
 test("strip output-side examples from input JSON schema for codec", () => {
-  // Codec is implicitly transforming (decode/encode), so examples attached
-  // to the codec describe the OUTPUT representation and must not leak into
-  // the INPUT JSON schema.
   const codec = z
     .codec(z.string(), z.number(), { decode: (s) => Number(s), encode: (n) => String(n) })
     .meta({ examples: [42] });

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -525,7 +525,9 @@ export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, 
 
 export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, params) => {
   const def = schema._zod.def as schemas.$ZodPipeDef;
-  const innerType = ctx.io === "input" ? (def.in._zod.def.type === "transform" ? def.out : def.in) : def.out;
+  const isPreprocess = schema._zod.traits.has("$ZodPreprocess");
+  const innerType =
+    ctx.io === "input" ? (isPreprocess || def.in._zod.def.type === "transform" ? def.out : def.in) : def.out;
   process(innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = innerType;

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -525,10 +525,6 @@ export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, 
 
 export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, params) => {
   const def = schema._zod.def as schemas.$ZodPipeDef;
-  // For input-side JSON schema, fall through to B when the input slot is
-  // itself a transform (no input-side validation). Covers both the legacy
-  // `pipe(transform, ...)` form and `z.preprocess` (whose `def.in` is a
-  // real ZodTransform).
   const inIsTransform = def.in._zod.traits.has("$ZodTransform");
   const innerType = ctx.io === "input" ? (inIsTransform ? def.out : def.in) : def.out;
   process(innerType, ctx as any, params);

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -525,11 +525,12 @@ export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, 
 
 export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, params) => {
   const def = schema._zod.def as schemas.$ZodPipeDef;
-  // Use B for input-side JSON schema when the input contributes no validation:
-  // either a ZodPreprocess (synthetic z.unknown() input) or a legacy
-  // pipe(transform, ...) form. Both detected via traits for consistency.
-  const inIsPassthrough = schema._zod.traits.has("$ZodPreprocess") || def.in._zod.traits.has("$ZodTransform");
-  const innerType = ctx.io === "input" ? (inIsPassthrough ? def.out : def.in) : def.out;
+  // For input-side JSON schema, fall through to B when the input slot is
+  // itself a transform (no input-side validation). Covers both the legacy
+  // `pipe(transform, ...)` form and `z.preprocess` (whose `def.in` is a
+  // real ZodTransform).
+  const inIsTransform = def.in._zod.traits.has("$ZodTransform");
+  const innerType = ctx.io === "input" ? (inIsTransform ? def.out : def.in) : def.out;
   process(innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = innerType;

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -525,9 +525,11 @@ export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, 
 
 export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, params) => {
   const def = schema._zod.def as schemas.$ZodPipeDef;
-  const isPreprocess = schema._zod.traits.has("$ZodPreprocess");
-  const innerType =
-    ctx.io === "input" ? (isPreprocess || def.in._zod.def.type === "transform" ? def.out : def.in) : def.out;
+  // Use B for input-side JSON schema when the input contributes no validation:
+  // either a ZodPreprocess (synthetic z.unknown() input) or a legacy
+  // pipe(transform, ...) form. Both detected via traits for consistency.
+  const inIsPassthrough = schema._zod.traits.has("$ZodPreprocess") || def.in._zod.traits.has("$ZodTransform");
+  const innerType = ctx.io === "input" ? (inIsPassthrough ? def.out : def.in) : def.out;
   process(innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = innerType;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4125,37 +4125,35 @@ function handleCodecTxResult(left: ParsePayload, value: any, nextSchema: SomeTyp
 //////////                             //////////
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-// Preprocess is a structural subtype of $ZodPipe whose `def.type` stays "pipe".
-// It pins `def.in` to a synthetic permissive schema and re-exposes B's
-// presence surface (optin/optout). Detect via
-// `inst._zod.traits.has("$ZodPreprocess")`.
+// Preprocess is a structural subtype of $ZodPipe<$ZodTransform, B> whose
+// only deviation from a vanilla pipe is its presence surface: `optin` and
+// `optout` defer to B (the inner schema) instead of A (the leading
+// transform). The runtime parse, the def shape, and `def.in._zod` are all
+// the same as the legacy `pipe(transform(fn), schema)` form — we just
+// override the static optionality lazies.
 //
 // Asymmetry between presence (optin/optout) and input-set descriptors
 // (values/propValues): presence semantics describe whether the *outer*
 // container can omit this slot, and preprocess is transparent to that — we
 // want `z.preprocess(fn, schema.optional())` and `z.preprocess(fn,
-// schema).optional()` to be equivalent.
-//
-// `values` and `propValues`, by contrast, are claims about the *input* set
-// the schema accepts. The preprocess `fn` can map any input to a B-accepted
-// value, so the actual input set is unknowable statically. Deferring them
-// to B would corrupt the discriminated-union disc map (which uses
-// `propValues` as a fast-path) and the record-key enumerator (which uses
-// `values` to iterate expected keys). Both must stay `undefined`, matching
-// the legacy `pipe(transform, ...)` form.
-export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodType, B> {
-  in: $ZodType;
+// schema).optional()` to be equivalent. By contrast, `values` and
+// `propValues` describe the literal *input* set the schema accepts. The
+// preprocess `fn` can map any input to a B-accepted value, so deferring
+// those to B would corrupt the discriminated-union disc map and the
+// record-key enumerator. They stay inherited from A (the transform), which
+// has neither — matching the legacy form exactly.
+export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodTransform, B> {
+  in: $ZodTransform;
   out: B;
-  transform: (value: unknown, payload: ParsePayload<unknown>) => util.MaybeAsync<core.input<B>>;
 }
 
-export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodType, B> {
+export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodTransform, B> {
   def: $ZodPreprocessDef<B>;
   optin: B["_zod"]["optin"];
   optout: B["_zod"]["optout"];
 }
 
-export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodType, B> {
+export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodTransform, B> {
   _zod: $ZodPreprocessInternals<B>;
 }
 
@@ -4163,33 +4161,8 @@ export const $ZodPreprocess: core.$constructor<$ZodPreprocess> = /*@__PURE__*/ c
   "$ZodPreprocess",
   (inst, def) => {
     $ZodPipe.init(inst, def);
-    // Override the lazies installed by $ZodPipe so presence semantics defer
-    // to B. Leave `values` and `propValues` as A's (undefined for the
-    // synthetic z.unknown() input) — see comment above for why.
     util.defineLazy(inst._zod, "optin", () => def.out._zod.optin);
     util.defineLazy(inst._zod, "optout", () => def.out._zod.optout);
-
-    inst._zod.parse = (payload, ctx) => {
-      if (ctx.direction === "backward") {
-        throw new core.$ZodEncodeError(inst.constructor.name);
-      }
-
-      const _out = def.transform(payload.value, payload);
-      if (ctx.async) {
-        const output = _out instanceof Promise ? _out : Promise.resolve(_out);
-        return output.then((output) => {
-          payload.value = output;
-          return handlePipeResult(payload, def.out, ctx);
-        });
-      }
-
-      if (_out instanceof Promise) {
-        throw new core.$ZodAsyncError();
-      }
-
-      payload.value = _out;
-      return handlePipeResult(payload, def.out, ctx);
-    };
   }
 );
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4126,9 +4126,23 @@ function handleCodecTxResult(left: ParsePayload, value: any, nextSchema: SomeTyp
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
 // Preprocess is a structural subtype of $ZodPipe whose `def.type` stays "pipe".
-// It pins `def.in` to a synthetic permissive schema and exposes B's optionality
-// surface (optin/optout/values/propValues) instead of A's. Detect via
+// It pins `def.in` to a synthetic permissive schema and re-exposes B's
+// presence surface (optin/optout). Detect via
 // `inst._zod.traits.has("$ZodPreprocess")`.
+//
+// Asymmetry between presence (optin/optout) and input-set descriptors
+// (values/propValues): presence semantics describe whether the *outer*
+// container can omit this slot, and preprocess is transparent to that — we
+// want `z.preprocess(fn, schema.optional())` and `z.preprocess(fn,
+// schema).optional()` to be equivalent.
+//
+// `values` and `propValues`, by contrast, are claims about the *input* set
+// the schema accepts. The preprocess `fn` can map any input to a B-accepted
+// value, so the actual input set is unknowable statically. Deferring them
+// to B would corrupt the discriminated-union disc map (which uses
+// `propValues` as a fast-path) and the record-key enumerator (which uses
+// `values` to iterate expected keys). Both must stay `undefined`, matching
+// the legacy `pipe(transform, ...)` form.
 export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodType, B> {
   in: $ZodType;
   out: B;
@@ -4137,10 +4151,8 @@ export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPi
 
 export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodType, B> {
   def: $ZodPreprocessDef<B>;
-  values: B["_zod"]["values"];
   optin: B["_zod"]["optin"];
   optout: B["_zod"]["optout"];
-  propValues: B["_zod"]["propValues"];
 }
 
 export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodType, B> {
@@ -4151,12 +4163,11 @@ export const $ZodPreprocess: core.$constructor<$ZodPreprocess> = /*@__PURE__*/ c
   "$ZodPreprocess",
   (inst, def) => {
     $ZodPipe.init(inst, def);
-    // Override the lazies installed by $ZodPipe so optionality surface defers
-    // to B (the inner schema) instead of A (the synthetic permissive input).
-    util.defineLazy(inst._zod, "values", () => def.out._zod.values);
+    // Override the lazies installed by $ZodPipe so presence semantics defer
+    // to B. Leave `values` and `propValues` as A's (undefined for the
+    // synthetic z.unknown() input) — see comment above for why.
     util.defineLazy(inst._zod, "optin", () => def.out._zod.optin);
     util.defineLazy(inst._zod, "optout", () => def.out._zod.optout);
-    util.defineLazy(inst._zod, "propValues", () => def.out._zod.propValues);
 
     inst._zod.parse = (payload, ctx) => {
       if (ctx.direction === "backward") {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4125,23 +4125,6 @@ function handleCodecTxResult(left: ParsePayload, value: any, nextSchema: SomeTyp
 //////////                             //////////
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-// Preprocess is a structural subtype of $ZodPipe<$ZodTransform, B> whose
-// only deviation from a vanilla pipe is its presence surface: `optin` and
-// `optout` defer to B (the inner schema) instead of A (the leading
-// transform). The runtime parse, the def shape, and `def.in._zod` are all
-// the same as the legacy `pipe(transform(fn), schema)` form — we just
-// override the static optionality lazies.
-//
-// Asymmetry between presence (optin/optout) and input-set descriptors
-// (values/propValues): presence semantics describe whether the *outer*
-// container can omit this slot, and preprocess is transparent to that — we
-// want `z.preprocess(fn, schema.optional())` and `z.preprocess(fn,
-// schema).optional()` to be equivalent. By contrast, `values` and
-// `propValues` describe the literal *input* set the schema accepts. The
-// preprocess `fn` can map any input to a B-accepted value, so deferring
-// those to B would corrupt the discriminated-union disc map and the
-// record-key enumerator. They stay inherited from A (the transform), which
-// has neither — matching the legacy form exactly.
 export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodTransform, B> {
   in: $ZodTransform;
   out: B;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4118,6 +4118,70 @@ function handleCodecTxResult(left: ParsePayload, value: any, nextSchema: SomeTyp
   return nextSchema._zod.run({ value, issues: left.issues }, ctx);
 }
 
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+//////////                             //////////
+//////////      $ZodPreprocess         //////////
+//////////                             //////////
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+// Preprocess is a structural subtype of $ZodPipe whose `def.type` stays "pipe".
+// It pins `def.in` to a synthetic permissive schema and exposes B's optionality
+// surface (optin/optout/values/propValues) instead of A's. Detect via
+// `inst._zod.traits.has("$ZodPreprocess")`.
+export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodType, B> {
+  in: $ZodType;
+  out: B;
+  transform: (value: unknown, payload: ParsePayload<unknown>) => util.MaybeAsync<core.input<B>>;
+}
+
+export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodType, B> {
+  def: $ZodPreprocessDef<B>;
+  values: B["_zod"]["values"];
+  optin: B["_zod"]["optin"];
+  optout: B["_zod"]["optout"];
+  propValues: B["_zod"]["propValues"];
+}
+
+export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodType, B> {
+  _zod: $ZodPreprocessInternals<B>;
+}
+
+export const $ZodPreprocess: core.$constructor<$ZodPreprocess> = /*@__PURE__*/ core.$constructor(
+  "$ZodPreprocess",
+  (inst, def) => {
+    $ZodPipe.init(inst, def);
+    // Override the lazies installed by $ZodPipe so optionality surface defers
+    // to B (the inner schema) instead of A (the synthetic permissive input).
+    util.defineLazy(inst._zod, "values", () => def.out._zod.values);
+    util.defineLazy(inst._zod, "optin", () => def.out._zod.optin);
+    util.defineLazy(inst._zod, "optout", () => def.out._zod.optout);
+    util.defineLazy(inst._zod, "propValues", () => def.out._zod.propValues);
+
+    inst._zod.parse = (payload, ctx) => {
+      if (ctx.direction === "backward") {
+        throw new core.$ZodEncodeError(inst.constructor.name);
+      }
+
+      const _out = def.transform(payload.value, payload);
+      if (ctx.async) {
+        const output = _out instanceof Promise ? _out : Promise.resolve(_out);
+        return output.then((output) => {
+          payload.value = output;
+          return handlePipeResult(payload, def.out, ctx);
+        });
+      }
+
+      if (_out instanceof Promise) {
+        throw new core.$ZodAsyncError();
+      }
+
+      payload.value = _out;
+      return handlePipeResult(payload, def.out, ctx);
+    };
+  }
+);
+
 ////////////////////////////////////////////
 ////////////////////////////////////////////
 //////////                        //////////

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -561,6 +561,7 @@ function isTransforming(
     return isTransforming(def.keyType, ctx) || isTransforming(def.valueType, ctx);
   }
   if (def.type === "pipe") {
+    if (_schema._zod.traits.has("$ZodPreprocess")) return true;
     return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
   }
 

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -561,10 +561,11 @@ function isTransforming(
     return isTransforming(def.keyType, ctx) || isTransforming(def.valueType, ctx);
   }
   if (def.type === "pipe") {
-    // Preprocess and codec embed an implicit transform fn that the
-    // recursive checks below can't see (their def.in/def.out are
-    // validating schemas). Detect them via traits.
-    if (_schema._zod.traits.has("$ZodPreprocess") || _schema._zod.traits.has("$ZodCodec")) return true;
+    // Codec embeds an implicit transform fn directly on its def, so the
+    // recursive walk below can't see it (def.in/def.out are validating
+    // schemas). Detect via traits. Preprocess doesn't need this — its
+    // def.in is a real ZodTransform and the recursion picks it up.
+    if (_schema._zod.traits.has("$ZodCodec")) return true;
     return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
   }
 

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -561,10 +561,6 @@ function isTransforming(
     return isTransforming(def.keyType, ctx) || isTransforming(def.valueType, ctx);
   }
   if (def.type === "pipe") {
-    // Codec embeds an implicit transform fn directly on its def, so the
-    // recursive walk below can't see it (def.in/def.out are validating
-    // schemas). Detect via traits. Preprocess doesn't need this — its
-    // def.in is a real ZodTransform and the recursion picks it up.
     if (_schema._zod.traits.has("$ZodCodec")) return true;
     return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
   }

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -561,7 +561,10 @@ function isTransforming(
     return isTransforming(def.keyType, ctx) || isTransforming(def.valueType, ctx);
   }
   if (def.type === "pipe") {
-    if (_schema._zod.traits.has("$ZodPreprocess")) return true;
+    // Preprocess and codec embed an implicit transform fn that the
+    // recursive checks below can't see (their def.in/def.out are
+    // validating schemas). Detect them via traits.
+    if (_schema._zod.traits.has("$ZodPreprocess") || _schema._zod.traits.has("$ZodCodec")) return true;
     return isTransforming(def.in, ctx) || isTransforming(def.out, ctx);
   }
 


### PR DESCRIPTION
Fixes #5917.

`z.preprocess(fn, schema)` desugared to `pipe(transform(fn), schema)`, so the resulting pipe inherited `optin` from `ZodTransform` (undefined) instead of from the inner schema. When the inner schema was itself optional and the preprocess sat as an object property, the object compiler took the `!isOptionalIn` branch and synthesized a `nonoptional` issue for missing keys — making the position of `.optional()` change presence semantics:

```ts
z.object({ x: z.preprocess(v => v, z.number()).optional() }).safeParse({}).success;  // true
z.object({ x: z.preprocess(v => v, z.number().optional()) }).safeParse({}).success;  // false on main, true here
```

Introduce `ZodPreprocess` as a structural subtype of `ZodPipe` (same ``def.type === "pipe"``, ``instanceof ZodPipe`` still true). It pins `def.in` to a permissive `z.unknown()` and re-installs the four lazy metadata props so `optin`, `optout`, `values`, and `propValues` all defer to `def.out` (the inner schema). Forward direction skips the no-op `def.in.run()` and embeds the user fn as the codec's decode; backward throws, matching today's behavior.

The two JSON-schema sites that special-cased the old `pipe(transform, ...)` shape (`pipeProcessor` and `isTransforming`) now also detect preprocess via `_zod.traits`.