### PR TITLE
fix(json-schema): encode  pointer tokens per RFC 6901 (rebased)

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3129,3 +3129,11 @@ test("recursive lazy with describe does not stack overflow", () => {
   expect(result).toBeDefined();
   expect(result.$defs).toBeDefined();
 });
+
+test("$ref pointer encodes / and ~ in defId (issue #6027)", () => {
+  const inner = z.string().meta({ id: "foo/bar~baz" });
+  const result = z.toJSONSchema(z.object({ a: inner, b: inner }));
+  expect(result.$defs).toEqual({ "foo/bar~baz": { type: "string" } });
+  expect((result.properties as any).a).toEqual({ $ref: "#/$defs/foo~1bar~0baz" });
+  expect((result.properties as any).b).toEqual({ $ref: "#/$defs/foo~1bar~0baz" });
+});

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -239,6 +239,8 @@ export function extractDefs<T extends schemas.$ZodType>(
     }
   }
 
+  const escapePointer = (s: string) => s.replace(/~/g, "~0").replace(/\//g, "~1");
+
   // returns a ref to the schema
   // defId will be empty if the ref points to an external schema (or #)
   const makeURI = (entry: [schemas.$ZodType<unknown, unknown>, Seen]): { ref: string; defId?: string } => {
@@ -260,7 +262,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${escapePointer(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +273,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + escapePointer(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
## Summary

Rebased version ensuring JSON Schema  pointers properly escape \/\ and \~\ characters per RFC 6901 specification.

## Changes

- Updated \packages/zod/src/v4/core/to-json-schema.ts\ to escape pointer tokens
- Added tests in \packages/zod/src/v4/classic/tests/to-json-schema.test.ts\

## Related

Rebased version of #6284 (fix/json-schema-ref-pointer-encoding).