### PR TITLE
feat: handle edge cases in plainObject, improve performance

### DIFF
--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -860,11 +860,15 @@ test("isPlainObject", () => {
   expect(z.core.util.isPlainObject({ constructor: [] })).toEqual(true);
   expect(z.core.util.isPlainObject(new Proxy({}, {}))).toEqual(true);
   expect(z.core.util.isPlainObject(new Proxy({ plainKey: 1 }, {}))).toEqual(true);
-  expect(z.core.util.isPlainObject(new Proxy(new Date(), {
-    get(target, _prop, _receiver) {
-      return target;
-    },
-  }))).toEqual(false)
+  expect(
+    z.core.util.isPlainObject(
+      new Proxy(new Date(), {
+        get(target, _prop, _receiver) {
+          return target;
+        },
+      })
+    )
+  ).toEqual(false);
   function ObjectConstructor() {}
   // @ts-expect-error to allow testing crafted objects
   expect(z.core.util.isPlainObject(new ObjectConstructor())).toEqual(false);

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -843,7 +843,9 @@ test("z.promise", async () => {
 test("isPlainObject", () => {
   expect(z.core.util.isPlainObject({})).toEqual(true);
   expect(z.core.util.isPlainObject(Object.create(null))).toEqual(true);
+  expect(z.core.util.isPlainObject(Object.create(Object.create(null)))).toEqual(true);
   expect(z.core.util.isPlainObject(Object.create({}))).toEqual(false);
+  expect(z.core.util.isPlainObject(Object.create(Object.create({})))).toEqual(false);
   expect(z.core.util.isPlainObject([])).toEqual(false);
   expect(z.core.util.isPlainObject(new Date())).toEqual(false);
   expect(z.core.util.isPlainObject(null)).toEqual(false);

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -843,6 +843,7 @@ test("z.promise", async () => {
 test("isPlainObject", () => {
   expect(z.core.util.isPlainObject({})).toEqual(true);
   expect(z.core.util.isPlainObject(Object.create(null))).toEqual(true);
+  expect(z.core.util.isPlainObject(Object.create({}))).toEqual(false);
   expect(z.core.util.isPlainObject([])).toEqual(false);
   expect(z.core.util.isPlainObject(new Date())).toEqual(false);
   expect(z.core.util.isPlainObject(null)).toEqual(false);
@@ -857,6 +858,16 @@ test("isPlainObject", () => {
   expect(z.core.util.isPlainObject({ constructor: true })).toEqual(true);
   expect(z.core.util.isPlainObject({ constructor: {} })).toEqual(true);
   expect(z.core.util.isPlainObject({ constructor: [] })).toEqual(true);
+  expect(z.core.util.isPlainObject(new Proxy({}, {}))).toEqual(true);
+  expect(z.core.util.isPlainObject(new Proxy({ plainKey: 1 }, {}))).toEqual(true);
+  expect(z.core.util.isPlainObject(new Proxy(new Date(), {
+    get(target, _prop, _receiver) {
+      return target;
+    },
+  }))).toEqual(false)
+  function ObjectConstructor() {}
+  // @ts-expect-error to allow testing crafted objects
+  expect(z.core.util.isPlainObject(new ObjectConstructor())).toEqual(false);
 });
 
 test("shallowClone with constructor field", () => {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -383,24 +383,17 @@ export const allowsEval: { value: boolean } = /* @__PURE__*/ cached(() => {
 });
 
 export function isPlainObject(o: any): o is Record<PropertyKey, unknown> {
-  if (isObject(o) === false) return false;
-
-  // modified constructor
-  const ctor = o.constructor;
-  if (ctor === undefined) return true;
-
-  if (typeof ctor !== "function") return true;
-
-  // modified prototype
-  const prot = ctor.prototype;
-  if (isObject(prot) === false) return false;
-
-  // ctor doesn't have static `isPrototypeOf`
-  if (Object.prototype.hasOwnProperty.call(prot, "isPrototypeOf") === false) {
+  if (o === null || typeof o !== "object") {
     return false;
   }
 
-  return true;
+  const proto = Object.getPrototypeOf(o) as typeof Object.prototype | null;
+  return (
+    proto === null ||
+    proto === Object.prototype ||
+    // Required to support node:vm.runInNewContext({})
+    Object.getPrototypeOf(proto) === null
+  );
 }
 
 export function shallowClone(o: any): any {


### PR DESCRIPTION
Hello here's a proposal to fix some edge cases and improve isPlainObject performance

Tests for cases that weren't (imho) properly checked by the current implementation, notably:

- [x] `Object.create({})` shouldn't be a plain object (open to discuss, see risk below)
- [x] If using `Proxy`, they should behave like their targets
- [x] Instanciating a function (new fct) shouldn't be a plain object

**Risk:**

```typescript
const defaults = { host: "localhost" };
const cfg = Object.create(defaults); // This usage will break
cfg.port = 3000;
z.record(z.string(), z.any()).parse(cfg); // was: ok — becomes: invalid_type
```

**Other info**

The implementation is taken from https://github.com/belgattitude/httpx/tree/main/packages/plain-object#readme (I'm the author). Note [that the tests](https://github.com/belgattitude/httpx/blob/main/packages/plain-object/src/__tests__/is-plain-object.test.ts) are passing CI node 20, 22, 24, 26, bun, cloudflare, edge, playwright chromium and deno. 

I've tested the performance against the zod implementation to see if there won't be regression. On the specific benchmarks, node 24 -> 1.22x faster, bun 1.3.13 -> 2.76 faster.

Note that benchs might not be realistic from the zod perspective. 

Open to discuss

 
### Node 24.15.0

```
 ✓ bench/comparative.bench.ts > Compare calling isPlainObject with 110x mixed types values 7424ms
     name                                                           hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · "@httpx/plain-object": `isPlainObject(v)`            1,267,258.73  0.0007  0.8912  0.0008  0.0007  0.0015  0.0018  0.0102  ±0.67%   633631
   · "is-plain-obj":"4.1.0": 'isPlainObj(v)'              1,167,969.53  0.0007  2.5366  0.0009  0.0007  0.0015  0.0018  0.0104  ±1.27%   583985
   · "@sindresorhus/is":"8.0.0": 'is.plainObject(v)'      1,176,458.30  0.0007  0.7647  0.0009  0.0007  0.0014  0.0018  0.0130  ±0.77%   588230
   · "zod":"4.4.3": 'zod.util.isPlainObject(v)'             997,663.61  0.0008  1.8923  0.0010  0.0009  0.0017  0.0022  0.0143  ±1.08%   498832
   · "es-toolkit":"1.46.1": 'isPlainObject(v)'            1,040,376.28  0.0008  0.5971  0.0010  0.0008  0.0020  0.0022  0.0155  ±0.67%   520189
   · "redux":"5.0.1": 'isPlainObject(v)'                    406,199.96  0.0020  1.0312  0.0025  0.0021  0.0052  0.0061  0.0251  ±0.82%   203116
   · "is-plain-object":"5.0.0": 'isPlainObject(v)'          583,263.88  0.0014  4.1774  0.0017  0.0015  0.0035  0.0040  0.0207  ±1.81%   291632
   · "immer/is-plain-object":"4.2.0": 'isPlainObject(v)'    477,915.74  0.0019  0.6726  0.0021  0.0019  0.0038  0.0050  0.0208  ±0.62%   238958
   · lodash-es:"4.18.1": '_.isPlainObject(v)'                16,747.84  0.0467  1.8359  0.0597  0.0646  0.1725  0.2622  0.5797  ±1.46%     8375

 BENCH  Summary
                                                                                                                                                                                    
  "@httpx/plain-object": `isPlainObject(v)` - bench/comparative.bench.ts > Compare calling isPlainObject with 110x mixed types values
    1.08x faster than "@sindresorhus/is":"8.0.0": 'is.plainObject(v)'
    1.09x faster than "is-plain-obj":"4.1.0": 'isPlainObj(v)'
    1.22x faster than "es-toolkit":"1.46.1": 'isPlainObject(v)'
    1.27x faster than "zod":"4.4.3": 'zod.util.isPlainObject(v)'
    2.17x faster than "is-plain-object":"5.0.0": 'isPlainObject(v)'
    2.65x faster than "immer/is-plain-object":"4.2.0": 'isPlainObject(v)'
    3.12x faster than "redux":"5.0.1": 'isPlainObject(v)'
    75.67x faster than lodash-es:"4.18.1": '_.isPlainObject(v)'

```
### Bun 1.3.13

```
✓ bench/comparative.bench.ts > Compare calling isPlainObject with 110x mixed types values 8270ms
     name                                                           hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · "@httpx/plain-object": `isPlainObject(v)`            3,035,494.74  0.0002  2.0300  0.0003  0.0003  0.0006  0.0007  0.0018  ±0.98%  1517748
   · "is-plain-obj":"4.1.0": 'isPlainObj(v)'              2,910,611.34  0.0003  0.9960  0.0003  0.0003  0.0006  0.0007  0.0019  ±0.86%  1455306
   · "@sindresorhus/is":"8.0.0": 'is.plainObject(v)'      3,195,461.39  0.0003  1.8672  0.0003  0.0003  0.0006  0.0007  0.0017  ±1.15%  1597731
   · "zod":"4.4.3": 'zod.util.isPlainObject(v)'           1,158,960.66  0.0008  0.5257  0.0009  0.0008  0.0016  0.0020  0.0052  ±0.46%   579481
   · "es-toolkit":"1.46.1": 'isPlainObject(v)'            1,096,506.16  0.0008  1.5147  0.0009  0.0008  0.0016  0.0020  0.0102  ±0.80%   548254
   · "redux":"5.0.1": 'isPlainObject(v)'                  1,357,176.37  0.0005  2.1069  0.0007  0.0006  0.0013  0.0015  0.0067  ±1.31%   678589
   · "is-plain-object":"5.0.0": 'isPlainObject(v)'          567,347.42  0.0014  4.8731  0.0018  0.0015  0.0036  0.0043  0.0184  ±3.94%   283674
   · "immer/is-plain-object":"4.2.0": 'isPlainObject(v)'  1,607,338.90  0.0005  1.3589  0.0006  0.0006  0.0011  0.0014  0.0058  ±0.92%   803670
   · lodash-es:"4.18.1": '_.isPlainObject(v)'                40,471.25  0.0073  2.2837  0.0247  0.0289  0.1214  0.1528  0.3628  ±1.82%    20236

 BENCH  Summary
                                                                                                                                                                                    
  "@sindresorhus/is":"8.0.0": 'is.plainObject(v)' - bench/comparative.bench.ts > Compare calling isPlainObject with 110x mixed types values
    1.05x faster than "@httpx/plain-object": `isPlainObject(v)`
    1.10x faster than "is-plain-obj":"4.1.0": 'isPlainObj(v)'
    1.99x faster than "immer/is-plain-object":"4.2.0": 'isPlainObject(v)'
    2.35x faster than "redux":"5.0.1": 'isPlainObject(v)'
    2.76x faster than "zod":"4.4.3": 'zod.util.isPlainObject(v)'
    2.91x faster than "es-toolkit":"1.46.1": 'isPlainObject(v)'
    5.63x faster than "is-plain-object":"5.0.0": 'isPlainObject(v)'
    78.96x faster than lodash-es:"4.18.1": '_.isPlainObject(v)'
```