### PR TITLE
fix(toJSONSchema): preserve default for ZodDefault/ZodCatch even when inner type transforms

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2628,6 +2628,7 @@ test("defaults/prefaults", () => {
   expect(z.toJSONSchema(c, { io: "input" })).toMatchInlineSnapshot(`
     {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": 1234,
       "type": "string",
     }
   `);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -200,8 +200,12 @@ export function process<T extends schemas.$ZodType>(
 
   if (ctx.io === "input" && isTransforming(schema)) {
     // examples/defaults only apply to output type of pipe
-    delete result.schema.examples;
-    delete result.schema.default;
+    // But preserve default if the schema itself explicitly set it (e.g. ZodDefault/ZodCatch)
+    const defType = schema._zod.def.type;
+    if (defType !== "default" && defType !== "catch") {
+      delete result.schema.examples;
+      delete result.schema.default;
+    }
   }
 
   // set prefault as default


### PR DESCRIPTION
Fixes #6049. The generic transforming-schema check at the end of process() was deleting default even for ZodDefault/ZodCatch schemas that intentionally set it. Now skips the deletion for those schema types.