### PR TITLE
fix: accept RFC 3339 offsets from JSON Schema

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -271,7 +271,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         } else if (format === "uuid" || format === "guid") {
           stringSchema = stringSchema.check(z.uuid());
         } else if (format === "date-time") {
-          stringSchema = stringSchema.check(z.iso.datetime());
+          stringSchema = stringSchema.check(z.iso.datetime({ offset: true }));
         } else if (format === "date") {
           stringSchema = stringSchema.check(z.iso.date());
         } else if (format === "time") {

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -457,6 +457,29 @@ test("string format - uuid", () => {
   expect(schema.parse(uuid)).toBe(uuid);
 });
 
+test("string format - date-time", () => {
+  const schema = fromJSONSchema({
+    type: "string",
+    format: "date-time",
+  });
+  expect(schema.safeParse("2026-07-29T14:30:00Z").success).toBe(true);
+  expect(schema.safeParse("2026-07-29T16:30:00+02:00").success).toBe(true);
+  expect(schema.safeParse("2026-07-29T14:30:00").success).toBe(false);
+  expect(schema.safeParse("2026-07-29T16:30:00+0200").success).toBe(false);
+
+  const zuluOnly = fromJSONSchema({
+    type: "string",
+    format: "date-time",
+    pattern: "Z$",
+  });
+  expect(zuluOnly.safeParse("2026-07-29T14:30:00Z").success).toBe(true);
+  expect(zuluOnly.safeParse("2026-07-29T16:30:00+02:00").success).toBe(false);
+  expect(zuluOnly.safeParse("garbageZ").success).toBe(false);
+
+  const roundTripped = fromJSONSchema(z.toJSONSchema(z.iso.datetime({ offset: true })));
+  expect(roundTripped.safeParse("2026-07-29T16:30:00+02:00").success).toBe(true);
+});
+
 test("exclusiveMinimum and exclusiveMaximum", () => {
   const schema = fromJSONSchema({
     type: "number",


### PR DESCRIPTION
`fromJSONSchema` now maps JSON Schema `date-time` formats to `z.iso.datetime({ offset: true })`, accepting RFC 3339 numeric UTC offsets while still rejecting local timestamps and compact offsets. The regression coverage also preserves authored `pattern` intersections and verifies an offset-enabled Zod schema round-trips through JSON Schema.

Fixes #6296.