### PR TITLE
fix(treeifyError): guard against Object.prototype inherited keys in path segments

### DIFF
--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -370,7 +370,10 @@ export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIss
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ??= {};
-            curr.properties[el] ??= { errors: [] };
+            // Guard against prototype-polluted keys (toString, valueOf, etc.)
+            if (!Object.hasOwn(curr.properties, el)) {
+              curr.properties[el] = { errors: [] };
+            }
             curr = curr.properties[el];
           } else {
             curr.items ??= [];

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -371,7 +371,7 @@ export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIss
           if (typeof el === "string") {
             curr.properties ??= {};
             // Guard against prototype-polluted keys (toString, valueOf, etc.)
-            if (!Object.hasOwn(curr.properties, el)) {
+            if (!Object.prototype.hasOwnProperty.call(curr.properties, el)) {
               curr.properties[el] = { errors: [] };
             }
             curr = curr.properties[el];

--- a/packages/zod/src/v4/core/tests/prototype-keys.test.ts
+++ b/packages/zod/src/v4/core/tests/prototype-keys.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import * as z from "zod/v3";
+import * as z from "zod/v4";
 
 test("z.treeifyError handles prototype keys", () => {
   const schema = z.object({ toString: z.string() });

--- a/packages/zod/src/v4/core/tests/prototype-keys.test.ts
+++ b/packages/zod/src/v4/core/tests/prototype-keys.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "vitest";
+import * as z from "zod/v3";
+
+test("z.treeifyError handles prototype keys", () => {
+  const schema = z.object({ toString: z.string() });
+  const result = schema.safeParse({ toString: 1 });
+  const tree = z.treeifyError(result.error!);
+  expect(tree.properties?.toString?.errors).toBeDefined();
+  expect(tree.properties?.toString?.errors[0]).toBe("Invalid input: expected string, received number");
+});

--- a/packages/zod/src/v4/core/tests/prototype-keys.test.ts
+++ b/packages/zod/src/v4/core/tests/prototype-keys.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+﻿import { expect, test } from "vitest";
 import * as z from "zod/v4";
 
 test("z.treeifyError handles prototype keys", () => {


### PR DESCRIPTION
Closes #6070

When a path segment (e.g. `toString`, `valueOf`, `constructor`) matches an `Object.prototype` property, `curr.properties[el]` returns the inherited member instead of `undefined`. The `??=` short-circuits, the node is never created, and `curr` is assigned the inherited function (which has no `errors` array).

Fix: add an `Object.hasOwn` guard before accessing `curr.properties[el]` to ensure inherited prototype members don't shadow real property lookups.