### PR TITLE
fix(exactOptional): skip coercion check for absent optional keys

### DIFF
--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -268,6 +268,21 @@ test("exactOptional vs optional comparison", () => {
   expect(exactOptionalSchema.safeParse({ a: undefined }).success).toEqual(false);
 });
 
+test("exactOptional with coercion", () => {
+  // Absent key should not produce value
+  expect(z.object({ a: z.coerce.number().exactOptional() }).parse({})).toEqual({});
+  expect(z.object({ a: z.coerce.string().exactOptional() }).parse({})).toEqual({});
+  expect(z.object({ a: z.coerce.boolean().exactOptional() }).parse({})).toEqual({});
+  expect(z.object({ a: z.coerce.bigint().exactOptional() }).parse({})).toEqual({});
+  expect(z.object({ a: z.coerce.date().exactOptional() }).parse({})).toEqual({});
+
+  // Explicit undefined should still reject with coercion
+  expect(z.object({ a: z.coerce.number().exactOptional() }).safeParse({ a: undefined }).success).toEqual(false);
+
+  // Present value with coercion should still work
+  expect(z.object({ a: z.coerce.number().exactOptional() }).parse({ a: "42" })).toEqual({ a: 42 });
+});
+
 // Defensive inference coverage: every schema that propagates `optout` participates
 // in object-key optionality inference. If anyone ever changes the set of values that
 // `optout` can take (or how OptionalOutSchema matches them), these assertions must

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3544,9 +3544,18 @@ export const $ZodExactOptional: core.$constructor<$ZodExactOptional> = /*@__PURE
     util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
     util.defineLazy(inst._zod, "pattern", () => def.innerType._zod.pattern);
 
-    // Override parse to just delegate (no undefined handling)
     inst._zod.parse = (payload, ctx) => {
-      return def.innerType._zod.run(payload, ctx);
+      const wasUndefined = payload.value === undefined;
+      const result = def.innerType._zod.run(payload, ctx);
+      if (wasUndefined) {
+        const overwrite = (r: ParsePayload) => {
+          r.value = undefined;
+          return r;
+        };
+        if (result instanceof Promise) return result.then(overwrite);
+        return overwrite(result);
+      }
+      return result;
     };
   }
 );


### PR DESCRIPTION
Fixes #6236. Prevents coercion errors on absent exactOptional keys.