### PR TITLE
Schema in object being inferred differently (and weirdly)

### DIFF
--- a/packages/zod/src/v3/tests/object.test.ts
+++ b/packages/zod/src/v3/tests/object.test.ts
@@ -217,6 +217,20 @@ test("inferred merged object type with optional properties", async () => {
   // util.assertEqual<Merged, { a?: string | undefined; b: string }>(true);
 });
 
+test("inferred property type from inline union schema (#2654)", () => {
+  const EventNameSchema = z.string().or(z.array(z.string()));
+  type EventName = z.infer<typeof EventNameSchema>;
+
+  const EventSchema = z.object({
+    name: z.string().or(z.array(z.string())),
+  });
+  type EventName2 = z.infer<typeof EventSchema>["name"];
+
+  util.assertEqual<EventName, string | string[]>(true);
+  util.assertEqual<EventName2, string | string[]>(true);
+  util.assertEqual<EventName2, EventName>(true);
+});
+
 test("inferred unioned object type with optional properties", async () => {
   const Unioned = z.union([
     z.object({ a: z.string(), b: z.string().optional() }),


### PR DESCRIPTION
Closes #2654

## Summary
t equality — fails if EventName2 is the buggy
   // (string | string[]) & (string | string[] | undefined) intersection.
   util.assertEqual<EventName, EventName2>(true);
+
+  // EventName2 must not include undefined.
+  util.assertEqual<undefined extends EventName2 ? true : false, false>(true);
 
   expect(EventSchema.parse({ name: "x" })).toEqual({ name: "x" });
   expect(EventSchema.parse({ name: ["x"] })).toEqual({ name: ["x"] });
  ┊ review diff
a/packages/zod/src/v3/tests/issue-2654.test.ts → b/packages/zod/src/v3/tests/issue-2654.test.ts
@@ -4,23 +4,30 @@
 import * as z from "zod/v3";
 import { util } from "../helpers/util.js";
 
-test("issue #2654: union inside z.object should infer the same as standalone union", () => {
+// Repro for issue #2654
+test("issue #2654: union type used inside z.object infers same as standalone", () => {
   const EventNameSchema = z.string().or(z.array(z.string()));
   type EventName = z.infer<typeof EventNameSchema>;
 
   const EventSchema = z.object({
     name: z.string().or(z.array(z.string())),
   });
-  type EventWithName = z.infer<typeof EventSchema>;
-  type EventName2 = EventWithName["name"];
+  type EventName2 = z.infer<typeof EventSchema>["name"];
 
-  // Strict, invariant equality — fails if EventName2 is the buggy
-  // (string | string[]) & (string | string[] | undefined) intersection.
+  // Strict invariant equality — fails to compile if the inferred property
+  // type is the buggy `(string | string[]) & (string | string[] | undefined)`
+  // intersection instead of `string | string[]`.
   util.assertEqual<EventName, EventName2>(true);
 
-  // EventName2 must not include undefined.
+  // The property type must not include undefined.
   util.assertEqual<undefined extends EventName2 ? true : false, false>(true);
 
+  // Assignability is preserved with the fix: a value of either type works.
+  const a: EventName = "x";
+  const a2: EventName2 = a;
+  const b: EventName = a2;
+  expect(b).toBe("x");
+
   expect(EventSchema.parse({ name: "x" })).toEqual({ name: "x" });
-  expect(EventSchema.parse({ name: ["x"] })).toEqual({ name: ["x"] });
+  expect(EventSchema.parse({ name: ["x", "y"] })).toEqual({ name: ["x", "y"] });
 });
  ┊ review diff
a/packages/zod/probe-2654.ts → b/packages/zod/probe-2654.ts
@@ -0,0 +1,26 @@
+import * as z from "zod/v3";
+
+const EventNameSchema = z.string().or(z.array(z.string()));
+type EventName = z.infer<typeof EventNameSchema>;
+
+const EventSchema = z.object({
+  name: z.string().or(z.array(z.string())),
+});
+type EventWithName = z.infer<typeof EventSchema>;
+type EventName2 = EventWithName["name"];
+
+// Bivariant equality
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2)
+    ? ((<T>() => T extends B ? 1 : 2) extends (<T>() => T extends A ? 1 : 2)
+        ? "equal"
+        : "subset-of-A-not-B")
+    : "not-equal";
+
+type Result = Equals<EventName, EventName2>;
+declare const r: Result;
+// If the bug exists, Result will be "not-equal" or similar — this assignment
+// will fail. If the types match, Result is "equal" and assignment succeeds.
+const ok: "equal" = r;
+console.log(ok);
  ┊ review diff
a//home/azureuser/.cache/bounty-hunter/colinhacks_zod-2654/repo/packages/zod/probe-2654.ts → b//home/azureuser/.cache/bounty-hunter/colinhacks_zod-2654/repo/packages/zod/probe-2654.ts
@@ -20,7 +20,6 @@
 
 type Result = Equals<EventName, EventName2>;
 declare const r: Result;
-// If the bug exists, Result will be "not-equal" or similar — this assignment
-// will fail. If the types match, Result is "equal" and assignment succeeds.
-const ok: "equal" = r;
+// FORCE FAIL: r should be "equal" but we expect "not-equal" to show the bug
+const ok: "not-equal" = r;
 console.log(ok);
  ┊ review diff
a/packages/zod/probe-2654.ts → b/packages/zod/probe-2654.ts
@@ -9,17 +9,18 @@
 type EventWithName = z.infer<typeof EventSchema
