### PR TITLE
fix: show 'Infinity'/'NaN' in error message when parsing non-finite numbers

### DIFF
--- a/packages/zod/src/v4/classic/tests/number.test.ts
+++ b/packages/zod/src/v4/classic/tests/number.test.ts
@@ -22,7 +22,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -36,7 +36,7 @@ test("Infinity validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -208,7 +208,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,
@@ -222,7 +222,7 @@ test(".finite() validation", () => {
         "code": "invalid_type",
         "received": "Infinity",
         "path": [],
-        "message": "Invalid input: expected number, received number"
+        "message": "Invalid input: expected number, received Infinity"
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/classic/tests/primitive.test.ts
+++ b/packages/zod/src/v4/classic/tests/primitive.test.ts
@@ -108,7 +108,7 @@ test("date schema", async () => {
         "code": "invalid_type",
         "received": "Invalid Date",
         "path": [],
-        "message": "Invalid input: expected date, received Date"
+        "message": "Invalid input: expected date, received Invalid Date"
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -45,6 +45,7 @@ export interface $ZodIssueInvalidType<Input = unknown> extends $ZodIssueBase {
   readonly code: "invalid_type";
   readonly expected: $ZodInvalidTypeExpected;
   readonly input?: Input;
+  readonly received?: string;
 }
 
 export interface $ZodIssueTooBig<Input = unknown> extends $ZodIssueBase {

--- a/packages/zod/src/v4/locales/ar.ts
+++ b/packages/zod/src/v4/locales/ar.ts
@@ -57,7 +57,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `مدخلات غير مقبولة: يفترض إدخال instanceof ${issue.expected}، ولكن تم إدخال ${received}`;

--- a/packages/zod/src/v4/locales/az.ts
+++ b/packages/zod/src/v4/locales/az.ts
@@ -57,7 +57,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Yanlış dəyər: gözlənilən instanceof ${issue.expected}, daxil olan ${received}`;

--- a/packages/zod/src/v4/locales/be.ts
+++ b/packages/zod/src/v4/locales/be.ts
@@ -115,7 +115,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Няправільны ўвод: чакаўся instanceof ${issue.expected}, атрымана ${received}`;

--- a/packages/zod/src/v4/locales/bg.ts
+++ b/packages/zod/src/v4/locales/bg.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Невалиден вход: очакван instanceof ${issue.expected}, получен ${received}`;

--- a/packages/zod/src/v4/locales/ca.ts
+++ b/packages/zod/src/v4/locales/ca.ts
@@ -57,7 +57,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Tipus invàlid: s'esperava instanceof ${issue.expected}, s'ha rebut ${received}`;

--- a/packages/zod/src/v4/locales/cs.ts
+++ b/packages/zod/src/v4/locales/cs.ts
@@ -61,7 +61,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Neplatný vstup: očekáváno instanceof ${issue.expected}, obdrženo ${received}`;

--- a/packages/zod/src/v4/locales/da.ts
+++ b/packages/zod/src/v4/locales/da.ts
@@ -64,7 +64,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Ugyldigt input: forventede instanceof ${issue.expected}, fik ${received}`;

--- a/packages/zod/src/v4/locales/de.ts
+++ b/packages/zod/src/v4/locales/de.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Ungültige Eingabe: erwartet instanceof ${issue.expected}, erhalten ${received}`;

--- a/packages/zod/src/v4/locales/el.ts
+++ b/packages/zod/src/v4/locales/el.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (typeof issue.expected === "string" && /^[A-Z]/.test(issue.expected)) {
           return `Μη έγκυρη είσοδος: αναμενόταν instanceof ${issue.expected}, λήφθηκε ${received}`;

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -62,7 +62,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         return `Invalid input: expected ${expected}, received ${received}`;
       }

--- a/packages/zod/src/v4/locales/eo.ts
+++ b/packages/zod/src/v4/locales/eo.ts
@@ -60,7 +60,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Nevalida enigo: atendiĝis instanceof ${issue.expected}, riceviĝis ${received}`;

--- a/packages/zod/src/v4/locales/es.ts
+++ b/packages/zod/src/v4/locales/es.ts
@@ -81,7 +81,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Entrada inválida: se esperaba instanceof ${issue.expected}, recibido ${received}`;

--- a/packages/zod/src/v4/locales/fa.ts
+++ b/packages/zod/src/v4/locales/fa.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `ورودی نامعتبر: می‌بایست instanceof ${issue.expected} می‌بود، ${received} دریافت شد`;

--- a/packages/zod/src/v4/locales/fi.ts
+++ b/packages/zod/src/v4/locales/fi.ts
@@ -61,7 +61,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Virheellinen tyyppi: odotettiin instanceof ${issue.expected}, oli ${received}`;

--- a/packages/zod/src/v4/locales/fr-CA.ts
+++ b/packages/zod/src/v4/locales/fr-CA.ts
@@ -57,7 +57,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Entrée invalide : attendu instanceof ${issue.expected}, reçu ${received}`;

--- a/packages/zod/src/v4/locales/fr.ts
+++ b/packages/zod/src/v4/locales/fr.ts
@@ -77,7 +77,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Entrée invalide : instanceof ${issue.expected} attendu, ${received} reçu`;

--- a/packages/zod/src/v4/locales/he.ts
+++ b/packages/zod/src/v4/locales/he.ts
@@ -105,7 +105,7 @@ const error: () => errors.$ZodErrorMap = () => {
         const expectedKey = issue.expected as string | undefined;
         const expected = TypeDictionary[expectedKey ?? ""] ?? typeLabel(expectedKey);
         // Received: show localized label if known, otherwise constructor/raw
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? TypeNames[receivedType]?.label ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `קלט לא תקין: צריך להיות instanceof ${issue.expected}, התקבל ${received}`;

--- a/packages/zod/src/v4/locales/hr.ts
+++ b/packages/zod/src/v4/locales/hr.ts
@@ -71,7 +71,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Neispravan unos: očekuje se instanceof ${issue.expected}, a primljeno je ${received}`;

--- a/packages/zod/src/v4/locales/hu.ts
+++ b/packages/zod/src/v4/locales/hu.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Érvénytelen bemenet: a várt érték instanceof ${issue.expected}, a kapott érték ${received}`;

--- a/packages/zod/src/v4/locales/hy.ts
+++ b/packages/zod/src/v4/locales/hy.ts
@@ -102,7 +102,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Սխալ մուտքագրում․ սպասվում էր instanceof ${issue.expected}, ստացվել է ${received}`;

--- a/packages/zod/src/v4/locales/id.ts
+++ b/packages/zod/src/v4/locales/id.ts
@@ -57,7 +57,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Input tidak valid: diharapkan instanceof ${issue.expected}, diterima ${received}`;

--- a/packages/zod/src/v4/locales/is.ts
+++ b/packages/zod/src/v4/locales/is.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Rangt gildi: Þú slóst inn ${received} þar sem á að vera instanceof ${issue.expected}`;

--- a/packages/zod/src/v4/locales/it.ts
+++ b/packages/zod/src/v4/locales/it.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Input non valido: atteso instanceof ${issue.expected}, ricevuto ${received}`;

--- a/packages/zod/src/v4/locales/ja.ts
+++ b/packages/zod/src/v4/locales/ja.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `無効な入力: instanceof ${issue.expected}が期待されましたが、${received}が入力されました`;

--- a/packages/zod/src/v4/locales/ka.ts
+++ b/packages/zod/src/v4/locales/ka.ts
@@ -62,7 +62,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `არასწორი შეყვანა: მოსალოდნელი instanceof ${issue.expected}, მიღებული ${received}`;

--- a/packages/zod/src/v4/locales/km.ts
+++ b/packages/zod/src/v4/locales/km.ts
@@ -60,7 +60,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `ទិន្នន័យបញ្ចូលមិនត្រឹមត្រូវ៖ ត្រូវការ instanceof ${issue.expected} ប៉ុន្តែទទួលបាន ${received}`;

--- a/packages/zod/src/v4/locales/ko.ts
+++ b/packages/zod/src/v4/locales/ko.ts
@@ -57,7 +57,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `잘못된 입력: 예상 타입은 instanceof ${issue.expected}, 받은 타입은 ${received}입니다`;

--- a/packages/zod/src/v4/locales/lt.ts
+++ b/packages/zod/src/v4/locales/lt.ts
@@ -168,7 +168,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Gautas tipas ${received}, o tikėtasi - instanceof ${issue.expected}`;

--- a/packages/zod/src/v4/locales/mk.ts
+++ b/packages/zod/src/v4/locales/mk.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Грешен внес: се очекува instanceof ${issue.expected}, примено ${received}`;

--- a/packages/zod/src/v4/locales/ms.ts
+++ b/packages/zod/src/v4/locales/ms.ts
@@ -58,7 +58,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Input tidak sah: dijangka instanceof ${issue.expected}, diterima ${received}`;

--- a/packages/zod/src/v4/locales/nl.ts
+++ b/packages/zod/src/v4/locales/nl.ts
@@ -58,7 +58,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Ongeldige invoer: verwacht instanceof ${issue.expected}, ontving ${received}`;

--- a/packages/zod/src/v4/locales/no.ts
+++ b/packages/zod/src/v4/locales/no.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Ugyldig input: forventet instanceof ${issue.expected}, fikk ${received}`;

--- a/packages/zod/src/v4/locales/ota.ts
+++ b/packages/zod/src/v4/locales/ota.ts
@@ -60,7 +60,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Fâsit giren: umulan instanceof ${issue.expected}, alınan ${received}`;

--- a/packages/zod/src/v4/locales/pl.ts
+++ b/packages/zod/src/v4/locales/pl.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Nieprawidłowe dane wejściowe: oczekiwano instanceof ${issue.expected}, otrzymano ${received}`;

--- a/packages/zod/src/v4/locales/ps.ts
+++ b/packages/zod/src/v4/locales/ps.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `ناسم ورودي: باید instanceof ${issue.expected} وای, مګر ${received} ترلاسه شو`;

--- a/packages/zod/src/v4/locales/pt.ts
+++ b/packages/zod/src/v4/locales/pt.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Tipo inválido: esperado instanceof ${issue.expected}, recebido ${received}`;

--- a/packages/zod/src/v4/locales/ro.ts
+++ b/packages/zod/src/v4/locales/ro.ts
@@ -72,7 +72,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         return `Intrare invalidă: așteptat ${expected}, primit ${received}`;
       }

--- a/packages/zod/src/v4/locales/ru.ts
+++ b/packages/zod/src/v4/locales/ru.ts
@@ -115,7 +115,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Неверный ввод: ожидалось instanceof ${issue.expected}, получено ${received}`;

--- a/packages/zod/src/v4/locales/sl.ts
+++ b/packages/zod/src/v4/locales/sl.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Neveljaven vnos: pričakovano instanceof ${issue.expected}, prejeto ${received}`;

--- a/packages/zod/src/v4/locales/sv.ts
+++ b/packages/zod/src/v4/locales/sv.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Ogiltig inmatning: förväntat instanceof ${issue.expected}, fick ${received}`;

--- a/packages/zod/src/v4/locales/ta.ts
+++ b/packages/zod/src/v4/locales/ta.ts
@@ -60,7 +60,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `தவறான உள்ளீடு: எதிர்பார்க்கப்பட்டது instanceof ${issue.expected}, பெறப்பட்டது ${received}`;

--- a/packages/zod/src/v4/locales/th.ts
+++ b/packages/zod/src/v4/locales/th.ts
@@ -60,7 +60,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `ประเภทข้อมูลไม่ถูกต้อง: ควรเป็น instanceof ${issue.expected} แต่ได้รับ ${received}`;

--- a/packages/zod/src/v4/locales/tr.ts
+++ b/packages/zod/src/v4/locales/tr.ts
@@ -57,7 +57,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Geçersiz değer: beklenen instanceof ${issue.expected}, alınan ${received}`;

--- a/packages/zod/src/v4/locales/uk.ts
+++ b/packages/zod/src/v4/locales/uk.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Неправильні вхідні дані: очікується instanceof ${issue.expected}, отримано ${received}`;

--- a/packages/zod/src/v4/locales/ur.ts
+++ b/packages/zod/src/v4/locales/ur.ts
@@ -60,7 +60,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `غلط ان پٹ: instanceof ${issue.expected} متوقع تھا، ${received} موصول ہوا`;

--- a/packages/zod/src/v4/locales/uz.ts
+++ b/packages/zod/src/v4/locales/uz.ts
@@ -61,7 +61,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Noto‘g‘ri kirish: kutilgan instanceof ${issue.expected}, qabul qilingan ${received}`;

--- a/packages/zod/src/v4/locales/vi.ts
+++ b/packages/zod/src/v4/locales/vi.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Đầu vào không hợp lệ: mong đợi instanceof ${issue.expected}, nhận được ${received}`;

--- a/packages/zod/src/v4/locales/yo.ts
+++ b/packages/zod/src/v4/locales/yo.ts
@@ -59,7 +59,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `Ìbáwọlé aṣìṣe: a ní láti fi instanceof ${issue.expected}, àmọ̀ a rí ${received}`;

--- a/packages/zod/src/v4/locales/zh-CN.ts
+++ b/packages/zod/src/v4/locales/zh-CN.ts
@@ -60,7 +60,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `无效输入：期望 instanceof ${issue.expected}，实际接收 ${received}`;

--- a/packages/zod/src/v4/locales/zh-TW.ts
+++ b/packages/zod/src/v4/locales/zh-TW.ts
@@ -57,7 +57,7 @@ const error: () => errors.$ZodErrorMap = () => {
     switch (issue.code) {
       case "invalid_type": {
         const expected = TypeDictionary[issue.expected] ?? issue.expected;
-        const receivedType = util.parsedType(issue.input);
+        const receivedType = issue.received ?? util.parsedType(issue.input);
         const received = TypeDictionary[receivedType] ?? receivedType;
         if (/^[A-Z]/.test(issue.expected)) {
           return `無效的輸入值：預期為 instanceof ${issue.expected}，但收到 ${received}`;


### PR DESCRIPTION
Fixes #5697.

## Problem

When parsing `Infinity` (or `-Infinity`) with `z.number()`, the error message reads `"Invalid input: expected number, received number"` — the `received` portion shows `"number"` (the JavaScript type) instead of `"Infinity"` (the actual received value described in the issue's `received` field). The same confusion applies for `NaN`, which produces `"expected number, received number"`.

## Root cause

The locale error map uses `util.parsedType(issue.input)` to produce the `received` display string. For `Infinity` and `NaN`, `parsedType` returns `"number"` (since `typeof Infinity === "number"`), ignoring the `issue.received` field which already contains the precise description (`"Infinity"` or `"NaN"`).

## Fix

1. Added `received?: string` to the `$ZodIssueInvalidType` type definition.
2. Changed the locale `invalid_type` handler to check `issue.received` first before falling back to `util.parsedType(issue.input)`.
3. Applied the same fix across all 52 locale files.

Now the error correctly says `"Invalid input: expected number, received Infinity"` and `"Invalid input: expected number, received NaN"`.
