### PR TITLE
feat: implement tuple discriminator detection for union optimization

### DIFF
--- a/packages/zod/src/v4/classic/tests/union.test.ts
+++ b/packages/zod/src/v4/classic/tests/union.test.ts
@@ -271,3 +271,17 @@ test("z.discriminatedUnion with empty options constructs and rejects", () => {
     expect((obj.error.issues[0] as any).options).toEqual([]);
   }
 });
+
+test("tuple union optimizer - deep nested recursive schema", () => {
+  const schema: z.ZodType<any> = z.lazy(() =>
+    z.union([...[...Array(1000).keys()].map((i) => z.tuple([z.literal(`key-${i}`), schema])), z.string()])
+  );
+
+  let data: unknown = "leaf-value";
+  for (let i = 0; i < 1000; i++) {
+    data = [`key-${i % 1000}`, data];
+  }
+
+  const result = schema.parse(data);
+  expect(result).toBeDefined();
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2258,7 +2258,7 @@ export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$const
 
     const results: util.MaybeAsync<ParsePayload>[] = [];
     const disc = tupleDisc.value;
-    const opt = disc?.map.get(payload.value[0]);
+    const opt = Array.isArray(payload.value) ? disc?.map.get(payload.value[0]) : undefined;
 
     if (Array.isArray(payload.value) && disc && !opt) {
       results.push({

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2189,6 +2189,38 @@ function handleUnionResults(results: ParsePayload[], final: ParsePayload, inst: 
   return final;
 }
 
+function detectTupleDiscriminator(options: readonly SomeType[]): { map: Map<util.Primitive, $ZodTuple> } | null {
+  // Skip optimization if there are fewer than 3 options
+  if (options.length < 3) return null;
+
+  const tuples: $ZodTuple[] = [];
+  for (const option of options) {
+    if (option._zod.def.type === "tuple") tuples.push(option as $ZodTuple);
+  }
+
+  // Skip optimization if there are fewer than 2 tuple options
+  if (tuples.length < 2) return null;
+  const map = new Map<util.Primitive, $ZodTuple>();
+
+  for (const tuple of tuples) {
+    const items = tuple._zod.def.items;
+    // Skip if the tuple has no discriminative values
+    if (!items?.length) return null;
+
+    const values = items[0]._zod.values;
+    // Skip if the first item has no discriminative values
+    if (!values?.size) return null;
+
+    for (const value of values) {
+      // Skip if a value maps to multiple tuples
+      if (map.has(value)) return null;
+      map.set(value, tuple);
+    }
+  }
+
+  return { map };
+}
+
 export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$constructor("$ZodUnion", (inst, def) => {
   $ZodType.init(inst, def);
 
@@ -2216,6 +2248,7 @@ export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$const
   });
 
   const first = def.options.length === 1 ? def.options[0]._zod.run : null;
+  const tupleDisc = util.cached(() => detectTupleDiscriminator(def.options));
 
   inst._zod.parse = (payload, ctx) => {
     if (first) {
@@ -2224,7 +2257,27 @@ export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$const
     let async = false;
 
     const results: util.MaybeAsync<ParsePayload>[] = [];
+    const disc = tupleDisc.value;
+    const opt = disc?.map.get(payload.value[0]);
+
+    if (Array.isArray(payload.value) && disc && !opt) {
+      results.push({
+        issues: [
+          {
+            code: "invalid_value",
+            message: "Expected a valid tuple discriminator value",
+            input: payload.value,
+            inst,
+            path: [0],
+            values: Array.from(disc.map.keys()),
+          },
+        ],
+        value: payload.value,
+      });
+    }
+
     for (const option of def.options) {
+      if (Array.isArray(payload.value) && disc && opt !== option) continue;
       const result = option._zod.run(
         {
           value: payload.value,


### PR DESCRIPTION
Rebased version of #5643. Adds tuple discriminator detection to skip non-matching union options, with early rejection for invalid tuple discriminator values. Keeps the single-option fast path already present in main.