### PR TITLE
fix(url): reject bare IPv6 addresses in z.url()

### DIFF
--- a/packages/zod/src/v4/classic/tests/url.test.ts
+++ b/packages/zod/src/v4/classic/tests/url.test.ts
@@ -11,3 +11,25 @@ test("url regex", () => {
     "^example\\.com$"
   );
 });
+
+test("bare IPv6 addresses are not valid URLs (#6031)", () => {
+  const url = z.url();
+  // The URL constructor mis-parses IPv6 addresses whose first group starts
+  // with a hex letter (e.g. "fe80::1") as `scheme:opaque-path`; reject them.
+  for (const addr of [
+    "::1",
+    "2001:db8::1",
+    "fe80::1",
+    "fe80::abcd:1234",
+    "fe80:0000:0000:0000:0000:0000:0000:0001",
+    "dead:beef:dead:beef:dead:beef:dead:beef",
+  ]) {
+    expect(url.safeParse(addr).success, addr).toBe(false);
+  }
+
+  // A bracketed IPv6 host inside a real URL stays valid; so do schemed URIs
+  // whose opaque part happens to look hex-ish.
+  for (const valid of ["http://[2001:db8::1]", "https://example.com", "c:", "mailto:foo@bar.com", "face:b00c"]) {
+    expect(url.safeParse(valid).success, valid).toBe(true);
+  }
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -484,6 +484,31 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
       // Trim whitespace from input
       const trimmed = payload.value.trim();
 
+      // A bare IPv6 address (e.g. "fe80::1") is not a URL. The URL constructor
+      // mis-parses addresses whose first group starts with a hex letter as
+      // `scheme:opaque-path`, so it would otherwise accept them. Reject any
+      // input that is itself a valid IPv6 literal. The cheap pre-check (only
+      // hex digits, colons, dots and zone `%`, and no `/`) keeps schemed URIs
+      // such as "c:" or "mailto:x" — and ordinary URLs — out of this branch.
+      if (trimmed.includes(":") && !trimmed.includes("/") && /^[0-9a-fA-F:.%]+$/.test(trimmed)) {
+        try {
+          // @ts-ignore
+          new URL(`http://[${trimmed}]`);
+          // The probe succeeded, so `trimmed` is a valid bare IPv6 address.
+          payload.issues.push({
+            code: "invalid_format",
+            format: "url",
+            note: "Invalid URL format",
+            input: payload.value,
+            inst,
+            continue: !def.abort,
+          });
+          return;
+        } catch {
+          // Not a bare IPv6 address; fall through to normal URL handling.
+        }
+      }
+
       // When normalize is off, require :// for http/https URLs
       // This prevents strings like "http:example.com" or "https:/path" from being silently accepted
       if (!def.normalize && def.protocol?.source === regexes.httpProtocol.source) {


### PR DESCRIPTION
Fixes #6031.

## Problem
`z.url()` accepts bare IPv6 link-local addresses such as `fe80::1` as valid URLs, while correctly rejecting `::1`, `2001:db8::1`, and `192.168.1.1`:

```js
z.url().safeParse("fe80::1");   // ✅ VALID  — bug (should be invalid)
z.url().safeParse("2001:db8::1"); // ❌ invalid — correct
```

The cause is the WHATWG `URL` constructor: a bare IPv6 address whose first group starts with a hex letter (`fe80:`) is parsed as `scheme:opaque-path`, so `new URL("fe80::1")` succeeds.

## Fix
Before normal URL handling, reject any input that is itself a valid IPv6 literal by probing `new URL("http://[<input>]")` — the same technique Zod's `ipv6()` validator already uses. A cheap pre-check (only hex digits, colons, dots and a zone `%`, and no `/`) keeps schemed URIs and ordinary URLs out of this branch, so the existing behaviour is preserved:

- rejected: `::1`, `2001:db8::1`, `fe80::1`, `fe80::abcd:1234`, full-form `fe80:0000:…:0001`, `dead:beef:…` (×8)
- still valid: `http://[2001:db8::1]`, `https://example.com`, `c:`, `mailto:foo@bar.com`, `face:b00c`

## Tests
Adds a regression test in `url.test.ts` covering both the rejected bare-IPv6 cases and the preserved valid cases. Verified red without the fix, green with it; full suite (3817 tests) passes.