### PR TITLE
fix: propagate @deprecated JSDoc through type aliases

### DIFF
--- a/packages/zod/src/v4/classic/compat.ts
+++ b/packages/zod/src/v4/classic/compat.ts
@@ -54,14 +54,12 @@ export function getErrorMap(): core.$ZodErrorMap<core.$ZodIssue> | undefined {
   return core.config().customError;
 }
 
-export type {
-  /** @deprecated Use z.ZodType (without generics) instead. */
-  ZodType as ZodTypeAny,
-  /** @deprecated Use `z.ZodType` */
-  ZodType as ZodSchema,
-  /** @deprecated Use `z.ZodType` */
-  ZodType as Schema,
-};
+/** @deprecated Use z.ZodType (without generics) instead. */
+export type ZodTypeAny = ZodType;
+/** @deprecated Use `z.ZodType` */
+export type ZodSchema = ZodType;
+/** @deprecated Use `z.ZodType` */
+export type Schema = ZodType;
 
 /** Included for Zod 3 compatibility */
 export type ZodRawShape = core.$ZodShape;


### PR DESCRIPTION
Fixes #6038.

## Problem

export type { ZodType as ZodTypeAny } re-export syntax in TypeScript discards @deprecated JSDoc tags. IDEs like VSCode don't show deprecation strikethroughs for these aliases.

## Fix

Replace export type { A as B } with explicit type alias declarations (export type B = A) so the @deprecated JSDoc is preserved and IDEs display strikethroughs correctly.