### PR TITLE
fix(partial): skip wrapping already-optional fields with ZodOptional

### DIFF
--- a/packages/zod/src/v4/classic/tests/partial.test.ts
+++ b/packages/zod/src/v4/classic/tests/partial.test.ts
@@ -119,7 +119,8 @@ test("partial with mask", async () => {
 
   expect(masked.shape.name).toBeInstanceOf(z.ZodOptional);
   expect(masked.shape.age).toBeInstanceOf(z.ZodOptional);
-  expect(masked.shape.field).toBeInstanceOf(z.ZodOptional);
+  // field already has optin via .default(), so .partial() doesn't double-wrap
+  expect(masked.shape.field).toBeInstanceOf(z.ZodDefault);
   expect(masked.shape.country).toBeInstanceOf(z.ZodString);
 
   masked.parse({ country: "US" });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -740,7 +740,7 @@ export function partial(
             throw new Error(`Unrecognized key: "${key}"`);
           }
           if (!(mask as any)[key]) continue;
-          // if (oldShape[key]!._zod.optin === "optional") continue;
+          if (oldShape[key]!._zod.optin === "optional") continue;
           shape[key] = Class
             ? new Class({
                 type: "optional",


### PR DESCRIPTION
Fixes #6171. When .partial() is called, fields that already have optin: 'optional' (from .optional() or .default()) are no longer double-wrapped with another ZodOptional.