### PR TITLE
docs(ecosystem): Add `@chrock-studio/overload` and `@chrock-studio/zod-utils`

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -286,7 +286,7 @@ const poweredByZodProjects: ZodResource[] = [
   {
     name: "@chrock-studio/override",
     url: "https://jsr.io/@chrock-studio/overload",
-    description: "Type-safe runtime function overloading that allows runtime dispatch based on argument types.",
+    description: "A lightweight, type-safe runtime function overloading library that allows runtime dispatch based on argument types.",
     slug: "chrock-studio/toolbox",
   }
 ];
@@ -337,7 +337,7 @@ const zodUtilities: ZodResource[] = [
   {
     name: "@chrock-studio/zod-utils",
     url: "https://jsr.io/@chrock-studio/zod-utils",
-    description: "Zod utilities library providing enhanced functionality (e.g. Rich Domain Mode) for Zod schemas.",
+    description: "A collection of Zod utilities focusing on enhanced functionality (e.g. classless Rich Domain Models while maintaining pure data structures).",
     slug: "chrock-studio/toolbox",
   }
 ];

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -283,6 +283,12 @@ const poweredByZodProjects: ZodResource[] = [
     description: "A fast, type-safe JSON migration tool with Zod schema validation.",
     slug: "Nano-Collective/json-up",
   },
+  {
+    name: "@chrock-studio/override",
+    url: "https://jsr.io/@chrock-studio/overload",
+    description: "Type-safe runtime function overloading that allows runtime dispatch based on argument types.",
+    slug: "chrock-studio/toolbox",
+  }
 ];
 
 const zodUtilities: ZodResource[] = [
@@ -328,6 +334,12 @@ const zodUtilities: ZodResource[] = [
     description: "Compile Zod schemas into zero-overhead validation functions at build time. 2-64x faster validation with no code changes.",
     slug: "wakita181009/zod-aot",
   },
+  {
+    name: "@chrock-studio/zod-utils",
+    url: "https://jsr.io/@chrock-studio/zod-utils",
+    description: "Zod utilities library providing enhanced functionality (e.g. Rich Domain Mode) for Zod schemas.",
+    slug: "chrock-studio/toolbox",
+  }
 ];
 
 export {

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -284,10 +284,10 @@ const poweredByZodProjects: ZodResource[] = [
     slug: "Nano-Collective/json-up",
   },
   {
-    name: "@chrock-studio/override",
+    name: "@chrock-studio/overload",
     url: "https://jsr.io/@chrock-studio/overload",
     description: "A lightweight, type-safe runtime function overloading library that allows runtime dispatch based on argument types.",
-    slug: "chrock-studio/toolbox",
+    slug: "chrock-studio/toolbox/tree/main/packages/overload",
   }
 ];
 
@@ -338,7 +338,7 @@ const zodUtilities: ZodResource[] = [
     name: "@chrock-studio/zod-utils",
     url: "https://jsr.io/@chrock-studio/zod-utils",
     description: "A collection of Zod utilities focusing on enhanced functionality (e.g. classless Rich Domain Models while maintaining pure data structures).",
-    slug: "chrock-studio/toolbox",
+    slug: "chrock-studio/toolbox/tree/main/packages/zod-utils",
   }
 ];
 


### PR DESCRIPTION
Hi! I'd like to add two libraries I authored that enhance DX when working with Zod:

- [`@chrock-studio/overload`](https://jsr.io/@chrock-studio/overload): A lightweight, type-safe runtime function overloading library that allows runtime dispatch based on argument types.
    - It works seamlessly with Zod schemas (and other `Standard-Schema` compliant validators) to validate overload cases.
    - add to "Powered by Zod" section
- [`@chrock-studio/zod-utils`](https://jsr.io/@chrock-studio/zod-utils): A collection of Zod utilities focusing on enhanced functionality (e.g. classless Rich Domain Models while maintaining pure data structures).
    - add to "Zod Utilities" section

I'd like to add them to the `Zod Utilities` and `Powered by Zod` section of the Ecosystem list to help developers working with Zod and some design patterns! :D

*(Note: If you feel these would fit better under alternative sections, please let me know!)*

Thanks for your work!