### PR TITLE
perf: optimize `$ZodObjectJIT` fastpass

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2086,11 +2086,11 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
 
       doc.write(`payload.value = newResult;`);
       doc.write(`return payload;`);
-      const fn = doc.compile();
-      return (payload: any, ctx: any) => fn(shape, payload, ctx);
+      return doc.compile() as (shape: any, payload: any, ctx: any) => any;
     };
 
     let fastpass!: ReturnType<typeof generateFastpass>;
+    let fastpassShape!: any;
 
     const isObject = util.isObject;
     const jit = !core.globalConfig.jitless;
@@ -2116,8 +2116,11 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
 
       if (jit && fastEnabled && ctx?.async === false && ctx.jitless !== true) {
         // always synchronous
-        if (!fastpass) fastpass = generateFastpass(def.shape);
-        payload = fastpass(payload, ctx);
+        if (!fastpass) {
+          fastpassShape = def.shape;
+          fastpass = generateFastpass(fastpassShape);
+        }
+        payload = fastpass(fastpassShape, payload, ctx);
 
         if (!catchall) return payload;
         return handleCatchall([], input, payload, ctx, value, inst);


### PR DESCRIPTION
Drop the fastpass wrapper frame in `$ZodObjectJIT`, the compiled parser that backs `z.object().parse()` and everything built on it.

`generateFastpass` returned `(payload, ctx) => fn(shape, payload, ctx)`, a forwarding closure that ran on every object parse and that V8 wouldn't inline. It now returns the compiled function directly; `shape` is captured once and passed at the call site, so the forwarding frame disappears from the hot path.

Profiled with a mixed object schema (string/number/boolean/nested/array) over ~30k CPU samples:

| | Before | After |
|---|---|---|
| Wrapper frame self time | 139ms | removed |
| Total | 4.06s | 3.92s (−3.4%) |