### PR TITLE
fix(v4): preserve default English locale across tree-shaken bundles

### DIFF
--- a/packages/treeshake/default-locale.test.ts
+++ b/packages/treeshake/default-locale.test.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import resolve from "@rollup/plugin-node-resolve";
+import { type Plugin, rollup } from "rollup";
+import { afterAll, expect, test } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// The built package is what carries the `sideEffects: false` stub package.json
+// files, so these bundle against `packages/zod`'s output rather than src. A bare
+// `config(en())` at module scope in `classic/external.ts` is dropped by every
+// bundler that honors the flag, which silently degraded every message to
+// "Invalid input" from 4.4.1 onward — see #5953, #5725, #4891.
+
+const tmp = mkdtempSync(path.join(tmpdir(), "zod-treeshake-"));
+afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+function entry(code: string): Plugin {
+  const id = path.join(__dirname, "__default_locale_entry__.mjs");
+  return {
+    name: "entry",
+    resolveId: (source) => (source === id ? id : null),
+    load: (loaded) => (loaded === id ? code : null),
+    options: (opts) => ({ ...opts, input: id }),
+  };
+}
+
+async function bundleAndRun(code: string): Promise<Record<string, string>> {
+  const build = await rollup({
+    input: "ignored",
+    plugins: [entry(code), resolve()],
+    treeshake: { preset: "smallest", annotations: true },
+    onwarn: () => {},
+  });
+  const { output } = await build.generate({ format: "esm" });
+  await build.close();
+  const file = path.join(tmp, `${Math.random().toString(36).slice(2)}.mjs`);
+  writeFileSync(file, output.map((chunk) => (chunk.type === "chunk" ? chunk.code : "")).join(""));
+  return import(pathToFileURL(file).href);
+}
+
+test("a tree-shaken bundle keeps the default English locale", async () => {
+  const { message } = await bundleAndRun(
+    `import * as z from "zod/v4";
+     export const message = z.enum(["km", "mi"]).safeParse("feet").error.issues[0].message;`
+  );
+  expect(message).toBe('Invalid option: expected one of "km"|"mi"');
+});
+
+test("an explicitly configured locale still wins in a tree-shaken bundle", async () => {
+  const { message } = await bundleAndRun(
+    `import * as z from "zod/v4";
+     z.config(z.locales.fr());
+     export const message = z.enum(["km", "mi"]).safeParse("feet").error.issues[0].message;`
+  );
+  expect(message).toBe('Option invalide : une valeur parmi "km"|"mi" attendue');
+});

--- a/packages/treeshake/default-locale.test.ts
+++ b/packages/treeshake/default-locale.test.ts
@@ -1,10 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import resolve from "@rollup/plugin-node-resolve";
 import { type Plugin, rollup } from "rollup";
-import { afterAll, expect, test } from "vitest";
+import { afterAll, beforeAll, expect, test } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -13,6 +13,29 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // `config(en())` at module scope in `classic/external.ts` is dropped by every
 // bundler that honors the flag, which silently degraded every message to
 // "Invalid input" from 4.4.1 onward — see #5953, #5725, #4891.
+//
+// Bundling build output is the only way to cover the shipped layout, but it means
+// a missing or stale build would otherwise answer with an opaque ENOENT or — worse
+// for a regression guard — a confident false green. Hence the freshness check.
+
+const zodRoot = path.resolve(__dirname, "../zod");
+const builtEntry = path.join(zodRoot, "v4/index.js");
+
+function newestMtime(dir: string): number {
+  let newest = 0;
+  for (const item of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, item.name);
+    newest = Math.max(newest, item.isDirectory() ? newestMtime(full) : statSync(full).mtimeMs);
+  }
+  return newest;
+}
+
+beforeAll(() => {
+  if (!existsSync(builtEntry)) throw new Error(`${builtEntry} is missing. Run \`pnpm build\` first.`);
+  if (newestMtime(path.join(zodRoot, "src")) > statSync(builtEntry).mtimeMs) {
+    throw new Error(`${builtEntry} is older than packages/zod/src. Run \`pnpm build\` first.`);
+  }
+});
 
 const tmp = mkdtempSync(path.join(tmpdir(), "zod-treeshake-"));
 afterAll(() => rmSync(tmp, { recursive: true, force: true }));

--- a/packages/zod/src/v4/classic/external.ts
+++ b/packages/zod/src/v4/classic/external.ts
@@ -5,11 +5,6 @@ export * from "./errors.js";
 export * from "./parse.js";
 export * from "./compat.js";
 
-// zod-specified
-import { config } from "../core/index.js";
-import en from "../locales/en.js";
-config(en());
-
 export type { infer, output, input } from "../core/index.js";
 export type { JSONType } from "../core/util.js";
 export {

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -3,9 +3,19 @@ import { util } from "../core/index.js";
 import * as processors from "../core/json-schema-processors.js";
 import type { StandardSchemaWithJSONProps } from "../core/standard-schema.js";
 import { createStandardJSONSchemaMethod, createToJSONSchemaMethod } from "../core/to-json-schema.js";
+import en from "../locales/en.js";
 
 import * as checks from "./checks.js";
 import * as parse from "./parse.js";
+
+// Register English as the default locale on first ZodType construction. Hooked
+// into the `ZodType` `$constructor` (rather than a top-level `config(en())` in
+// `external.ts`) so bundlers honoring `sideEffects: false` can't tree-shake it
+// out — see #5953, #5725. An explicit `z.config(z.locales.xx())` call wins
+// regardless of order, since this only sets the default when none is present.
+function _ensureDefaultLocale(): void {
+  if (!core.globalConfig.localeError) core.config(en());
+}
 
 // Lazy-bind builder methods.
 //
@@ -213,6 +223,7 @@ export interface _ZodType<out Internals extends core.$ZodTypeInternals = core.$Z
   extends ZodType<any, any, Internals> {}
 
 export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$constructor("ZodType", (inst, def) => {
+  _ensureDefaultLocale();
   core.$ZodType.init(inst, def);
   Object.assign(inst["~standard"], {
     jsonSchema: {

--- a/packages/zod/src/v4/classic/tests/default-locale.test.ts
+++ b/packages/zod/src/v4/classic/tests/default-locale.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, expect, test } from "vitest";
+import * as z from "zod/v4";
+
+// English is the default locale and must register on first ZodType
+// construction even when bundlers tree-shake `sideEffects: false` modules
+// (#5953, #5725). Reset between tests so each one observes the lazy init.
+beforeEach(() => {
+  z.config({ localeError: undefined });
+});
+
+test("first ZodType construction registers the English default locale", () => {
+  expect(z.config().localeError).toBeUndefined();
+  const schema = z.enum(["km", "mi"]);
+  expect(z.config().localeError).toBeDefined();
+  const result = schema.safeParse("feet");
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0].message).toBe('Invalid option: expected one of "km"|"mi"');
+});
+
+test("explicit locale set before schema construction is preserved", () => {
+  z.config(z.locales.fr());
+  const schema = z.enum(["km", "mi"]);
+  const result = schema.safeParse("feet");
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0].message).toBe('Option invalide : une valeur parmi "km"|"mi" attendue');
+});
+
+test("explicit locale set after schema construction overrides default", () => {
+  const schema = z.enum(["km", "mi"]);
+  z.config(z.locales.fr());
+  const result = schema.safeParse("feet");
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0].message).toBe('Option invalide : une valeur parmi "km"|"mi" attendue');
+});


### PR DESCRIPTION
The top-level `config(en())` in `classic/external.ts` was being tree-shaken out by bundlers honoring `sideEffects: false` on the stub `package.json` files added in #5689 — esbuild and Rollup (Vite prod) drop it as an unused side-effectful statement, so issue messages fall through to the hardcoded `"Invalid input"` fallback in `core/util.js`. Reported in #5953 (esbuild) and #5725 (Vite).

`sideEffects` arrays on the nested stubs don't reliably override esbuild's traversal, and there's no inline annotation that *forces* a bundler to keep a top-level call. The fix moves the registration into a `_ensureDefaultLocale()` helper called from inside the `ZodType` `$constructor` body — a runtime-reachable code path no tree-shaker can drop. Gated on `!core.globalConfig.localeError` so an explicit `z.config(z.locales.xx())` always wins regardless of call order.

Closes #5953, #5725.