### PR TITLE
fix(looseRecord): pass through unrecognized keys in loose mode for closed key schemas

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2937,8 +2937,12 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       let unrecognized!: string[];
       for (const key in input) {
         if (!recordKeys.has(key)) {
-          unrecognized = unrecognized ?? [];
-          unrecognized.push(key);
+          if (def.mode === "loose") {
+            payload.value[key] = input[key];
+          } else {
+            unrecognized = unrecognized ?? [];
+            unrecognized.push(key);
+          }
         }
       }
       if (unrecognized && unrecognized.length > 0) {


### PR DESCRIPTION
Fixes #6156. When a looseRecord uses a closed key schema (like z.enum), unrecognized keys are now passed through instead of reporting unrecognized_keys errors.