### PR TITLE
fix(v4): restore catch handling for absent object keys (#5937)

### DIFF
--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -128,8 +128,9 @@ test("native enum", () => {
     fruit: z.nativeEnum(Fruits).catch(Fruits.apple),
   });
 
-  expect(schema.safeParse({}).success).toEqual(false);
-  expect(schema.safeParse({}, { jitless: true }).success).toEqual(false);
+  // Absent keys flow through to the catch handler.
+  expect(schema.parse({})).toEqual({ fruit: Fruits.apple });
+  expect(schema.parse({}, { jitless: true })).toEqual({ fruit: Fruits.apple });
   expect(schema.parse({ fruit: 15 })).toEqual({ fruit: Fruits.apple });
 });
 
@@ -138,8 +139,8 @@ test("enum", () => {
     fruit: z.enum(["apple", "orange"]).catch("apple"),
   });
 
-  expect(schema.safeParse({}).success).toEqual(false);
-  expect(schema.safeParse({}, { jitless: true }).success).toEqual(false);
+  expect(schema.parse({})).toEqual({ fruit: "apple" });
+  expect(schema.parse({}, { jitless: true })).toEqual({ fruit: "apple" });
   expect(schema.parse({ fruit: true })).toEqual({ fruit: "apple" });
   expect(schema.parse({ fruit: 15 })).toEqual({ fruit: "apple" });
 });

--- a/packages/zod/src/v4/classic/tests/partial.test.ts
+++ b/packages/zod/src/v4/classic/tests/partial.test.ts
@@ -156,30 +156,27 @@ test("catch/prefault/default", () => {
     f: z.string().prefault("prefault value"),
   });
 
-  expect(mySchema.safeParse({}).error!.issues).toMatchInlineSnapshot(`
-    [
-      {
-        "code": "invalid_type",
-        "expected": "nonoptional",
-        "message": "Invalid input: expected nonoptional, received undefined",
-        "path": [
-          "d",
-        ],
-      },
-    ]
+  // Catch (d) and default/prefault (b, c, e, f) handle absent keys gracefully.
+  // `a: catch().optional()` short-circuits to undefined when the original
+  // input was undefined, so the property is omitted from the output. All
+  // other catch/default/prefault keys produce their fallback values.
+  expect(mySchema.parse({})).toMatchInlineSnapshot(`
+    {
+      "b": "default value",
+      "c": "prefault value",
+      "d": "catch value",
+      "e": "default value",
+      "f": "prefault value",
+    }
   `);
-
-  expect(mySchema.safeParse({}, { jitless: true }).error!.issues).toMatchInlineSnapshot(`
-    [
-      {
-        "code": "invalid_type",
-        "expected": "nonoptional",
-        "message": "Invalid input: expected nonoptional, received undefined",
-        "path": [
-          "d",
-        ],
-      },
-    ]
+  expect(mySchema.parse({}, { jitless: true })).toMatchInlineSnapshot(`
+    {
+      "b": "default value",
+      "c": "prefault value",
+      "d": "catch value",
+      "e": "default value",
+      "f": "prefault value",
+    }
   `);
 
   expect(mySchema.parse({ d: undefined })).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2731,7 +2731,6 @@ test("input type", () => {
       "required": [
         "a",
         "d",
-        "f",
         "g",
       ],
       "type": "object",

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -36,6 +36,8 @@ export interface ParsePayload<T = unknown> {
   issues: errors.$ZodRawIssue[];
   /** A way to mark a whole payload as aborted. Used in codecs/pipes. */
   aborted?: boolean;
+  /** @internal Set when $ZodCatch substitutes its catchValue. */
+  caught?: boolean;
 }
 
 export type CheckFn<T> = (input: ParsePayload<T>) => util.MaybeAsync<void>;
@@ -3468,7 +3470,7 @@ export interface $ZodOptional<T extends SomeType = $ZodType> extends $ZodType {
 }
 
 function handleOptionalResult(result: ParsePayload, input: unknown) {
-  if (result.issues.length && input === undefined) {
+  if (input === undefined && (result.issues.length || result.caught)) {
     return { issues: [], value: undefined };
   }
   return result;
@@ -3491,9 +3493,10 @@ export const $ZodOptional: core.$constructor<$ZodOptional> = /*@__PURE__*/ core.
 
     inst._zod.parse = (payload, ctx) => {
       if (def.innerType._zod.optin === "optional") {
+        const input = payload.value;
         const result = def.innerType._zod.run(payload, ctx);
-        if (result instanceof Promise) return result.then((r) => handleOptionalResult(r, payload.value));
-        return handleOptionalResult(result, payload.value);
+        if (result instanceof Promise) return result.then((r) => handleOptionalResult(r, input));
+        return handleOptionalResult(result, input);
       }
       if (payload.value === undefined) {
         return payload;
@@ -3886,7 +3889,7 @@ export interface $ZodCatch<T extends SomeType = $ZodType> extends $ZodType {
 
 export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$constructor("$ZodCatch", (inst, def) => {
   $ZodType.init(inst, def);
-  util.defineLazy(inst._zod, "optin", () => def.innerType._zod.optin);
+  inst._zod.optin = "optional";
   util.defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
   util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
 
@@ -3909,6 +3912,7 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
             input: payload.value,
           });
           payload.issues = [];
+          payload.caught = true;
         }
 
         return payload;
@@ -3926,6 +3930,7 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
       });
 
       payload.issues = [];
+      payload.caught = true;
     }
 
     return payload;


### PR DESCRIPTION
## Summary

Closes #5937.

In v4.4.0, [`fd0f83d1`](https://github.com/colinhacks/zod/commit/fd0f83d1) (PR #5661) tightened `$ZodObject` to reject absent keys whose schema doesn't have `optin === "optional"`. `$ZodCatch` was deferring its `optin` to the inner schema, so any `z.X.catch(...)` field on an `optin`-required schema (e.g. `z.preprocess(...).catch([])`, `z.enum([...]).catch(...)`) started failing to parse `{}` even though the catch handler should fire.

This PR restores the v4.3.x behavior by marking `$ZodCatch` as `optin === "optional"` unconditionally. A catch wrapper always handles missing input gracefully — its handler runs with `undefined` and produces the catch value — so it's correct to advertise that to `$ZodObject`.

To preserve the existing semantics where an outer `.optional()` overrides the catch fallback with `undefined`, this introduces an internal `caught` flag on `ParsePayload`:

- `$ZodCatch` sets `payload.caught = true` whenever `catchValue` fires (unconditionally — no `undefined` check).
- `handleOptionalResult` reads it alongside the existing `issues.length` check, so an outer `optional` returns `undefined` when the original input was `undefined` and either the inner produced issues *or* a catch fired.
- `$ZodOptional` captures the input value before invoking the inner schema (a wrapped `$ZodCatch` rewrites `payload.value` to its catchValue, so the post-run value can't be used to detect "input was `undefined`").

### Behavior changes (vs v4.4.x)

These restore v4.3.x semantics for `catch` fields on objects:

| Schema | Input | v4.4.x | This PR |
|---|---|---|---|
| `z.object({ arr: z.preprocess(..., z.string().array()).catch([]) })` | `{}` | error | `{ arr: [] }` |
| `z.object({ a: z.string().catch("c") })` | `{}` | error | `{ a: "c" }` |
| `z.object({ fruit: z.enum([...]).catch("apple") })` | `{}` | error | `{ fruit: "apple" }` |

`.optional()` semantics are preserved:

| Schema | Input | Result |
|---|---|---|
| `z.string().catch("c").optional()` | `undefined` | `undefined` (catch suppressed by outer optional) |
| `z.string().catch("c").optional()` | `123` | `"c"` (catch fires) |
| `z.string().catch("c").optional()` | `"hi"` | `"hi"` |

JSON Schema generation no longer marks bare `.catch()` fields as `required` (they're now legitimately optional-in).

### Performance

The `caught` check lives inside `handleOptionalResult`, which only runs on `$ZodOptional`'s `optin === "optional"` branch. The plain optional hot path is untouched.

| Bench (p75) | Baseline | This PR |
|---|---|---|
| `optional plain — present` | 3.44 ns | 3.32 ns |
| `optional plain — undefined` | 6.61 ns | 6.61 ns |
| `optional<default> — undefined` | 48.91 ns | 48.91 ns |
| `optional<catch> — present` | 83 ns | 83 ns |
| `optional<catch> — undefined` | 37 ns | **208 ns** |
| `object{a?,b?,c?} — partial/empty/full` | flat | flat |
| `object{catch,catch} — invalid` | 375 ns | 375 ns |

The one regression is `.catch().optional()` parsing `undefined`. Cause: `$ZodCatch` is now `optin === "optional"`, so `$ZodOptional` takes branch A (run inner) instead of short-circuiting on `undefined`. Catch genuinely fires and produces a value, then `handleOptionalResult` overrides with `undefined`. That work is necessary for correctness — there's no way to know whether `caught` should be set without running catch.

## Test plan

- [x] `pnpm vitest run` — 3807/3807 passing
- [x] Issue #5937 reproduction returns `{ arr: [] }`
- [x] `z.string().catch("c").optional()` parity matrix (`undefined`, `"hi"`, `123`)
- [x] Updated assertions in `catch.test.ts` (enum/native enum), `partial.test.ts` (catch/prefault/default snapshot), `to-json-schema.test.ts` (input type required array) to reflect restored v4.3.x semantics