### PR TITLE
fix(v4): allow catch/preprocess to handle absent object keys (#5937)

### DIFF
--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -128,8 +128,8 @@ test("native enum", () => {
     fruit: z.nativeEnum(Fruits).catch(Fruits.apple),
   });
 
-  expect(schema.safeParse({}).success).toEqual(false);
-  expect(schema.safeParse({}, { jitless: true }).success).toEqual(false);
+  expect(schema.parse({})).toEqual({ fruit: Fruits.apple });
+  expect(schema.parse({}, { jitless: true })).toEqual({ fruit: Fruits.apple });
   expect(schema.parse({ fruit: 15 })).toEqual({ fruit: Fruits.apple });
 });
 
@@ -138,10 +138,21 @@ test("enum", () => {
     fruit: z.enum(["apple", "orange"]).catch("apple"),
   });
 
-  expect(schema.safeParse({}).success).toEqual(false);
-  expect(schema.safeParse({}, { jitless: true }).success).toEqual(false);
+  expect(schema.parse({})).toEqual({ fruit: "apple" });
+  expect(schema.parse({}, { jitless: true })).toEqual({ fruit: "apple" });
   expect(schema.parse({ fruit: true })).toEqual({ fruit: "apple" });
   expect(schema.parse({ fruit: 15 })).toEqual({ fruit: "apple" });
+});
+
+test("preprocess + catch on absent key (#5937)", () => {
+  const schema = z.object({
+    area: z.preprocess((v) => (v ? v.toString().split(",") : []), z.array(z.string())).catch([]),
+  });
+
+  expect(schema.parse({})).toEqual({ area: [] });
+  expect(schema.parse({}, { jitless: true })).toEqual({ area: [] });
+  expect(schema.parse({ area: "a,b,c" })).toEqual({ area: ["a", "b", "c"] });
+  expect(schema.parse({ area: 123 })).toEqual({ area: ["123"] });
 });
 
 test("reported issues with nested usage", () => {

--- a/packages/zod/src/v4/classic/tests/partial.test.ts
+++ b/packages/zod/src/v4/classic/tests/partial.test.ts
@@ -156,30 +156,23 @@ test("catch/prefault/default", () => {
     f: z.string().prefault("prefault value"),
   });
 
-  expect(mySchema.safeParse({}).error!.issues).toMatchInlineSnapshot(`
-    [
-      {
-        "code": "invalid_type",
-        "expected": "nonoptional",
-        "message": "Invalid input: expected nonoptional, received undefined",
-        "path": [
-          "d",
-        ],
-      },
-    ]
+  expect(mySchema.parse({})).toMatchInlineSnapshot(`
+    {
+      "b": "default value",
+      "c": "prefault value",
+      "d": "catch value",
+      "e": "default value",
+      "f": "prefault value",
+    }
   `);
-
-  expect(mySchema.safeParse({}, { jitless: true }).error!.issues).toMatchInlineSnapshot(`
-    [
-      {
-        "code": "invalid_type",
-        "expected": "nonoptional",
-        "message": "Invalid input: expected nonoptional, received undefined",
-        "path": [
-          "d",
-        ],
-      },
-    ]
+  expect(mySchema.parse({}, { jitless: true })).toMatchInlineSnapshot(`
+    {
+      "b": "default value",
+      "c": "prefault value",
+      "d": "catch value",
+      "e": "default value",
+      "f": "prefault value",
+    }
   `);
 
   expect(mySchema.parse({ d: undefined })).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1759,7 +1759,7 @@ function handlePropertyResult(
     final.issues.push(...util.prefixIssues(key, result.issues));
   }
 
-  if (!isPresent && !isOptionalIn) {
+  if (!isPresent && !isOptionalIn && result.value === undefined) {
     if (!result.issues.length) {
       final.issues.push({
         code: "invalid_type",
@@ -2040,7 +2040,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
             path: iss.path ? [${k}, ...iss.path] : [${k}]
           })));
         }
-        if (!${id}_present && !${id}.issues.length) {
+        if (!${id}_present && !${id}.issues.length && ${id}.value === undefined) {
           payload.issues.push({
             code: "invalid_type",
             expected: "nonoptional",
@@ -2049,7 +2049,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
           });
         }
 
-        if (${id}_present) {
+        if (${id}_present || ${id}.value !== undefined) {
           if (${id}.value === undefined) {
             newResult[${k}] = undefined;
           } else {


### PR DESCRIPTION
Closes #5937. Alternative to #5939.

In v4.4.0, [`fd0f83d1`](https://github.com/colinhacks/zod/commit/fd0f83d1) tightened `$ZodObject` to synthesize a `nonoptional` issue whenever a key is absent and its schema's `optin !== "optional"`. That regression broke patterns like `z.preprocess(...).catch([])` and bare `z.X.catch(c)` on object fields, even though their inner runs return a defined value when called with `undefined`.

The fix is one extra clause in the synthesis condition:

```diff
- if (!isPresent && !isOptionalIn) {
+ if (!isPresent && !isOptionalIn && result.value === undefined) {
```

If the schema produced a value for an absent key, trust it. Strictness for genuinely-undefined producers (`z.undefined()`, `z.union([..., z.undefined()])`) is preserved — their `result.value` is still `undefined`. The JIT object codegen mirrors the same change.

`$ZodCatch`, `$ZodOptional`, `ParsePayload`, and `handleOptionalResult` are untouched. `optional<catch>(undefined)` continues to short-circuit through `$ZodOptional`'s branch B because `catch.optin` stays deferred to `inner.optin`, so optional preempts catch entirely on undefined input — no extra coordination needed.

### Behavior matrix (`parse({})`)

| Schema for `a` | Result |
|---|---|
| `z.string()` | issue (`invalid_type` from `string`) |
| `z.string().optional()` | `{}` |
| `z.string().catch("c")` | `{ a: "c" }` |
| `z.preprocess(v => v ? v : [], z.array(z.string())).catch([])` | `{ a: [] }` |
| `z.string().default("d")` | `{ a: "d" }` |
| `z.undefined()` | `nonoptional` issue |
| `z.union([z.string(), z.undefined()])` | `nonoptional` issue |
| `z.string().transform(...).pipe(z.string().optional())` | issue (string fails) |

### vs #5939

That PR addresses the same issue by marking `catch.optin = "optional"` and threading a `caught` flag through `ParsePayload` so that `$ZodOptional` can override the catch value with `undefined`. This PR achieves the same runtime semantics with a single object-parser relaxation, no payload field, and no changes to `$ZodOptional` or `$ZodCatch`. Trade-off: this PR doesn't address [#4768](https://github.com/colinhacks/zod/issues/4768) (JSON Schema marking `.catch()` fields as `required` in input mode) — that would need a separate one-line carve-out in `json-schema-processors.ts`.