### PR TITLE
fix(regexes): enforce RFC 1035 length limits in regexes.domain

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -464,6 +464,15 @@ test("httpurl", () => {
   ).toThrow();
   expect(() => httpUrl.parse("http://asdf.c")).toThrow();
   expect(() => httpUrl.parse("mailto:asdf@lckj.com")).toThrow();
+  // RFC 1035 length limits, matching z.hostname() — #5965
+  // TLD longer than 63 characters
+  expect(() => httpUrl.parse(`https://example.${"a".repeat(64)}`)).toThrow();
+  // total host length over 253 characters (built from valid <=63 char labels)
+  const over253 = `${Array.from({ length: 5 }, () => "a".repeat(60)).join(".")}.com`;
+  expect(over253.length).toBeGreaterThan(253);
+  expect(() => httpUrl.parse(`https://${over253}`)).toThrow();
+  // a 63-char label remains valid
+  httpUrl.parse(`https://${"a".repeat(63)}.com`);
   // missing // after protocol
   expect(() => httpUrl.parse("http:example.com")).toThrow();
   expect(() => httpUrl.parse("https:example.com")).toThrow();

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -84,7 +84,10 @@ export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
 export const hostname: RegExp =
   /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
 
-export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+// RFC 1035 length limits are enforced (matching `hostname` above): the total
+// length is capped at 253 characters and every label — including the TLD — at
+// 63. (#5965)
+export const domain: RegExp = /^(?=.{1,253}$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
 
 export const httpProtocol: RegExp = /^https?$/;
 


### PR DESCRIPTION
Fixes #5965.

## Problem

`regexes.domain` (used by `z.httpUrl()` for the host check) has no length anchors:

```ts
export const domain = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
```

whereas `regexes.hostname` (used by `z.hostname()`) enforces the RFC 1035 limits. So `z.httpUrl()` accepts hosts that `z.hostname()` rejects:

- a total host length over **253** characters
- a TLD longer than **63** characters

## Fix

Add a `(?=.{1,253}$)` total-length lookahead and cap the TLD at `{2,63}`, matching the limits already enforced by `regexes.hostname`. Non-TLD labels were already capped at 63 by the existing `{0,61}` quantifier.

```ts
export const domain = /^(?=.{1,253}$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
```

This closes the gap so `z.httpUrl()` and `z.hostname()` agree on DNS length limits. (RFC 3986 / WHATWG URL don't themselves impose DNS length limits, but the underlying DNS does, and the two helpers diverging is surprising — see the issue discussion.)

## Tests

Extended the `httpurl` test in `string.test.ts`: over-253-character hosts and over-63-character TLDs now throw, and a 63-character label still parses. Full v4 suite passes.
