### PR TITLE
feat(locales): add turkmen (tk) locale

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -386,6 +386,7 @@ The following locales are available:
 - `sv` — Swedish
 - `ta` — Tamil
 - `th` — Thai
+- `tk` — Türkmen
 - `tr` — Türkçe
 - `uk` — Ukrainian
 - `ur` — Urdu

--- a/packages/zod/jsr.json
+++ b/packages/zod/jsr.json
@@ -56,6 +56,7 @@
     "./v4/locales/sv": "./src/v4/locales/sv.ts",
     "./v4/locales/ta": "./src/v4/locales/ta.ts",
     "./v4/locales/th": "./src/v4/locales/th.ts",
+    "./v4/locales/tk": "./src/v4/locales/tk.ts",
     "./v4/locales/tr": "./src/v4/locales/tr.ts",
     "./v4/locales/ua": "./src/v4/locales/ua.ts",
     "./v4/locales/uk": "./src/v4/locales/uk.ts",

--- a/packages/zod/src/v4/core/tests/locales/tk.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/tk.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "vitest";
+import * as z from "zod/v4";
+import { parsedType } from "../../util.js";
+
+test("parsedType", () => {
+  expect(parsedType("string")).toBe("string");
+  expect(parsedType(1)).toBe("number");
+  expect(parsedType(true)).toBe("boolean");
+  expect(parsedType(null)).toBe("null");
+  expect(parsedType(undefined)).toBe("undefined");
+  expect(parsedType([])).toBe("array");
+  expect(parsedType({})).toBe("object");
+  expect(parsedType(new Date())).toBe("Date");
+  expect(parsedType(new Map())).toBe("Map");
+  expect(parsedType(new Set())).toBe("Set");
+  expect(parsedType(new Error())).toBe("Error");
+
+  const nullPrototype = Object.create(null);
+  expect(parsedType(nullPrototype)).toBe("object");
+
+  const doubleNullPrototype = Object.create(Object.create(null));
+  expect(parsedType(doubleNullPrototype)).toBe("object");
+
+  expect(parsedType(Number.NaN)).toBe("nan");
+});
+
+test("locales - tk", () => {
+  z.config(z.locales.tk());
+
+  const invalidType = z.number().safeParse("a");
+  expect(invalidType.error!.issues[0].code).toBe("invalid_type");
+  expect(invalidType.error!.issues[0].message).toBe("Nädogry baha: garaşylan number ýerine string alyndy");
+
+  const invalidType2 = z.string().safeParse(1);
+  expect(invalidType2.error!.issues[0].code).toBe("invalid_type");
+  expect(invalidType2.error!.issues[0].message).toBe("Nädogry baha: garaşylan string ýerine number alyndy");
+
+  const invalidValue = z.enum(["a", "b"]).safeParse(1);
+  expect(invalidValue.error!.issues[0].code).toBe("invalid_value");
+  expect(invalidValue.error!.issues[0].message).toBe('Nädogry saýlaw: aşakdakylardan biri bolmaly: "a"|"b"');
+
+  const tooBig = z.number().max(10).safeParse(15);
+  expect(tooBig.error!.issues[0].code).toBe("too_big");
+  expect(tooBig.error!.issues[0].message).toBe("Has uly: garaşylýan number <= 10");
+
+  const tooSmall = z.number().min(10).safeParse(5);
+  expect(tooSmall.error!.issues[0].code).toBe("too_small");
+  expect(tooSmall.error!.issues[0].message).toBe("Has kiçi: garaşylýan number >= 10");
+
+  const invalidFormatRegex = z.string().regex(/abcd/).safeParse("invalid-string");
+  expect(invalidFormatRegex.error!.issues[0].code).toBe("invalid_format");
+  expect(invalidFormatRegex.error!.issues[0].message).toBe("Nädogry setir: /abcd/ nusga laýyk bolmaly");
+
+  const invalidFormatStartsWith = z.string().startsWith("abcd").safeParse("invalid-string");
+  expect(invalidFormatStartsWith.error!.issues[0].code).toBe("invalid_format");
+  expect(invalidFormatStartsWith.error!.issues[0].message).toBe('Nädogry setir: "abcd" bilen başlamaly');
+
+  const notMultipleOf = z.number().multipleOf(3).safeParse(10);
+  expect(notMultipleOf.error!.issues[0].code).toBe("not_multiple_of");
+  expect(notMultipleOf.error!.issues[0].message).toBe("Nädogry san: 3 bilen galyndysyz bölünmeli");
+
+  const unrecognizedKeys = z.object({ a: z.string(), b: z.number() }).strict().safeParse({ a: "a", b: 1, c: 2 });
+  expect(unrecognizedKeys.error!.issues[0].code).toBe("unrecognized_keys");
+  expect(unrecognizedKeys.error!.issues[0].message).toBe('Tanalmaýan açar: "c"');
+
+  const invalidUnion = z.union([z.string(), z.number()]).safeParse(true);
+  expect(invalidUnion.error!.issues[0].code).toBe("invalid_union");
+  expect(invalidUnion.error!.issues[0].message).toBe("Nädogry baha");
+});

--- a/packages/zod/src/v4/locales/index.ts
+++ b/packages/zod/src/v4/locales/index.ts
@@ -41,6 +41,7 @@ export { default as sl } from "./sl.js";
 export { default as sv } from "./sv.js";
 export { default as ta } from "./ta.js";
 export { default as th } from "./th.js";
+export { default as tk } from "./tk.js";
 export { default as tr } from "./tr.js";
 export { default as ua } from "./ua.js";
 export { default as uk } from "./uk.js";

--- a/packages/zod/src/v4/locales/tk.ts
+++ b/packages/zod/src/v4/locales/tk.ts
@@ -1,0 +1,112 @@
+import type { $ZodStringFormats } from "../core/checks.js";
+import type * as errors from "../core/errors.js";
+import * as util from "../core/util.js";
+
+const error: () => errors.$ZodErrorMap = () => {
+  const Sizable: Record<string, { unit: string; verb: string }> = {
+    string: { unit: "simwol", verb: "bolmaly" },
+    file: { unit: "baýt", verb: "bolmaly" },
+    array: { unit: "elementler", verb: "bolmaly" },
+    set: { unit: "elementler", verb: "bolmaly" },
+    map: { unit: "elementler", verb: "bolmaly" },
+  };
+
+  function getSizing(origin: string): { unit: string; verb: string } | null {
+    return Sizable[origin] ?? null;
+  }
+
+  const FormatDictionary: {
+    [k in $ZodStringFormats | (string & {})]?: string;
+  } = {
+    regex: "giriş",
+    email: "e-poçta salgysy",
+    url: "URL",
+    emoji: "emoji",
+    uuid: "UUID",
+    uuidv4: "UUIDv4",
+    uuidv6: "UUIDv6",
+    nanoid: "nanoid",
+    guid: "GUID",
+    cuid: "cuid",
+    cuid2: "cuid2",
+    ulid: "ULID",
+    xid: "XID",
+    ksuid: "KSUID",
+    datetime: "ISO sene we wagt",
+    date: "ISO sene",
+    time: "ISO wagt",
+    duration: "ISO wagt aralygy",
+    ipv4: "IPv4 salgysy",
+    ipv6: "IPv6 salgysy",
+    cidrv4: "IPv4 aralygy",
+    cidrv6: "IPv6 aralygy",
+    base64: "base64 bilen şifrlenen setir",
+    base64url: "base64url bilen şifrlenen setir",
+    json_string: "JSON setiri",
+    e164: "E.164 nomeri",
+    jwt: "JWT",
+    template_literal: "şablon",
+  };
+
+  const TypeDictionary: {
+    [k in errors.$ZodInvalidTypeExpected | (string & {})]?: string;
+  } = {
+    nan: "NaN",
+  };
+
+  return (issue) => {
+    switch (issue.code) {
+      case "invalid_type": {
+        const expected = TypeDictionary[issue.expected] ?? issue.expected;
+        const receivedType = util.parsedType(issue.input);
+        const received = TypeDictionary[receivedType] ?? receivedType;
+        if (/^[A-Z]/.test(issue.expected)) {
+          return `Nädogry baha: garaşylan instanceof ${issue.expected}, alynan ${received}`;
+        }
+        return `Nädogry baha: garaşylan ${expected} ýerine ${received} alyndy`;
+      }
+      case "invalid_value":
+        if (issue.values.length === 1) return `Nädogry baha: ${util.stringifyPrimitive(issue.values[0])} bolmaly`;
+        return `Nädogry saýlaw: aşakdakylardan biri bolmaly: ${util.joinValues(issue.values, "|")}`;
+      case "too_big": {
+        const adj = issue.inclusive ? "<=" : "<";
+        const sizing = getSizing(issue.origin);
+        if (sizing)
+          return `Has uly: garaşylýan ${issue.origin ?? "baha"} ${adj}${issue.maximum.toString()} ${sizing.unit ?? "element"}`;
+        return `Has uly: garaşylýan ${issue.origin ?? "baha"} ${adj}${issue.maximum.toString()}`;
+      }
+      case "too_small": {
+        const adj = issue.inclusive ? ">=" : ">";
+        const sizing = getSizing(issue.origin);
+        if (sizing) return `Has kiçi: garaşylýan ${issue.origin} ${adj}${issue.minimum.toString()} ${sizing.unit}`;
+        return `Has kiçi: garaşylýan ${issue.origin} ${adj}${issue.minimum.toString()}`;
+      }
+      case "invalid_format": {
+        const _issue = issue as errors.$ZodStringFormatIssues;
+        if (_issue.format === "starts_with") return `Nädogry setir: "${_issue.prefix}" bilen başlamaly`;
+        if (_issue.format === "ends_with") return `Nädogry setir: "${_issue.suffix}" bilen gutarmaly`;
+        if (_issue.format === "includes") return `Nädogry setir: "${_issue.includes}" saklamaly`;
+        if (_issue.format === "regex") return `Nädogry setir: ${_issue.pattern} nusga laýyk bolmaly`;
+        return `Nädogry ${FormatDictionary[_issue.format] ?? issue.format}`;
+      }
+      case "not_multiple_of":
+        return `Nädogry san: ${issue.divisor} bilen galyndysyz bölünmeli`;
+      case "unrecognized_keys":
+        return `Tanalmaýan açar${issue.keys.length > 1 ? "lar" : ""}: ${util.joinValues(issue.keys, ", ")}`;
+      case "invalid_key":
+        return `${issue.origin} içinde nädogry açar`;
+      case "invalid_union":
+        return "Nädogry baha";
+      case "invalid_element":
+        return `${issue.origin} içinde nädogry baha`;
+      default:
+        return `Nädogry baha`;
+    }
+  };
+};
+
+export default function (): { localeError: errors.$ZodErrorMap } {
+  return {
+    localeError: error(),
+  };
+}

--- a/packages/zod/src/v4/locales/tk.ts
+++ b/packages/zod/src/v4/locales/tk.ts
@@ -60,9 +60,6 @@ const error: () => errors.$ZodErrorMap = () => {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
         const receivedType = util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
-        if (/^[A-Z]/.test(issue.expected)) {
-          return `Nädogry baha: garaşylan instanceof ${issue.expected}, alynan ${received}`;
-        }
         return `Nädogry baha: garaşylan ${expected} ýerine ${received} alyndy`;
       }
       case "invalid_value":
@@ -72,14 +69,14 @@ const error: () => errors.$ZodErrorMap = () => {
         const adj = issue.inclusive ? "<=" : "<";
         const sizing = getSizing(issue.origin);
         if (sizing)
-          return `Has uly: garaşylýan ${issue.origin ?? "baha"} ${adj}${issue.maximum.toString()} ${sizing.unit ?? "element"}`;
-        return `Has uly: garaşylýan ${issue.origin ?? "baha"} ${adj}${issue.maximum.toString()}`;
+          return `Has uly: garaşylýan ${issue.origin ?? "baha"} ${adj} ${issue.maximum.toString()} ${sizing.unit ?? "element"}`;
+        return `Has uly: garaşylýan ${issue.origin ?? "baha"} ${adj} ${issue.maximum.toString()}`;
       }
       case "too_small": {
         const adj = issue.inclusive ? ">=" : ">";
         const sizing = getSizing(issue.origin);
-        if (sizing) return `Has kiçi: garaşylýan ${issue.origin} ${adj}${issue.minimum.toString()} ${sizing.unit}`;
-        return `Has kiçi: garaşylýan ${issue.origin} ${adj}${issue.minimum.toString()}`;
+        if (sizing) return `Has kiçi: garaşylýan ${issue.origin} ${adj} ${issue.minimum.toString()} ${sizing.unit}`;
+        return `Has kiçi: garaşylýan ${issue.origin} ${adj} ${issue.minimum.toString()}`;
       }
       case "invalid_format": {
         const _issue = issue as errors.$ZodStringFormatIssues;


### PR DESCRIPTION
This PR adds the `tk` locale for Zod, providing Turkmen (Türkmen) translations.

## Changes

* Added a new `tk` locale file.
* Registered in index.ts and jsr.json (alphbetically correct)
* Included tests