### PR TITLE
fix(docs): make the prefault example runnable (declare `const schema`)

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2843,7 +2843,7 @@ schema.parse(undefined); // => 0
 Sometimes, it's useful to define a *prefault* ("pre-parse default") value. If the input is `undefined`, the prefault value will be parsed instead. The parsing process is *not* short circuited. As such, the prefault value must be assignable to the *input type* of the schema.
 
 ```ts
-z.string().transform(val => val.length).prefault("tuna");
+const schema = z.string().transform(val => val.length).prefault("tuna");
 schema.parse(undefined); // => 4
 ```
 


### PR DESCRIPTION
## Summary

The second example in the **Prefaults** section of `api.mdx` is not runnable:

```ts
z.string().transform(val => val.length).prefault("tuna");
schema.parse(undefined); // => 4
```

The first line is a dangling expression — `schema` is never declared — and the second line then calls `schema.parse(...)` on an undefined binding. Copy-pasting this throws a `ReferenceError` (or, if a `schema` from a previous block is in scope, silently uses that one, which returns `0`, contradicting the `// => 4` comment).

Every parallel example in the surrounding Defaults/Prefaults/Catch sections binds `const schema = ...` — including the `default(0)` example directly above this one.

## Change

Prepend `const schema = ` so the example is self-contained and correct:

```ts
const schema = z.string().transform(val => val.length).prefault("tuna");
schema.parse(undefined); // => 4
```

Now `prefault` feeds `"tuna"` through the `string → length` transform, yielding `4` as the comment states. Docs-only change.
