### PR TITLE
feat: add timezone offset option to z.iso.time() for RFC3339 full-time

### DIFF
--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -150,6 +150,14 @@ test("z.iso.time", () => {
   expect(z.safeParse(c, d1).success).toEqual(true);
   expect(z.safeParse(c, d2).success).toEqual(true);
   expect(z.safeParse(c, d3).success).toEqual(false);
+
+  // offset: true allows timezone suffixes (Z, +HH:MM, -HH:MM)
+  const withOffset = z.iso.time({ offset: true });
+  expect(z.safeParse(withOffset, "10:15:30Z").success).toEqual(true);
+  expect(z.safeParse(withOffset, "10:15:30+02:00").success).toEqual(true);
+  expect(z.safeParse(withOffset, "10:15:30-05:30").success).toEqual(true);
+  expect(z.safeParse(withOffset, "10:15:30").success).toEqual(false); // no offset ??? rejected when offset required
+  expect(z.safeParse(withOffset, "bad data").success).toEqual(false);
 });
 
 test("z.iso.duration", () => {

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -110,9 +110,14 @@ function timeSource(args: { precision?: number | null | undefined }) {
 }
 export function time(args: {
   precision?: number | null;
+  offset?: boolean;
   // local?: boolean;
 }): RegExp {
-  return new RegExp(`^${timeSource(args)}$`);
+  const t = timeSource(args);
+  if (args.offset) {
+    return new RegExp(`^${t}(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$`);
+  }
+  return new RegExp(`^${t}$`);
 }
 
 // Adapted from https://stackoverflow.com/a/3143231

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -730,6 +730,7 @@ export const $ZodISODate: core.$constructor<$ZodISODate> = /*@__PURE__*/ core.$c
 
 export interface $ZodISOTimeDef extends $ZodStringFormatDef<"time"> {
   precision?: number | null;
+  offset?: boolean;
 }
 
 export interface $ZodISOTimeInternals extends $ZodStringFormatInternals<"time"> {


### PR DESCRIPTION
Fixes #6204. Adds support for RFC3339 full-time with timezone offset.