### PR TITLE
docs(ecosystem): add zodql to API Libraries

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -59,6 +59,13 @@ const apiLibraries: ZodResource[] = [
     description: "Advanced fetch client builder",
     slug: "L-Blondy/up-fetch",
   },
+  {
+    name: "zodql",
+    url: "https://github.com/mattiasahlsen/zodql",
+    description:
+      "Use a single Zod schema as the source of truth for a GraphQL query, its inferred response type, and runtime validation.",
+    slug: "mattiasahlsen/zodql",
+  },
   // https://github.com/honojs/middleware/tree/main/packages/zod-validator
   // {
   //   name: "@hono/zod-validator",


### PR DESCRIPTION
Add [zodql](https://github.com/mattiasahlsen/zodql) to the API Libraries section of the ecosystem page — use a single Zod schema as the source of truth for a GraphQL query, its inferred response type, and runtime validation.