### PR TITLE
fix: z.string().includes(sub,{position:N}) pattern should allow ≥N leading chars

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -486,7 +486,7 @@ describe("toJSONSchema", () => {
             "pattern": "cruel",
           },
           {
-            "pattern": "^.{10}dark",
+            "pattern": "^.{10,}dark",
           },
           {
             "pattern": ".*world$",
@@ -525,7 +525,7 @@ describe("toJSONSchema", () => {
             "type": "string",
           },
           {
-            "pattern": "^.{10}dark",
+            "pattern": "^.{10,}dark",
             "type": "string",
           },
           {
@@ -540,6 +540,19 @@ describe("toJSONSchema", () => {
         "type": "string",
       }
     `);
+  });
+
+  test("includes with position emits a pattern matching runtime semantics", () => {
+    // String.prototype.includes(sub, position) matches `sub` at `position` OR
+    // LATER, so the JSON Schema pattern must allow >= position leading chars.
+    const schema = z.string().includes("foo", { position: 2 });
+    const json = z.toJSONSchema(schema) as { pattern?: string };
+    expect(json.pattern).toBe("^.{2,}foo");
+
+    const re = new RegExp(json.pattern!);
+    for (const input of ["xxfoo", "xxxfoo", "xfoo", "ab"]) {
+      expect(re.test(input)).toBe(schema.safeParse(input).success);
+    }
   });
 
   test("number constraints", () => {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -967,7 +967,10 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     $ZodCheck.init(inst, def);
 
     const escapedRegex = util.escapeRegex(def.includes);
-    const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position}}${escapedRegex}` : escapedRegex);
+    // `String.prototype.includes(sub, position)` matches `sub` at `position`
+    // OR LATER, so the pattern must allow at least `position` leading chars
+    // (`{N,}`), not exactly `position` chars (`{N}`).
+    const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position},}${escapedRegex}` : escapedRegex);
     def.pattern = pattern;
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];


### PR DESCRIPTION
## Bug

`z.string().includes(sub, { position: N })` emits a JSON Schema pattern that rejects strings the validator accepts.

### Root cause

In `$ZodCheckIncludes`, the pattern is built as:

```ts
// current:
`^.{${def.position}}${escapedRegex}`
//   ^^^ exact: allows exactly N leading chars
```

But `String.prototype.includes(searchString, position)` treats `position` as a **start offset**, not a fixed offset — it matches `searchString` at `position` **or later**. The correct regex quantifier is `{N,}` (at least N), not `{N}` (exactly N).

### Consequence

```ts
const schema = z.string().includes("foo", { position: 2 });

schema.safeParse("xxfoo").success;   // true  (starts at 2)
schema.safeParse("xxxfoo").success;  // true  (starts at 3 — ≥ 2, allowed by runtime)

// The generated JSON Schema pattern  ^.{2}foo  rejects "xxxfoo":
/^.{2}foo/.test("xxxfoo")   // false  ← schema says invalid, Zod says valid
/^.{2,}foo/.test("xxxfoo")  // true   ← correct
```

This produces a schema/validator mismatch: the Zod runtime accepts inputs that the emitted JSON Schema pattern rejects. Any downstream consumer validating against the JSON Schema output would reject valid inputs.

The same bug affects the existing inline snapshot test in `to-json-schema.test.ts` (two places show `"^.{10}dark"` where `"^.{10,}dark"` is correct).

## Fix

```ts
// before:
`^.{${def.position}}${escapedRegex}`

// after:
`^.{${def.position},}${escapedRegex}`
```

Also fixes the two existing snapshot assertions to `"^.{10,}dark"`.

## Test

Added a test in `to-json-schema.test.ts` that verifies:
1. The emitted pattern is `"^.{2,}foo"`
2. For a set of inputs, `re.test(input) === schema.safeParse(input).success` (schema and validator agree)

Full suite: **3813 tests pass**.