### PR TITLE
fix: use separate type declarations for ESM and CJS exports

### DIFF
--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -53,63 +53,113 @@
     "./package.json": "./package.json",
     ".": {
       "@zod/source": "./src/index.ts",
-      "types": "./index.d.cts",
-      "import": "./index.js",
-      "require": "./index.cjs"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "require": {
+        "types": "./index.d.cts",
+        "default": "./index.cjs"
+      }
     },
     "./mini": {
       "@zod/source": "./src/mini/index.ts",
-      "types": "./mini/index.d.cts",
-      "import": "./mini/index.js",
-      "require": "./mini/index.cjs"
+      "import": {
+        "types": "./mini/index.d.ts",
+        "default": "./mini/index.js"
+      },
+      "require": {
+        "types": "./mini/index.d.cts",
+        "default": "./mini/index.cjs"
+      }
     },
     "./locales": {
       "@zod/source": "./src/locales/index.ts",
-      "types": "./locales/index.d.cts",
-      "import": "./locales/index.js",
-      "require": "./locales/index.cjs"
+      "import": {
+        "types": "./locales/index.d.ts",
+        "default": "./locales/index.js"
+      },
+      "require": {
+        "types": "./locales/index.d.cts",
+        "default": "./locales/index.cjs"
+      }
     },
     "./v3": {
       "@zod/source": "./src/v3/index.ts",
-      "types": "./v3/index.d.cts",
-      "import": "./v3/index.js",
-      "require": "./v3/index.cjs"
+      "import": {
+        "types": "./v3/index.d.ts",
+        "default": "./v3/index.js"
+      },
+      "require": {
+        "types": "./v3/index.d.cts",
+        "default": "./v3/index.cjs"
+      }
     },
     "./v4": {
       "@zod/source": "./src/v4/index.ts",
-      "types": "./v4/index.d.cts",
-      "import": "./v4/index.js",
-      "require": "./v4/index.cjs"
+      "import": {
+        "types": "./v4/index.d.ts",
+        "default": "./v4/index.js"
+      },
+      "require": {
+        "types": "./v4/index.d.cts",
+        "default": "./v4/index.cjs"
+      }
     },
     "./v4-mini": {
       "@zod/source": "./src/v4-mini/index.ts",
-      "types": "./v4-mini/index.d.cts",
-      "import": "./v4-mini/index.js",
-      "require": "./v4-mini/index.cjs"
+      "import": {
+        "types": "./v4-mini/index.d.ts",
+        "default": "./v4-mini/index.js"
+      },
+      "require": {
+        "types": "./v4-mini/index.d.cts",
+        "default": "./v4-mini/index.cjs"
+      }
     },
     "./v4/mini": {
       "@zod/source": "./src/v4/mini/index.ts",
-      "types": "./v4/mini/index.d.cts",
-      "import": "./v4/mini/index.js",
-      "require": "./v4/mini/index.cjs"
+      "import": {
+        "types": "./v4/mini/index.d.ts",
+        "default": "./v4/mini/index.js"
+      },
+      "require": {
+        "types": "./v4/mini/index.d.cts",
+        "default": "./v4/mini/index.cjs"
+      }
     },
     "./v4/core": {
       "@zod/source": "./src/v4/core/index.ts",
-      "types": "./v4/core/index.d.cts",
-      "import": "./v4/core/index.js",
-      "require": "./v4/core/index.cjs"
+      "import": {
+        "types": "./v4/core/index.d.ts",
+        "default": "./v4/core/index.js"
+      },
+      "require": {
+        "types": "./v4/core/index.d.cts",
+        "default": "./v4/core/index.cjs"
+      }
     },
     "./v4/locales": {
       "@zod/source": "./src/v4/locales/index.ts",
-      "types": "./v4/locales/index.d.cts",
-      "import": "./v4/locales/index.js",
-      "require": "./v4/locales/index.cjs"
+      "import": {
+        "types": "./v4/locales/index.d.ts",
+        "default": "./v4/locales/index.js"
+      },
+      "require": {
+        "types": "./v4/locales/index.d.cts",
+        "default": "./v4/locales/index.cjs"
+      }
     },
     "./v4/locales/*": {
       "@zod/source": "./src/v4/locales/*",
-      "types": "./v4/locales/*",
-      "import": "./v4/locales/*",
-      "require": "./v4/locales/*"
+      "import": {
+        "types": "./v4/locales/*.d.ts",
+        "default": "./v4/locales/*"
+      },
+      "require": {
+        "types": "./v4/locales/*.d.cts",
+        "default": "./v4/locales/*"
+      }
     }
   },
   "repository": {


### PR DESCRIPTION
## Summary

- Fixes #5686: The `exports` field in `packages/zod/package.json` used a single flat `types` condition pointing to `.d.cts` (CJS declarations) for all entry points
- This caused TypeScript to resolve ESM imports to CJS declaration files, resulting in broken type inference (e.g. `z.z.core.$strip` instead of `z.core.$strip`) in ESM projects using `module: "nodenext"`
- This change nests the `types` condition under `import` and `require` sub-conditions so that ESM consumers resolve to `.d.ts` and CJS consumers resolve to `.d.cts`

## Changes

Restructured all export entries in `packages/zod/package.json` from:

```json
".": {
  "types": "./index.d.cts",
  "import": "./index.js",
  "require": "./index.cjs"
}
```

To:

```json
".": {
  "import": {
    "types": "./index.d.ts",
    "default": "./index.js"
  },
  "require": {
    "types": "./index.d.cts",
    "default": "./index.cjs"
  }
}
```

Applied to all entry points: `.`, `./mini`, `./locales`, `./v3`, `./v4`, `./v4-mini`, `./v4/mini`, `./v4/core`, `./v4/locales`, `./v4/locales/*`.

## Test plan

- [ ] Verify `pnpm build` generates both `.d.ts` and `.d.cts` files
- [ ] Verify ESM project with `module: "nodenext"` resolves to `.d.ts`
- [ ] Verify CJS project resolves to `.d.cts`
- [ ] Verify type inference works correctly (`z.object({}).shape` not `z.z.core.$strip`)