### PR TITLE
fix(toJSONSchema): serialize bigint defaults without throwing

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2665,6 +2665,19 @@ test("falsy prefaults (false, 0, empty string)", () => {
   `);
 });
 
+test("bigint default toJSONSchema", () => {
+  const a = z.coerce.bigint().optional().default(0n);
+  expect(() => z.toJSONSchema(a, { unrepresentable: "any" })).not.toThrow();
+  expect(z.toJSONSchema(a, { unrepresentable: "any" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": 0,
+    }
+  `);
+  const b = z.coerce.bigint().prefault(0n);
+  expect(() => z.toJSONSchema(b, { unrepresentable: "any", io: "input" })).not.toThrow();
+});
+
 test("input type", () => {
   const schema = z.object({
     a: z.string(),

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -498,7 +498,8 @@ export const defaultProcessor: Processor<schemas.$ZodDefault> = (schema, ctx, js
   process(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
-  json.default = JSON.parse(JSON.stringify(def.defaultValue));
+  const dv = typeof def.defaultValue === "bigint" ? Number(def.defaultValue) : def.defaultValue;
+  json.default = JSON.parse(JSON.stringify(dv));
 };
 
 export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, json, params) => {
@@ -506,7 +507,10 @@ export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, 
   process(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
-  if (ctx.io === "input") json._prefault = JSON.parse(JSON.stringify(def.defaultValue));
+  if (ctx.io === "input") {
+    const dv = typeof def.defaultValue === "bigint" ? Number(def.defaultValue) : def.defaultValue;
+    json._prefault = JSON.parse(JSON.stringify(dv));
+  }
 };
 
 export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, params) => {


### PR DESCRIPTION
Fixes #6209

JSON.parse(JSON.stringify(...)) throws a TypeError when the default value is a BigInt because BigInt is not serializable by JSON.stringify. Convert to Number before serializing, matching the existing approach in \literalProcessor\ (line 177).