### PR TITLE
feat: support passing arguments through .apply() to mapper function

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -206,7 +206,7 @@ export interface ZodType<
    * ```
    */
   isNullable(): boolean;
-  apply<T>(fn: (schema: this) => T): T;
+  apply<T, TArgs extends unknown[] = []>(fn: (schema: this, ...args: TArgs) => T, ...args: TArgs): T;
 }
 
 export interface _ZodType<out Internals extends core.$ZodTypeInternals = core.$ZodTypeInternals>
@@ -351,8 +351,8 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     isNullable() {
       return this.safeParse(null).success;
     },
-    apply(fn) {
-      return fn(this);
+    apply(fn, ...args) {
+      return fn(this, ...args);
     },
   });
   Object.defineProperty(inst, "description", {

--- a/packages/zod/src/v4/classic/tests/apply.test.ts
+++ b/packages/zod/src/v4/classic/tests/apply.test.ts
@@ -57,3 +57,23 @@ test("The callback's return value becomes the apply's return value.", () => {
   expect(result).toBe(symbol);
   expectTypeOf<typeof result>().toEqualTypeOf<symbol>();
 });
+
+test("apply forwards rest arguments to mapper function", () => {
+  const applyWithArgs = (schema: z.ZodNumber, min: number, max: number) => schema.min(min).max(max);
+
+  const schema = z.number().apply(applyWithArgs, 0, 100);
+
+  expect(() => schema.parse(-1)).toThrowError();
+  expect(() => schema.parse(101)).toThrowError();
+  expect(schema.parse(50)).toBe(50);
+  expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<number>();
+});
+
+test("apply with multiple arg types", () => {
+  const transform = (schema: z.ZodString, prefix: string, maxLen: number) => schema.startsWith(prefix).max(maxLen);
+
+  const schema = z.string().apply(transform, "https://", 100);
+
+  expect(() => schema.parse("http://example.com")).toThrowError();
+  expect(schema.parse("https://example.com")).toBe("https://example.com");
+});

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -34,7 +34,7 @@ export interface ZodMiniType<
     data: unknown,
     params?: core.ParseContext<core.$ZodIssue>
   ): Promise<util.SafeParseResult<core.output<this>>>;
-  apply<T>(fn: (schema: this) => T): T;
+  apply<T, TArgs extends unknown[] = []>(fn: (schema: this, ...args: TArgs) => T, ...args: TArgs): T;
 }
 
 interface _ZodMiniType<out Internals extends core.$ZodTypeInternals = core.$ZodTypeInternals>
@@ -78,7 +78,7 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
       reg.add(inst, meta);
       return inst;
     }) as any;
-    inst.apply = (fn) => fn(inst);
+    inst.apply = (fn, ...args) => fn(inst, ...args);
   }
 );
 

--- a/packages/zod/src/v4/mini/tests/apply.test.ts
+++ b/packages/zod/src/v4/mini/tests/apply.test.ts
@@ -22,3 +22,15 @@ test("The callback's return value becomes the apply's return value.", () => {
   expect(result).toBe(symbol);
   expectTypeOf<typeof result>().toEqualTypeOf<symbol>();
 });
+
+test("apply forwards rest arguments to mapper function", () => {
+  const applyWithArgs = (schema: z.ZodMiniNumber, min: number, max: number) =>
+    schema.check(z.minimum(min), z.maximum(max));
+
+  const schema = z.number().apply(applyWithArgs, 0, 100);
+
+  expect(() => z.parse(schema, -1)).toThrowError();
+  expect(() => z.parse(schema, 101)).toThrowError();
+  expect(z.parse(schema, 50)).toBe(50);
+  expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<number>();
+});


### PR DESCRIPTION
## Summary

- Added rest parameter support to the `.apply()` method on `ZodType` (classic) and `ZodMiniType` (mini)
- Users can now pass additional arguments directly through `.apply()` to the mapper function

## Example

```ts
function nullishWithFallback<TSchema extends z.ZodType>(
  schema: TSchema,
  defaultValue: z.output<TSchema>,
) {
  return schema.nullish().transform((x) => x ?? defaultValue);
}

// Before: needed a wrapper lambda
const myObject = z.object({
  id: z.string().apply((x) => nullishWithFallback(x, "default-id")),
});

// After: pass arguments directly
const myObject = z.object({
  id: z.string().apply(nullishWithFallback, "default-id"),
});
```

## Type signature change

```ts
// Before
apply<T>(fn: (schema: this) => T): T;

// After
apply<T, TArgs extends unknown[] = []>(fn: (schema: this, ...args: TArgs) => T, ...args: TArgs): T;
```

The default type parameter `= []` ensures full backward compatibility — existing code without extra arguments continues to work without changes.

Closes #5909