### PR TITLE
fix: escape JSON Pointer in $ref tokens per RFC 6901

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -239,6 +239,9 @@ export function extractDefs<T extends schemas.$ZodType>(
     }
   }
 
+  // Escape JSON Pointer tokens per RFC 6901: ~ → ~0, / → ~1
+  const escapeJsonPointer = (token: string): string => token.replace(/~/g, "~0").replace(/\//g, "~1");
+
   // returns a ref to the schema
   // defId will be empty if the ref points to an external schema (or #)
   const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
@@ -260,7 +263,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${escapeJsonPointer(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +274,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + escapeJsonPointer(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
## Problem

When `toJSONSchema()` is called on schemas whose meta ids contain `/` or `~`, the generated `$ref` value contains unescaped characters, producing invalid JSON Pointers per [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901).

For example, `z.string().meta({ id: "Shared/User~" })` generates:
```json
{
  "$ref": "#/$defs/Shared/User~",
  "$defs": {
    "Shared/User~": {}
  }
}
```

The `$ref` value `Shared/User~` should be `Shared~1User~0`.

## Root cause

The `makeURI` function in `to-json-schema.ts` concatenates the raw defId into the `$ref` URI fragment without applying RFC 6901 escaping.

## Changes

- Added `escapeJsonPointer()` helper that escapes `~` → `~0` and `/` → `~1`
- Applied it to `$ref` pointer paths in `makeURI()` for both self-contained and external schema cases
- The `$defs` object keys remain unescaped as they are plain JSON object keys, not pointer paths

## Why this matters

Without this fix, JSON Schema consumers that parse `$ref` pointers (e.g., OpenAPI validators, JSON Schema validators) would misinterpret the pointer path when meta ids contain `/` or `~`.

Closes https://github.com/colinhacks/zod/issues/6027