### PR TITLE
Add regression test for object union inference

### DIFF
--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -715,3 +715,16 @@ describe("__proto__ in object catchall paths", () => {
     expect(result.success).toBe(true);
   });
 });
+
+test("object property union inference matches standalone union", () => {
+  const EventNameSchema = z.string().or(z.array(z.string()));
+  type EventName = z.infer<typeof EventNameSchema>;
+
+  const EventSchema = z.object({
+    name: z.string().or(z.array(z.string())),
+  });
+  type EventWithName = z.infer<typeof EventSchema>;
+
+  expectTypeOf<EventWithName["name"]>().toEqualTypeOf<EventName>();
+  expectTypeOf<EventWithName["name"]>().toEqualTypeOf<string | string[]>();
+});


### PR DESCRIPTION
This adds a focused regression test for the object-property union inference case from #2654. The current v4 type inference already produces the same type for a standalone union schema and the same union inside an object property, so this keeps that behavior covered.\n\nValidation:\n- Ran a standalone TypeScript check against latest zod with the original repro shape.\n\n/claim #2654