### PR TITLE
feat(v4): add toOutputSchema()

### DIFF
--- a/packages/zod/src/v4/classic/external.ts
+++ b/packages/zod/src/v4/classic/external.ts
@@ -31,6 +31,7 @@ export {
   NEVER,
 } from "../core/index.js";
 export { toJSONSchema } from "../core/json-schema-processors.js";
+export { toOutputSchema } from "../core/to-output-schema.js";
 export { fromJSONSchema } from "./from-json-schema.js";
 
 export * as locales from "../locales/index.js";

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -3,6 +3,7 @@ import { util } from "../core/index.js";
 import * as processors from "../core/json-schema-processors.js";
 import type { StandardSchemaWithJSONProps } from "../core/standard-schema.js";
 import { createStandardJSONSchemaMethod, createToJSONSchemaMethod } from "../core/to-json-schema.js";
+import { toOutputSchema } from "../core/to-output-schema.js";
 
 import * as checks from "./checks.js";
 import * as iso from "./iso.js";
@@ -147,6 +148,11 @@ export interface ZodType<
     params?: core.ParseContext<core.$ZodIssue>
   ): Promise<parse.ZodSafeParseResult<core.output<this>>>;
 
+  // output schema
+  /** Returns a new schema that validates the *output* (decoded) shape,
+   *  with all pipes/codecs resolved to their `.out` schemas. */
+  outputSchema(): this;
+
   // refinements
   refine<Ch extends (arg: core.output<this>) => unknown | Promise<unknown>>(
     check: Ch,
@@ -245,6 +251,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   inst.safeDecode = (data, params) => parse.safeDecode(inst, data, params);
   inst.safeEncodeAsync = async (data, params) => parse.safeEncodeAsync(inst, data, params);
   inst.safeDecodeAsync = async (data, params) => parse.safeDecodeAsync(inst, data, params);
+  inst.outputSchema = () => toOutputSchema(inst) as any;
 
   // All builder methods are placed on the internal prototype as lazy-bind
   // getters. On first access per-instance, a bound thunk is allocated and

--- a/packages/zod/src/v4/classic/tests/output-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/output-schema.test.ts
@@ -1,0 +1,135 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as z from "zod/v4";
+
+// Helper: a JSON string <-> object codec
+const jsonCodec = <T extends z.ZodType>(inner: T) =>
+  z.codec(z.string(), inner, {
+    decode: (s) => JSON.parse(s),
+    encode: (v) => JSON.stringify(v),
+  });
+
+test("leaf schema returns same instance", () => {
+  const str = z.string();
+  expect(z.toOutputSchema(str)).toBe(str);
+
+  const num = z.number();
+  expect(z.toOutputSchema(num)).toBe(num);
+
+  const bool = z.boolean();
+  expect(z.toOutputSchema(bool)).toBe(bool);
+});
+
+test("simple codec replaced by .out schema", () => {
+  const codec = z.codec(z.string(), z.number(), {
+    decode: (s) => Number(s),
+    encode: (n) => String(n),
+  });
+
+  const output = z.toOutputSchema(codec);
+  // The output schema should validate numbers, not strings
+  expect(output.safeParse(42).success).toBe(true);
+  expect(output.safeParse("42").success).toBe(false);
+});
+
+test("object with codec field — validates decoded objects, rejects encoded strings", () => {
+  const schema = z.object({
+    name: z.string(),
+    metadata: jsonCodec(z.object({ role: z.string() })),
+  });
+
+  const output = z.toOutputSchema(schema);
+
+  // Should accept the decoded form
+  expect(output.safeParse({ name: "Alice", metadata: { role: "admin" } }).success).toBe(true);
+
+  // Should reject the encoded (string) form
+  expect(output.safeParse({ name: "Alice", metadata: '{"role":"admin"}' }).success).toBe(false);
+});
+
+test("array of objects with codecs", () => {
+  const itemSchema = z.object({
+    value: jsonCodec(z.number()),
+  });
+  const schema = z.array(itemSchema);
+
+  const output = z.toOutputSchema(schema);
+  expect(output.safeParse([{ value: 42 }, { value: 7 }]).success).toBe(true);
+  expect(output.safeParse([{ value: "42" }]).success).toBe(false);
+});
+
+test("discriminated union with codec fields", () => {
+  const schema = z.union([
+    z.object({ type: z.literal("a"), data: jsonCodec(z.number()) }),
+    z.object({ type: z.literal("b"), data: z.string() }),
+  ]);
+
+  const output = z.toOutputSchema(schema);
+  expect(output.safeParse({ type: "a", data: 123 }).success).toBe(true);
+  expect(output.safeParse({ type: "b", data: "hello" }).success).toBe(true);
+  expect(output.safeParse({ type: "a", data: "123" }).success).toBe(false);
+});
+
+test("optional/nullable codec field", () => {
+  const schema = z.object({
+    opt: jsonCodec(z.number()).optional(),
+    nul: jsonCodec(z.boolean()).nullable(),
+  });
+
+  const output = z.toOutputSchema(schema);
+  expect(output.safeParse({ opt: 42, nul: true }).success).toBe(true);
+  expect(output.safeParse({ nul: null }).success).toBe(true);
+  expect(output.safeParse({ opt: undefined, nul: false }).success).toBe(true);
+  expect(output.safeParse({ opt: "42", nul: true }).success).toBe(false);
+});
+
+test("schema with no codecs returns same instance (identity optimisation)", () => {
+  const schema = z.object({
+    name: z.string(),
+    age: z.number(),
+    tags: z.array(z.string()),
+  });
+
+  expect(z.toOutputSchema(schema)).toBe(schema);
+});
+
+test("deeply nested: codec inside optional inside array inside object", () => {
+  const schema = z.object({
+    items: z.array(jsonCodec(z.object({ id: z.number() })).optional()),
+  });
+
+  const output = z.toOutputSchema(schema);
+  expect(output.safeParse({ items: [{ id: 1 }, undefined, { id: 3 }] }).success).toBe(true);
+  expect(output.safeParse({ items: ['{"id":1}'] }).success).toBe(false);
+});
+
+test("z.output<> type inference on the result", () => {
+  const codec = z.codec(z.string(), z.number(), {
+    decode: (s) => Number(s),
+    encode: (n) => String(n),
+  });
+  const schema = z.object({ value: codec });
+
+  const output = z.toOutputSchema(schema);
+  type OutputType = z.output<typeof output>;
+
+  // The output type should have `value: number`, not `value: string`
+  expectTypeOf<OutputType>().toEqualTypeOf<{ value: number }>();
+});
+
+test("standalone z.toOutputSchema() function works same as instance method", () => {
+  const schema = z.object({
+    data: jsonCodec(z.number()),
+  });
+
+  const fromStandalone = z.toOutputSchema(schema);
+  const fromInstance = schema.outputSchema();
+
+  // Both should validate the same way
+  const testData = { data: 42 };
+  expect(fromStandalone.safeParse(testData).success).toBe(true);
+  expect(fromInstance.safeParse(testData).success).toBe(true);
+
+  const badData = { data: "42" };
+  expect(fromStandalone.safeParse(badData).success).toBe(false);
+  expect(fromInstance.safeParse(badData).success).toBe(false);
+});

--- a/packages/zod/src/v4/core/index.ts
+++ b/packages/zod/src/v4/core/index.ts
@@ -12,5 +12,6 @@ export * from "./doc.js";
 export * from "./api.js";
 export * from "./to-json-schema.js";
 export { toJSONSchema } from "./json-schema-processors.js";
+export { toOutputSchema } from "./to-output-schema.js";
 export { JSONSchemaGenerator } from "./json-schema-generator.js";
 export * as JSONSchema from "./json-schema.js";

--- a/packages/zod/src/v4/core/to-output-schema.ts
+++ b/packages/zod/src/v4/core/to-output-schema.ts
@@ -1,0 +1,234 @@
+import type { $ZodType } from "./schemas.js";
+
+/**
+ * Recursively walks a zod schema tree and resolves every pipe/codec to its
+ * `.out` (output) schema. The result is a new zod schema that validates the
+ * *decoded* shape — useful when a framework needs to validate data that has
+ * already been through the codec's decode step.
+ *
+ * When the subtree contains no pipes/codecs the **same instance** is returned
+ * (zero extra allocations for codec-free schemas).
+ */
+export function toOutputSchema<T extends $ZodType>(schema: T): T {
+  return recurse(schema) as T;
+}
+
+const _cache = new WeakMap<$ZodType, $ZodType>();
+
+function recurse(schema: $ZodType): $ZodType {
+  if (_cache.has(schema)) return _cache.get(schema)!;
+
+  // Eagerly store — handles cycles (lazy schemas that reference themselves).
+  _cache.set(schema, schema);
+
+  // Cast to `any` because $ZodTypeDef only declares `type` + `checks`;
+  // the child-specific properties (innerType, shape, element, …) live on
+  // the concrete def sub-interfaces.
+  const def: any = schema._zod.def;
+  let result: $ZodType;
+
+  switch (def.type as string) {
+    // ── Leaf types — return as-is ──────────────────────────────────────
+    case "string":
+    case "number":
+    case "int":
+    case "boolean":
+    case "bigint":
+    case "symbol":
+    case "null":
+    case "undefined":
+    case "void":
+    case "never":
+    case "any":
+    case "unknown":
+    case "date":
+    case "enum":
+    case "literal":
+    case "nan":
+    case "template_literal":
+    case "file":
+    case "success":
+    case "custom":
+    case "function":
+    case "transform":
+      result = schema;
+      break;
+
+    // ── Pipe / codec — resolve to the output side ──────────────────────
+    case "pipe": {
+      result = recurse(def.out);
+      break;
+    }
+
+    // ── Single-child wrappers ──────────────────────────────────────────
+    case "optional":
+    case "nullable":
+    case "nonoptional":
+    case "default":
+    case "prefault":
+    case "catch":
+    case "readonly":
+    case "promise": {
+      const inner = def.innerType as $ZodType;
+      const newInner = recurse(inner);
+      if (newInner === inner) {
+        result = schema;
+      } else {
+        result = new (schema._zod.constr as any)({ ...def, innerType: newInner });
+      }
+      break;
+    }
+
+    // ── Object ─────────────────────────────────────────────────────────
+    case "object": {
+      const shape: Record<string, $ZodType> = def.shape;
+      let changed = false;
+      const newShape: Record<string, $ZodType> = {};
+      for (const key in shape) {
+        const field = shape[key]!;
+        const newField = recurse(field);
+        newShape[key] = newField;
+        if (newField !== field) changed = true;
+      }
+      let newCatchall = def.catchall as $ZodType | undefined;
+      if (newCatchall) {
+        const resolved = recurse(newCatchall);
+        if (resolved !== newCatchall) {
+          newCatchall = resolved;
+          changed = true;
+        }
+      }
+      if (changed) {
+        result = new (schema._zod.constr as any)({ ...def, shape: newShape, catchall: newCatchall });
+      } else {
+        result = schema;
+      }
+      break;
+    }
+
+    // ── Array ──────────────────────────────────────────────────────────
+    case "array": {
+      const element = def.element as $ZodType;
+      const newElement = recurse(element);
+      if (newElement === element) {
+        result = schema;
+      } else {
+        result = new (schema._zod.constr as any)({ ...def, element: newElement });
+      }
+      break;
+    }
+
+    // ── Union ──────────────────────────────────────────────────────────
+    case "union": {
+      const options: readonly $ZodType[] = def.options;
+      let changed = false;
+      const newOptions = options.map((opt) => {
+        const newOpt = recurse(opt);
+        if (newOpt !== opt) changed = true;
+        return newOpt;
+      });
+      if (changed) {
+        result = new (schema._zod.constr as any)({ ...def, options: newOptions });
+      } else {
+        result = schema;
+      }
+      break;
+    }
+
+    // ── Intersection ───────────────────────────────────────────────────
+    case "intersection": {
+      const left = def.left as $ZodType;
+      const right = def.right as $ZodType;
+      const newLeft = recurse(left);
+      const newRight = recurse(right);
+      if (newLeft === left && newRight === right) {
+        result = schema;
+      } else {
+        result = new (schema._zod.constr as any)({ ...def, left: newLeft, right: newRight });
+      }
+      break;
+    }
+
+    // ── Tuple ──────────────────────────────────────────────────────────
+    case "tuple": {
+      const items: readonly $ZodType[] = def.items;
+      let changed = false;
+      const newItems = items.map((item) => {
+        const newItem = recurse(item);
+        if (newItem !== item) changed = true;
+        return newItem;
+      });
+      let newRest = def.rest as $ZodType | null;
+      if (newRest) {
+        const resolvedRest = recurse(newRest);
+        if (resolvedRest !== newRest) {
+          newRest = resolvedRest;
+          changed = true;
+        }
+      }
+      if (changed) {
+        result = new (schema._zod.constr as any)({ ...def, items: newItems, rest: newRest });
+      } else {
+        result = schema;
+      }
+      break;
+    }
+
+    // ── Record ─────────────────────────────────────────────────────────
+    case "record": {
+      const keyType = def.keyType as $ZodType;
+      const valueType = def.valueType as $ZodType;
+      const newKeyType = recurse(keyType);
+      const newValueType = recurse(valueType);
+      if (newKeyType === keyType && newValueType === valueType) {
+        result = schema;
+      } else {
+        result = new (schema._zod.constr as any)({ ...def, keyType: newKeyType, valueType: newValueType });
+      }
+      break;
+    }
+
+    // ── Map ────────────────────────────────────────────────────────────
+    case "map": {
+      const keyType = def.keyType as $ZodType;
+      const valueType = def.valueType as $ZodType;
+      const newKeyType = recurse(keyType);
+      const newValueType = recurse(valueType);
+      if (newKeyType === keyType && newValueType === valueType) {
+        result = schema;
+      } else {
+        result = new (schema._zod.constr as any)({ ...def, keyType: newKeyType, valueType: newValueType });
+      }
+      break;
+    }
+
+    // ── Set ────────────────────────────────────────────────────────────
+    case "set": {
+      const valueType = def.valueType as $ZodType;
+      const newValueType = recurse(valueType);
+      if (newValueType === valueType) {
+        result = schema;
+      } else {
+        result = new (schema._zod.constr as any)({ ...def, valueType: newValueType });
+      }
+      break;
+    }
+
+    // ── Lazy ───────────────────────────────────────────────────────────
+    case "lazy": {
+      const getter = def.getter as () => $ZodType;
+      result = new (schema._zod.constr as any)({
+        ...def,
+        getter: () => recurse(getter()),
+      });
+      break;
+    }
+
+    // ── Fallback: unknown type — return as-is ──────────────────────────
+    default:
+      result = schema;
+  }
+
+  _cache.set(schema, result);
+  return result;
+}

--- a/packages/zod/src/v4/mini/external.ts
+++ b/packages/zod/src/v4/mini/external.ts
@@ -23,6 +23,7 @@ export {
   NEVER,
 } from "../core/index.js";
 export { toJSONSchema } from "../core/json-schema-processors.js";
+export { toOutputSchema } from "../core/to-output-schema.js";
 
 export * as locales from "../locales/index.js";
 /** A special constant with type `never` */


### PR DESCRIPTION
## Summary

- Adds a standalone `toOutputSchema(schema)` function that recursively walks a composed zod schema and resolves every pipe/codec to its `.out` schema, returning a plain zod schema for the output (decoded) shape
- Exported from core, classic, and mini layers (standalone function only — follows the `toJSONSchema` pattern)
- Also adds `.outputSchema()` instance method on `ZodType` in the classic layer (matching `inst.toJSONSchema`)

Closes #6016. Also addresses the use case in #5377 and draft PR #5704.

## Test plan

- [x] New test file `packages/zod/src/v4/classic/tests/output-schema.test.ts` with 10 test cases:
  - Leaf schemas return same instance
  - Simple codec resolved to `.out` schema
  - Object with codec fields validates decoded shape
  - Array of objects with codecs
  - Discriminated union with codec fields
  - Optional/nullable codec fields
  - Identity optimisation (no codecs → same instance)
  - Deeply nested: codec inside optional inside array inside object
  - `z.output<>` type inference on result
  - Standalone `z.toOutputSchema()` matches instance `.outputSchema()`
- [x] All existing classic tests pass (160 files, 2204 tests, 0 type errors)
- [x] All existing mini tests pass (30 files, 340 tests, 0 type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)