### PR TITLE
docs: fix UUID helper list in v4 introduction

### DIFF
--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -652,8 +652,8 @@ All "string formats" (email, etc.) have been promoted to top-level functions on 
 ```ts
 z.email();
 z.uuidv4();
+z.uuidv6();
 z.uuidv7();
-z.uuidv8();
 z.ipv4();
 z.ipv6();
 z.cidrv4();


### PR DESCRIPTION
The "Top-level string formats" list in the v4 introduction includes `z.uuidv8()`, which doesn't exist, and omits `z.uuidv6()`, which does.

```diff
 z.uuidv4();
+z.uuidv6();
 z.uuidv7();
-z.uuidv8();
```

`packages/zod/src/v4/classic/schemas.ts` declares exactly three: `uuidv4` (line 692), `uuidv6` (698) and `uuidv7` (704). `uuidv8` appears nowhere in `packages/zod/src` or `packages/core/src`.

`packages/docs/content/api.mdx:325-327` already lists the correct trio, so this line now matches it.
