### PR TITLE
fix(errors): report non-finite numbers as "Infinity" in invalid_type message

### DIFF
--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -22,7 +22,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -36,7 +36,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -208,7 +208,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -222,7 +222,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -886,7 +886,12 @@ export function parsedType(data: unknown): errors.$ZodInvalidTypeExpected {
   const t = typeof data;
   switch (t) {
     case "number": {
-      return Number.isNaN(data) ? "nan" : "number";
+      // Non-finite numbers are reported distinctly so the message matches the
+      // issue's `received` field (e.g. `z.number().parse(Infinity)`), instead
+      // of the confusing "expected number, received number".
+      if (Number.isNaN(data)) return "nan";
+      if (!Number.isFinite(data)) return "Infinity";
+      return "number";
     }
     case "object": {
       if (data === null) {


### PR DESCRIPTION
Fixes #5697.

## Problem

Parsing a non-finite number produced a confusing, self-contradictory message:

```ts
z.number().finite().safeParse(Infinity).error;
// {
//   code: "invalid_type",
//   expected: "number",
//   received: "Infinity",                                  // ← correct
//   message: "Invalid input: expected number, received number"  // ❌ "number"
// }
```

The issue's `received` field is already `"Infinity"`, but the rendered message said "received number".

## Cause

The locale message recomputes the received type via `util.parsedType(issue.input)`. That helper special-cased `NaN` (→ `"nan"`, displayed as `"NaN"`) but not non-finite numbers, so `Infinity`/`-Infinity` fell through to `"number"`.

## Fix

`parsedType` now returns `"Infinity"` for non-finite numbers, mirroring the existing `NaN` handling and matching the issue's `received` field:

```ts
z.number().finite().safeParse(Infinity).error;
// message: "Invalid input: expected number, received Infinity"   ✅
```

Because every locale shares `parsedType`, this fixes the message consistently across all of them.

## Tests

Updated the existing `Infinity validation` and `.finite() validation` snapshots in `number.test.ts` — they previously captured the buggy "received number" message (right next to `received: "Infinity"`); they now assert the corrected message. Full v4 suite passes.


---
_Restores #6115, which closed automatically when my fork was briefly deleted. The fix commit is unchanged._
