### PR TITLE
fix: surface @deprecated on re-exported compat aliases

### DIFF
--- a/packages/zod/src/v4/classic/compat.ts
+++ b/packages/zod/src/v4/classic/compat.ts
@@ -3,14 +3,12 @@
 import * as core from "../core/index.js";
 import type { ZodType } from "./schemas.js";
 
-export type {
-  /** @deprecated Use `z.output<T>` instead. */
-  output as TypeOf,
-  /** @deprecated Use `z.output<T>` instead. */
-  output as Infer,
-  /** @deprecated Use `z.core.$$ZodFirstPartyTypes` instead */
-  $ZodTypes as ZodFirstPartySchemaTypes,
-} from "../core/index.js";
+/** @deprecated Use `z.output<T>` instead. */
+export type TypeOf<T> = core.output<T>;
+/** @deprecated Use `z.output<T>` instead. */
+export type Infer<T> = core.output<T>;
+/** @deprecated Use `z.core.$$ZodFirstPartyTypes` instead */
+export type ZodFirstPartySchemaTypes = core.$ZodTypes;
 
 /** @deprecated Use the raw string literal codes instead, e.g. "invalid_type". */
 export const ZodIssueCode = {
@@ -54,14 +52,12 @@ export function getErrorMap(): core.$ZodErrorMap<core.$ZodIssue> | undefined {
   return core.config().customError;
 }
 
-export type {
-  /** @deprecated Use z.ZodType (without generics) instead. */
-  ZodType as ZodTypeAny,
-  /** @deprecated Use `z.ZodType` */
-  ZodType as ZodSchema,
-  /** @deprecated Use `z.ZodType` */
-  ZodType as Schema,
-};
+/** @deprecated Use z.ZodType (without generics) instead. */
+export type ZodTypeAny = ZodType;
+/** @deprecated Use `z.ZodType` */
+export type ZodSchema = ZodType;
+/** @deprecated Use `z.ZodType` */
+export type Schema = ZodType;
 
 /** Included for Zod 3 compatibility */
 export type ZodRawShape = core.$ZodShape;

--- a/packages/zod/src/v4/classic/compat.ts
+++ b/packages/zod/src/v4/classic/compat.ts
@@ -53,11 +53,23 @@ export function getErrorMap(): core.$ZodErrorMap<core.$ZodIssue> | undefined {
 }
 
 /** @deprecated Use z.ZodType (without generics) instead. */
-export type ZodTypeAny = ZodType;
+export type ZodTypeAny<
+  Output = unknown,
+  Input = unknown,
+  Internals extends core.$ZodTypeInternals<Output, Input> = core.$ZodTypeInternals<Output, Input>,
+> = ZodType<Output, Input, Internals>;
 /** @deprecated Use `z.ZodType` */
-export type ZodSchema = ZodType;
+export type ZodSchema<
+  Output = unknown,
+  Input = unknown,
+  Internals extends core.$ZodTypeInternals<Output, Input> = core.$ZodTypeInternals<Output, Input>,
+> = ZodType<Output, Input, Internals>;
 /** @deprecated Use `z.ZodType` */
-export type Schema = ZodType;
+export type Schema<
+  Output = unknown,
+  Input = unknown,
+  Internals extends core.$ZodTypeInternals<Output, Input> = core.$ZodTypeInternals<Output, Input>,
+> = ZodType<Output, Input, Internals>;
 
 /** Included for Zod 3 compatibility */
 export type ZodRawShape = core.$ZodShape;

--- a/packages/zod/src/v4/classic/errors.ts
+++ b/packages/zod/src/v4/classic/errors.ts
@@ -66,14 +66,12 @@ export const ZodRealError: core.$constructor<ZodError> = /*@__PURE__*/ core.$con
   Parent: Error,
 });
 
-export type {
-  /** @deprecated Use `z.core.$ZodFlattenedError` instead. */
-  $ZodFlattenedError as ZodFlattenedError,
-  /** @deprecated Use `z.core.$ZodFormattedError` instead. */
-  $ZodFormattedError as ZodFormattedError,
-  /** @deprecated Use `z.core.$ZodErrorMap` instead. */
-  $ZodErrorMap as ZodErrorMap,
-} from "../core/index.js";
+/** @deprecated Use `z.core.$ZodFlattenedError` instead. */
+export type ZodFlattenedError<T, U = string> = core.$ZodFlattenedError<T, U>;
+/** @deprecated Use `z.core.$ZodFormattedError` instead. */
+export type ZodFormattedError<T, U = string> = core.$ZodFormattedError<T, U>;
+/** @deprecated Use `z.core.$ZodErrorMap` instead. */
+export type ZodErrorMap<T extends core.$ZodIssueBase = core.$ZodIssue> = core.$ZodErrorMap<T>;
 
 /** @deprecated Use `z.core.$ZodRawIssue` instead. */
 export type IssueData = core.$ZodRawIssue;

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -879,10 +879,8 @@ export function _lte(
     inclusive: true,
   });
 }
-export {
-  /** @deprecated Use `z.lte()` instead. */
-  _lte as _max,
-};
+/** @deprecated Use `z.lte()` instead. */
+export const _max = _lte;
 
 // ZodCheckGreaterThan
 export type $ZodCheckGreaterThanParams = CheckParams<checks.$ZodCheckGreaterThan, "inclusive" | "value" | "when">;
@@ -907,10 +905,8 @@ export function _gte(value: util.Numeric, params?: string | $ZodCheckGreaterThan
   });
 }
 
-export {
-  /** @deprecated Use `z.gte()` instead. */
-  _gte as _min,
-};
+/** @deprecated Use `z.gte()` instead. */
+export const _min = _gte;
 
 // @__NO_SIDE_EFFECTS__
 export function _positive(params?: string | $ZodCheckGreaterThanParams): checks.$ZodCheckGreaterThan {

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -879,8 +879,10 @@ export function _lte(
     inclusive: true,
   });
 }
-/** @deprecated Use `z.lte()` instead. */
-export const _max = _lte;
+export {
+  /** @deprecated Use `z.lte()` instead. */
+  _lte as _max,
+};
 
 // ZodCheckGreaterThan
 export type $ZodCheckGreaterThanParams = CheckParams<checks.$ZodCheckGreaterThan, "inclusive" | "value" | "when">;
@@ -905,8 +907,10 @@ export function _gte(value: util.Numeric, params?: string | $ZodCheckGreaterThan
   });
 }
 
-/** @deprecated Use `z.gte()` instead. */
-export const _min = _gte;
+export {
+  /** @deprecated Use `z.gte()` instead. */
+  _gte as _min,
+};
 
 // @__NO_SIDE_EFFECTS__
 export function _positive(params?: string | $ZodCheckGreaterThanParams): checks.$ZodCheckGreaterThan {


### PR DESCRIPTION
Closes #6038.

`@deprecated` written on an `export { X as Y }` / `export type { X as Y }` specifier is dropped once the alias is re-exported again through the package entry, so none of the Zod 3 compat aliases actually rendered as deprecated in editors — `ZodTypeAny`, `ZodSchema`, `Schema`, `TypeOf`, `Infer`, `ZodFirstPartySchemaTypes` (compat.ts), `ZodFlattenedError`, `ZodFormattedError`, `ZodErrorMap` (errors.ts), and `_max` / `_min` (core/api.ts).

This redeclares each as a standalone aliased declaration with the JSDoc attached directly — the same form `inferFlattenedErrors`, `inferFormattedError`, and `BRAND` already use in compat.ts — so the tag survives re-export.

Verified against the built `.d.ts` via the language service: a fixture importing these through the package entry reports **0** deprecation diagnostics (6385) before the change and **9** after (the two `_` value aliases carry the tag on their emitted `const` declarations as well).
