### PR TITLE
Support pluggable regex engines

### DIFF
--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -131,5 +131,8 @@
     "test:watch": "pnpm vitest",
     "test": "pnpm vitest run",
     "prepublishOnly": "tsx ../../scripts/check-versions.ts"
+  },
+  "devDependencies": {
+    "re2js": "^2.8.0"
   }
 }

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1,5 +1,6 @@
 import * as checks from "./checks.js";
 import type * as core from "./core.js";
+import { testRegex } from "./core.js";
 import type * as errors from "./errors.js";
 import * as registries from "./registries.js";
 import * as schemas from "./schemas.js";
@@ -1811,7 +1812,7 @@ export function _stringFormat<Format extends string>(
     check: "string_format",
     type: "string",
     format,
-    fn: typeof fnOrRegex === "function" ? fnOrRegex : (val) => fnOrRegex.test(val),
+    fn: typeof fnOrRegex === "function" ? fnOrRegex : (val) => testRegex(fnOrRegex, val as string),
     ...params,
   };
   if (fnOrRegex instanceof RegExp) {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -811,7 +811,7 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
     if (def.pattern)
       inst._zod.check ??= (payload) => {
         def.pattern!.lastIndex = 0;
-        if (def.pattern!.test(payload.value)) return;
+        if (core.testRegex(def.pattern!, payload.value)) return;
         payload.issues.push({
           origin: "string",
           code: "invalid_format",
@@ -849,8 +849,8 @@ export const $ZodCheckRegex: core.$constructor<$ZodCheckRegex> = /*@__PURE__*/ c
     $ZodCheckStringFormat.init(inst, def);
 
     inst._zod.check = (payload) => {
-      def.pattern.lastIndex = 0;
-      if (def.pattern.test(payload.value)) return;
+      if (core.testRegex(def.pattern!, payload.value)) return;
+
       payload.issues.push({
         origin: "string",
         code: "invalid_format",

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -128,6 +128,8 @@ export interface $ZodConfig {
   localeError?: errors.$ZodErrorMap | undefined;
   /** Disable JIT schema compilation. Useful in environments that disallow `eval`. */
   jitless?: boolean | undefined;
+  /** Inject a custom regex tester (e.g., RE2) */
+  regexTester?: ((regex: RegExp) => { test: (val: string) => boolean }) | undefined;
 }
 
 interface GlobalThisWithConfig {
@@ -150,4 +152,28 @@ export const globalConfig: $ZodConfig = (globalThis as GlobalThisWithConfig).__z
 export function config(newConfig?: Partial<$ZodConfig>): $ZodConfig {
   if (newConfig) Object.assign(globalConfig, newConfig);
   return globalConfig;
+}
+
+let lastRegexTester: $ZodConfig["regexTester"];
+let testerCache = new WeakMap<RegExp, { test: (val: string) => boolean }>();
+
+export function testRegex(regex: RegExp, value: string): boolean {
+  // Clear the cache if the user dynamically updates the global config
+  if (lastRegexTester !== globalConfig.regexTester) {
+    testerCache = new WeakMap();
+    lastRegexTester = globalConfig.regexTester;
+  }
+
+  let tester = testerCache.get(regex);
+  if (!tester) {
+    tester = globalConfig.regexTester ? globalConfig.regexTester(regex) : regex;
+    testerCache.set(regex, tester);
+  }
+
+  // Reset stateful native regexes
+  if (tester === regex) {
+    regex.lastIndex = 0;
+  }
+
+  return tester.test(value);
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -487,7 +487,7 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
       // When normalize is off, require :// for http/https URLs
       // This prevents strings like "http:example.com" or "https:/path" from being silently accepted
       if (!def.normalize && def.protocol?.source === regexes.httpProtocol.source) {
-        if (!/^https?:\/\//i.test(trimmed)) {
+        if (!core.testRegex(/^https?:\/\//i, trimmed)) {
           payload.issues.push({
             code: "invalid_format",
             format: "url",
@@ -505,7 +505,7 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
 
       if (def.hostname) {
         def.hostname.lastIndex = 0;
-        if (!def.hostname.test(url.hostname)) {
+        if (!core.testRegex(def.hostname, url.hostname)) {
           payload.issues.push({
             code: "invalid_format",
             format: "url",
@@ -520,7 +520,7 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
 
       if (def.protocol) {
         def.protocol.lastIndex = 0;
-        if (!def.protocol.test(url.protocol.endsWith(":") ? url.protocol.slice(0, -1) : url.protocol)) {
+        if (!core.testRegex(def.protocol, url.protocol.endsWith(":") ? url.protocol.slice(0, -1) : url.protocol)) {
           payload.issues.push({
             code: "invalid_format",
             format: "url",
@@ -913,7 +913,7 @@ export const $ZodCIDRv6: core.$constructor<$ZodCIDRv6> = /*@__PURE__*/ core.$con
 export function isValidBase64(data: string): boolean {
   if (data === "") return true;
   // atob ignores whitespace, so reject it up front.
-  if (/\s/.test(data)) return false;
+  if (core.testRegex(/\s/, data)) return false;
   if (data.length % 4 !== 0) return false;
   try {
     // @ts-ignore
@@ -955,7 +955,7 @@ export const $ZodBase64: core.$constructor<$ZodBase64> = /*@__PURE__*/ core.$con
 
 //////////////////////////////   ZodBase64   //////////////////////////////
 export function isValidBase64URL(data: string): boolean {
-  if (!regexes.base64url.test(data)) return false;
+  if (!core.testRegex(regexes.base64url, data)) return false;
   const base64 = data.replace(/[-_]/g, (c) => (c === "-" ? "+" : "/"));
   const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
   return isValidBase64(padded);
@@ -2026,7 +2026,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
             })));
           }
         }
-        
+
         if (${id}.value === undefined) {
           if (${k} in input) {
             newResult[${k}] = undefined;
@@ -2034,7 +2034,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         } else {
           newResult[${k}] = ${id}.value;
         }
-        
+
       `);
         } else if (!isOptionalIn) {
           doc.write(`
@@ -2071,7 +2071,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
             path: iss.path ? [${k}, ...iss.path] : [${k}]
           })));
         }
-        
+
         if (${id}.value === undefined) {
           if (${k} in input) {
             newResult[${k}] = undefined;
@@ -2079,7 +2079,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         } else {
           newResult[${k}] = ${id}.value;
         }
-        
+
       `);
         }
       }
@@ -2963,7 +2963,8 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
 
         // Numeric string fallback: if key is a numeric string and failed, retry with Number(key)
         // This handles z.number(), z.literal([1, 2, 3]), and unions containing numeric literals
-        const checkNumericKey = typeof key === "string" && regexes.number.test(key) && keyResult.issues.length;
+        const checkNumericKey =
+          typeof key === "string" && core.testRegex(regexes.number, key) && keyResult.issues.length;
         if (checkNumericKey) {
           const retryResult = def.keyType._zod.run({ value: Number(key), issues: [] }, ctx);
           if (retryResult instanceof Promise) {
@@ -4326,7 +4327,7 @@ export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__
 
       inst._zod.pattern.lastIndex = 0;
 
-      if (!inst._zod.pattern.test(payload.value)) {
+      if (!core.testRegex(inst._zod.pattern, payload.value)) {
         payload.issues.push({
           input: payload.value,
           inst,

--- a/packages/zod/src/v4/core/tests/regex-engines.test.ts
+++ b/packages/zod/src/v4/core/tests/regex-engines.test.ts
@@ -1,0 +1,73 @@
+import { RE2JS } from "re2js"; // RE2 engine
+import { afterEach, describe, expect, test } from "vitest";
+import * as z from "zod/v4";
+
+describe("Pluggable Regex Engines", () => {
+  // Reset back to native RegExp after each test
+  afterEach(() => {
+    z.config({ regexTester: undefined });
+  });
+
+  describe("Compatibility checks", () => {
+    const testCases = () => {
+      // Standard string formats
+      const emailSchema = z.email();
+      expect(emailSchema.safeParse("test@example.com").success).toBe(true);
+      expect(emailSchema.safeParse("invalid-email").success).toBe(false);
+
+      // Custom Regexes
+      const customRegex = z.string().regex(/^[0-9A-F]{4}$/i);
+      expect(customRegex.safeParse("1A3F").success).toBe(true);
+      expect(customRegex.safeParse("XYZW").success).toBe(false);
+
+      // UUIDs
+      const uuidSchema = z.uuid();
+      expect(uuidSchema.safeParse("123e4567-e89b-12d3-a456-426614174000").success).toBe(true);
+      expect(uuidSchema.safeParse("not-a-uuid").success).toBe(false);
+    };
+
+    test("Native RegExp works", () => {
+      testCases();
+    });
+
+    test("RE2JS (pure JS) works seamlessly (except lookahead/lookbehind)", () => {
+      z.config({
+        regexTester: (nativeRegex) => {
+          try {
+            // Attempt to compile with strict O(n) RE2JS engine
+            return RE2JS.compile(nativeRegex.source);
+          } catch {
+            // Zod's internal email and URL regexes use lookaheads.
+            // Catch the RE2 syntax error and seamlessly fallback to native RegExp.
+            return nativeRegex;
+          }
+        },
+      });
+      testCases();
+    });
+  });
+
+  describe("ReDoS vulnerability protection", () => {
+    // A catastrophic backtracking regex
+    const vulnerableRegex = /^([a-z]+)+$/;
+
+    // A massive payload. If the regex engine uses backtracking (O(2^n)),
+    // evaluating this string will completely freeze the CI runner until a hard timeout.
+    const maliciousPayload = "a".repeat(50000) + "!";
+
+    test("Injected RE2JS correctly evaluates catastrophic payload without hanging", () => {
+      z.config({
+        regexTester: (regex) => RE2JS.compile(regex.source),
+      });
+
+      const schema = z.string().regex(vulnerableRegex);
+
+      // The functional assertion: This line must actually complete.
+      // If the engine isn't safe, the test runner will freeze here.
+      const result = schema.safeParse(maliciousPayload);
+
+      // Assert that it correctly identified the string as invalid
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,7 +318,11 @@ importers:
         specifier: npm:zod@4.0.0-beta.20250420T053007
         version: zod@4.0.0-beta.20250420T053007
 
-  packages/zod: {}
+  packages/zod:
+    devDependencies:
+      re2js:
+        specifier: ^2.8.0
+        version: 2.8.0
 
 packages:
 
@@ -2785,6 +2789,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/analytics@1.5.0':
     resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
@@ -5164,6 +5169,9 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  re2js@2.8.0:
+    resolution: {integrity: sha512-HCjH9S3vdPyoYqv6++dZGa0RtG9xr7cAV00I0ymNHaKgiYOISsfTOMAj2UAP9miRWP+786AO/a4bIvtzTFOI1Q==}
+
   react-dom@19.0.0:
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
@@ -5775,6 +5783,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser@5.39.0:
     resolution: {integrity: sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==}
@@ -11247,6 +11256,8 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  re2js@2.8.0: {}
 
   react-dom@19.0.0(react@19.0.0):
     dependencies:


### PR DESCRIPTION
Currently, zod relies entirely on the native V8 `RegExp` engine for string validations (`.regex()`, `.email()`, `.uuid()`, etc.) and when compiling dynamic constraints via `fromJsonSchema()`. Because the native JS regex engine relies on backtracking ($O(2^n)$ time complexity), it is vulnerable to ReDoS (Regular Expression Denial of Service).

This PR introduces the Adapter Pattern to Zod's internal configuration, allowing developers to inject their own regex execution environment via IoC, without Zod having to ship the engine itself. In test cases added example with re2js - pure JS RE2 regex port. Usage example:

```js
import { z } from "zod";
import { RE2JS } from "re2js";

z.config({
  regexTester: (regex) => RE2JS.compile(regex.source),
});

// This schema is now mathematically immune to ReDoS
const schema = z.string().regex(/^(a+)+b$/);
```

