### PR TITLE
fix(preprocess): infer input type from the preprocessor

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2429,12 +2429,12 @@ export function invertCodec<A extends core.SomeType, B extends core.SomeType>(co
 }
 
 // ZodPreprocess
-export interface ZodPreprocess<B extends core.SomeType = core.$ZodType>
-  extends ZodPipe<core.$ZodTransform, B>,
-    core.$ZodPreprocess<B> {
+export interface ZodPreprocess<U extends core.SomeType = core.$ZodType, A = unknown, B = unknown>
+  extends ZodPipe<core.$ZodTransform<A, B>, U>,
+    core.$ZodPreprocess<U, A, B> {
   "~standard": ZodStandardSchemaWithJSON<this>;
-  _zod: core.$ZodPreprocessInternals<B>;
-  def: core.$ZodPreprocessDef<B>;
+  _zod: core.$ZodPreprocessInternals<U, A, B>;
+  def: core.$ZodPreprocessDef<U, A, B>;
 }
 export const ZodPreprocess: core.$constructor<ZodPreprocess> = /*@__PURE__*/ core.$constructor(
   "ZodPreprocess",
@@ -2728,10 +2728,10 @@ export function json(params?: string | core.$ZodCustomParams): ZodJSONSchema {
 export function preprocess<A, U extends core.SomeType, B = unknown>(
   fn: (arg: B, ctx: core.$RefinementCtx) => A,
   schema: U
-): ZodPreprocess<U> {
+): ZodPreprocess<U, A, B> {
   return new ZodPreprocess({
     type: "pipe",
-    in: transform(fn as any) as any as core.$ZodTransform,
+    in: transform(fn as any) as any as core.$ZodTransform<A, B>,
     out: schema as any as core.$ZodType,
   }) as any;
 }

--- a/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
@@ -23,4 +23,8 @@ test("ZodPreprocess input/output inference", () => {
   const pre = z.preprocess((v) => v, z.number().optional());
   expectTypeOf<z.output<typeof pre>>().toEqualTypeOf<number | undefined>();
   expectTypeOf<z.input<typeof pre>>().toEqualTypeOf<unknown>();
+
+  const preTypedInput = z.preprocess((v: number | null | undefined) => v ?? undefined, z.number().optional());
+  expectTypeOf<z.output<typeof preTypedInput>>().toEqualTypeOf<number | undefined>();
+  expectTypeOf<z.input<typeof preTypedInput>>().toEqualTypeOf<number | null | undefined>();
 });

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4136,19 +4136,22 @@ function handleCodecTxResult(left: ParsePayload, value: any, nextSchema: SomeTyp
 //////////                             //////////
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodTransform, B> {
-  in: $ZodTransform;
-  out: B;
+export interface $ZodPreprocessDef<U extends SomeType = $ZodType, A = unknown, B = unknown>
+  extends $ZodPipeDef<$ZodTransform<A, B>, U> {
+  in: $ZodTransform<A, B>;
+  out: U;
 }
 
-export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodTransform, B> {
-  def: $ZodPreprocessDef<B>;
-  optin: B["_zod"]["optin"];
-  optout: B["_zod"]["optout"];
+export interface $ZodPreprocessInternals<U extends SomeType = $ZodType, A = unknown, B = unknown>
+  extends $ZodPipeInternals<$ZodTransform<A, B>, U> {
+  def: $ZodPreprocessDef<U, A, B>;
+  optin: U["_zod"]["optin"];
+  optout: U["_zod"]["optout"];
 }
 
-export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodTransform, B> {
-  _zod: $ZodPreprocessInternals<B>;
+export interface $ZodPreprocess<U extends SomeType = $ZodType, A = unknown, B = unknown>
+  extends $ZodPipe<$ZodTransform<A, B>, U> {
+  _zod: $ZodPreprocessInternals<U, A, B>;
 }
 
 export const $ZodPreprocess: core.$constructor<$ZodPreprocess> = /*@__PURE__*/ core.$constructor(


### PR DESCRIPTION
starting from version 4.4.2 the preprocess method does not infer input type from preprocessor function. Documentation says:

By default, the input type of a z.preprocess() schema is unknown, since the preprocessor is expected to handle arbitrary input. To narrow the input type, annotate the preprocessor's parameter directly:

```ts
const trimmed = z.preprocess(
  (val: string | null | undefined) => val?.trim() ?? "",
  z.string()
);
 
type Input = z.input<typeof trimmed>;  // string | null | undefined
type Output = z.output<typeof trimmed>; // string
```

but currently `type Input = z.input<typeof trimmed>` is `unknown`.

This PR fixes it.