### PR TITLE
fix: narrow format type on ZodInt, ZodFloat32, ZodFloat64, ZodInt32, …

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1,5 +1,5 @@
 import * as core from "../core/index.js";
-import { util } from "../core/index.js";
+import { type $ZodNumberFormats, util } from "../core/index.js";
 import * as processors from "../core/json-schema-processors.js";
 import type { StandardSchemaWithJSONProps } from "../core/standard-schema.js";
 import { createStandardJSONSchemaMethod, createToJSONSchemaMethod } from "../core/to-json-schema.js";
@@ -1130,8 +1130,8 @@ export function number(params?: string | core.$ZodNumberParams): ZodNumber {
 }
 
 // ZodNumberFormat
-export interface ZodNumberFormat extends ZodNumber {
-  _zod: core.$ZodNumberFormatInternals;
+export interface ZodNumberFormat<Format extends $ZodNumberFormats = $ZodNumberFormats> extends ZodNumber {
+  _zod: core.$ZodNumberFormatInternals<Format>;
 }
 export const ZodNumberFormat: core.$constructor<ZodNumberFormat> = /*@__PURE__*/ core.$constructor(
   "ZodNumberFormat",
@@ -1142,33 +1142,33 @@ export const ZodNumberFormat: core.$constructor<ZodNumberFormat> = /*@__PURE__*/
 );
 
 // int
-export interface ZodInt extends ZodNumberFormat {}
+export interface ZodInt extends ZodNumberFormat<"safeint"> {}
 export function int(params?: string | core.$ZodCheckNumberFormatParams): ZodInt {
-  return core._int(ZodNumberFormat, params);
+  return core._int(ZodNumberFormat, params) as ZodInt;
 }
 
 // float32
-export interface ZodFloat32 extends ZodNumberFormat {}
+export interface ZodFloat32 extends ZodNumberFormat<"float32"> {}
 export function float32(params?: string | core.$ZodCheckNumberFormatParams): ZodFloat32 {
-  return core._float32(ZodNumberFormat, params);
+  return core._float32(ZodNumberFormat, params) as ZodFloat32;
 }
 
 // float64
-export interface ZodFloat64 extends ZodNumberFormat {}
+export interface ZodFloat64 extends ZodNumberFormat<"float64"> {}
 export function float64(params?: string | core.$ZodCheckNumberFormatParams): ZodFloat64 {
-  return core._float64(ZodNumberFormat, params);
+  return core._float64(ZodNumberFormat, params) as ZodFloat64;
 }
 
 // int32
-export interface ZodInt32 extends ZodNumberFormat {}
+export interface ZodInt32 extends ZodNumberFormat<"int32"> {}
 export function int32(params?: string | core.$ZodCheckNumberFormatParams): ZodInt32 {
-  return core._int32(ZodNumberFormat, params);
+  return core._int32(ZodNumberFormat, params) as ZodInt32;
 }
 
 // uint32
-export interface ZodUInt32 extends ZodNumberFormat {}
+export interface ZodUInt32 extends ZodNumberFormat<"uint32"> {}
 export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodUInt32 {
-  return core._uint32(ZodNumberFormat, params);
+  return core._uint32(ZodNumberFormat, params) as ZodUInt32;
 }
 
 // boolean

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1,5 +1,5 @@
 import * as core from "../core/index.js";
-import { type $ZodNumberFormats, util } from "../core/index.js";
+import { util, type $ZodNumberFormats } from "../core/index.js";
 import * as processors from "../core/json-schema-processors.js";
 import type { StandardSchemaWithJSONProps } from "../core/standard-schema.js";
 import { createStandardJSONSchemaMethod, createToJSONSchemaMethod } from "../core/to-json-schema.js";

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1,3 +1,4 @@
+import type { $ZodBigIntFormats } from "../core/checks.js";
 import * as core from "../core/index.js";
 import { util, type $ZodNumberFormats } from "../core/index.js";
 import * as processors from "../core/json-schema-processors.js";
@@ -1237,8 +1238,8 @@ export function bigint(params?: string | core.$ZodBigIntParams): ZodBigInt {
 // bigint formats
 
 // ZodBigIntFormat
-export interface ZodBigIntFormat extends ZodBigInt {
-  _zod: core.$ZodBigIntFormatInternals;
+export interface ZodBigIntFormat<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends ZodBigInt {
+  _zod: core.$ZodBigIntFormatInternals<Format>;
 }
 export const ZodBigIntFormat: core.$constructor<ZodBigIntFormat> = /*@__PURE__*/ core.$constructor(
   "ZodBigIntFormat",
@@ -1249,13 +1250,13 @@ export const ZodBigIntFormat: core.$constructor<ZodBigIntFormat> = /*@__PURE__*/
 );
 
 // int64
-export function int64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat {
-  return core._int64(ZodBigIntFormat, params);
+export function int64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat<"int64"> {
+  return core._int64(ZodBigIntFormat, params) as ZodBigIntFormat<"int64">;
 }
 
 // uint64
-export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat {
-  return core._uint64(ZodBigIntFormat, params);
+export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat<"uint64"> {
+  return core._uint64(ZodBigIntFormat, params) as ZodBigIntFormat<"uint64">;
 }
 
 // symbol

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1341,13 +1341,15 @@ export const ZodBigIntFormat: core.$constructor<ZodBigIntFormat> = /*@__PURE__*/
 );
 
 // int64
-export function int64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat<"int64"> {
-  return core._int64(ZodBigIntFormat, params) as ZodBigIntFormat<"int64">;
+export interface ZodInt64 extends ZodBigIntFormat<"int64"> {}
+export function int64(params?: string | core.$ZodBigIntFormatParams): ZodInt64 {
+  return core._int64(ZodBigIntFormat, params) as ZodInt64;
 }
 
 // uint64
-export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat<"uint64"> {
-  return core._uint64(ZodBigIntFormat, params) as ZodBigIntFormat<"uint64">;
+export interface ZodUInt64 extends ZodBigIntFormat<"uint64"> {}
+export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodUInt64 {
+  return core._uint64(ZodBigIntFormat, params) as ZodUInt64;
 }
 
 // symbol

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1,5 +1,5 @@
 import * as core from "../core/index.js";
-import { util } from "../core/index.js";
+import { type $ZodNumberFormats, util } from "../core/index.js";
 import * as processors from "../core/json-schema-processors.js";
 import type { StandardSchemaWithJSONProps } from "../core/standard-schema.js";
 import { createStandardJSONSchemaMethod, createToJSONSchemaMethod } from "../core/to-json-schema.js";
@@ -1195,8 +1195,8 @@ export function number(params?: string | core.$ZodNumberParams): ZodNumber {
 }
 
 // ZodNumberFormat
-export interface ZodNumberFormat extends ZodNumber {
-  _zod: core.$ZodNumberFormatInternals;
+export interface ZodNumberFormat<Format extends $ZodNumberFormats = $ZodNumberFormats> extends ZodNumber {
+  _zod: core.$ZodNumberFormatInternals<Format>;
 }
 export const ZodNumberFormat: core.$constructor<ZodNumberFormat> = /*@__PURE__*/ core.$constructor(
   "ZodNumberFormat",
@@ -1207,33 +1207,33 @@ export const ZodNumberFormat: core.$constructor<ZodNumberFormat> = /*@__PURE__*/
 );
 
 // int
-export interface ZodInt extends ZodNumberFormat {}
+export interface ZodInt extends ZodNumberFormat<"safeint"> {}
 export function int(params?: string | core.$ZodCheckNumberFormatParams): ZodInt {
-  return core._int(ZodNumberFormat, params);
+  return core._int(ZodNumberFormat, params) as ZodInt;
 }
 
 // float32
-export interface ZodFloat32 extends ZodNumberFormat {}
+export interface ZodFloat32 extends ZodNumberFormat<"float32"> {}
 export function float32(params?: string | core.$ZodCheckNumberFormatParams): ZodFloat32 {
-  return core._float32(ZodNumberFormat, params);
+  return core._float32(ZodNumberFormat, params) as ZodFloat32;
 }
 
 // float64
-export interface ZodFloat64 extends ZodNumberFormat {}
+export interface ZodFloat64 extends ZodNumberFormat<"float64"> {}
 export function float64(params?: string | core.$ZodCheckNumberFormatParams): ZodFloat64 {
-  return core._float64(ZodNumberFormat, params);
+  return core._float64(ZodNumberFormat, params) as ZodFloat64;
 }
 
 // int32
-export interface ZodInt32 extends ZodNumberFormat {}
+export interface ZodInt32 extends ZodNumberFormat<"int32"> {}
 export function int32(params?: string | core.$ZodCheckNumberFormatParams): ZodInt32 {
-  return core._int32(ZodNumberFormat, params);
+  return core._int32(ZodNumberFormat, params) as ZodInt32;
 }
 
 // uint32
-export interface ZodUInt32 extends ZodNumberFormat {}
+export interface ZodUInt32 extends ZodNumberFormat<"uint32"> {}
 export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodUInt32 {
-  return core._uint32(ZodNumberFormat, params);
+  return core._uint32(ZodNumberFormat, params) as ZodUInt32;
 }
 
 // boolean

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1,3 +1,4 @@
+import type { $ZodBigIntFormats } from "../core/checks.js";
 import * as core from "../core/index.js";
 import { util, type $ZodNumberFormats } from "../core/index.js";
 import * as processors from "../core/json-schema-processors.js";
@@ -1328,8 +1329,8 @@ export function bigint(params?: string | core.$ZodBigIntParams): ZodBigInt {
 // bigint formats
 
 // ZodBigIntFormat
-export interface ZodBigIntFormat extends ZodBigInt {
-  _zod: core.$ZodBigIntFormatInternals;
+export interface ZodBigIntFormat<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends ZodBigInt {
+  _zod: core.$ZodBigIntFormatInternals<Format>;
 }
 export const ZodBigIntFormat: core.$constructor<ZodBigIntFormat> = /*@__PURE__*/ core.$constructor(
   "ZodBigIntFormat",
@@ -1340,13 +1341,13 @@ export const ZodBigIntFormat: core.$constructor<ZodBigIntFormat> = /*@__PURE__*/
 );
 
 // int64
-export function int64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat {
-  return core._int64(ZodBigIntFormat, params);
+export function int64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat<"int64"> {
+  return core._int64(ZodBigIntFormat, params) as ZodBigIntFormat<"int64">;
 }
 
 // uint64
-export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat {
-  return core._uint64(ZodBigIntFormat, params);
+export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodBigIntFormat<"uint64"> {
+  return core._uint64(ZodBigIntFormat, params) as ZodBigIntFormat<"uint64">;
 }
 
 // symbol

--- a/packages/zod/src/v4/classic/tests/bigint.test.ts
+++ b/packages/zod/src/v4/classic/tests/bigint.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 
 import * as z from "zod/v4";
 
@@ -51,4 +51,15 @@ test("min max getters", () => {
 
   expect(z.bigint().max(BigInt(5)).maxValue).toEqual(BigInt(5));
   expect(z.bigint().max(BigInt(5)).max(BigInt(1)).maxValue).toEqual(BigInt(1));
+});
+
+test("bigint formats are distinct at the type level", () => {
+  expectTypeOf(z.int64()._zod.def.format).toEqualTypeOf<"int64">();
+  expectTypeOf(z.uint64()._zod.def.format).toEqualTypeOf<"uint64">();
+
+  z.int64() satisfies z.ZodBigIntFormat;
+  z.int64() satisfies z.ZodBigInt;
+
+  // @ts-expect-error a uint64 schema is not a ZodInt64
+  z.uint64() satisfies z.ZodInt64;
 });

--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 
 import * as z from "zod/v4";
 
@@ -321,4 +321,32 @@ test("negative zero edge case", () => {
 test("error customization", () => {
   z.number().gte(5, { error: (iss) => "Min: " + iss.minimum.valueOf() });
   z.number().lte(5, { error: (iss) => "Max: " + iss.maximum.valueOf() });
+});
+
+test("number formats are distinct at the type level", () => {
+  expectTypeOf(z.int()._zod.def.format).toEqualTypeOf<"safeint">();
+  expectTypeOf(z.int32()._zod.def.format).toEqualTypeOf<"int32">();
+  expectTypeOf(z.uint32()._zod.def.format).toEqualTypeOf<"uint32">();
+  expectTypeOf(z.float32()._zod.def.format).toEqualTypeOf<"float32">();
+  expectTypeOf(z.float64()._zod.def.format).toEqualTypeOf<"float64">();
+
+  z.int() satisfies z.ZodNumberFormat;
+  z.int() satisfies z.ZodNumber;
+
+  // @ts-expect-error a float32 schema is not a ZodInt
+  z.float32() satisfies z.ZodInt;
+  // @ts-expect-error a uint32 schema is not a ZodInt32
+  z.uint32() satisfies z.ZodInt32;
+
+  // the point of the distinction: dispatching on the schema type in a conditional type
+  type Sql<T> = T extends z.ZodUInt32
+    ? "BIGINT"
+    : T extends z.ZodInt32
+      ? "INTEGER"
+      : T extends z.ZodFloat32
+        ? "REAL"
+        : never;
+  expectTypeOf<Sql<z.ZodUInt32>>().toEqualTypeOf<"BIGINT">();
+  expectTypeOf<Sql<z.ZodInt32>>().toEqualTypeOf<"INTEGER">();
+  expectTypeOf<Sql<z.ZodFloat32>>().toEqualTypeOf<"REAL">();
 });

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -378,18 +378,19 @@ export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /
 
 export type $ZodBigIntFormats = "int64" | "uint64";
 
-export interface $ZodCheckBigIntFormatDef extends $ZodCheckDef {
+export interface $ZodCheckBigIntFormatDef<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends $ZodCheckDef {
   check: "bigint_format";
-  format: $ZodBigIntFormats | undefined;
+  format: Format;
 }
 
-export interface $ZodCheckBigIntFormatInternals extends $ZodCheckInternals<bigint> {
-  def: $ZodCheckBigIntFormatDef;
+export interface $ZodCheckBigIntFormatInternals<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
+  extends $ZodCheckInternals<bigint> {
+  def: $ZodCheckBigIntFormatDef<Format>;
   issc: errors.$ZodIssueTooBig<"bigint"> | errors.$ZodIssueTooSmall<"bigint">;
 }
 
-export interface $ZodCheckBigIntFormat extends $ZodCheck<bigint> {
-  _zod: $ZodCheckBigIntFormatInternals;
+export interface $ZodCheckBigIntFormat<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends $ZodCheck<bigint> {
+  _zod: $ZodCheckBigIntFormatInternals<Format>;
 }
 
 export const $ZodCheckBigIntFormat: core.$constructor<$ZodCheckBigIntFormat> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -243,22 +243,23 @@ export const $ZodCheckMultipleOf: core.$constructor<$ZodCheckMultipleOf<number |
 
 export type $ZodNumberFormats = "int32" | "uint32" | "float32" | "float64" | "safeint";
 
-export interface $ZodCheckNumberFormatDef extends $ZodCheckDef {
+export interface $ZodCheckNumberFormatDef<Format extends $ZodNumberFormats = $ZodNumberFormats> extends $ZodCheckDef {
   check: "number_format";
-  format: $ZodNumberFormats;
+  format: Format;
   // abort?: boolean;
 }
 
-export interface $ZodCheckNumberFormatInternals extends $ZodCheckInternals<number> {
-  def: $ZodCheckNumberFormatDef;
+export interface $ZodCheckNumberFormatInternals<Format extends $ZodNumberFormats = $ZodNumberFormats>
+  extends $ZodCheckInternals<number> {
+  def: $ZodCheckNumberFormatDef<Format>;
   issc: errors.$ZodIssueInvalidType | errors.$ZodIssueTooBig<"number"> | errors.$ZodIssueTooSmall<"number">;
   // bag: util.LoosePartial<{
   //   minimum?: number | undefined;
   // }>;
 }
 
-export interface $ZodCheckNumberFormat extends $ZodCheck<number> {
-  _zod: $ZodCheckNumberFormatInternals;
+export interface $ZodCheckNumberFormat<Format extends $ZodNumberFormats = $ZodNumberFormats> extends $ZodCheck<number> {
+  _zod: $ZodCheckNumberFormatInternals<Format>;
 }
 
 export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -255,22 +255,23 @@ export const $ZodCheckMultipleOf: core.$constructor<$ZodCheckMultipleOf<number |
 
 export type $ZodNumberFormats = "int32" | "uint32" | "float32" | "float64" | "safeint";
 
-export interface $ZodCheckNumberFormatDef extends $ZodCheckDef {
+export interface $ZodCheckNumberFormatDef<Format extends $ZodNumberFormats = $ZodNumberFormats> extends $ZodCheckDef {
   check: "number_format";
-  format: $ZodNumberFormats;
+  format: Format;
   // abort?: boolean;
 }
 
-export interface $ZodCheckNumberFormatInternals extends $ZodCheckInternals<number> {
-  def: $ZodCheckNumberFormatDef;
+export interface $ZodCheckNumberFormatInternals<Format extends $ZodNumberFormats = $ZodNumberFormats>
+  extends $ZodCheckInternals<number> {
+  def: $ZodCheckNumberFormatDef<Format>;
   issc: errors.$ZodIssueInvalidType | errors.$ZodIssueTooBig<"number"> | errors.$ZodIssueTooSmall<"number">;
   // bag: util.LoosePartial<{
   //   minimum?: number | undefined;
   // }>;
 }
 
-export interface $ZodCheckNumberFormat extends $ZodCheck<number> {
-  _zod: $ZodCheckNumberFormatInternals;
+export interface $ZodCheckNumberFormat<Format extends $ZodNumberFormats = $ZodNumberFormats> extends $ZodCheck<number> {
+  _zod: $ZodCheckNumberFormatInternals<Format>;
 }
 
 export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -390,18 +390,19 @@ export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /
 
 export type $ZodBigIntFormats = "int64" | "uint64";
 
-export interface $ZodCheckBigIntFormatDef extends $ZodCheckDef {
+export interface $ZodCheckBigIntFormatDef<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends $ZodCheckDef {
   check: "bigint_format";
-  format: $ZodBigIntFormats | undefined;
+  format: Format;
 }
 
-export interface $ZodCheckBigIntFormatInternals extends $ZodCheckInternals<bigint> {
-  def: $ZodCheckBigIntFormatDef;
+export interface $ZodCheckBigIntFormatInternals<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
+  extends $ZodCheckInternals<bigint> {
+  def: $ZodCheckBigIntFormatDef<Format>;
   issc: errors.$ZodIssueTooBig<"bigint"> | errors.$ZodIssueTooSmall<"bigint">;
 }
 
-export interface $ZodCheckBigIntFormat extends $ZodCheck<bigint> {
-  _zod: $ZodCheckBigIntFormatInternals;
+export interface $ZodCheckBigIntFormat<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends $ZodCheck<bigint> {
+  _zod: $ZodCheckBigIntFormatInternals<Format>;
 }
 
 export const $ZodCheckBigIntFormat: core.$constructor<$ZodCheckBigIntFormat> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -392,7 +392,7 @@ export type $ZodBigIntFormats = "int64" | "uint64";
 
 export interface $ZodCheckBigIntFormatDef<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends $ZodCheckDef {
   check: "bigint_format";
-  format: Format;
+  format: Format | undefined;
 }
 
 export interface $ZodCheckBigIntFormatInternals<Format extends $ZodBigIntFormats = $ZodBigIntFormats>

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -392,7 +392,7 @@ export type $ZodBigIntFormats = "int64" | "uint64";
 
 export interface $ZodCheckBigIntFormatDef<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends $ZodCheckDef {
   check: "bigint_format";
-  format: Format | undefined;
+  format: Format;
 }
 
 export interface $ZodCheckBigIntFormatInternals<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
@@ -410,7 +410,7 @@ export const $ZodCheckBigIntFormat: core.$constructor<$ZodCheckBigIntFormat> = /
   (inst, def) => {
     $ZodCheck.init(inst, def); // no format checks
 
-    const [minimum, maximum] = util.BIGINT_FORMAT_RANGES[def.format!];
+    const [minimum, maximum] = util.BIGINT_FORMAT_RANGES[def.format];
 
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1,5 +1,6 @@
 import type { $ZodTypeDiscriminable } from "./api.js";
 import * as checks from "./checks.js";
+import type { $ZodNumberFormats } from "./checks.js";
 import * as core from "./core.js";
 import { Doc } from "./doc.js";
 import type * as errors from "./errors.js";
@@ -1155,15 +1156,19 @@ export const $ZodNumber: core.$constructor<$ZodNumber> = /*@__PURE__*/ core.$con
 ///////////////////////////////////////////////
 //////////      ZodNumberFormat      //////////
 ///////////////////////////////////////////////
-export interface $ZodNumberFormatDef extends $ZodNumberDef, checks.$ZodCheckNumberFormatDef {}
+export interface $ZodNumberFormatDef<Format extends $ZodNumberFormats = $ZodNumberFormats>
+  extends $ZodNumberDef,
+    checks.$ZodCheckNumberFormatDef<Format> {}
 
-export interface $ZodNumberFormatInternals extends $ZodNumberInternals<number>, checks.$ZodCheckNumberFormatInternals {
-  def: $ZodNumberFormatDef;
+export interface $ZodNumberFormatInternals<Format extends $ZodNumberFormats = $ZodNumberFormats>
+  extends $ZodNumberInternals<number>,
+    checks.$ZodCheckNumberFormatInternals<Format> {
+  def: $ZodNumberFormatDef<Format>;
   isst: errors.$ZodIssueInvalidType;
 }
 
-export interface $ZodNumberFormat extends $ZodType {
-  _zod: $ZodNumberFormatInternals;
+export interface $ZodNumberFormat<Format extends $ZodNumberFormats = $ZodNumberFormats> extends $ZodType {
+  _zod: $ZodNumberFormatInternals<Format>;
 }
 
 export const $ZodNumberFormat: core.$constructor<$ZodNumberFormat> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1,6 +1,7 @@
 import type { $ZodTypeDiscriminable } from "./api.js";
 import * as checks from "./checks.js";
 import type { $ZodNumberFormats } from "./checks.js";
+import type { $ZodBigIntFormats } from "./checks.js";
 import * as core from "./core.js";
 import { Doc } from "./doc.js";
 import type * as errors from "./errors.js";
@@ -1283,16 +1284,20 @@ export const $ZodBigInt: core.$constructor<$ZodBigInt> = /*@__PURE__*/ core.$con
 ///////////////////////////////////////////////
 //////////      ZodBigIntFormat      //////////
 ///////////////////////////////////////////////
-export interface $ZodBigIntFormatDef extends $ZodBigIntDef, checks.$ZodCheckBigIntFormatDef {
+export interface $ZodBigIntFormatDef<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
+  extends $ZodBigIntDef,
+    checks.$ZodCheckBigIntFormatDef<Format> {
   check: "bigint_format";
 }
 
-export interface $ZodBigIntFormatInternals extends $ZodBigIntInternals<bigint>, checks.$ZodCheckBigIntFormatInternals {
-  def: $ZodBigIntFormatDef;
+export interface $ZodBigIntFormatInternals<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
+  extends $ZodBigIntInternals<bigint>,
+    checks.$ZodCheckBigIntFormatInternals<Format> {
+  def: $ZodBigIntFormatDef<Format>;
 }
 
-export interface $ZodBigIntFormat extends $ZodType {
-  _zod: $ZodBigIntFormatInternals;
+export interface $ZodBigIntFormat<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends $ZodType {
+  _zod: $ZodBigIntFormatInternals<Format>;
 }
 
 export const $ZodBigIntFormat: core.$constructor<$ZodBigIntFormat> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1413,8 +1413,6 @@ export interface $ZodBigIntFormatDef<Format extends $ZodBigIntFormats = $ZodBigI
   extends $ZodBigIntDef,
     checks.$ZodCheckBigIntFormatDef<Format> {
   check: "bigint_format";
-  // narrower than the check def it extends: a bigint format schema is only ever built by z.int64()/z.uint64(), which always set a format
-  format: Format;
 }
 
 export interface $ZodBigIntFormatInternals<Format extends $ZodBigIntFormats = $ZodBigIntFormats>

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1,4 +1,5 @@
 import * as checks from "./checks.js";
+import type { $ZodNumberFormats } from "./checks.js";
 import * as core from "./core.js";
 import { Doc } from "./doc.js";
 import type * as errors from "./errors.js";
@@ -1280,15 +1281,19 @@ export const $ZodNumber: core.$constructor<$ZodNumber> = /*@__PURE__*/ core.$con
 ///////////////////////////////////////////////
 //////////      ZodNumberFormat      //////////
 ///////////////////////////////////////////////
-export interface $ZodNumberFormatDef extends $ZodNumberDef, checks.$ZodCheckNumberFormatDef {}
+export interface $ZodNumberFormatDef<Format extends $ZodNumberFormats = $ZodNumberFormats>
+  extends $ZodNumberDef,
+    checks.$ZodCheckNumberFormatDef<Format> {}
 
-export interface $ZodNumberFormatInternals extends $ZodNumberInternals<number>, checks.$ZodCheckNumberFormatInternals {
-  def: $ZodNumberFormatDef;
+export interface $ZodNumberFormatInternals<Format extends $ZodNumberFormats = $ZodNumberFormats>
+  extends $ZodNumberInternals<number>,
+    checks.$ZodCheckNumberFormatInternals<Format> {
+  def: $ZodNumberFormatDef<Format>;
   isst: errors.$ZodIssueInvalidType;
 }
 
-export interface $ZodNumberFormat extends $ZodType {
-  _zod: $ZodNumberFormatInternals;
+export interface $ZodNumberFormat<Format extends $ZodNumberFormats = $ZodNumberFormats> extends $ZodType {
+  _zod: $ZodNumberFormatInternals<Format>;
 }
 
 export const $ZodNumberFormat: core.$constructor<$ZodNumberFormat> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1413,6 +1413,8 @@ export interface $ZodBigIntFormatDef<Format extends $ZodBigIntFormats = $ZodBigI
   extends $ZodBigIntDef,
     checks.$ZodCheckBigIntFormatDef<Format> {
   check: "bigint_format";
+  // narrower than the check def it extends: a bigint format schema is only ever built by z.int64()/z.uint64(), which always set a format
+  format: Format;
 }
 
 export interface $ZodBigIntFormatInternals<Format extends $ZodBigIntFormats = $ZodBigIntFormats>

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1,5 +1,6 @@
 import * as checks from "./checks.js";
 import type { $ZodNumberFormats } from "./checks.js";
+import type { $ZodBigIntFormats } from "./checks.js";
 import * as core from "./core.js";
 import { Doc } from "./doc.js";
 import type * as errors from "./errors.js";
@@ -1408,16 +1409,20 @@ export const $ZodBigInt: core.$constructor<$ZodBigInt> = /*@__PURE__*/ core.$con
 ///////////////////////////////////////////////
 //////////      ZodBigIntFormat      //////////
 ///////////////////////////////////////////////
-export interface $ZodBigIntFormatDef extends $ZodBigIntDef, checks.$ZodCheckBigIntFormatDef {
+export interface $ZodBigIntFormatDef<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
+  extends $ZodBigIntDef,
+    checks.$ZodCheckBigIntFormatDef<Format> {
   check: "bigint_format";
 }
 
-export interface $ZodBigIntFormatInternals extends $ZodBigIntInternals<bigint>, checks.$ZodCheckBigIntFormatInternals {
-  def: $ZodBigIntFormatDef;
+export interface $ZodBigIntFormatInternals<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
+  extends $ZodBigIntInternals<bigint>,
+    checks.$ZodCheckBigIntFormatInternals<Format> {
+  def: $ZodBigIntFormatDef<Format>;
 }
 
-export interface $ZodBigIntFormat extends $ZodType {
-  _zod: $ZodBigIntFormatInternals;
+export interface $ZodBigIntFormat<Format extends $ZodBigIntFormats = $ZodBigIntFormats> extends $ZodType {
+  _zod: $ZodBigIntFormatInternals<Format>;
 }
 
 export const $ZodBigIntFormat: core.$constructor<$ZodBigIntFormat> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1,4 +1,5 @@
 import * as core from "../core/index.js";
+import type { $ZodBigIntFormats } from "../core/index.js";
 import * as util from "../core/util.js";
 import * as parse from "./parse.js";
 
@@ -642,8 +643,9 @@ export function bigint(params?: string | core.$ZodBigIntParams): ZodMiniBigInt<b
 // bigint formats
 
 // ZodMiniBigIntFormat
-export interface ZodMiniBigIntFormat extends _ZodMiniType<core.$ZodBigIntFormatInternals> {
-  // _zod: core.$ZodBigIntFormatInternals;
+export interface ZodMiniBigIntFormat<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
+  extends _ZodMiniType<core.$ZodBigIntFormatInternals<Format>> {
+  // _zod: core.$ZodBigIntFormatInternals<Format>;
 }
 export const ZodMiniBigIntFormat: core.$constructor<ZodMiniBigIntFormat> = /*@__PURE__*/ core.$constructor(
   "ZodMiniBigIntFormat",
@@ -656,15 +658,15 @@ export const ZodMiniBigIntFormat: core.$constructor<ZodMiniBigIntFormat> = /*@__
 // int64
 
 // @__NO_SIDE_EFFECTS__
-export function int64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat {
-  return core._int64(ZodMiniBigIntFormat, params);
+export function int64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat<"int64"> {
+  return core._int64(ZodMiniBigIntFormat, params) as ZodMiniBigIntFormat<"int64">;
 }
 
 // uint64
 
 // @__NO_SIDE_EFFECTS__
-export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat {
-  return core._uint64(ZodMiniBigIntFormat, params);
+export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat<"uint64"> {
+  return core._uint64(ZodMiniBigIntFormat, params) as ZodMiniBigIntFormat<"uint64">;
 }
 
 // ZodMiniSymbol

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -559,7 +559,9 @@ export function number(params?: string | core.$ZodNumberParams): ZodMiniNumber<n
 }
 
 // ZodMiniNumberFormat
-export interface ZodMiniNumberFormat extends _ZodMiniNumber<core.$ZodNumberFormatInternals>, core.$ZodNumberFormat {}
+export interface ZodMiniNumberFormat<Format extends core.$ZodNumberFormats = core.$ZodNumberFormats>
+  extends _ZodMiniNumber<core.$ZodNumberFormatInternals<Format>>,
+    core.$ZodNumberFormat<Format> {}
 export const ZodMiniNumberFormat: core.$constructor<ZodMiniNumberFormat> = /*@__PURE__*/ core.$constructor(
   "ZodMiniNumberFormat",
   (inst, def) => {
@@ -571,36 +573,36 @@ export const ZodMiniNumberFormat: core.$constructor<ZodMiniNumberFormat> = /*@__
 // int
 
 // @__NO_SIDE_EFFECTS__
-export function int(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._int(ZodMiniNumberFormat, params);
+export function int(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"safeint"> {
+  return core._int(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"safeint">;
 }
 
 // float32
 
 // @__NO_SIDE_EFFECTS__
-export function float32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._float32(ZodMiniNumberFormat, params);
+export function float32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"float32"> {
+  return core._float32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"float32">;
 }
 
 // float64
 
 // @__NO_SIDE_EFFECTS__
-export function float64(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._float64(ZodMiniNumberFormat, params);
+export function float64(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"float64"> {
+  return core._float64(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"float64">;
 }
 
 // int32
 
 // @__NO_SIDE_EFFECTS__
-export function int32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._int32(ZodMiniNumberFormat, params);
+export function int32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"int32"> {
+  return core._int32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"int32">;
 }
 
 // uint32
 
 // @__NO_SIDE_EFFECTS__
-export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._uint32(ZodMiniNumberFormat, params);
+export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"uint32"> {
+  return core._uint32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"uint32">;
 }
 
 // ZodMiniBoolean

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -608,36 +608,41 @@ export const ZodMiniNumberFormat: core.$constructor<ZodMiniNumberFormat> = /*@__
 // int
 
 // @__NO_SIDE_EFFECTS__
-export function int(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"safeint"> {
-  return core._int(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"safeint">;
+export interface ZodMiniInt extends ZodMiniNumberFormat<"safeint"> {}
+export function int(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniInt {
+  return core._int(ZodMiniNumberFormat, params) as ZodMiniInt;
 }
 
 // float32
 
 // @__NO_SIDE_EFFECTS__
-export function float32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"float32"> {
-  return core._float32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"float32">;
+export interface ZodMiniFloat32 extends ZodMiniNumberFormat<"float32"> {}
+export function float32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniFloat32 {
+  return core._float32(ZodMiniNumberFormat, params) as ZodMiniFloat32;
 }
 
 // float64
 
 // @__NO_SIDE_EFFECTS__
-export function float64(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"float64"> {
-  return core._float64(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"float64">;
+export interface ZodMiniFloat64 extends ZodMiniNumberFormat<"float64"> {}
+export function float64(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniFloat64 {
+  return core._float64(ZodMiniNumberFormat, params) as ZodMiniFloat64;
 }
 
 // int32
 
 // @__NO_SIDE_EFFECTS__
-export function int32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"int32"> {
-  return core._int32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"int32">;
+export interface ZodMiniInt32 extends ZodMiniNumberFormat<"int32"> {}
+export function int32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniInt32 {
+  return core._int32(ZodMiniNumberFormat, params) as ZodMiniInt32;
 }
 
 // uint32
 
 // @__NO_SIDE_EFFECTS__
-export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"uint32"> {
-  return core._uint32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"uint32">;
+export interface ZodMiniUInt32 extends ZodMiniNumberFormat<"uint32"> {}
+export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniUInt32 {
+  return core._uint32(ZodMiniNumberFormat, params) as ZodMiniUInt32;
 }
 
 // ZodMiniBoolean
@@ -692,15 +697,17 @@ export const ZodMiniBigIntFormat: core.$constructor<ZodMiniBigIntFormat> = /*@__
 // int64
 
 // @__NO_SIDE_EFFECTS__
-export function int64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat<"int64"> {
-  return core._int64(ZodMiniBigIntFormat, params) as ZodMiniBigIntFormat<"int64">;
+export interface ZodMiniInt64 extends ZodMiniBigIntFormat<"int64"> {}
+export function int64(params?: string | core.$ZodBigIntFormatParams): ZodMiniInt64 {
+  return core._int64(ZodMiniBigIntFormat, params) as ZodMiniInt64;
 }
 
 // uint64
 
 // @__NO_SIDE_EFFECTS__
-export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat<"uint64"> {
-  return core._uint64(ZodMiniBigIntFormat, params) as ZodMiniBigIntFormat<"uint64">;
+export interface ZodMiniUInt64 extends ZodMiniBigIntFormat<"uint64"> {}
+export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodMiniUInt64 {
+  return core._uint64(ZodMiniBigIntFormat, params) as ZodMiniUInt64;
 }
 
 // ZodMiniSymbol

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1,4 +1,5 @@
 import * as core from "../core/index.js";
+import type { $ZodBigIntFormats } from "../core/index.js";
 import * as util from "../core/util.js";
 import * as parse from "./parse.js";
 
@@ -676,8 +677,9 @@ export function bigint(params?: string | core.$ZodBigIntParams): ZodMiniBigInt<b
 // bigint formats
 
 // ZodMiniBigIntFormat
-export interface ZodMiniBigIntFormat extends _ZodMiniType<core.$ZodBigIntFormatInternals> {
-  // _zod: core.$ZodBigIntFormatInternals;
+export interface ZodMiniBigIntFormat<Format extends $ZodBigIntFormats = $ZodBigIntFormats>
+  extends _ZodMiniType<core.$ZodBigIntFormatInternals<Format>> {
+  // _zod: core.$ZodBigIntFormatInternals<Format>;
 }
 export const ZodMiniBigIntFormat: core.$constructor<ZodMiniBigIntFormat> = /*@__PURE__*/ core.$constructor(
   "ZodMiniBigIntFormat",
@@ -690,15 +692,15 @@ export const ZodMiniBigIntFormat: core.$constructor<ZodMiniBigIntFormat> = /*@__
 // int64
 
 // @__NO_SIDE_EFFECTS__
-export function int64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat {
-  return core._int64(ZodMiniBigIntFormat, params);
+export function int64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat<"int64"> {
+  return core._int64(ZodMiniBigIntFormat, params) as ZodMiniBigIntFormat<"int64">;
 }
 
 // uint64
 
 // @__NO_SIDE_EFFECTS__
-export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat {
-  return core._uint64(ZodMiniBigIntFormat, params);
+export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodMiniBigIntFormat<"uint64"> {
+  return core._uint64(ZodMiniBigIntFormat, params) as ZodMiniBigIntFormat<"uint64">;
 }
 
 // ZodMiniSymbol

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -593,7 +593,9 @@ export function number(params?: string | core.$ZodNumberParams): ZodMiniNumber<n
 }
 
 // ZodMiniNumberFormat
-export interface ZodMiniNumberFormat extends _ZodMiniNumber<core.$ZodNumberFormatInternals>, core.$ZodNumberFormat {}
+export interface ZodMiniNumberFormat<Format extends core.$ZodNumberFormats = core.$ZodNumberFormats>
+  extends _ZodMiniNumber<core.$ZodNumberFormatInternals<Format>>,
+    core.$ZodNumberFormat<Format> {}
 export const ZodMiniNumberFormat: core.$constructor<ZodMiniNumberFormat> = /*@__PURE__*/ core.$constructor(
   "ZodMiniNumberFormat",
   (inst, def) => {
@@ -605,36 +607,36 @@ export const ZodMiniNumberFormat: core.$constructor<ZodMiniNumberFormat> = /*@__
 // int
 
 // @__NO_SIDE_EFFECTS__
-export function int(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._int(ZodMiniNumberFormat, params);
+export function int(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"safeint"> {
+  return core._int(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"safeint">;
 }
 
 // float32
 
 // @__NO_SIDE_EFFECTS__
-export function float32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._float32(ZodMiniNumberFormat, params);
+export function float32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"float32"> {
+  return core._float32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"float32">;
 }
 
 // float64
 
 // @__NO_SIDE_EFFECTS__
-export function float64(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._float64(ZodMiniNumberFormat, params);
+export function float64(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"float64"> {
+  return core._float64(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"float64">;
 }
 
 // int32
 
 // @__NO_SIDE_EFFECTS__
-export function int32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._int32(ZodMiniNumberFormat, params);
+export function int32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"int32"> {
+  return core._int32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"int32">;
 }
 
 // uint32
 
 // @__NO_SIDE_EFFECTS__
-export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat {
-  return core._uint32(ZodMiniNumberFormat, params);
+export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodMiniNumberFormat<"uint32"> {
+  return core._uint32(ZodMiniNumberFormat, params) as ZodMiniNumberFormat<"uint32">;
 }
 
 // ZodMiniBoolean

--- a/packages/zod/src/v4/mini/tests/number.test.ts
+++ b/packages/zod/src/v4/mini/tests/number.test.ts
@@ -93,3 +93,17 @@ test("z.uint64", () => {
   // expect(() => z.parse(a, BigInt("18446744073709551616"))).toThrow(); // Exceeds max
   // expect(() => z.parse(a, BigInt("-1"))).toThrow(); // Below min
 });
+
+test("number and bigint formats are distinct at the type level", () => {
+  expectTypeOf(z.int()._zod.def.format).toEqualTypeOf<"safeint">();
+  expectTypeOf(z.uint32()._zod.def.format).toEqualTypeOf<"uint32">();
+  expectTypeOf(z.int64()._zod.def.format).toEqualTypeOf<"int64">();
+
+  z.int32() satisfies z.ZodMiniInt32;
+  z.uint64() satisfies z.ZodMiniUInt64;
+
+  // @ts-expect-error a float64 schema is not a ZodMiniFloat32
+  z.float64() satisfies z.ZodMiniFloat32;
+  // @ts-expect-error a uint64 schema is not a ZodMiniInt64
+  z.uint64() satisfies z.ZodMiniInt64;
+});

--- a/play.ts
+++ b/play.ts
@@ -5,10 +5,10 @@ function toPostgresType(schema: z.ZodInt | z.ZodFloat32 | z.ZodFloat64 | z.ZodIn
   if (schema._zod.def.format === "safeint") return "INTEGER";
   if (schema._zod.def.format === "float32") return "REAL";
   if (schema._zod.def.format === "float64") return "DOUBLE PRECISION";
-  if (schema._zod.def.format === "int32")   return "INTEGER";
-  if (schema._zod.def.format === "uint32")  return "BIGINT";
+  if (schema._zod.def.format === "int32") return "INTEGER";
+  if (schema._zod.def.format === "uint32") return "BIGINT";
 }
 
-console.log(toPostgresType(z.int()));     // INTEGER
+console.log(toPostgresType(z.int())); // INTEGER
 console.log(toPostgresType(z.float32())); // REAL
 console.log(toPostgresType(z.float64())); // DOUBLE PRECISION

--- a/play.ts
+++ b/play.ts
@@ -1,10 +1,14 @@
-import { z } from "zod";
+import * as z from "zod";
 
-const formDate = z.iso
-  .datetime({ offset: true })
-  .or(z.literal(""))
-  .transform((v) => (v === "" ? null : v));
+// this function should only work because TypeScript can now tell them apart
+function toPostgresType(schema: z.ZodInt | z.ZodFloat32 | z.ZodFloat64 | z.ZodInt32 | z.ZodUInt32) {
+  if (schema._zod.def.format === "safeint") return "INTEGER";
+  if (schema._zod.def.format === "float32") return "REAL";
+  if (schema._zod.def.format === "float64") return "DOUBLE PRECISION";
+  if (schema._zod.def.format === "int32")   return "INTEGER";
+  if (schema._zod.def.format === "uint32")  return "BIGINT";
+}
 
-console.log("empty:", formDate.safeParse(""));
-console.log("valid:", formDate.safeParse("2024-01-15T10:30:00.000Z"));
-console.log("invalid:", formDate.safeParse("not-a-date"));
+console.log(toPostgresType(z.int()));     // INTEGER
+console.log(toPostgresType(z.float32())); // REAL
+console.log(toPostgresType(z.float64())); // DOUBLE PRECISION

--- a/play.ts
+++ b/play.ts
@@ -1,14 +1,27 @@
 import * as z from "zod";
 
-// this function should only work because TypeScript can now tell them apart
-function toPostgresType(schema: z.ZodInt | z.ZodFloat32 | z.ZodFloat64 | z.ZodInt32 | z.ZodUInt32) {
-  if (schema._zod.def.format === "safeint") return "INTEGER";
-  if (schema._zod.def.format === "float32") return "REAL";
-  if (schema._zod.def.format === "float64") return "DOUBLE PRECISION";
-  if (schema._zod.def.format === "int32") return "INTEGER";
-  if (schema._zod.def.format === "uint32") return "BIGINT";
+// number format narrowing
+function describeNumberFormat(schema: z.ZodInt | z.ZodFloat32 | z.ZodFloat64 | z.ZodInt32 | z.ZodUInt32) {
+  const fmt = schema._zod.def.format;
+  if (fmt === "safeint") return "safeint";
+  if (fmt === "float32") return "float32";
+  if (fmt === "float64") return "float64";
+  if (fmt === "int32") return "int32";
+  if (fmt === "uint32") return "uint32";
 }
 
-console.log(toPostgresType(z.int())); // INTEGER
-console.log(toPostgresType(z.float32())); // REAL
-console.log(toPostgresType(z.float64())); // DOUBLE PRECISION
+console.log(describeNumberFormat(z.int())); // safeint
+console.log(describeNumberFormat(z.float32())); // float32
+console.log(describeNumberFormat(z.float64())); // float64
+console.log(describeNumberFormat(z.int32())); // int32
+console.log(describeNumberFormat(z.uint32())); // uint32
+
+// bigint format narrowing
+function describeBigIntFormat(schema: z.ZodBigIntFormat<"int64"> | z.ZodBigIntFormat<"uint64">) {
+  const fmt = schema._zod.def.format;
+  if (fmt === "int64") return "int64";
+  if (fmt === "uint64") return "uint64";
+}
+
+console.log(describeBigIntFormat(z.int64())); // int64
+console.log(describeBigIntFormat(z.uint64())); // uint64

--- a/play.ts
+++ b/play.ts
@@ -1,27 +1,10 @@
-import * as z from "zod";
+import { z } from "zod";
 
-// number format narrowing
-function describeNumberFormat(schema: z.ZodInt | z.ZodFloat32 | z.ZodFloat64 | z.ZodInt32 | z.ZodUInt32) {
-  const fmt = schema._zod.def.format;
-  if (fmt === "safeint") return "safeint";
-  if (fmt === "float32") return "float32";
-  if (fmt === "float64") return "float64";
-  if (fmt === "int32") return "int32";
-  if (fmt === "uint32") return "uint32";
-}
+const formDate = z.iso
+  .datetime({ offset: true })
+  .or(z.literal(""))
+  .transform((v) => (v === "" ? null : v));
 
-console.log(describeNumberFormat(z.int())); // safeint
-console.log(describeNumberFormat(z.float32())); // float32
-console.log(describeNumberFormat(z.float64())); // float64
-console.log(describeNumberFormat(z.int32())); // int32
-console.log(describeNumberFormat(z.uint32())); // uint32
-
-// bigint format narrowing
-function describeBigIntFormat(schema: z.ZodBigIntFormat<"int64"> | z.ZodBigIntFormat<"uint64">) {
-  const fmt = schema._zod.def.format;
-  if (fmt === "int64") return "int64";
-  if (fmt === "uint64") return "uint64";
-}
-
-console.log(describeBigIntFormat(z.int64())); // int64
-console.log(describeBigIntFormat(z.uint64())); // uint64
+console.log("empty:", formDate.safeParse(""));
+console.log("valid:", formDate.safeParse("2024-01-15T10:30:00.000Z"));
+console.log("invalid:", formDate.safeParse("not-a-date"));


### PR DESCRIPTION
Fixes #6045

Added generic <Format> parameter to $ZodCheckNumberFormatDef, 
$ZodNumberFormatInternals, $ZodNumberFormat in core, and 
ZodNumberFormat/ZodMiniNumberFormat in classic/mini packages.

This allows ZodInt, ZodFloat32, ZodFloat64, ZodInt32, ZodUInt32 
to be distinguished at the type level:

// before
ZodInt extends ZodNumberFormat {}  // no format info

// after  
ZodInt extends ZodNumberFormat<"safeint">  // TypeScript knows the format