### PR TITLE
fix(v4): stop broadening optional/default/prefault fields with partial

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1437,6 +1437,18 @@ export type SafeExtendShape<Base extends core.$ZodShape, Ext extends core.$ZodLo
     : Ext[K];
 };
 
+// `.partial()` leaves a field untouched when it already accepts absent input
+// *and* produces a deliberate value for it (`optional`, `default`, `prefault`);
+// otherwise it wraps in `ZodOptional`. Keyed on `def.type` rather than `optin`
+// on purpose: `catch`/`transform`/`preprocess` also report `optin: "optional"`
+// at runtime, but their static optin defers to the inner type, and the wrapping
+// `ZodOptional` does real work for them (clobbering their fallback on absent
+// input). Matching on `def.type` keeps the inferred type and the runtime shape
+// in sync for every schema.
+type PartialField<T extends core.SomeType> = T extends { _zod: { def: { type: "optional" | "default" | "prefault" } } }
+  ? T
+  : ZodOptional<T>;
+
 export interface ZodObject<
   /** @ts-ignore Cast variance */
   out Shape extends core.$ZodShape = core.$ZodLooseShape,
@@ -1482,7 +1494,7 @@ export interface ZodObject<
 
   partial(): ZodObject<
     {
-      -readonly [k in keyof Shape]: ZodOptional<Shape[k]>;
+      -readonly [k in keyof Shape]: PartialField<Shape[k]>;
     },
     Config
   >;
@@ -1490,12 +1502,7 @@ export interface ZodObject<
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
   ): ZodObject<
     {
-      -readonly [k in keyof Shape]: k extends keyof M
-        ? // Shape[k] extends OptionalInSchema
-          //   ? Shape[k]
-          //   :
-          ZodOptional<Shape[k]>
-        : Shape[k];
+      -readonly [k in keyof Shape]: k extends keyof M ? PartialField<Shape[k]> : Shape[k];
     },
     Config
   >;

--- a/packages/zod/src/v4/classic/tests/partial.test.ts
+++ b/packages/zod/src/v4/classic/tests/partial.test.ts
@@ -8,6 +8,7 @@ const nested = z.object({
     inner: z.string(),
   }),
   array: z.array(z.object({ asdf: z.string() })),
+  default: z.number().default(1),
 });
 
 test("shallow inference", () => {
@@ -19,6 +20,7 @@ test("shallow inference", () => {
     age?: number | undefined;
     outer?: { inner: string } | undefined;
     array?: { asdf: string }[] | undefined;
+    default: number;
   }>();
 });
 
@@ -119,7 +121,8 @@ test("partial with mask", async () => {
 
   expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
-  expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
+  // `field` is already optional-in via its default, so it's left untouched
+  expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
   expect(masked.shape.country).toBeInstanceOf(z.ZodString);
 
   masked.parse({ country: "US" });
@@ -198,6 +201,58 @@ test("catch/prefault/default", () => {
       "f": "prefault value",
     }
   `);
+});
+
+test("partial for optional/prefault/default", () => {
+  const schema = z.object({
+    required: z.string(),
+    opt: z.string().optional(),
+    a: z.string().default("a"),
+    b: z.string().prefault("b"),
+  });
+
+  const partialed = schema.partial();
+  expect(partialed.shape.required).toBeInstanceOf(z.ZodOptional);
+  expect(partialed.shape.required.unwrap()).toBeInstanceOf(z.ZodString);
+  expect(partialed.shape.opt).toBeInstanceOf(z.ZodOptional);
+  expect(partialed.shape.opt.unwrap()).toBeInstanceOf(z.ZodString);
+  expect(partialed.shape.a).toBeInstanceOf(z.ZodDefault);
+  expect(partialed.shape.a.unwrap()).toBeInstanceOf(z.ZodString);
+  expect(partialed.shape.b).toBeInstanceOf(z.ZodPrefault);
+  expect(partialed.shape.b.unwrap()).toBeInstanceOf(z.ZodString);
+
+  const masked = schema.partial({ opt: true, a: true, b: true });
+  expect(masked.shape.opt).toBeInstanceOf(z.ZodOptional);
+  expect(masked.shape.opt.unwrap()).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.a).toBeInstanceOf(z.ZodDefault);
+  expect(masked.shape.a.unwrap()).toBeInstanceOf(z.ZodString);
+  expect(masked.shape.b).toBeInstanceOf(z.ZodPrefault);
+  expect(masked.shape.b.unwrap()).toBeInstanceOf(z.ZodString);
+});
+
+test("partial keeps accurate types and preserves fallback fields", () => {
+  const schema = z.object({
+    opt: z.string().optional(),
+    def: z.string().default("d"),
+    caught: z.string().catch("c"),
+    pre: z.preprocess((v) => v ?? "p", z.string()),
+  });
+  const p = schema.partial();
+
+  // optional is not re-wrapped and the default is not broadened to `| undefined`
+  // (the default always produces a value, so `def` stays a required output key)
+  expectTypeOf<z.output<typeof p>>().toEqualTypeOf<{
+    opt?: string | undefined;
+    def: string;
+    caught?: string | undefined;
+    pre?: string | undefined;
+  }>();
+
+  // catch/preprocess report optin "optional" at runtime but produce a clobbered
+  // fallback, so they stay wrapped: absent input stays absent, matching the type
+  expect(p.shape.caught).toBeInstanceOf(z.ZodOptional);
+  expect(p.shape.pre).toBeInstanceOf(z.ZodOptional);
+  expect(p.parse({})).toEqual({ def: "d" });
 });
 
 test("handleOptionalObjectResult branches", () => {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -717,6 +717,14 @@ export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
   return clone(a, def) as any;
 }
 
+// Field kinds `.partial()` leaves untouched: already input-optional AND
+// producing a deliberate value for absent input (never a clobbered fallback),
+// so wrapping them in `ZodOptional` would only nest the type / broaden the
+// output. Mirrors `PartialField` in the classic layer. catch/transform/
+// preprocess are intentionally excluded: their runtime `optin` is "optional"
+// but the wrapping `ZodOptional` still does real work (clobbering fallback).
+const partialSkipTypes = new Set(["optional", "default", "prefault"]);
+
 export function partial(
   Class: SchemaClass<schemas.$ZodOptional> | null,
   schema: schemas.$ZodObject,
@@ -740,7 +748,7 @@ export function partial(
             throw new Error(`Unrecognized key: "${key}"`);
           }
           if (!(mask as any)[key]) continue;
-          // if (oldShape[key]!._zod.optin === "optional") continue;
+          if (partialSkipTypes.has(oldShape[key]!._zod.def.type)) continue;
           shape[key] = Class
             ? new Class({
                 type: "optional",
@@ -750,7 +758,7 @@ export function partial(
         }
       } else {
         for (const key in oldShape) {
-          // if (oldShape[key]!._zod.optin === "optional") continue;
+          if (partialSkipTypes.has(oldShape[key]!._zod.def.type)) continue;
           shape[key] = Class
             ? new Class({
                 type: "optional",


### PR DESCRIPTION
Fixes #6171.

While looking into the incorrect types produced by `.partial()`, we found this logic already implemented but commented out.

Simply enabling it doesn't quite work: it keys on `_zod.optin`, which also changes the behavior of `catch`/`transform`/`preprocess`. Their wrapping `ZodOptional` is still semantically meaningful, so skipping it changes `partial().parse(...)`.

This instead keys on `def.type` (`optional`, `default`, `prefault`), fixing the two typing issues without changing runtime behavior:

- already-optional fields no longer become `ZodOptional<ZodOptional<...>>`;
- `default`/`prefault` fields no longer infer `T | undefined` when parsing always produces a value.

This may not be the final direction—especially with the optionality work in flight—but it seemed like a useful starting point. If the intent is to solve this through `optin`/`fallback` instead, we're happy to reshape or fold this into that work. Refs #5235, #5315, #5642, #4799.