### PR TITLE
fix: encode / and ~ in \ pointer per RFC 6901

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2045,6 +2045,40 @@ test("passthrough schemas", () => {
   `);
 });
 
+test("$ref pointer encodes / and ~ per RFC 6901", () => {
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User }));
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "Shared/User~": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "User": {
+          "$ref": "#/$defs/Shared~1User~0",
+        },
+      },
+      "required": [
+        "User",
+      ],
+      "type": "object",
+    }
+  `);
+});
+
 test("extract schemas with id", () => {
   const name = z.string().meta({ id: "name" });
   const result = z.toJSONSchema(

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -239,6 +239,9 @@ export function extractDefs<T extends schemas.$ZodType>(
     }
   }
 
+  // RFC 6901 JSON Pointer: escape ~ as ~0 and / as ~1
+  const encodePointerRef = (id: string): string => id.replace(/~/g, "~0").replace(/\//g, "~1");
+
   // returns a ref to the schema
   // defId will be empty if the ref points to an external schema (or #)
   const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
@@ -260,7 +263,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${encodePointerRef(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +274,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + encodePointerRef(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
Per RFC 6901, JSON Pointer reference tokens must escape ~ as ~0 and / as ~1.

When z.toJSONSchema() builds the \ URI fragment from a schema's .meta({ id }), it now applies these escapes to the pointer path. The \ key itself stays unescaped (it is a plain object key, not a pointer token).

Fixes #6027

Changes:
- Added encodePointerRef() helper in to-json-schema.ts
- Applied encoding to both self-contained and external shared \ paths
- Added regression test with Shared/User~ id