### PR TITLE
feat: allow structured ZodIssueMessage values for deferred error message rendering

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -79,7 +79,7 @@ test(".flatten()", () => {
 });
 
 test("custom .flatten()", () => {
-  type ErrorType = { message: string; code: number };
+  type ErrorType = { message: string | { key: string; values?: object }; code: number };
   const flattened = parsed.error!.flatten((iss) => ({
     message: iss.message,
     code: 1234,
@@ -162,7 +162,7 @@ test(".format()", () => {
 });
 
 test("custom .format()", () => {
-  type ErrorType = { message: string; code: number };
+  type ErrorType = { message: string | { key: string; values?: object }; code: number };
   const formatted = parsed.error!.format((iss) => ({
     message: iss.message,
     code: 1234,
@@ -258,7 +258,7 @@ test("all errors", () => {
     }
   `);
 
-  expect(z.core.flattenError(r2.error!, (iss) => iss.message.toUpperCase())).toMatchInlineSnapshot(`
+  expect(z.core.flattenError(r2.error!, (iss) => (iss.message as string).toUpperCase())).toMatchInlineSnapshot(`
     {
       "fieldErrors": {
         "a": [
@@ -302,7 +302,7 @@ test("all errors", () => {
   `);
 
   // Test mapping
-  const f1 = z.core.flattenError(r2.error!, (i: z.ZodIssue) => i.message.length);
+  const f1 = z.core.flattenError(r2.error!, (i: z.ZodIssue) => (i.message as string).length);
   expect(f1).toMatchInlineSnapshot(`
     {
       "fieldErrors": {

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -709,3 +709,30 @@ test("error serialization", () => {
     `);
   }
 });
+
+test("error with object type message", () => {
+  const schema = z.object({
+    name: z.string().min(5, { error: () => ({ message: { key: "test", values: { foo: "bar" } } }) }),
+  });
+
+  const obj = {
+    name: "tes",
+  };
+
+  const result = schema.safeParse(obj);
+  expect(result.success).toBe(false);
+  expect(result.error).toMatchInlineSnapshot(`
+  [ZodError: [
+    {
+      "origin": "string",
+      "code": "too_small",
+      "minimum": 5,
+      "inclusive": true,
+      "path": [
+        "name"
+      ],
+      "message": "{\\"key\\":\\"test\\",\\"values\\":{\\"foo\\":\\"bar\\"}}"
+    }
+  ]]
+  `);
+});

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -3,6 +3,9 @@ import { $constructor } from "./core.js";
 import type { $ZodType } from "./schemas.js";
 import type { StandardSchemaV1 } from "./standard-schema.js";
 import * as util from "./util.js";
+import { toMessageString } from "./util.js";
+
+export type $ZodIssueMessage = string | { key: string; values?: object };
 
 ///////////////////////////
 ////     base type     ////
@@ -11,7 +14,7 @@ export interface $ZodIssueBase {
   readonly code?: string;
   readonly input?: unknown;
   readonly path: PropertyKey[];
-  readonly message: string;
+  readonly message: $ZodIssueMessage;
 }
 
 ////////////////////////////////
@@ -210,7 +213,7 @@ export type $ZodRawIssue<T extends $ZodIssueBase = $ZodIssue> = $ZodInternalIssu
 
 export interface $ZodErrorMap<T extends $ZodIssueBase = $ZodIssue> {
   // biome-ignore lint:
-  (issue: $ZodRawIssue<T>): { message: string } | string | undefined | null;
+  (issue: $ZodRawIssue<T>): { message: $ZodIssueMessage } | string | undefined | null;
 }
 
 ////////////////////////    ERROR CLASS   ////////////////////////
@@ -262,7 +265,7 @@ type _FlattenedError<T, U = string> = {
 
 export function flattenError<T>(error: $ZodError<T>): _FlattenedError<T>;
 export function flattenError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): _FlattenedError<T, U>;
-export function flattenError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
+export function flattenError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => toMessageString(issue.message) as U) {
   const fieldErrors: Record<PropertyKey, any> = {};
   const formErrors: U[] = [];
   for (const sub of error.issues) {
@@ -290,7 +293,7 @@ export type $ZodFormattedError<T, U = string> = {
 
 export function formatError<T>(error: $ZodError<T>): $ZodFormattedError<T>;
 export function formatError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodFormattedError<T, U>;
-export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
+export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => toMessageString(issue.message) as U) {
   const fieldErrors: $ZodFormattedError<T> = { _errors: [] } as any;
   const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
     for (const issue of error.issues) {
@@ -344,7 +347,7 @@ export type $ZodErrorTree<T, U = string> = T extends util.Primitive
 
 export function treeifyError<T>(error: $ZodError<T>): $ZodErrorTree<T>;
 export function treeifyError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodErrorTree<T, U>;
-export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
+export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => toMessageString(issue.message) as U) {
   const result: $ZodErrorTree<T, U> = { errors: [] } as any;
   const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
     for (const issue of error.issues) {
@@ -446,7 +449,8 @@ export function prettifyError(error: StandardSchemaV1.FailureResult): string {
 
   // Process each issue
   for (const issue of issues) {
-    lines.push(`✖ ${issue.message}`);
+    const m = toMessageString(issue.message);
+    lines.push(`✖ ${m}`);
     if (issue.path?.length) lines.push(`  → at ${toDotPath(issue.path)}`);
   }
 

--- a/packages/zod/src/v4/core/standard-schema.ts
+++ b/packages/zod/src/v4/core/standard-schema.ts
@@ -1,3 +1,5 @@
+import type { $ZodIssueMessage } from "./errors.js";
+
 /** The Standard interface. */
 export interface StandardTypedV1<Input = unknown, Output = Input> {
   /** The Standard properties. */
@@ -71,7 +73,7 @@ export declare namespace StandardSchemaV1 {
   /** The issue interface of the failure output. */
   export interface Issue {
     /** The error message of the issue. */
-    readonly message: string;
+    readonly message: $ZodIssueMessage;
     /** The path of the issue, if any. */
     readonly path?: ReadonlyArray<PropertyKey | PathSegment> | undefined;
   }

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -2,6 +2,7 @@ import type * as checks from "./checks.js";
 import { globalConfig } from "./core.js";
 import type { $ZodConfig } from "./core.js";
 import type * as errors from "./errors.js";
+import type { $ZodIssueMessage } from "./errors.js";
 import type * as schemas from "./schemas.js";
 
 // json
@@ -842,8 +843,11 @@ export function prefixIssues(path: PropertyKey, issues: errors.$ZodRawIssue[]): 
   });
 }
 
-export function unwrapMessage(message: string | { message: string } | undefined | null): string | undefined {
-  return typeof message === "string" ? message : message?.message;
+export function unwrapMessage(message: string | { message: $ZodIssueMessage } | undefined | null): string | undefined {
+  if (message === undefined) {
+    return undefined;
+  }
+  return typeof message === "string" ? message : toMessageString(message?.message || "");
 }
 
 export function finalizeIssue(
@@ -975,6 +979,14 @@ export function uint8ArrayToHex(bytes: Uint8Array): string {
   return Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
+}
+
+export function toMessageString(message: $ZodIssueMessage): string {
+  if (typeof message === "string") {
+    return message;
+  } else {
+    return JSON.stringify(message);
+  }
 }
 
 // instanceof


### PR DESCRIPTION
Rebased fix for #6182 on latest main. Structured message type support was partially landed; this restores full support for \string | { key, values }\ issue messages via \	oMessageString\.