### PR TITLE
docs(v3): add Attaform to Form integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ There are a growing number of tools that are built atop or support Zod natively!
 - [`zod-form-renderer`](https://github.com/thepeaklab/zod-form-renderer): Auto-infer form fields from zod schema and render them with react-hook-form with E2E type safety.
 - [`antd-zod`](https://github.com/MrBr/antd-zod): Zod adapter for Ant Design form fields validation.
 - [`frrm`](https://github.com/schalkventer/frrm): Tiny 0.5kb Zod-based, HTML form abstraction that goes brr.
+- [`Attaform`](https://attaform.dev): Type-safe, Zod-first form library for Vue 3 and Nuxt, with first-class support for both Zod 3 and Zod 4.
 
 #### Zod to X
 


### PR DESCRIPTION
Adds [Attaform](https://attaform.dev) to the **Form integrations** list in the Zod 3 docs.

Attaform is a type-safe, schema-driven form library for Vue 3 and Nuxt with Zod as its first-class schema source. It has **full first-class support for both Zod 3 and Zod 4**, built and tested against both adapters, so Zod 3 users get the complete experience today with a clear path to Zod 4 whenever they are ready.

- Repo: https://github.com/attaform/Attaform
- Docs: https://attaform.dev
- npm: https://www.npmjs.com/package/attaform

Companion to the Zod 4 ecosystem addition in colinhacks/zod#6188. Single-line docs addition, no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
