### PR TITLE
Fix: escape JSON Pointer tokens in $ref per RFC 6901

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3115,6 +3115,18 @@ test("cycle detection - mutual recursion", () => {
   `);
 });
 
+test("RFC 6901: $ref pointer tokens escape ~ and / in meta id", () => {
+  // When a schema's meta id contains / or ~, the $defs key stays unescaped
+  // but the $ref URI fragment must encode per RFC 6901: ~ -> ~0, / -> ~1
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User }));
+
+  // $defs key uses the original id (unescaped)
+  expect(result.$defs!["Shared/User~"]).toBeDefined();
+  // $ref pointer path must be RFC 6901 encoded
+  expect((result.properties as any).User.$ref).toBe("#/$defs/Shared~1User~0");
+});
+
 test("recursive lazy with describe does not stack overflow", () => {
   const NodeSchema: z.ZodType = z.lazy(() =>
     z

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -239,6 +239,11 @@ export function extractDefs<T extends schemas.$ZodType>(
     }
   }
 
+  // Escape a single JSON Pointer reference token per RFC 6901.
+  // Must be applied to each token in a $ref URI fragment, but NOT to
+  // the $defs dictionary key (that stays as the original id).
+  const escapePointerToken = (token: string): string => token.replace(/~/g, "~0").replace(/\//g, "~1");
+
   // returns a ref to the schema
   // defId will be empty if the ref points to an external schema (or #)
   const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
@@ -260,7 +265,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${escapePointerToken(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +276,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + escapePointerToken(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
## Summary

Fixes #6027

When a schema's `meta({ id })` contains `/` or `~` characters, `z.toJSONSchema()` builds the `$ref` URI fragment using the raw id without applying RFC 6901 escaping. Per RFC 6901, reference tokens in a JSON Pointer must escape `~` as `~0` and `/` as `~1`.

## Changes

- Added `escapePointerToken` helper inside `extractDefs` that applies RFC 6901 encoding (`~` -> `~0`, `/` -> `~1`)
- Applied escaping to the `$ref` path in both the self-contained and external schema URI branches of `makeURI`
- The `$defs` dictionary key remains unescaped (it is a plain JSON object key, not a pointer token)
- Added a regression test that verifies the `$ref` is correctly encoded while the `$defs` key stays as the original id

## Before

```json
{
  "$ref": "#/$defs/Shared/User~"
}
```

## After

```json
{
  "$ref": "#/$defs/Shared~1User~0"
}
```

The `$defs` key remains `"Shared/User~"` (unescaped) as expected.