### PR TITLE
Fix preprocess input JSON Schema required

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1422,6 +1422,18 @@ describe("toJSONSchema", () => {
     `);
   });
 
+  test("preprocess object properties use inner optionality in input mode", () => {
+    const schema = z.object({
+      noPreprocess: z.string(),
+      withPreprocess: z.preprocess((val) => val, z.string()),
+      optionalPreprocess: z.preprocess((val) => val, z.string().optional()),
+    });
+
+    const jsonSchema = z.toJSONSchema(schema, { io: "input" }) as z.core.JSONSchema.ObjectSchema;
+
+    expect(jsonSchema.required).toEqual(["noPreprocess", "withPreprocess"]);
+  });
+
   test("simple objects", () => {
     const schema = z.object({
       name: z.string(),

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -307,6 +307,9 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
     [...allKeys].filter((key) => {
       const v = def.shape[key]!._zod;
       if (ctx.io === "input") {
+        if (v.traits.has("$ZodPreprocess")) {
+          return (v.def as schemas.$ZodPreprocessDef).out._zod.optin === undefined;
+        }
         return v.optin === undefined;
       } else {
         return v.optout === undefined;


### PR DESCRIPTION
Fixes #5968.

This keeps `z.preprocess(...)` requiredness aligned with its inner schema when generating input JSON Schema. A required preprocessed property now stays listed under `required`, while an optional inner schema remains optional.

Validated with:

- `pnpm vitest run packages/zod/src/v4/classic/tests/to-json-schema.test.ts --testNamePattern 'preprocess object properties use inner optionality in input mode'`
- `pnpm vitest run packages/zod/src/v4/classic/tests/to-json-schema.test.ts`
- `pnpm exec biome check packages/zod/src/v4/core/schemas.ts packages/zod/src/v4/classic/tests/to-json-schema.test.ts`
- `pnpm lint:check`
- `git diff --check origin/main...HEAD`

I also tried `pnpm exec tsc -p packages/zod/tsconfig.json --noEmit --pretty false`; it is blocked locally by pre-existing unused test declarations outside the touched files.
