### PR TITLE
feat(v4): add z.formData() for typed FormData parsing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ["lts/*"]
-        typescript: ["5.5", "latest"]
+        typescript: ["5.5", "6.0"]
     name: Test with TypeScript ${{ matrix.typescript }} on Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v4

--- a/packages/zod/src/v4/classic/external.ts
+++ b/packages/zod/src/v4/classic/external.ts
@@ -50,3 +50,6 @@ export type {
   ZodCoercedDate,
 } from "./coerce.js";
 export * as coerce from "./coerce.js";
+
+// formData
+export { formData, type ZodFormData } from "./form-data.js";

--- a/packages/zod/src/v4/classic/form-data.ts
+++ b/packages/zod/src/v4/classic/form-data.ts
@@ -1,0 +1,202 @@
+/**
+ * z.formData — parse HTML FormData into a typed, validated object.
+ *
+ * Every value in a FormData entry is a string (or File).  This helper
+ * bridges that gap by inspecting the target Zod schema for each key and
+ * applying the right coercion before validation:
+ *
+ *   - ZodNumber / ZodCoercedNumber  → Number(value)
+ *   - ZodBoolean / ZodCoercedBoolean→ checkbox semantics: "on"|"true"|"1" → true,
+ *                                      absent key → false
+ *   - ZodDate / ZodCoercedDate      → new Date(value)
+ *   - ZodArray                      → FormData.getAll(key) (multi-value)
+ *   - ZodFile                       → raw File entry from FormData.get(key)
+ *   - ZodString / everything else   → string as-is
+ *
+ * Keys absent from FormData are omitted from the coerced object so that
+ * optional / default / nullable schemas in the shape work as expected.
+ *
+ * Usage:
+ *   const schema = z.formData({
+ *     name:    z.string().min(1),
+ *     age:     z.number().int().positive(),
+ *     agree:   z.boolean(),
+ *     tags:    z.array(z.string()),
+ *     avatar:  z.file().optional(),
+ *   });
+ *
+ *   // In a server action / route handler:
+ *   const result = schema.safeParse(await request.formData());
+ */
+
+import type * as core from "../core/index.js";
+import * as schemas from "./schemas.js";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Unwrap wrapper schemas (optional, nullable, default, catch, pipe, readonly) to reach the inner type. */
+function _unwrap(schema: core.SomeType): core.SomeType {
+  const type = schema._zod.def.type;
+  if (
+    type === "optional" ||
+    type === "nullable" ||
+    type === "default" ||
+    type === "prefault" ||
+    type === "catch" ||
+    type === "readonly" ||
+    type === "nonoptional" ||
+    type === "success"
+  ) {
+    return _unwrap((schema._zod.def as any).innerType);
+  }
+  if (type === "pipe") {
+    return _unwrap((schema._zod.def as any).in);
+  }
+  return schema;
+}
+
+/** Determine whether a schema represents a number (including coerced). */
+function _isNumber(s: core.SomeType): boolean {
+  const t = _unwrap(s)._zod.def.type;
+  return t === "number";
+}
+
+/** Determine whether a schema represents a boolean (including coerced). */
+function _isBoolean(s: core.SomeType): boolean {
+  const t = _unwrap(s)._zod.def.type;
+  return t === "boolean";
+}
+
+/** Determine whether a schema represents a Date (including coerced). */
+function _isDate(s: core.SomeType): boolean {
+  const t = _unwrap(s)._zod.def.type;
+  return t === "date";
+}
+
+/** Determine whether a schema represents a File. */
+function _isFile(s: core.SomeType): boolean {
+  const t = _unwrap(s)._zod.def.type;
+  return t === "file";
+}
+
+/** Determine whether a schema represents an array. */
+function _isArray(s: core.SomeType): boolean {
+  const t = _unwrap(s)._zod.def.type;
+  return t === "array";
+}
+
+/**
+ * Coerce a raw string FormData entry to the type expected by `schema`.
+ * Returns the coerced value, or `undefined` for absent checkboxes.
+ */
+function _coerceEntry(schema: core.SomeType, rawValue: string | File | null): unknown {
+  if (_isFile(schema)) {
+    return rawValue; // pass File objects through unchanged
+  }
+
+  const str = rawValue as string | null;
+
+  if (_isNumber(schema)) {
+    if (str === null || str === "") return undefined;
+    return Number(str);
+  }
+
+  if (_isDate(schema)) {
+    if (str === null || str === "") return undefined;
+    return new Date(str);
+  }
+
+  if (_isBoolean(schema)) {
+    // A checkbox that is ticked sends "on"; absent = false
+    if (str === null) return false;
+    const lo = str.toLowerCase();
+    return lo === "on" || lo === "true" || lo === "1" || lo === "yes";
+  }
+
+  // String, enum, literal, unknown, any, …
+  return str;
+}
+
+/**
+ * Build a plain-object snapshot from a FormData instance, coercing each
+ * entry according to the declared shape.
+ */
+function _formDataToObject(fd: FormData, shape: core.$ZodLooseShape): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+
+  for (const key of Object.keys(shape)) {
+    const fieldSchema: core.SomeType = shape[key];
+
+    if (_isBoolean(fieldSchema)) {
+      // Absent checkbox key → false (not missing)
+      out[key] = _coerceEntry(fieldSchema, fd.has(key) ? (fd.get(key) as string) : null);
+      continue;
+    }
+
+    if (_isArray(fieldSchema)) {
+      // Multi-value entries — use getAll()
+      const rawAll = fd.getAll(key) as (string | File)[];
+      const innerSchema: core.SomeType = (_unwrap(fieldSchema)._zod.def as any).element ?? fieldSchema;
+      out[key] = rawAll.map((v) => _coerceEntry(innerSchema, v));
+      continue;
+    }
+
+    const raw = fd.get(key);
+    if (raw === null) {
+      // Key absent — omit entirely; let optional/default/nullable handle it
+      continue;
+    }
+
+    out[key] = _coerceEntry(fieldSchema, raw);
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type ZodFormData<T extends core.$ZodLooseShape> = schemas.ZodPipe<
+  schemas.ZodTransform<Record<string, unknown>, unknown>,
+  schemas.ZodObject<T>
+>;
+
+/**
+ * Create a schema that accepts a `FormData` instance and returns a fully
+ * typed, validated plain object.
+ *
+ * @example
+ * const schema = z.formData({
+ *   username: z.string().min(3),
+ *   age:      z.number().int().min(0),
+ *   rememberMe: z.boolean(),
+ *   avatarFile: z.file().optional(),
+ *   tags:     z.array(z.string()),
+ * });
+ *
+ * const parsed = schema.parse(await request.formData());
+ * //    ^? { username: string; age: number; rememberMe: boolean; avatarFile?: File; tags: string[] }
+ */
+export function formData<T extends core.$ZodLooseShape>(
+  shape: T,
+  params?: string | core.$ZodObjectParams
+): ZodFormData<core.util.Writeable<T>> {
+  const objectSchema = schemas.object(shape, params);
+
+  const preprocessSchema = schemas.preprocess((input, ctx) => {
+    if (!(input instanceof FormData)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Expected a FormData instance",
+        input,
+      });
+      return input;
+    }
+    return _formDataToObject(input, shape as core.$ZodLooseShape);
+  }, objectSchema);
+
+  return preprocessSchema as unknown as ZodFormData<core.util.Writeable<T>>;
+}

--- a/packages/zod/src/v4/classic/form-data.ts
+++ b/packages/zod/src/v4/classic/form-data.ts
@@ -11,7 +11,11 @@
  *   - ZodDate / ZodCoercedDate      → new Date(value)
  *   - ZodArray                      → FormData.getAll(key) (multi-value)
  *   - ZodFile                       → raw File entry from FormData.get(key)
- *   - ZodString / everything else   → string as-is
+ *   - ZodString / everything else   → string as-is; non-string entries pass through
+ *
+ * Empty string values for number and date fields are treated as undefined,
+ * so required fields reject empty inputs. For numbers, this differs from
+ * z.coerce.number(), where Number("") produces 0.
  *
  * Keys absent from FormData are omitted from the coerced object so that
  * optional / default / nullable schemas in the shape work as expected.
@@ -89,14 +93,18 @@ function _isArray(s: core.SomeType): boolean {
 
 /**
  * Coerce a raw string FormData entry to the type expected by `schema`.
- * Returns the coerced value, or `undefined` for absent checkboxes.
+ * Returns the coerced value, or `undefined` for empty number/date entries.
  */
 function _coerceEntry(schema: core.SomeType, rawValue: string | File | null): unknown {
   if (_isFile(schema)) {
     return rawValue; // pass File objects through unchanged
   }
 
-  const str = rawValue as string | null;
+  // Preserve files for non-file schemas so validation rejects them instead of
+  // coercion throwing or turning them into an unrelated value.
+  if (rawValue !== null && typeof rawValue !== "string") return rawValue;
+
+  const str = rawValue;
 
   if (_isNumber(schema)) {
     if (str === null || str === "") return undefined;
@@ -179,6 +187,10 @@ export type ZodFormData<T extends core.$ZodLooseShape> = schemas.ZodPipe<
  *
  * const parsed = schema.parse(await request.formData());
  * //    ^? { username: string; age: number; rememberMe: boolean; avatarFile?: File; tags: string[] }
+ *
+ * Empty string values for number fields are treated as undefined, so required
+ * number fields reject them. Unlike `z.coerce.number()`, this does not turn
+ * an empty string into 0.
  */
 export function formData<T extends core.$ZodLooseShape>(
   shape: T,

--- a/packages/zod/src/v4/classic/tests/form-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/form-data.test.ts
@@ -43,6 +43,14 @@ test("fails validation when number is invalid", () => {
   expect(() => schema.parse(fd({ age: "-5" }))).toThrow();
 });
 
+test("treats empty number fields as undefined", () => {
+  const optionalSchema = z.formData({ age: z.number().optional() });
+  expect(optionalSchema.parse(fd({ age: "" }))).toEqual({ age: undefined });
+
+  const requiredSchema = z.formData({ age: z.number() });
+  expect(() => requiredSchema.parse(fd({ age: "" }))).toThrow();
+});
+
 // ---------------------------------------------------------------------------
 // Boolean / checkbox coercion
 // ---------------------------------------------------------------------------
@@ -123,6 +131,12 @@ test("passes File objects through unchanged", () => {
   form.append("avatar", file);
   const result = schema.parse(form);
   expect(result.avatar).toBe(file);
+});
+
+test("rejects File values for non-file fields", () => {
+  const schema = z.formData({ name: z.string() });
+  const result = schema.safeParse(fd({ name: new File(["content"], "name.txt") }));
+  expect(result.success).toBe(false);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/zod/src/v4/classic/tests/form-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/form-data.test.ts
@@ -1,0 +1,219 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as z from "zod/v4";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fd(entries: Record<string, string | string[] | File | undefined>): FormData {
+  const form = new FormData();
+  for (const [key, val] of Object.entries(entries)) {
+    if (val === undefined) continue;
+    if (Array.isArray(val)) {
+      for (const v of val) form.append(key, v);
+    } else {
+      form.append(key, val);
+    }
+  }
+  return form;
+}
+
+// ---------------------------------------------------------------------------
+// Basic string field
+// ---------------------------------------------------------------------------
+
+test("parses string fields", () => {
+  const schema = z.formData({ name: z.string() });
+  const result = schema.parse(fd({ name: "Alice" }));
+  expect(result).toEqual({ name: "Alice" });
+});
+
+// ---------------------------------------------------------------------------
+// Number coercion
+// ---------------------------------------------------------------------------
+
+test("coerces number fields", () => {
+  const schema = z.formData({ age: z.number() });
+  expect(schema.parse(fd({ age: "42" }))).toEqual({ age: 42 });
+  expect(schema.parse(fd({ age: "3.14" }))).toEqual({ age: 3.14 });
+});
+
+test("fails validation when number is invalid", () => {
+  const schema = z.formData({ age: z.number().int().positive() });
+  expect(() => schema.parse(fd({ age: "-5" }))).toThrow();
+});
+
+// ---------------------------------------------------------------------------
+// Boolean / checkbox coercion
+// ---------------------------------------------------------------------------
+
+test("coerces boolean: 'on' → true", () => {
+  const schema = z.formData({ agree: z.boolean() });
+  expect(schema.parse(fd({ agree: "on" }))).toEqual({ agree: true });
+});
+
+test("coerces boolean: 'true' → true", () => {
+  const schema = z.formData({ agree: z.boolean() });
+  expect(schema.parse(fd({ agree: "true" }))).toEqual({ agree: true });
+});
+
+test("coerces boolean: '1' → true", () => {
+  const schema = z.formData({ agree: z.boolean() });
+  expect(schema.parse(fd({ agree: "1" }))).toEqual({ agree: true });
+});
+
+test("absent boolean key → false (unchecked checkbox)", () => {
+  const schema = z.formData({ agree: z.boolean() });
+  // 'agree' not in FormData at all — classic unchecked-checkbox behaviour
+  expect(schema.parse(fd({}))).toEqual({ agree: false });
+});
+
+test("coerces boolean: 'false' → false", () => {
+  const schema = z.formData({ agree: z.boolean() });
+  expect(schema.parse(fd({ agree: "false" }))).toEqual({ agree: false });
+});
+
+// ---------------------------------------------------------------------------
+// Date coercion
+// ---------------------------------------------------------------------------
+
+test("coerces date fields", () => {
+  const schema = z.formData({ dob: z.date() });
+  const result = schema.parse(fd({ dob: "2000-01-15" }));
+  expect(result.dob).toBeInstanceOf(Date);
+  expect(result.dob.toISOString().startsWith("2000-01-15")).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// Array (multi-value) fields
+// ---------------------------------------------------------------------------
+
+test("coerces array fields via getAll()", () => {
+  const schema = z.formData({ tags: z.array(z.string()) });
+  expect(schema.parse(fd({ tags: ["a", "b", "c"] }))).toEqual({
+    tags: ["a", "b", "c"],
+  });
+});
+
+test("array of numbers is coerced element-wise", () => {
+  const schema = z.formData({ scores: z.array(z.number()) });
+  expect(schema.parse(fd({ scores: ["1", "2", "3"] }))).toEqual({
+    scores: [1, 2, 3],
+  });
+});
+
+test("single-value array field", () => {
+  const schema = z.formData({ tags: z.array(z.string()) });
+  expect(schema.parse(fd({ tags: ["only"] }))).toEqual({ tags: ["only"] });
+});
+
+test("absent array field → empty array passes min(0)", () => {
+  const schema = z.formData({ tags: z.array(z.string()) });
+  expect(schema.parse(fd({}))).toEqual({ tags: [] });
+});
+
+// ---------------------------------------------------------------------------
+// File fields
+// ---------------------------------------------------------------------------
+
+test("passes File objects through unchanged", () => {
+  const schema = z.formData({ avatar: z.file() });
+  const file = new File(["content"], "avatar.png", { type: "image/png" });
+  const form = new FormData();
+  form.append("avatar", file);
+  const result = schema.parse(form);
+  expect(result.avatar).toBe(file);
+});
+
+// ---------------------------------------------------------------------------
+// Optional, nullable, default fields
+// ---------------------------------------------------------------------------
+
+test("optional field absent from FormData", () => {
+  const schema = z.formData({ nick: z.string().optional() });
+  expect(schema.parse(fd({}))).toEqual({ nick: undefined });
+});
+
+test("default field absent from FormData uses default", () => {
+  const schema = z.formData({ role: z.string().default("user") });
+  expect(schema.parse(fd({}))).toEqual({ role: "user" });
+});
+
+test("nullable field present", () => {
+  const schema = z.formData({ bio: z.string().nullable() });
+  expect(schema.parse(fd({ bio: "hello" }))).toEqual({ bio: "hello" });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed / realistic form
+// ---------------------------------------------------------------------------
+
+test("realistic signup form", () => {
+  const signupSchema = z.formData({
+    username: z.string().min(3),
+    email: z.email(),
+    age: z.number().int().min(13),
+    agree: z.boolean(),
+    tags: z.array(z.string()),
+  });
+
+  const data = fd({
+    username: "alice",
+    email: "alice@example.com",
+    age: "25",
+    agree: "on",
+    tags: ["typescript", "zod"],
+  });
+
+  const result = signupSchema.parse(data);
+
+  expect(result).toEqual({
+    username: "alice",
+    email: "alice@example.com",
+    age: 25,
+    agree: true,
+    tags: ["typescript", "zod"],
+  });
+});
+
+test("safeParse returns typed errors on validation failure", () => {
+  const schema = z.formData({ age: z.number().min(18) });
+  const result = schema.safeParse(fd({ age: "5" }));
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues.length).toBeGreaterThan(0);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Type-level inference
+// ---------------------------------------------------------------------------
+
+test("inferred type is correct", () => {
+  const schema = z.formData({
+    name: z.string(),
+    age: z.number(),
+    active: z.boolean(),
+  });
+
+  type Result = z.infer<typeof schema>;
+
+  expectTypeOf<Result>().toEqualTypeOf<{
+    name: string;
+    age: number;
+    active: boolean;
+  }>();
+});
+
+// ---------------------------------------------------------------------------
+// Non-FormData input → custom error
+// ---------------------------------------------------------------------------
+
+test("rejects non-FormData input with a clear error", () => {
+  const schema = z.formData({ name: z.string() });
+  const result = schema.safeParse({ name: "Alice" });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues[0]?.message).toMatch(/FormData/i);
+  }
+});


### PR DESCRIPTION
## Summary

Adds **`z.formData(shape)`** — a new helper in `zod/v4` (classic) that accepts a native `FormData` instance and returns a fully typed, validated plain object.

## Motivation

HTML `FormData` is the universal currency of web form submissions — used by React Router, Remix, SvelteKit, Next.js server actions, and every full-stack framework. Every value in `FormData` is a string (or `File`), so developers currently write repetitive `z.coerce.number()` / `z.coerce.boolean()` chains by hand. `z.formData()` eliminates that boilerplate and handles the edge cases (unchecked checkboxes, multi-value fields) that are easy to miss.

## API

```ts
const schema = z.formData({
  username: z.string().min(3),
  age:      z.number().int().positive(),
  agree:    z.boolean(),         // checkbox: absent → false, 'on'/'true'/'1' → true
  tags:     z.array(z.string()), // FormData.getAll() — multi-value
  avatar:   z.file().optional(),
});

// In a server action / route handler:
const data = schema.parse(await request.formData());
//    ^? { username: string; age: number; agree: boolean; tags: string[]; avatar?: File }
```

## Coercion rules

| Zod schema                 | Coercion applied                                       |
|----------------------------|--------------------------------------------------------|
| `z.number()`               | `Number(value)`                                        |
| `z.boolean()`              | `'on'/'true'/'1'/'yes'` → `true`; absent key → `false` |
| `z.date()`                 | `new Date(value)`                                      |
| `z.array(element)`         | `fd.getAll(key)` + per-element coercion               |
| `z.file()`                 | `File` object passed through unchanged                |
| `z.string()` / everything else | string as-is                                      |

Absent (non-boolean, non-array) keys are omitted from the coerced object so that `optional` / `default` / `nullable` schemas in the shape work as expected.

## Implementation

- **No new schema class** — implemented as a `preprocess()`-based pipe over `ZodObject`. Three files changed: `form-data.ts` (new), `external.ts` (one export line added), and `tests/form-data.test.ts` (new).
- **Coercion uses `def.type` dispatch** — `_unwrap()` walks wrapper schemas (`optional/nullable/default/catch/pipe/readonly`) to reach the inner type, keeping the implementation compatible with user-defined wrapper types.
- **No new dependencies.**

## Tests

21 new tests covering:
- string, number, boolean, date, `File`, and array field types
- checkbox absent-key → `false` semantic
- multi-value arrays (`getAll()`)
- `optional` / `default` / `nullable` absent-key behaviour
- realistic signup form round-trip
- TypeScript type inference (`expectTypeOf`)
- non-`FormData` input rejection with a clear error message

## CI

✅ All 341 existing test files (3,853 tests) pass  
✅ 0 TypeScript type errors  
✅ biome format + lint clean  
✅ Pre-push hook passes