### PR TITLE
docs: add generic usage example section to README

### DIFF
--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -71,6 +71,17 @@ console.log(data.name);
 - Works with TypeScript and plain JS
 - Built-in JSON Schema conversion
 - Extensive ecosystem
+- **Type-safe generics** for reusable schemas
+
+## Type-safe generics
+
+Define reusable schemas with generics for type-safe APIs:
+
+```ts
+function createSchema<T>(schema: z.ZodType<T>) {
+  return schema;
+}
+```
 
 <br/>
 


### PR DESCRIPTION
## Summary

Adds a generic usage example section to the README demonstrating type-safe generics with Zod.

## Changes

- Updated \packages/zod/README.md\ to include a generic feature highlight section.