### PR TITLE
fix(v4): allow underscores in domain regex hostnames

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -441,6 +441,9 @@ test("httpurl", () => {
   // subdomains
   httpUrl.parse("https://sub.example.com");
   httpUrl.parse("http://sub.example.com");
+  // underscores in labels (uncommon but valid in DNS hostnames)
+  httpUrl.parse("https://foo_bar.example.com");
+  httpUrl.parse("https://exa_mple.com");
   // paths
   httpUrl.parse("https://example.com/path/to/resource");
   httpUrl.parse("http://example.com/path/to/resource");

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -81,10 +81,12 @@ export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
 
 // based on https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
 // export const hostname: RegExp = /^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/;
+// `hostname` follows the strict RFC 1035 LDH rule (no underscores) and is used by `z.hostname()`.
+// `domain` is used as the URL host check for `z.httpUrl()`, where RFC 3986 / WHATWG URL allow `_`.
 export const hostname: RegExp =
   /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
 
-export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9_-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
 
 export const httpProtocol: RegExp = /^https?$/;
 


### PR DESCRIPTION
Closes #5960

The `domain` regex used by `z.httpUrl()` (via `hostname: regexes.domain`) rejected underscores in DNS labels, so URLs like `https://foo_bar.example.com` failed validation. RFC 3986 §2.3 puts `_` in `unreserved`, and WHATWG URL parses `https://foo_bar.example.com` cleanly — so this was a real validator gap, not a strictness choice.

This PR allows `_` inside non-TLD labels of `regexes.domain`, keeping the existing constraints that labels start and end with an alphanumeric and that the TLD is letters-only.

`regexes.hostname` is intentionally **not** changed: it follows the strict RFC 1035 LDH rule (used by `z.hostname()`), and an existing test asserts that `hostname.parse("example_com")` throws. The two regexes serve different purposes — URL host validation vs. strict DNS hostname — so the divergence is by design and now documented inline.

## Changes
- `regexes.domain`: `[a-zA-Z0-9-]` → `[a-zA-Z0-9_-]` in the label body.
- Comment in `regexes.ts` documenting why `hostname` and `domain` differ on `_`.
- Added `httpurl` test cases for underscore subdomains.