### PR TITLE
fix(v4): formatError and treeifyError no longer throw on inherited-name path elements (__proto__, constructor, ...)

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -805,3 +805,25 @@ test("z.treeifyError nested union with real schema", () => {
     }
   }
 });
+
+// Regression: an issue path element that collides with an inherited property
+// name (e.g. "__proto__", "constructor") must not crash the error formatters
+// or mutate any prototype. Such paths are reachable through the public API via
+// a custom issue path (superRefine/check), e.g. when validating dynamic field
+// names taken from user input.
+test("formatError handles __proto__ / inherited-name path elements", () => {
+  for (const key of ["__proto__", "constructor", "toString", "hasOwnProperty"]) {
+    const schema = z.string().check((ctx) => {
+      ctx.issues.push({ code: "custom", message: "bad", path: [key], input: ctx.value });
+    });
+    const err = schema.safeParse("x").error!;
+    const formatted = z.formatError(err) as any;
+    expect(Object.prototype.hasOwnProperty.call(formatted, key)).toBe(true);
+    expect(formatted[key]._errors).toEqual(["bad"]);
+    const tree = z.treeifyError(err) as any;
+    expect(Object.prototype.hasOwnProperty.call(tree.properties, key)).toBe(true);
+    expect(tree.properties[key].errors).toEqual(["bad"]);
+  }
+  // no prototype pollution occurred
+  expect(({} as any).bad).toBeUndefined();
+});

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -311,10 +311,21 @@ export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssu
             const el = fullpath[i]!;
             const terminal = i === fullpath.length - 1;
 
-            if (!terminal) {
-              curr[el] = curr[el] || { _errors: [] };
-            } else {
-              curr[el] = curr[el] || { _errors: [] };
+            // A path element may collide with an inherited property name such as
+            // "__proto__" or "constructor". Truthiness checks read the prototype
+            // (so no node is created, then ._errors.push throws), and bracket
+            // assignment of "__proto__" hits the setter instead of creating an
+            // own key. Guard the read with hasOwnProperty and create the node
+            // with defineProperty so any path element becomes a real own key.
+            if (!Object.prototype.hasOwnProperty.call(curr, el)) {
+              Object.defineProperty(curr, el, {
+                value: { _errors: [] },
+                enumerable: true,
+                writable: true,
+                configurable: true,
+              });
+            }
+            if (terminal) {
               curr[el]._errors.push(mapper(issue));
             }
 
@@ -370,7 +381,19 @@ export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIss
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ??= {};
-            curr.properties[el] ??= { errors: [] };
+            // el may collide with an inherited property name ("__proto__",
+            // "constructor", ...); ??= reads the prototype so the node is never
+            // created and curr.errors.push throws. Guard with hasOwnProperty and
+            // create the node with defineProperty so "__proto__" becomes a real
+            // own key rather than invoking the prototype setter.
+            if (!Object.prototype.hasOwnProperty.call(curr.properties, el)) {
+              Object.defineProperty(curr.properties, el, {
+                value: { errors: [] },
+                enumerable: true,
+                writable: true,
+                configurable: true,
+              });
+            }
             curr = curr.properties[el];
           } else {
             curr.items ??= [];


### PR DESCRIPTION
Closes #6211

### Problem

`z.formatError()` and `z.treeifyError()` throw `TypeError: Cannot read properties of undefined (reading 'push')` when an issue path element is a name inherited from `Object.prototype` (`__proto__`, `constructor`, `toString`, `hasOwnProperty`, `valueOf`). Reachable via a custom issue path from `.check()` / `.superRefine()`, or any flow that puts user-controlled keys into an issue path. Verified on published 4.4.3: all 5 names throw in both functions. For `__proto__`, plain bracket assignment additionally hits the prototype setter instead of creating an own key.

### Fix

In both tree builders, replace the truthy / nullish node-existence checks with an own-property guard, and create nodes with `Object.defineProperty` (enumerable, writable, configurable, so behavior is unchanged for normal keys):

- `formatError`: `curr[el] = curr[el] || { _errors: [] }` saw the inherited member as truthy, never created the node, then crashed on `._errors.push`.
- `treeifyError`: `curr.properties[el] ??= { errors: [] }` saw the inherited member as non-nullish, same failure.

`defineProperty` also makes `__proto__` a real own data property, so no prototype is mutated.

### Tests

Added a regression test in `error-utils.test.ts` covering `__proto__`, `constructor`, `toString`, and `hasOwnProperty` against both functions, plus a no-pollution assertion. `error-utils.test.ts` passes 36/36 and `error.test.ts` 54/54, with no type errors.

### Scope

2 files, ~50 lines: `packages/zod/src/v4/core/errors.ts` and `packages/zod/src/v4/classic/tests/error-utils.test.ts`.

### Relation to existing PRs

#6083, #6139, and #6181 address the `formatError` half of this. This PR covers `treeifyError` as well, which fails identically (see the issue for the executed repro matrix). Credit to those authors for prior art on the `formatError` side.
