### PR TITLE
docs: add Attaform to ecosystem

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -112,6 +112,12 @@ const formIntegrations: ZodResource[] = [
     description: "Components, hooks & utilities for creating and managing delightfully simple form experiences in React.",
     slug: "maanlamp/react-f3",
   },
+  {
+    name: "Attaform",
+    url: "https://attaform.dev",
+    description: "Type-safe, Zod-first form library for Vue 3 and Nuxt.",
+    slug: "attaform/Attaform",
+  },
 ];
 
 const zodToXConverters: ZodResource[] = [


### PR DESCRIPTION
Adds [Attaform](https://attaform.dev) to the **Form integrations** section.

Attaform is a type-safe, schema-driven form library for Vue 3 and Nuxt, with Zod as its first-class schema source. It has full support for **Zod 4** (and Zod 3), so it meets the ecosystem's Zod 4 requirement.

- Repo: https://github.com/attaform/Attaform
- Docs: https://attaform.dev
- npm: https://www.npmjs.com/package/attaform

Single-line addition to the `formIntegrations` array; stars resolve automatically from the `slug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
