### PR TITLE
Fix z.any missing object keys

### DIFF
--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -45,6 +45,12 @@ test("optionality", () => {
   expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
+  const any = z.any();
+  expect(any._zod.optin).toEqual("optional");
+  expect(any._zod.optout).toEqual(undefined);
+  expectTypeOf<typeof any._zod.optin>().toEqualTypeOf<"optional">();
+  expectTypeOf<typeof any._zod.optout>().toEqualTypeOf<"optional" | undefined>();
+
   // z.union should be optional if any of the types are optional
   const g = z.union([z.string(), z.undefined()]);
   expect(g._zod.optin).toEqual(undefined);
@@ -166,6 +172,11 @@ test("object absent keys require optin optional", () => {
     value: undefined,
     union: undefined,
   });
+
+  const valueAny = z.object({ value: z.any() });
+  expect(valueAny.parse({})).toEqual({});
+  expect(valueAny.parse({}, { jitless: true })).toEqual({});
+  expect(valueAny.parse({ value: undefined })).toEqual({ value: undefined });
 
   const optionalOutOnly = z.object({
     value: z

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1435,6 +1435,7 @@ export interface $ZodAnyDef extends $ZodTypeDef {
 
 export interface $ZodAnyInternals extends $ZodTypeInternals<any, any> {
   def: $ZodAnyDef;
+  optin: "optional";
   isst: never;
 }
 
@@ -1444,6 +1445,7 @@ export interface $ZodAny extends $ZodType {
 
 export const $ZodAny: core.$constructor<$ZodAny> = /*@__PURE__*/ core.$constructor("$ZodAny", (inst, def) => {
   $ZodType.init(inst, def);
+  inst._zod.optin = "optional";
 
   inst._zod.parse = (payload) => payload;
 });


### PR DESCRIPTION
Fixes #5997.

`z.any()` accepts `undefined`, so absent object keys using `z.any()` should not be rejected by the missing-key guard before the schema result is handled. This marks `z.any()` as optional on input while preserving its output requiredness, with coverage for both JIT and jitless object parsing.
