### PR TITLE
fix(errors): make formatError prototype-safe (crash + prototype pollution)

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -805,3 +805,34 @@ test("z.treeifyError nested union with real schema", () => {
     }
   }
 });
+
+test("z.formatError does not crash on Object.prototype-named keys", () => {
+  // A field whose name shadows an Object.prototype member used to make the
+  // accumulator resolve to the inherited member and throw "Cannot read
+  // properties of undefined (reading 'push')".
+  for (const key of ["constructor", "toString", "valueOf", "hasOwnProperty", "isPrototypeOf"]) {
+    const schema = z.object({ [key]: z.number() });
+    const result = schema.safeParse({ [key]: "not a number" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const formatted: any = z.formatError(result.error);
+      expect(Array.isArray(formatted[key]?._errors)).toBe(true);
+      expect(formatted[key]._errors.length).toBeGreaterThan(0);
+    }
+  }
+});
+
+test("z.formatError does not crash or pollute Object.prototype on __proto__ paths", () => {
+  // single-level "__proto__" path: must not throw
+  const single = new z.ZodError([{ code: "custom", path: ["__proto__"], message: "boom", input: undefined }] as any);
+  expect(() => z.formatError(single)).not.toThrow();
+
+  // nested "__proto__" path: must not mutate the global Object.prototype
+  const nested = new z.ZodError([
+    { code: "custom", path: ["__proto__", "polluted"], message: "boom", input: undefined },
+  ] as any);
+  const formatted: any = z.formatError(nested);
+  expect(({} as any).polluted).toBeUndefined();
+  // the error is still represented under an own "__proto__" key
+  expect(formatted.__proto__?.polluted?._errors).toEqual(["boom"]);
+});

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -311,14 +311,27 @@ export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssu
             const el = fullpath[i]!;
             const terminal = i === fullpath.length - 1;
 
-            if (!terminal) {
-              curr[el] = curr[el] || { _errors: [] };
-            } else {
-              curr[el] = curr[el] || { _errors: [] };
-              curr[el]._errors.push(mapper(issue));
+            // A path segment may name an `Object.prototype` member (e.g.
+            // "constructor", "toString") or "__proto__". A plain `curr[el]`
+            // read would resolve to the inherited member, and a plain
+            // `curr[el] = ...` for "__proto__" would invoke the prototype
+            // setter — walking into and polluting the prototype chain instead
+            // of building the tree. Use an own-property check plus
+            // `defineProperty` so every node is a fresh own data property and
+            // the inherited accessor is never triggered.
+            if (!Object.prototype.hasOwnProperty.call(curr, el)) {
+              Object.defineProperty(curr, el, {
+                value: { _errors: [] },
+                writable: true,
+                enumerable: true,
+                configurable: true,
+              });
             }
 
             curr = curr[el];
+            if (terminal) {
+              curr._errors.push(mapper(issue));
+            }
             i++;
           }
         }


### PR DESCRIPTION
## Summary

`z.formatError` / `.format()` throws on validation errors whose path contains a
key named after an `Object.prototype` member (`constructor`, `toString`,
`valueOf`, `hasOwnProperty`, …). Because those keys can come straight from
**untrusted input** via `z.record` (or any object-shaped schema), an attacker can
turn a normal "invalid input" response into an **unhandled exception** in the
error-handling path.

### Concrete impact: DoS via `z.record` + `formatError`

```ts
const schema = z.record(z.string(), z.number());

// untrusted request body — the attacker controls the keys
const body = JSON.parse('{"constructor": "not-a-number"}');

const result = schema.safeParse(body);
if (!result.success) {
  // extremely common in error handlers / API responses:
  return res.status(400).json(z.formatError(result.error));
  //                          ^ throws: TypeError: Cannot read properties of
  //                            undefined (reading 'push')
}
```

A single field named `constructor` (or `toString`, etc.) makes `formatError`
throw instead of returning the field errors, so the request crashes rather than
returning a clean 400. Any app that validates record/loose-object input and
formats the error with `formatError`/`.format()` is affected.

### Secondary: prototype-pollution hardening

The same accumulator also mishandles a `__proto__` path segment: a single-level
`__proto__` path crashes, and a nested one writes onto the global
`Object.prototype`:

```ts
const s = z.string().superRefine((_, ctx) =>
  ctx.addIssue({ code: "custom", message: "x", path: ["__proto__", "polluted"] })
);
z.formatError(s.safeParse("y").error);
({} as any).polluted; // => { _errors: ["x"] }   ❌ global prototype mutated
```

Note this branch is **not** reachable from untrusted data — zod's parser already
strips `__proto__` keys, so a real issue path never contains `__proto__`; you have
to author such a path yourself (e.g. a custom `superRefine`). It's fixed here as
defense-in-depth, but the attacker-reachable problem is the crash above.

## Fix

The accumulator built each node with `curr[el] = curr[el] || { _errors: [] }`.
For a segment like `constructor`/`toString`, the truthy read resolves to the
inherited prototype member, so the node is never created and `curr._errors.push`
throws. For `__proto__`, the inherited accessor is walked instead — crashing on a
single-level path and mutating the global prototype on a nested one.

Each node is now created with an own-property check plus `Object.defineProperty`,
so a fresh own data property is always made and the inherited accessor is never
triggered. `treeifyError` already uses the analogous own-property guard; this
brings `formatError` in line and closes the pollution sink. The result keeps its
normal object shape, so existing snapshots are unaffected.

## Test

Adds two regression tests to `error-utils.test.ts`:
- `formatError` over `constructor`/`toString`/`valueOf`/`hasOwnProperty`/`isPrototypeOf`
  fields returns the errors under the corresponding key instead of throwing.
- `formatError` on `["__proto__"]` does not throw, and on `["__proto__","polluted"]`
  does not mutate `Object.prototype` (`({}).polluted` stays `undefined`).

Both fail on `main` and pass with this change; the full `zod` suite (3812 tests)
stays green.

## Reference

This is the `formatError` counterpart to the `treeifyError` prototype-key
hardening, and matches zod's existing `__proto__` guards in object/record parsing
(`core/schemas.ts`).
