### PR TITLE
fix(to-json-schema): apply RFC 6901 encoding to $ref pointer path

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3129,3 +3129,32 @@ test("recursive lazy with describe does not stack overflow", () => {
   expect(result).toBeDefined();
   expect(result.$defs).toBeDefined();
 });
+
+// RFC 6901: $ref pointer tokens must escape '~' → '~0' and '/' → '~1'
+// but the $defs key itself is a plain JSON object key and stays unescaped.
+// See https://github.com/colinhacks/zod/issues/6027
+test("toJSONSchema encodes '/' in meta id as '~1' in $ref pointer (RFC 6901)", () => {
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User" });
+  const result = z.toJSONSchema(z.object({ User }));
+
+  // $defs key uses the raw id (plain object key — no escaping needed)
+  expect(result.$defs).toHaveProperty("Shared/User");
+  // $ref pointer encodes '/' as '~1'
+  expect((result as any).properties.User.$ref).toBe("#/$defs/Shared~1User");
+});
+
+test("toJSONSchema encodes '~' in meta id as '~0' in $ref pointer (RFC 6901)", () => {
+  const Model = z.object({ value: z.number() }).meta({ id: "My~Model" });
+  const result = z.toJSONSchema(z.object({ Model }));
+
+  expect(result.$defs).toHaveProperty("My~Model");
+  expect((result as any).properties.Model.$ref).toBe("#/$defs/My~0Model");
+});
+
+test("toJSONSchema encodes both '~' and '/' in meta id in $ref pointer (RFC 6901)", () => {
+  const Schema = z.object({ x: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ Schema }));
+
+  expect(result.$defs).toHaveProperty("Shared/User~");
+  expect((result as any).properties.Schema.$ref).toBe("#/$defs/Shared~1User~0");
+});

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -260,7 +260,8 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      const encodedId = id.replace(/~/g, "~0").replace(/\//g, "~1");
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${encodedId}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +272,11 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    // RFC 6901 §3: in a JSON Pointer reference token, '~' must be encoded as '~0'
+    // and '/' must be encoded as '~1'. The $defs key itself is a plain JSON object
+    // key and does NOT need escaping — only the $ref pointer path does.
+    const encodedDefId = defId.replace(/~/g, "~0").replace(/\//g, "~1");
+    return { defId, ref: defUriPrefix + encodedDefId };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
## Summary

When a schema's `.meta({ id })` contains `/` or `~`, the `$ref` pointer generated by `z.toJSONSchema()` is invalid per [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901).

**Before** (broken):
```json
{ "$ref": "#/$defs/Shared/User~" }
```

**After** (correct):
```json
{ "$ref": "#/$defs/Shared~1User~0" }
```

## Root cause

In `to-json-schema.ts`, the `$ref` path is built by concatenating the raw `defId` string:

```typescript
return { defId, ref: defUriPrefix + defId };  // ← missing RFC 6901 encoding
```

RFC 6901 §3 requires that inside a JSON Pointer reference token:
- `~` is encoded as `~0`
- `/` is encoded as `~1`

The `$defs` object **key** is a plain JSON key (not a pointer) and must stay unencoded so validators can look up the definition by its original id.

## Fix

```typescript
const encodedDefId = defId.replace(/~/g, "~0").replace(/\//g, "~1");
return { defId, ref: defUriPrefix + encodedDefId };
```

The same fix is applied to the `external` code path.

## Tests

Three regression tests added to `to-json-schema.test.ts`:
1. meta id containing `/` → `$ref` uses `~1`, `$defs` key stays raw
2. meta id containing `~` → `$ref` uses `~0`, `$defs` key stays raw
3. meta id containing both `/` and `~` → correct combined encoding

All 3817 existing tests continue to pass.

Fixes #6027