### PR TITLE
fix: make z.any() and z.unknown() object properties optional

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1436,6 +1436,7 @@ export interface $ZodAnyDef extends $ZodTypeDef {
 export interface $ZodAnyInternals extends $ZodTypeInternals<any, any> {
   def: $ZodAnyDef;
   isst: never;
+  optin: "optional";
 }
 
 export interface $ZodAny extends $ZodType {
@@ -1463,6 +1464,7 @@ export interface $ZodUnknownDef extends $ZodTypeDef {
 export interface $ZodUnknownInternals extends $ZodTypeInternals<unknown, unknown> {
   def: $ZodUnknownDef;
   isst: never;
+  optin: "optional";
 }
 
 export interface $ZodUnknown extends $ZodType {


### PR DESCRIPTION
Fixes #5997. z.any() and z.unknown() should accept missing object keys since they accept all input values including undefined.