### PR TITLE
fix(object): report __proto__ as unrecognized key in strict mode (#6220)

### DIFF
--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -709,9 +709,15 @@ describe("__proto__ in object catchall paths", () => {
     }
   });
 
-  test("strict does not surface __proto__ as unrecognized", () => {
+  test("strict surfaces __proto__ as unrecognized", () => {
     const schema = z.object({ name: z.string() }).strict();
     const result = schema.safeParse(protoInput());
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].code).toBe("unrecognized_keys");
+      if (result.error.issues[0].code === "unrecognized_keys") {
+        expect(result.error.issues[0].keys).toContain("__proto__");
+      }
+    }
   });
 });

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -720,4 +720,25 @@ describe("__proto__ in object catchall paths", () => {
       }
     }
   });
+
+  test("strict does not report inherited __proto__ from prototype chain", () => {
+    // for...in iterates enumerable inherited keys. __proto__ is an accessor
+    // on Object.prototype, not an enumerable key — so it's never visited.
+    // Properties inside the __proto__ object (e.g. isAdmin) ARE iterated
+    // and reported as unrecognized. This test documents that boundary.
+    const input = Object.create({ __proto__: { isAdmin: true } });
+    input.name = "alice";
+    const schema = z.object({ name: z.string() }).strict();
+    const result = schema.safeParse(input);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].code).toBe("unrecognized_keys");
+      if (result.error.issues[0].code === "unrecognized_keys") {
+        // isAdmin is inherited via the prototype chain and iterated by for...in
+        expect(result.error.issues[0].keys).toContain("isAdmin");
+        // __proto__ itself is not an enumerable key, so it's not reported
+        expect(result.error.issues[0].keys).not.toContain("__proto__");
+      }
+    }
+  });
 });

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -82,6 +82,12 @@ export interface $ZodIssueNotMultipleOf<Input extends number | bigint = number |
 
 export interface $ZodIssueUnrecognizedKeys extends $ZodIssueBase {
   readonly code: "unrecognized_keys";
+  /**
+   * The unrecognized key names. May include "__proto__" as a literal string.
+   * Consumers should treat these as raw strings — avoid passing them through
+   * Object.assign, spread, or JSON.parse without sanitization, as "__proto__"
+   * can re-introduce prototype pollution if re-interpreted as an accessor.
+   */
   readonly keys: string[];
   readonly input?: Record<string, unknown>;
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1870,7 +1870,10 @@ function handleCatchall(
   for (const key in input) {
     // skip __proto__ so it can't replace the result prototype via the
     // assignment setter on the plain {} we build into
-    if (key === "__proto__") continue;
+    if (key === "__proto__") {
+      if (t === "never") unrecognized.push(key);
+      continue;
+    }
     if (keySet.has(key)) continue;
     if (t === "never") {
       unrecognized.push(key);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1870,6 +1870,10 @@ function handleCatchall(
   for (const key in input) {
     // skip __proto__ so it can't replace the result prototype via the
     // assignment setter on the plain {} we build into
+    // Only report as unrecognized in strict mode (t === "never") because
+    // passthrough/strip/catchall silently drop __proto__ by design — the key
+    // is never copied into the result regardless of mode, so there's nothing
+    // to report in non-strict modes.
     if (key === "__proto__") {
       if (t === "never") unrecognized.push(key);
       continue;


### PR DESCRIPTION
Fixes #6220

When using `.strict()` (or `z.strictObject`), an own `__proto__` key in the input was silently accepted and dropped from the output without being reported as `unrecognized_keys`. This meant strict mode flagged every unknown key except the one an attacker would actually send, and downstream code inspecting the parsed data never learned the key was there.

The prototype pollution defense (skipping `__proto__` in the copy loop) is preserved — the fix only moves the `unrecognized` reporting before the `continue`, so the key is still not copied into the result but is now correctly surfaced in the error issues.

### Changes

- **`schemas.ts`**: In `handleCatchall`, report `__proto__` as unrecognized before skipping the copy
- **`object.test.ts`**: Updated the existing test to expect `__proto__` to be reported as unrecognized, and verified the error contains the key

### Testing

- 3811 tests pass (339 test files)
- TypeScript: clean