### PR TITLE
test(v3): pin union-in-object inference (issue #2654)

### DIFF
--- a/packages/zod/src/v3/tests/unions.test.ts
+++ b/packages/zod/src/v3/tests/unions.test.ts
@@ -2,6 +2,7 @@
 import { expect, test } from "vitest";
 
 import * as z from "zod/v3";
+import { util } from "../helpers/util.js";
 
 test("function parsing", () => {
   const schema = z.union([z.string().refine(() => false), z.number().refine(() => false)]);
@@ -54,4 +55,12 @@ test("readonly union", async () => {
   const union = z.union(options);
   union.parse("asdf");
   union.parse(12);
+});
+
+test("union nested in object infers cleanly (issue #2654)", () => {
+  const EventSchema = z.object({
+    name: z.string().or(z.array(z.string())),
+  });
+  type Inferred = z.infer<typeof EventSchema>;
+  util.assertEqual<Inferred, { name: string | string[] }>(true);
 });


### PR DESCRIPTION
## Summary

Add v3 regression test locking the inferred type for a union nested in z.object so the original #2654 bug can't silently return.

## Closes

Fixes Algora bounty: https://github.com/colinhacks/zod/issues/2654

## Disclosure

This PR was AI-assisted (Claude Code) and reviewed by a human before submission.
