### PR TITLE
fix(core): treat any/unknown/coerced-boolean object properties as optional-in

### DIFF
--- a/packages/zod/src/v4/classic/tests/anyunknown.test.ts
+++ b/packages/zod/src/v4/classic/tests/anyunknown.test.ts
@@ -24,3 +24,17 @@ test("check never inference", () => {
   expect(() => t1.parse("asdf")).toThrow();
   expect(() => t1.parse(null)).toThrow();
 });
+
+test("any object property tolerates an absent key (#5997)", () => {
+  const schema = z.object({ foo: z.any() });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({});
+});
+
+test("unknown object property tolerates an absent key", () => {
+  const schema = z.object({ foo: z.unknown() });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({});
+});

--- a/packages/zod/src/v4/classic/tests/coerce.test.ts
+++ b/packages/zod/src/v4/classic/tests/coerce.test.ts
@@ -75,6 +75,19 @@ test("boolean coercion", () => {
   expect(schema.parse(new Date(1670139203496))).toEqual(true);
 });
 
+test("coerced boolean object property tolerates an absent key (#5957)", () => {
+  const schema = z.object({ foo: z.coerce.boolean() });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(true);
+  expect(result.data).toEqual({ foo: false });
+});
+
+test("non-coerced boolean object property is still required", () => {
+  const schema = z.object({ foo: z.boolean() });
+  const result = schema.safeParse({});
+  expect(result.success).toBe(false);
+});
+
 test("bigint coercion", () => {
   const schema = z.coerce.bigint();
   expect(schema.parse("5")).toEqual(BigInt(5));

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1204,6 +1204,8 @@ export const $ZodBoolean: core.$constructor<$ZodBoolean> = /*@__PURE__*/ core.$c
     $ZodType.init(inst, def);
     inst._zod.pattern = regexes.boolean;
 
+    if (def.coerce) inst._zod.optin = "optional";
+
     inst._zod.parse = (payload, _ctx) => {
       if (def.coerce)
         try {
@@ -1445,6 +1447,7 @@ export interface $ZodAny extends $ZodType {
 export const $ZodAny: core.$constructor<$ZodAny> = /*@__PURE__*/ core.$constructor("$ZodAny", (inst, def) => {
   $ZodType.init(inst, def);
 
+  inst._zod.optin = "optional";
   inst._zod.parse = (payload) => payload;
 });
 
@@ -1474,6 +1477,7 @@ export const $ZodUnknown: core.$constructor<$ZodUnknown> = /*@__PURE__*/ core.$c
   (inst, def) => {
     $ZodType.init(inst, def);
 
+    inst._zod.optin = "optional";
     inst._zod.parse = (payload) => payload;
   }
 );


### PR DESCRIPTION
Ensures object properties typed as any/unknown/coerced-boolean are treated as optional when using optional-in semantics.