### PR TITLE
fix(intersection): run checks/refinements/transforms on strict branches

### DIFF
--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -67,6 +67,47 @@ test("object intersection: strict + strict", () => {
   `);
 });
 
+test("strict intersection runs checks/superRefine/transform on each branch (#5663)", () => {
+  // Each strict branch flags the other branch's keys as unrecognized; those
+  // issues are reconciled away, but they must not skip the branch's own checks.
+  let superRefineCalls = 0;
+  const sr = z.intersection(
+    z.strictObject({ x: z.string() }).superRefine((_d, ctx) => {
+      superRefineCalls++;
+      ctx.addIssue({ code: "custom", message: "fail-left" });
+    }),
+    z.strictObject({ a: z.string() }).superRefine((_d, ctx) => {
+      superRefineCalls++;
+      ctx.addIssue({ code: "custom", message: "fail-right" });
+    })
+  );
+  const srResult = sr.safeParse({ x: "test", a: "hello" });
+  expect(superRefineCalls).toBe(2);
+  expect(srResult.success).toBe(false);
+  expect(srResult.error?.issues.map((i) => i.message).sort()).toEqual(["fail-left", "fail-right"]);
+
+  // `.refine()` likewise runs and can fail the parse.
+  const rf = z.intersection(
+    z.strictObject({ x: z.string() }).refine((d) => d.x === "ok", "bad-x"),
+    z.strictObject({ a: z.string() })
+  );
+  expect(rf.safeParse({ x: "no", a: "hello" }).success).toBe(false);
+  expect(rf.safeParse({ x: "ok", a: "hello" }).success).toBe(true);
+
+  // `.transform()` on a strict branch runs and its output is merged.
+  let transformCalls = 0;
+  const tx = z.intersection(
+    z.strictObject({ x: z.string() }).transform((v) => {
+      transformCalls++;
+      return { ...v, x: v.x.toUpperCase() };
+    }),
+    z.strictObject({ a: z.string() })
+  );
+  const txResult = tx.safeParse({ x: "test", a: "hello" });
+  expect(transformCalls).toBe(1);
+  expect(txResult).toMatchObject({ success: true, data: { x: "TEST", a: "hello" } });
+});
+
 test("deep intersection", () => {
   const Animal = z.object({
     properties: z.object({

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -29,6 +29,12 @@ export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> ex
   readonly async?: boolean | undefined;
   readonly direction?: "forward" | "backward";
   readonly skipChecks?: boolean;
+  /** @internal When set, `unrecognized_keys` issues do not abort a schema's
+   * checks. Set while parsing the branches of an intersection: each strict
+   * branch flags the *other* branch's keys as unrecognized, and those issues
+   * are reconciled afterward by `handleIntersectionResults`, so they must not
+   * skip the branch's own checks/transforms. */
+  readonly nonAbortingUnrecognizedKeys?: boolean;
 }
 
 export interface ParsePayload<T = unknown> {
@@ -220,7 +226,9 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
       checks: checks.$ZodCheck<never>[],
       ctx?: ParseContextInternal | undefined
     ): util.MaybeAsync<ParsePayload> => {
-      let isAborted = util.aborted(payload);
+      let isAborted = ctx?.nonAbortingUnrecognizedKeys
+        ? util.abortedExceptUnrecognizedKeys(payload)
+        : util.aborted(payload);
 
       let asyncResult!: Promise<unknown> | undefined;
       for (const ch of checks) {
@@ -2477,8 +2485,13 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
 
     inst._zod.parse = (payload, ctx) => {
       const input = payload.value;
-      const left = def.left._zod.run({ value: input, issues: [] }, ctx);
-      const right = def.right._zod.run({ value: input, issues: [] }, ctx);
+      // Each branch sees the full input, so a strict branch flags the other
+      // branch's keys as unrecognized. Those issues are reconciled below by
+      // handleIntersectionResults; they must not abort each branch's own
+      // checks/transforms, so parse the branches in non-aborting mode.
+      const branchCtx = ctx.nonAbortingUnrecognizedKeys ? ctx : { ...ctx, nonAbortingUnrecognizedKeys: true };
+      const left = def.left._zod.run({ value: input, issues: [] }, branchCtx);
+      const right = def.right._zod.run({ value: input, issues: [] }, branchCtx);
       const async = left instanceof Promise || right instanceof Promise;
 
       if (async) {
@@ -4036,7 +4049,14 @@ export const $ZodPipe: core.$constructor<$ZodPipe> = /*@__PURE__*/ core.$constru
 });
 
 function handlePipeResult(left: ParsePayload, next: $ZodType, ctx: ParseContextInternal) {
-  if (left.issues.length) {
+  // When parsing an intersection branch, `unrecognized_keys` issues are
+  // reconciled later (see handleIntersectionResults) and must not stop the pipe
+  // from running its `out` step (e.g. a `.transform()` on a strict object). Any
+  // other issue still aborts; the unrecognized issues are carried forward.
+  const blocking = ctx.nonAbortingUnrecognizedKeys
+    ? left.issues.some((iss) => iss.code !== "unrecognized_keys")
+    : left.issues.length > 0;
+  if (blocking) {
     // prevent further checks
     left.aborted = true;
     return left;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -822,6 +822,21 @@ export function aborted(x: schemas.ParsePayload, startIndex = 0): boolean {
   return false;
 }
 
+// Like `aborted`, but ignores `unrecognized_keys` issues. Used when parsing the
+// branches of an intersection: each strict branch flags the other branch's keys
+// as unrecognized, and those issues are reconciled by handleIntersectionResults,
+// so they must not skip the branch's own checks.
+export function abortedExceptUnrecognizedKeys(x: schemas.ParsePayload, startIndex = 0): boolean {
+  if (x.aborted === true) return true;
+  for (let i = startIndex; i < x.issues.length; i++) {
+    const iss = x.issues[i];
+    if (iss?.continue !== true && iss?.code !== "unrecognized_keys") {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Checks for explicit abort (continue === false), as opposed to implicit abort (continue === undefined).
 // Used to respect `abort: true` in .refine() even for checks that have a `when` function.
 export function explicitlyAborted(x: schemas.ParsePayload, startIndex = 0): boolean {


### PR DESCRIPTION
Fixes #5663.

## Problem

In `z.intersection(a, b)`, checks/refinements/transforms attached to a **strict** object branch were silently skipped, and an intersection of strict objects could pass validation that should have failed:

```ts
const schema = z.intersection(
  z.strictObject({ x: z.string() }).superRefine((_d, ctx) =>
    ctx.addIssue({ code: "custom", message: "fail" })
  ),
  z.strictObject({ a: z.string() }),
);

schema.safeParse({ x: "test", a: "hello" }).success;
// → true   ❌  (the superRefine never ran)
```

`z.object()` branches work; only `strictObject`/`.strict()` branches were affected. The same happens for `.check()`, `.refine()`, and `.transform()`.

## Cause

Each branch is parsed against the **full** input, so a strict branch flags the *other* branch's keys as `unrecognized_keys`. `handleIntersectionResults` already reconciles these (only keys unrecognized by *both* sides are reported). But those issues are produced during each branch's own parse and mark the payload **aborted**, so `runChecks` (and the pipe step backing `.transform()`) skip the branch's own checks — before the intersection ever reconciles the keys.

## Fix

Parse intersection branches in a non-aborting mode via an internal `nonAbortingUnrecognizedKeys` context flag. When set:

- `runChecks` treats `unrecognized_keys` issues as non-blocking, so the branch's checks/refinements run.
- the pipe step (`.transform()`) proceeds to its `out` step and carries the `unrecognized_keys` issues forward.

Any other issue still aborts as before, the issues are still recorded and reconciled by `handleIntersectionResults`, and **behavior outside intersections is unchanged** (standalone strict objects, the existing "unrecognized by both sides errors" case, etc.).

## Tests

Added a regression test in `intersection.test.ts` covering `superRefine`, `refine`, and `transform` on strict branches (each verified to run, fail, and merge correctly). Verified red without the fix, green with it. Full v4 suite (2764 tests) passes with no other snapshot changes.
