### PR TITLE
fix(v4): preserve discriminatedUnion inference for recursive getter options

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1692,7 +1692,7 @@ export function discriminatedUnion<
   // const [options, params] = args;
   return new ZodDiscriminatedUnion({
     type: "union",
-    options,
+    options: options as any as core.$ZodType[],
     discriminator,
     ...util.normalizeParams(params),
   }) as any;

--- a/packages/zod/src/v4/classic/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/recursive-types.test.ts
@@ -629,3 +629,51 @@ test("recursive type with `id` meta", () => {
     },
   });
 });
+
+test("mutual recursion through discriminatedUnion getter", () => {
+  // Mutually-recursive getter variants that recurse back through the union.
+  // Previously z.discriminatedUnion broke inference here (ts7022/ts2615 -> any),
+  // while the equivalent z.union worked. Both should now infer the same type.
+  // Children are optional so the recursion has a terminating runtime value.
+  const variantA = z.object({
+    kind: z.literal("a"),
+    get child() {
+      return tree.optional();
+    },
+  });
+
+  const variantB = z.object({
+    kind: z.literal("b"),
+    get sibling() {
+      return tree.optional();
+    },
+  });
+
+  const tree = z.discriminatedUnion("kind", [variantA, variantB]);
+  type Tree = z.input<typeof tree>;
+
+  type _Tree =
+    | {
+        kind: "a";
+        child?: _Tree | undefined;
+      }
+    | {
+        kind: "b";
+        sibling?: _Tree | undefined;
+      };
+
+  // The inferred type must be the recursive union shape, not `any`.
+  expectTypeOf<Tree>().toEqualTypeOf<_Tree>();
+  expectTypeOf<Tree>().not.toBeAny();
+
+  // discriminatedUnion and the union equivalent must infer the same type.
+  const treeUnion = z.union([variantA, variantB]);
+  expectTypeOf<z.input<typeof tree>>().toEqualTypeOf<z.input<typeof treeUnion>>();
+
+  // Runtime still works, including the discriminator fast path.
+  expect(tree.parse({ kind: "a", child: { kind: "b", sibling: { kind: "a" } } })).toEqual({
+    kind: "a",
+    child: { kind: "b", sibling: { kind: "a" } },
+  });
+  expect(() => tree.parse({ kind: "c" })).toThrow();
+});

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1207,14 +1207,33 @@ export function _xor<const T extends readonly schemas.$ZodObject[]>(
 }
 
 // ZodDiscriminatedUnion
-export interface $ZodTypeDiscriminableInternals<Disc extends string = string>
-  extends schemas.$ZodTypeInternals<unknown, { [K in Disc]?: unknown }> {
+export interface $ZodTypeDiscriminableInternals {
   propValues: util.PropValues;
 }
 
-export interface $ZodTypeDiscriminable<Disc extends string = string> extends schemas.$ZodType {
-  _zod: $ZodTypeDiscriminableInternals<Disc>;
-}
+/**
+ * Constraint for `discriminatedUnion` options: each option must expose the
+ * discriminator key.
+ *
+ * The shape of this type is load-bearing for recursion support. It is based on
+ * `SomeType` (not `$ZodType`) and deliberately does not constrain the option's
+ * `output`/`input` directly; for object schemas the discriminator key is checked
+ * against `def.shape`, not the resolved input type. Constraining `$ZodType`
+ * (which carries `~standard`, referencing `input`/`output`) or constraining the
+ * `input` of object options would force their inferred input to be evaluated
+ * while the constraint is checked. For mutually-recursive getter schemas — whose
+ * input references the union itself — that eager evaluation makes TypeScript
+ * report circularity errors (ts2615/ts7022) and collapse the inferred type to
+ * `any`, even though the equivalent `union` infers correctly. Non-object options
+ * (e.g. pipes/transforms, which have no `shape`) fall back to checking the
+ * inferred input, preserving the previous behavior for those options.
+ */
+export type $ZodTypeDiscriminable<Disc extends string = string> = schemas.SomeType & {
+  _zod: $ZodTypeDiscriminableInternals;
+} & (
+    | { _zod: { def: { shape: { [K in Disc]: schemas.SomeType } } } }
+    | { _zod: { def: { shape?: undefined }; input: { [K in Disc]?: unknown } } }
+  );
 
 export type $ZodDiscriminatedUnionParams = TypeParams<schemas.$ZodDiscriminatedUnion, "options" | "discriminator">;
 // @__NO_SIDE_EFFECTS__
@@ -1229,7 +1248,7 @@ export function _discriminatedUnion<
 ): schemas.$ZodDiscriminatedUnion<Types, Disc> {
   return new Class({
     type: "union",
-    options,
+    options: options as any as schemas.$ZodType[],
     discriminator,
     ...util.normalizeParams(params),
   }) as any;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1,4 +1,3 @@
-import type { $ZodTypeDiscriminable } from "./api.js";
 import * as checks from "./checks.js";
 import * as core from "./core.js";
 import { Doc } from "./doc.js";
@@ -2382,7 +2381,7 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
     });
 
     const disc = util.cached(() => {
-      const opts = def.options as $ZodTypeDiscriminable[];
+      const opts = def.options;
       const map: Map<util.Primitive, $ZodType> = new Map();
       for (const o of opts) {
         const values = o._zod.propValues?.[def.discriminator];

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1092,10 +1092,10 @@ export function discriminatedUnion<
 ): ZodMiniDiscriminatedUnion<Types, Disc> {
   return new ZodMiniDiscriminatedUnion({
     type: "union",
-    options,
+    options: options as any as core.$ZodType[],
     discriminator,
     ...util.normalizeParams(params),
-  }) as ZodMiniDiscriminatedUnion<Types, Disc>;
+  }) as any as ZodMiniDiscriminatedUnion<Types, Disc>;
 }
 
 // ZodMiniIntersection

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -252,6 +252,42 @@ test("z.discriminatedUnion rejects object options missing the discriminator at t
   z.discriminatedUnion("type", [z.object({ value: z.string() })]);
 });
 
+test("z.discriminatedUnion infers mutually-recursive getter options", () => {
+  const variantA = z.object({
+    kind: z.literal("a"),
+    get child() {
+      return z.optional(tree);
+    },
+  });
+
+  const variantB = z.object({
+    kind: z.literal("b"),
+    get sibling() {
+      return z.optional(tree);
+    },
+  });
+
+  const tree = z.discriminatedUnion("kind", [variantA, variantB]);
+  type Tree = z.input<typeof tree>;
+
+  type _Tree =
+    | {
+        kind: "a";
+        child?: _Tree | undefined;
+      }
+    | {
+        kind: "b";
+        sibling?: _Tree | undefined;
+      };
+
+  // Inference must not collapse to `any`.
+  expectTypeOf<Tree>().toEqualTypeOf<_Tree>();
+  expectTypeOf<Tree>().not.toBeAny();
+
+  expect(z.parse(tree, { kind: "a", child: { kind: "b" } })).toEqual({ kind: "a", child: { kind: "b" } });
+  expect(() => z.parse(tree, { kind: "c" })).toThrow();
+});
+
 test("z.intersection", () => {
   const a = z.intersection(z.object({ a: z.string() }), z.object({ b: z.number() }));
   expect(z.parse(a, { a: "hello", b: 123 })).toEqual({ a: "hello", b: 123 });


### PR DESCRIPTION
## Summary
`z.discriminatedUnion` collapsed TypeScript inference to `any` (emitting ts(7022)/ts(2615)) for mutually-recursive, getter-based object schemas that recurse back through the union, while the equivalent `z.union` inferred correctly.

## Root cause
The option constraint `$ZodTypeDiscriminable` was based on `$ZodType` and required the discriminator on each option's resolved `input` (`{ [K in Disc]?: unknown }`). Both force the option's inferred input to be evaluated while the call's argument constraint is checked. For schemas whose input references the union itself this is circular, so TS reports ts(2615)/ts(7022) and falls back to `any`. `z.union` does not constrain option input in argument position, so it stays lazy and infers fine.

## Fix
`$ZodTypeDiscriminable<Disc>` is now based on `SomeType` and, for object options, checks the discriminator against `def.shape` rather than the resolved input. Non-object options (pipes/transforms, which have no `shape`) still validate via `input`, preserving prior behavior. The three factory bodies cast `options` exactly like the existing `union`/`xor` factories.

Preserved guarantees (covered by existing + new type tests): an object option missing the discriminator is still a type error; a pipe option whose object lacks the discriminator is still a type error; an empty options list is still rejected; non-recursive and nested discriminated unions infer unchanged.

## Test plan
- New type + runtime tests for the recursive getter case (classic + mini); both fail without the fix
- `pnpm test` — 339 files / 3815 tests pass, no type errors
- `tsc -p tsconfig.test.json --noEmit` clean

Closes #5991