### PR TITLE
fix: prevent metadata from overriding schema-derived type in toJSONSchema

### DIFF
--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -194,9 +194,12 @@ export function process<T extends schemas.$ZodType>(
     }
   }
 
-  // metadata
+  // metadata (schema-derived fields take precedence)
   const meta = ctx.metadataRegistry.get(schema);
-  if (meta) Object.assign(result.schema, meta);
+  if (meta) {
+    const { type: _t, ...metaRest } = meta;
+    Object.assign(result.schema, metaRest);
+  }
 
   if (ctx.io === "input" && isTransforming(schema)) {
     // examples/defaults only apply to output type of pipe


### PR DESCRIPTION
Fixes #5990.

## Problem

Calling `z.string().meta({ type: 'number' }).toJSONSchema()` produces `{ type: "number" }` because all metadata fields are blindly copied into the JSON Schema output, allowing metadata to override schema-derived properties like `type`.

## Fix

Exclude the `type` field from metadata before merging into the JSON Schema. Schema-derived properties always take precedence over metadata.
