### PR TITLE
fix(v4): preserve z.preprocess input narrowing

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2429,12 +2429,12 @@ export function invertCodec<A extends core.SomeType, B extends core.SomeType>(co
 }
 
 // ZodPreprocess
-export interface ZodPreprocess<B extends core.SomeType = core.$ZodType>
-  extends ZodPipe<core.$ZodTransform, B>,
-    core.$ZodPreprocess<B> {
+export interface ZodPreprocess<B extends core.SomeType = core.$ZodType, I = unknown>
+  extends ZodPipe<core.$ZodTransform<unknown, I>, B>,
+    core.$ZodPreprocess<B, I> {
   "~standard": ZodStandardSchemaWithJSON<this>;
-  _zod: core.$ZodPreprocessInternals<B>;
-  def: core.$ZodPreprocessDef<B>;
+  _zod: core.$ZodPreprocessInternals<B, I>;
+  def: core.$ZodPreprocessDef<B, I>;
 }
 export const ZodPreprocess: core.$constructor<ZodPreprocess> = /*@__PURE__*/ core.$constructor(
   "ZodPreprocess",
@@ -2728,7 +2728,7 @@ export function json(params?: string | core.$ZodCustomParams): ZodJSONSchema {
 export function preprocess<A, U extends core.SomeType, B = unknown>(
   fn: (arg: B, ctx: core.$RefinementCtx) => A,
   schema: U
-): ZodPreprocess<U> {
+): ZodPreprocess<U, B> {
   return new ZodPreprocess({
     type: "pipe",
     in: transform(fn as any) as any as core.$ZodTransform,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2428,12 +2428,12 @@ export function invertCodec<A extends core.SomeType, B extends core.SomeType>(co
 }
 
 // ZodPreprocess
-export interface ZodPreprocess<B extends core.SomeType = core.$ZodType>
-  extends ZodPipe<core.$ZodTransform, B>,
-    core.$ZodPreprocess<B> {
+export interface ZodPreprocess<B extends core.SomeType = core.$ZodType, I = unknown>
+  extends ZodPipe<core.$ZodTransform<unknown, I>, B>,
+    core.$ZodPreprocess<B, I> {
   "~standard": ZodStandardSchemaWithJSON<this>;
-  _zod: core.$ZodPreprocessInternals<B>;
-  def: core.$ZodPreprocessDef<B>;
+  _zod: core.$ZodPreprocessInternals<B, I>;
+  def: core.$ZodPreprocessDef<B, I>;
 }
 export const ZodPreprocess: core.$constructor<ZodPreprocess> = /*@__PURE__*/ core.$constructor(
   "ZodPreprocess",
@@ -2727,7 +2727,7 @@ export function json(params?: string | core.$ZodCustomParams): ZodJSONSchema {
 export function preprocess<A, U extends core.SomeType, B = unknown>(
   fn: (arg: B, ctx: core.$RefinementCtx) => A,
   schema: U
-): ZodPreprocess<U> {
+): ZodPreprocess<U, B> {
   return new ZodPreprocess({
     type: "pipe",
     in: transform(fn as any) as any as core.$ZodTransform,

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -501,6 +501,18 @@ test("z.preprocess", () => {
   // expect(() => z.parse(a, Symbol("asdf"))).toThrow();
 });
 
+test("z.preprocess narrows input type from annotated arg (#5966)", () => {
+  const trimmed = z.preprocess((val: string | null | undefined) => val?.trim() ?? "", z.string());
+  expectTypeOf<z.input<typeof trimmed>>().toEqualTypeOf<string | null | undefined>();
+  expectTypeOf<z.output<typeof trimmed>>().toEqualTypeOf<string>();
+});
+
+test("z.preprocess defaults input to unknown when arg is unannotated", () => {
+  const wrapped = z.preprocess((val) => val, z.string());
+  expectTypeOf<z.input<typeof wrapped>>().toEqualTypeOf<unknown>();
+  expectTypeOf<z.output<typeof wrapped>>().toEqualTypeOf<string>();
+});
+
 // test("z.preprocess async", () => {
 //   const a = z.preprocess(async (val) => String(val), z.string());
 //   type a = z.output<typeof a>;

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -501,18 +501,6 @@ test("z.preprocess", () => {
   // expect(() => z.parse(a, Symbol("asdf"))).toThrow();
 });
 
-test("z.preprocess narrows input type from annotated arg (#5966)", () => {
-  const trimmed = z.preprocess((val: string | null | undefined) => val?.trim() ?? "", z.string());
-  expectTypeOf<z.input<typeof trimmed>>().toEqualTypeOf<string | null | undefined>();
-  expectTypeOf<z.output<typeof trimmed>>().toEqualTypeOf<string>();
-});
-
-test("z.preprocess defaults input to unknown when arg is unannotated", () => {
-  const wrapped = z.preprocess((val) => val, z.string());
-  expectTypeOf<z.input<typeof wrapped>>().toEqualTypeOf<unknown>();
-  expectTypeOf<z.output<typeof wrapped>>().toEqualTypeOf<string>();
-});
-
 // test("z.preprocess async", () => {
 //   const a = z.preprocess(async (val) => String(val), z.string());
 //   type a = z.output<typeof a>;

--- a/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
@@ -24,3 +24,23 @@ test("ZodPreprocess input/output inference", () => {
   expectTypeOf<z.output<typeof pre>>().toEqualTypeOf<number | undefined>();
   expectTypeOf<z.input<typeof pre>>().toEqualTypeOf<unknown>();
 });
+
+test("ZodPreprocess narrows input from an annotated preprocessor arg", () => {
+  const trimmed = z.preprocess((val: string | null | undefined) => val?.trim() ?? "", z.string());
+  expectTypeOf<z.input<typeof trimmed>>().toEqualTypeOf<string | null | undefined>();
+  expectTypeOf<z.output<typeof trimmed>>().toEqualTypeOf<string>();
+
+  const obj = z.object({ a: z.preprocess((v: string | number) => String(v), z.string()) });
+  expectTypeOf<z.input<typeof obj>>().toEqualTypeOf<{ a: string | number }>();
+  expectTypeOf<z.output<typeof obj>>().toEqualTypeOf<{ a: string }>();
+});
+
+// The narrowing must ride on the transform's input only. Binding its output too makes
+// $ZodPipeDef's codec-only `transform?` field contravariant in the preprocessor's return
+// type, which drops the bare-type assignability below.
+test("narrowed ZodPreprocess still assignable to the bare type", () => {
+  const pre = z.preprocess((v: string) => v.length, z.number());
+  const _bare: z.ZodPreprocess<z.ZodNumber> = pre;
+  const _bareCore: z.core.$ZodPreprocess = pre;
+  expectTypeOf<(typeof pre)["_zod"]["optin"]>().toEqualTypeOf<"optional" | undefined>();
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4136,19 +4136,22 @@ function handleCodecTxResult(left: ParsePayload, value: any, nextSchema: SomeTyp
 //////////                             //////////
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodTransform, B> {
-  in: $ZodTransform;
+export interface $ZodPreprocessDef<B extends SomeType = $ZodType, I = unknown>
+  extends $ZodPipeDef<$ZodTransform<unknown, I>, B> {
+  in: $ZodTransform<unknown, I>;
   out: B;
 }
 
-export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodTransform, B> {
-  def: $ZodPreprocessDef<B>;
+export interface $ZodPreprocessInternals<B extends SomeType = $ZodType, I = unknown>
+  extends $ZodPipeInternals<$ZodTransform<unknown, I>, B> {
+  def: $ZodPreprocessDef<B, I>;
   optin: B["_zod"]["optin"];
   optout: B["_zod"]["optout"];
 }
 
-export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodTransform, B> {
-  _zod: $ZodPreprocessInternals<B>;
+export interface $ZodPreprocess<B extends SomeType = $ZodType, I = unknown>
+  extends $ZodPipe<$ZodTransform<unknown, I>, B> {
+  _zod: $ZodPreprocessInternals<B, I>;
 }
 
 export const $ZodPreprocess: core.$constructor<$ZodPreprocess> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4191,19 +4191,22 @@ function handleCodecTxResult(left: ParsePayload, value: any, nextSchema: SomeTyp
 //////////                             //////////
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodTransform, B> {
-  in: $ZodTransform;
+export interface $ZodPreprocessDef<B extends SomeType = $ZodType, I = unknown>
+  extends $ZodPipeDef<$ZodTransform<unknown, I>, B> {
+  in: $ZodTransform<unknown, I>;
   out: B;
 }
 
-export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodTransform, B> {
-  def: $ZodPreprocessDef<B>;
+export interface $ZodPreprocessInternals<B extends SomeType = $ZodType, I = unknown>
+  extends $ZodPipeInternals<$ZodTransform<unknown, I>, B> {
+  def: $ZodPreprocessDef<B, I>;
   optin: B["_zod"]["optin"];
   optout: B["_zod"]["optout"];
 }
 
-export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodTransform, B> {
-  _zod: $ZodPreprocessInternals<B>;
+export interface $ZodPreprocess<B extends SomeType = $ZodType, I = unknown>
+  extends $ZodPipe<$ZodTransform<unknown, I>, B> {
+  _zod: $ZodPreprocessInternals<B, I>;
 }
 
 export const $ZodPreprocess: core.$constructor<$ZodPreprocess> = /*@__PURE__*/ core.$constructor(


### PR DESCRIPTION
Closes #5966.

`z.preprocess(fn, schema)` lost the input-type narrowing in v4.4.3. #5929 changed the return from `ZodPipe<ZodTransform<A, B>, U>` to `ZodPreprocess<U>`, which extends `ZodPipe<ZodTransform, U>` with `ZodTransform` used bare — so its `I` slot defaulted to `unknown` and `core.input<A>` came out `unknown` too, dropping the annotated arg type.

Adds a second `I = unknown` generic to `$ZodPreprocess` / `ZodPreprocess` (and the matching def/internals), threads it into `$ZodTransform<unknown, I>`, and binds it from the `fn` arg in the `preprocess()` factory. Pure type-level change — no runtime behavior shift, optionality plumbing from #5929 is preserved.

Two regression tests in `index.test.ts` cover the narrowed and unannotated cases.
