### PR TITLE
fix(core): treat any/unknown/coerced-boolean object properties as optional-in

### DIFF
--- a/packages/zod/src/v4/classic/tests/anyunknown.test.ts
+++ b/packages/zod/src/v4/classic/tests/anyunknown.test.ts
@@ -24,3 +24,17 @@ test("check never inference", () => {
   expect(() => t1.parse("asdf")).toThrow();
   expect(() => t1.parse(null)).toThrow();
 });
+
+test("any object property tolerates an absent key (#5997)", () => {
+  const schema = z.object({ foo: z.any() });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({});
+});
+
+test("unknown object property tolerates an absent key", () => {
+  const schema = z.object({ foo: z.unknown() });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({});
+});

--- a/packages/zod/src/v4/classic/tests/coerce.test.ts
+++ b/packages/zod/src/v4/classic/tests/coerce.test.ts
@@ -75,6 +75,19 @@ test("boolean coercion", () => {
   expect(schema.parse(new Date(1670139203496))).toEqual(true);
 });
 
+test("coerced boolean object property tolerates an absent key (#5957)", () => {
+  const schema = z.object({ foo: z.coerce.boolean() });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({ foo: false });
+});
+
+test("non-coerced boolean object property is still required", () => {
+  const schema = z.object({ foo: z.boolean() });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(false);
+});
+
 test("bigint coercion", () => {
   const schema = z.coerce.bigint();
   expect(schema.parse("5")).toEqual(BigInt(5));

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1204,6 +1204,11 @@ export const $ZodBoolean: core.$constructor<$ZodBoolean> = /*@__PURE__*/ core.$c
     $ZodType.init(inst, def);
     inst._zod.pattern = regexes.boolean;
 
+    // A coercing boolean accepts undefined (Boolean(undefined) === false),
+    // so an absent object key should be coerced rather than rejected as a
+    // missing required property.
+    if (def.coerce) inst._zod.optin = "optional";
+
     inst._zod.parse = (payload, _ctx) => {
       if (def.coerce)
         try {
@@ -1445,6 +1450,9 @@ export interface $ZodAny extends $ZodType {
 export const $ZodAny: core.$constructor<$ZodAny> = /*@__PURE__*/ core.$constructor("$ZodAny", (inst, def) => {
   $ZodType.init(inst, def);
 
+  // `any` accepts undefined as a valid value, so an absent object key
+  // should not be treated as a missing required property either.
+  inst._zod.optin = "optional";
   inst._zod.parse = (payload) => payload;
 });
 
@@ -1474,6 +1482,9 @@ export const $ZodUnknown: core.$constructor<$ZodUnknown> = /*@__PURE__*/ core.$c
   (inst, def) => {
     $ZodType.init(inst, def);
 
+    // Same as `any`: unknown accepts undefined, so an absent object key
+    // should not be treated as a missing required property.
+    inst._zod.optin = "optional";
     inst._zod.parse = (payload) => payload;
   }
 );


### PR DESCRIPTION
# fix(core): treat any/unknown/coerced-boolean object properties as optional-in

Fixes #5997
Fixes #5957

## Root cause

`handlePropertyResult` in `packages/zod/src/v4/core/schemas.ts` decides whether
a missing object key is an error by checking `el._zod.optin === "optional"`:

```ts
if (!isPresent && !isOptionalIn) {
  if (!result.issues.length) {
    final.issues.push({
      code: "invalid_type",
      expected: "nonoptional",
      input: undefined,
      path: [key],
    });
  }
  return;
}
```

`$ZodAny`, `$ZodUnknown`, and `$ZodBoolean` (even with `coerce: true`) never
set `optin = "optional"`, so an absent key on these properties gets rejected
as a missing required property — even though these schemas are semantically
supposed to tolerate an absent/undefined input:

- `z.any()` / `z.unknown()` accept `undefined` unconditionally.
- `z.coerce.boolean()` coerces via `Boolean(payload.value)`, and
  `Boolean(undefined) === false` — so it should coerce an absent key to
  `false`, not throw.

This is the shared root cause behind two separately-reported regressions:

- #5997 — `z.any()` object properties became required in v4.4.0 (undocumented)
- #5957 — `z.coerce.boolean()` rejects an absent key instead of coercing it to `false`

## Fix

Set `inst._zod.optin = "optional"`:
- Unconditionally in `$ZodAny` and `$ZodUnknown`.
- In `$ZodBoolean`, only when `def.coerce` is `true` — a plain, non-coercing
  `z.boolean()` correctly remains required (covered by a new test).

## Testing

- Added test cases to `anyunknown.test.ts` and `coerce.test.ts` covering both
  reported regressions plus the "non-coerced boolean still required" guard.
- Ran the full package test suite (`pnpm vitest run --project zod`): **336
  test files, 3808 tests, 0 failures, 0 type errors** — no regressions
  elsewhere in the suite.

## Disclosure

I used Claude Code (Anthropic) to help trace the root cause through the
source, prepare this patch, and write/run the verification above. I reviewed
the change and test results myself before opening this PR.
