### PR TITLE
fix(errors): treeifyError no longer throws on Object.prototype keys

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -447,6 +447,25 @@ test("z.treeifyError 2", () => {
   `);
 });
 
+test("z.treeifyError handles keys inherited from Object.prototype (#6070)", () => {
+  const schema = z.object({
+    toString: z.string(),
+    valueOf: z.number(),
+    constructor: z.boolean(),
+    hasOwnProperty: z.string(),
+  });
+
+  const result = schema.safeParse({});
+  expect(result.success).toEqual(false);
+
+  // Previously threw: TypeError: Cannot read properties of undefined (reading 'push')
+  const tree = z.treeifyError(result.error!);
+  expect(tree.properties?.toString?.errors.length).toBeGreaterThan(0);
+  expect(tree.properties?.valueOf?.errors.length).toBeGreaterThan(0);
+  expect(tree.properties?.constructor?.errors.length).toBeGreaterThan(0);
+  expect(tree.properties?.hasOwnProperty?.errors.length).toBeGreaterThan(0);
+});
+
 test("z.prettifyError", () => {
   expect(z.prettifyError(result.error!)).toMatchInlineSnapshot(`
     "✖ Unrecognized key: "extra"

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -370,7 +370,13 @@ export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIss
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ??= {};
-            curr.properties[el] ??= { errors: [] };
+            // Use a hasOwnProperty guard instead of `??=`: a path segment whose
+            // name is inherited from Object.prototype (e.g. "toString", "valueOf",
+            // "constructor") would otherwise resolve to the prototype member and
+            // skip initialization, throwing on the later `curr.errors.push`. (#6070)
+            if (!Object.prototype.hasOwnProperty.call(curr.properties, el)) {
+              curr.properties[el] = { errors: [] };
+            }
             curr = curr.properties[el];
           } else {
             curr.items ??= [];


### PR DESCRIPTION
## Problem

`treeifyError` throws a `TypeError` whenever a validation issue's `path` contains a segment whose name is inherited from `Object.prototype` (`toString`, `valueOf`, `constructor`, `hasOwnProperty`, …):

```ts
const schema = z.object({ toString: z.string() });
const result = schema.safeParse({});   // success: false (correct)
treeifyError(result.error!);           // 💥 TypeError: Cannot read properties of undefined (reading 'push')
```

## Root cause

`treeifyError` builds its tree using a plain object as a dictionary. For a key like `toString`, `curr.properties[el]` resolves to the inherited `Object.prototype.toString` (truthy), so the `??=` initializer is skipped. `curr` then points at the prototype function and the later `curr.errors.push(...)` throws.

## Fix

Guard the assignment with `Object.prototype.hasOwnProperty.call`, so only *own* keys short-circuit. Output shape is unchanged (still a plain object) — only the previously-crashing colliding-key case is fixed. Matches the existing prototype-safe idiom already used in `core/util.ts`.

## Test

Added a reproducing case in `error-utils.test.ts` covering `toString` / `valueOf` / `constructor` / `hasOwnProperty`; it throws on `main` and passes with the fix.

Fixes #6070

---
_Restores #6099, which closed automatically when my fork was briefly deleted. The fix commit is unchanged._
