### PR TITLE
fix(multipleOf): use ULP-based tolerance to reject near-multiple values

### DIFF
--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -137,6 +137,17 @@ test("multipleOf", () => {
   expect(() => schemas.schema7.parse(numbers.number8)).toThrow();
 });
 
+test(".multipleOf() accepts exact decimal multiples", () => {
+  // 2.03 === 29 * 0.07, but val / step lands ~1.1 ULP away from 29, so a
+  // one-ULP tolerance wrongly rejected it while neighbours (1.96, 2.10) passed.
+  const schema = z.number().multipleOf(0.07);
+  expect(schema.safeParse(2.03).success).toBe(true);
+  expect(schema.safeParse(4.06).success).toBe(true);
+  expect(schema.safeParse(8.54).success).toBe(true);
+  // genuine non-multiples must still be rejected
+  expect(schema.safeParse(2.04).success).toBe(false);
+});
+
 test(".multipleOf() with positive divisor", () => {
   const schema = z.number().multipleOf(5);
   expect(schema.parse(15)).toEqual(15);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -248,8 +248,11 @@ export function cleanRegex(source: string): string {
 export function floatSafeRemainder(val: number, step: number): number {
   const ratio = val / step;
   const roundedRatio = Math.round(ratio);
-  // Use a relative epsilon scaled to the magnitude of the result
-  const tolerance = Number.EPSILON * Math.max(Math.abs(ratio), 1);
+  // The quotient val / step accumulates rounding error from representing
+  // `val` and `step` as floats and from the division itself, so allow a few
+  // ULPs of tolerance. A single ULP (the previous value) rejected exact decimal
+  // multiples such as 2.03 === 29 * 0.07, whose quotient lands ~1.1 ULP away.
+  const tolerance = 4 * Number.EPSILON * Math.max(Math.abs(ratio), 1);
   if (Math.abs(ratio - roundedRatio) < tolerance) return 0;
   return ratio - roundedRatio;
 }


### PR DESCRIPTION
Improves multipleOf validation precision for decimal values.