### PR TITLE
fix: json schema tuple rest compliance

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -18,6 +18,10 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
   **Experimental** — The `z.fromJSONSchema()` function is experimental and is not considered part of Zod's stable API. It is likely to undergo implementation changes in future releases.
 </Callout>
 
+<Callout type="info">
+  **Note on Tuples:** Per Draft-07 and Draft-2020-12 specifications, positional tuples generated via `prefixItems` or `items[]` arrays are open-ended by default and will append `.rest(z.any())`. To enforce a strict, closed tuple boundary, you must explicitly declare `items: false` or `additionalItems: false` within your source JSON Schema.
+</Callout>
+
 Zod provides `z.fromJSONSchema()` to convert a JSON Schema into a Zod schema.
 
 ```ts

--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -18,10 +18,6 @@ import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
   **Experimental** — The `z.fromJSONSchema()` function is experimental and is not considered part of Zod's stable API. It is likely to undergo implementation changes in future releases.
 </Callout>
 
-<Callout type="info">
-  **Note on Tuples:** Per Draft-07 and Draft-2020-12 specifications, positional tuples generated via `prefixItems` or `items[]` arrays are open-ended by default and will append `.rest(z.any())`. To enforce a strict, closed tuple boundary, you must explicitly declare `items: false` or `additionalItems: false` within your source JSON Schema.
-</Callout>
-
 Zod provides `z.fromJSONSchema()` to convert a JSON Schema into a Zod schema.
 
 ```ts

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -149,6 +149,16 @@ function resolveRef(ref: string, ctx: ConversionContext): JSONSchema.JSONSchema 
   throw new Error(`Reference not found: ${ref}`);
 }
 
+function getTupleRest(restSchema: JSONSchema._JSONSchema | undefined, ctx: ConversionContext): ZodType | undefined {
+  if (restSchema === false) {
+    return undefined;
+  }
+  if (restSchema === undefined || restSchema === true) {
+    return z.any();
+  }
+  return convertSchema(restSchema, ctx);
+}
+
 function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext): ZodType {
   // Handle unsupported features
   if (schema.not !== undefined) {
@@ -503,10 +513,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         const minItems = typeof schema.minItems === "number" ? schema.minItems : 0;
         const tupleItems = prefixItems.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
         const positionalItems = applyMinItems(tupleItems, minItems);
-        const rest =
-          items && typeof items === "object" && !Array.isArray(items)
-            ? convertSchema(items as JSONSchema.JSONSchema, ctx)
-            : undefined;
+        const rest = !Array.isArray(items) ? getTupleRest(items, ctx) : undefined;
         const tupleSchema = z.tuple(positionalItems as [ZodType, ...ZodType[]]);
         zodSchema = rest ? tupleSchema.rest(rest) : tupleSchema;
         // Apply minItems/maxItems constraints to tuples
@@ -521,10 +528,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         const minItems = typeof schema.minItems === "number" ? schema.minItems : 0;
         const tupleItems = items.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
         const positionalItems = applyMinItems(tupleItems, minItems);
-        const rest =
-          schema.additionalItems && typeof schema.additionalItems === "object"
-            ? convertSchema(schema.additionalItems as JSONSchema.JSONSchema, ctx)
-            : undefined; // additionalItems: false means no rest, handled by default tuple behavior
+        const rest = getTupleRest(schema.additionalItems, ctx);
         const tupleSchema = z.tuple(positionalItems as [ZodType, ...ZodType[]]);
         zodSchema = rest ? tupleSchema.rest(rest) : tupleSchema;
         // Apply minItems/maxItems constraints to tuples

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -176,6 +176,16 @@ test("tuple with prefixItems respects items schema (draft-2020-12)", () => {
   expect(() => schema.parse(["hello", 1, "extra"])).toThrow();
 });
 
+test("tuple with prefixItems and items true allows extra items (draft-2020-12)", () => {
+  const schema = fromJSONSchema({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "array",
+    prefixItems: [{ type: "string" }, { type: "number" }],
+    items: true,
+  });
+  expect(schema.parse(["hello", 42, "extra", true])).toEqual(["hello", 42, "extra", true]);
+});
+
 test("tuple with prefixItems and items false rejects extra items (draft-2020-12)", () => {
   const schema = fromJSONSchema({
     $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -231,6 +241,16 @@ test("tuple with items array allows extra items by default (draft-7)", () => {
     items: [{ type: "string" }],
   });
   expect(schema.parse(["hello", 42, true])).toEqual(["hello", 42, true]);
+});
+
+test("tuple with items array and additionalItems true allows extra items (draft-7)", () => {
+  const schema = fromJSONSchema({
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "array",
+    items: [{ type: "string" }, { type: "number" }],
+    additionalItems: true,
+  });
+  expect(schema.parse(["hello", 42, "extra", true])).toEqual(["hello", 42, "extra", true]);
 });
 
 test("tuple with items array respects additionalItems schema (draft-7)", () => {

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -130,9 +130,10 @@ test("tuple with prefixItems (draft-2020-12)", () => {
   expect(schema.parse([])).toEqual([]);
   expect(schema.parse(["hello"])).toEqual(["hello"]);
   expect(schema.parse(["hello", 42])).toEqual(["hello", 42]);
+  // no `items`, so the tail is unconstrained
+  expect(schema.parse(["hello", 42, "extra"])).toEqual(["hello", 42, "extra"]);
   expect(() => schema.parse([1])).toThrow();
   expect(() => schema.parse(["hello", "world"])).toThrow();
-  expect(() => schema.parse(["hello", 42, "extra"])).toThrow();
 });
 
 test("tuple with prefixItems and minItems (draft-2020-12)", () => {
@@ -153,6 +154,37 @@ test("tuple with prefixItems and minItems (draft-2020-12)", () => {
   });
   expect(() => allRequired.parse(["hello"])).toThrow();
   expect(allRequired.parse(["hello", 42])).toEqual(["hello", 42]);
+});
+
+test("tuple with prefixItems allows extra items by default (draft-2020-12)", () => {
+  const schema = fromJSONSchema({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "array",
+    prefixItems: [{ type: "string" }],
+  });
+  expect(schema.parse(["hello", 42, true])).toEqual(["hello", 42, true]);
+});
+
+test("tuple with prefixItems respects items schema (draft-2020-12)", () => {
+  const schema = fromJSONSchema({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "array",
+    prefixItems: [{ type: "string" }],
+    items: { type: "number" },
+  });
+  expect(schema.parse(["hello", 1, 2])).toEqual(["hello", 1, 2]);
+  expect(() => schema.parse(["hello", 1, "extra"])).toThrow();
+});
+
+test("tuple with prefixItems and items false rejects extra items (draft-2020-12)", () => {
+  const schema = fromJSONSchema({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "array",
+    prefixItems: [{ type: "string" }],
+    items: false,
+  });
+  expect(schema.parse(["hello"])).toEqual(["hello"]);
+  expect(() => schema.parse(["hello", 42])).toThrow();
 });
 
 test("tuple with items array (draft-7)", () => {
@@ -190,6 +222,26 @@ test("tuple with items array and minItems (draft-7)", () => {
   });
   expect(() => allRequired.parse(["hello"])).toThrow();
   expect(allRequired.parse(["hello", 42])).toEqual(["hello", 42]);
+});
+
+test("tuple with items array allows extra items by default (draft-7)", () => {
+  const schema = fromJSONSchema({
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "array",
+    items: [{ type: "string" }],
+  });
+  expect(schema.parse(["hello", 42, true])).toEqual(["hello", 42, true]);
+});
+
+test("tuple with items array respects additionalItems schema (draft-7)", () => {
+  const schema = fromJSONSchema({
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "array",
+    items: [{ type: "string" }],
+    additionalItems: { type: "number" },
+  });
+  expect(schema.parse(["hello", 1, 2])).toEqual(["hello", 1, 2]);
+  expect(() => schema.parse(["hello", 1, "extra"])).toThrow();
 });
 
 test("enum schema", () => {


### PR DESCRIPTION
### Summary
Fixes JSON Schema to Zod v4 translation compliance regarding positional tuples with trailing elements. 

By default, both Draft-7 and Draft-2020-12 specifications allow open-ended arrays when positional items are specified, unless explicitly locked down by `additionalItems: false` or `items: false`. The parser previously defaulted to generating a strict Zod tuple that rejected trailing elements when these configuration properties were omitted or evaluated to booleans.

### Root Cause
In `packages/zod/src/v4/classic/from-json-schema.ts`, the logic transforming `prefixItems` (Draft-2020-12) and `items` arrays (Draft-7) expected a nested schema object to evaluate `.rest()`. It did not account for:
1. Implicitly allowing any trailing elements when configuration attributes are completely missing (`undefined`).
2. Expressly handling JSON Schema boolean parameters (`true` / `false`) for array continuation rules.

### Changes
* Introduced `getTupleRest` helper to evaluate boolean schema constraints and map `undefined`/`true` conditions to `.rest(z.any())`.
* Unified the rest parameter assignment across Draft-7 (`additionalItems`) and Draft-2020-12 (`items`) compilation branches.
* Appended 5 regression test suites inside `from-json-schema.test.ts` to cover boolean constraints and default open-ended schemas.

### Behavior Comparison

#### 1. Input Schema (Draft-2020-12 Open Tuple)

```JSON
{
  "$schema": "[https://json-schema.org/draft/2020-12/schema](https://json-schema.org/draft/2020-12/schema)",
  "type": "array",
  "prefixItems": [{ "type": "string" }]
}
```

##### Before This PR
Generated a rigid tuple matching only the explicit prefix length. Passing trailing elements threw a validation error.

```TypeScript
// Parsed Output
z.tuple([z.string()]); 

schema.parse(["hello", 42]); // ❌ Throws ZodError (unexpected element)
```

##### After This PR
Correctly attaches an open-ended fallback rest layer to match specification defaults

```TypeScript
// Parsed Output
z.tuple([z.string()]).rest(z.any()); 

schema.parse(["hello", 42]); // ✅ Returns ["hello", 42]
```

#### 2. Input Schema (Draft-2020-12 Closed Tuple)

```JSON
{
  "$schema": "[https://json-schema.org/draft/2020-12/schema](https://json-schema.org/draft/2020-12/schema)",
  "type": "array",
  "prefixItems": [{ "type": "string" }],
  "items": false
}
```

#### After This PR
Correctly interprets false to suppress .rest() injection, maintaining strict length boundaries.

```TypeScript
// Parsed Output
z.tuple([z.string()]); 

schema.parse(["hello"]);     // ✅ Returns ["hello"]
schema.parse(["hello", 42]); // ❌ Throws ZodError
```

---

### ⚠️ Behavioral Note for Existing Users
This PR introduces a behavioral change for existing `fromJSONSchema` invocations where a tuple schema relies on implicit defaults for trailing elements (e.g., `{ prefixItems: [{ type: "string" }] }`). 

* **Previous Behavior:** Generated a closed tuple that strictly rejected trailing elements.
* **New Behavior:** Generates an open tuple (`.rest(z.any())`) that accepts trailing elements, fully conforming to Draft-7 and Draft-2020-12 specifications. 

Because `fromJSONSchema` is an experimental feature, this alignment does not break stable API surfaces but is surfaced here for changelog tracking.