### PR TITLE
docs(ecosystem): add fullproduct.dev to v4 ecosystem page

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -283,6 +283,12 @@ const poweredByZodProjects: ZodResource[] = [
     description: "A fast, type-safe JSON migration tool with Zod schema validation.",
     slug: "Nano-Collective/json-up",
   },
+  {
+    name: "fullproduct.dev",
+    url: "https://fullproduct.dev?via=zod-v4-docs",
+    description: "Zod & TS-first approach to building Universal Expo + Next.js apps using schemas as single source of truth",
+    slug: "FullProduct-dev/green-stack-starter-demo",
+  },
 ];
 
 const zodUtilities: ZodResource[] = [

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -327,6 +327,12 @@ const poweredByZodProjects: ZodResource[] = [
     description: "Environment variable validation from editor to runtime, for Next.js, Nuxt, Node.js, Vite, Bun, and more.",
     slug: "yamcodes/arkenv",
   },
+  {
+    name: "fullproduct.dev",
+    url: "https://fullproduct.dev?via=zod-v4-docs",
+    description: "Zod & TS-first approach to building Universal Expo + Next.js apps using schemas as single source of truth",
+    slug: "FullProduct-dev/green-stack-starter-demo",
+  },
 ];
 
 const zodUtilities: ZodResource[] = [

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -329,7 +329,7 @@ const poweredByZodProjects: ZodResource[] = [
   },
   {
     name: "fullproduct.dev",
-    url: "https://fullproduct.dev?via=zod-v4-docs",
+    url: "https://fullproduct.dev",
     description: "Zod & TS-first approach to building Universal Expo + Next.js apps using schemas as single source of truth",
     slug: "FullProduct-dev/green-stack-starter-demo",
   },


### PR DESCRIPTION
## Summary 
 
- Adds [FullProduct.dev](https://fullproduct.dev) to the Zod Ecosystem section & page

## What is FullProduct.dev, how is it powered by Zod?
 
_**Zod as the single source of truth**_ for this universal app starterkit:
- Expands Zod schemas (v3 + v4 + mini) with powerful additional metadata and introspection API's
- Transform zod component prop schemas to Interactive MDX docs with Nextra
- Scaffold out an auto-generated graphql schema (+ queries) from your resolver's Zod input and output schemas
- Plugins to create DB models from Zod schemas to e.g. Mongoose Models
- `useFormState()` hook to further keep things in sync

## Related

- V3 PR that got merged into V3 docs: #4131
- How Zod is used as the core for Single Sources of Truth: https://fullproduct.dev/docs/single-sources-of-truth
