### PR TITLE
fix(core): Throw error if enum schema has no values

### DIFF
--- a/packages/zod/src/v4/classic/tests/enum.test.ts
+++ b/packages/zod/src/v4/classic/tests/enum.test.ts
@@ -155,9 +155,7 @@ test("exclude", () => {
   expect(UnhealthyEnum.safeParse("Salad").success).toEqual(false);
   expectTypeOf<z.infer<typeof UnhealthyEnum>>().toEqualTypeOf<"Pasta" | "Pizza" | "Tacos" | "Burgers">();
 
-  const EmptyFoodEnum = FoodEnum.exclude(foods);
-  expectTypeOf<typeof EmptyFoodEnum>().toEqualTypeOf<z.ZodEnum<{}>>();
-  expectTypeOf<z.infer<typeof EmptyFoodEnum>>().toEqualTypeOf<never>();
+  expect(() => FoodEnum.exclude(foods)).toThrow(/no valid values/);
 });
 
 test("error map inheritance", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3221,6 +3221,9 @@ export const $ZodEnum: core.$constructor<$ZodEnum> = /*@__PURE__*/ core.$constru
   $ZodType.init(inst, def);
 
   const values = util.getEnumValues(def.entries);
+  if (values.length === 0) {
+    throw new Error("Cannot create enum schema with no valid values");
+  }
   const valuesSet = new Set<util.Primitive>(values);
   inst._zod.values = valuesSet;
 


### PR DESCRIPTION
`z.literal([])` throws since 4.0.9: see https://github.com/colinhacks/zod/commit/4e7a3ef180f6a5525d9021638e9df20b3ca50456#diff-f84405ad925758ccb224a20fe7ca8c6ee375d7faa88431059e008077550f8cd9R2785

but `z.enum([])` does not.

Since the signatures of both methods allow empty arrays, I'm suggesting to implement the same runtime validation for consistency.