### PR TITLE
fix(from-json-schema): allow extra items when additionalItems/items is `true`

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -468,9 +468,11 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         // Tuple with prefixItems (draft-2020-12)
         const tupleItems = prefixItems.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
         const rest =
-          items && typeof items === "object" && !Array.isArray(items)
-            ? convertSchema(items as JSONSchema.JSONSchema, ctx)
-            : undefined;
+          items === true
+            ? z.unknown()
+            : items && typeof items === "object" && !Array.isArray(items)
+              ? convertSchema(items as JSONSchema.JSONSchema, ctx)
+              : undefined;
         if (rest) {
           zodSchema = z.tuple(tupleItems as [ZodType, ...ZodType[]]).rest(rest);
         } else {
@@ -487,9 +489,11 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         // Tuple with items array (draft-7)
         const tupleItems = items.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
         const rest =
-          schema.additionalItems && typeof schema.additionalItems === "object"
-            ? convertSchema(schema.additionalItems as JSONSchema.JSONSchema, ctx)
-            : undefined; // additionalItems: false means no rest, handled by default tuple behavior
+          schema.additionalItems === true
+            ? z.unknown() // additionalItems: true means any extra items are allowed
+            : schema.additionalItems && typeof schema.additionalItems === "object"
+              ? convertSchema(schema.additionalItems as JSONSchema.JSONSchema, ctx)
+              : undefined; // additionalItems: false means no rest, handled by default tuple behavior
         if (rest) {
           zodSchema = z.tuple(tupleItems as [ZodType, ...ZodType[]]).rest(rest);
         } else {

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -143,6 +143,30 @@ test("tuple with items array (draft-7)", () => {
   expect(() => schema.parse(["hello", 42, "extra"])).toThrow();
 });
 
+test("tuple with items array and additionalItems: true (draft-7) allows extra items", () => {
+  const schema = fromJSONSchema({
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "array",
+    items: [{ type: "string" }, { type: "number" }],
+    additionalItems: true,
+  });
+  expect(schema.parse(["hello", 42])).toEqual(["hello", 42]);
+  // additionalItems: true => extra items of any type are permitted
+  expect(schema.parse(["hello", 42, "extra", true])).toEqual(["hello", 42, "extra", true]);
+});
+
+test("tuple with prefixItems and items: true (draft-2020-12) allows extra items", () => {
+  const schema = fromJSONSchema({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "array",
+    prefixItems: [{ type: "string" }, { type: "number" }],
+    items: true,
+  });
+  expect(schema.parse(["hello", 42])).toEqual(["hello", 42]);
+  // items: true => additional items beyond the prefix are permitted
+  expect(schema.parse(["hello", 42, "extra", true])).toEqual(["hello", 42, "extra", true]);
+});
+
 test("enum schema", () => {
   const schema = fromJSONSchema({
     enum: ["red", "green", "blue"],


### PR DESCRIPTION
## What

`fromJSONSchema` converts a draft-07 array tuple (`items` as an array) with
`additionalItems: true`, and a draft-2020-12 tuple (`prefixItems`) with `items: true`,
into a **fixed-length** `z.tuple([...])` that rejects any extra items.

```ts
const schema = fromJSONSchema({
  $schema: "http://json-schema.org/draft-07/schema#",
  type: "array",
  items: [{ type: "string" }, { type: "number" }],
  additionalItems: true,
});
schema.parse(["hello", 42, "extra"]); // ❌ throws — but additionalItems:true should allow it
```

## Why it's wrong

In both drafts a boolean `true` means "additional items of any type are allowed".
The converter already handles the `false` case (no rest — correct) and the
schema-object case (typed `.rest(...)` — correct), but a boolean `true` falls through
to `rest = undefined`, producing the *same* fixed-length tuple as `false`.

## Why a reviewer might miss it

The existing tests only cover `additionalItems: false`, and the `false`/`true` paths
look almost identical — the missing branch is invisible unless you specifically
exercise the `true` case. Every other `additionalItems` value behaves correctly, so
it never surfaces in normal use.

## Fix

Map a boolean `true` to `.rest(z.unknown())` so extra items of any type are accepted.
The `false` (no rest) and schema-object (typed rest) cases are unchanged. Blast radius
is the tuple `rest` derivation only — no public API or signature change.

## Tests

Added regression tests for draft-07 `additionalItems: true` and draft-2020-12
`items: true` (both assert mixed-type extras are accepted). Full `from-json-schema`
suite: **148/148 pass, 0 type errors**.
