### PR TITLE
fix: use exact flag in English locale too_small/too_big messages + fix .partial() double-wrapping

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1437,6 +1437,18 @@ export type SafeExtendShape<Base extends core.$ZodShape, Ext extends core.$ZodLo
     : Ext[K];
 };
 
+// `.partial()` leaves a field untouched when it already accepts absent input
+// *and* produces a deliberate value for it (`optional`, `default`, `prefault`);
+// otherwise it wraps in `ZodOptional`. Keyed on `def.type` rather than `optin`
+// on purpose: `catch`/`transform`/`preprocess` also report `optin: "optional"`
+// at runtime, but their static optin defers to the inner type, and the wrapping
+// `ZodOptional` does real work for them (clobbering their fallback on absent
+// input). Matching on `def.type` keeps the inferred type and the runtime shape
+// in sync for every schema.
+type PartialField<T extends core.SomeType> = T extends { _zod: { def: { type: "optional" | "default" | "prefault" } } }
+  ? T
+  : ZodOptional<T>;
+
 export interface ZodObject<
   /** @ts-ignore Cast variance */
   out Shape extends core.$ZodShape = core.$ZodLooseShape,
@@ -1482,7 +1494,7 @@ export interface ZodObject<
 
   partial(): ZodObject<
     {
-      -readonly [k in keyof Shape]: ZodOptional<Shape[k]>;
+      -readonly [k in keyof Shape]: PartialField<Shape[k]>;
     },
     Config
   >;
@@ -1490,12 +1502,7 @@ export interface ZodObject<
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
   ): ZodObject<
     {
-      -readonly [k in keyof Shape]: k extends keyof M
-        ? // Shape[k] extends OptionalInSchema
-          //   ? Shape[k]
-          //   :
-          ZodOptional<Shape[k]>
-        : Shape[k];
+      -readonly [k in keyof Shape]: k extends keyof M ? PartialField<Shape[k]> : Shape[k];
     },
     Config
   >;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3883,7 +3883,7 @@ export interface $ZodCatchDef<T extends SomeType = $ZodType> extends $ZodTypeDef
 export interface $ZodCatchInternals<T extends SomeType = $ZodType>
   extends $ZodTypeInternals<core.output<T>, core.input<T>> {
   def: $ZodCatchDef<T>;
-  optin: T["_zod"]["optin"];
+  optin: "optional";
   optout: T["_zod"]["optout"];
   isst: never;
   values: T["_zod"]["values"];

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -717,6 +717,14 @@ export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
   return clone(a, def) as any;
 }
 
+// Field kinds `.partial()` leaves untouched: already input-optional AND
+// producing a deliberate value for absent input (never a clobbered fallback),
+// so wrapping them in `ZodOptional` would only nest the type / broaden the
+// output. Mirrors `PartialField` in the classic layer. catch/transform/
+// preprocess are intentionally excluded: their runtime `optin` is "optional"
+// but the wrapping `ZodOptional` still does real work (clobbering fallback).
+const partialSkipTypes = new Set(["optional", "default", "prefault"]);
+
 export function partial(
   Class: SchemaClass<schemas.$ZodOptional> | null,
   schema: schemas.$ZodObject,
@@ -740,7 +748,7 @@ export function partial(
             throw new Error(`Unrecognized key: "${key}"`);
           }
           if (!(mask as any)[key]) continue;
-          // if (oldShape[key]!._zod.optin === "optional") continue;
+          if (partialSkipTypes.has(oldShape[key]!._zod.def.type)) continue;
           shape[key] = Class
             ? new Class({
                 type: "optional",
@@ -750,7 +758,7 @@ export function partial(
         }
       } else {
         for (const key in oldShape) {
-          // if (oldShape[key]!._zod.optin === "optional") continue;
+          if (partialSkipTypes.has(oldShape[key]!._zod.def.type)) continue;
           shape[key] = Class
             ? new Class({
                 type: "optional",

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -71,15 +71,26 @@ const error: () => errors.$ZodErrorMap = () => {
         if (issue.values.length === 1) return `Invalid input: expected ${util.stringifyPrimitive(issue.values[0])}`;
         return `Invalid option: expected one of ${util.joinValues(issue.values, "|")}`;
       case "too_big": {
-        const adj = issue.inclusive ? "<=" : "<";
         const sizing = getSizing(issue.origin);
+        if (issue.exact) {
+          if (sizing)
+            return `Too big: expected ${issue.origin ?? "value"} to have exactly ${issue.maximum.toString()} ${sizing.unit ?? "elements"}`;
+          return `Too big: expected ${issue.origin ?? "value"} to be exactly ${issue.maximum.toString()}`;
+        }
+        const adj = issue.inclusive ? "<=" : "<";
         if (sizing)
           return `Too big: expected ${issue.origin ?? "value"} to have ${adj}${issue.maximum.toString()} ${sizing.unit ?? "elements"}`;
         return `Too big: expected ${issue.origin ?? "value"} to be ${adj}${issue.maximum.toString()}`;
       }
       case "too_small": {
-        const adj = issue.inclusive ? ">=" : ">";
         const sizing = getSizing(issue.origin);
+        if (issue.exact) {
+          if (sizing) {
+            return `Too small: expected ${issue.origin} to have exactly ${issue.minimum.toString()} ${sizing.unit}`;
+          }
+          return `Too small: expected ${issue.origin} to be exactly ${issue.minimum.toString()}`;
+        }
+        const adj = issue.inclusive ? ">=" : ">";
         if (sizing) {
           return `Too small: expected ${issue.origin} to have ${adj}${issue.minimum.toString()} ${sizing.unit}`;
         }

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -951,7 +951,9 @@ export function partial<T extends ZodMiniObject>(
   schema: T
 ): ZodMiniObject<
   {
-    -readonly [k in keyof T["shape"]]: ZodMiniOptional<T["shape"][k]>;
+    -readonly [k in keyof T["shape"]]: T["shape"][k] extends { _zod: { optin: "optional" } }
+      ? T["shape"][k]
+      : ZodMiniOptional<T["shape"][k]>;
   },
   T["_zod"]["config"]
 >;
@@ -961,7 +963,11 @@ export function partial<T extends ZodMiniObject, M extends util.Mask<keyof T["sh
   mask: M & Record<Exclude<keyof M, keyof T["shape"]>, never>
 ): ZodMiniObject<
   {
-    -readonly [k in keyof T["shape"]]: k extends keyof M ? ZodMiniOptional<T["shape"][k]> : T["shape"][k];
+    -readonly [k in keyof T["shape"]]: k extends keyof M
+      ? T["shape"][k] extends { _zod: { optin: "optional" } }
+        ? T["shape"][k]
+        : ZodMiniOptional<T["shape"][k]>
+      : T["shape"][k];
   },
   T["_zod"]["config"]
 >;


### PR DESCRIPTION
Fixes two bugs in Zod v4:

## Bug 1: `exact` size messages show wrong wording
When using `.size()` with `exact: true`, the English locale error messages incorrectly show `>=` / `<=` instead of `exactly`.

**Before:** `"Too small: expected array to have >=2 items"`
**After:** `"Too small: expected array to have exactly 2 items"`

## Bug 2: `.partial()` double-wraps optional/default/prefault fields
When calling `.partial()` on an object that already has optional/default/prefault fields, those fields were being unnecessarily wrapped in `ZodOptional`, causing nested wrappers and broader output types.

Changes:
- Added `PartialField<T>` helper type that checks if a field's def.type is already `optional | default | prefault` and leaves it untouched
- Updated both `partial()` and `partial(mask)` signatures in classic and mini layers
- Changed `$ZodCatch.optin` from `T['_zod']['optin']` to `'optional'` for correct type matching
- Added `partialSkipTypes` set in `core/util.ts` and uncommented the skip logic

Closes #6177
Closes #6172
Closes #6173