### PR TITLE
fix(json-schema): RFC 6901 encode JSON Pointer tokens in $ref when meta id contains '/' or '~'

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3129,3 +3129,12 @@ test("recursive lazy with describe does not stack overflow", () => {
   expect(result).toBeDefined();
   expect(result.$defs).toBeDefined();
 });
+
+test("meta id with '/' and '~' is RFC 6901 encoded in $ref but preserved as-is in $defs key", () => {
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User }));
+  // The $defs key is a plain JSON object key — no encoding needed there
+  expect((result as any).$defs["Shared/User~"]).toBeDefined();
+  // The $ref pointer token must escape ~ as ~0 and / as ~1 (RFC 6901)
+  expect((result as any).properties.User.$ref).toBe("#/$defs/Shared~1User~0");
+});

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -214,6 +214,11 @@ export function process<T extends schemas.$ZodType>(
   return _result.schema;
 }
 
+// RFC 6901 §3: `~` → `~0` and `/` → `~1` (in that order) when used as a JSON Pointer token.
+function encodeJsonPointerToken(token: string): string {
+  return token.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
 export function extractDefs<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
@@ -260,7 +265,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${encodeJsonPointerToken(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +276,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + encodeJsonPointerToken(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
## Problem

`z.toJSONSchema()` concatenates the raw schema id directly into the `$ref` URI fragment:

```ts
return { defId, ref: defUriPrefix + defId };
// → { ref: "#/$defs/Shared/User~" }   // broken
```

Per [RFC 6901 §3](https://datatracker.ietf.org/doc/html/rfc6901#section-3), reference tokens inside a JSON Pointer must escape `~` → `~0` and `/` → `~1`. Without this, a meta id like `"Shared/User~"` produces an invalid pointer that parsers decode as two path segments (`Shared`, `User~`) instead of the single key `"Shared/User~"`.

Fixes #6027

## Fix

Added `encodeJsonPointerToken(token: string)` (two `.replace()` calls, RFC-specified order: `~` first) and applied it in both `$ref`-building sites in `to-json-schema.ts`. The `$defs` key (a plain JSON object key) is intentionally **not** encoded so the definition map remains keyed by the original id.

## Test

```ts
const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
const result = z.toJSONSchema(z.object({ User }));
// $defs key stays raw:  result.$defs["Shared/User~"] exists
// $ref is encoded:      result.properties.User.$ref === "#/$defs/Shared~1User~0"
```