### PR TITLE
fix(regexes): allow underscores inside httpUrl hostname labels

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -430,7 +430,7 @@ test("httpurl", () => {
   const httpUrl = z.url({
     protocol: /^https?$/,
     hostname: z.regexes.domain,
-    // /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
+    // /^([a-zA-Z0-9](?:[a-zA-Z0-9_-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
   });
 
   httpUrl.parse("https://example.com");
@@ -441,6 +441,10 @@ test("httpurl", () => {
   // subdomains
   httpUrl.parse("https://sub.example.com");
   httpUrl.parse("http://sub.example.com");
+  // underscores inside hostname labels (accepted by the WHATWG URL parser) — #5960
+  httpUrl.parse("https://foo_bar.example.com");
+  httpUrl.parse("https://exa_mple.com");
+  httpUrl.parse("https://julia_artberg.artstation.com");
   // paths
   httpUrl.parse("https://example.com/path/to/resource");
   httpUrl.parse("http://example.com/path/to/resource");
@@ -457,6 +461,8 @@ test("httpurl", () => {
   expect(() => httpUrl.parse("http://")).toThrow();
   expect(() => httpUrl.parse("http://localhost")).toThrow();
   expect(() => httpUrl.parse("http://-asdf.com")).toThrow();
+  // underscore is only allowed inside a label, not at its start/end — #5960
+  expect(() => httpUrl.parse("http://_asdf.com")).toThrow();
   expect(() =>
     httpUrl.parse(
       "http://asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf.com"

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -84,7 +84,10 @@ export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
 export const hostname: RegExp =
   /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
 
-export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+// Underscores are permitted inside a label (not as the first/last character,
+// mirroring how hyphens are handled). The WHATWG URL parser accepts hostnames
+// like `foo_bar.example.com`, so `z.httpUrl()` should too. (#5960)
+export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9_-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
 
 export const httpProtocol: RegExp = /^https?$/;
 


### PR DESCRIPTION
## Problem

`z.httpUrl()` rejects URLs whose hostname contains an underscore, even though the WHATWG URL parser accepts them:

```ts
const schema = z.httpUrl();
schema.safeParse(https://example.com/image.jpg);      // ✅ ok
schema.safeParse(https://foo_bar.example.com/img.jpg); // ❌ fails (should pass)
schema.safeParse(https://exa_mple.com/img.jpg);        // ❌ fails (should pass)
```

`new URL(https://foo_bar.example.com)` parses fine and yields hostname `foo_bar.example.com`, so `z.httpUrl()` was rejecting hosts the URL parser had already accepted.

## Root cause

`z.httpUrl()` validates the URL host against `regexes.domain`, whose per-label character class `[a-zA-Z0-9-]` excluded `_`.

## Fix

Add `_` to the inner character class (`[a-zA-Z0-9_-]`) so underscores are permitted **inside** a label, but not as its first or last character — mirroring exactly how hyphens are already handled. Leading/trailing-underscore labels (e.g. `_asdf.com`) remain invalid.

`regexes.domain` is only used by `z.httpUrl()`, so this change has no effect on other formats (e.g. email).

## Test

Extended the `httpurl` test in `string.test.ts`:
- positive: `foo_bar.example.com`, `exa_mple.com`, `julia_artberg.artstation.com`
- negative (boundary): `_asdf.com` still throws.

Fixes #5960

---
_Restores #6101, which closed automatically when my fork was briefly deleted. The fix commit is unchanged._
