### PR TITLE
fix(v4): prevent formatError from throwing on Object.prototype keys in path

### DIFF
--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -709,3 +709,22 @@ test("error serialization", () => {
     `);
   }
 });
+
+test("formatError does not throw on Object.prototype keys in path", () => {
+  // Regression test: a path segment matching an inherited Object.prototype
+  // member (e.g. "toString", "constructor") used to make formatError throw a
+  // TypeError because `curr[el] || {...}` returned the inherited member.
+  const schema = z.object({
+    toString: z.string(),
+    constructor: z.string(),
+    valueOf: z.string(),
+  });
+  const result = schema.safeParse({});
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    const formatted = z.formatError(result.error) as any;
+    expect(formatted.toString._errors.length).toBeGreaterThan(0);
+    expect(formatted.constructor._errors.length).toBeGreaterThan(0);
+    expect(formatted.valueOf._errors.length).toBeGreaterThan(0);
+  }
+});

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -311,10 +311,14 @@ export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssu
             const el = fullpath[i]!;
             const terminal = i === fullpath.length - 1;
 
-            if (!terminal) {
-              curr[el] = curr[el] || { _errors: [] };
-            } else {
-              curr[el] = curr[el] || { _errors: [] };
+            // Guard against path segments that collide with inherited
+            // Object.prototype members (e.g. "toString", "constructor"). Using
+            // `curr[el] || ...` would return the inherited member instead of
+            // undefined, leaving `curr` without an `_errors` array and throwing.
+            if (!Object.prototype.hasOwnProperty.call(curr, el)) {
+              curr[el] = { _errors: [] };
+            }
+            if (terminal) {
               curr[el]._errors.push(mapper(issue));
             }
 


### PR DESCRIPTION
# fix(v4): prevent `formatError` from throwing on `Object.prototype` keys in path

## Problem

`formatError` builds its nested error tree using a plain object as a dictionary, initializing each node with:

```ts
curr[el] = curr[el] || { _errors: [] };
```

When a validation issue's `path` segment matches a member inherited from `Object.prototype` (e.g. `toString`, `constructor`, `valueOf`, `hasOwnProperty`), `curr[el]` resolves to the **inherited member** instead of `undefined`. The `||` short-circuits, `curr` is assigned that member (a function, with no `_errors` array), and the subsequent `curr[el]._errors.push(...)` throws:

```
TypeError: Cannot read properties of undefined (reading 'push')
```

### Reproduction

```ts
import { z } from "zod";

const schema = z.object({ toString: z.string() });
const result = schema.safeParse({}); // success: false

if (!result.success) {
  z.formatError(result.error); // 💥 throws TypeError
}
```

This is the same class of bug as the reported `treeifyError` issue (#6070) and the previously-fixed `flatten()` issue (#5265 → #5266). #6070's fix addresses `treeifyError`'s `properties` dictionary; **`formatError` has the identical vulnerability and is not covered by that fix.**

## Fix

Guard node initialization with `Object.prototype.hasOwnProperty.call(...)` before assigning, so inherited members are never mistaken for existing nodes — mirroring the guard used in `treeifyError` and the `Object.create(null)` approach used for `flatten()`:

```ts
if (!Object.prototype.hasOwnProperty.call(curr, el)) {
  curr[el] = { _errors: [] };
}
if (terminal) {
  curr[el]._errors.push(mapper(issue));
}
```

Behavior is unchanged for all non-prototype keys.

## Tests

Adds a regression test (`formatError does not throw on Object.prototype keys in path`) that parses a schema with `toString`, `constructor`, and `valueOf` fields and asserts `formatError` returns the populated tree instead of throwing. The test **fails on the current code** (TypeError) and passes with this change.

Verified locally:
- `vitest run error.test` → **118 passed, 0 type errors** (with fix)
- Reverting the fix makes the new test fail with the exact `TypeError` above (confirming it's a true regression test)
- `biome check` clean

---

> **Relationship to #6070 / #6071 — complementary, not a duplicate.** The open `treeifyError` fixes (#6071, and #6081) address only `treeifyError`. This PR covers the sibling `formatError` path, which those leave unaddressed. The two can land independently.
