### PR TITLE
fix(toJSONSchema): preserve default value through pipe/transform in input mode

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2628,6 +2628,35 @@ test("defaults/prefaults", () => {
   expect(z.toJSONSchema(c, { io: "input" })).toMatchInlineSnapshot(`
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": 1234,
+      "type": "string",
+    }
+  `);
+});
+
+test("default preserved through pipe/transform (issue #6049)", () => {
+  // z.string().transform(s => s).default("hello") should emit default: "hello" in io: "input" mode
+  const schema = z
+    .string()
+    .transform((s) => s)
+    .default("hello");
+  expect(z.toJSONSchema(schema, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": "hello",
+      "type": "string",
+    }
+  `);
+  // With a proper output terminus, default appears in output mode too
+  const schemaWithPipe = z
+    .string()
+    .transform((s) => s.toUpperCase())
+    .pipe(z.string())
+    .default("hello");
+  expect(z.toJSONSchema(schemaWithPipe, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": "hello",
       "type": "string",
     }
   `);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -201,7 +201,10 @@ export function process<T extends schemas.$ZodType>(
   if (ctx.io === "input" && isTransforming(schema)) {
     // examples/defaults only apply to output type of pipe
     delete result.schema.examples;
-    delete result.schema.default;
+    // ZodDefault explicitly declares the input-side default — preserve it even when the inner type transforms
+    if (def.type !== "default") {
+      delete result.schema.default;
+    }
   }
 
   // set prefault as default


### PR DESCRIPTION
## Problem

`z.string().transform(s => s).default("hello")` passed to `z.toJSONSchema({ io: "input" })` silently drops the `default` keyword:

```ts
z.toJSONSchema(z.string().transform(s => s).default("hello"), { io: "input" })
// emits { type: "string" }  ← default: "hello" is lost

// without the transform it works correctly:
z.toJSONSchema(z.string().default("hello"), { io: "input" })
// { type: "string", default: "hello" }  ✓
```

Fixes #6049.

## Root cause

`process()` in `to-json-schema.ts` runs `isTransforming(schema)` after every processor and unconditionally deletes `result.schema.default` when the check returns `true`. For a `ZodDefault` whose inner type is a `ZodPipe` containing a transform, `isTransforming` returns `true` — so the `default` value that `defaultProcessor` just set on the schema is immediately wiped.

The deletion was intended for cases where `default` is inherited from a *pipe* (output-side default), not for `ZodDefault`, which always declares an explicit input-side default.

## Fix

Skip the `delete result.schema.default` step when `def.type === "default"`. The `ZodDefault` processor always sets `default` intentionally; removing it here is wrong regardless of whether the inner type transforms.

```ts
// to-json-schema.ts
if (ctx.io === "input" && isTransforming(schema)) {
  delete result.schema.examples;
  // ZodDefault explicitly declares the input-side default — preserve it even through transforms
  if (def.type !== "default") {
    delete result.schema.default;
  }
}
```

## Test changes

- Updated existing snapshot for `a.default(1234)` (type-changing transform): with this fix, `default: 1234` now appears in the input schema. The `default` keyword in JSON Schema is advisory and does not need to validate against the schema type, so this is spec-compliant and more informative for tooling.
- Added a new test reproducing the exact case from #6049.
