### PR TITLE
fix(v4): infer partial input for defaulted enum records

### DIFF
--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -25,11 +25,17 @@ test("type inference", () => {
   const recordWithTypescriptEnum = z.record(z.enum(Enum), z.string());
   type recordWithTypescriptEnum = z.infer<typeof recordWithTypescriptEnum>;
 
+  const recordWithEnumKeysAndDefault = z.record(z.enum(["UP", "DOWN"]), z.string().default("unknown"));
+  type recordWithEnumKeysAndDefaultInput = z.input<typeof recordWithEnumKeysAndDefault>;
+  type recordWithEnumKeysAndDefaultOutput = z.output<typeof recordWithEnumKeysAndDefault>;
+
   expectTypeOf<booleanRecord>().toEqualTypeOf<Record<string, boolean>>();
   expectTypeOf<recordWithEnumKeys>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
   expectTypeOf<recordWithLiteralKey>().toEqualTypeOf<Record<"Tuna" | "Salmon" | 21, string>>();
   expectTypeOf<recordWithLiteralUnionKeys>().toEqualTypeOf<Record<"Tuna" | "Salmon" | 21, string>>();
   expectTypeOf<recordWithTypescriptEnum>().toEqualTypeOf<Record<Enum, string>>();
+  expectTypeOf<recordWithEnumKeysAndDefaultInput>().toEqualTypeOf<Partial<Record<"UP" | "DOWN", string | undefined>>>();
+  expectTypeOf<recordWithEnumKeysAndDefaultOutput>().toEqualTypeOf<Record<"UP" | "DOWN", string>>();
 });
 
 test("enum exhaustiveness", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2856,7 +2856,9 @@ export type $InferZodRecordInput<
   Value extends SomeType = $ZodType,
 > = Key extends $partial
   ? Partial<Record<core.input<Key> & PropertyKey, core.input<Value>>>
-  : Record<core.input<Key> & PropertyKey, core.input<Value>>;
+  : Value["_zod"]["optin"] extends "optional"
+    ? Partial<Record<core.input<Key> & PropertyKey, core.input<Value>>>
+    : Record<core.input<Key> & PropertyKey, core.input<Value>>;
 
 export interface $ZodRecordInternals<Key extends $ZodRecordKey = $ZodRecordKey, Value extends SomeType = $ZodType>
   extends $ZodTypeInternals<$InferZodRecordOutput<Key, Value>, $InferZodRecordInput<Key, Value>> {


### PR DESCRIPTION
Align record input inference with the existing exhaustive-record runtime behavior when the value schema accepts absent input.

For `z.record(z.enum([...]), z.string().default(...))`, parsing already runs the value schema for every enum key and fills defaults for missing keys. This updates `$InferZodRecordInput` so those missing enum keys are optional in `z.input`, while keeping the output type exhaustive. Adds a type regression test for the defaulted enum-record case.

Refs #6163.