### PR TITLE
fix: escape JSON Pointer tokens in toJSONSchema $ref paths

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3129,3 +3129,183 @@ test("recursive lazy with describe does not stack overflow", () => {
   expect(result).toBeDefined();
   expect(result.$defs).toBeDefined();
 });
+
+test("JSON Pointer escaping - tilde in schema id", () => {
+  const tildeSchema = z.string().meta({ id: "my~tilde" });
+  const result = z.toJSONSchema(
+    z.object({
+      value: tildeSchema,
+    })
+  );
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "my~tilde": {
+          "type": "string",
+        },
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/my~0tilde",
+        },
+      },
+      "required": [
+        "value",
+      ],
+      "type": "object",
+    }
+  `);
+});
+
+test("JSON Pointer escaping - slash in schema id", () => {
+  const slashSchema = z.number().meta({ id: "path/to/schema" });
+  const result = z.toJSONSchema(
+    z.object({
+      value: slashSchema,
+    })
+  );
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "path/to/schema": {
+          "type": "number",
+        },
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/path~1to~1schema",
+        },
+      },
+      "required": [
+        "value",
+      ],
+      "type": "object",
+    }
+  `);
+});
+
+test("JSON Pointer escaping - tilde and slash together", () => {
+  const mixedSchema = z.boolean().meta({ id: "a~b/c" });
+  const result = z.toJSONSchema(
+    z.object({
+      value: mixedSchema,
+    })
+  );
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "a~b/c": {
+          "type": "boolean",
+        },
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/a~0b~1c",
+        },
+      },
+      "required": [
+        "value",
+      ],
+      "type": "object",
+    }
+  `);
+});
+
+test("JSON Pointer escaping - multiple tildes and slashes", () => {
+  const complexSchema = z.string().meta({ id: "~/~~//~1" });
+  const result = z.toJSONSchema(
+    z.object({
+      value: complexSchema,
+    })
+  );
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "~/~~//~1": {
+          "type": "string",
+        },
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/~0~1~0~0~1~1~01",
+        },
+      },
+      "required": [
+        "value",
+      ],
+      "type": "object",
+    }
+  `);
+});
+
+test("JSON Pointer escaping - reused ref with tilde in id", () => {
+  const tildeSchema = z.string().meta({ id: "foo~bar" });
+  const result = z.toJSONSchema(
+    z.object({
+      a: tildeSchema,
+      b: tildeSchema,
+    }),
+    { reused: "ref" }
+  );
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "foo~bar": {
+          "type": "string",
+        },
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "a": {
+          "$ref": "#/$defs/foo~0bar",
+        },
+        "b": {
+          "$ref": "#/$defs/foo~0bar",
+        },
+      },
+      "required": [
+        "a",
+        "b",
+      ],
+      "type": "object",
+    }
+  `);
+});
+
+test("JSON Pointer escaping - registry with slash in id", () => {
+  const myRegistry = z.registry<{ id: string }>();
+  const SchemaA = z.string().meta({ id: "a/b" });
+  const SchemaB = z.number().meta({ id: "c~d" });
+
+  myRegistry.add(SchemaA, { id: "a/b" });
+  myRegistry.add(SchemaB, { id: "c~d" });
+
+  const result = z.toJSONSchema(myRegistry, {
+    uri: (id) => `https://example.com/${id}.json`,
+  });
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "schemas": {
+        "a/b": {
+          "$id": "https://example.com/a/b.json",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "string",
+        },
+        "c~d": {
+          "$id": "https://example.com/c~d.json",
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "number",
+        },
+      },
+    }
+  `);
+});

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -239,6 +239,10 @@ export function extractDefs<T extends schemas.$ZodType>(
     }
   }
 
+  // Escape a string for use as a JSON Pointer token per RFC 6901.
+  // ~ → ~0, / → ~1
+  const escapeJsonPointer = (s: string): string => s.replace(/~/g, "~0").replace(/\//g, "~1");
+
   // returns a ref to the schema
   // defId will be empty if the ref points to an external schema (or #)
   const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
@@ -260,7 +264,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${escapeJsonPointer(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +275,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + escapeJsonPointer(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
Per RFC 6901, JSON Pointer path segments must escape  as  and  as . The  function in  was using the raw schema id without escaping, producing invalid  URIs for ids containing these characters.

Added  helper and applied it to both the self-contained and external registry ref paths.

Fixes #6027