### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/packages/docs/content/index.mdx
+++ b/packages/docs/content/index.mdx
@@ -108,6 +108,7 @@ console.log(data.name);
 
 ```sh
 npm install zod
+deno install zod
 ```
 
 > Zod is also available as `@zod/zod` on [jsr.io](https://jsr.io/@zod/zod).

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -78,6 +78,7 @@ console.log(data.name);
 
 ```sh
 npm install zod
+deno install zod
 ```
 
 <br/>


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list npm, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install zod
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install zod`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it to a docs site instead.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
