### PR TITLE
feat(proposal): mask

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3256,7 +3256,7 @@ schema.parseAndMask({ id: "usr_1", name: "Other Name" });
 
 
 <Callout>
-  The deterministic pick algorithm for array masks is stable within a major version. Test fixtures built against `mask([...])` output will not break across patch or minor releases.
+  The deterministic pick algorithm for array masks is stable within a major version — exact picks for known seeds are pinned by fixture tests. Test fixtures built against `mask([...])` output will not break across patch or minor releases.
 </Callout>
 
 ### `.parseAndMask()` / `.safeParseAndMask()`

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3172,3 +3172,113 @@ z.parse(schema, null); // => null
 ```
 </Tab>
 </Tabs>
+
+## Masking
+
+Use `.mask()` to mark schema fields for PII masking. Then use `.parseAndMask()` instead of `.parse()` to validate data *and* replace masked fields in a single step.
+
+<Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
+<Tab value="Zod">
+```ts
+const User = z.object({
+  id: z.string(),
+  name: z.string().mask("REDACTED"),
+  email: z.string().mask((seed) => `${seed}@example.com`),
+  role: z.string().mask(["viewer", "editor"]),
+});
+
+User.parseAndMask({
+  id: "usr_1",
+  name: "Alice",
+  email: "alice@real.com",
+  role: "admin",
+});
+// => { id: "usr_1", name: "REDACTED", email: "usr_1@example.com", role: "viewer" }
+```
+</Tab>
+<Tab value="Zod Mini">
+```ts
+const User = z.object({
+  id: z.string(),
+  name: z.string().check(z._mask("REDACTED")),
+  email: z.string().check(z._mask((seed) => `${seed}@example.com`)),
+  role: z.string().check(z._mask(["viewer", "editor"])),
+});
+
+const parsed = z.parseAndMask(User, {
+  id: "usr_1",
+  name: "Alice",
+  email: "alice@real.com",
+  role: "admin",
+});
+// => { id: "usr_1", name: "REDACTED", email: "usr_1@example.com", role: "viewer" }
+```
+</Tab>
+</Tabs>
+
+### Mask types
+
+The `.mask()` method accepts three kinds of values. The mask value must match the schema's output type — passing a number to a string schema is a type error.
+
+| Mask type | Example | Behavior |
+|---|---|---|
+| Single value | `z.string().mask("***")` | Always replaces with that value |
+| Array | `z.string().mask(["A", "B"])` | Deterministic pick based on a hashed seed |
+| Function | `z.string().mask((seed) => ...)` | Called with the entity seed |
+
+Masking works with any schema type:
+
+```ts
+z.string().mask("hidden");
+z.number().mask(0);
+z.boolean().mask(false);
+z.number().mask([10, 20, 30]);
+z.boolean().mask([true, false]);
+```
+
+### Seed resolution
+
+When masking objects, Zod resolves a *seed* for deterministic masking. If the object has an `id` field, its value is used as the seed. Otherwise, a composite seed is derived from masked string fields.
+
+```ts
+const schema = z.object({
+  id: z.string(),
+  name: z.string().mask(["Alice", "Bob", "Charlie"]),
+});
+
+schema.parseAndMask({ id: "usr_1", name: "Real Name" });
+schema.parseAndMask({ id: "usr_1", name: "Other Name" });
+// same id => same masked name, regardless of the real name
+```
+
+### `.parseAndMask()` / `.safeParseAndMask()`
+
+Every schema exposes parse-and-mask methods that mirror the standard parse methods:
+
+<Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
+<Tab value="Zod">
+```ts
+schema.parseAndMask(data);          // throws on invalid input
+schema.safeParseAndMask(data);      // returns a result object
+
+await schema.parseAndMaskAsync(data);
+await schema.safeParseAndMaskAsync(data);
+```
+</Tab>
+<Tab value="Zod Mini">
+```ts
+z.parseAndMask(schema, data);       // throws on invalid input
+z.safeParseAndMask(schema, data);   // returns a result object
+
+await z.parseAndMaskAsync(schema, data);
+await z.safeParseAndMaskAsync(schema, data);
+```
+</Tab>
+</Tabs>
+
+<Callout>
+  These methods first validate the input (identical to `.parse()` / `.safeParse()`), then walk the schema tree and replace masked values. If validation fails, masking is skipped — you get the same `ZodError` you'd get from `.parse()`.
+</Callout>
+
+The masking walker recursively handles objects, arrays, optionals, nullables, defaults, readonly, unions, discriminated unions, pipes, and lazy schemas. `undefined` and `null` values always pass through unmasked.
+

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3238,7 +3238,7 @@ z.boolean().mask([true, false]);
 
 ### Seed resolution
 
-When masking objects, Zod resolves a *seed* for deterministic masking. If the object has an `id` field, its value is used as the seed. Otherwise, a composite seed is derived from masked string fields.
+When masking objects, Zod resolves a *seed* for deterministic masking. If the object has an `id` field (of type `string`, `number`, or `bigint`), its value is used as the seed. Otherwise, a composite seed is derived from masked string fields.
 
 ```ts
 const schema = z.object({
@@ -3250,6 +3250,19 @@ schema.parseAndMask({ id: "usr_1", name: "Real Name" });
 schema.parseAndMask({ id: "usr_1", name: "Other Name" });
 // same id => same masked name, regardless of the real name
 ```
+
+For schemas using other key patterns (e.g. `_id`, `userId`), use the function mask form for explicit seed control:
+
+```ts
+const schema = z.object({
+  _id: z.string(),
+  name: z.string().mask((seed) => `user-${seed}`),
+});
+```
+
+<Callout>
+  The deterministic pick algorithm for array masks is stable within a major version. Test fixtures built against `mask([...])` output will not break across patch or minor releases.
+</Callout>
 
 ### `.parseAndMask()` / `.safeParseAndMask()`
 
@@ -3280,5 +3293,5 @@ await z.safeParseAndMaskAsync(schema, data);
   These methods first validate the input (identical to `.parse()` / `.safeParse()`), then walk the schema tree and replace masked values. If validation fails, masking is skipped — you get the same `ZodError` you'd get from `.parse()`.
 </Callout>
 
-The masking walker recursively handles objects, arrays, optionals, nullables, defaults, readonly, unions, discriminated unions, pipes, and lazy schemas. `undefined` and `null` values always pass through unmasked.
+The masking walker recursively handles objects, arrays, records, tuples, maps, sets, optionals, nullables, defaults, readonly, unions, discriminated unions, pipes, and lazy schemas. `undefined` and `null` values always pass through unmasked.
 

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3250,15 +3250,10 @@ schema.parseAndMask({ id: "usr_1", name: "Real Name" });
 schema.parseAndMask({ id: "usr_1", name: "Other Name" });
 // same id => same masked name, regardless of the real name
 ```
+<Callout>
+  Only a field named exactly `id` (of type `string`, `number`, or `bigint`) is used as the seed. Other key patterns like `_id` or `userId` are not recognized — the seed will fall back to a composite of masked string field values.
+</Callout>
 
-For schemas using other key patterns (e.g. `_id`, `userId`), use the function mask form for explicit seed control:
-
-```ts
-const schema = z.object({
-  _id: z.string(),
-  name: z.string().mask((seed) => `user-${seed}`),
-});
-```
 
 <Callout>
   The deterministic pick algorithm for array masks is stable within a major version. Test fixtures built against `mask([...])` output will not break across patch or minor releases.

--- a/packages/zod/src/v4/classic/parse.ts
+++ b/packages/zod/src/v4/classic/parse.ts
@@ -32,6 +32,33 @@ export const safeParseAsync: <T extends core.$ZodType>(
   _ctx?: core.ParseContext<core.$ZodIssue>
 ) => Promise<ZodSafeParseResult<core.output<T>>> = /* @__PURE__ */ core._safeParseAsync(ZodRealError) as any;
 
+// Parse-and-mask functions
+export const parseAndMask: <T extends core.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: core.ParseContext<core.$ZodIssue>,
+  _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
+) => core.output<T> = /* @__PURE__ */ core._parseAndMask(ZodRealError);
+
+export const parseAndMaskAsync: <T extends core.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: core.ParseContext<core.$ZodIssue>,
+  _params?: { callee?: core.util.AnyFunc; Err?: core.$ZodErrorClass }
+) => Promise<core.output<T>> = /* @__PURE__ */ core._parseAndMaskAsync(ZodRealError);
+
+export const safeParseAndMask: <T extends core.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: core.ParseContext<core.$ZodIssue>
+) => ZodSafeParseResult<core.output<T>> = /* @__PURE__ */ core._safeParseAndMask(ZodRealError) as any;
+
+export const safeParseAndMaskAsync: <T extends core.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: core.ParseContext<core.$ZodIssue>
+) => Promise<ZodSafeParseResult<core.output<T>>> = /* @__PURE__ */ core._safeParseAndMaskAsync(ZodRealError) as any;
+
 // Codec functions
 export const encode: <T extends core.$ZodType>(
   schema: T,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -188,6 +188,18 @@ export interface ZodType<
   /** Returns a new instance that has been registered in `z.globalRegistry` with the specified metadata */
   meta(data: core.$replace<core.GlobalMeta, this>): this;
 
+  mask(value: core.output<this> | core.output<this>[] | ((seed: string) => core.output<this>)): this;
+  parseAndMask(data: unknown, params?: core.ParseContext<core.$ZodIssue>): core.output<this>;
+  safeParseAndMask(
+    data: unknown,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): parse.ZodSafeParseResult<core.output<this>>;
+  parseAndMaskAsync(data: unknown, params?: core.ParseContext<core.$ZodIssue>): Promise<core.output<this>>;
+  safeParseAndMaskAsync(
+    data: unknown,
+    params?: core.ParseContext<core.$ZodIssue>
+  ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
+
   // helpers
   /** @deprecated Try safe-parsing `undefined` (this is what `isOptional` does internally):
    *
@@ -244,6 +256,11 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   inst.safeDecode = (data, params) => parse.safeDecode(inst, data, params);
   inst.safeEncodeAsync = async (data, params) => parse.safeEncodeAsync(inst, data, params);
   inst.safeDecodeAsync = async (data, params) => parse.safeDecodeAsync(inst, data, params);
+  inst.parseAndMask = (data, params) => parse.parseAndMask(inst, data, params, { callee: inst.parseAndMask });
+  inst.safeParseAndMask = (data, params) => parse.safeParseAndMask(inst, data, params);
+  inst.parseAndMaskAsync = async (data, params) =>
+    parse.parseAndMaskAsync(inst, data, params, { callee: inst.parseAndMaskAsync });
+  inst.safeParseAndMaskAsync = async (data, params) => parse.safeParseAndMaskAsync(inst, data, params);
 
   // All builder methods are placed on the internal prototype as lazy-bind
   // getters. On first access per-instance, a bound thunk is allocated and
@@ -344,6 +361,9 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
       const cl = this.clone();
       core.globalRegistry.add(cl, args[0]);
       return cl;
+    },
+    mask(maskValue) {
+      return this.check(core._mask(maskValue));
     },
     isOptional() {
       return this.safeParse(undefined).success;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -256,11 +256,6 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   inst.safeDecode = (data, params) => parse.safeDecode(inst, data, params);
   inst.safeEncodeAsync = async (data, params) => parse.safeEncodeAsync(inst, data, params);
   inst.safeDecodeAsync = async (data, params) => parse.safeDecodeAsync(inst, data, params);
-  inst.parseAndMask = (data, params) => parse.parseAndMask(inst, data, params, { callee: inst.parseAndMask });
-  inst.safeParseAndMask = (data, params) => parse.safeParseAndMask(inst, data, params);
-  inst.parseAndMaskAsync = async (data, params) =>
-    parse.parseAndMaskAsync(inst, data, params, { callee: inst.parseAndMaskAsync });
-  inst.safeParseAndMaskAsync = async (data, params) => parse.safeParseAndMaskAsync(inst, data, params);
 
   // All builder methods are placed on the internal prototype as lazy-bind
   // getters. On first access per-instance, a bound thunk is allocated and
@@ -364,6 +359,18 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     },
     mask(maskValue) {
       return this.check(core._mask(maskValue));
+    },
+    parseAndMask(data, params) {
+      return parse.parseAndMask(this, data, params, { callee: this.parseAndMask });
+    },
+    safeParseAndMask(data, params) {
+      return parse.safeParseAndMask(this, data, params);
+    },
+    async parseAndMaskAsync(data, params) {
+      return parse.parseAndMaskAsync(this, data, params, { callee: this.parseAndMaskAsync });
+    },
+    async safeParseAndMaskAsync(data, params) {
+      return parse.safeParseAndMaskAsync(this, data, params);
     },
     isOptional() {
       return this.safeParse(undefined).success;

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -1,6 +1,30 @@
 import { expect, test } from "vitest";
 import * as z from "zod/v4";
 
+test("parse ignores mask", () => {
+  const schema = z.object({ a: z.string().mask("***"), b: z.number().mask(0) });
+  expect(schema.parse({ a: "real", b: 42 })).toEqual({ a: "real", b: 42 });
+});
+
+test("safeParse ignores mask", () => {
+  const schema = z.object({ a: z.string().mask("***") });
+  const r = schema.safeParse({ a: "real" });
+  expect(r.success).toBe(true);
+  if (r.success) expect(r.data.a).toBe("real");
+});
+
+test("parseAsync ignores mask", async () => {
+  const schema = z.object({ a: z.string().mask("***") });
+  expect(await schema.parseAsync({ a: "real" })).toEqual({ a: "real" });
+});
+
+test("safeParseAsync ignores mask", async () => {
+  const schema = z.object({ a: z.string().mask("***") });
+  const r = await schema.safeParseAsync({ a: "real" });
+  expect(r.success).toBe(true);
+  if (r.success) expect(r.data.a).toBe("real");
+});
+
 test("static string mask", () => {
   const schema = z.object({ a: z.string().mask("***") });
   expect(schema.parseAndMask({ a: "asdf" })).toEqual({ a: "***" });

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -39,6 +39,14 @@ test("seed from id field", () => {
   expect(r.id).toBe("id1");
 });
 
+test("seed from numeric id field", () => {
+  const schema = z.object({
+    id: z.number(),
+    s: z.string().mask((seed) => `s-${seed}`),
+  });
+  expect(schema.parseAndMask({ id: 42, s: "hidden" }).s).toBe("s-42");
+});
+
 test("composite seed when no id", () => {
   const schema = z.object({
     a: z.string().mask(["X", "Y"]),

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -157,6 +157,28 @@ test("success preserves boolean", () => {
   expect(schema.parseAndMask({ ok: "valid" })).toEqual({ ok: true });
 });
 
+test("record masks values", () => {
+  const schema = z.object({ r: z.record(z.string(), z.string().mask("X")) });
+  expect(schema.parseAndMask({ r: { a: "1", b: "2" } })).toEqual({ r: { a: "X", b: "X" } });
+});
+
+test("tuple masks items", () => {
+  const schema = z.object({ t: z.tuple([z.string().mask("A"), z.number().mask(0)]) });
+  expect(schema.parseAndMask({ t: ["hello", 42] })).toEqual({ t: ["A", 0] });
+});
+
+test("map masks values", () => {
+  const schema = z.object({ m: z.map(z.string(), z.string().mask("X")) });
+  const r = schema.parseAndMask({ m: new Map([["a", "1"]]) });
+  expect(r.m.get("a")).toBe("X");
+});
+
+test("set masks values", () => {
+  const schema = z.object({ s: z.set(z.string().mask("X")) });
+  const r = schema.parseAndMask({ s: new Set(["a", "b"]) });
+  expect(r.s).toEqual(new Set(["X"]));
+});
+
 test("unmasked fields pass through", () => {
   const schema = z.object({ a: z.string(), b: z.string().mask("R") });
   const r = schema.parseAndMask({ a: "hello", b: "hidden" });

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -1,0 +1,286 @@
+import { expect, test } from "vitest";
+import * as z from "zod/v4";
+
+test("static string mask", () => {
+  const schema = z.object({ a: z.string().mask("***") });
+  expect(schema.parseAndMask({ a: "asdf" })).toEqual({ a: "***" });
+});
+
+test("array mask picks deterministically", () => {
+  const opts = ["x", "y", "z"];
+  const schema = z.object({
+    id: z.string(),
+    name: z.string().mask(opts),
+  });
+  const a = schema.parseAndMask({ id: "1", name: "asdf" });
+  const b = schema.parseAndMask({ id: "1", name: "qwer" });
+  expect(a.name).toBe(b.name);
+  expect(opts).toContain(a.name);
+
+  const c = schema.parseAndMask({ id: "2", name: "asdf" });
+  expect(opts).toContain(c.name);
+});
+
+test("function mask receives seed", () => {
+  const schema = z.object({
+    id: z.string(),
+    v: z.string().mask((seed) => `m-${seed}`),
+  });
+  expect(schema.parseAndMask({ id: "abc", v: "secret" }).v).toBe("m-abc");
+});
+
+test("seed from id field", () => {
+  const schema = z.object({
+    id: z.string(),
+    s: z.string().mask((seed) => `s-${seed}`),
+  });
+  const r = schema.parseAndMask({ id: "id1", s: "hidden" });
+  expect(r.s).toBe("s-id1");
+  expect(r.id).toBe("id1");
+});
+
+test("composite seed when no id", () => {
+  const schema = z.object({
+    a: z.string().mask(["X", "Y"]),
+    b: z.string().mask(["P", "Q"]),
+  });
+  const r = schema.parseAndMask({ a: "foo", b: "bar" });
+  expect(["X", "Y"]).toContain(r.a);
+  expect(["P", "Q"]).toContain(r.b);
+});
+
+test("nested objects", () => {
+  const schema = z.object({
+    inner: z.object({
+      id: z.string(),
+      s: z.string().mask("R"),
+    }),
+  });
+  const r = schema.parseAndMask({ inner: { id: "1", s: "asdf" } });
+  expect(r.inner.s).toBe("R");
+  expect(r.inner.id).toBe("1");
+});
+
+test("array of objects", () => {
+  const schema = z.object({
+    items: z.array(z.object({ id: z.string(), s: z.string().mask("H") })),
+  });
+  const r = schema.parseAndMask({
+    items: [
+      { id: "1", s: "a" },
+      { id: "2", s: "b" },
+    ],
+  });
+  expect(r.items[0].s).toBe("H");
+  expect(r.items[1].s).toBe("H");
+  expect(r.items[0].id).toBe("1");
+});
+
+test("array of primitives", () => {
+  const schema = z.object({ tags: z.array(z.string().mask("*")) });
+  expect(schema.parseAndMask({ tags: ["a", "b"] })).toEqual({ tags: ["*", "*"] });
+});
+
+test("optional with value", () => {
+  const schema = z.object({ a: z.string().mask("M").optional() });
+  expect(schema.parseAndMask({ a: "asdf" })).toEqual({ a: "M" });
+});
+
+test("optional undefined passthrough", () => {
+  const schema = z.object({ a: z.string().mask("M").optional() });
+  expect(schema.parseAndMask({})).toEqual({});
+});
+
+test("nullable with value", () => {
+  const schema = z.object({ a: z.string().mask("M").nullable() });
+  expect(schema.parseAndMask({ a: "asdf" })).toEqual({ a: "M" });
+});
+
+test("nullable null passthrough", () => {
+  const schema = z.object({ a: z.string().mask("M").nullable() });
+  expect(schema.parseAndMask({ a: null })).toEqual({ a: null });
+});
+
+test("default wrapper", () => {
+  const schema = z.object({ a: z.string().mask("M").default("d") });
+  expect(schema.parseAndMask({ a: "asdf" })).toEqual({ a: "M" });
+  expect(schema.parseAndMask({})).toEqual({ a: "M" });
+});
+
+test("readonly wrapper", () => {
+  const schema = z.object({ a: z.string().mask("M").readonly() });
+  expect(schema.parseAndMask({ a: "asdf" })).toEqual({ a: "M" });
+});
+
+test("union", () => {
+  const schema = z.object({
+    v: z.union([
+      z.object({ t: z.literal("a"), s: z.string().mask("X") }),
+      z.object({ t: z.literal("b"), s: z.string().mask("Y") }),
+    ]),
+  });
+  expect(schema.parseAndMask({ v: { t: "a", s: "foo" } }).v.s).toBe("X");
+  expect(schema.parseAndMask({ v: { t: "b", s: "bar" } }).v.s).toBe("Y");
+});
+
+test("discriminated union", () => {
+  const schema = z.object({
+    v: z.discriminatedUnion("t", [
+      z.object({ t: z.literal("a"), s: z.string().mask("X") }),
+      z.object({ t: z.literal("b"), s: z.string().mask("Y") }),
+    ]),
+  });
+  expect(schema.parseAndMask({ v: { t: "a", s: "foo" } }).v.s).toBe("X");
+});
+
+test("pipe", () => {
+  const schema = z.object({ a: z.string().mask("M").pipe(z.string().min(1)) });
+  expect(schema.parseAndMask({ a: "asdf" })).toEqual({ a: "M" });
+});
+
+test("unmasked fields pass through", () => {
+  const schema = z.object({ a: z.string(), b: z.string().mask("R") });
+  const r = schema.parseAndMask({ a: "hello", b: "hidden" });
+  expect(r.a).toBe("hello");
+  expect(r.b).toBe("R");
+});
+
+test("parseAndMask throws on invalid", () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  expect(() => schema.parseAndMask({ a: 123 })).toThrow();
+});
+
+test("safeParseAndMask success", () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  const r = schema.safeParseAndMask({ a: "asdf" });
+  expect(r.success).toBe(true);
+  if (r.success) expect(r.data.a).toBe("M");
+});
+
+test("safeParseAndMask error", () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  const r = schema.safeParseAndMask({ a: 123 });
+  expect(r.success).toBe(false);
+  if (!r.success) expect(r.error.issues.length).toBeGreaterThan(0);
+});
+
+test("parseAndMaskAsync success", async () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  expect(await schema.parseAndMaskAsync({ a: "asdf" })).toEqual({ a: "M" });
+});
+
+test("parseAndMaskAsync throws on invalid", async () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  await expect(schema.parseAndMaskAsync({ a: 123 })).rejects.toThrow();
+});
+
+test("safeParseAndMaskAsync success", async () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  const r = await schema.safeParseAndMaskAsync({ a: "asdf" });
+  expect(r.success).toBe(true);
+  if (r.success) expect(r.data.a).toBe("M");
+});
+
+test("safeParseAndMaskAsync error", async () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  const r = await schema.safeParseAndMaskAsync({ a: 123 });
+  expect(r.success).toBe(false);
+});
+
+test("async transform with mask", async () => {
+  const schema = z.object({
+    a: z
+      .string()
+      .transform(async (v) => v.trim())
+      .pipe(z.string().mask("M")),
+  });
+  expect(await schema.parseAndMaskAsync({ a: "  asdf  " })).toEqual({ a: "M" });
+});
+
+test("z.parseAndMask function form", () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  expect(z.parseAndMask(schema, { a: "asdf" })).toEqual({ a: "M" });
+});
+
+test("z.safeParseAndMask function form", () => {
+  const schema = z.object({ a: z.string().mask("M") });
+  const r = z.safeParseAndMask(schema, { a: "asdf" });
+  expect(r.success).toBe(true);
+  if (r.success) expect(r.data.a).toBe("M");
+});
+
+test("no masks acts as normal parse", () => {
+  const schema = z.object({ a: z.string(), b: z.number() });
+  expect(schema.parseAndMask({ a: "asdf", b: 5 })).toEqual({ a: "asdf", b: 5 });
+});
+
+test("deeply nested", () => {
+  const schema = z.object({ l1: z.object({ l2: z.object({ l3: z.object({ s: z.string().mask("D") }) }) }) });
+  expect(schema.parseAndMask({ l1: { l2: { l3: { s: "asdf" } } } }).l1.l2.l3.s).toBe("D");
+});
+
+test("number single value mask", () => {
+  const schema = z.object({ n: z.number().mask(0) });
+  expect(schema.parseAndMask({ n: 1234 })).toEqual({ n: 0 });
+});
+
+test("number array mask picks deterministically", () => {
+  const opts = [10, 20, 30];
+  const schema = z.object({ id: z.string(), n: z.number().mask(opts) });
+  const a = schema.parseAndMask({ id: "1", n: 999 });
+  const b = schema.parseAndMask({ id: "1", n: 777 });
+  expect(a.n).toBe(b.n);
+  expect(opts).toContain(a.n);
+});
+
+test("number function mask", () => {
+  const schema = z.object({ id: z.string(), n: z.number().mask(() => 42) });
+  expect(schema.parseAndMask({ id: "1", n: 999 }).n).toBe(42);
+});
+
+test("boolean single value mask", () => {
+  const schema = z.object({ b: z.boolean().mask(false) });
+  expect(schema.parseAndMask({ b: true })).toEqual({ b: false });
+});
+
+test("boolean array mask picks deterministically", () => {
+  const schema = z.object({ id: z.string(), b: z.boolean().mask([true, false]) });
+  const a = schema.parseAndMask({ id: "1", b: true });
+  const b = schema.parseAndMask({ id: "1", b: false });
+  expect(a.b).toBe(b.b);
+  expect([true, false]).toContain(a.b);
+});
+
+test("boolean function mask", () => {
+  const schema = z.object({ b: z.boolean().mask(() => false) });
+  expect(schema.parseAndMask({ b: true }).b).toBe(false);
+});
+
+test("string array mask picks deterministically", () => {
+  const opts = ["a", "b", "c"];
+  const schema = z.object({ id: z.string(), s: z.string().mask(opts) });
+  const a = schema.parseAndMask({ id: "1", s: "x" });
+  const b = schema.parseAndMask({ id: "1", s: "y" });
+  expect(a.s).toBe(b.s);
+  expect(opts).toContain(a.s);
+});
+
+test("mask type safety", () => {
+  z.string().mask("ok");
+  z.string().mask(["a", "b"]);
+  z.number().mask(0);
+  z.number().mask([1, 2]);
+  z.boolean().mask(true);
+  z.boolean().mask([true, false]);
+
+  // @ts-expect-error - number not assignable to string mask
+  z.string().mask(123);
+  // @ts-expect-error - string not assignable to number mask
+  z.number().mask("asdf");
+  // @ts-expect-error - string not assignable to boolean mask
+  z.boolean().mask("asdf");
+  // @ts-expect-error - number array not assignable to string mask
+  z.string().mask([1, 2]);
+  // @ts-expect-error - string array not assignable to number mask
+  z.number().mask(["a", "b"]);
+});

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -123,6 +123,20 @@ test("union", () => {
   expect(schema.parseAndMask({ v: { t: "b", s: "bar" } }).v.s).toBe("Y");
 });
 
+test("union with transform matches original branch", () => {
+  const schema = z.object({
+    v: z.union([
+      z
+        .string()
+        .mask("MASKED")
+        .transform((s) => Number(s)),
+      z.number().mask(0),
+    ]),
+  });
+  expect(schema.parseAndMask({ v: "42" }).v).toBe("MASKED");
+  expect(schema.parseAndMask({ v: 99 }).v).toBe(0);
+});
+
 test("discriminated union", () => {
   const schema = z.object({
     v: z.discriminatedUnion("t", [

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -211,6 +211,20 @@ test("async transform with mask", async () => {
   expect(await schema.parseAndMaskAsync({ a: "  asdf  " })).toEqual({ a: "M" });
 });
 
+test("async union branch masks correctly", async () => {
+  const schema = z.object({
+    v: z.union([
+      z
+        .string()
+        .mask("MASKED")
+        .transform(async (s) => s.toUpperCase()),
+      z.number(),
+    ]),
+  });
+  expect((await schema.parseAndMaskAsync({ v: "hello" })).v).toBe("MASKED");
+  expect((await schema.parseAndMaskAsync({ v: 42 })).v).toBe(42);
+});
+
 test("z.parseAndMask function form", () => {
   const schema = z.object({ a: z.string().mask("M") });
   expect(z.parseAndMask(schema, { a: "asdf" })).toEqual({ a: "M" });

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -247,6 +247,14 @@ test("deeply nested", () => {
   expect(schema.parseAndMask({ l1: { l2: { l3: { s: "asdf" } } } }).l1.l2.l3.s).toBe("D");
 });
 
+test("recursive lazy schema does not blow stack", () => {
+  type Tree = { v: string; children: Tree[] };
+  const Tree: z.ZodType<Tree> = z.lazy(() => z.object({ v: z.string(), children: z.array(Tree) }));
+  const schema = z.object({ tree: Tree.pipe(z.any()) });
+  const data = { tree: { v: "root", children: [{ v: "leaf", children: [] }] } };
+  expect(schema.parseAndMask(data)).toEqual(data);
+});
+
 test("number single value mask", () => {
   const schema = z.object({ n: z.number().mask(0) });
   expect(schema.parseAndMask({ n: 1234 })).toEqual({ n: 0 });

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -338,6 +338,20 @@ test("async union masking does not re-fire transforms", async () => {
   expect(count).toBe(1);
 });
 
+test("async union with async refine on input schema", async () => {
+  const schema = z.object({
+    v: z.union([
+      z
+        .string()
+        .refine(async () => true)
+        .mask("M"),
+      z.number(),
+    ]),
+  });
+  expect((await schema.parseAndMaskAsync({ v: "hello" })).v).toBe("M");
+  expect((await schema.parseAndMaskAsync({ v: 42 })).v).toBe(42);
+});
+
 test("z.parseAndMask function form", () => {
   const schema = z.object({ a: z.string().mask("M") });
   expect(z.parseAndMask(schema, { a: "asdf" })).toEqual({ a: "M" });

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -236,6 +236,22 @@ test("safeParseAndMaskAsync error", async () => {
   expect(r.success).toBe(false);
 });
 
+test("pipe with transform and nested union masks correctly", () => {
+  const schema = z.object({
+    v: z
+      .string()
+      .transform((s) => JSON.parse(s) as { k: string; s: string })
+      .pipe(
+        z.union([
+          z.object({ k: z.literal("a"), s: z.string().mask("M") }),
+          z.object({ k: z.literal("b"), s: z.string() }),
+        ])
+      ),
+  });
+  expect(schema.parseAndMask({ v: '{"k":"a","s":"secret"}' }).v.s).toBe("M");
+  expect(schema.parseAndMask({ v: '{"k":"b","s":"visible"}' }).v.s).toBe("visible");
+});
+
 test("async transform with mask", async () => {
   const schema = z.object({
     a: z

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -276,6 +276,44 @@ test("async union branch masks correctly", async () => {
   expect((await schema.parseAndMaskAsync({ v: 42 })).v).toBe(42);
 });
 
+test("union masking does not re-fire transforms", () => {
+  let count = 0;
+  const schema = z.object({
+    v: z.union([
+      z
+        .string()
+        .mask("MASKED")
+        .transform((s) => {
+          count++;
+          return Number(s);
+        }),
+      z.number().mask(0),
+    ]),
+  });
+  count = 0;
+  schema.parseAndMask({ v: "42" });
+  expect(count).toBe(1);
+});
+
+test("async union masking does not re-fire transforms", async () => {
+  let count = 0;
+  const schema = z.object({
+    v: z.union([
+      z
+        .string()
+        .mask("MASKED")
+        .transform(async (s) => {
+          count++;
+          return s.toUpperCase();
+        }),
+      z.number(),
+    ]),
+  });
+  count = 0;
+  await schema.parseAndMaskAsync({ v: "hello" });
+  expect(count).toBe(1);
+});
+
 test("z.parseAndMask function form", () => {
   const schema = z.object({ a: z.string().mask("M") });
   expect(z.parseAndMask(schema, { a: "asdf" })).toEqual({ a: "M" });

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -409,3 +409,23 @@ test("mask type safety", () => {
   // @ts-expect-error - string array not assignable to number mask
   z.number().mask(["a", "b"]);
 });
+
+// Pinned picks — these lock the DJB2 hash + seed + key salting algorithm.
+// Changing hash() or the salt format breaks these and the documented stability promise.
+test("pinned string array mask picks", () => {
+  const opts = ["Alice", "Bob", "Charlie", "Diana", "Eve"];
+  const schema = z.object({ id: z.string(), name: z.string().mask(opts) });
+  expect(schema.parseAndMask({ id: "usr_1", name: "ignored" }).name).toBe("Charlie");
+  expect(schema.parseAndMask({ id: "usr_2", name: "ignored" }).name).toBe("Charlie");
+  expect(schema.parseAndMask({ id: "usr_3", name: "ignored" }).name).toBe("Bob");
+  expect(schema.parseAndMask({ id: "42", name: "ignored" }).name).toBe("Alice");
+  expect(schema.parseAndMask({ id: "abc", name: "ignored" }).name).toBe("Charlie");
+});
+
+test("pinned number array mask picks", () => {
+  const opts = [10, 20, 30];
+  const schema = z.object({ id: z.string(), n: z.number().mask(opts) });
+  expect(schema.parseAndMask({ id: "usr_1", n: 999 }).n).toBe(10);
+  expect(schema.parseAndMask({ id: "usr_2", n: 999 }).n).toBe(10);
+  expect(schema.parseAndMask({ id: "42", n: 999 }).n).toBe(20);
+});

--- a/packages/zod/src/v4/classic/tests/mask.test.ts
+++ b/packages/zod/src/v4/classic/tests/mask.test.ts
@@ -152,6 +152,11 @@ test("pipe", () => {
   expect(schema.parseAndMask({ a: "asdf" })).toEqual({ a: "M" });
 });
 
+test("success preserves boolean", () => {
+  const schema = z.object({ ok: z.success(z.string().mask("M")) });
+  expect(schema.parseAndMask({ ok: "valid" })).toEqual({ ok: true });
+});
+
 test("unmasked fields pass through", () => {
   const schema = z.object({ a: z.string(), b: z.string().mask("R") });
   const r = schema.parseAndMask({ a: "hello", b: "hidden" });

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1718,6 +1718,18 @@ export function meta<T>(metadata: registries.GlobalMeta): checks.$ZodCheck<T> {
   return ch;
 }
 
+// @__NO_SIDE_EFFECTS__
+export function _mask<T>(maskValue: T | T[] | ((seed: string) => T)): checks.$ZodCheck<T> {
+  const ch = new checks.$ZodCheck({ check: "mask" });
+  ch._zod.onattach = [
+    (inst) => {
+      inst._zod.bag.mask = maskValue;
+    },
+  ];
+  ch._zod.check = () => {}; // no-op check
+  return ch;
+}
+
 // export type $ZodCustomParams = CheckTypeParams<schemas.$ZodCustom, "fn">
 
 /////////    STRINGBOOL   /////////

--- a/packages/zod/src/v4/core/index.ts
+++ b/packages/zod/src/v4/core/index.ts
@@ -1,4 +1,5 @@
 export * from "./core.js";
+export * from "./mask.js";
 export * from "./parse.js";
 export * from "./errors.js";
 export * from "./schemas.js";

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -286,9 +286,9 @@ export async function applyMaskAsync<T>(
     case "union": {
       for (const option of def.options as schemas.$ZodType[]) {
         const base = inputSchema(option);
-        const result = base._zod.run({ value: inp, issues: [] }, { async: false });
-        if (!(result instanceof Promise) && result.issues.length === 0)
-          return applyMaskAsync(option, data, seed, key, inp);
+        let result = base._zod.run({ value: inp, issues: [] }, { async: true });
+        if (result instanceof Promise) result = await result;
+        if (result.issues.length === 0) return applyMaskAsync(option, data, seed, key, inp);
       }
       return data;
     }

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -32,6 +32,15 @@ function hasMask(schema: schemas.$ZodType, seen: WeakSet<schemas.$ZodType> = new
       return false;
     case "array":
       return hasMask(def.element, seen);
+    case "record":
+      return hasMask(def.valueType, seen);
+    case "tuple":
+      if (def.items.some((item: schemas.$ZodType) => hasMask(item, seen))) return true;
+      return def.rest ? hasMask(def.rest, seen) : false;
+    case "map":
+      return hasMask(def.valueType, seen);
+    case "set":
+      return hasMask(def.valueType, seen);
     case "optional":
     case "nullable":
     case "default":
@@ -85,6 +94,45 @@ export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, ke
       if (!Array.isArray(data)) return data;
       const inputArr = Array.isArray(inp) ? inp : data;
       return data.map((item, i) => applyMask(def.element, item, seed, key, inputArr[i])) as T;
+    }
+    case "record": {
+      if (typeof data !== "object" || data === null || Array.isArray(data)) return data;
+      const rec = data as Record<string, unknown>;
+      const inpRec = (typeof inp === "object" && inp !== null && !Array.isArray(inp) ? inp : rec) as Record<
+        string,
+        unknown
+      >;
+      const result: Record<string, unknown> = {};
+      for (const k in rec) {
+        result[k] = rec[k] != null ? applyMask(def.valueType, rec[k], seed, k, inpRec[k]) : rec[k];
+      }
+      return result as T;
+    }
+    case "tuple": {
+      if (!Array.isArray(data)) return data;
+      const inputArr = Array.isArray(inp) ? inp : data;
+      const items = def.items as schemas.$ZodType[];
+      return data.map((item, i) => {
+        const schema = i < items.length ? items[i]! : def.rest;
+        return schema && item != null ? applyMask(schema, item, seed, key, inputArr[i]) : item;
+      }) as T;
+    }
+    case "map": {
+      if (!(data instanceof Map)) return data;
+      const inpMap = inp instanceof Map ? inp : data;
+      const result = new Map();
+      for (const [k, v] of data) {
+        result.set(k, v != null ? applyMask(def.valueType, v, seed, String(k), inpMap.get(k)) : v);
+      }
+      return result as T;
+    }
+    case "set": {
+      if (!(data instanceof Set)) return data;
+      const result = new Set();
+      for (const v of data) {
+        result.add(v != null ? applyMask(def.valueType, v, seed, key) : v);
+      }
+      return result as T;
     }
     case "optional":
     case "nullable":
@@ -153,6 +201,47 @@ export async function applyMaskAsync<T>(
       return Promise.all(
         data.map((item, i) => applyMaskAsync(def.element, item, seed, key, inputArr[i]))
       ) as Promise<T>;
+    }
+    case "record": {
+      if (typeof data !== "object" || data === null || Array.isArray(data)) return data;
+      const rec = data as Record<string, unknown>;
+      const inpRec = (typeof inp === "object" && inp !== null && !Array.isArray(inp) ? inp : rec) as Record<
+        string,
+        unknown
+      >;
+      const result: Record<string, unknown> = {};
+      for (const k in rec) {
+        result[k] = rec[k] != null ? await applyMaskAsync(def.valueType, rec[k], seed, k, inpRec[k]) : rec[k];
+      }
+      return result as T;
+    }
+    case "tuple": {
+      if (!Array.isArray(data)) return data;
+      const inputArr = Array.isArray(inp) ? inp : data;
+      const items = def.items as schemas.$ZodType[];
+      return Promise.all(
+        data.map((item, i) => {
+          const schema = i < items.length ? items[i]! : def.rest;
+          return schema && item != null ? applyMaskAsync(schema, item, seed, key, inputArr[i]) : item;
+        })
+      ) as Promise<T>;
+    }
+    case "map": {
+      if (!(data instanceof Map)) return data;
+      const inpMap = inp instanceof Map ? inp : data;
+      const result = new Map();
+      for (const [k, v] of data) {
+        result.set(k, v != null ? await applyMaskAsync(def.valueType, v, seed, String(k), inpMap.get(k)) : v);
+      }
+      return result as T;
+    }
+    case "set": {
+      if (!(data instanceof Set)) return data;
+      const result = new Set();
+      for (const v of data) {
+        result.add(v != null ? await applyMaskAsync(def.valueType, v, seed, key) : v);
+      }
+      return result as T;
     }
     case "optional":
     case "nullable":

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -110,3 +110,73 @@ export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, ke
       return data;
   }
 }
+
+export async function applyMaskAsync<T>(
+  schema: schemas.$ZodType,
+  data: T,
+  seed: string,
+  key = "",
+  input?: unknown
+): Promise<T> {
+  if (data == null) return data;
+
+  const mask = schema._zod.bag.mask;
+  if (mask !== undefined) {
+    const s = seed || String(data);
+    if (typeof mask === "function") return mask(s) as T;
+    if (Array.isArray(mask)) return mask[hash(s + key) % mask.length] as T;
+    return mask as T;
+  }
+
+  const def: any = schema._zod.def;
+  const inp = input ?? data;
+  switch (def.type) {
+    case "object": {
+      if (typeof data !== "object" || Array.isArray(data)) return data;
+      const shape = def.shape as Record<string, schemas.$ZodType>;
+      const record = data as Record<string, unknown>;
+      const inputRecord = (typeof inp === "object" && inp !== null && !Array.isArray(inp) ? inp : record) as Record<
+        string,
+        unknown
+      >;
+      const objectSeed = resolveSeed(shape, record, seed);
+      const result = { ...record };
+      for (const k in shape) {
+        if (k in result && result[k] != null)
+          result[k] = await applyMaskAsync(shape[k]!, result[k], objectSeed, k, inputRecord[k]);
+      }
+      return result as T;
+    }
+    case "array": {
+      if (!Array.isArray(data)) return data;
+      const inputArr = Array.isArray(inp) ? inp : data;
+      return Promise.all(
+        data.map((item, i) => applyMaskAsync(def.element, item, seed, key, inputArr[i]))
+      ) as Promise<T>;
+    }
+    case "optional":
+    case "nullable":
+    case "default":
+    case "readonly":
+    case "catch":
+    case "nonoptional":
+    case "success":
+    case "prefault":
+      return applyMaskAsync(def.innerType, data, seed, key, inp);
+    case "pipe":
+      if (hasMask(def.out)) return applyMaskAsync(def.out, data, seed, key, inp);
+      return applyMaskAsync(def.in, data, seed, key, inp);
+    case "union": {
+      for (const option of def.options as schemas.$ZodType[]) {
+        let result = option._zod.run({ value: inp, issues: [] }, { async: true });
+        if (result instanceof Promise) result = await result;
+        if (result.issues.length === 0) return applyMaskAsync(option, data, seed, key, inp);
+      }
+      return data;
+    }
+    case "lazy":
+      return applyMaskAsync(def.getter(), data, seed, key, inp);
+    default:
+      return data;
+  }
+}

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -1,0 +1,105 @@
+import type * as schemas from "./schemas.js";
+
+function hash(str: string): number {
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) h = (h * 33) ^ str.charCodeAt(i);
+  return h >>> 0;
+}
+
+function resolveSeed(
+  shape: Record<string, schemas.$ZodType>,
+  data: Record<string, unknown>,
+  parentSeed: string
+): string {
+  if (typeof data.id === "string" && data.id) return data.id;
+  let composite = "";
+  for (const key in shape) {
+    if (shape[key]!._zod.bag.mask && typeof data[key] === "string") composite += data[key];
+  }
+  return composite || parentSeed;
+}
+
+function hasMask(schema: schemas.$ZodType): boolean {
+  if (schema._zod.bag.mask !== undefined) return true;
+  const def: any = schema._zod.def;
+  switch (def.type) {
+    case "object":
+      for (const k in def.shape) {
+        if (hasMask(def.shape[k]!)) return true;
+      }
+      return false;
+    case "array":
+      return hasMask(def.element);
+    case "optional":
+    case "nullable":
+    case "default":
+    case "readonly":
+    case "catch":
+    case "nonoptional":
+    case "success":
+    case "prefault":
+      return hasMask(def.innerType);
+    case "pipe":
+      return hasMask(def.in) || hasMask(def.out);
+    case "union":
+      return def.options.some((o: schemas.$ZodType) => hasMask(o));
+    case "lazy":
+      return hasMask(def.getter());
+    default:
+      return false;
+  }
+}
+
+export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, key = ""): T {
+  if (data == null) return data;
+
+  const mask = schema._zod.bag.mask;
+  if (mask !== undefined) {
+    const s = seed || String(data);
+    if (typeof mask === "function") return mask(s) as T;
+    if (Array.isArray(mask)) return mask[hash(s + key) % mask.length] as T;
+    return mask as T;
+  }
+
+  const def: any = schema._zod.def;
+  switch (def.type) {
+    case "object": {
+      if (typeof data !== "object" || Array.isArray(data)) return data;
+      const shape = def.shape as Record<string, schemas.$ZodType>;
+      const record = data as Record<string, unknown>;
+      const objectSeed = resolveSeed(shape, record, seed);
+      const result = { ...record };
+      for (const k in shape) {
+        if (k in result && result[k] != null) result[k] = applyMask(shape[k]!, result[k], objectSeed, k);
+      }
+      return result as T;
+    }
+    case "array": {
+      if (!Array.isArray(data)) return data;
+      return data.map((item) => applyMask(def.element, item, seed, key)) as T;
+    }
+    case "optional":
+    case "nullable":
+    case "default":
+    case "readonly":
+    case "catch":
+    case "nonoptional":
+    case "success":
+    case "prefault":
+      return applyMask(def.innerType, data, seed, key);
+    case "pipe":
+      if (hasMask(def.out)) return applyMask(def.out, data, seed, key);
+      return applyMask(def.in, data, seed, key);
+    case "union": {
+      for (const option of def.options as schemas.$ZodType[]) {
+        const result = option._zod.run({ value: data, issues: [] }, { async: false });
+        if (!(result instanceof Promise) && result.issues.length === 0) return applyMask(option, data, seed, key);
+      }
+      return data;
+    }
+    case "lazy":
+      return applyMask(def.getter(), data, seed, key);
+    default:
+      return data;
+  }
+}

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -61,6 +61,28 @@ function hasMask(schema: schemas.$ZodType, seen: WeakSet<schemas.$ZodType> = new
   }
 }
 
+function inputSchema(schema: schemas.$ZodType): schemas.$ZodType {
+  const def: any = schema._zod.def;
+  switch (def.type) {
+    case "pipe":
+      return inputSchema(def.in);
+    case "transform":
+      return schema;
+    case "optional":
+    case "nullable":
+    case "default":
+    case "readonly":
+    case "catch":
+    case "nonoptional":
+    case "prefault":
+      return inputSchema(def.innerType);
+    case "lazy":
+      return inputSchema(def.getter());
+    default:
+      return schema;
+  }
+}
+
 export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, key = "", input?: unknown): T {
   if (data == null) return data;
 
@@ -148,7 +170,8 @@ export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, ke
       return applyMask(def.in, data, seed, key, inp);
     case "union": {
       for (const option of def.options as schemas.$ZodType[]) {
-        const result = option._zod.run({ value: inp, issues: [] }, { async: false });
+        const base = inputSchema(option);
+        const result = base._zod.run({ value: inp, issues: [] }, { async: false });
         if (!(result instanceof Promise) && result.issues.length === 0) return applyMask(option, data, seed, key, inp);
       }
       return data;
@@ -257,9 +280,10 @@ export async function applyMaskAsync<T>(
       return applyMaskAsync(def.in, data, seed, key, inp);
     case "union": {
       for (const option of def.options as schemas.$ZodType[]) {
-        let result = option._zod.run({ value: inp, issues: [] }, { async: true });
-        if (result instanceof Promise) result = await result;
-        if (result.issues.length === 0) return applyMaskAsync(option, data, seed, key, inp);
+        const base = inputSchema(option);
+        const result = base._zod.run({ value: inp, issues: [] }, { async: false });
+        if (!(result instanceof Promise) && result.issues.length === 0)
+          return applyMaskAsync(option, data, seed, key, inp);
       }
       return data;
     }

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -19,17 +19,19 @@ function resolveSeed(
   return composite || parentSeed;
 }
 
-function hasMask(schema: schemas.$ZodType): boolean {
+function hasMask(schema: schemas.$ZodType, seen: WeakSet<schemas.$ZodType> = new WeakSet()): boolean {
+  if (seen.has(schema)) return false;
+  seen.add(schema);
   if (schema._zod.bag.mask !== undefined) return true;
   const def: any = schema._zod.def;
   switch (def.type) {
     case "object":
       for (const k in def.shape) {
-        if (hasMask(def.shape[k]!)) return true;
+        if (hasMask(def.shape[k]!, seen)) return true;
       }
       return false;
     case "array":
-      return hasMask(def.element);
+      return hasMask(def.element, seen);
     case "optional":
     case "nullable":
     case "default":
@@ -38,13 +40,13 @@ function hasMask(schema: schemas.$ZodType): boolean {
     case "nonoptional":
     case "success":
     case "prefault":
-      return hasMask(def.innerType);
+      return hasMask(def.innerType, seen);
     case "pipe":
-      return hasMask(def.in) || hasMask(def.out);
+      return hasMask(def.in, seen) || hasMask(def.out, seen);
     case "union":
-      return def.options.some((o: schemas.$ZodType) => hasMask(o));
+      return def.options.some((o: schemas.$ZodType) => hasMask(o, seen));
     case "lazy":
-      return hasMask(def.getter());
+      return hasMask(def.getter(), seen);
     default:
       return false;
   }

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -1,5 +1,6 @@
 import type * as schemas from "./schemas.js";
 
+// DJB2 hash — frozen; exact picks from array masks are pinned in mask.test.ts.
 function hash(str: string): number {
   let h = 5381;
   for (let i = 0; i < str.length; i++) h = (h * 33) ^ str.charCodeAt(i);

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -38,7 +38,6 @@ function hasMask(schema: schemas.$ZodType, seen: WeakSet<schemas.$ZodType> = new
     case "readonly":
     case "catch":
     case "nonoptional":
-    case "success":
     case "prefault":
       return hasMask(def.innerType, seen);
     case "pipe":
@@ -93,7 +92,6 @@ export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, ke
     case "readonly":
     case "catch":
     case "nonoptional":
-    case "success":
     case "prefault":
       return applyMask(def.innerType, data, seed, key, inp);
     case "pipe":
@@ -162,7 +160,6 @@ export async function applyMaskAsync<T>(
     case "readonly":
     case "catch":
     case "nonoptional":
-    case "success":
     case "prefault":
       return applyMaskAsync(def.innerType, data, seed, key, inp);
     case "pipe":

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -144,7 +144,7 @@ export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, ke
     case "prefault":
       return applyMask(def.innerType, data, seed, key, inp);
     case "pipe":
-      if (hasMask(def.out)) return applyMask(def.out, data, seed, key, inp);
+      if (hasMask(def.out)) return applyMask(def.out, data, seed, key, data);
       return applyMask(def.in, data, seed, key, inp);
     case "union": {
       for (const option of def.options as schemas.$ZodType[]) {
@@ -253,7 +253,7 @@ export async function applyMaskAsync<T>(
     case "prefault":
       return applyMaskAsync(def.innerType, data, seed, key, inp);
     case "pipe":
-      if (hasMask(def.out)) return applyMaskAsync(def.out, data, seed, key, inp);
+      if (hasMask(def.out)) return applyMaskAsync(def.out, data, seed, key, data);
       return applyMaskAsync(def.in, data, seed, key, inp);
     case "union": {
       for (const option of def.options as schemas.$ZodType[]) {

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -11,7 +11,8 @@ function resolveSeed(
   data: Record<string, unknown>,
   parentSeed: string
 ): string {
-  if (typeof data.id === "string" && data.id) return data.id;
+  const id = data.id;
+  if (id != null && (typeof id === "string" || typeof id === "number" || typeof id === "bigint")) return String(id);
   let composite = "";
   for (const key in shape) {
     if (shape[key]!._zod.bag.mask && typeof data[key] === "string") composite += data[key];

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -151,9 +151,11 @@ export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, ke
     }
     case "set": {
       if (!(data instanceof Set)) return data;
+      const inpIter = inp instanceof Set ? inp.values() : data.values();
       const result = new Set();
       for (const v of data) {
-        result.add(v != null ? applyMask(def.valueType, v, seed, key) : v);
+        const iv = inpIter.next().value;
+        result.add(v != null ? applyMask(def.valueType, v, seed, key, iv) : v);
       }
       return result as T;
     }
@@ -261,9 +263,11 @@ export async function applyMaskAsync<T>(
     }
     case "set": {
       if (!(data instanceof Set)) return data;
+      const inpIter = inp instanceof Set ? inp.values() : data.values();
       const result = new Set();
       for (const v of data) {
-        result.add(v != null ? await applyMaskAsync(def.valueType, v, seed, key) : v);
+        const iv = inpIter.next().value;
+        result.add(v != null ? await applyMaskAsync(def.valueType, v, seed, key, iv) : v);
       }
       return result as T;
     }

--- a/packages/zod/src/v4/core/mask.ts
+++ b/packages/zod/src/v4/core/mask.ts
@@ -50,7 +50,7 @@ function hasMask(schema: schemas.$ZodType): boolean {
   }
 }
 
-export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, key = ""): T {
+export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, key = "", input?: unknown): T {
   if (data == null) return data;
 
   const mask = schema._zod.bag.mask;
@@ -62,21 +62,28 @@ export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, ke
   }
 
   const def: any = schema._zod.def;
+  const inp = input ?? data;
   switch (def.type) {
     case "object": {
       if (typeof data !== "object" || Array.isArray(data)) return data;
       const shape = def.shape as Record<string, schemas.$ZodType>;
       const record = data as Record<string, unknown>;
+      const inputRecord = (typeof inp === "object" && inp !== null && !Array.isArray(inp) ? inp : record) as Record<
+        string,
+        unknown
+      >;
       const objectSeed = resolveSeed(shape, record, seed);
       const result = { ...record };
       for (const k in shape) {
-        if (k in result && result[k] != null) result[k] = applyMask(shape[k]!, result[k], objectSeed, k);
+        if (k in result && result[k] != null)
+          result[k] = applyMask(shape[k]!, result[k], objectSeed, k, inputRecord[k]);
       }
       return result as T;
     }
     case "array": {
       if (!Array.isArray(data)) return data;
-      return data.map((item) => applyMask(def.element, item, seed, key)) as T;
+      const inputArr = Array.isArray(inp) ? inp : data;
+      return data.map((item, i) => applyMask(def.element, item, seed, key, inputArr[i])) as T;
     }
     case "optional":
     case "nullable":
@@ -86,19 +93,19 @@ export function applyMask<T>(schema: schemas.$ZodType, data: T, seed: string, ke
     case "nonoptional":
     case "success":
     case "prefault":
-      return applyMask(def.innerType, data, seed, key);
+      return applyMask(def.innerType, data, seed, key, inp);
     case "pipe":
-      if (hasMask(def.out)) return applyMask(def.out, data, seed, key);
-      return applyMask(def.in, data, seed, key);
+      if (hasMask(def.out)) return applyMask(def.out, data, seed, key, inp);
+      return applyMask(def.in, data, seed, key, inp);
     case "union": {
       for (const option of def.options as schemas.$ZodType[]) {
-        const result = option._zod.run({ value: data, issues: [] }, { async: false });
-        if (!(result instanceof Promise) && result.issues.length === 0) return applyMask(option, data, seed, key);
+        const result = option._zod.run({ value: inp, issues: [] }, { async: false });
+        if (!(result instanceof Promise) && result.issues.length === 0) return applyMask(option, data, seed, key, inp);
       }
       return data;
     }
     case "lazy":
-      return applyMask(def.getter(), data, seed, key);
+      return applyMask(def.getter(), data, seed, key, inp);
     default:
       return data;
   }

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -104,7 +104,7 @@ export type $ParseAndMask = <T extends schemas.$ZodType>(
 
 export const _parseAndMask: (_Err: $ZodErrorClass) => $ParseAndMask = (_Err) => (schema, value, _ctx, _params) => {
   const parsed = _parse(_Err)(schema, value, _ctx, _params);
-  return applyMask(schema, parsed, "");
+  return applyMask(schema, parsed, "", "", value);
 };
 
 export const parseAndMask: $ParseAndMask = /* @__PURE__*/ _parseAndMask(errors.$ZodRealError);
@@ -119,7 +119,7 @@ export type $ParseAndMaskAsync = <T extends schemas.$ZodType>(
 export const _parseAndMaskAsync: (_Err: $ZodErrorClass) => $ParseAndMaskAsync =
   (_Err) => async (schema, value, _ctx, _params) => {
     const parsed = await _parseAsync(_Err)(schema, value, _ctx, _params);
-    return applyMask(schema, parsed, "");
+    return applyMask(schema, parsed, "", "", value);
   };
 
 export const parseAndMaskAsync: $ParseAndMaskAsync = /* @__PURE__*/ _parseAndMaskAsync(errors.$ZodRealError);
@@ -133,7 +133,7 @@ export type $SafeParseAndMask = <T extends schemas.$ZodType>(
 export const _safeParseAndMask: (_Err: $ZodErrorClass) => $SafeParseAndMask = (_Err) => (schema, value, _ctx) => {
   const result = _safeParse(_Err)(schema, value, _ctx);
   if (!result.success) return result;
-  return { success: true, data: applyMask(schema, result.data, "") } as any;
+  return { success: true, data: applyMask(schema, result.data, "", "", value) } as any;
 };
 
 export const safeParseAndMask: $SafeParseAndMask = /* @__PURE__*/ _safeParseAndMask(errors.$ZodRealError);
@@ -148,7 +148,7 @@ export const _safeParseAndMaskAsync: (_Err: $ZodErrorClass) => $SafeParseAndMask
   (_Err) => async (schema, value, _ctx) => {
     const result = await _safeParseAsync(_Err)(schema, value, _ctx);
     if (!result.success) return result;
-    return { success: true, data: applyMask(schema, result.data, "") } as any;
+    return { success: true, data: applyMask(schema, result.data, "", "", value) } as any;
   };
 
 export const safeParseAndMaskAsync: $SafeParseAndMaskAsync = /* @__PURE__*/ _safeParseAndMaskAsync(

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -1,5 +1,6 @@
 import * as core from "./core.js";
 import * as errors from "./errors.js";
+import { applyMask } from "./mask.js";
 import type * as schemas from "./schemas.js";
 import * as util from "./util.js";
 
@@ -92,6 +93,67 @@ export const _safeParseAsync: (_Err: $ZodErrorClass) => $SafeParseAsync = (_Err)
 };
 
 export const safeParseAsync: $SafeParseAsync = /* @__PURE__*/ _safeParseAsync(errors.$ZodRealError);
+
+// Parse-and-mask functions
+export type $ParseAndMask = <T extends schemas.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>,
+  _params?: { callee?: util.AnyFunc; Err?: $ZodErrorClass }
+) => core.output<T>;
+
+export const _parseAndMask: (_Err: $ZodErrorClass) => $ParseAndMask = (_Err) => (schema, value, _ctx, _params) => {
+  const parsed = _parse(_Err)(schema, value, _ctx, _params);
+  return applyMask(schema, parsed, "");
+};
+
+export const parseAndMask: $ParseAndMask = /* @__PURE__*/ _parseAndMask(errors.$ZodRealError);
+
+export type $ParseAndMaskAsync = <T extends schemas.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>,
+  _params?: { callee?: util.AnyFunc; Err?: $ZodErrorClass }
+) => Promise<core.output<T>>;
+
+export const _parseAndMaskAsync: (_Err: $ZodErrorClass) => $ParseAndMaskAsync =
+  (_Err) => async (schema, value, _ctx, _params) => {
+    const parsed = await _parseAsync(_Err)(schema, value, _ctx, _params);
+    return applyMask(schema, parsed, "");
+  };
+
+export const parseAndMaskAsync: $ParseAndMaskAsync = /* @__PURE__*/ _parseAndMaskAsync(errors.$ZodRealError);
+
+export type $SafeParseAndMask = <T extends schemas.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>
+) => util.SafeParseResult<core.output<T>>;
+
+export const _safeParseAndMask: (_Err: $ZodErrorClass) => $SafeParseAndMask = (_Err) => (schema, value, _ctx) => {
+  const result = _safeParse(_Err)(schema, value, _ctx);
+  if (!result.success) return result;
+  return { success: true, data: applyMask(schema, result.data, "") } as any;
+};
+
+export const safeParseAndMask: $SafeParseAndMask = /* @__PURE__*/ _safeParseAndMask(errors.$ZodRealError);
+
+export type $SafeParseAndMaskAsync = <T extends schemas.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>
+) => Promise<util.SafeParseResult<core.output<T>>>;
+
+export const _safeParseAndMaskAsync: (_Err: $ZodErrorClass) => $SafeParseAndMaskAsync =
+  (_Err) => async (schema, value, _ctx) => {
+    const result = await _safeParseAsync(_Err)(schema, value, _ctx);
+    if (!result.success) return result;
+    return { success: true, data: applyMask(schema, result.data, "") } as any;
+  };
+
+export const safeParseAndMaskAsync: $SafeParseAndMaskAsync = /* @__PURE__*/ _safeParseAndMaskAsync(
+  errors.$ZodRealError
+);
 
 // Codec functions
 export type $Encode = <T extends schemas.$ZodType>(

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -1,6 +1,6 @@
 import * as core from "./core.js";
 import * as errors from "./errors.js";
-import { applyMask } from "./mask.js";
+import { applyMask, applyMaskAsync } from "./mask.js";
 import type * as schemas from "./schemas.js";
 import * as util from "./util.js";
 
@@ -119,7 +119,7 @@ export type $ParseAndMaskAsync = <T extends schemas.$ZodType>(
 export const _parseAndMaskAsync: (_Err: $ZodErrorClass) => $ParseAndMaskAsync =
   (_Err) => async (schema, value, _ctx, _params) => {
     const parsed = await _parseAsync(_Err)(schema, value, _ctx, _params);
-    return applyMask(schema, parsed, "", "", value);
+    return applyMaskAsync(schema, parsed, "", "", value);
   };
 
 export const parseAndMaskAsync: $ParseAndMaskAsync = /* @__PURE__*/ _parseAndMaskAsync(errors.$ZodRealError);
@@ -148,7 +148,7 @@ export const _safeParseAndMaskAsync: (_Err: $ZodErrorClass) => $SafeParseAndMask
   (_Err) => async (schema, value, _ctx) => {
     const result = await _safeParseAsync(_Err)(schema, value, _ctx);
     if (!result.success) return result;
-    return { success: true, data: applyMask(schema, result.data, "", "", value) } as any;
+    return { success: true, data: await applyMaskAsync(schema, result.data, "", "", value) } as any;
   };
 
 export const safeParseAndMaskAsync: $SafeParseAndMaskAsync = /* @__PURE__*/ _safeParseAndMaskAsync(


### PR DESCRIPTION
## Background

I was trying to find a way to dynamically replace sensitive fields from a server response during schema parsing and ended up building a small utility in a Typescript repo I work on that uses `.meta({ mask })` to tag fields, and then a `withAutoMasking()` wrapper that walks the schema and replaces tagged values on the fly. It supports static values, deterministic array picks (hashed by entity id), and function-based masks. It handles nested objects, arrays, unions, optionals, pipes, etc. The main benefit of this was being able to use production data with some sensitive values replaced dynamically in contexts where it shouldn't be exposed and not have to fiddle with mock data.

I'm really happy I was able to leverage zod in this way and it's made my life a little easier so I figured I'd try to implement it natively in Zod, where it can benefit from proper type safety and a cleaner API.
Consider this a mere suggestion and a wish. No hard feelings if there's no interest in adding such functionality at this point.

## What this PR adds

A `.mask()` method to mark fields for PII replacement and `parseAndMask`/`safeParseAndMask` (+ async variants) that validate and redact in one step:

```ts
const User = z.object({
  id: z.string(),
  name: z.string().mask("REDACTED"),
  age: z.number().mask(0),
  role: z.string().mask(["viewer", "editor"]),
  email: z.string().mask((id) => `${id}@example.com`),
});

User.parseAndMask({
  id: "usr_1",
  name: "Alice",
  age: 28,
  email: "alice@real.com",
  role: "admin",
});
// => { id: "usr_1", name: "REDACTED", age: 0, role: "viewer", email: "usr_1@example.com" }
```

### Mask types

`.mask()` is typed against the schema output, so `z.string().mask(123)` won't compile.

- A value: always used as the replacement
- An array: one is picked deterministically per entity
- A function: receives the entity's id and returns the replacement

### Deterministic masking

Array and function masks need a stable identifier so the same record always produces the same fake data. When masking an object, this identifier is resolved automatically:

1. If the object has a string `id` field, its value is used
2. Otherwise, a hash of the object's masked field values is used as a fallback

### Schema support

The walker handles nested objects, arrays, optionals, nullables, defaults, readonly, unions, discriminated unions, pipes, and lazy schemas. Null/undefined always pass through unmasked.

### Files changed

- `core/mask.ts` (new): recursive schema walker, ~100 LOC
- `core/api.ts`: `_mask` check factory, stores config in `_zod.bag`, no-op at parse time
- `core/parse.ts`: `parseAndMask` / `safeParseAndMask` + async variants
- `classic/schemas.ts`: `.mask()` method on `ZodType` via `_installLazyMethods`
- `classic/parse.ts`: re-exports for classic API
- `core/index.ts`: exports
- `classic/tests/mask.test.ts` (new): 38 tests
- `api.mdx`: docs section

_Disclaimer: The code in this PR was written with a lot of agentic assistance based on my original implementation. Consider this as a conversation starter. Sorry, for skipping the issue. Felt like this context may sell the idea better._
