### PR TITLE
fix(fromJSONSchema): make prefixItems tuple elements optional when minItems is omitted

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -1,4 +1,4 @@
-import type * as JSONSchema from "../core/json-schema.js";
+﻿import type * as JSONSchema from "../core/json-schema.js";
 import { type $ZodRegistry, globalRegistry } from "../core/registries.js";
 import { assignProp } from "../core/util.js";
 import * as _checks from "./checks.js";
@@ -470,7 +470,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         // Tuple with prefixItems (draft-2020-12)
         // Without minItems, prefix items beyond the minimum are optional-out so shorter arrays are valid
         const minRequired = typeof schema.minItems === "number" ? schema.minItems : 0;
-        let tupleItems: ZodType[] = prefixItems.map((item, i) => {
+        const tupleItems: ZodType[] = prefixItems.map((item, i) => {
           const schema = convertSchema(item as JSONSchema.JSONSchema, ctx);
           return i >= minRequired ? schema.optional() : schema;
         });
@@ -494,7 +494,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         // Tuple with items array (draft-7)
         // Without minItems, array-form items beyond the minimum are optional-out so shorter arrays are valid
         const minRequired = typeof schema.minItems === "number" ? schema.minItems : 0;
-        let tupleItems: ZodType[] = items.map((item, i) => {
+        const tupleItems: ZodType[] = items.map((item, i) => {
           const schema = convertSchema(item as JSONSchema.JSONSchema, ctx);
           return i >= minRequired ? schema.optional() : schema;
         });

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -468,7 +468,12 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
 
       if (prefixItems && Array.isArray(prefixItems)) {
         // Tuple with prefixItems (draft-2020-12)
-        const tupleItems = prefixItems.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
+        // Without minItems, prefix items beyond the minimum are optional-out so shorter arrays are valid
+        const minRequired = typeof schema.minItems === "number" ? schema.minItems : 0;
+        let tupleItems: ZodType[] = prefixItems.map((item, i) => {
+          const schema = convertSchema(item as JSONSchema.JSONSchema, ctx);
+          return i >= minRequired ? schema.optional() : schema;
+        });
         const rest =
           items && typeof items === "object" && !Array.isArray(items)
             ? convertSchema(items as JSONSchema.JSONSchema, ctx)
@@ -487,7 +492,12 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         }
       } else if (Array.isArray(items)) {
         // Tuple with items array (draft-7)
-        const tupleItems = items.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
+        // Without minItems, array-form items beyond the minimum are optional-out so shorter arrays are valid
+        const minRequired = typeof schema.minItems === "number" ? schema.minItems : 0;
+        let tupleItems: ZodType[] = items.map((item, i) => {
+          const schema = convertSchema(item as JSONSchema.JSONSchema, ctx);
+          return i >= minRequired ? schema.optional() : schema;
+        });
         const rest =
           schema.additionalItems && typeof schema.additionalItems === "object"
             ? convertSchema(schema.additionalItems as JSONSchema.JSONSchema, ctx)

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -128,7 +128,9 @@ test("tuple with prefixItems (draft-2020-12)", () => {
     prefixItems: [{ type: "string" }, { type: "number" }],
   });
   expect(schema.parse(["hello", 42])).toEqual(["hello", 42]);
-  expect(() => schema.parse(["hello"])).toThrow();
+  // Without minItems, shorter arrays are valid — present items are validated positionally
+  expect(schema.parse(["hello"])).toEqual(["hello"]);
+  expect(schema.parse([])).toEqual([]);
   expect(() => schema.parse(["hello", "world"])).toThrow();
 });
 
@@ -140,7 +142,13 @@ test("tuple with items array (draft-7)", () => {
     additionalItems: false,
   });
   expect(schema.parse(["hello", 42])).toEqual(["hello", 42]);
+  // Without minItems, shorter arrays are valid
+  expect(schema.parse(["hello"])).toEqual(["hello"]);
+  expect(schema.parse([])).toEqual([]);
+  // Additional items beyond the positional schemas are still rejected
   expect(() => schema.parse(["hello", 42, "extra"])).toThrow();
+  // Wrong type at position 1 still fails
+  expect(() => schema.parse(["hello", "world"])).toThrow();
 });
 
 test("enum schema", () => {


### PR DESCRIPTION
Fixes #6200. Tuple elements beyond minItems are now optional-out, allowing shorter arrays to validate. When minItems is not set (defaults to 0), all positional elements are optional.