### PR TITLE
fix(v4): encode / and ~ in $ref JSON Pointer paths (RFC 6901)

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2212,6 +2212,15 @@ test("id is observable in override callback", () => {
   expect(seenIds).toContain("Inner");
 });
 
+test("$ref pointer encodes / and ~ in meta id (RFC 6901)", () => {
+  // ids with slashes or tildes need RFC 6901 encoding in the $ref pointer path
+  // but the $defs key should remain the raw id
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ user: User }));
+  expect((result as any).$defs?.["Shared/User~"]).toBeDefined();
+  expect((result.properties as any)?.user?.$ref).toBe("#/$defs/Shared~1User~0");
+});
+
 test("describe with id on wrapper", () => {
   // Test that $ref propagation works when processor sets a different ref (readonly -> innerType)
   // but parent was extracted due to having an id

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -260,7 +260,9 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      // RFC 6901: encode ~ as ~0 and / as ~1 in JSON Pointer reference tokens
+      const encodedId = id.replace(/~/g, "~0").replace(/\//g, "~1");
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${encodedId}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +273,9 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    // RFC 6901: encode ~ as ~0 and / as ~1 in JSON Pointer reference tokens
+    const encodedId = defId.replace(/~/g, "~0").replace(/\//g, "~1");
+    return { defId, ref: defUriPrefix + encodedId };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
Fixes #6027

When a schema has a `.meta({ id })` containing `/` or `~`, the generated `$ref` URI fragment was using the raw id, producing an invalid JSON Pointer.

Per [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901), reference tokens in a JSON Pointer must escape:
- `~` → `~0`
- `/` → `~1`

The `$defs` key (a plain JSON object key) correctly keeps the raw id. Only the `$ref` pointer path needs the encoding.

**Before:**
```json
{ "$ref": "#/$defs/Shared/User~" }
```

**After:**
```json
{ "$ref": "#/$defs/Shared~1User~0" }
```

Applied the same fix to both the self-contained path and the external registry path.