### PR TITLE
fix: constrain array length for closed tuples in toJSONSchema

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1092,6 +1092,9 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "items": false,
+        "maxItems": 2,
+        "minItems": 2,
         "prefixItems": [
           {
             "type": "string",
@@ -1209,6 +1212,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(schema, { target: "draft-7", io: "input" })).toMatchInlineSnapshot(`
       {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalItems": false,
         "items": [
           {
             "type": "string",
@@ -1217,6 +1221,8 @@ describe("toJSONSchema", () => {
             "type": "number",
           },
         ],
+        "maxItems": 2,
+        "minItems": 2,
         "type": "array",
       }
     `);

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -396,6 +396,8 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
     json.prefixItems = prefixItems;
     if (rest) {
       json.items = rest;
+    } else {
+      json.items = false;
     }
   } else if (ctx.target === "openapi-3.0") {
     json.items = {
@@ -413,14 +415,19 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
     json.items = prefixItems;
     if (rest) {
       json.additionalItems = rest;
+    } else {
+      json.additionalItems = false;
     }
   }
 
-  // length
   const { minimum, maximum } = schema._zod.bag as {
     minimum?: number;
     maximum?: number;
   };
+  if (!rest) {
+    if (typeof minimum !== "number") json.minItems = prefixItems.length;
+    if (typeof maximum !== "number") json.maxItems = prefixItems.length;
+  }
   if (typeof minimum === "number") json.minItems = minimum;
   if (typeof maximum === "number") json.maxItems = maximum;
 };


### PR DESCRIPTION
Fixes #6193