### PR TITLE
docs(v4): document coerce missing-key breaking change

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -380,6 +380,16 @@ type schemaInput = z.input<typeof schema>;
 // Zod 4: unknown;
 ```
 
+A missing key on an object schema with a `z.coerce.*` field now errors. Use `.default()` to declare the fallback explicitly.
+
+```ts
+const schema = z.object({ foo: z.coerce.boolean() });
+schema.parse({});
+
+// Zod 3: { foo: false }
+// Zod 4: ZodError: Invalid input: expected nonoptional, received undefined
+```
+
 ## `.default()` updates
 
 The application of `.default()` has changed in a subtle way. If the input is `undefined`, `ZodDefault` short-circuits the parsing process and returns the default value. The default value must be assignable to the *output type*.


### PR DESCRIPTION
Refs #5957.

The v4 object parser checks required keys before delegating to field validators, so a `z.coerce.*` field on an object schema now rejects a missing key with `expected: \"nonoptional\"` instead of coercing \`undefined\`. This is intentional (and the only coherent choice across all coercers — `String(undefined)` → `\"undefined\"`, `Number(undefined)` → `NaN`), but it wasn't called out in the migration guide. Adds a short note next to the existing `z.coerce` section pointing users to `.default()`.

## Test plan

- [x] Renders correctly in fumadocs (no syntax errors in the mdx)