### PR TITLE
feat(types): implement native .partial method for ZodTuple schemas

### DIFF
--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -3460,6 +3460,17 @@ export class ZodTuple<
     });
   }
 
+  partial(): ZodTuple<
+    { [K in keyof T]: T[K] extends ZodTypeAny ? ZodOptional<T[K]> : never } & (ZodTupleItems | []),
+    Rest extends ZodTypeAny ? ZodOptional<Rest> : null
+  > {
+    return new ZodTuple({
+      ...this._def,
+      items: this._def.items.map((item: any) => item.optional()) as any,
+      rest: this._def.rest ? this._def.rest.optional() : null,
+    }) as any;
+  }
+
   static create = <Items extends [ZodTypeAny, ...ZodTypeAny[]] | []>(
     schemas: Items,
     params?: RawCreateParams


### PR DESCRIPTION
### Description
This PR introduces a native `.partial()` instance method to the `ZodTuple` schema engine. This allows developers to relax element schemas within a tuple down to optional types while fully preserving the fixed-length tuple positional constraints.

### Technical Context
Previously, `ZodTuple` lacked an independent `.partial()` implementation, requiring developers to rely on global recursive strategies like `.deepPartial()` from a parent object. When trying to make tuple items optional directly, type structures often fell back to generic array mappings, losing critical fixed-length index metadata. 

### Resolution Strategy
* **Native Class Expansion:** Injected the `partial()` signature directly onto the `ZodTuple` prototype inside `packages/zod/src/v3/types.ts`.
* **Positional Index Retention:** Utilized `.map()` over the internal `this._def.items` schema collection to explicitly wrap each positional index node inside a `ZodOptional` wrapper.
* **Variadic Rest Support:** Added handling to ensure that if a variadic rest schema element (`this._def.rest`) exists on the tuple configuration, it is automatically relaxed via `.optional()` as well.