### PR TITLE
docs: add dynamic error message and combined refinement examples for refine()

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2127,6 +2127,31 @@ const myString = z.string().check(
 </Tab>
 </Tabs>
 
+The `error` option also accepts a **function** for dynamic error messages. The function receives the raw issue object, including `iss.input` (the value that failed validation):
+
+<Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
+<Tab value="Zod">
+```ts
+const myString = z.string().refine(
+  (val) => val.startsWith("hello"),
+  {
+    error: (iss) => `Expected greeting, got "${iss.input}"`,
+  }
+);
+```
+</Tab>
+<Tab value="Zod Mini">
+```ts
+const myString = z.string().check(
+  z.refine(
+    (val) => val.startsWith("hello"),
+    { error: (iss) => `Expected greeting, got "${iss.input}"` }
+  )
+);
+```
+</Tab>
+</Tabs>
+
 #### `abort` 
 
 By default, validation issues from checks are considered *continuable*; that is, Zod will execute *all* checks in sequence, even if one of them causes a validation error. This is usually desirable, as it means Zod can surface as many errors as possible in one go.

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2127,27 +2127,25 @@ const myString = z.string().check(
 </Tab>
 </Tabs>
 
-The `error` option also accepts a **function** for dynamic error messages. The function receives the raw issue object, including `iss.input` (the value that failed validation):
+The `error` option also accepts a function that receives the issue:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">
 ```ts
-const myString = z.string().refine(
-  (val) => val.startsWith("hello"),
-  {
-    error: (iss) => `Expected greeting, got "${iss.input}"`,
-  }
-);
+const myString = z.string().refine((val) => val.length > 8, {
+  error: (iss) => `Too short: "${iss.input}"`
+});
+
+myString.parse("OH NO"); // ❌ Too short: "OH NO"
 ```
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 const myString = z.string().check(
-  z.refine(
-    (val) => val.startsWith("hello"),
-    { error: (iss) => `Expected greeting, got "${iss.input}"` }
-  )
+  z.refine((val) => val.length > 8, { error: (iss) => `Too short: "${iss.input}"` })
 );
+
+z.parse(myString, "OH NO"); // ❌ Too short: "OH NO"
 ```
 </Tab>
 </Tabs>


### PR DESCRIPTION
Fixes [#5998](https://github.com/colinhacks/zod/issues/5998)

  Add more examples of custom error messages with `.refine()` to the API docs:

  - **Dynamic error messages**: shows how to pass a function to the `error` option, giving access to `iss.input` to build messages based on the failing value  - **Combined `.refine()` + `.superRefine()`**: a practical password schema example demonstrating when to use each — `.refine()` for simple single-message checks,
  `.superRefine()` when multiple issues or full control over issue codes/paths is needed
  - **Best practices guidance**: prose note clarifying the decision boundary between the two methods, with a cross-link to the `.superRefine()` section