### PR TITLE
fix(strict): preserve Shape type inference through wrapper functions

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1448,18 +1448,18 @@ export interface ZodObject<
 
   keyof(): ZodEnum<util.ToEnum<keyof Shape & string>>;
   /** Define a schema to validate all unrecognized keys. This overrides the existing strict/loose behavior. */
-  catchall<T extends core.SomeType>(schema: T): ZodObject<Shape, core.$catchall<T>>;
+  catchall<T extends core.SomeType>(schema: T): ZodObject<this["shape"], core.$catchall<T>>;
 
   /** @deprecated Use `z.looseObject()` or `.loose()` instead. */
-  passthrough(): ZodObject<Shape, core.$loose>;
+  passthrough(): ZodObject<this["shape"], core.$loose>;
   /** Consider `z.looseObject(A.shape)` instead */
-  loose(): ZodObject<Shape, core.$loose>;
+  loose(): ZodObject<this["shape"], core.$loose>;
 
   /** Consider `z.strictObject(A.shape)` instead */
-  strict(): ZodObject<Shape, core.$strict>;
+  strict(): ZodObject<this["shape"], core.$strict>;
 
   /** This is the default behavior. This method call is likely unnecessary. */
-  strip(): ZodObject<Shape, core.$strip>;
+  strip(): ZodObject<this["shape"], core.$strip>;
 
   extend<U extends core.$ZodLooseShape>(shape: U): ZodObject<util.Extend<Shape, util.Writeable<U>>, Config>;
 

--- a/packages/zod/src/v4/classic/tests/issue-6039-strict-wrapper.test.ts
+++ b/packages/zod/src/v4/classic/tests/issue-6039-strict-wrapper.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import * as z from "zod";
+
+// Test reproducer for #6039
+
+describe("#6039 nested type inference with wrappers", () => {
+  test(".strict() wrapper breaks nested inference (issue)", () => {
+    const strictIfTesting = <T extends z.ZodObject>(schema: T) => {
+      return schema.strict();
+    };
+
+    const wrapped = strictIfTesting(
+      z.object({
+        someKey: z.object({
+          anotherKey: z.string(),
+        }),
+      }),
+    );
+
+    // expect: myObject.someKey is { anotherKey: string }
+    type T = z.infer<typeof wrapped>;
+    const t: T = { someKey: { anotherKey: "x" } };
+    expect(typeof t.someKey.anotherKey).toBe("string");
+  });
+
+  test(".passthrough() wrapper (control)", () => {
+    const wrap = <T extends z.ZodObject>(schema: T) => schema.passthrough();
+
+    const wrapped = wrap(
+      z.object({
+        someKey: z.object({
+          anotherKey: z.string(),
+        }),
+      }),
+    );
+
+    type T = z.infer<typeof wrapped>;
+    const t: T = { someKey: { anotherKey: "x" } };
+    expect(typeof t.someKey.anotherKey).toBe("string");
+  });
+
+  test(".loose() wrapper (control)", () => {
+    const wrap = <T extends z.ZodObject>(schema: T) => schema.loose();
+
+    const wrapped = wrap(
+      z.object({
+        someKey: z.object({
+          anotherKey: z.string(),
+        }),
+      }),
+    );
+
+    type T = z.infer<typeof wrapped>;
+    const t: T = { someKey: { anotherKey: "x" } };
+    expect(typeof t.someKey.anotherKey).toBe("string");
+  });
+
+  test(".strip() wrapper (control)", () => {
+    const wrap = <T extends z.ZodObject>(schema: T) => schema.strip();
+
+    const wrapped = wrap(
+      z.object({
+        someKey: z.object({
+          anotherKey: z.string(),
+        }),
+      }),
+    );
+
+    type T = z.infer<typeof wrapped>;
+    const t: T = { someKey: { anotherKey: "x" } };
+    expect(typeof t.someKey.anotherKey).toBe("string");
+  });
+
+  test("issue's exact reproducer", () => {
+    const strictIfTesting = <T extends z.ZodObject>(schema: T) => {
+      const isProductionEnvironment = "window" in globalThis;
+      return isProductionEnvironment ? schema : schema.strict();
+    };
+
+    const mySchema = () =>
+      strictIfTesting(
+        z.object({
+          someKey: strictIfTesting(
+            z.object({
+              anotherKey: z.string().nonempty().nonoptional(),
+            }),
+          ).nonoptional(),
+        }),
+      );
+
+    const myObject = mySchema().parse({ someKey: { anotherKey: "hello" } });
+
+    expect(typeof myObject.someKey.anotherKey).toBe("string");
+    expect(myObject.someKey.anotherKey).toBe("hello");
+  });
+});

--- a/packages/zod/src/v4/classic/tests/issue-6039-strict-wrapper.test.ts
+++ b/packages/zod/src/v4/classic/tests/issue-6039-strict-wrapper.test.ts
@@ -14,7 +14,7 @@ describe("#6039 nested type inference with wrappers", () => {
         someKey: z.object({
           anotherKey: z.string(),
         }),
-      }),
+      })
     );
 
     // expect: myObject.someKey is { anotherKey: string }
@@ -31,7 +31,7 @@ describe("#6039 nested type inference with wrappers", () => {
         someKey: z.object({
           anotherKey: z.string(),
         }),
-      }),
+      })
     );
 
     type T = z.infer<typeof wrapped>;
@@ -47,7 +47,7 @@ describe("#6039 nested type inference with wrappers", () => {
         someKey: z.object({
           anotherKey: z.string(),
         }),
-      }),
+      })
     );
 
     type T = z.infer<typeof wrapped>;
@@ -63,7 +63,7 @@ describe("#6039 nested type inference with wrappers", () => {
         someKey: z.object({
           anotherKey: z.string(),
         }),
-      }),
+      })
     );
 
     type T = z.infer<typeof wrapped>;
@@ -83,9 +83,9 @@ describe("#6039 nested type inference with wrappers", () => {
           someKey: strictIfTesting(
             z.object({
               anotherKey: z.string().nonempty().nonoptional(),
-            }),
+            })
           ).nonoptional(),
-        }),
+        })
       );
 
     const myObject = mySchema().parse({ someKey: { anotherKey: "hello" } });


### PR DESCRIPTION
When `.strict()` is called through a generic wrapper like:

```ts
const wrap = <T extends z.ZodObject>(schema: T) => schema.strict();
```

the concrete Shape was lost (defaulted to `$ZodLooseShape`), making nested properties `unknown`.

Fix: change `.strict()`, `.loose()`, `.passthrough()`, `.strip()` signatures to use polymorphic `this["shape"]` instead of the generic `Shape` parameter. TypeScript's method shorthand preserves `this` correctly at each call site, so Shape is properly inferred through wrappers.

Fixes #6039