### PR TITLE
fix(v4): keep default locale across the full import chain (alternative to #5954)

### DIFF
--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -10,7 +10,10 @@
   "llmsFull": "https://zod.dev/llms-full.txt",
   "mcpServer": "https://mcp.inkeep.com/zod/mcp",
   "funding": "https://github.com/sponsors/colinhacks",
-  "sideEffects": false,
+  "sideEffects": [
+    "./index.js",
+    "./index.cjs"
+  ],
   "files": [
     "src",
     "**/*.js",

--- a/scripts/write-stub-package-jsons.ts
+++ b/scripts/write-stub-package-jsons.ts
@@ -3,14 +3,25 @@
 import { readdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-const STUB_PACKAGE_JSON_CONTENT = `{ 
+// Files in the import chain to v4/classic/external.js's `config(en())` —
+// every link must be flagged, not just the terminal.
+const SIDE_EFFECTFUL_STUBS: Record<string, readonly string[]> = {
+  v4: ["./index.js", "./index.cjs"],
+  "v4/classic": ["./index.js", "./index.cjs", "./external.js", "./external.cjs"],
+};
+
+function stubFor(dir: string): string {
+  const normalized = dir.split(/[\\/]/).join("/");
+  const sideEffects: false | readonly string[] = SIDE_EFFECTFUL_STUBS[normalized] ?? false;
+  return `{
   "type": "module",
   "main": "./index.cjs",
   "module": "./index.js",
   "types": "./index.d.cts",
-  "sideEffects": false
+  "sideEffects": ${JSON.stringify(sideEffects)}
 }
 `;
+}
 
 /**
  * Recursively find all index.d.cts files in a directory
@@ -76,7 +87,7 @@ function writeStubPackageJsons() {
     const packageJsonPath = join(zodPackageRoot, dir, "package.json");
 
     // Write the stub package.json
-    writeFileSync(packageJsonPath, STUB_PACKAGE_JSON_CONTENT, "utf8");
+    writeFileSync(packageJsonPath, stubFor(dir), "utf8");
     console.log(`✅ Created ${dir}/package.json`);
   }
 


### PR DESCRIPTION
## Summary

Closes #5953. Alternative to #5954, which only patched the root manifest and is overridden by the subpath stubs (verified in [pullfrog's review](https://github.com/colinhacks/zod/pull/5954#pullrequestreview-4229518288)).

## Why the root-only fix doesn't work

Bundlers read the **nearest-ancestor `package.json`** to each resolved module. The post-build stub generator (`scripts/write-stub-package-jsons.ts`) writes a `package.json` with `"sideEffects": false` into every subpath (`v4/`, `v4/classic/`, `v4/core/`, …). When esbuild resolves `zod/v4/classic/external.js`, it lands on `v4/classic/package.json` — never the root — and tree-shakes the bare `config(en())` statement.

Marking only the terminal file is also not enough: bundlers drop side-effect-free re-exporting modules **before** following them. So every link from the entry point down to the registration must be flagged. The chain reaching `config(en())` is:

- `import "zod/v4"` → `v4/index.js` → `v4/classic/index.js` → `v4/classic/external.js`
- `import "zod"` (root) → `index.js` → `v4/classic/external.js`

## Fix

`scripts/write-stub-package-jsons.ts` now emits an array form for the two stubs in the chain:

```jsonc
// v4/package.json
"sideEffects": ["./index.js", "./index.cjs"]

// v4/classic/package.json
"sideEffects": ["./index.js", "./index.cjs", "./external.js", "./external.cjs"]
```

All other subpath stubs (`v4/core`, `v4/locales`, `v4/mini`, `mini`, `locales`, `v3`, …) keep `"sideEffects": false`, preserving the tree-shaking benefit introduced by #5689.

The root `packages/zod/package.json` gains the same array (`./index.js`, `./index.cjs`) so `import "zod"` is covered. `.mjs` is **not** included — zod's build produces `.js` and `.cjs` only.

## Verification

End-to-end with the issue's reproduction (esbuild ESM bundle, Node platform):

```
$ node output.mjs
{"message":"Invalid option: expected one of \"km\"|\"mi\"","code":"invalid_value"}
```

(was `{"message":"Invalid input"}` before the fix)

Cross-checks:

| Import | Locale present in bundle? | Expected |
|---|---|---|
| `import "zod"` (ESM) | ✅ | needed |
| `import "zod/v4"` (ESM) | ✅ | needed |
| `import "zod/v4"` (CJS) | ✅ | needed |
| `import {} from "zod/v4/core"` | ❌ | tree-shaking still works |

The last row was tested by grepping the bundle for distinctive `en.ts` strings (`"greater than or equal to"`, `"Custom input"`), which are absent. `import * as core from "zod/v4/core"` still pulls the namespace contents but the locale strings stay tree-shaken — the #5689 benefit is preserved either way.

## Files

- `scripts/write-stub-package-jsons.ts` — emits per-directory `sideEffects` arrays for the entry chain to `external`; default `false` everywhere else.
- `packages/zod/package.json` — root `sideEffects` switched from `false` to `["./index.js", "./index.cjs"]` to cover `import "zod"`.

## Test plan

- [x] `pnpm --filter zod build` (zshy + biome) — clean
- [x] `pnpm vitest run` — 3811/3811 pass
- [x] Manual repro: esbuild bundle of `import "zod/v4"` + `z.enum(...).safeParse(...)` returns the localized message
- [x] `import "zod/v4/core"` does not include locale strings in the bundle

## Note

The PR author of #5954 was on the right track — happy to defer if they prefer to fold these changes into their PR instead.