### PR TITLE
fix(json-schema): don't let metadata override Zod-derived keywords

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1841,6 +1841,34 @@ describe("toJSONSchema", () => {
   });
 });
 
+test("metadata does not override Zod-derived keywords", () => {
+  // `type` is derived from the schema and must not be clobbered by metadata.
+  expect(z.toJSONSchema(z.string().meta({ type: "number" } as any))).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+    }
+  `);
+
+  // Metadata still contributes keys Zod did not produce.
+  expect(z.toJSONSchema(z.string().meta({ description: "a name", format: "email" } as any))).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "a name",
+      "format": "email",
+      "type": "string",
+    }
+  `);
+
+  // Metadata may still supply `type` for an otherwise-unrepresentable schema.
+  expect(z.toJSONSchema(z.unknown().meta({ type: "string" } as any))).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+    }
+  `);
+});
+
 test("override", () => {
   const schema = z.toJSONSchema(z.string(), {
     override: (ctx) => {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -195,8 +195,17 @@ export function process<T extends schemas.$ZodType>(
   }
 
   // metadata
+  // Keywords derived from the schema itself take precedence over metadata:
+  // metadata may only contribute keys Zod did not already produce (description,
+  // examples, custom vocabulary, or a `type` for an otherwise-unrepresentable
+  // schema). This prevents `z.string().meta({ type: "number" })` from emitting a
+  // `type` that contradicts the actual schema.
   const meta = ctx.metadataRegistry.get(schema);
-  if (meta) Object.assign(result.schema, meta);
+  if (meta) {
+    for (const key in meta) {
+      if (!(key in result.schema)) result.schema[key] = meta[key];
+    }
+  }
 
   if (ctx.io === "input" && isTransforming(schema)) {
     // examples/defaults only apply to output type of pipe


### PR DESCRIPTION
Fixes #5990.

## Problem

`z.toJSONSchema()` copied a schema's registered metadata over the generated schema with `Object.assign`, letting metadata clobber keywords Zod derives from the schema itself:

```ts
z.toJSONSchema(z.string().meta({ type: "number" }));
// { "$schema": "...", "type": "number" }   ❌  contradicts the schema
```

## Fix

Metadata now fills only keys Zod did **not** already produce. Schema-derived keywords (`type`, `properties`, `format` from validators, …) take precedence, so the example above keeps `type: "string"`.

Metadata is still additive for everything else:

- It contributes keys Zod doesn't emit (`description`, `examples`, custom vocabulary).
- It can still supply a `type` for an otherwise-unrepresentable schema (e.g. `z.unknown().meta({ type: "string" })` → `type: "string"`).

```ts
z.toJSONSchema(z.string().meta({ type: "number" }));
// { "$schema": "...", "type": "string" }   ✅
```

This matches proposal 2 in the issue ("zod values take precedence and overwrite meta"). Note it's a behavior change for anyone relying on metadata to override a derived keyword; the empty-registry escape hatch (`schema.toJSONSchema({ metadata: z.registry() })`) is unaffected.

## Tests

Added a regression test in `to-json-schema.test.ts` covering all three cases (override blocked, additive metadata preserved, `type` still supplied for unrepresentable schemas). No existing snapshots change.


---
_Restores #6113, which closed automatically when my fork was briefly deleted. The fix commit is unchanged._
