### PR TITLE
fix(json-schema): encode  pointer tokens per RFC 6901 (rebased)

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2173,6 +2173,13 @@ test("describe with id", () => {
   `);
 });
 
+test("$ref pointer escapes RFC 6901 special characters in meta id", () => {
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User })) as any;
+  expect(result.$defs["Shared/User~"]).toBeDefined();
+  expect(result.properties.User.$ref).toBe("#/$defs/Shared~1User~0");
+});
+
 test("id is stripped from $defs entries (draft-2020-12)", () => {
   // The `id` in `.meta()` is a registration tag — it determines the $defs key
   // but should not leak into the definition body, where it is redundant.
@@ -2210,6 +2217,13 @@ test("id is observable in override callback", () => {
     },
   });
   expect(seenIds).toContain("Inner");
+});
+
+test("$ref pointer escapes RFC 6901 special characters in meta id", () => {
+  const User = z.object({ name: z.string() }).meta({ id: "Shared/User~" });
+  const result = z.toJSONSchema(z.object({ User })) as any;
+  expect(result.$defs["Shared/User~"]).toBeDefined();
+  expect(result.properties.User.$ref).toBe("#/$defs/Shared~1User~0");
 });
 
 test("describe with id on wrapper", () => {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -214,6 +214,10 @@ export function process<T extends schemas.$ZodType>(
   return _result.schema;
 }
 
+function escapeJSONPointerSegment(id: string): string {
+  return id.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
 export function extractDefs<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
@@ -260,7 +264,7 @@ export function extractDefs<T extends schemas.$ZodType>(
       // otherwise, add to __shared
       const id: string = entry[1].defId ?? (entry[1].schema.id as string) ?? `schema${ctx.counter++}`;
       entry[1].defId = id; // set defId so it will be reused if needed
-      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${id}` };
+      return { defId: id, ref: `${uriGenerator("__shared")}#/${defsSegment}/${escapeJSONPointerSegment(id)}` };
     }
 
     if (entry[1] === root) {
@@ -271,7 +275,7 @@ export function extractDefs<T extends schemas.$ZodType>(
     const uriPrefix = `#`;
     const defUriPrefix = `${uriPrefix}/${defsSegment}/`;
     const defId = entry[1].schema.id ?? `__schema${ctx.counter++}`;
-    return { defId, ref: defUriPrefix + defId };
+    return { defId, ref: defUriPrefix + escapeJSONPointerSegment(defId) };
   };
 
   // stored cached version in `def` property


### PR DESCRIPTION
## Summary

Rebased version ensuring JSON Schema \ pointers properly escape \/\ and \~\ characters per RFC 6901 specification.

## Changes

- Updated \packages/zod/src/v4/core/to-json-schema.ts\ to escape pointer tokens
- Added tests in \packages/zod/src/v4/classic/tests/to-json-schema.test.ts\

## Related

Rebased version of #6283 (fix/to-json-schema-ref-pointer-escaping).