### PR TITLE
fix: add RFC 1035 length limits to domain regex

### DIFF
--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -84,7 +84,8 @@ export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
 export const hostname: RegExp =
   /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
 
-export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+export const domain: RegExp =
+  /^(?=.{1,253}\.?$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
 
 export const httpProtocol: RegExp = /^https?$/;
 


### PR DESCRIPTION
Fixes #5965.

## Problem

The \domain\ regex (used by \z.httpUrl()\ for host validation) has per-label length limits but no overall domain length limit. RFC 1035 requires domain names be at most 253 characters.

## Fix

- Add \(?=.{1,253}\\.?\$)\ lookahead to enforce the RFC 1035 overall length limit
- Cap TLD labels at 63 characters (\[a-zA-Z]{2,63}\ → \[a-zA-Z]{2,63}\)

This brings the \domain\ regex in line with the \hostname\ regex which already enforces these limits.