### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,36 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite

--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -29,8 +29,9 @@ jobs:
           sarif: 'true'
 
       - name: Upload SARIF to Code Scanning
-        if: always() && hashFiles('*.sarif') != ''
+        if: always()
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
-          sarif_file: cve-lite-*.sarif
+          sarif_file: .
           category: cve-lite

--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Scan for vulnerabilities
-        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        uses: OWASP/cve-lite-cli@99b7b0dcd4c687116890515dbfa8f955871776cc # v1
         with:
           fail-on: high
           sarif: 'true'


### PR DESCRIPTION
This adds a CVE Lite dependency audit workflow to the zod repository. CVE Lite CLI is an OWASP Lab Project that scans lockfiles locally for vulnerable dependencies using the OSV advisory database -- no package installation required, no network calls to registry endpoints during the scan.

A scan of the current pnpm lockfile found 25 findings across 1,247 packages, including 2 high-severity direct dependencies (next and vite) that have patched versions available. The full breakdown is 2 high direct, 1 critical transitive, 14 high transitive, 7 medium transitive, and 1 low transitive.

The workflow runs on every push and pull request to main, plus a weekly Monday schedule to catch newly published advisories against unchanged dependencies. When findings are present, it generates a SARIF report and uploads it to GitHub Code Scanning via the codeql-action/upload-sarif step, so vulnerabilities appear in the Security tab with file-level location data. The workflow uses `fail-on: high` so CI blocks on high or critical findings.

All GitHub Actions references are pinned to immutable commit SHA digests rather than mutable version tags, following supply chain security best practices.

More about CVE Lite CLI and how it works: https://owasp.org/cve-lite-cli
