### PR TITLE
fix: preserve date origin when number timestamp passed to .min()/.max()

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1365,8 +1365,8 @@ export const ZodDate: core.$constructor<ZodDate> = /*@__PURE__*/ core.$construct
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.dateProcessor(inst, ctx, json, params);
 
-  inst.min = (value, params) => inst.check(checks.gte(value, params));
-  inst.max = (value, params) => inst.check(checks.lte(value, params));
+  inst.min = (value, params) => inst.check(checks.gte(value instanceof Date ? value : new Date(value), params));
+  inst.max = (value, params) => inst.check(checks.lte(value instanceof Date ? value : new Date(value), params));
 
   const c = inst._zod.bag;
   inst.minDate = c.minimum ? new Date(c.minimum) : null;

--- a/packages/zod/src/v4/classic/tests/date.test.ts
+++ b/packages/zod/src/v4/classic/tests/date.test.ts
@@ -53,6 +53,40 @@ test("date max", () => {
   `);
 });
 
+test("date min with number timestamp", () => {
+  const result = z.date().min(benchmarkDate.getTime()).safeParse(beforeBenchmarkDate);
+  expect(result.success).toEqual(false);
+  expect(result.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "too_small",
+        "inclusive": true,
+        "message": "Too small: expected date to be >=1667606400000",
+        "minimum": 1667606400000,
+        "origin": "date",
+        "path": [],
+      },
+    ]
+  `);
+});
+
+test("date max with number timestamp", () => {
+  const result = z.date().max(benchmarkDate.getTime()).safeParse(afterBenchmarkDate);
+  expect(result.success).toEqual(false);
+  expect(result.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "too_big",
+        "inclusive": true,
+        "maximum": 1667606400000,
+        "message": "Too big: expected date to be <=1667606400000",
+        "origin": "date",
+        "path": [],
+      },
+    ]
+  `);
+});
+
 test("min max getters", () => {
   expect(minCheck.minDate).toEqual(benchmarkDate);
   expect(minCheck.min(afterBenchmarkDate).minDate).toEqual(afterBenchmarkDate);


### PR DESCRIPTION
Fixes #5980.

`z.date().min(timestamp)` and `z.date().max(timestamp)` produce `origin: "number"` in the validation issue when the argument is a number. The origin should always be `"date"` since the schema is a `ZodDate`.

Root cause: `$ZodCheckGreaterThan` / `$ZodCheckLessThan` derive `origin` from `typeof def.value` via `numericOriginMap`. When a `Date` is passed, `typeof` is `"object"` → `"date"`. When a number timestamp is passed, `typeof` is `"number"` → `"number"`.

Fix: normalize the value to a `Date` in `ZodDate.min` / `ZodDate.max` before passing to `checks.gte` / `checks.lte`. This also brings the runtime behavior in line with `$ZodDateInternals.bag`, which already types `minimum` and `maximum` as `Date`.