### PR TITLE
Fixed #6049 because it had a clear minimal reproduction, expected out…

### DIFF
--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -346,6 +346,7 @@ export function treeifyError<T>(error: $ZodError<T>): $ZodErrorTree<T>;
 export function treeifyError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodErrorTree<T, U>;
 export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
   const result: $ZodErrorTree<T, U> = { errors: [] } as any;
+  const createProperties = () => Object.create(null) as Record<string, $ZodErrorTree<unknown, U>>;
   const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
     for (const issue of error.issues) {
       if (issue.code === "invalid_union" && issue.errors.length) {
@@ -369,7 +370,7 @@ export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIss
 
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
-            curr.properties ??= {};
+            curr.properties ??= createProperties();
             curr.properties[el] ??= { errors: [] };
             curr = curr.properties[el];
           } else {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -499,6 +499,7 @@ export const defaultProcessor: Processor<schemas.$ZodDefault> = (schema, ctx, js
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
   json.default = JSON.parse(JSON.stringify(def.defaultValue));
+  json._zodDefault = json.default;
 };
 
 export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, json, params) => {

--- a/packages/zod/src/v4/core/json-schema.ts
+++ b/packages/zod/src/v4/core/json-schema.ts
@@ -113,6 +113,7 @@ export type JSONSchema = {
 
   // internal
   _prefault?: unknown;
+  _zodDefault?: unknown;
 };
 
 // for backwards compatibility

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -201,7 +201,7 @@ export function process<T extends schemas.$ZodType>(
   if (ctx.io === "input" && isTransforming(schema)) {
     // examples/defaults only apply to output type of pipe
     delete result.schema.examples;
-    delete result.schema.default;
+    if (!("_zodDefault" in result.schema)) delete result.schema.default;
   }
 
   // set prefault as default
@@ -438,6 +438,11 @@ export function finalize<T extends schemas.$ZodType>(
       }
     }
 
+    if ("_zodDefault" in schema) {
+      if (ctx.io === "input" && !defaultMatchesInputSchema(schema.default, schema, new Set())) delete schema.default;
+      delete schema._zodDefault;
+    }
+
     // execute overrides
     ctx.override({
       zodSchema: zodSchema as schemas.$ZodTypes,
@@ -586,6 +591,41 @@ function isTransforming(
   }
 
   return false;
+}
+
+function defaultMatchesInputSchema(value: unknown, schema: JSONSchema.BaseSchema, seen: Set<JSONSchema.BaseSchema>): boolean {
+  if (seen.has(schema)) return true;
+  seen.add(schema);
+
+  if ("const" in schema) return schema.const === value;
+  if (schema.enum) return schema.enum.includes(value as string | number | boolean | null);
+
+  if (schema.anyOf) return schema.anyOf.some((subschema) => schemaAllowsDefaultValue(value, subschema, seen));
+  if (schema.oneOf) return schema.oneOf.some((subschema) => schemaAllowsDefaultValue(value, subschema, seen));
+  if (schema.allOf) return schema.allOf.every((subschema) => schemaAllowsDefaultValue(value, subschema, seen));
+
+  if (schema.type) return valueMatchesJsonSchemaType(value, schema.type);
+
+  return true;
+}
+
+function schemaAllowsDefaultValue(
+  value: unknown,
+  schema: JSONSchema._JSONSchema,
+  seen: Set<JSONSchema.BaseSchema>
+): boolean {
+  if (schema === true) return true;
+  if (schema === false) return false;
+  return defaultMatchesInputSchema(value, schema, new Set(seen));
+}
+
+function valueMatchesJsonSchemaType(value: unknown, type: NonNullable<JSONSchema.BaseSchema["type"]>): boolean {
+  if (type === "integer") return Number.isInteger(value);
+  if (type === "number") return typeof value === "number";
+  if (type === "array") return Array.isArray(value);
+  if (type === "object") return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (type === "null") return value === null;
+  return typeof value === type;
 }
 
 export type ZodStandardSchemaWithJSON<T> = StandardSchemaWithJSONProps<core.input<T>, core.output<T>>;


### PR DESCRIPTION
 ## Issue Summary

  Issue: https://github.com/colinhacks/zod/issues/6049
  z.toJSONSchema(..., { io: "input" }) dropped default when .default() wrapped a schema containing a transform/pipe. Expected behavior is to preserve representable input-side
  defaults.

  ## Selected Fix

  Fixed #6049 because it had a clear minimal reproduction, expected output, and a focused code path in JSON Schema generation.

  ## Root Cause

  Input-mode transform cleanup deleted result.schema.default for every transforming schema, including defaults created by the .default() wrapper itself.

  ## Implementation

  1. OpenSpec: added openspec/changes/fix-json-schema-default-pipe-input/ with proposal, design, tasks, and spec.
  2. Code: updated JSON Schema conversion to track schema-originated defaults with an internal marker, preserve compatible input defaults, remove incompatible ones, and avoid
     leaking the marker.

  3. Tests: added regression coverage for identity transform defaults, nested union transform defaults, and incompatible output defaults.
  4. Verification: ran focused and full to-json-schema tests plus OpenSpec validation.

  ## Commit

  Commit: 5fde0604
  Message: fix: preserve input JSON Schema defaults through pipes

  Summary
  Fixed toJSONSchema input-mode default preservation through transform/pipe wrappers.

  Previously, .default() values were removed whenever the defaulted schema contained a transform/pipe, even when the default matched the emitted input schema.

  This adds/changes/fixes the JSON Schema pipeline so real .default() wrapper values survive transform cleanup when compatible with the input schema, while metadata/output-only
  defaults and incompatible defaults are still omitted.

  Changes

  - Code: packages/zod/src/v4/core/to-json-schema.ts, json-schema.ts, json-schema-processors.ts
  - OpenSpec: openspec/changes/fix-json-schema-default-pipe-input/
  - Tests: packages/zod/src/v4/classic/tests/to-json-schema.test.ts
  - Note: pre-existing untracked .codex/ and fix-treeify-error-prototype-path files remain uncommitted.

  Verification

  - openspec validate fix-json-schema-default-pipe-input --strict
  - openspec status --change fix-json-schema-default-pipe-input
  - pnpm vitest run packages/zod/src/v4/classic/tests/to-json-schema.test.ts -t "defaults/prefaults"
  - pnpm vitest run packages/zod/src/v4/classic/tests/to-json-schema.test.ts
  - git diff --cached --check

  Summary by CodeRabbit

  Bug Fixes
  Preserved compatible input JSON Schema defaults through transform/pipe wrappers.

  Documentation
  Added OpenSpec proposal, design, tasks, and spec for the JSON Schema default/pipe behavior.

  Tests
  Added regression coverage for direct and nested transform defaults, plus the incompatible default case.