### PR TITLE
fix(object): report __proto__ as unrecognized key in strict mode (#6220)

### DIFF
--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -709,9 +709,15 @@ describe("__proto__ in object catchall paths", () => {
     }
   });
 
-  test("strict does not surface __proto__ as unrecognized", () => {
+  test("strict surfaces __proto__ as unrecognized", () => {
     const schema = z.object({ name: z.string() }).strict();
     const result = schema.safeParse(protoInput());
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].code).toBe("unrecognized_keys");
+      if (result.error.issues[0].code === "unrecognized_keys") {
+        expect(result.error.issues[0].keys).toContain("__proto__");
+      }
+    }
   });
 });

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1868,9 +1868,10 @@ function handleCatchall(
   const isOptionalIn = _catchall.optin === "optional";
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
-    // skip __proto__ so it can't replace the result prototype via the
-    // assignment setter on the plain {} we build into
-    if (key === "__proto__") continue;
+    if (key === "__proto__") {
+      if (t === "never") unrecognized.push(key);
+      continue;
+    }
     if (keySet.has(key)) continue;
     if (t === "never") {
       unrecognized.push(key);


### PR DESCRIPTION
﻿In strict mode, __proto__ in the input should be reported as an unrecognized key rather than silently dropped. The key is still not assigned to the result object (prototype pollution prevention), but strict validation now surfaces it in the error.

Fixes #6220
