### PR TITLE
fix(json-schema): encode `$ref` pointer per RFC 6901

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2212,6 +2212,28 @@ test("id is observable in override callback", () => {
   expect(seenIds).toContain("Inner");
 });
 
+test("$ref encodes `/` and `~` per RFC 6901 (issue #6027)", () => {
+  // RFC 6901 §3 requires `~` and `/` to be escaped inside reference tokens
+  // (as `~0` and `~1` respectively). The `$defs` key stays raw — only the
+  // pointer path needs encoding.
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User }));
+
+  expect((result.properties?.User as any).$ref).toBe("#/$defs/Shared~1User~0");
+  expect(result.$defs).toHaveProperty("Shared/User~");
+});
+
+test("$ref encoding handles slash and tilde independently", () => {
+  // Order matters: `~` is encoded before `/`, otherwise a `/` turning into
+  // `~1` would be re-encoded as `~01` on the second pass.
+  const A = z.string().meta({ id: "a/b" });
+  const B = z.string().meta({ id: "c~d" });
+  const result = z.toJSONSchema(z.object({ a: A, b: B }));
+
+  expect((result.properties?.a as any).$ref).toBe("#/$defs/a~1b");
+  expect((result.properties?.b as any).$ref).toBe("#/$defs/c~0d");
+});
+
 test("describe with id on wrapper", () => {
   // Test that $ref propagation works when processor sets a different ref (readonly -> innerType)
   // but parent was extracted due to having an id

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -239,6 +239,12 @@ export function extractDefs<T extends schemas.$ZodType>(
     }
   }
 
+  // RFC 6901 §3 — `~` must escape to `~0` and `/` to `~1` inside reference
+  // tokens. The replacement order matters: encode `~` first so that a `/`
+  // turning into `~1` is not later re-encoded as `~01`. The `$defs` key
+  // itself stays raw — only the pointer path needs escaping.
+  const encodeJsonPointerToken = (token: string): string => token.replace(/~/g, "~0").replace(/\//g, "~1");
+
   // returns a ref to the schema
   // defId will be empty if the ref points to an external schema (or #)
   const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
@@ -260,7 +266,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${encodeJsonPointerToken(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +277,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + encodeJsonPointerToken(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
Fixes #6027.

The `$ref` URI fragment built in `makeURI` interpolated the meta `id` directly into the pointer path. RFC 6901 §3 requires reference tokens to escape `~` as `~0` and `/` as `~1`; without that, a meta `id` containing either character produces a `$ref` that consumers can't dereference back to the `$defs` key.

The encoding applies to the pointer path only — the `$defs` key itself is a plain JSON object key and stays raw — and the replacement order is pinned (`~` first) so a `/` turning into `~1` is not re-encoded as `~01`.

Before:

```jsonc
{
  "properties": { "User": { "$ref": "#/$defs/Shared/User~" } },
  "$defs": { "Shared/User~": {} }
}
```

After:

```jsonc
{
  "properties": { "User": { "$ref": "#/$defs/Shared~1User~0" } },
  "$defs": { "Shared/User~": {} }
}
```