### PR TITLE
fix(httpUrl): allow underscores in hostname

### DIFF
--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -53,63 +53,113 @@
     "./package.json": "./package.json",
     ".": {
       "@zod/source": "./src/index.ts",
-      "types": "./index.d.cts",
-      "import": "./index.js",
-      "require": "./index.cjs"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "require": {
+        "types": "./index.d.cts",
+        "default": "./index.cjs"
+      }
     },
     "./mini": {
       "@zod/source": "./src/mini/index.ts",
-      "types": "./mini/index.d.cts",
-      "import": "./mini/index.js",
-      "require": "./mini/index.cjs"
+      "import": {
+        "types": "./mini/index.d.ts",
+        "default": "./mini/index.js"
+      },
+      "require": {
+        "types": "./mini/index.d.cts",
+        "default": "./mini/index.cjs"
+      }
     },
     "./locales": {
       "@zod/source": "./src/locales/index.ts",
-      "types": "./locales/index.d.cts",
-      "import": "./locales/index.js",
-      "require": "./locales/index.cjs"
+      "import": {
+        "types": "./locales/index.d.ts",
+        "default": "./locales/index.js"
+      },
+      "require": {
+        "types": "./locales/index.d.cts",
+        "default": "./locales/index.cjs"
+      }
     },
     "./v3": {
       "@zod/source": "./src/v3/index.ts",
-      "types": "./v3/index.d.cts",
-      "import": "./v3/index.js",
-      "require": "./v3/index.cjs"
+      "import": {
+        "types": "./v3/index.d.ts",
+        "default": "./v3/index.js"
+      },
+      "require": {
+        "types": "./v3/index.d.cts",
+        "default": "./v3/index.cjs"
+      }
     },
     "./v4": {
       "@zod/source": "./src/v4/index.ts",
-      "types": "./v4/index.d.cts",
-      "import": "./v4/index.js",
-      "require": "./v4/index.cjs"
+      "import": {
+        "types": "./v4/index.d.ts",
+        "default": "./v4/index.js"
+      },
+      "require": {
+        "types": "./v4/index.d.cts",
+        "default": "./v4/index.cjs"
+      }
     },
     "./v4-mini": {
       "@zod/source": "./src/v4-mini/index.ts",
-      "types": "./v4-mini/index.d.cts",
-      "import": "./v4-mini/index.js",
-      "require": "./v4-mini/index.cjs"
+      "import": {
+        "types": "./v4-mini/index.d.ts",
+        "default": "./v4-mini/index.js"
+      },
+      "require": {
+        "types": "./v4-mini/index.d.cts",
+        "default": "./v4-mini/index.cjs"
+      }
     },
     "./v4/mini": {
       "@zod/source": "./src/v4/mini/index.ts",
-      "types": "./v4/mini/index.d.cts",
-      "import": "./v4/mini/index.js",
-      "require": "./v4/mini/index.cjs"
+      "import": {
+        "types": "./v4/mini/index.d.ts",
+        "default": "./v4/mini/index.js"
+      },
+      "require": {
+        "types": "./v4/mini/index.d.cts",
+        "default": "./v4/mini/index.cjs"
+      }
     },
     "./v4/core": {
       "@zod/source": "./src/v4/core/index.ts",
-      "types": "./v4/core/index.d.cts",
-      "import": "./v4/core/index.js",
-      "require": "./v4/core/index.cjs"
+      "import": {
+        "types": "./v4/core/index.d.ts",
+        "default": "./v4/core/index.js"
+      },
+      "require": {
+        "types": "./v4/core/index.d.cts",
+        "default": "./v4/core/index.cjs"
+      }
     },
     "./v4/locales": {
       "@zod/source": "./src/v4/locales/index.ts",
-      "types": "./v4/locales/index.d.cts",
-      "import": "./v4/locales/index.js",
-      "require": "./v4/locales/index.cjs"
+      "import": {
+        "types": "./v4/locales/index.d.ts",
+        "default": "./v4/locales/index.js"
+      },
+      "require": {
+        "types": "./v4/locales/index.d.cts",
+        "default": "./v4/locales/index.cjs"
+      }
     },
     "./v4/locales/*": {
       "@zod/source": "./src/v4/locales/*",
-      "types": "./v4/locales/*",
-      "import": "./v4/locales/*",
-      "require": "./v4/locales/*"
+      "import": {
+        "types": "./v4/locales/*.d.ts",
+        "default": "./v4/locales/*"
+      },
+      "require": {
+        "types": "./v4/locales/*.d.cts",
+        "default": "./v4/locales/*"
+      }
     }
   },
   "repository": {

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -84,7 +84,7 @@ export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
 export const hostname: RegExp =
   /^(?=.{1,253}\.?$)[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[-0-9a-zA-Z]{0,61}[0-9a-zA-Z])?)*\.?$/;
 
-export const domain: RegExp = /^([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/;
+export const domain: RegExp = /^([a-zA-Z0-9_](?:[a-zA-Z0-9_-]{0,61}[a-zA-Z0-9_])?\.)+[a-zA-Z]{2,}$/;
 
 export const httpProtocol: RegExp = /^https?$/;
 


### PR DESCRIPTION
Fixes #5960.

## Problem

`z.httpUrl()` rejects hostnames containing underscores (e.g., `https://julia_artberg.artstation.com/` or `https://exa_mple.com/`), even though underscores are commonly used in real-world URLs.

## Root cause

The `domain` regex used by `httpUrl()` for hostname validation only allows letters, digits, and hyphens in each label. Underscores (`_`) are excluded.

## Fix

Added `_` to the allowed character set in the domain regex — both for the start/end of each label (`[a-zA-Z0-9_]`) and for the middle positions (`[a-zA-Z0-9_-]`).
