### PR TITLE
fix(json-schema): encode  pointer tokens per RFC 6901

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -260,7 +260,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id.replace(/~/g, "~0").replace(/\//g, "~1")}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +271,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + defId.replace(/~/g, "~0").replace(/\//g, "~1") };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
Fixes #6027. Escapes ~ and / characters in JSON Pointer tokens when constructing  URIs from schema meta ids, per RFC 6901.