### PR TITLE
docs: update keyof() ZodEnum type to the v4 form

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1210,13 +1210,13 @@ To create a `ZodEnum` schema from the keys of an object schema:
 <Tab value="Zod">
 ```ts
 const keySchema = Dog.keyof();
-// => ZodEnum<["name", "age"]>
+// => ZodEnum<{ name: "name"; age: "age" }>
 ```
 </Tab>
 <Tab value="Zod Mini">
 ```ts
 const keySchema = z.keyof(Dog);
-// => ZodEnum<["name", "age"]>
+// => ZodEnum<{ name: "name"; age: "age" }>
 ```
 </Tab>
 </Tabs>


### PR DESCRIPTION
The `.keyof()` examples show the result type as `ZodEnum<["name", "age"]>`, which is the Zod 3 form where `ZodEnum`'s parameter was a string tuple.

In Zod 4 `ZodEnum` takes an enum-like object instead (`EnumLike = Readonly<Record<string, EnumValue>>`), and `keyof()` returns `ZodEnum<util.ToEnum<keyof Shape & string>>`. For `Dog` with keys `name` and `age` that resolves to `ZodEnum<{ name: "name"; age: "age" }>`, so this updates both the Zod and Zod Mini examples to match.

Docs-only change.