### PR TITLE
Add v4 regression test for object union inference

### DIFF
--- a/packages/zod/src/v3/tests/object.test.ts
+++ b/packages/zod/src/v3/tests/object.test.ts
@@ -22,19 +22,6 @@ test("object type inference", () => {
   util.assertEqual<z.TypeOf<typeof Test>, TestType>(true);
 });
 
-test("object property preserves union output type", () => {
-  const EventNameSchema = z.string().or(z.array(z.string()));
-
-  const EventSchema = z.object({
-    name: EventNameSchema,
-  });
-
-  type EventName = z.infer<typeof EventNameSchema>;
-  type EventWithName = z.infer<typeof EventSchema>;
-
-  util.assertEqual<EventWithName["name"], EventName>(true);
-});
-
 test("unknown throw", () => {
   const asdf: unknown = 35;
   expect(() => Test.parse(asdf)).toThrow();

--- a/packages/zod/src/v3/tests/object.test.ts
+++ b/packages/zod/src/v3/tests/object.test.ts
@@ -22,6 +22,19 @@ test("object type inference", () => {
   util.assertEqual<z.TypeOf<typeof Test>, TestType>(true);
 });
 
+test("object property preserves union output type", () => {
+  const EventNameSchema = z.string().or(z.array(z.string()));
+
+  const EventSchema = z.object({
+    name: EventNameSchema,
+  });
+
+  type EventName = z.infer<typeof EventNameSchema>;
+  type EventWithName = z.infer<typeof EventSchema>;
+
+  util.assertEqual<EventWithName["name"], EventName>(true);
+});
+
 test("unknown throw", () => {
   const asdf: unknown = 35;
   expect(() => Test.parse(asdf)).toThrow();

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -20,6 +20,19 @@ test("object type inference", () => {
   expectTypeOf<z.TypeOf<typeof Test>>().toEqualTypeOf<TestType>();
 });
 
+test("object property preserves union output type", () => {
+  const EventNameSchema = z.string().or(z.array(z.string()));
+
+  const EventSchema = z.object({
+    name: EventNameSchema,
+  });
+
+  type EventName = z.infer<typeof EventNameSchema>;
+  type EventWithName = z.infer<typeof EventSchema>;
+
+  expectTypeOf<EventWithName["name"]>().toEqualTypeOf<EventName>();
+});
+
 test("unknown throw", () => {
   const asdf: unknown = 35;
   expect(() => Test.parse(asdf)).toThrow();


### PR DESCRIPTION
Closes #2654

## Summary
- adds a v4 classic type regression test for object properties whose schema is a union created with `.or()`
- verifies the inferred object property type remains identical to the standalone schema output type
- covers the reported `string | string[]` object-property inference case

## Validation
- `pnpm vitest run packages/zod/src/v4/classic/tests/object.test.ts --typecheck`
- `pnpm test`