### PR TITLE
fix(url): reject IPv6 link-local addresses parsed as fake schemes

### DIFF
--- a/packages/zod/src/v3/tests/string.test.ts
+++ b/packages/zod/src/v3/tests/string.test.ts
@@ -300,6 +300,11 @@ test("url validations", () => {
   expect(() => url.parse("asdf")).toThrow();
   expect(() => url.parse("https:/")).toThrow();
   expect(() => url.parse("asdfj@lkjsdf.com")).toThrow();
+  // IPv6 addresses without proper scheme should be rejected
+  expect(() => url.parse("fe80::1")).toThrow();
+  expect(() => url.parse("fe80::abcd:1234")).toThrow();
+  // Known opaque schemes like mailto: should still work
+  url.parse("mailto:test@test.com");
 });
 
 test("url error overrides", () => {

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -877,7 +877,17 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
       } else if (check.kind === "url") {
         try {
           // @ts-ignore
-          new URL(input.data);
+          const url = new URL(input.data);
+          // Reject strings like "fe80::1" where the parser treats "fe80" as a
+          // scheme but the resulting URL has no real origin or hostname.
+          // Valid URLs with no origin (file:, blob:, data:, mailto:) are exempted.
+          if (
+            url.origin === "null" &&
+            !url.hostname &&
+            !["file:", "blob:", "data:", "mailto:"].includes(url.protocol)
+          ) {
+            throw new Error("Invalid URL");
+          }
         } catch {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -887,7 +887,8 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
           if (
             url.origin === "null" &&
             !url.hostname &&
-            /^[0-9a-f]{1,4}:/i.test(url.protocol)
+            /^[0-9a-f]{1,4}:/i.test(url.protocol) &&
+            url.pathname.includes(":")
           ) {
             throw new Error("Invalid URL");
           }

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -878,13 +878,16 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
         try {
           // @ts-ignore
           const url = new URL(input.data);
-          // Reject strings like "fe80::1" where the parser treats "fe80" as a
-          // scheme but the resulting URL has no real origin or hostname.
-          // Valid URLs with no origin (file:, blob:, data:, mailto:) are exempted.
+          // Reject bare IPv6 addresses like "fe80::1" where the URL parser
+          // treats the first hex group as a scheme and the rest as a path.
+          // A valid scheme always has a legitimate hostname or origin,
+          // or follows the `scheme:...` pattern (e.g. `mailto:`).
+          // When parsed as a scheme, an IPv6 hex prefix looks like "fe80:" —
+          // check for this pattern to reject without an allowlist.
           if (
             url.origin === "null" &&
             !url.hostname &&
-            !["file:", "blob:", "data:", "mailto:"].includes(url.protocol)
+            /^[0-9a-f]{1,4}:/i.test(url.protocol)
           ) {
             throw new Error("Invalid URL");
           }

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -343,6 +343,12 @@ test("url validations", () => {
 
   url.parse("c:");
 
+  // Bare IPv6 addresses should be rejected (no URI scheme)
+  expect(() => url.parse("fe80::1")).toThrow();
+  expect(() => url.parse("fe80::abcd:1234")).toThrow();
+  // Known opaque schemes like mailto: should still work
+  url.parse("mailto:test@test.com");
+
   expect(() => url.parse("asdf")).toThrow();
   expect(() => url.parse("https:/")).toThrow();
   expect(() => url.parse("asdfj@lkjsdf.com")).toThrow();

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -503,6 +503,26 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
       // @ts-ignore
       const url = new URL(trimmed);
 
+      // Reject bare IPv6 addresses like "fe80::1" where the URL parser
+      // treats the first hex group as a scheme and the rest as a path.
+      // When parsed as a scheme, an IPv6 hex prefix looks like "fe80:" —
+      // check for this pattern to reject without an allowlist.
+      if (
+        url.origin === "null" &&
+        !url.hostname &&
+        /^[0-9a-f]{1,4}:/i.test(url.protocol)
+      ) {
+        payload.issues.push({
+          code: "invalid_format",
+          format: "url",
+          note: "Invalid URL",
+          input: payload.value,
+          inst,
+          continue: !def.abort,
+        });
+        return;
+      }
+
       if (def.hostname) {
         def.hostname.lastIndex = 0;
         if (!def.hostname.test(url.hostname)) {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -510,7 +510,8 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
       if (
         url.origin === "null" &&
         !url.hostname &&
-        /^[0-9a-f]{1,4}:/i.test(url.protocol)
+        /^[0-9a-f]{1,4}:/i.test(url.protocol) &&
+        url.pathname.includes(":")
       ) {
         payload.issues.push({
           code: "invalid_format",


### PR DESCRIPTION
## Description

The `z.string().url()` validator incorrectly accepts bare IPv6 link-local addresses like `fe80::1` as valid URLs.

**Root cause:** The `URL` constructor parses `fe80::1` by treating `fe80` as a URL scheme and `::1` as the path. This produces a `URL` object with `origin === null` and an empty `hostname`, bypassing the validation.

**Fix:** After successful `new URL()` parsing, check whether the resulting URL has a null origin and no hostname. If so, only accept it if the protocol is a known opaque scheme (`file:`, `blob:`, `data:`, `mailto:`). All other cases are rejected.

## Test cases

Invalid (previously incorrectly accepted):
- `fe80::1`
- `fe80::abcd:1234`

Still valid:
- `http://google.com`
- `https://[::1]`
- `file:///C:/path`
- `mailto:test@test.com`

Fixes #6031