### PR TITLE
Add Central Kurdish (ckb) locale

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -351,6 +351,7 @@ The following locales are available:
 - `be` — Belarusian
 - `bg` — Bulgarian
 - `ca` — Catalan
+- `ckb` — Kurdish (Central)
 - `cs` — Czech
 - `da` — Danish
 - `de` — German

--- a/packages/zod/jsr.json
+++ b/packages/zod/jsr.json
@@ -17,6 +17,7 @@
     "./v4/locales/be": "./src/v4/locales/be.ts",
     "./v4/locales/bg": "./src/v4/locales/bg.ts",
     "./v4/locales/ca": "./src/v4/locales/ca.ts",
+    "./v4/locales/ckb": "./src/v4/locales/ckb.ts",
     "./v4/locales/cs": "./src/v4/locales/cs.ts",
     "./v4/locales/da": "./src/v4/locales/da.ts",
     "./v4/locales/de": "./src/v4/locales/de.ts",

--- a/packages/zod/src/v4/locales/ckb.ts
+++ b/packages/zod/src/v4/locales/ckb.ts
@@ -83,7 +83,7 @@ const error: () => errors.$ZodErrorMap = () => {
         const postfix = ["ا", "و", "ۆ", "وو", "ە", "ی", "ێ"].some((p) => received.endsWith(p)) ? "یە" : "ە";
         const isEnglish = /^[a-zA-Z]+$/.test(received);
         if (receivedType === "null" || receivedType === "undefined") return `داواکراوە`;
-        return ` چاوەڕوانکراوە ${expected} بێت، بەڵام ${received}${isEnglish ? "" : postfix}`;
+        return `چاوەڕوانکراوە ${expected} بێت، بەڵام ${received}${isEnglish ? "" : postfix}`;
       }
 
       case "invalid_value":

--- a/packages/zod/src/v4/locales/ckb.ts
+++ b/packages/zod/src/v4/locales/ckb.ts
@@ -1,0 +1,137 @@
+import type { $ZodStringFormats } from "../core/checks.js";
+import type * as errors from "../core/errors.js";
+import * as util from "../core/util.js";
+
+const error: () => errors.$ZodErrorMap = () => {
+  const Sizable: Record<string, { unit: string; verb: string }> = {
+    string: { unit: "پیت", verb: "بێت" },
+    file: { unit: "بایت", verb: "بێت" },
+    array: { unit: "دانە", verb: "بێت" },
+    set: { unit: "دانە", verb: "بێت" },
+    map: { unit: "دانە", verb: "بێت" },
+  };
+
+  function getSizing(origin: string): { unit: string; verb: string } | null {
+    return Sizable[origin] ?? null;
+  }
+
+  const FormatDictionary: {
+    [k in $ZodStringFormats | (string & {})]?: string;
+  } = {
+    regex: "regex",
+    email: "ئیمەیڵ",
+    url: "بەستەر (URL)",
+    emoji: "ئیمۆجی",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "ڕێکەوت و کات",
+    date: "ڕێکەوت",
+    time: "کات",
+    duration: "ماوە",
+    ipv4: "ناونیشانی IPv4",
+    ipv6: "ناونیشانی IPv6",
+    mac: "ناونیشانی MAC",
+    cidrv4: "مەودای IPv4",
+    cidrv6: "مەودای IPv6",
+    base64: "دەقی base64",
+    base64url: "دەقی base64url",
+    json_string: "دەقی JSON",
+    e164: "ژمارەی E.164",
+    jwt: "JWT",
+    template_literal: "تێکردە",
+  };
+
+  // type names: missing keys = do not translate (use raw value via ?? fallback)
+  const TypeDictionary: {
+    [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
+  } = {
+    nan: "NaN",
+    string: "نووسین",
+    number: "ژمارە",
+    boolean: "boolean",
+    array: "array",
+    object: "object",
+    date: "ڕێکەوت",
+    integer: "ژمارە",
+    float: "ژمارە",
+    null: "null",
+    undefined: "undefined",
+    function: "function",
+    symbol: "symbol",
+    unknown: "unknown",
+    promise: "promise",
+    void: "void",
+    never: "never",
+    map: "map",
+    set: "set",
+  };
+
+  return (issue) => {
+    switch (issue.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue.expected] ?? issue.expected;
+        const receivedType = util.parsedType(issue.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        const postfix = ["ا", "و", "ۆ", "وو", "ە", "ی", "ێ"].some((p) => received.endsWith(p)) ? "یە" : "ە";
+        const isEnglish = /^[a-zA-Z]+$/.test(received);
+        if (receivedType === "null" || receivedType === "undefined") return `داواکراوە`;
+        return ` چاوەڕوانکراوە ${expected} بێت، بەڵام ${received}${isEnglish ? "" : postfix}`;
+      }
+
+      case "invalid_value":
+        if (issue.values.length === 1)
+          return `بەهاکە نادرووستە: چاوەڕوانکراوە ${util.stringifyPrimitive(issue.values[0])} بێت`;
+        return `هەڵبژاردەی نادروست: چاوەڕوانکراوە یەکێک بێت لە ${util.joinValues(issue.values, "|")}`;
+      case "too_big": {
+        const sizing = getSizing(issue.origin);
+        if (sizing) return `پێویستە بە لایەنی زۆرەوە ${issue.maximum.toString()} ${sizing.unit} ${sizing.verb}`;
+        return `پێویستە بە لایەنی زۆرەوە ${issue.maximum.toString()} بێت`;
+      }
+      case "too_small": {
+        const sizing = getSizing(issue.origin);
+        if (sizing) return `پێویستە بە لایەنی زۆرەوە ${issue.minimum.toString()} ${sizing.unit} ${sizing.verb}`;
+        return `پێویستە بە لایەنی زۆرەوە ${issue.minimum.toString()} بێت`;
+      }
+      case "invalid_format": {
+        const _issue = issue as errors.$ZodStringFormatIssues;
+        if (_issue.format === "starts_with") {
+          return `دەقی نادروست: پێویستە دەستپێبکات بە "${_issue.prefix}"`;
+        }
+        if (_issue.format === "ends_with") return `دەقی نادروست: پێویستە کۆتاییبێت بە "${_issue.suffix}"`;
+        if (_issue.format === "includes") return `دەقی نادروست: پێویستە "${_issue.includes}" لەخۆبگرێت`;
+        if (_issue.format === "regex") return `دەقی نادروست: پێویستە لەگەڵ پاتێرنی ${_issue.pattern} بگونجێت`;
+        return `بەهای ${FormatDictionary[_issue.format] ?? issue.format} نادروستە`;
+      }
+      case "not_multiple_of":
+        return `ژمارەی نادروست: دەبێت چەند هێندە بێت بۆ ${issue.divisor}`;
+      case "unrecognized_keys":
+        return `کلیلی نەناسراو: ${util.joinValues(issue.keys, ", ")}`;
+      case "invalid_key":
+        return `کلیلی نادروست لە ${issue.origin}`;
+      case "invalid_union":
+        if (issue.options && Array.isArray(issue.options) && issue.options.length > 0) {
+          const opts = issue.options.map((o) => `'${o}'`).join(" | ");
+          return `بەهای نەناسراو هەیە. بەهای چاوەڕوانکراو: ${opts}`;
+        }
+        return "یەکگرتنی نادروست";
+      case "invalid_element":
+        return `${issue.origin} بەهاکە نادروستە`;
+      default:
+        return `تێکردەی نادروست`;
+    }
+  };
+};
+
+export default function (): { localeError: errors.$ZodErrorMap } {
+  return {
+    localeError: error(),
+  };
+}

--- a/packages/zod/src/v4/locales/ckb.ts
+++ b/packages/zod/src/v4/locales/ckb.ts
@@ -97,8 +97,8 @@ const error: () => errors.$ZodErrorMap = () => {
       }
       case "too_small": {
         const sizing = getSizing(issue.origin);
-        if (sizing) return `پێویستە بە لایەنی زۆرەوە ${issue.minimum.toString()} ${sizing.unit} ${sizing.verb}`;
-        return `پێویستە بە لایەنی زۆرەوە ${issue.minimum.toString()} بێت`;
+        if (sizing) return `پێویستە بە لایەنی کەمەوە ${issue.minimum.toString()} ${sizing.unit} ${sizing.verb}`;
+        return `پێویستە بە لایەنی کەمەوە ${issue.minimum.toString()} بێت`;
       }
       case "invalid_format": {
         const _issue = issue as errors.$ZodStringFormatIssues;

--- a/packages/zod/src/v4/locales/index.ts
+++ b/packages/zod/src/v4/locales/index.ts
@@ -3,6 +3,7 @@ export { default as az } from "./az.js";
 export { default as be } from "./be.js";
 export { default as bg } from "./bg.js";
 export { default as ca } from "./ca.js";
+export { default as ckb } from "./ckb.js";
 export { default as cs } from "./cs.js";
 export { default as da } from "./da.js";
 export { default as de } from "./de.js";


### PR DESCRIPTION
## Summary

This PR adds the `ckb` locale for Zod, providing Central Kurdish / Sorani translations for validation error messages.

## Changes

* Added a new `ckb` locale file.
* Added translated error messages for Zod validation issues.
* Exported the locale so it can be used alongside the existing locales.

## Motivation

This makes Zod more accessible for Kurdish-speaking Sorani dialect users and applications that need validation messages in Central Kurdish / Sorani.

## Testing

* Ran the existing test suite with `pnpm test`.
* Verified that the new locale follows the same structure as the other locale files.
