### PR TITLE
fix(6070):treeifyError throws TypeError when an issue path contains a key inherited from Object.prototype (e.g. toString)

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -447,6 +447,45 @@ test("z.treeifyError 2", () => {
   `);
 });
 
+test("z.treeifyError handles Object.prototype property names", () => {
+  const schema = z.object({
+    toString: z.string(),
+    constructor: z.number(),
+  });
+
+  const result = schema.safeParse({
+    toString: 123,
+    constructor: "nope",
+  });
+
+  const tree: any = z.treeifyError(result.error!);
+
+  expect(Object.prototype.hasOwnProperty.call(tree.properties, "toString")).toBe(true);
+  expect(tree.properties.toString.errors).toEqual(["Invalid input: expected string, received number"]);
+  expect(Object.prototype.hasOwnProperty.call(tree.properties, "constructor")).toBe(true);
+  expect(tree.properties.constructor.errors).toEqual(["Invalid input: expected number, received string"]);
+});
+
+test("z.treeifyError preserves mixed object and array paths with prototype property names", () => {
+  const schema = z.object({
+    users: z.array(
+      z.object({
+        toString: z.string(),
+      })
+    ),
+  });
+
+  const result = schema.safeParse({
+    users: [{ toString: 123 }],
+  });
+
+  const tree: any = z.treeifyError(result.error!);
+
+  expect(tree.properties.users.items[0].properties.toString.errors).toEqual([
+    "Invalid input: expected string, received number",
+  ]);
+});
+
 test("z.prettifyError", () => {
   expect(z.prettifyError(result.error!)).toMatchInlineSnapshot(`
     "✖ Unrecognized key: "extra"

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -346,6 +346,7 @@ export function treeifyError<T>(error: $ZodError<T>): $ZodErrorTree<T>;
 export function treeifyError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodErrorTree<T, U>;
 export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
   const result: $ZodErrorTree<T, U> = { errors: [] } as any;
+  const createProperties = () => Object.create(null) as Record<string, $ZodErrorTree<unknown, U>>;
   const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
     for (const issue of error.issues) {
       if (issue.code === "invalid_union" && issue.errors.length) {
@@ -369,7 +370,7 @@ export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIss
 
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
-            curr.properties ??= {};
+            curr.properties ??= createProperties();
             curr.properties[el] ??= { errors: [] };
             curr = curr.properties[el];
           } else {


### PR DESCRIPTION
Fixes `z.treeifyError` path handling when object keys collide with inherited `Object.prototype` properties like `toString` or `constructor`.

  `properties` containers now use null-prototype records, so those path segments are treated as own keys in the generated error tree instead of resolving inherited object
  methods. Added regression coverage for both direct object paths and mixed object/array paths.