### PR TITLE
fix(fr): remove hyphen in "non-optionnel"

### DIFF
--- a/packages/zod/src/v4/locales/fr.ts
+++ b/packages/zod/src/v4/locales/fr.ts
@@ -68,7 +68,7 @@ const error: () => errors.$ZodErrorMap = () => {
     map: "carte",
     set: "ensemble",
     file: "fichier",
-    nonoptional: "non-optionnel",
+    nonoptional: "non optionnel",
     nan: "NaN",
     function: "fonction",
   };


### PR DESCRIPTION
In French, "non" followed by an adjective generally does not have a hyphen, contrary to "non" followed by a noun. As "optionnel" can only be an adjective, the hyphen should be removed.

References:
1. https://grammaire.reverso.net/non-et-trait-dunion/
2. https://vitrinelinguistique.oqlf.gouv.qc.ca/21613/lorthographe/emploi-du-trait-dunion/mots-composes/mots-composes-avec-preposition-ou-adverbe/emploi-du-trait-dunion-dans-les-mots-composes-avec-non

(I am also not really sure about the translation of "map" into "carte" (even though I did not suggest any changes in the commit). AFAIK the term "map" is also commonly used in French in a programming context. On [this French MDN page](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Map) for example, no occurrences of "carte" can be found.)