### PR TITLE
fix(checks): don't throw from safeParse on bigint multipleOf(0n)

### DIFF
--- a/packages/zod/src/v4/classic/tests/bigint.test.ts
+++ b/packages/zod/src/v4/classic/tests/bigint.test.ts
@@ -52,3 +52,13 @@ test("min max getters", () => {
   expect(z.bigint().max(BigInt(5)).maxValue).toEqual(BigInt(5));
   expect(z.bigint().max(BigInt(5)).max(BigInt(1)).maxValue).toEqual(BigInt(1));
 });
+
+test("multipleOf(0n) does not throw from safeParse", () => {
+  // `value % 0n` throws RangeError; safeParse must never throw. Mirror the
+  // number branch, where z.number().multipleOf(0) reports a failure instead.
+  const schema = z.bigint().multipleOf(BigInt(0));
+  const result = schema.safeParse(BigInt(10));
+  expect(result.success).toBe(false);
+  // consistent with the number equivalent
+  expect(z.number().multipleOf(0).safeParse(10).success).toBe(false);
+});

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -178,7 +178,10 @@ export const $ZodCheckMultipleOf: core.$constructor<$ZodCheckMultipleOf<number |
         throw new Error("Cannot mix number and bigint in multiple_of check.");
       const isMultiple =
         typeof payload.value === "bigint"
-          ? payload.value % (def.value as bigint) === BigInt(0)
+          ? // Guard against a 0n divisor: `value % 0n` throws RangeError, which
+            // would escape safeParse. Treat it as "not a multiple", matching the
+            // number branch where floatSafeRemainder(value, 0) is NaN !== 0.
+            (def.value as bigint) !== BigInt(0) && payload.value % (def.value as bigint) === BigInt(0)
           : util.floatSafeRemainder(payload.value, def.value as number) === 0;
 
       if (isMultiple) return;


### PR DESCRIPTION
## Summary

`z.bigint().multipleOf(0n).safeParse(10n)` throws `RangeError: Division by zero`
instead of returning a result object. `safeParse` is contractually never supposed
to throw, and the number equivalent already returns `{ success: false }`:

```ts
z.number().multipleOf(0).safeParse(10);   // { success: false }  ✅
z.bigint().multipleOf(0n).safeParse(10n); // throws RangeError    ❌
```

## Fix

The `multiple_of` check's bigint branch computed `value % def.value` directly, and
`value % 0n` throws. The number branch already tolerates a 0 divisor —
`floatSafeRemainder(value, 0)` is `NaN`, which `!== 0`, so the value is reported as
not-a-multiple. Guard the bigint branch so a `0n` divisor is likewise treated as
not-a-multiple, making the two branches consistent and keeping `safeParse`
throw-free.

## Test

Adds a regression test asserting `z.bigint().multipleOf(0n).safeParse(10n)` returns
`success: false`, alongside the matching `z.number().multipleOf(0)` behavior. Fails
on `main`, passes here; full `zod` suite stays green.
