### PR TITLE
fix(json-schema): RFC 6901 encode $ref pointer for ids containing / or ~

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2182,6 +2182,28 @@ test("id is stripped from $defs entries (draft-2020-12)", () => {
   expect((result.$defs?.Inner as any).id).toBeUndefined();
 });
 
+test("$ref pointer is RFC 6901 encoded when id contains / or ~ (#6027)", () => {
+  // Per RFC 6901, a JSON Pointer reference token must escape `~` -> `~0` and
+  // `/` -> `~1`. The `$ref` pointer path needs this encoding; the `$defs` key
+  // itself is a plain object key and stays the raw id.
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User }));
+  expect((result.properties?.User as any).$ref).toBe("#/$defs/Shared~1User~0");
+  expect(result.$defs?.["Shared/User~"]).toEqual({
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+    additionalProperties: false,
+  });
+});
+
+test("$ref pointer is RFC 6901 encoded for draft-04 definitions (#6027)", () => {
+  const User = z.object({ name: z.string() }).meta({ id: "a/b~c" });
+  const result = z.toJSONSchema(z.object({ User }), { target: "draft-04" }) as any;
+  expect(result.properties?.User?.$ref).toBe("#/definitions/a~1b~0c");
+  expect(result.definitions?.["a/b~c"]).toBeDefined();
+});
+
 test("id is stripped from definitions entries (draft-04)", () => {
   // In draft-04, `id` is a reserved keyword that sets a base URI for the
   // subschema. Leaking Zod's registration tag here is semantically wrong, so

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -239,6 +239,11 @@ export function extractDefs<T extends schemas.$ZodType>(
     }
   }
 
+  // Encode a single JSON Pointer reference token per RFC 6901: `~` -> `~0`,
+  // `/` -> `~1`. Order matters (encode `~` first). The `$defs`/`definitions`
+  // object key stays the raw id; only the `$ref` pointer path is encoded.
+  const encodePointerToken = (token: string): string => token.replace(/~/g, "~0").replace(/\//g, "~1");
+
   // returns a ref to the schema
   // defId will be empty if the ref points to an external schema (or #)
   const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
@@ -260,7 +265,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${encodePointerToken(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +276,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + encodePointerToken(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
Fixes #6027.

## Problem
When a schema's `.meta({ id })` contains `/` or `~`, `z.toJSONSchema()` built the `$ref` pointer from the raw id, producing an invalid JSON Pointer:

```jsonc
"$ref": "#/$defs/Shared/User~"   // invalid per RFC 6901
```

## Fix
Per [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901), a JSON Pointer reference token must escape `~` → `~0` and `/` → `~1` (in that order). `makeURI` now encodes the def id when building the `$ref` path, in both the self-contained (`#/$defs/…`) and external (`__shared`) branches.

The `$defs`/`definitions` **object key** stays the raw id — it is a plain JSON key and needs no escaping, exactly as the issue specifies.

```jsonc
"$ref": "#/$defs/Shared~1User~0",
"$defs": { "Shared/User~": { /* … */ } }
```

## Tests
Two regression tests added in `to-json-schema.test.ts` (draft-2020-12 `$defs` and draft-04 `definitions`). Verified red without the fix, green with it. Encoding is a no-op for ordinary ids, so no existing snapshots change.