### PR TITLE
fix(json-schema): keep preprocess object properties required in input mode

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2901,6 +2901,39 @@ test("use output type for preprocess", () => {
   `);
 });
 
+test("object property with preprocess stays required in input JSON schema", () => {
+  const schema = z.object({
+    noPreprocess: z.string(),
+    withPreprocess: z.preprocess((v) => v, z.string()),
+    optionalPreprocess: z.preprocess((v) => v, z.string().optional()),
+  });
+
+  // A preprocessed property is only optional when its inner schema is — the
+  // transform wrapper must not make a required property optional in the input
+  // JSON schema (matches runtime: `schema.parse({})` rejects `withPreprocess`).
+  expect(z.toJSONSchema(schema, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "noPreprocess": {
+          "type": "string",
+        },
+        "optionalPreprocess": {
+          "type": "string",
+        },
+        "withPreprocess": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "noPreprocess",
+        "withPreprocess",
+      ],
+      "type": "object",
+    }
+  `);
+});
+
 test("strip output-side examples from input JSON schema for codec", () => {
   const codec = z
     .codec(z.string(), z.number(), { decode: (s) => Number(s), encode: (n) => String(n) })

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -287,6 +287,21 @@ export const arrayProcessor: Processor<schemas.$ZodArray> = (schema, ctx, _json,
   });
 };
 
+// `z.preprocess(fn, inner)` builds a pipe whose `in` is a transform. A bare
+// transform reports `optin: "optional"` so the preprocessor can still run on
+// absent object keys at parse time, but that input-optionality belongs to the
+// transform, not the property: for JSON Schema the input shape is the inner
+// `out` schema, so a preprocessed property is only optional when that inner
+// schema is. Defer to the inner schema's optionality, mirroring runtime parsing
+// (`z.object({ a: z.preprocess(v => v, z.string()) }).parse({})` rejects `a`).
+function inputOptin(schema: schemas.$ZodType): "optional" | undefined {
+  const def = schema._zod.def as schemas.$ZodPipeDef;
+  if (def.type === "pipe" && def.in._zod.traits.has("$ZodTransform")) {
+    return inputOptin(def.out);
+  }
+  return schema._zod.optin;
+}
+
 export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.ObjectSchema;
   const def = schema._zod.def as schemas.$ZodObjectDef;
@@ -305,11 +320,11 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
   const allKeys = new Set(Object.keys(shape));
   const requiredKeys = new Set(
     [...allKeys].filter((key) => {
-      const v = def.shape[key]!._zod;
+      const field = def.shape[key]!;
       if (ctx.io === "input") {
-        return v.optin === undefined;
+        return inputOptin(field) === undefined;
       } else {
-        return v.optout === undefined;
+        return field._zod.optout === undefined;
       }
     })
   );


### PR DESCRIPTION
Fixes #5968.

## Problem

`z.toJSONSchema(schema, { io: "input" })` marked object properties defined with `z.preprocess(...)` as **not required** — a regression since v4.4.3 (#5941):

```ts
z.toJSONSchema(
  z.object({ a: z.string(), b: z.preprocess((v) => v, z.string()) }),
  { io: "input" },
);
// required: ["a"]   ❌  ("b" dropped)
```

This contradicts runtime parsing — the absent key is rejected:

```ts
z.object({ b: z.preprocess((v) => v, z.string()) }).parse({});
// ✖ ZodError: expected string, received undefined
```

## Cause

`z.preprocess(fn, inner)` builds a `ZodPipe` whose `in` is a transform. A bare transform reports `optin: "optional"` (so the preprocessor can still run on absent keys at parse time), and `ZodPipe` inherits `optin` from its `in`. The object processor's required-keys filter (`optin === undefined`) therefore excluded preprocessed properties.

## Fix

In the JSON Schema object processor only, resolve input-optionality through transform-`in` pipes to the inner `out` schema. A preprocessed property is now required unless its inner schema is genuinely optional — restoring the v4.4.2 behavior and the design of #5929. Runtime `optin` is left untouched.

```ts
// required: ["a", "b"]   ✅
```

## Tests

Regression test added in `to-json-schema.test.ts` covering a required preprocess property and an optional-inner preprocess property. Verified red without the fix, green with it. No existing snapshots change (the encoding is a no-op for non-preprocess schemas).
