### PR TITLE
fix: use isThenable instead of instanceof Promise for Zone.js compat

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -234,10 +234,10 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
         const currLen = payload.issues.length;
         const _ = ch._zod.check(payload as any) as any as ParsePayload;
 
-        if (_ instanceof Promise && ctx?.async === false) {
+        if (util.isThenable(_) && ctx?.async === false) {
           throw new core.$ZodAsyncError();
         }
-        if (asyncResult || _ instanceof Promise) {
+        if (asyncResult || util.isThenable(_)) {
           asyncResult = (asyncResult ?? Promise.resolve()).then(async () => {
             await _;
             const nextLen = payload.issues.length;
@@ -268,7 +268,7 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
 
       // run checks first, then
       const checkResult = runChecks(payload, checks, ctx);
-      if (checkResult instanceof Promise) {
+      if (util.isThenable(checkResult)) {
         if (ctx.async === false) throw new core.$ZodAsyncError();
         return checkResult.then((checkResult) => inst._zod.parse(checkResult, ctx));
       }
@@ -284,7 +284,7 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
         // initial pass (no checks)
         const canary = inst._zod.parse({ value: payload.value, issues: [] }, { ...ctx, skipChecks: true });
 
-        if (canary instanceof Promise) {
+        if (util.isThenable(canary)) {
           return canary.then((canary) => {
             return handleCanaryResult(canary, payload, ctx);
           });
@@ -295,7 +295,7 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
 
       // forward
       const result = inst._zod.parse(payload, ctx);
-      if (result instanceof Promise) {
+      if (util.isThenable(result)) {
         if (ctx.async === false) throw new core.$ZodAsyncError();
         return result.then((result) => runChecks(result, checks, ctx));
       }

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -153,6 +153,9 @@ export type TupleItems = ReadonlyArray<schemas.SomeType>;
 export type AnyFunc = (...args: any[]) => any;
 export type IsProp<T, K extends keyof T> = T[K] extends AnyFunc ? never : K;
 export type MaybeAsync<T> = T | Promise<T>;
+export function isThenable(value: unknown): value is Promise<unknown> {
+  return value != null && typeof (value as any).then === "function";
+}
 export type KeyOf<T> = keyof OmitIndexSignature<T>;
 export type OmitIndexSignature<T> = {
   [K in keyof T as string extends K ? never : K extends string ? K : never]: T[K];


### PR DESCRIPTION
Fixes #6019.

## Problem

When \globalThis.Promise\ is patched by Zone.js, NgZone, \@opentelemetry/context-zone\, etc., \sync function\ still returns native Promise (from the internal %Promise% intrinsic), while the bare identifier \Promise\ resolves to the patched subclass. The check \esult instanceof Promise\ returns \alse\ even for async results, causing zod to fall through to the sync path. This silently drops \ctx.addIssue()\ calls inside \sync superRefine\ callbacks.

## Fix

Replace \instanceof Promise\ with a duck-typing \isThenable()\ check (\alue != null && typeof value.then === 'function'\). This is the idiomatic Promise/A+ approach and matches how \wait\ itself recognizes thenables internally.

Affected environments: Zone.js, Angular (NgZone), OpenTelemetry context-zone, and any other code that patches \globalThis.Promise\.