### PR TITLE
fix(v3): correct union property inference inside objects (#2654)

### DIFF
--- a/packages/zod/src/v3/helpers/util.ts
+++ b/packages/zod/src/v3/helpers/util.ts
@@ -87,16 +87,10 @@ export namespace objectUtil {
           [k in Exclude<keyof U, keyof V>]: U[k];
         } & V;
 
-  type optionalKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? k : never;
-  }[keyof T];
-  type requiredKeys<T extends object> = {
-    [k in keyof T]: undefined extends T[k] ? never : k;
-  }[keyof T];
   export type addQuestionMarks<T extends object, _O = any> = {
-    [K in requiredKeys<T>]: T[K];
+    [K in keyof T as undefined extends T[K] ? never : K]: T[K];
   } & {
-    [K in optionalKeys<T>]?: T[K];
+    [K in keyof T as undefined extends T[K] ? K : never]?: T[K];
   } & { [k in keyof T]?: unknown };
 
   export type identity<T> = T;

--- a/packages/zod/src/v3/tests/object.test.ts
+++ b/packages/zod/src/v3/tests/object.test.ts
@@ -432,3 +432,16 @@ test("xor", () => {
     data: z.union([z.object({ name: z.string(), a: z.number() }), z.object({ name: z.string(), b: z.number() })]),
   });
 });
+
+// https://github.com/colinhacks/zod/issues/2654
+test("union property inference inside object (issue 2654)", () => {
+  const EventNameSchema = z.string().or(z.array(z.string()));
+  type EventName = z.infer<typeof EventNameSchema>;
+  util.assertEqual<EventName, string | string[]>(true);
+
+  const EventSchema = z.object({
+    name: z.string().or(z.array(z.string())),
+  });
+  type EventNameFromObject = z.infer<typeof EventSchema>["name"];
+  util.assertEqual<EventNameFromObject, string | string[]>(true);
+});


### PR DESCRIPTION
Closes #2654

/claim #2654

## Summary

Fixes incorrect type inference when a `ZodUnion` (e.g. `.or()`) is used inside `z.object()`.

Previously, `z.infer` for a property like `string | string[]` became `(string | string[]) & (string | string[] | undefined)` due to distributive conditional types in `addQuestionMarks`.

## Changes

- **`packages/zod/src/v3/helpers/util.ts`** — rewrite `addQuestionMarks` with `as`-clause key remapping
- **`packages/zod/src/v3/tests/object.test.ts`** — regression test from issue reproduction

## Test plan

- [x] `vitest run packages/zod/src/v3/tests/object.test.ts` — pass, no type errors
- [x] Full suite: 3812/3813 pass locally (1 unrelated flaky timeout in `datetime.test.ts` redos checker)


Made with [Cursor](https://cursor.com)