### PR TITLE
feat(2654): Schema in object being inferred differently (and weirdly)

### DIFF
--- a/packages/zod/src/v3/helpers/util.ts
+++ b/packages/zod/src/v3/helpers/util.ts
@@ -87,16 +87,10 @@ export namespace objectUtil {
           [k in Exclude<keyof U, keyof V>]: U[k];
         } & V;
 
-  type optionalKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? k : never;
-  }[keyof T];
-  type requiredKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? never : k;
-  }[keyof T];
   export type addQuestionMarks<T extends object, _O = any> = {
-    [K in requiredKeys<T>]: T[K];
+    [K in keyof T as undefined extends T[K] ? never : K]: T[K];
   } & {
-    [K in optionalKeys<T>]?: T[K];
+    [K in keyof T as undefined extends T[K] ? K : never]?: T[K];
   } & { [k in keyof T]?: unknown };
 
   export type identity<T> = T;


### PR DESCRIPTION
Closes #2654
/claim #2654

> **Disclosure:** This PR was authored by [@ultra-pod](https://github.com/ultra-pod), an autonomous pod of AI agents that implements, peer-reviews, and synthesizes each change before submission. Flag any concerns and we'll address them or close the PR.

## Summary

Fixes a type inference bug in Zod v3 where schemas using `.or()` (i.e., `ZodUnion`) inside `z.object()` produced an incorrect, widened type for the inferred property. A field typed as `string | string[]` became `(string | string[]) & (string | string[] | undefined)` when accessed through the object's inferred type, even though the same schema assigned to a standalone variable inferred correctly.

- **`packages/zod/src/v3/helpers/util.ts`** — The root cause was in `objectUtil.addQuestionMarks`, the mapped type responsible for splitting object keys into required and optional buckets. The previous implementation used two intermediate helper types, `optionalKeys` and `requiredKeys`, which extracted key unions via a distributive conditional mapped type. When a property's type was itself a union (e.g., `string | string[]`), TypeScript's distribution over that union in the key-extraction step caused the `undefined extends T[k]` check to produce incorrect results, leaking `undefined` into the final intersection and yielding the spurious `& (string | string[] | undefined)`. The fix rewrites both mapped type halves to use `as`-clause key remapping (`[K in keyof T as undefined extends T[K] ? never : K]`) directly on the full object type, eliminating the intermediate key-union extraction and the distribution problem entirely. The `_O = any` parameter and the trailing `{ [k in keyof T]?: unknown }` intersection are preserved, keeping the existing behavior for genuinely optional (i.e., `T[K] | undefined`) fields.

## Verification

Ran `pnpm run test` locally — exit 0 in 5.8s.

<details><summary>Tail of test output</summary>

```

> @ test /Users/voorheesai/ultra-pod/work/colinhacks__zod
> vitest run


 RUN  v4.1.5 /Users/voorheesai/ultra-pod/work/colinhacks__zod


 Test Files  339 passed (339)
      Tests  3811 passed (3811)
Type Errors  no errors
   Start at  04:31:56
   Duration  5.04s (transform 3.87s, setup 1.30s, import 15.76s, tests 3.86s, environment 11ms, typecheck 1.40s)


--- stderr ---
Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.
Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.
Testing types with tsc and vue-tsc is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.

```

</details>