### PR TITLE
fix: move pnpm build before matrix TypeScript swap in CI (issue #6185)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm build
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all
       - run: pnpm run --filter @zod/integration test:all


### PR DESCRIPTION
﻿The `pnpm build` step was running after `pnpm add typescript@latest`, which caused zshy to crash on TypeScript 7.x (which ships the Go-native compiler without the JS compiler API).

Moving `pnpm build` before the matrix TypeScript swap ensures the build uses the repo's pinned TypeScript. The matrix swap continues to apply to the test and typecheck phase (which is the intended purpose of the matrix).
