### PR TITLE
fix: escape JSON Pointer reserved characters in toJSONSchema $ref

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2098,6 +2098,15 @@ test("extract schemas with id", () => {
   `);
 });
 
+test("escapes JSON Pointer reserved characters in $ref but not in $defs key", () => {
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User }));
+  // the $ref pointer escapes `/` -> `~1` and `~` -> `~0` (RFC 6901),
+  // while the $defs key keeps the original id
+  expect((result.properties!.User as any).$ref).toBe("#/$defs/Shared~1User~0");
+  expect(Object.keys(result.$defs!)).toEqual(["Shared/User~"]);
+});
+
 test("unrepresentable literal values are ignored", () => {
   const a = z.toJSONSchema(z.literal(["hello", null, 5, BigInt(1324), undefined]), { unrepresentable: "any" });
   expect(a).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -214,6 +214,12 @@ export function process<T extends schemas.$ZodType>(
   return _result.schema;
 }
 
+// Escape a reference token for use in a JSON Pointer fragment (RFC 6901):
+// `~` becomes `~0` and `/` becomes `~1`. The `~` replacement must run first.
+function encodeJSONPointerSegment(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
 export function extractDefs<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
@@ -260,7 +266,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${encodeJSONPointerSegment(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +277,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + encodeJSONPointerSegment(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
`toJSONSchema` built `$ref` pointers by interpolating a schema's raw `meta({ id })` into the path, so an id containing the JSON Pointer reserved characters `/` or `~` produced an invalid reference. Per RFC 6901, tokens in a JSON Pointer must escape `~` as `~0` and `/` as `~1`.

```ts
z.toJSONSchema(z.object({ User: z.object({ name: z.string() }).meta({ id: "Shared/User~" }) }))
// $ref was "#/$defs/Shared/User~"  →  now "#/$defs/Shared~1User~0"
```

The `$defs` key is a plain object key and stays as the original, unescaped id; only the `$ref` pointer path is encoded.

Closes #6027.
