### PR TITLE
fix(preprocess): infer input type from the preprocessor argument

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2429,12 +2429,12 @@ export function invertCodec<A extends core.SomeType, B extends core.SomeType>(co
 }
 
 // ZodPreprocess
-export interface ZodPreprocess<B extends core.SomeType = core.$ZodType>
-  extends ZodPipe<core.$ZodTransform, B>,
-    core.$ZodPreprocess<B> {
+export interface ZodPreprocess<B extends core.SomeType = core.$ZodType, In = unknown>
+  extends ZodPipe<core.$ZodTransform<unknown, In>, B>,
+    core.$ZodPreprocess<B, In> {
   "~standard": ZodStandardSchemaWithJSON<this>;
-  _zod: core.$ZodPreprocessInternals<B>;
-  def: core.$ZodPreprocessDef<B>;
+  _zod: core.$ZodPreprocessInternals<B, In>;
+  def: core.$ZodPreprocessDef<B, In>;
 }
 export const ZodPreprocess: core.$constructor<ZodPreprocess> = /*@__PURE__*/ core.$constructor(
   "ZodPreprocess",
@@ -2728,7 +2728,7 @@ export function json(params?: string | core.$ZodCustomParams): ZodJSONSchema {
 export function preprocess<A, U extends core.SomeType, B = unknown>(
   fn: (arg: B, ctx: core.$RefinementCtx) => A,
   schema: U
-): ZodPreprocess<U> {
+): ZodPreprocess<U, B> {
   return new ZodPreprocess({
     type: "pipe",
     in: transform(fn as any) as any as core.$ZodTransform,

--- a/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
@@ -22,5 +22,12 @@ test("ZodPreprocess optin/optout defer to B", () => {
 test("ZodPreprocess input/output inference", () => {
   const pre = z.preprocess((v) => v, z.number().optional());
   expectTypeOf<z.output<typeof pre>>().toEqualTypeOf<number | undefined>();
+  // An un-annotated preprocessor arg leaves the input as `unknown`.
   expectTypeOf<z.input<typeof pre>>().toEqualTypeOf<unknown>();
+});
+
+test("ZodPreprocess infers input from annotated preprocessor arg (#5966)", () => {
+  const trimmed = z.preprocess((val: string | null | undefined) => val?.trim() ?? "", z.string());
+  expectTypeOf<z.input<typeof trimmed>>().toEqualTypeOf<string | null | undefined>();
+  expectTypeOf<z.output<typeof trimmed>>().toEqualTypeOf<string>();
 });

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4136,19 +4136,22 @@ function handleCodecTxResult(left: ParsePayload, value: any, nextSchema: SomeTyp
 //////////                             //////////
 /////////////////////////////////////////////////
 /////////////////////////////////////////////////
-export interface $ZodPreprocessDef<B extends SomeType = $ZodType> extends $ZodPipeDef<$ZodTransform, B> {
-  in: $ZodTransform;
+export interface $ZodPreprocessDef<B extends SomeType = $ZodType, In = unknown>
+  extends $ZodPipeDef<$ZodTransform<unknown, In>, B> {
+  in: $ZodTransform<unknown, In>;
   out: B;
 }
 
-export interface $ZodPreprocessInternals<B extends SomeType = $ZodType> extends $ZodPipeInternals<$ZodTransform, B> {
-  def: $ZodPreprocessDef<B>;
+export interface $ZodPreprocessInternals<B extends SomeType = $ZodType, In = unknown>
+  extends $ZodPipeInternals<$ZodTransform<unknown, In>, B> {
+  def: $ZodPreprocessDef<B, In>;
   optin: B["_zod"]["optin"];
   optout: B["_zod"]["optout"];
 }
 
-export interface $ZodPreprocess<B extends SomeType = $ZodType> extends $ZodPipe<$ZodTransform, B> {
-  _zod: $ZodPreprocessInternals<B>;
+export interface $ZodPreprocess<B extends SomeType = $ZodType, In = unknown>
+  extends $ZodPipe<$ZodTransform<unknown, In>, B> {
+  _zod: $ZodPreprocessInternals<B, In>;
 }
 
 export const $ZodPreprocess: core.$constructor<$ZodPreprocess> = /*@__PURE__*/ core.$constructor(


### PR DESCRIPTION
Fixes #5966.

## Problem

The input type of `z.preprocess` no longer reflects the preprocessor's argument type — a regression since v4.4.3. From the docs example:

```ts
const trimmed = z.preprocess(
  (val: string | null | undefined) => val?.trim() ?? "",
  z.string(),
);

type Input = z.input<typeof trimmed>;  // unknown   ❌  (docs say string | null | undefined)
type Output = z.output<typeof trimmed>; // string
```

## Cause

`ZodPreprocess`/`$ZodPreprocess` were hardcoded to a bare `$ZodTransform`, whose input is `unknown`. Since a pipe's input is its `in` schema's input, the annotated argument type of the preprocessor function was discarded.

## Fix

Add an `In` type parameter (defaulted to `unknown`) to the preprocess types and type the inner transform as `$ZodTransform<unknown, In>`, so the pipe's input reflects the preprocessor argument:

```ts
type Input = z.input<typeof trimmed>;  // string | null | undefined   ✅
```

The parameter defaults to `unknown`, so this is backward compatible — an un-annotated preprocessor (`(v) => v`) still infers `unknown`. Runtime behavior is unchanged (the change is purely type-level).

## Tests

Added a type test in `preprocess-types.test.ts` asserting the annotated-argument case infers the correct input, and kept the existing un-annotated case (`unknown`). Full v4 suite passes with no type errors.
