### PR TITLE
fix(v3): correct seconds quantifier scope in time/datetime regex

### DIFF
--- a/packages/zod/src/v3/tests/string.test.ts
+++ b/packages/zod/src/v3/tests/string.test.ts
@@ -625,6 +625,7 @@ test("datetime parsing", () => {
   expect(() => datetime3Ms.parse("1970-01-01T00:00:00.12Z")).toThrow();
   expect(() => datetime3Ms.parse("2022-10-13T09:52:31Z")).toThrow();
   expect(() => datetime3Ms.parse("2022-10-13T09:52Z")).toThrow();
+  expect(() => datetime3Ms.parse("2022-10-13T09:52:31.123:31.456Z")).toThrow();
 
   const datetimeOffset = z.string().datetime({ offset: true });
   datetimeOffset.parse("1970-01-01T00:00:00.000Z");
@@ -763,6 +764,7 @@ test("time parsing", () => {
   expect(() => time2.parse("00:00:00.000")).toThrow();
   expect(() => time2.parse("00:00:00.00+00:00")).toThrow();
   expect(() => time2.parse("23:59")).toThrow();
+  expect(() => time2.parse("10:20:30.12:31.45")).toThrow();
 
   // const time3 = z.string().time({ offset: true });
   // time3.parse("00:00:00Z");

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -657,8 +657,9 @@ function timeRegexSource(args: { precision?: number | null }) {
     secondsRegexSource = `${secondsRegexSource}(\\.\\d+)?`;
   }
 
-  const secondsQuantifier = args.precision ? "+" : "?"; // require seconds if precision is nonzero
-  return `([01]\\d|2[0-3]):[0-5]\\d(:${secondsRegexSource})${secondsQuantifier}`;
+  // require seconds if precision is nonzero
+  const secondsPart = args.precision ? `:${secondsRegexSource}` : `(:${secondsRegexSource})?`;
+  return `([01]\\d|2[0-3]):[0-5]\\d${secondsPart}`;
 }
 
 function timeRegex(args: {


### PR DESCRIPTION
In `timeRegexSource`, when `precision` was non-zero the `+` quantifier was applied to the entire `(:${secondsRegexSource})` group, letting the `:ss[.fff]` segment — colon included — repeat. As a result, strings like `"2022-10-13T09:52:31.123:31.456Z"` were accepted by `z.string().datetime({ precision: 3 })`, and `"10:20:30.12:31.45"` by `z.string().time({ precision: 2 })`.

This drops the quantifier and inlines the seconds segment directly: when `precision` is set, the seconds portion is required and matched exactly once; otherwise it stays optional. Behavior for `precision` omitted and `precision: 0` is unchanged — the latter is intentional, as existing tests such as `datetimeNoMs.parse("2022-10-13T09:52Z")` already pin that shape.

The quantifier-scope issue is already absent in v4 — `timeSource` in `packages/zod/src/v4/core/regexes.ts` inlines the seconds segment without a repeating group — so this brings v3 in line on that specific point. (`precision: 0` semantics still differ between v3 and v4 and aren't touched here.)

Added two regression cases covering the previously-accepted repeating inputs (one in `time parsing`, one in `datetime parsing`).