### PR TITLE
fix(locale): add exact flag support for length/size messages (rebased)

### DIFF
--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -71,15 +71,26 @@ const error: () => errors.$ZodErrorMap = () => {
         if (issue.values.length === 1) return `Invalid input: expected ${util.stringifyPrimitive(issue.values[0])}`;
         return `Invalid option: expected one of ${util.joinValues(issue.values, "|")}`;
       case "too_big": {
-        const adj = issue.inclusive ? "<=" : "<";
         const sizing = getSizing(issue.origin);
+        if (issue.exact) {
+          if (sizing)
+            return `Too big: expected ${issue.origin ?? "value"} to have exactly ${issue.maximum.toString()} ${sizing.unit ?? "elements"}`;
+          return `Too big: expected ${issue.origin ?? "value"} to be exactly ${issue.maximum.toString()}`;
+        }
+        const adj = issue.inclusive ? "<=" : "<";
         if (sizing)
           return `Too big: expected ${issue.origin ?? "value"} to have ${adj}${issue.maximum.toString()} ${sizing.unit ?? "elements"}`;
         return `Too big: expected ${issue.origin ?? "value"} to be ${adj}${issue.maximum.toString()}`;
       }
       case "too_small": {
-        const adj = issue.inclusive ? ">=" : ">";
         const sizing = getSizing(issue.origin);
+        if (issue.exact) {
+          if (sizing) {
+            return `Too small: expected ${issue.origin} to have exactly ${issue.minimum.toString()} ${sizing.unit}`;
+          }
+          return `Too small: expected ${issue.origin} to be exactly ${issue.minimum.toString()}`;
+        }
+        const adj = issue.inclusive ? ">=" : ">";
         if (sizing) {
           return `Too small: expected ${issue.origin} to have ${adj}${issue.minimum.toString()} ${sizing.unit}`;
         }


### PR DESCRIPTION
## Summary

Rebased version adding support for the \exact\ flag in locale messages for length/size validation errors.

## Changes

- Updated \packages/zod/src/v4/locales/en.ts\ to add exact message keys

## Related

Rebased version of #6280 (fix/exact-flag-locale-messages).