### PR TITLE
fix: preserve explicit superRefine issue input

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2088,7 +2088,7 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
 
           if (_issue.fatal) _issue.continue = false;
           _issue.code ??= "custom";
-          _issue.input ??= payload.value;
+          if (!("input" in _issue)) _issue.input = payload.value;
           _issue.inst ??= inst;
           // _issue.continue ??= true;
           payload.issues.push(util.issue(_issue));

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -736,6 +736,26 @@ test("z.refine", () => {
   expect(() => z.parse(a, "hi")).toThrow();
 });
 
+test("z.superRefine preserves explicit nullish issue input", () => {
+  const schema = z.string().check(
+    z.superRefine((_, ctx) => {
+      ctx.addIssue({ code: "custom", message: "default" });
+      ctx.addIssue({ code: "custom", message: "null", input: null });
+      ctx.addIssue({ code: "custom", message: "undefined", input: undefined });
+    })
+  );
+
+  const result = z.safeParse(schema, "sensitive", { reportInput: true });
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.issues).toHaveLength(3);
+    expect(result.error.issues[0].input).toEqual("sensitive");
+    expect(result.error.issues[1].input).toEqual(null);
+    expect(result.error.issues[2]).toHaveProperty("input");
+    expect(result.error.issues[2].input).toEqual(undefined);
+  }
+});
+
 // test("z.superRefine", () => {
 //   const a = z.number([
 //     z.superRefine((val, ctx) => {

--- a/packages/zod/src/v4/classic/tests/refine.test.ts
+++ b/packages/zod/src/v4/classic/tests/refine.test.ts
@@ -338,6 +338,24 @@ describe("superRefine functionality", () => {
     }
   });
 
+  test("should preserve explicit nullish issue input", () => {
+    const schema = z.string().superRefine((_, ctx) => {
+      ctx.addIssue({ code: "custom", message: "default" });
+      ctx.addIssue({ code: "custom", message: "null", input: null });
+      ctx.addIssue({ code: "custom", message: "undefined", input: undefined });
+    });
+
+    const result = schema.safeParse("sensitive", { reportInput: true });
+    expect(result.success).toEqual(false);
+    if (!result.success) {
+      expect(result.error.issues).toHaveLength(3);
+      expect(result.error.issues[0].input).toEqual("sensitive");
+      expect(result.error.issues[1].input).toEqual(null);
+      expect(result.error.issues[2]).toHaveProperty("input");
+      expect(result.error.issues[2].input).toEqual(undefined);
+    }
+  });
+
   test("should respect fatal flag in superRefine", () => {
     const schema = z
       .string()

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1669,7 +1669,7 @@ export function _superRefine<T>(
         const _issue: any = issue;
         if (_issue.fatal) _issue.continue = false;
         _issue.code ??= "custom";
-        _issue.input ??= payload.value;
+        if (!("input" in _issue)) _issue.input = payload.value;
         _issue.inst ??= ch;
         _issue.continue ??= !ch._zod.def.abort; // abort is always undefined, so this is always true...
         payload.issues.push(util.issue(_issue));


### PR DESCRIPTION
`superRefine` currently uses nullish assignment when backfilling an issue's `input`, so an issue author who explicitly passes `input: null` or `input: undefined` has that value replaced with the parsed payload value when `reportInput` is enabled.

This switches the defaulting check to property presence in both `superRefine` paths, so omitted `input` still reports the parsed value while explicit nullish values are preserved. It also adds regression coverage for both `.superRefine(...)` and top-level `z.superRefine(...)` through `.check(...)`.

Validated with `pnpm test`, `pnpm lint:check`, and `pnpm format:check`.