### PR TITLE
feat(locales): add Norwegian Nynorsk (nn) locale

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -1,4 +1,4 @@
-—---
+---
 title: Customizing errors
 description: "Guide to customizing validation error messages and error handling patterns"
 ---

--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -1,4 +1,4 @@
----
+—---
 title: Customizing errors
 description: "Guide to customizing validation error messages and error handling patterns"
 ---
@@ -375,6 +375,7 @@ The following locales are available:
 - `mk` — Macedonian
 - `ms` — Malay
 - `nl` — Dutch
+- `nn` — Norwegian Nynorsk
 - `no` — Norwegian
 - `ota` — Türkî
 - `ps` — Pashto

--- a/packages/zod/jsr.json
+++ b/packages/zod/jsr.json
@@ -45,6 +45,7 @@
     "./v4/locales/mk": "./src/v4/locales/mk.ts",
     "./v4/locales/ms": "./src/v4/locales/ms.ts",
     "./v4/locales/nl": "./src/v4/locales/nl.ts",
+    "./v4/locales/nn": "./src/v4/locales/nn.ts",
     "./v4/locales/no": "./src/v4/locales/no.ts",
     "./v4/locales/ota": "./src/v4/locales/ota.ts",
     "./v4/locales/pl": "./src/v4/locales/pl.ts",

--- a/packages/zod/src/v4/locales/index.ts
+++ b/packages/zod/src/v4/locales/index.ts
@@ -30,6 +30,7 @@ export { default as lt } from "./lt.js";
 export { default as mk } from "./mk.js";
 export { default as ms } from "./ms.js";
 export { default as nl } from "./nl.js";
+export { default as nn } from "./nn.js";
 export { default as no } from "./no.js";
 export { default as ota } from "./ota.js";
 export { default as ps } from "./ps.js";

--- a/packages/zod/src/v4/locales/nn.ts
+++ b/packages/zod/src/v4/locales/nn.ts
@@ -1,0 +1,116 @@
+import type { $ZodStringFormats } from "../core/checks.js";
+import type * as errors from "../core/errors.js";
+import * as util from "../core/util.js";
+
+const error: () => errors.$ZodErrorMap = () => {
+  const Sizable: Record<string, { unit: string; verb: string }> = {
+    string: { unit: "teikn", verb: "å ha" },
+    file: { unit: "bytes", verb: "å ha" },
+    array: { unit: "element", verb: "å innehalde" },
+    set: { unit: "element", verb: "å innehalde" },
+  };
+
+  function getSizing(origin: string): { unit: string; verb: string } | null {
+    return Sizable[origin] ?? null;
+  }
+
+  const FormatDictionary: {
+    [k in $ZodStringFormats | (string & {})]?: string;
+  } = {
+    regex: "input",
+    email: "e-postadresse",
+    url: "URL",
+    emoji: "emoji",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "ISO dato- og klokkeslett",
+    date: "ISO-dato",
+    time: "ISO-klokkeslett",
+    duration: "ISO-varigheit",
+    ipv4: "IPv4-område",
+    ipv6: "IPv6-område",
+    cidrv4: "IPv4-spekter",
+    cidrv6: "IPv6-spekter",
+    base64: "base64-enkoda streng",
+    base64url: "base64url-enkoda streng",
+    json_string: "JSON-streng",
+    e164: "E.164-nummer",
+    jwt: "JWT",
+    template_literal: "input",
+  };
+
+  const TypeDictionary: {
+    [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
+  } = {
+    nan: "NaN",
+    number: "tal",
+    array: "liste",
+  };
+
+  return (issue) => {
+    switch (issue.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue.expected] ?? issue.expected;
+        const receivedType = util.parsedType(issue.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        if (/^[A-Z]/.test(issue.expected)) {
+          return `Ugyldig input: forventa instanceof ${issue.expected}, fekk ${received}`;
+        }
+        return `Ugyldig input: forventa ${expected}, fekk ${received}`;
+      }
+      case "invalid_value":
+        if (issue.values.length === 1) return `Ugyldig verdi: forventa ${util.stringifyPrimitive(issue.values[0])}`;
+        return `Ugyldig val: forventa eitt av ${util.joinValues(issue.values, "|")}`;
+      case "too_big": {
+        const adj = issue.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue.origin);
+        if (sizing)
+          return `For stor(t): forventa ${issue.origin ?? "value"} til å ha ${adj}${issue.maximum.toString()} ${sizing.unit ?? "element"}`;
+        return `For stor(t): forventa ${issue.origin ?? "value"} til å ha ${adj}${issue.maximum.toString()}`;
+      }
+      case "too_small": {
+        const adj = issue.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue.origin);
+        if (sizing) {
+          return `For lite(n): forventa ${issue.origin} til å ha ${adj}${issue.minimum.toString()} ${sizing.unit}`;
+        }
+
+        return `For lite(n): forventa ${issue.origin} til å ha ${adj}${issue.minimum.toString()}`;
+      }
+      case "invalid_format": {
+        const _issue = issue as errors.$ZodStringFormatIssues;
+        if (_issue.format === "starts_with") return `Ugyldig streng: må starte med "${_issue.prefix}"`;
+        if (_issue.format === "ends_with") return `Ugyldig streng: må slutte med "${_issue.suffix}"`;
+        if (_issue.format === "includes") return `Ugyldig streng: må innehalde "${_issue.includes}"`;
+        if (_issue.format === "regex") return `Ugyldig streng: må matche mønsteret ${_issue.pattern}`;
+        return `Ugyldig ${FormatDictionary[_issue.format] ?? issue.format}`;
+      }
+      case "not_multiple_of":
+        return `Ugyldig tal: må vere eit multiplum av ${issue.divisor}`;
+      case "unrecognized_keys":
+        return `${issue.keys.length > 1 ? "Ukjende nøklar" : "Ukjend nøkkel"}: ${util.joinValues(issue.keys, ", ")}`;
+      case "invalid_key":
+        return `Ugyldig nøkkel i ${issue.origin}`;
+      case "invalid_union":
+        return "Ugyldig input";
+      case "invalid_element":
+        return `Ugyldig verdi i ${issue.origin}`;
+      default:
+        return `Ugyldig input`;
+    }
+  };
+};
+
+export default function (): { localeError: errors.$ZodErrorMap } {
+  return {
+    localeError: error(),
+  };
+}


### PR DESCRIPTION
Adds a Norwegian **Nynorsk** (`nn`) locale for Zod v4 error messages.

Zod already ships a generic Norwegian (`no`, in practice Bokmål); this adds Nynorsk as a separate written standard (variants are encouraged per the locale-contribution guide). The file mirrors `no.ts` exactly in structure — only the message text is changed to Nynorsk — and `nn` is exported from `index.ts` alphabetically (between `nl` and `no`).

AI disclosure: the translation was produced with AI assistance (Claude) and reviewed by me, a native Norwegian speaker. Note: I'm more fluent in Bokmål than in Nynorsk, so a Nynorsk reviewer's pass on wording would be welcome.

I wasn't able to run the full `pnpm test` suite locally — happy to fix anything CI flags.