### PR TITLE
fix: accept exact decimal multiples in multipleOf

### DIFF
--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -137,6 +137,14 @@ test("multipleOf", () => {
   expect(() => schemas.schema7.parse(numbers.number8)).toThrow();
 });
 
+test(".multipleOf() accepts exact decimal multiples", () => {
+  const schema = z.number().multipleOf(0.07);
+  expect(schema.safeParse(2.03).success).toBe(true);
+  expect(schema.safeParse(4.06).success).toBe(true);
+  expect(schema.safeParse(8.54).success).toBe(true);
+  expect(schema.safeParse(2.04).success).toBe(false);
+});
+
 test(".multipleOf() with positive divisor", () => {
   const schema = z.number().multipleOf(5);
   expect(schema.parse(15)).toEqual(15);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -248,8 +248,7 @@ export function cleanRegex(source: string): string {
 export function floatSafeRemainder(val: number, step: number): number {
   const ratio = val / step;
   const roundedRatio = Math.round(ratio);
-  // Use a relative epsilon scaled to the magnitude of the result
-  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
+  const tolerance = 4 * Number.EPSILON * Math.max(Math.abs(ratio), 1);
   if (Math.abs(ratio - roundedRatio) < tolerance) return 0;
   return ratio - roundedRatio;
 }


### PR DESCRIPTION
Floating-point division accumulates rounding error from representing both val and step as floats. A single-ULP tolerance rejected exact decimal multiples; widening to 4 ULPs covers the error range while still rejecting genuine non-multiples.