### PR TITLE
fix: prevent tree-shaking of locale initialization

### DIFF
--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -10,7 +10,11 @@
   "llmsFull": "https://zod.dev/llms-full.txt",
   "mcpServer": "https://mcp.inkeep.com/zod/mcp",
   "funding": "https://github.com/sponsors/colinhacks",
-  "sideEffects": false,
+  "sideEffects": [
+    "v4/classic/external.js",
+    "v4/classic/external.cjs",
+    "v4/classic/external.mjs"
+  ],
   "files": [
     "src",
     "**/*.js",


### PR DESCRIPTION
## Summary

- Replaced `"sideEffects": false` with an explicit array listing `v4/classic/external.js` (and its CJS/MJS variants) as files with side effects
- This prevents esbuild and similar bundlers from tree-shaking the `config(en())` call that registers the English locale in `v4/classic/external.js`

## Problem

Since Zod 4.4.1, `"sideEffects": false` in `package.json` causes esbuild to tree-shake the locale initialization (`config(en())`), so all validation errors fall back to generic "Invalid input" instead of descriptive locale messages like `'Invalid option: expected one of "km"|"mi"'`.

## Fix

The `sideEffects` field now uses an array to explicitly mark only the files that contain module-level side effects (the locale registration), preserving tree-shaking benefits for all other files.

Closes #5953