### PR TITLE
fix(ci): move pnpm build before typescript matrix override

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm build
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all
       - run: pnpm run --filter @zod/integration test:all


### PR DESCRIPTION
Fixes #6185. Building with the repo's pinned TypeScript before installing the matrix-specified version so zshy isn't broken by TS 7.0.2's Go-native compiler.