### PR TITLE
fix(v4): preserve input-valid default on transforming schema in toJSONSchema (#6049)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ["lts/*"]
-        typescript: ["5.5", "latest"]
+        typescript: ["5.5", "5"]
     name: Test with TypeScript ${{ matrix.typescript }} on Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +28,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm build
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all
       - run: pnpm run --filter @zod/integration test:all

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2674,6 +2674,40 @@ test("keep input-valid default on transforming schema (#6049)", () => {
   `);
 });
 
+test("strip type-mismatched default on transforming schema (#4557)", () => {
+  // default is output-typed (number) but the input type is string → still stripped in input mode
+  const a = z
+    .string()
+    .transform((v) => v.length)
+    .pipe(z.number())
+    .default(1234);
+  expect(z.toJSONSchema(a, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+    }
+  `);
+  expect(z.toJSONSchema(a, { io: "output" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": 1234,
+      "type": "number",
+    }
+  `);
+
+  // same polarity without an explicit .pipe()
+  const b = z
+    .string()
+    .transform((s) => s.length)
+    .default(42);
+  expect(z.toJSONSchema(b, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+    }
+  `);
+});
+
 test("falsy prefaults (false, 0, empty string)", () => {
   // boolean prefault false
   const a = z.boolean().prefault(false);

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2633,6 +2633,47 @@ test("defaults/prefaults", () => {
   `);
 });
 
+test("keep input-valid default on transforming schema (#6049)", () => {
+  // default value matches the input type (string) → preserved in input mode
+  const a = z
+    .string()
+    .transform((s) => s)
+    .default("hello");
+  expect(z.toJSONSchema(a, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": "hello",
+      "type": "string",
+    }
+  `);
+  expect(z.toJSONSchema(a, { io: "output", unrepresentable: "any" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": "hello",
+    }
+  `);
+
+  // survives when nested in an object property
+  const obj = z.object({
+    name: z
+      .string()
+      .transform((s) => s.trim())
+      .default("anon"),
+  });
+  expect(z.toJSONSchema(obj, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "name": {
+          "default": "anon",
+          "type": "string",
+        },
+      },
+      "type": "object",
+    }
+  `);
+});
+
 test("falsy prefaults (false, 0, empty string)", () => {
   // boolean prefault false
   const a = z.boolean().prefault(false);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -201,7 +201,14 @@ export function process<T extends schemas.$ZodType>(
   if (ctx.io === "input" && isTransforming(schema)) {
     // examples/defaults only apply to output type of pipe
     delete result.schema.examples;
-    delete result.schema.default;
+    // A `.default()` value is output-typed, so on a transforming schema it may not match the input
+    // type (#4557 strips it for that reason). Keep it only when it is valid input — i.e. its JSON
+    // type matches the resolved input schema (#6049).
+    const keepDefault =
+      def.type === "default" && defaultMatchesInputType(result.schema.default, resolveInputType(result.ref, ctx));
+    if (!keepDefault) {
+      delete result.schema.default;
+    }
   }
 
   // set prefault as default
@@ -521,6 +528,31 @@ export function finalize<T extends schemas.$ZodType>(
   } catch (_err) {
     throw new Error("Error converting schema to JSON.");
   }
+}
+
+// Follow the `ref` chain of a seen schema to the first concrete JSON `type`. A `.default()` node only
+// records `default` on its own schema; its input type lives on the schema it refs (see defaultProcessor).
+function resolveInputType(start: schemas.$ZodType | null | undefined, ctx: ToJSONSchemaContext) {
+  const guard = new Set<schemas.$ZodType>();
+  let cur: schemas.$ZodType | null | undefined = start;
+  while (cur && !guard.has(cur)) {
+    guard.add(cur);
+    const seen = ctx.seen.get(cur);
+    if (!seen) return undefined;
+    if (seen.schema.type !== undefined) return seen.schema.type;
+    cur = seen.ref;
+  }
+  return undefined;
+}
+
+// Whether a `.default()` value is a valid instance of the schema's resolved input type. Decides if the
+// default survives input-mode extraction on a transforming schema (#6049 keeps it, #4557 strips it).
+function defaultMatchesInputType(value: unknown, type: JSONSchema.BaseSchema["type"]): boolean {
+  if (type === undefined) return false;
+  const jsonType = value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
+  const expected = jsonType === "number" ? ["number", "integer"] : [jsonType];
+  const declared = Array.isArray(type) ? type : [type];
+  return expected.some((t) => declared.includes(t as any));
 }
 
 function isTransforming(

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -204,6 +204,8 @@ export function process<T extends schemas.$ZodType>(
     // A `.default()` value is output-typed, so on a transforming schema it may not match the input
     // type (#4557 strips it for that reason). Keep it only when it is valid input — i.e. its JSON
     // type matches the resolved input schema (#6049).
+    // Only `default` needs this check: `.prefault()` is input-typed by definition (it is substituted
+    // *before* parsing), so it is always valid input and is emitted unconditionally just below.
     const keepDefault =
       def.type === "default" && defaultMatchesInputType(result.schema.default, resolveInputType(result.ref, ctx));
     if (!keepDefault) {
@@ -532,6 +534,9 @@ export function finalize<T extends schemas.$ZodType>(
 
 // Follow the `ref` chain of a seen schema to the first concrete JSON `type`. A `.default()` node only
 // records `default` on its own schema; its input type lives on the schema it refs (see defaultProcessor).
+// Returns `undefined` when the chain is cyclic, unprocessed, or never reaches a typed schema (e.g. a
+// union or `z.any()`); callers treat that as "input type unknown", which strips the default — the
+// conservative choice, matching the pre-#6049 behavior.
 function resolveInputType(start: schemas.$ZodType | null | undefined, ctx: ToJSONSchemaContext) {
   const guard = new Set<schemas.$ZodType>();
   let cur: schemas.$ZodType | null | undefined = start;
@@ -550,9 +555,12 @@ function resolveInputType(start: schemas.$ZodType | null | undefined, ctx: ToJSO
 function defaultMatchesInputType(value: unknown, type: JSONSchema.BaseSchema["type"]): boolean {
   if (type === undefined) return false;
   const jsonType = value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
-  const expected = jsonType === "number" ? ["number", "integer"] : [jsonType];
-  const declared = Array.isArray(type) ? type : [type];
-  return expected.some((t) => declared.includes(t as any));
+  // a JSON number satisfies both `number` and `integer` declarations
+  const expected: string[] = jsonType === "number" ? ["number", "integer"] : [jsonType];
+  // `type` is a single keyword in our types, but JSON Schema permits an array of them and an
+  // `override`/metadata hook can produce one, so accept both shapes.
+  const declared = new Set<string>(Array.isArray(type) ? type : [type]);
+  return expected.some((t) => declared.has(t));
 }
 
 function isTransforming(


### PR DESCRIPTION
`z.toJSONSchema(schema, { io: "input" })` dropped the `default` keyword whenever the defaulted schema contained a transform:

```ts
z.string().transform((s) => s).default("hello")
// input mode → { type: "string" }   ← default "hello" lost
```

The strip dates to #4557, which broadened the input-mode deletion from `def.type === "pipe"` to any `isTransforming(schema)`. That correctly removes an output-typed default that can't fit the input type — e.g. `z.string().transform((v) => v.length).pipe(z.number()).default(1234)`, where `1234` doesn't belong on a `string` input — but it also removed defaults that are valid input.

A `.default()` value now survives input extraction when its JSON type matches the schema's resolved input type, so `"hello"` is kept while the `1234`-on-`string` case still strips.

Closes #6049
