### PR TITLE
fix: reject bare IPv6 addresses in z.string().url()

### DIFF
--- a/packages/zod/src/v3/tests/string.test.ts
+++ b/packages/zod/src/v3/tests/string.test.ts
@@ -300,6 +300,19 @@ test("url validations", () => {
   expect(() => url.parse("asdf")).toThrow();
   expect(() => url.parse("https:/")).toThrow();
   expect(() => url.parse("asdfj@lkjsdf.com")).toThrow();
+
+  // bare IPv6 addresses must not be accepted as URLs
+  expect(() => url.parse("fe80::1")).toThrow();
+  expect(() => url.parse("fe80::abcd:1234")).toThrow();
+  expect(() => url.parse("fe80:0000:0000:0000:0000:0000:0000:0001")).toThrow();
+  expect(() => url.parse("abcd::1")).toThrow();
+  expect(() => url.parse("::1")).toThrow();
+  expect(() => url.parse("2001:db8::1")).toThrow();
+
+  // valid URLs containing IPv6 in brackets must still be accepted
+  url.parse("http://[::1]");
+  url.parse("http://[2001:db8::1]");
+  url.parse("http://[fe80::1]");
 });
 
 test("url error overrides", () => {

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -877,7 +877,11 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
       } else if (check.kind === "url") {
         try {
           // @ts-ignore
-          new URL(input.data);
+          const url = new URL(input.data);
+          // Reject bare IPv6 addresses misinterpreted as URLs
+          if (ipv6Regex.test(input.data)) {
+            throw new Error("bare IPv6 address");
+          }
         } catch {
           ctx = this._getOrReturnCtx(input, ctx);
           addIssueToContext(ctx, {

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -876,8 +876,7 @@ export class ZodString extends ZodType<string, ZodStringDef, string> {
         }
       } else if (check.kind === "url") {
         try {
-          // @ts-ignore
-          const url = new URL(input.data);
+          new URL(input.data);
           // Reject bare IPv6 addresses misinterpreted as URLs
           if (ipv6Regex.test(input.data)) {
             throw new Error("bare IPv6 address");

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -347,6 +347,19 @@ test("url validations", () => {
   expect(() => url.parse("https:/")).toThrow();
   expect(() => url.parse("asdfj@lkjsdf.com")).toThrow();
   expect(() => url.parse("https://")).toThrow();
+
+  // bare IPv6 addresses must not be accepted as URLs
+  expect(() => url.parse("fe80::1")).toThrow();
+  expect(() => url.parse("fe80::abcd:1234")).toThrow();
+  expect(() => url.parse("fe80:0000:0000:0000:0000:0000:0000:0001")).toThrow();
+  expect(() => url.parse("abcd::1")).toThrow();
+  expect(() => url.parse("::1")).toThrow();
+  expect(() => url.parse("2001:db8::1")).toThrow();
+
+  // valid URLs containing IPv6 in brackets must still be accepted
+  url.parse("http://[::1]");
+  url.parse("http://[2001:db8::1]");
+  url.parse("http://[fe80::1]");
 });
 
 test("url preserves original input", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -503,6 +503,22 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
       // @ts-ignore
       const url = new URL(trimmed);
 
+      // Reject bare IPv6 addresses that new URL() misinterprets as having
+      // a valid scheme. e.g. "fe80::1" parses with protocol "fe80:" because
+      // "fe80" satisfies the scheme grammar (starts with a letter, followed
+      // by alphanumerics). Check the original input against the IPv6 regex
+      // to catch this without false-positiving on strings like "c:".
+      if (regexes.ipv6.test(trimmed)) {
+        payload.issues.push({
+          code: "invalid_format",
+          format: "url",
+          input: payload.value,
+          inst,
+          continue: !def.abort,
+        });
+        return;
+      }
+
       if (def.hostname) {
         def.hostname.lastIndex = 0;
         if (!def.hostname.test(url.hostname)) {


### PR DESCRIPTION
## Fixes

Fixes #6031

## Summary

`z.string().url()` incorrectly accepts certain bare IPv6 addresses such as `fe80::1` as valid URLs.

The root cause is that JavaScript's `new URL()` parser interprets the first IPv6 hex group as a URI scheme. For example, in `fe80::1`, the `fe80:` portion satisfies the URI scheme grammar because it starts with a letter and is followed by alphanumeric characters. As a result, `new URL("fe80::1")` succeeds and produces a URL object with:

```ts
{
  protocol: "fe80:"
}
```

This issue only affects bare IPv6 addresses whose first segment happens to be a valid scheme name (for example `fe80`, `abcd`, etc.). Addresses that begin with `::` or a digit, such as `::1` or `2001:db8::1`, already fail during `new URL()` parsing.

## Solution

After `new URL()` successfully parses the input, this change validates the original input against the existing IPv6 regex.

This ensures that bare IPv6 addresses are rejected while avoiding false positives for short scheme-like strings such as `c:`.

## Behavior Changes

| Input | Before | After |
|---------|---------|---------|
| `fe80::1` | ✅ Accepted | ❌ Rejected |
| `fe80::abcd:1234` | ✅ Accepted | ❌ Rejected |
| `fe80:0000:...:0001` | ✅ Accepted | ❌ Rejected |
| `abcd::1` | ✅ Accepted | ❌ Rejected |
| `::1` | ❌ Rejected | ❌ Rejected |
| `2001:db8::1` | ❌ Rejected | ❌ Rejected |
| `c:` | ✅ Accepted | ✅ Accepted |
| `http://[fe80::1]` | ✅ Accepted | ✅ Accepted |

## Scope

This fix has been applied to:

- `src/v3/types.ts`
- `src/v4/core/schemas.ts`

Corresponding test cases have also been added for both versions.