### PR TITLE
fix(v4): make wrapper internals recursion-safe (#4611)

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2056,9 +2056,10 @@ export function transform<I = unknown, O = I>(
 
 // ZodOptional
 export interface ZodOptional<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodOptionalInternals<T>>,
+  extends _ZodType<core.$ZodOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodOptional<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
 }
 export const ZodOptional: core.$constructor<ZodOptional> = /*@__PURE__*/ core.$constructor(
@@ -2081,9 +2082,10 @@ export function optional<T extends core.SomeType>(innerType: T): ZodOptional<T> 
 
 // ZodExactOptional
 export interface ZodExactOptional<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodExactOptionalInternals<T>>,
+  extends _ZodType<core.$ZodExactOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodExactOptional<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodExactOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
 }
 export const ZodExactOptional: core.$constructor<ZodExactOptional> = /*@__PURE__*/ core.$constructor(
@@ -2106,9 +2108,10 @@ export function exactOptional<T extends core.SomeType>(innerType: T): ZodExactOp
 
 // ZodNullable
 export interface ZodNullable<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodNullableInternals<T>>,
+  extends _ZodType<core.$ZodNullableInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodNullable<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodNullableInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
 }
 export const ZodNullable: core.$constructor<ZodNullable> = /*@__PURE__*/ core.$constructor(
@@ -2136,9 +2139,10 @@ export function nullish<T extends core.SomeType>(innerType: T): ZodOptional<ZodN
 
 // ZodDefault
 export interface ZodDefault<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodDefaultInternals<T>>,
+  extends _ZodType<core.$ZodDefaultInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodDefault<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodDefaultInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
   /** @deprecated Use `.unwrap()` instead. */
   removeDefault(): T;
@@ -2167,9 +2171,10 @@ export function _default<T extends core.SomeType>(
 
 // ZodPrefault
 export interface ZodPrefault<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodPrefaultInternals<T>>,
+  extends _ZodType<core.$ZodPrefaultInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodPrefault<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodPrefaultInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
 }
 export const ZodPrefault: core.$constructor<ZodPrefault> = /*@__PURE__*/ core.$constructor(
@@ -2197,9 +2202,10 @@ export function prefault<T extends core.SomeType>(
 
 // ZodNonOptional
 export interface ZodNonOptional<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodNonOptionalInternals<T>>,
+  extends _ZodType<core.$ZodNonOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodNonOptional<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodNonOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
 }
 export const ZodNonOptional: core.$constructor<ZodNonOptional> = /*@__PURE__*/ core.$constructor(
@@ -2226,9 +2232,10 @@ export function nonoptional<T extends core.SomeType>(
 
 // ZodSuccess
 export interface ZodSuccess<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodSuccessInternals<T>>,
+  extends _ZodType<core.$ZodSuccessInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodSuccess<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodSuccessInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
 }
 export const ZodSuccess: core.$constructor<ZodSuccess> = /*@__PURE__*/ core.$constructor("ZodSuccess", (inst, def) => {
@@ -2248,9 +2255,10 @@ export function success<T extends core.SomeType>(innerType: T): ZodSuccess<T> {
 
 // ZodCatch
 export interface ZodCatch<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodCatchInternals<T>>,
+  extends _ZodType<core.$ZodCatchInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodCatch<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodCatchInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
   /** @deprecated Use `.unwrap()` instead. */
   removeCatch(): T;
@@ -2294,9 +2302,10 @@ export function nan(params?: string | core.$ZodNaNParams): ZodNaN {
 
 // ZodPipe
 export interface ZodPipe<A extends core.SomeType = core.$ZodType, B extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodPipeInternals<A, B>>,
+  extends _ZodType<core.$ZodPipeInternals<A, B, core.$ZodPipeMetadataExact<A, B>>>,
     core.$ZodPipe<A, B> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodPipeInternals<A, B, core.$ZodPipeMetadataExact<A, B>>;
   in: A;
   out: B;
 }
@@ -2327,7 +2336,7 @@ export interface ZodCodec<A extends core.SomeType = core.$ZodType, B extends cor
   extends ZodPipe<A, B>,
     core.$ZodCodec<A, B> {
   "~standard": ZodStandardSchemaWithJSON<this>;
-  _zod: core.$ZodCodecInternals<A, B>;
+  _zod: core.$ZodCodecInternals<A, B, core.$ZodPipeMetadataExact<A, B>>;
   def: core.$ZodCodecDef<A, B>;
 }
 export const ZodCodec: core.$constructor<ZodCodec> = /*@__PURE__*/ core.$constructor("ZodCodec", (inst, def) => {
@@ -2368,7 +2377,7 @@ export interface ZodPreprocess<B extends core.SomeType = core.$ZodType>
   extends ZodPipe<core.$ZodTransform, B>,
     core.$ZodPreprocess<B> {
   "~standard": ZodStandardSchemaWithJSON<this>;
-  _zod: core.$ZodPreprocessInternals<B>;
+  _zod: core.$ZodPreprocessInternals<B, core.$ZodWrapperMetadataExact<B>>;
   def: core.$ZodPreprocessDef<B>;
 }
 export const ZodPreprocess: core.$constructor<ZodPreprocess> = /*@__PURE__*/ core.$constructor(
@@ -2381,9 +2390,10 @@ export const ZodPreprocess: core.$constructor<ZodPreprocess> = /*@__PURE__*/ cor
 
 // ZodReadonly
 export interface ZodReadonly<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodReadonlyInternals<T>>,
+  extends _ZodType<core.$ZodReadonlyInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodReadonly<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodReadonlyInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
 }
 export const ZodReadonly: core.$constructor<ZodReadonly> = /*@__PURE__*/ core.$constructor(
@@ -2432,9 +2442,10 @@ export function templateLiteral<const Parts extends core.$ZodTemplateLiteralPart
 
 // ZodLazy
 export interface ZodLazy<T extends core.SomeType = core.$ZodType>
-  extends _ZodType<core.$ZodLazyInternals<T>>,
+  extends _ZodType<core.$ZodLazyInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodLazy<T> {
   "~standard": ZodStandardSchemaWithJSON<this>;
+  _zod: core.$ZodLazyInternals<T, core.$ZodWrapperMetadataExact<T>>;
   unwrap(): T;
 }
 export const ZodLazy: core.$constructor<ZodLazy> = /*@__PURE__*/ core.$constructor("ZodLazy", (inst, def) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3461,19 +3461,25 @@ export interface $ZodOptionalDef<T extends SomeType = $ZodType> extends $ZodType
   innerType: T;
 }
 
-export interface $ZodOptionalInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<core.output<T> | undefined, core.input<T> | undefined> {
+export interface $ZodOptionalInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<core.output<T> | undefined, core.input<T> | undefined> {
   def: $ZodOptionalDef<T>;
   optin: "optional";
   optout: "optional";
   isst: never;
-  values: T["_zod"]["values"];
-  pattern: T["_zod"]["pattern"];
+  values: Meta["values"];
+  pattern: Meta["pattern"];
 }
 
 export interface $ZodOptional<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodOptionalInternals<T>;
 }
+
+export type $ZodOptionalExact<T extends SomeType = $ZodType> = $ZodOptional<T> & {
+  _zod: $ZodOptionalInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 function handleOptionalResult(result: ParsePayload, input: unknown) {
   if (input === undefined && (result.issues.length || result.fallback)) {
@@ -3524,7 +3530,10 @@ export const $ZodOptional: core.$constructor<$ZodOptional> = /*@__PURE__*/ core.
 export interface $ZodExactOptionalDef<T extends SomeType = $ZodType> extends $ZodOptionalDef<T> {}
 
 // Internals extends $ZodOptionalInternals but narrows output/input types (removes | undefined)
-export interface $ZodExactOptionalInternals<T extends SomeType = $ZodType> extends $ZodOptionalInternals<T> {
+export interface $ZodExactOptionalInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodOptionalInternals<T, Meta> {
   def: $ZodExactOptionalDef<T>;
   output: core.output<T>; // NO | undefined (narrowed from parent)
   input: core.input<T>; // NO | undefined (narrowed from parent)
@@ -3533,6 +3542,10 @@ export interface $ZodExactOptionalInternals<T extends SomeType = $ZodType> exten
 export interface $ZodExactOptional<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodExactOptionalInternals<T>;
 }
+
+export type $ZodExactOptionalExact<T extends SomeType = $ZodType> = $ZodExactOptional<T> & {
+  _zod: $ZodExactOptionalInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodExactOptional: core.$constructor<$ZodExactOptional> = /*@__PURE__*/ core.$constructor(
   "$ZodExactOptional",
@@ -3563,19 +3576,25 @@ export interface $ZodNullableDef<T extends SomeType = $ZodType> extends $ZodType
   innerType: T;
 }
 
-export interface $ZodNullableInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<core.output<T> | null, core.input<T> | null> {
+export interface $ZodNullableInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<core.output<T> | null, core.input<T> | null> {
   def: $ZodNullableDef<T>;
-  optin: T["_zod"]["optin"];
-  optout: T["_zod"]["optout"];
+  optin: Meta["optin"];
+  optout: Meta["optout"];
   isst: never;
-  values: T["_zod"]["values"];
-  pattern: T["_zod"]["pattern"];
+  values: Meta["values"];
+  pattern: Meta["pattern"];
 }
 
 export interface $ZodNullable<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodNullableInternals<T>;
 }
+
+export type $ZodNullableExact<T extends SomeType = $ZodType> = $ZodNullable<T> & {
+  _zod: $ZodNullableInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodNullable: core.$constructor<$ZodNullable> = /*@__PURE__*/ core.$constructor(
   "$ZodNullable",
@@ -3616,18 +3635,24 @@ export interface $ZodDefaultDef<T extends SomeType = $ZodType> extends $ZodTypeD
   defaultValue: util.NoUndefined<core.output<T>>;
 }
 
-export interface $ZodDefaultInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, core.input<T> | undefined> {
+export interface $ZodDefaultInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, core.input<T> | undefined> {
   def: $ZodDefaultDef<T>;
   optin: "optional";
   optout?: "optional" | undefined; // required
   isst: never;
-  values: T["_zod"]["values"];
+  values: Meta["values"];
 }
 
 export interface $ZodDefault<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodDefaultInternals<T>;
 }
+
+export type $ZodDefaultExact<T extends SomeType = $ZodType> = $ZodDefault<T> & {
+  _zod: $ZodDefaultInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodDefault: core.$constructor<$ZodDefault> = /*@__PURE__*/ core.$constructor(
   "$ZodDefault",
@@ -3683,18 +3708,24 @@ export interface $ZodPrefaultDef<T extends SomeType = $ZodType> extends $ZodType
   defaultValue: core.input<T>;
 }
 
-export interface $ZodPrefaultInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, core.input<T> | undefined> {
+export interface $ZodPrefaultInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, core.input<T> | undefined> {
   def: $ZodPrefaultDef<T>;
   optin: "optional";
   optout?: "optional" | undefined;
   isst: never;
-  values: T["_zod"]["values"];
+  values: Meta["values"];
 }
 
 export interface $ZodPrefault<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodPrefaultInternals<T>;
 }
+
+export type $ZodPrefaultExact<T extends SomeType = $ZodType> = $ZodPrefault<T> & {
+  _zod: $ZodPrefaultInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodPrefault: core.$constructor<$ZodPrefault> = /*@__PURE__*/ core.$constructor(
   "$ZodPrefault",
@@ -3730,11 +3761,13 @@ export interface $ZodNonOptionalDef<T extends SomeType = $ZodType> extends $ZodT
   innerType: T;
 }
 
-export interface $ZodNonOptionalInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, util.NoUndefined<core.input<T>>> {
+export interface $ZodNonOptionalInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, util.NoUndefined<core.input<T>>> {
   def: $ZodNonOptionalDef<T>;
   isst: errors.$ZodIssueInvalidType;
-  values: T["_zod"]["values"];
+  values: Meta["values"];
   optin: "optional" | undefined;
   optout: "optional" | undefined;
 }
@@ -3742,6 +3775,10 @@ export interface $ZodNonOptionalInternals<T extends SomeType = $ZodType>
 export interface $ZodNonOptional<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodNonOptionalInternals<T>;
 }
+
+export type $ZodNonOptionalExact<T extends SomeType = $ZodType> = $ZodNonOptional<T> & {
+  _zod: $ZodNonOptionalInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodNonOptional: core.$constructor<$ZodNonOptional> = /*@__PURE__*/ core.$constructor(
   "$ZodNonOptional",
@@ -3827,16 +3864,23 @@ export interface $ZodSuccessDef<T extends SomeType = $ZodType> extends $ZodTypeD
   innerType: T;
 }
 
-export interface $ZodSuccessInternals<T extends SomeType = $ZodType> extends $ZodTypeInternals<boolean, core.input<T>> {
+export interface $ZodSuccessInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<boolean, core.input<T>> {
   def: $ZodSuccessDef<T>;
   isst: never;
-  optin: T["_zod"]["optin"];
+  optin: Meta["optin"];
   optout: "optional" | undefined;
 }
 
 export interface $ZodSuccess<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodSuccessInternals<T>;
 }
+
+export type $ZodSuccessExact<T extends SomeType = $ZodType> = $ZodSuccess<T> & {
+  _zod: $ZodSuccessInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodSuccess: core.$constructor<$ZodSuccess> = /*@__PURE__*/ core.$constructor(
   "$ZodSuccess",
@@ -3880,18 +3924,24 @@ export interface $ZodCatchDef<T extends SomeType = $ZodType> extends $ZodTypeDef
   catchValue: (ctx: $ZodCatchCtx) => unknown;
 }
 
-export interface $ZodCatchInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<core.output<T>, core.input<T>> {
+export interface $ZodCatchInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<core.output<T>, core.input<T>> {
   def: $ZodCatchDef<T>;
-  optin: T["_zod"]["optin"];
-  optout: T["_zod"]["optout"];
+  optin: Meta["optin"];
+  optout: Meta["optout"];
   isst: never;
-  values: T["_zod"]["values"];
+  values: Meta["values"];
 }
 
 export interface $ZodCatch<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodCatchInternals<T>;
 }
+
+export type $ZodCatchExact<T extends SomeType = $ZodType> = $ZodCatch<T> & {
+  _zod: $ZodCatchInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$constructor("$ZodCatch", (inst, def) => {
   $ZodType.init(inst, def);
@@ -3997,19 +4047,60 @@ export interface $ZodPipeDef<A extends SomeType = $ZodType, B extends SomeType =
   reverseTransform?: (value: core.input<B>, payload: ParsePayload<core.input<B>>) => util.MaybeAsync<core.output<A>>;
 }
 
-export interface $ZodPipeInternals<A extends SomeType = $ZodType, B extends SomeType = $ZodType>
-  extends $ZodTypeInternals<core.output<B>, core.input<A>> {
-  def: $ZodPipeDef<A, B>;
-  isst: never;
+/** Recursion-safe wrapper metadata. The fields use the same broad shapes as
+ * `$ZodTypeInternals`, so they don't force evaluation of an inner `T["_zod"]`,
+ * which would expand forever for self-referential aliases. See #4611. */
+export type $ZodWrapperMetadataBase = {
+  values?: util.PrimitiveSet | undefined;
+  optin?: "optional" | undefined;
+  optout?: "optional" | undefined;
+  propValues?: util.PropValues | undefined;
+  pattern?: RegExp | undefined;
+};
+
+/** Exact wrapper metadata bubbled up from the wrapped schema. Used by
+ * classic/mini where the precise metadata is needed for downstream type math. */
+export type $ZodWrapperMetadataExact<T extends SomeType> = {
+  values: T["_zod"]["values"];
+  optin: T["_zod"]["optin"];
+  optout: T["_zod"]["optout"];
+  propValues: T["_zod"]["propValues"];
+  pattern: T["_zod"]["pattern"];
+};
+
+/** Exact pipe/codec metadata bubbled up from the wrapped schemas. Used by
+ * classic/mini where the precise metadata is needed for downstream type math. */
+export type $ZodPipeMetadataExact<A extends SomeType, B extends SomeType> = {
   values: A["_zod"]["values"];
   optin: A["_zod"]["optin"];
   optout: B["_zod"]["optout"];
   propValues: A["_zod"]["propValues"];
+};
+
+/** @deprecated Alias retained so external code that imported the pipe-only
+ * name keeps compiling. Prefer `$ZodWrapperMetadataBase`. */
+export type $ZodPipeMetadataBase = $ZodWrapperMetadataBase;
+
+export interface $ZodPipeInternals<
+  A extends SomeType = $ZodType,
+  B extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<core.output<B>, core.input<A>> {
+  def: $ZodPipeDef<A, B>;
+  isst: never;
+  values: Meta["values"];
+  optin: Meta["optin"];
+  optout: Meta["optout"];
+  propValues: Meta["propValues"];
 }
 
 export interface $ZodPipe<A extends SomeType = $ZodType, B extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodPipeInternals<A, B>;
 }
+
+export type $ZodPipeExact<A extends SomeType = $ZodType, B extends SomeType = $ZodType> = $ZodPipe<A, B> & {
+  _zod: $ZodPipeInternals<A, B, $ZodPipeMetadataExact<A, B>>;
+};
 
 export const $ZodPipe: core.$constructor<$ZodPipe> = /*@__PURE__*/ core.$constructor("$ZodPipe", (inst, def) => {
   $ZodType.init(inst, def);
@@ -4056,19 +4147,26 @@ export interface $ZodCodecDef<A extends SomeType = $ZodType, B extends SomeType 
   reverseTransform: (value: core.input<B>, payload: ParsePayload<core.input<B>>) => util.MaybeAsync<core.output<A>>;
 }
 
-export interface $ZodCodecInternals<A extends SomeType = $ZodType, B extends SomeType = $ZodType>
-  extends $ZodTypeInternals<core.output<B>, core.input<A>> {
+export interface $ZodCodecInternals<
+  A extends SomeType = $ZodType,
+  B extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<core.output<B>, core.input<A>> {
   def: $ZodCodecDef<A, B>;
   isst: never;
-  values: A["_zod"]["values"];
-  optin: A["_zod"]["optin"];
-  optout: B["_zod"]["optout"];
-  propValues: A["_zod"]["propValues"];
+  values: Meta["values"];
+  optin: Meta["optin"];
+  optout: Meta["optout"];
+  propValues: Meta["propValues"];
 }
 
 export interface $ZodCodec<A extends SomeType = $ZodType, B extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodCodecInternals<A, B>;
 }
+
+export type $ZodCodecExact<A extends SomeType = $ZodType, B extends SomeType = $ZodType> = $ZodCodec<A, B> & {
+  _zod: $ZodCodecInternals<A, B, $ZodPipeMetadataExact<A, B>>;
+};
 
 export const $ZodCodec: core.$constructor<$ZodCodec> = /*@__PURE__*/ core.$constructor("$ZodCodec", (inst, def) => {
   $ZodType.init(inst, def);
@@ -4141,15 +4239,22 @@ export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPi
   out: B;
 }
 
-export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodTransform, B> {
+export interface $ZodPreprocessInternals<
+  B extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodPipeInternals<$ZodTransform, B, Meta> {
   def: $ZodPreprocessDef<B>;
-  optin: B["_zod"]["optin"];
-  optout: B["_zod"]["optout"];
+  optin: Meta["optin"];
+  optout: Meta["optout"];
 }
 
 export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodTransform, B> {
   _zod: $ZodPreprocessInternals<B>;
 }
+
+export type $ZodPreprocessExact<B extends SomeType = $ZodType> = $ZodPreprocess<B> & {
+  _zod: $ZodPreprocessInternals<B, $ZodWrapperMetadataExact<B>>;
+};
 
 export const $ZodPreprocess: core.$constructor<$ZodPreprocess> = /*@__PURE__*/ core.$constructor(
   "$ZodPreprocess",
@@ -4171,19 +4276,25 @@ export interface $ZodReadonlyDef<T extends SomeType = $ZodType> extends $ZodType
   innerType: T;
 }
 
-export interface $ZodReadonlyInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<util.MakeReadonly<core.output<T>>, util.MakeReadonly<core.input<T>>> {
+export interface $ZodReadonlyInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<util.MakeReadonly<core.output<T>>, util.MakeReadonly<core.input<T>>> {
   def: $ZodReadonlyDef<T>;
-  optin: T["_zod"]["optin"];
-  optout: T["_zod"]["optout"];
+  optin: Meta["optin"];
+  optout: Meta["optout"];
   isst: never;
-  propValues: T["_zod"]["propValues"];
-  values: T["_zod"]["values"];
+  propValues: Meta["propValues"];
+  values: Meta["values"];
 }
 
 export interface $ZodReadonly<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodReadonlyInternals<T>;
 }
+
+export type $ZodReadonlyExact<T extends SomeType = $ZodType> = $ZodReadonly<T> & {
+  _zod: $ZodReadonlyInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodReadonly: core.$constructor<$ZodReadonly> = /*@__PURE__*/ core.$constructor(
   "$ZodReadonly",
@@ -4557,21 +4668,27 @@ export interface $ZodLazyDef<T extends SomeType = $ZodType> extends $ZodTypeDef 
   getter: () => T;
 }
 
-export interface $ZodLazyInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<core.output<T>, core.input<T>> {
+export interface $ZodLazyInternals<
+  T extends SomeType = $ZodType,
+  Meta extends $ZodWrapperMetadataBase = $ZodWrapperMetadataBase,
+> extends $ZodTypeInternals<core.output<T>, core.input<T>> {
   def: $ZodLazyDef<T>;
   isst: never;
   /** Auto-cached way to retrieve the inner schema */
   innerType: T;
-  pattern: T["_zod"]["pattern"];
-  propValues: T["_zod"]["propValues"];
-  optin: T["_zod"]["optin"];
-  optout: T["_zod"]["optout"];
+  pattern: Meta["pattern"];
+  propValues: Meta["propValues"];
+  optin: Meta["optin"];
+  optout: Meta["optout"];
 }
 
 export interface $ZodLazy<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodLazyInternals<T>;
 }
+
+export type $ZodLazyExact<T extends SomeType = $ZodType> = $ZodLazy<T> & {
+  _zod: $ZodLazyInternals<T, $ZodWrapperMetadataExact<T>>;
+};
 
 export const $ZodLazy: core.$constructor<$ZodLazy> = /*@__PURE__*/ core.$constructor("$ZodLazy", (inst, def) => {
   $ZodType.init(inst, def);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4077,10 +4077,6 @@ export type $ZodPipeMetadataExact<A extends SomeType, B extends SomeType> = {
   propValues: A["_zod"]["propValues"];
 };
 
-/** @deprecated Alias retained so external code that imported the pipe-only
- * name keeps compiling. Prefer `$ZodWrapperMetadataBase`. */
-export type $ZodPipeMetadataBase = $ZodWrapperMetadataBase;
-
 export interface $ZodPipeInternals<
   A extends SomeType = $ZodType,
   B extends SomeType = $ZodType,

--- a/packages/zod/src/v4/core/tests/recursive-pipe.test.ts
+++ b/packages/zod/src/v4/core/tests/recursive-pipe.test.ts
@@ -1,0 +1,121 @@
+import { test } from "vitest";
+import type {
+  $ZodCatch,
+  $ZodDefault,
+  $ZodLazy,
+  $ZodNonOptional,
+  $ZodNullable,
+  $ZodOptional,
+  $ZodPipe,
+  $ZodPipeExact,
+  $ZodPipeMetadataExact,
+  $ZodPrefault,
+  $ZodPreprocess,
+  $ZodReadonly,
+  $ZodString,
+  $ZodSuccess,
+  $ZodTransform,
+  $ZodWrapperMetadataExact,
+} from "zod/v4/core";
+
+// Regression test for #4611: a recursive type alias that includes a `$ZodPipe`
+// node used to fail with "Type instantiation is excessively deep and possibly
+// infinite" because `$ZodPipeInternals` referenced `A["_zod"]["values"]` etc.
+// directly. The default `$ZodPipe<A, B>` now uses recursion-safe metadata.
+test("recursive $ZodPipe alias (#4611)", () => {
+  type Foo = $ZodPipe<Bar, $ZodTransform>;
+  type Bar = $ZodString | Foo;
+
+  const _foo = null as unknown as Foo;
+  const _bar = null as unknown as Bar;
+  void _foo;
+  void _bar;
+});
+
+// `$ZodPipeExact` keeps the precise metadata used by classic/mini for input/
+// output optionality math. Asserting against the exact field types prevents
+// accidental widening of the exact view back to the recursion-safe defaults.
+test("$ZodPipeExact preserves exact bubbled metadata", () => {
+  type Exact = $ZodPipeExact<$ZodString, $ZodTransform>;
+  type Meta = $ZodPipeMetadataExact<$ZodString, $ZodTransform>;
+
+  const _optin = null as unknown as Exact["_zod"]["optin"] satisfies Meta["optin"];
+  const _optout = null as unknown as Exact["_zod"]["optout"] satisfies Meta["optout"];
+  const _values = null as unknown as Exact["_zod"]["values"] satisfies Meta["values"];
+  void _optin;
+  void _optout;
+  void _values;
+});
+
+// Schema-hub-style recursion: a `FieldSchema` alias that mixes `$ZodPipe` with
+// the other wrappers (lazy/nullable/readonly). All of these wrappers bubble
+// inner-type metadata via the same `Meta` parameter pattern, so the alias
+// resolves without TS2589.
+test("recursive pipe inside wrapper union (#4611, full)", () => {
+  type Wrapped =
+    | $ZodLazy<FieldSchema>
+    | $ZodNullable<FieldSchema>
+    | $ZodPipe<FieldSchema, $ZodTransform>
+    | $ZodReadonly<FieldSchema>;
+
+  type FieldSchema = $ZodString | Wrapped;
+
+  const _w = null as unknown as Wrapped;
+  const _f = null as unknown as FieldSchema;
+  void _w;
+  void _f;
+});
+
+// Per-wrapper recursion-safety: a self-referential alias `T = $ZodString |
+// $ZodWrapper<T>` must compile for every wrapper that bubbles inner-type
+// metadata. If any of these regress to the old `T["_zod"][...]` shape, the
+// corresponding alias here trips TS2589 and fails typecheck.
+//
+// `$ZodExactOptional` is intentionally omitted: it narrows
+// `output: core.output<T>` against its parent's `output: core.output<T> |
+// undefined`, and that narrowing redeclaration forces TS to eagerly resolve
+// `T["_zod"]` regardless of the wrapper-metadata shape. That recursion limit
+// is independent of #4611 and exists on `main`.
+test("recursive alias compiles for every wrapper", () => {
+  type _ZodOptional = $ZodString | $ZodOptional<_ZodOptional>;
+  type _ZodNullable = $ZodString | $ZodNullable<_ZodNullable>;
+  type _ZodDefault = $ZodString | $ZodDefault<_ZodDefault>;
+  type _ZodPrefault = $ZodString | $ZodPrefault<_ZodPrefault>;
+  type _ZodNonOptional = $ZodString | $ZodNonOptional<_ZodNonOptional>;
+  type _ZodSuccess = $ZodString | $ZodSuccess<_ZodSuccess>;
+  type _ZodCatch = $ZodString | $ZodCatch<_ZodCatch>;
+  type _ZodReadonly = $ZodString | $ZodReadonly<_ZodReadonly>;
+  type _ZodLazy = $ZodString | $ZodLazy<_ZodLazy>;
+  type _ZodPipe = $ZodString | $ZodPipe<_ZodPipe, $ZodTransform>;
+  type _ZodPreprocess = $ZodString | $ZodPreprocess<_ZodPreprocess>;
+
+  void (null as unknown as _ZodOptional);
+  void (null as unknown as _ZodNullable);
+  void (null as unknown as _ZodDefault);
+  void (null as unknown as _ZodPrefault);
+  void (null as unknown as _ZodNonOptional);
+  void (null as unknown as _ZodSuccess);
+  void (null as unknown as _ZodCatch);
+  void (null as unknown as _ZodReadonly);
+  void (null as unknown as _ZodLazy);
+  void (null as unknown as _ZodPipe);
+  void (null as unknown as _ZodPreprocess);
+});
+
+// `$ZodWrapperMetadataExact<T>` powers the exact-metadata variants of every
+// wrapper. Lock in that the exact metadata still resolves to the inner
+// `T["_zod"][...]` types — that's what classic/mini rely on.
+test("$ZodWrapperMetadataExact mirrors the inner schema metadata", () => {
+  type Exact = $ZodWrapperMetadataExact<$ZodString>;
+
+  const _values = null as unknown as Exact["values"] satisfies $ZodString["_zod"]["values"];
+  const _optin = null as unknown as Exact["optin"] satisfies $ZodString["_zod"]["optin"];
+  const _optout = null as unknown as Exact["optout"] satisfies $ZodString["_zod"]["optout"];
+  const _propValues = null as unknown as Exact["propValues"] satisfies $ZodString["_zod"]["propValues"];
+  const _pattern = null as unknown as Exact["pattern"] satisfies $ZodString["_zod"]["pattern"];
+  void _values;
+  void _optin;
+  void _optout;
+  void _propValues;
+  void _pattern;
+});

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1390,9 +1390,9 @@ export function transform<I = unknown, O = I>(
 
 // ZodMiniOptional
 export interface ZodMiniOptional<T extends SomeType = core.$ZodType>
-  extends _ZodMiniType<core.$ZodOptionalInternals<T>>,
+  extends _ZodMiniType<core.$ZodOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodOptional<T> {
-  // _zod: core.$ZodOptionalInternals<T>;
+  _zod: core.$ZodOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniOptional: core.$constructor<ZodMiniOptional> = /*@__PURE__*/ core.$constructor(
   "ZodMiniOptional",
@@ -1412,9 +1412,9 @@ export function optional<T extends SomeType>(innerType: T): ZodMiniOptional<T> {
 
 // ZodMiniExactOptional
 export interface ZodMiniExactOptional<T extends SomeType = core.$ZodType>
-  extends _ZodMiniType<core.$ZodExactOptionalInternals<T>>,
+  extends _ZodMiniType<core.$ZodExactOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>>,
     core.$ZodExactOptional<T> {
-  // _zod: core.$ZodExactOptionalInternals<T>;
+  _zod: core.$ZodExactOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniExactOptional: core.$constructor<ZodMiniExactOptional> = /*@__PURE__*/ core.$constructor(
   "ZodMiniExactOptional",
@@ -1434,8 +1434,8 @@ export function exactOptional<T extends SomeType>(innerType: T): ZodMiniExactOpt
 
 // ZodMiniNullable
 export interface ZodMiniNullable<T extends SomeType = core.$ZodType>
-  extends _ZodMiniType<core.$ZodNullableInternals<T>> {
-  // _zod: core.$ZodNullableInternals<T>;
+  extends _ZodMiniType<core.$ZodNullableInternals<T, core.$ZodWrapperMetadataExact<T>>> {
+  _zod: core.$ZodNullableInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniNullable: core.$constructor<ZodMiniNullable> = /*@__PURE__*/ core.$constructor(
   "ZodMiniNullable",
@@ -1460,8 +1460,9 @@ export function nullish<T extends SomeType>(innerType: T): ZodMiniOptional<ZodMi
 }
 
 // ZodMiniDefault
-export interface ZodMiniDefault<T extends SomeType = core.$ZodType> extends _ZodMiniType<core.$ZodDefaultInternals<T>> {
-  // _zod: core.$ZodDefaultInternals<T>;
+export interface ZodMiniDefault<T extends SomeType = core.$ZodType>
+  extends _ZodMiniType<core.$ZodDefaultInternals<T, core.$ZodWrapperMetadataExact<T>>> {
+  _zod: core.$ZodDefaultInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniDefault: core.$constructor<ZodMiniDefault> = /*@__PURE__*/ core.$constructor(
   "ZodMiniDefault",
@@ -1487,8 +1488,8 @@ export function _default<T extends SomeType>(
 
 // ZodMiniPrefault
 export interface ZodMiniPrefault<T extends SomeType = core.$ZodType>
-  extends _ZodMiniType<core.$ZodPrefaultInternals<T>> {
-  // _zod: core.$ZodPrefaultInternals<T>;
+  extends _ZodMiniType<core.$ZodPrefaultInternals<T, core.$ZodWrapperMetadataExact<T>>> {
+  _zod: core.$ZodPrefaultInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniPrefault: core.$constructor<ZodMiniPrefault> = /*@__PURE__*/ core.$constructor(
   "ZodMiniPrefault",
@@ -1513,8 +1514,8 @@ export function prefault<T extends SomeType>(
 
 // ZodMiniNonOptional
 export interface ZodMiniNonOptional<T extends SomeType = core.$ZodType>
-  extends _ZodMiniType<core.$ZodNonOptionalInternals<T>> {
-  // _zod: core.$ZodNonOptionalInternals<T>;
+  extends _ZodMiniType<core.$ZodNonOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>> {
+  _zod: core.$ZodNonOptionalInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniNonOptional: core.$constructor<ZodMiniNonOptional> = /*@__PURE__*/ core.$constructor(
   "ZodMiniNonOptional",
@@ -1537,8 +1538,9 @@ export function nonoptional<T extends SomeType>(
 }
 
 // ZodMiniSuccess
-export interface ZodMiniSuccess<T extends SomeType = core.$ZodType> extends _ZodMiniType<core.$ZodSuccessInternals<T>> {
-  // _zod: core.$ZodSuccessInternals<T>;
+export interface ZodMiniSuccess<T extends SomeType = core.$ZodType>
+  extends _ZodMiniType<core.$ZodSuccessInternals<T, core.$ZodWrapperMetadataExact<T>>> {
+  _zod: core.$ZodSuccessInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniSuccess: core.$constructor<ZodMiniSuccess> = /*@__PURE__*/ core.$constructor(
   "ZodMiniSuccess",
@@ -1557,8 +1559,9 @@ export function success<T extends SomeType>(innerType: T): ZodMiniSuccess<T> {
 }
 
 // ZodMiniCatch
-export interface ZodMiniCatch<T extends SomeType = core.$ZodType> extends _ZodMiniType<core.$ZodCatchInternals<T>> {
-  // _zod: core.$ZodCatchInternals<T>;
+export interface ZodMiniCatch<T extends SomeType = core.$ZodType>
+  extends _ZodMiniType<core.$ZodCatchInternals<T, core.$ZodWrapperMetadataExact<T>>> {
+  _zod: core.$ZodCatchInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniCatch: core.$constructor<ZodMiniCatch> = /*@__PURE__*/ core.$constructor(
   "ZodMiniCatch",
@@ -1599,8 +1602,8 @@ export function nan(params?: string | core.$ZodNaNParams): ZodMiniNaN {
 
 // ZodMiniPipe
 export interface ZodMiniPipe<A extends SomeType = core.$ZodType, B extends SomeType = core.$ZodType>
-  extends _ZodMiniType<core.$ZodPipeInternals<A, B>> {
-  // _zod: core.$ZodPipeInternals<A, B>;
+  extends _ZodMiniType<core.$ZodPipeInternals<A, B, core.$ZodPipeMetadataExact<A, B>>> {
+  _zod: core.$ZodPipeInternals<A, B, core.$ZodPipeMetadataExact<A, B>>;
 }
 export const ZodMiniPipe: core.$constructor<ZodMiniPipe> = /*@__PURE__*/ core.$constructor(
   "ZodMiniPipe",
@@ -1626,7 +1629,7 @@ export function pipe<
 export interface ZodMiniCodec<A extends SomeType = core.$ZodType, B extends SomeType = core.$ZodType>
   extends ZodMiniPipe<A, B>,
     core.$ZodCodec<A, B> {
-  _zod: core.$ZodCodecInternals<A, B>;
+  _zod: core.$ZodCodecInternals<A, B, core.$ZodPipeMetadataExact<A, B>>;
   def: core.$ZodCodecDef<A, B>;
 }
 export const ZodMiniCodec: core.$constructor<ZodMiniCodec> = /*@__PURE__*/ core.$constructor(
@@ -1669,8 +1672,8 @@ export function invertCodec<A extends SomeType, B extends SomeType>(codec: ZodMi
 
 // ZodMiniReadonly
 export interface ZodMiniReadonly<T extends SomeType = core.$ZodType>
-  extends _ZodMiniType<core.$ZodReadonlyInternals<T>> {
-  // _zod: core.$ZodReadonlyInternals<T>;
+  extends _ZodMiniType<core.$ZodReadonlyInternals<T, core.$ZodWrapperMetadataExact<T>>> {
+  _zod: core.$ZodReadonlyInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniReadonly: core.$constructor<ZodMiniReadonly> = /*@__PURE__*/ core.$constructor(
   "ZodMiniReadonly",
@@ -1714,8 +1717,9 @@ export function templateLiteral<const Parts extends core.$ZodTemplateLiteralPart
 }
 
 // ZodMiniLazy
-export interface ZodMiniLazy<T extends SomeType = core.$ZodType> extends _ZodMiniType<core.$ZodLazyInternals<T>> {
-  // _zod: core.$ZodLazyInternals<T>;
+export interface ZodMiniLazy<T extends SomeType = core.$ZodType>
+  extends _ZodMiniType<core.$ZodLazyInternals<T, core.$ZodWrapperMetadataExact<T>>> {
+  _zod: core.$ZodLazyInternals<T, core.$ZodWrapperMetadataExact<T>>;
 }
 export const ZodMiniLazy: core.$constructor<ZodMiniLazy> = /*@__PURE__*/ core.$constructor(
   "ZodMiniLazy",


### PR DESCRIPTION
  Closes #4611. Inspired by #5916, but keeps `@zod/core` as the precise generic substrate: each wrapper
  internals takes a `Meta` parameter defaulting to a recursion-safe broad shape, with a
  `$Zod<Wrapper>Exact` variant + `$ZodWrapperMetadataExact<T>` carrying the precise bubbled metadata that
  classic and mini wire in.

  Largely AI-assisted (Claude).
