### PR TITLE
fix: escape JSON Pointer tokens in toJSONSchema $ref (RFC 6901)

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -260,7 +260,9 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      // RFC 6901 JSON Pointer escaping for $ref URI fragment
+      const escapedId = id.split("~").join("~0").split("/").join("~1");
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${escapedId}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +273,9 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    // RFC 6901 JSON Pointer escaping for $ref URI fragment
+    const escapedDefId = defId.split("~").join("~0").split("/").join("~1");
+    return { defId, ref: defUriPrefix + escapedDefId };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
Fixes colinhacks/zod#6027

## Problem
When a schema id contains `/` or `~` characters, the `$ref` URI fragment was not being escaped per RFC 6901 (JSON Pointer):
- `~` should become `~0`
- `/` should become `~1`

For example, with id `Shared/User~`, the `$ref` was:
  `#/$defs/Shared/User~` (incorrect)

Now correctly produces:
  `#/$defs/Shared~1User~0`

The `$defs` object key remains unescaped (as it's a plain JSON object key, not a JSON Pointer).

## Fix
Apply `split("~").join("~0").split("/").join("~1")` to the defId in both `$ref` construction paths in `extractDefs`:
1. The shared schema path (line ~263)
2. The self-contained schema path (line ~274)

## Testing
Verified with three test cases:
- `id: "Shared/User~"` -> `$ref: "#/$defs/Shared~1User~0"` ✓
- `id: "MySchema"` -> `$ref: "#/$defs/MySchema"` ✓ (no change for normal ids)
- `id: "My~Schema"` -> `$ref: "#/$defs/My~0Schema"` ✓