### PR TITLE
fix(checks): correct includes position regex to match String.includes semantics

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -486,7 +486,7 @@ describe("toJSONSchema", () => {
             "pattern": "cruel",
           },
           {
-            "pattern": "^.{10}dark",
+            "pattern": "^.{10,}dark",
           },
           {
             "pattern": ".*world$",
@@ -525,7 +525,7 @@ describe("toJSONSchema", () => {
             "type": "string",
           },
           {
-            "pattern": "^.{10}dark",
+            "pattern": "^.{10,}dark",
             "type": "string",
           },
           {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -967,7 +967,7 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     $ZodCheck.init(inst, def);
 
     const escapedRegex = util.escapeRegex(def.includes);
-    const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position}}${escapedRegex}` : escapedRegex);
+    const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position},}${escapedRegex}` : escapedRegex);
     def.pattern = pattern;
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];


### PR DESCRIPTION
## Summary

The regex pattern generated by `$ZodCheckIncludes` for `bag.patterns` does not match the semantics of `String.prototype.includes(str, position)` when a `position` parameter is provided.

**Current behavior:** The regex `^.{N}substr` requires the substring to appear at **exactly** index N.

**Expected behavior:** `String.prototype.includes(str, N)` searches from index N **onward**, allowing the substring at any index >= N.

**Example:**
```ts
const schema = z.string().includes("abc", { position: 3 });

schema.parse("xxxXXXabc"); // ✅ passes runtime check (includes finds "abc" at index 6)
// but regex /^.{3}abc/ does NOT match → bag.patterns disagrees with actual validation
```

This can cause inconsistencies when downstream tools (e.g., JSON Schema generators, frontend validators) use the regex from `bag.patterns` for client-side validation.

## Fix

Changed `^.{N}substr` to `^.{N,}substr` — the greedy quantifier `.{N,}` allows N or more characters before the substring, matching the "search from position onward" semantics of `String.includes`.