### PR TITLE
ci: build with pinned TypeScript before installing matrix version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,10 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
+      # Build with the lockfile's pinned TypeScript — zshy doesn't support TS 7 (see #6185).
+      # The matrix TypeScript applies to the test steps below, which is what the matrix is for.
       - run: pnpm build
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all
       - run: pnpm run --filter @zod/integration test:all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,15 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      # Build with the lockfile's pinned TypeScript — zshy doesn't support TS 7 (see #6185).
-      # The matrix TypeScript applies to the test steps below, which is what the matrix is for.
+      # Build and run the workspace-pinned suites before installing the matrix TypeScript:
+      # zshy resolves the root TypeScript and doesn't support TS 7 (see #6185), and the
+      # @zod/resolution harness invokes zshy internally. resolution/integration pin their
+      # own typescript, so only `pnpm test` is meant to vary with the matrix.
       - run: pnpm build
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
-      - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all
       - run: pnpm run --filter @zod/integration test:all
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
+      - run: pnpm test
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI has failed on every PR since 2026-07-08, when TypeScript 7.0.2 became npm's `latest`. Root cause in #6185: the workflow installs the matrix TypeScript before `pnpm build`, and `zshy@0.7.2` (peer dep `typescript >5.5.0`) crashes on TS 7's compiler API:

```
Build failed: TypeError: Cannot read properties of undefined (reading 'readFile')
```

This moves `pnpm build` above `pnpm add typescript@${{ matrix.typescript }} -w`, so the package builds with the lockfile's pinned TypeScript while the matrix version still applies to the test steps — which is what the matrix exists to exercise.

Verified locally on `main`:

- `pnpm build` with the pinned TypeScript: passes
- `pnpm vitest run` after `pnpm add typescript@latest -w` (7.0.2): 339 files, 3813 tests, no type errors
- `@zod/resolution` / `@zod/integration` pin their own `typescript@^5.8.2` and are unaffected by the root swap

The "TypeScript 5.5" job in recent runs was cancelled by matrix fail-fast rather than failing on its own, so this one change should restore both legs.

Closes #6185
