### PR TITLE
docs: add ArkEnv to ecosystem page

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -311,7 +311,7 @@ const poweredByZodProjects: ZodResource[] = [
   {
     name: "ArkEnv",
     url: "https://github.com/yamcodes/arkenv",
-    description: "Environment variable validation from editor to runtime.",
+    description: "Environment variable validation from editor to runtime, for Next.js, Nuxt, Node.js, Vite, Bun, and more.",
     slug: "yamcodes/arkenv",
   },
 ];

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -311,7 +311,7 @@ const poweredByZodProjects: ZodResource[] = [
   {
     name: "ArkEnv",
     url: "https://github.com/yamcodes/arkenv",
-    description: "Typesafe environment variables validated with Zod, for Node.js, Vite, Bun, Next.js, and Nuxt.",
+    description: "Environment variable validation from editor to runtime.",
     slug: "yamcodes/arkenv",
   },
 ];

--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -307,7 +307,13 @@ const poweredByZodProjects: ZodResource[] = [
     url: "https://jsr.io/@chrock-studio/overload",
     description: "A lightweight, type-safe runtime function overloading library that allows runtime dispatch based on argument types.",
     slug: "chrock-studio/toolbox/tree/main/packages/overload",
-  }
+  },
+  {
+    name: "ArkEnv",
+    url: "https://github.com/yamcodes/arkenv",
+    description: "Typesafe environment variables validated with Zod, for Node.js, Vite, Bun, Next.js, and Nuxt.",
+    slug: "yamcodes/arkenv",
+  },
 ];
 
 const zodUtilities: ZodResource[] = [


### PR DESCRIPTION
Adds [ArkEnv](https://github.com/yamcodes/arkenv) to the "Powered by Zod" section of the ecosystem page.

ArkEnv provides typesafe environment variable parsing and validation using Zod schemas (or any Standard Schema library), with first-class integrations for Node.js, Vite, Bun, Next.js, and Nuxt. It supports Zod 4 (tested against Zod 4 in CI).

Docs: https://arkenv.js.org

Made with [Cursor](https://cursor.com)