### PR TITLE
fix(formatError): prevent throwing on Object.prototype keys in path

### DIFF
--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -709,3 +709,19 @@ test("error serialization", () => {
     `);
   }
 });
+
+test("formatError does not throw on Object.prototype keys in path", () => {
+  const schema = z.object({
+    toString: z.string(),
+    constructor: z.string(),
+    valueOf: z.string(),
+  });
+  const result = schema.safeParse({});
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    const formatted = z.formatError(result.error) as any;
+    expect(formatted.toString._errors.length).toBeGreaterThan(0);
+    expect(formatted.constructor._errors.length).toBeGreaterThan(0);
+    expect(formatted.valueOf._errors.length).toBeGreaterThan(0);
+  }
+});

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -311,10 +311,10 @@ export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssu
             const el = fullpath[i]!;
             const terminal = i === fullpath.length - 1;
 
-            if (!terminal) {
-              curr[el] = curr[el] || { _errors: [] };
-            } else {
-              curr[el] = curr[el] || { _errors: [] };
+            if (!Object.prototype.hasOwnProperty.call(curr, el)) {
+              curr[el] = { _errors: [] };
+            }
+            if (terminal) {
               curr[el]._errors.push(mapper(issue));
             }
 


### PR DESCRIPTION
Fixes formatError throwing a TypeError when path segments match Object.prototype members (toString, constructor, valueOf). Related to #5265.