### PR TITLE
docs: update UUID helper list to show v4 as the default version

### DIFF
--- a/packages/docs/content/v4/index.mdx
+++ b/packages/docs/content/v4/index.mdx
@@ -652,8 +652,8 @@ All "string formats" (email, etc.) have been promoted to top-level functions on 
 ```ts
 z.email();
 z.uuidv4();
+z.uuidv6();
 z.uuidv7();
-z.uuidv8();
 z.ipv4();
 z.ipv6();
 z.cidrv4();


### PR DESCRIPTION
Clarifies that Zod uses UUID v4 by default.