### PR TITLE
feat(v4): add `union` option to `z.toJSONSchema` for `oneOf` opt-in (#5807, #5493, #5494)

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema-union.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema-union.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import * as z from "zod";
+
+describe("z.toJSONSchema union option", () => {
+  test("default: inclusive union → anyOf", () => {
+    const schema = z.union([z.string(), z.number()]);
+    const json = z.toJSONSchema(schema);
+    expect(json.anyOf).toBeDefined();
+    expect(json.oneOf).toBeUndefined();
+  });
+
+  test('union: "oneOf" → inclusive union emits oneOf (regression #5807, #5493, #5494)', () => {
+    const schema = z.union([z.string(), z.number()]);
+    const json = z.toJSONSchema(schema, { union: "oneOf" });
+    expect(json.oneOf).toBeDefined();
+    expect(json.anyOf).toBeUndefined();
+  });
+
+  test('union: "anyOf" (explicit) matches default', () => {
+    const schema = z.union([z.string(), z.number()]);
+    expect(z.toJSONSchema(schema, { union: "anyOf" })).toEqual(z.toJSONSchema(schema));
+  });
+
+  test("discriminated unions always use oneOf, regardless of union option", () => {
+    const schema = z.discriminatedUnion("kind", [
+      z.object({ kind: z.literal("a"), a: z.string() }),
+      z.object({ kind: z.literal("b"), b: z.number() }),
+    ]);
+    expect(z.toJSONSchema(schema).oneOf).toBeDefined();
+    expect(z.toJSONSchema(schema, { union: "oneOf" }).oneOf).toBeDefined();
+    expect(z.toJSONSchema(schema, { union: "anyOf" }).oneOf).toBeDefined();
+  });
+
+  test("nested unions inside object are also rewritten", () => {
+    const schema = z.object({
+      x: z.union([z.string(), z.number()]),
+      y: z.union([z.boolean(), z.null()]),
+    });
+    const json = z.toJSONSchema(schema, { union: "oneOf" });
+    expect((json.properties as any).x.oneOf).toBeDefined();
+    expect((json.properties as any).y.oneOf).toBeDefined();
+    expect((json.properties as any).x.anyOf).toBeUndefined();
+  });
+});

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -335,20 +335,18 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
 
 export const unionProcessor: Processor<schemas.$ZodUnion> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodUnionDef;
-  // Exclusive unions (inclusive === false) use oneOf (exactly one match) instead of anyOf (one or more matches)
-  // This includes both z.xor() and discriminated unions
+  // Exclusive unions (z.xor / discriminated union) always emit oneOf.
+  // Inclusive unions default to anyOf, but the caller can opt into oneOf
+  // via `union: "oneOf"` for consumers that don't accept anyOf.
   const isExclusive = def.inclusive === false;
+  const keyword: "oneOf" | "anyOf" = isExclusive || ctx.union === "oneOf" ? "oneOf" : "anyOf";
   const options = def.options.map((x, i) =>
     process(x, ctx as any, {
       ...params,
-      path: [...params.path, isExclusive ? "oneOf" : "anyOf", i],
+      path: [...params.path, keyword, i],
     })
   );
-  if (isExclusive) {
-    json.oneOf = options;
-  } else {
-    json.anyOf = options;
-  }
+  json[keyword] = options;
 };
 
 export const intersectionProcessor: Processor<schemas.$ZodIntersection> = (schema, ctx, json, params) => {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -26,6 +26,12 @@ export interface JSONSchemaGeneratorParams {
    * - `"throw"` — Default. Unrepresentable types throw an error
    * - `"any"` — Unrepresentable types become `{}` */
   unrepresentable?: "throw" | "any";
+  /** How to encode `z.union(...)` (inclusive unions).
+   * - `"anyOf"` — Default. Matches JSON Schema spec semantics (one or more match).
+   * - `"oneOf"` — Emit `oneOf` instead. Useful for consumers that don't accept
+   *   `anyOf` (e.g. Google Gemini Function Calling). `z.xor()` and discriminated
+   *   unions are unaffected — they always emit `oneOf`. */
+  union?: "anyOf" | "oneOf";
   /** Arbitrary custom logic that can be used to modify the generated JSON Schema. */
   override?: (ctx: {
     zodSchema: schemas.$ZodTypes;
@@ -86,6 +92,7 @@ export interface ToJSONSchemaContext {
   metadataRegistry: $ZodRegistry<Record<string, any>>;
   target: "draft-04" | "draft-07" | "draft-2020-12" | "openapi-3.0" | ({} & string);
   unrepresentable: "throw" | "any";
+  union: "anyOf" | "oneOf";
   override: (ctx: {
     // must be schemas.$ZodType to prevent recursive type resolution error
     zodSchema: schemas.$ZodType;
@@ -126,6 +133,7 @@ export function initializeContext(params: JSONSchemaGeneratorParams): ToJSONSche
     metadataRegistry: params?.metadata ?? globalRegistry,
     target,
     unrepresentable: params?.unrepresentable ?? "throw",
+    union: params?.union ?? "anyOf",
     override: (params?.override as any) ?? (() => {}),
     io: params?.io ?? "output",
     counter: 0,


### PR DESCRIPTION
Closes #5807. Also addresses #5493 and #5494 which surface the same need from a different consumer.

## The problem

Multiple downstream consumers of `z.toJSONSchema()` reject the `anyOf` keyword that v4 emits for inclusive unions:

- **Google Gemini Function Calling** (#5807): schemas with `anyOf` cause silent tool-call failures or validation errors.
- **Swagger / OpenAPI codegen** (#5494): generated client bindings break on `anyOf` shapes.
- **Older language-binding generators** (#5493): same.

The default is sound, and stays put. As you noted in https://github.com/colinhacks/zod/issues/5494#issuecomment-3654057725:

> Discriminated union -> `oneOf`
> Union -> `anyOf`
>
> This is sound and mirrors the validation behavior of these keywords in JSON Schema.

`z.union(...)` is inclusive — multiple branches can match the same value — so `anyOf` matches the spec semantics. This PR doesn't change that.

## What this adds

A new opt-in parameter on `z.toJSONSchema()`:

```ts
z.toJSONSchema(schema, { union: "oneOf" });
```

When set, inclusive unions emit `oneOf` instead of `anyOf`. Default is `"anyOf"`.

Discriminated unions and `z.xor()` are unaffected — they're exclusive by construction and keep emitting `oneOf` regardless.

## Why a flag and not just `override`

Users hit by this today work around it by walking the produced schema after the fact:

```ts
z.toJSONSchema(schema, {
  override: (ctx) => {
    if (ctx.zodSchema._zod.def.type === "union" && ctx.jsonSchema.anyOf) {
      ctx.jsonSchema.oneOf = ctx.jsonSchema.anyOf;
      delete ctx.jsonSchema.anyOf;
    }
  },
});
```

It works but it's brittle: it rewrites the path keys after they've been computed (the `path` arg in any user `override` already references `anyOf` indices), it has to be duplicated in every project that hits the issue, and it's not discoverable from the docs. A flag is one parameter, doesn't cost anything when unused, and the path is correct from the start.

## Implementation

- `JSONSchemaGeneratorParams` and `ToJSONSchemaContext` get a `union: "anyOf" | "oneOf"` field.
- `initializeContext` defaults it to `"anyOf"`.
- `unionProcessor` picks the keyword once: `oneOf` if exclusive *or* opted in, else `anyOf`. The path argument and the output key are both written under the chosen keyword.

```ts
const keyword: "oneOf" | "anyOf" = isExclusive || ctx.union === "oneOf" ? "oneOf" : "anyOf";
const options = def.options.map((x, i) =>
  process(x, ctx as any, { ...params, path: [...params.path, keyword, i] })
);
json[keyword] = options;
```

## Test coverage

5 tests in `tests/to-json-schema-union.test.ts`:

- Default emits `anyOf` for inclusive union.
- `union: "oneOf"` emits `oneOf` for inclusive union.
- Explicit `union: "anyOf"` matches the default.
- Discriminated unions stay on `oneOf` regardless of the flag.
- Nested unions inside objects are also rewritten.

`pnpm vitest run to-json-schema*` — 344/344 passing locally with 0 type errors. No existing snapshots changed (default unchanged).

