### PR TITLE
fix: validate object and record intersection key types correctly

### DIFF
--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -196,3 +196,33 @@ test("invalid deep merge of object and array combination", async () => {
     `[Error: Unmergable intersection. Error path: ["students",0,"name"]]`
   );
 });
+
+test("object and record intersection: record should not validate keys owned by the object side", () => {
+  // Regression test for https://github.com/colinhacks/zod/issues/2573
+  // Previously, the record side of an object & record intersection ran
+  // against the *entire* input, including keys that structurally belong to
+  // the object side. If the record's valueType didn't match the object's
+  // field shapes, this produced a spurious validation failure even though
+  // the object side already validated those keys correctly.
+  const Config = z
+    .object({ name: z.object({ first: z.string() }) })
+    .and(z.record(z.string(), z.object({ sub: z.string() })));
+
+  const valid = { name: { first: "Ada" }, extra: { sub: "value" } };
+  expect(Config.parse(valid)).toEqual(valid);
+
+  // Symmetric case: record on the left, object on the right.
+  const ConfigReversed = z
+    .record(z.string(), z.object({ sub: z.string() }))
+    .and(z.object({ name: z.object({ first: z.string() }) }));
+  expect(ConfigReversed.parse(valid)).toEqual(valid);
+
+  // A key that is genuinely invalid under the record's valueType (and not
+  // owned by the object's shape) should still fail as before.
+  const invalid = { name: { first: "Ada" }, extra: { notSub: 1 } };
+  expect(() => Config.parse(invalid)).toThrow();
+
+  // The object side's own validation errors must still surface correctly.
+  const invalidObjectSide = { name: { first: 1 }, extra: { sub: "value" } };
+  expect(() => Config.parse(invalidObjectSide)).toThrow();
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2477,8 +2477,10 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
 
     inst._zod.parse = (payload, ctx) => {
       const input = payload.value;
-      const left = def.left._zod.run({ value: input, issues: [] }, ctx);
-      const right = def.right._zod.run({ value: input, issues: [] }, ctx);
+      const leftInput = getIntersectionSideInput(def.left, def.right, input);
+      const rightInput = getIntersectionSideInput(def.right, def.left, input);
+      const left = def.left._zod.run({ value: leftInput, issues: [] }, ctx);
+      const right = def.right._zod.run({ value: rightInput, issues: [] }, ctx);
       const async = left instanceof Promise || right instanceof Promise;
 
       if (async) {
@@ -2491,6 +2493,26 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
     };
   }
 );
+
+// When intersecting an object schema with a record schema, the record side
+// should not attempt to validate keys that structurally belong to the object
+// schema's own shape. Without this, a record valueType that doesn't match the
+// object's field shapes causes spurious validation failures on keys that the
+// object side already owns and validates correctly (see zod issue #2573).
+function getIntersectionSideInput(thisSchema: SomeType, otherSchema: SomeType, input: unknown): unknown {
+  const thisType = (thisSchema as any)?._zod?.def?.type;
+  const otherType = (otherSchema as any)?._zod?.def?.type;
+  if (thisType === "record" && otherType === "object" && util.isPlainObject(input)) {
+    const shape = (otherSchema as any)._zod.def.shape as Record<string, unknown>;
+    const shapeKeys = new Set(Object.keys(shape));
+    const filtered: Record<string, unknown> = {};
+    for (const key of Object.keys(input as Record<string, unknown>)) {
+      if (!shapeKeys.has(key)) filtered[key] = (input as Record<string, unknown>)[key];
+    }
+    return filtered;
+  }
+  return input;
+}
 
 function mergeValues(
   a: any,


### PR DESCRIPTION
Fixes key validation for object & record intersection schemas.