### PR TITLE
fix: union containing z.undefined() should be optional-in for object keys

### DIFF
--- a/packages/zod/src/v4/classic/tests/never-union-object.test.ts
+++ b/packages/zod/src/v4/classic/tests/never-union-object.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import * as z from "zod/v4";
+
+// Regression test for https://github.com/colinhacks/zod/issues/5993
+
+const choicesSchema = z.union([z.never(), z.array(z.never()), z.undefined()]);
+
+// The exact discord.js scenario: choices field in an object
+const optionSchema = z.object({
+  name: z.string(),
+  choices: choicesSchema,
+});
+
+test("z.never() union in object: accepts choices: undefined", () => {
+  expect(optionSchema.safeParse({ name: "opt", choices: undefined }).success).toBe(true);
+});
+
+test("z.never() union in object: accepts choices: []", () => {
+  expect(optionSchema.safeParse({ name: "opt", choices: [] }).success).toBe(true);
+});
+
+test("z.never() union in object: rejects choices: [{name:'x',value:'y'}]", () => {
+  // This is the broken case reported in #5993
+  const result = optionSchema.safeParse({ name: "opt", choices: [{ name: "x", value: "y" }] });
+  expect(result.success).toBe(false);
+});
+
+test("z.never() union in object: accepts missing choices key (optional-in because z.undefined() is a member)", () => {
+  // Because z.undefined() is one of the union options, the field should be optional-in
+  // (a missing key is treated as undefined, which is valid)
+  const result = optionSchema.safeParse({ name: "opt" });
+  expect(result.success).toBe(true);
+});
+
+test("z.union with z.undefined() is optional-in at the schema level", () => {
+  expect(choicesSchema._zod.optin).toBe("optional");
+});
+
+test("z.union without z.undefined() is NOT optional-in", () => {
+  const required = z.union([z.string(), z.number()]);
+  expect(required._zod.optin).toBeUndefined();
+});

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -45,10 +45,10 @@ test("optionality", () => {
   expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
-  // z.union should be optional if any of the types are optional
+  // z.union is optional if any of the member types accepts undefined as a value
   const g = z.union([z.string(), z.undefined()]);
-  expect(g._zod.optin).toEqual(undefined);
-  expect(g._zod.optout).toEqual(undefined);
+  expect(g._zod.optin).toEqual("optional");
+  expect(g._zod.optout).toEqual("optional");
   expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | undefined>();
   expectTypeOf<typeof g._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
@@ -149,14 +149,6 @@ test("object absent keys require optin optional", () => {
         "message": "Invalid input: expected nonoptional, received undefined",
         "path": [
           "value",
-        ],
-      },
-      {
-        "code": "invalid_type",
-        "expected": "nonoptional",
-        "message": "Invalid input: expected nonoptional, received undefined",
-        "path": [
-          "union",
         ],
       },
     ]

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2193,11 +2193,11 @@ export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$const
   $ZodType.init(inst, def);
 
   util.defineLazy(inst._zod, "optin", () =>
-    def.options.some((o) => o._zod.optin === "optional") ? "optional" : undefined
+    def.options.some((o) => o._zod.optin === "optional" || o._zod.values?.has(undefined)) ? "optional" : undefined
   );
 
   util.defineLazy(inst._zod, "optout", () =>
-    def.options.some((o) => o._zod.optout === "optional") ? "optional" : undefined
+    def.options.some((o) => o._zod.optout === "optional" || o._zod.values?.has(undefined)) ? "optional" : undefined
   );
 
   util.defineLazy(inst._zod, "values", () => {


### PR DESCRIPTION
Ran into this via the discord.js bug report in #5993 — after digging in I traced it to a change in 4.4.0 (commit b6066b3e, PR #5661) that stripped `optin`/`optout` off `$ZodUndefined`.

**The problem:**

`z.object` decides whether a missing key is valid by checking `el._zod.optin === "optional"`. Before 4.4, `z.undefined()` set that flag, so a union like:

```ts
z.union([z.never(), z.array(z.never()), z.undefined()])
```

was treated as optional-in and a missing key would silently coerce to `undefined` (which the union accepts). After the change, neither `z.undefined()` nor the union propagate that flag, so the object bails early with `"expected nonoptional"` before the schema even runs.

**The fix:**

In `$ZodUnion`'s lazy `optin`/`optout` computation, also check whether any option's `_zod.values` set includes `undefined`. `z.undefined()` has `values = new Set([undefined])`, so a union with a `z.undefined()` member now correctly inherits the optional-in/out behavior.

```ts
// before
def.options.some((o) => o._zod.optin === "optional")

// after
def.options.some((o) => o._zod.optin === "optional" || o._zod.values?.has(undefined))
```

This is intentionally conservative: the new check only fires when a member's static value set contains `undefined`, which is exactly when the union will accept a missing key.

**Repro:**

```ts
const schema = z.object({
  autocomplete: z.literal(true),
  choices: z.union([z.never(), z.never().array(), z.undefined()]),
});

schema.parse({ autocomplete: true });        // 4.3.x: ok — 4.4.x: throws nonoptional
schema.parse({ autocomplete: true, choices: undefined });  // ok in both
```

The updated snapshot in `optional.test.ts` (line ~144) reflects the corrected behavior: only the `z.undefined()` standalone field still requires an explicit key; a union containing `z.undefined()` does not.

Refs #5993.