### PR TITLE
fix(discriminatedUnion): route undefined input to .default() branch when discriminator key is absent

### DIFF
--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -372,6 +372,35 @@ test("valid - literals with .default or .pipe", () => {
   });
 });
 
+test("valid - .default() discriminator with key absent from input", () => {
+  // When the discriminator field is wrapped in .default(), omitting the key
+  // from the input (input[discriminator] === undefined) should still route to
+  // the correct branch — ZodDefault will supply the default value once that
+  // branch's object schema is invoked.  Previously this threw
+  // "No matching discriminator" because `undefined` was never added to the
+  // discriminator lookup map.
+  const schema = z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("foo").default("foo"),
+      a: z.string(),
+    }),
+    z.object({
+      type: z.literal("bar"),
+      b: z.string(),
+    }),
+  ]);
+
+  // Explicit discriminator value still works
+  expect(schema.parse({ type: "foo", a: "hello" })).toEqual({ type: "foo", a: "hello" });
+
+  // Missing discriminator key routes to the branch whose field has .default()
+  expect(schema.parse({ a: "hello" })).toEqual({ type: "foo", a: "hello" });
+
+  // Wrong explicit discriminator value still fails
+  const fail = schema.safeParse({ type: "unknown", a: "hello" });
+  expect(fail.success).toBe(false);
+});
+
 test("enum and nativeEnum", () => {
   enum MyEnum {
     d = 0,

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1929,6 +1929,16 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
       if (field.values) {
         propValues[key] ??= new Set();
         for (const v of field.values) propValues[key].add(v);
+        // If this field accepts `undefined` as a valid input (e.g. wrapped in
+        // ZodDefault or ZodOptional), include `undefined` in the propValues set
+        // so that discriminated unions can correctly route inputs where the
+        // discriminator key is absent or explicitly `undefined`.
+        // ZodOptional already adds `undefined` to its own `.values`, so this
+        // branch only widens the set for schemas like ZodDefault that accept
+        // `undefined` as input but do not expose it in their output `values`.
+        if (field.optin === "optional" && !field.values.has(undefined)) {
+          propValues[key].add(undefined);
+        }
       }
     }
     return propValues;


### PR DESCRIPTION
## Bug

When a discriminated union option's discriminator field is wrapped in `.default()`, inputs that omit the discriminator key entirely (so `input[discriminator] === undefined`) produce a spurious **"No matching discriminator"** error, even though the `.default()` wrapper would have supplied the correct value.

### Reproduction

```ts
const schema = z.discriminatedUnion("type", [
  z.object({ type: z.literal("foo").default("foo"), a: z.string() }),
  z.object({ type: z.literal("bar"),                b: z.string() }),
]);

schema.parse({ a: "hello" });
// throws: "Invalid discriminator value. Expected 'foo' | 'bar'"
// expected: { type: "foo", a: "hello" }
```

### Root cause

`$ZodDiscriminatedUnion` builds a discriminator-value → option map at schema-creation time, using each option's `_zod.propValues[discriminator]`. That set comes from `ZodObject.propValues`, which reads each field's `_zod.values`.

`ZodDefault` intentionally propagates only the **inner type's** output values (e.g. `Set(["foo"])`) because `values` represents valid *output* values and `undefined` is never an output of `ZodDefault`. However, `ZodDefault` does accept `undefined` as a valid *input* (replacing it with the default). This means `undefined` is never entered into the disc map, so `disc.get(undefined)` returns `undefined` and the parser falls to the "no match" error branch — bypassing the option that would have handled the input correctly.

`ZodOptional` does not have this problem because its `values` getter explicitly adds `undefined` to the inner type's set.

### Fix

In `$ZodObject.propValues`, after collecting values from a field, also add `undefined` when the field's schema accepts `undefined` as input (`field.optin === "optional"`) but its `values` set does not already include it. This covers `ZodDefault`, `ZodPrefault`, and any future wrapper that marks itself `optin: "optional"` without advertising `undefined` in `values`.

```diff
  util.defineLazy(inst._zod, "propValues", () => {
    const shape = def.shape;
    const propValues: util.PropValues = {};
    for (const key in shape) {
      const field = shape[key]!._zod;
      if (field.values) {
        propValues[key] ??= new Set();
        for (const v of field.values) propValues[key].add(v);
+       // ZodDefault accepts `undefined` as input but does not include it in
+       // its output `values`.  Add `undefined` here so the discriminator map
+       // can route inputs where the key is absent to this option.
+       if (field.optin === "optional" && !field.values.has(undefined)) {
+         propValues[key].add(undefined);
+       }
      }
    }
    return propValues;
  });
```

### Tests

Added a new test `"valid - .default() discriminator with key absent from input"` in `packages/zod/src/v4/classic/tests/discriminated-unions.test.ts` that was failing before this change.

The existing `"valid - optional discriminator (object)"` test (which already passes, because `ZodOptional` already adds `undefined` to `values`) continues to pass unmodified.