### PR TITLE
fix(toJSONSchema): escape RFC 6901 special characters in $ref pointers

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2173,6 +2173,16 @@ test("describe with id", () => {
   `);
 });
 
+test("$ref pointer escapes RFC 6901 special characters in meta id", () => {
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User })) as any;
+
+  // The $defs key is a plain object key and stays raw.
+  expect(result.$defs["Shared/User~"]).toBeDefined();
+  // The $ref pointer escapes `/` as `~1` and `~` as `~0` (RFC 6901).
+  expect(result.properties.User.$ref).toBe("#/$defs/Shared~1User~0");
+});
+
 test("id is stripped from $defs entries (draft-2020-12)", () => {
   // The `id` in `.meta()` is a registration tag — it determines the $defs key
   // but should not leak into the definition body, where it is redundant.

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -214,6 +214,12 @@ export function process<T extends schemas.$ZodType>(
   return _result.schema;
 }
 
+// Escapes a reference token for use in a JSON Pointer ($ref path) per RFC 6901.
+// The $defs object key itself uses the raw id and must not be escaped.
+function escapeJSONPointerSegment(id: string): string {
+  return id.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
 export function extractDefs<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
@@ -260,7 +266,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${escapeJSONPointerSegment(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +277,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + escapeJSONPointerSegment(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
When `z.toJSONSchema()` builds a `$ref` from a schema’s `.meta({ id })`, it inserts the raw id into the pointer path. Per [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901), reference tokens in a JSON Pointer must escape `~` as `~0` and `/` as `~1`, so an id containing either character produces an invalid pointer.

For example, `z.string().meta({ id: "Shared/User~" })` emitted `"$ref": "#/$defs/Shared/User~"` instead of `"#/$defs/Shared~1User~0"`.

The `$defs` object key is a plain JSON key and stays raw — only the pointer path is escaped.

resolves #6027