### PR TITLE
fix: enforce RFC 1035 length limits in regexes.domain

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -381,7 +381,7 @@ schema.parse("http://example.com"); // ❌
   This restricts the protocol to `http`/`https` and ensures the hostname is a valid domain name with the `z.regexes.domain` regular expression:
 
   ```ts
-  /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
+  /^(?=.{1,253}$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/
   ```
 </Callout>
 

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -464,6 +464,16 @@ test("httpurl", () => {
   ).toThrow();
   expect(() => httpUrl.parse("http://asdf.c")).toThrow();
   expect(() => httpUrl.parse("mailto:asdf@lckj.com")).toThrow();
+  // total host length over the RFC 1035 limit of 253 chars (built from valid-length labels)
+  const longHost = `${`${"a".repeat(50)}.`.repeat(5)}com`; // 5 * 51 + 3 = 258 chars
+  expect(longHost.length).toBeGreaterThan(253);
+  expect(() => httpUrl.parse(`http://${longHost}`)).toThrow();
+  // TLD over the 63-char label limit
+  expect(() => httpUrl.parse(`http://example.${"a".repeat(64)}`)).toThrow();
+  // a host at the 253-char boundary is still accepted
+  const maxHost = `${`${"a".repeat(61)}.`.repeat(4)}aaa`; // 4 * 62 + 3 = 251 chars
+  expect(maxHost.length).toBeLessThanOrEqual(253);
+  httpUrl.parse(`http://${maxHost}`);
   // missing // after protocol
   expect(() => httpUrl.parse("http:example.com")).toThrow();
   expect(() => httpUrl.parse("https:example.com")).toThrow();

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -430,7 +430,7 @@ test("httpurl", () => {
   const httpUrl = z.url({
     protocol: /^https?$/,
     hostname: z.regexes.domain,
-    // /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
+    // /^(?=.{1,253}$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/
   });
 
   httpUrl.parse("https://example.com");
@@ -470,10 +470,10 @@ test("httpurl", () => {
   expect(() => httpUrl.parse(`http://${longHost}`)).toThrow();
   // TLD over the 63-char label limit
   expect(() => httpUrl.parse(`http://example.${"a".repeat(64)}`)).toThrow();
-  // a host at the 253-char boundary is still accepted
-  const maxHost = `${`${"a".repeat(61)}.`.repeat(4)}aaa`; // 4 * 62 + 3 = 251 chars
-  expect(maxHost.length).toBeLessThanOrEqual(253);
+  // a host at exactly the 253-char limit is still accepted, one char more is not
+  const maxHost = `${`${"a".repeat(61)}.`.repeat(4)}aaaaa`; // 4 * 62 + 5 = 253 chars
   httpUrl.parse(`http://${maxHost}`);
+  expect(() => httpUrl.parse(`http://${maxHost}a`)).toThrow();
   // missing // after protocol
   expect(() => httpUrl.parse("http:example.com")).toThrow();
   expect(() => httpUrl.parse("https:example.com")).toThrow();

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -86,7 +86,7 @@ export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
 export const hostname: RegExp =
   /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
 
-export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+export const domain: RegExp = /^(?=.{1,253}$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
 
 export const httpProtocol: RegExp = /^https?$/;
 


### PR DESCRIPTION
Closes #5965.

## Problem

`regexes.domain` (used by `z.httpUrl()` for the host check) has no length anchors:

```ts
export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
```

`regexes.hostname` (used by `z.hostname()`) already enforces the RFC 1035 limits:

```ts
export const hostname: RegExp =
  /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
```

So `z.httpUrl()` accepts hosts that exceed the 253-char total or have a TLD longer than 63 chars, while `z.hostname()` rejects them. The two validators disagree on what a valid DNS name is.

## Change

```ts
export const domain: RegExp = /^(?=.{1,253}$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
```

- `(?=.{1,253}$)` caps the total length at 253 chars
- `[a-zA-Z]{2,63}` caps the TLD label at 63 chars

The per-label cap for non-TLD labels was already there via `[a-zA-Z0-9-]{0,61}`. The `domain` pattern never allows a trailing dot, so I dropped the `\.?` from the lookahead that `hostname` carries.

## A note on intent

The issue raised this as a question: RFC 3986 / WHATWG URL don't themselves impose DNS length limits, so the looseness in `z.httpUrl()` might be deliberate. I went with closing the gap because `z.hostname()` and `z.httpUrl()` validating the same host differently is surprising. If you'd rather keep `httpUrl` permissive, happy to close this.

## Tests

Added cases to the existing `httpurl` test for the total-length cap, the TLD cap, and a host at the 253-char boundary (which still parses). Full `string.test.ts` suite passes (94 tests).