### PR TITLE
docs(ecosystem): add zodql to API Libraries

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -59,6 +59,13 @@ const apiLibraries: ZodResource[] = [
     description: "Advanced fetch client builder",
     slug: "L-Blondy/up-fetch",
   },
+  {
+    name: "zodql",
+    url: "https://github.com/mattiasahlsen/zodql",
+    description:
+      "Use a single Zod schema as the source of truth for a GraphQL query, its inferred response type, and runtime validation.",
+    slug: "mattiasahlsen/zodql",
+  },
   // https://github.com/honojs/middleware/tree/main/packages/zod-validator
   // {
   //   name: "@hono/zod-validator",


### PR DESCRIPTION
Adds [zodql](https://github.com/mattiasahlsen/zodql) to the **API Libraries** section of the ecosystem page.

zodql lets you use a single Zod schema as the source of truth for a GraphQL operation: it compiles the schema into the query string, infers the TypeScript response type from it, and validates the response against that same schema at runtime — no separate query string to keep in sync and no codegen step. Because a query is just a Zod schema, it can be reshaped at runtime with ordinary Zod combinators (`.pick`, `.omit`, `.extend`, …).

- npm: https://www.npmjs.com/package/@mattiasahlsen/zodql
- Supports **Zod 4** (`zod` is a `^4.0.0` peer dependency).

Related discussion: https://github.com/colinhacks/zod/discussions/6226
