### PR TITLE
fix(checks): date min/max issue origin should reflect input, not bound

### DIFF
--- a/packages/zod/src/v4/classic/tests/date.test.ts
+++ b/packages/zod/src/v4/classic/tests/date.test.ts
@@ -53,6 +53,16 @@ test("date max", () => {
   `);
 });
 
+test("date min/max origin is 'date' for a numeric timestamp bound (#5980)", () => {
+  const minRes = z.date().min(benchmarkDate.getTime()).safeParse(beforeBenchmarkDate);
+  expect(minRes.success).toEqual(false);
+  expect(minRes.error!.issues[0]!).toHaveProperty("origin", "date");
+
+  const maxRes = z.date().max(benchmarkDate.getTime()).safeParse(afterBenchmarkDate);
+  expect(maxRes.success).toEqual(false);
+  expect(maxRes.error!.issues[0]!).toHaveProperty("origin", "date");
+});
+
 test("min max getters", () => {
   expect(minCheck.minDate).toEqual(benchmarkDate);
   expect(minCheck.min(afterBenchmarkDate).minDate).toEqual(afterBenchmarkDate);

--- a/packages/zod/src/v4/classic/tests/date.test.ts
+++ b/packages/zod/src/v4/classic/tests/date.test.ts
@@ -53,14 +53,34 @@ test("date max", () => {
   `);
 });
 
-test("date min/max origin is 'date' for a numeric timestamp bound (#5980)", () => {
+test("date min/max origin with numeric bound", () => {
   const minRes = z.date().min(benchmarkDate.getTime()).safeParse(beforeBenchmarkDate);
-  expect(minRes.success).toEqual(false);
-  expect(minRes.error!.issues[0]!).toHaveProperty("origin", "date");
+  expect(minRes.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "too_small",
+        "inclusive": true,
+        "message": "Too small: expected date to be >=1667606400000",
+        "minimum": 1667606400000,
+        "origin": "date",
+        "path": [],
+      },
+    ]
+  `);
 
   const maxRes = z.date().max(benchmarkDate.getTime()).safeParse(afterBenchmarkDate);
-  expect(maxRes.success).toEqual(false);
-  expect(maxRes.error!.issues[0]!).toHaveProperty("origin", "date");
+  expect(maxRes.error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "too_big",
+        "inclusive": true,
+        "maximum": 1667606400000,
+        "message": "Too big: expected date to be <=1667606400000",
+        "origin": "date",
+        "path": [],
+      },
+    ]
+  `);
 });
 
 test("min max getters", () => {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -82,10 +82,6 @@ export const $ZodCheckLessThan: core.$constructor<$ZodCheckLessThan> = /*@__PURE
       }
 
       payload.issues.push({
-        // Derive origin from the value being validated, not from the bound:
-        // e.g. `z.date().max(<timestamp:number>)` must report origin "date",
-        // not "number". Fall back to the bound-derived origin for inputs whose
-        // type isn't numeric/bigint/object (e.g. a failed base-type parse). (#5980)
         origin: numericOriginMap[typeof payload.value as "number" | "bigint" | "object"] ?? origin,
         code: "too_big",
         maximum: typeof def.value === "object" ? def.value.getTime() : def.value,
@@ -137,10 +133,6 @@ export const $ZodCheckGreaterThan: core.$constructor<$ZodCheckGreaterThan> = /*@
       }
 
       payload.issues.push({
-        // Derive origin from the value being validated, not from the bound:
-        // e.g. `z.date().min(<timestamp:number>)` must report origin "date",
-        // not "number". Fall back to the bound-derived origin for inputs whose
-        // type isn't numeric/bigint/object (e.g. a failed base-type parse). (#5980)
         origin: numericOriginMap[typeof payload.value as "number" | "bigint" | "object"] ?? origin,
         code: "too_small",
         minimum: typeof def.value === "object" ? def.value.getTime() : def.value,

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -82,7 +82,11 @@ export const $ZodCheckLessThan: core.$constructor<$ZodCheckLessThan> = /*@__PURE
       }
 
       payload.issues.push({
-        origin,
+        // Derive origin from the value being validated, not from the bound:
+        // e.g. `z.date().max(<timestamp:number>)` must report origin "date",
+        // not "number". Fall back to the bound-derived origin for inputs whose
+        // type isn't numeric/bigint/object (e.g. a failed base-type parse). (#5980)
+        origin: numericOriginMap[typeof payload.value as "number" | "bigint" | "object"] ?? origin,
         code: "too_big",
         maximum: typeof def.value === "object" ? def.value.getTime() : def.value,
         input: payload.value,
@@ -133,7 +137,11 @@ export const $ZodCheckGreaterThan: core.$constructor<$ZodCheckGreaterThan> = /*@
       }
 
       payload.issues.push({
-        origin,
+        // Derive origin from the value being validated, not from the bound:
+        // e.g. `z.date().min(<timestamp:number>)` must report origin "date",
+        // not "number". Fall back to the bound-derived origin for inputs whose
+        // type isn't numeric/bigint/object (e.g. a failed base-type parse). (#5980)
+        origin: numericOriginMap[typeof payload.value as "number" | "bigint" | "object"] ?? origin,
         code: "too_small",
         minimum: typeof def.value === "object" ? def.value.getTime() : def.value,
         input: payload.value,

--- a/packages/zod/src/v4/mini/tests/checks.test.ts
+++ b/packages/zod/src/v4/mini/tests/checks.test.ts
@@ -41,6 +41,14 @@ test("z.gte", () => {
   expect(z.safeParse(a, 9).success).toEqual(false);
 });
 
+test("z.gte/z.lte origin on a date schema with a numeric bound", () => {
+  const bound = new Date(Date.UTC(2022, 10, 5)).getTime();
+  const tooSmall = z.safeParse(z.date().check(z.gte(bound)), new Date(Date.UTC(2022, 10, 4)));
+  const tooBig = z.safeParse(z.date().check(z.lte(bound)), new Date(Date.UTC(2022, 10, 6)));
+  expect(tooSmall.error!.issues[0]).toMatchObject({ code: "too_small", origin: "date" });
+  expect(tooBig.error!.issues[0]).toMatchObject({ code: "too_big", origin: "date" });
+});
+
 // min;
 test("z.min", () => {
   const a = z.number().check(z.minimum(10));


### PR DESCRIPTION
## Problem

The issue `origin` produced by `z.date().min()` / `.max()` changes based on the *type of the bound* passed to `min`/`max`, rather than the schema:

```ts
z.date().min(new Date(2020, 6, 10)).safeParse(tooSmall);       // origin: date  ✅
z.date().min(new Date(2020, 6, 10).getTime()).safeParse(tooSmall); // origin: number ❌ (should be date)
```

## Root cause

In `$ZodCheckLessThan` / `$ZodCheckGreaterThan`, `origin` is derived from `numericOriginMap[typeof def.value]` — the runtime type of the bound. A numeric timestamp bound therefore yields `origin: number`, while a `Date` bound yields `date`.

## Fix

Derive `origin` from the value being validated (`payload.value`) instead of the bound, falling back to the previous bound-derived origin for inputs whose type isn't numeric/bigint/object (e.g. a failed base-type parse). The reported `minimum` / `maximum` still come from the bound and are unchanged.

## Test

Added a case in `date.test.ts` asserting `origin: date` for both `min` and `max` when the bound is a numeric timestamp. Existing date tests (which use a `Date` bound) are unaffected.

Fixes #5980

---
_Restores #6100, which closed automatically when my fork was briefly deleted. The fix commit is unchanged._
