### PR TITLE
feat: allow structured ZodIssueMessage values for deferred error message rendering

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -79,7 +79,7 @@ test(".flatten()", () => {
 });
 
 test("custom .flatten()", () => {
-  type ErrorType = { message: string; code: number };
+  type ErrorType = { message: string | { key: string; values?: object }; code: number };
   const flattened = parsed.error!.flatten((iss) => ({ message: iss.message, code: 1234 }));
   expectTypeOf(flattened).toMatchTypeOf<{
     formErrors: ErrorType[];
@@ -159,7 +159,7 @@ test(".format()", () => {
 });
 
 test("custom .format()", () => {
-  type ErrorType = { message: string; code: number };
+  type ErrorType = { message: string | { key: string; values?: object }; code: number };
   const formatted = parsed.error!.format((iss) => ({ message: iss.message, code: 1234 }));
   expectTypeOf(formatted).toMatchTypeOf<{
     _errors: ErrorType[];
@@ -252,7 +252,7 @@ test("all errors", () => {
     }
   `);
 
-  expect(z.core.flattenError(r2.error!, (iss) => iss.message.toUpperCase())).toMatchInlineSnapshot(`
+  expect(z.core.flattenError(r2.error!, (iss) => (iss.message as string).toUpperCase())).toMatchInlineSnapshot(`
     {
       "fieldErrors": {
         "a": [
@@ -296,7 +296,7 @@ test("all errors", () => {
   `);
 
   // Test mapping
-  const f1 = z.core.flattenError(r2.error!, (i: z.ZodIssue) => i.message.length);
+  const f1 = z.core.flattenError(r2.error!, (i: z.ZodIssue) => (i.message as string).length);
   expect(f1).toMatchInlineSnapshot(`
     {
       "fieldErrors": {

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -712,15 +712,27 @@ test("error serialization", () => {
 
 test("error with object type message", () => {
   const schema = z.object({
-    // name: z.string().min(5, { error: () => ({ message: { key: "test", values: { foo: "bar" } } }) }),
-    name: z.string().min(5, "too short"),
+    name: z.string().min(5, { error: () => ({ message: { key: "test", values: { foo: "bar" } } }) }),
   });
 
   const obj = {
     name: "tes",
   };
 
-  const res = schema.safeParse(obj);
-  const parseMessageObj = JSON.parse(res.error?.message || "");
-  console.log(parseMessageObj);
+  const result = schema.safeParse(obj);
+  expect(result.success).toBe(false);
+  expect(result.error).toMatchInlineSnapshot(`
+  [ZodError: [
+    {
+      "origin": "string",
+      "code": "too_small",
+      "minimum": 5,
+      "inclusive": true,
+      "path": [
+        "name"
+      ],
+      "message": "{\\"key\\":\\"test\\",\\"values\\":{\\"foo\\":\\"bar\\"}}"
+    }
+  ]]
+  `);
 });

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -709,3 +709,18 @@ test("error serialization", () => {
     `);
   }
 });
+
+test("error with object type message", () => {
+  const schema = z.object({
+    // name: z.string().min(5, { error: () => ({ message: { key: "test", values: { foo: "bar" } } }) }),
+    name: z.string().min(5, "too short"),
+  });
+
+  const obj = {
+    name: "tes",
+  };
+
+  const res = schema.safeParse(obj);
+  const parseMessageObj = JSON.parse(res.error?.message || "");
+  console.log(parseMessageObj);
+});

--- a/packages/zod/src/v4/core/standard-schema.ts
+++ b/packages/zod/src/v4/core/standard-schema.ts
@@ -1,3 +1,5 @@
+import type { $ZodIssueMessage } from "./errors.js";
+
 /** The Standard Schema interface. */
 export interface StandardSchemaV1<Input = unknown, Output = Input> {
   /** The Standard Schema properties. */
@@ -37,7 +39,7 @@ export declare namespace StandardSchemaV1 {
   /** The issue interface of the failure output. */
   export interface Issue {
     /** The error message of the issue. */
-    readonly message: string;
+    readonly message: $ZodIssueMessage;
     /** The path of the issue, if any. */
     readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
   }

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1,6 +1,7 @@
 import type * as checks from "./checks.js";
 import type { $ZodConfig } from "./core.js";
 import type * as errors from "./errors.js";
+import type { $ZodIssueMessage } from "./errors.js";
 import type * as schemas from "./schemas.js";
 
 // json
@@ -786,8 +787,11 @@ export function prefixIssues(path: PropertyKey, issues: errors.$ZodRawIssue[]): 
   });
 }
 
-export function unwrapMessage(message: string | { message: string } | undefined | null): string | undefined {
-  return typeof message === "string" ? message : message?.message;
+export function unwrapMessage(message: string | { message: $ZodIssueMessage } | undefined | null): string | undefined {
+  if (message === undefined) {
+    return undefined;
+  }
+  return typeof message === "string" ? message : toMessageString(message?.message || "");
 }
 
 export function finalizeIssue(
@@ -907,4 +911,12 @@ export function uint8ArrayToHex(bytes: Uint8Array): string {
 // instanceof
 export abstract class Class {
   constructor(..._args: any[]) {}
+}
+
+export function toMessageString(message: $ZodIssueMessage): string {
+  if (typeof message === "string") {
+    return message;
+  } else {
+    return JSON.stringify(message);
+  }
 }


### PR DESCRIPTION
## Motivation

Today, a `ZodIssueMessage` can only be a string. This means that validation messages must be fully resolved when the schema is created.

This becomes problematic in applications that support multiple languages. The translation function (`t`) is typically only available in the UI layer, while schemas are often defined as reusable constants or shared across multiple environments.

As a result, developers have to either:

- recreate the schema whenever the active language changes,
- inject the translation function into schema factories, or
- keep schemas inside UI components instead of defining them once.

In React, for example, this often leads to patterns like:

```ts
export function createFormSchema(t) {
  return z.object({
    firstName: z.string({
      message: t("some.translationKey", { someKey: "abc" }),
    }),
  });
}
```

```tsx
const { t, i18n } = useTranslation();

const schema = useMemo(
  () => createFormSchema(t),
  [i18n.language]
);
```

The validation logic itself is independent of the current language, yet the schema must be recreated whenever the language changes because the error messages have already been translated.

## Proposed solution

Allow `ZodIssueMessage` to also accept a structured object:

```ts
type ZodIssueMessage =
  | string
  | {
      key: string;
      values?: Record<string, unknown>;
    };
```

Schemas can then remain language-agnostic:

```ts
export const formSchema = z.object({
  firstName: z.string({
    message: {
      key: "some.translationKey",
      values: {
        someKey: "abc",
      },
    },
  }),
});
```

The rendering layer can translate the message when it is actually displayed:

```tsx
const issue = error.message;

if (typeof issue === "string") {
  return issue;
}

return t(issue.key, issue.values);
```

Libraries such as `@hookform/error-message` (or custom error renderers) can extract the translation key and interpolation values and perform localization at render time.

## Benefits

- Separates validation logic from presentation concerns.
- Schemas can be defined once and reused regardless of the active language.
- Eliminates the need to recreate schemas on language changes.
- Enables richer integrations with i18n libraries without imposing any particular translation solution.
- **Fully backwards compatible.** This change is purely additive: existing code that provides a string message continues to work unchanged, while applications that prefer deferred localization can opt into the new object format.