### PR TITLE
ci: cap TS matrix at 6 and build before swapping TS version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ["lts/*"]
-        typescript: ["5.5", "latest"]
+        typescript: ["5.5", "6"]
     name: Test with TypeScript ${{ matrix.typescript }} on Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +28,8 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm build
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all
       - run: pnpm run --filter @zod/integration test:all


### PR DESCRIPTION
﻿Fixes #6185.

Every CI run of \	est.yml\ fails at \pnpm build\ since TypeScript 7.0.2 became npm's \latest\ (2026-07-08). \	ypescript@latest\ now resolves to the Go-native compiler, which no longer ships \	s.sys\ — and \zshy\ (used by \packages/zod\ and \@zod/resolution\) reads tsconfigs through \	s.sys.readFile\, crashing with:

    Build failed: TypeError: Cannot read properties of undefined (reading 'readFile')

Both matrix jobs go red for this one root cause (the 5.5 job is only cancelled by matrix fail-fast).

Two changes:
- Move \pnpm build\ above \pnpm add typescript@… -w\ so the repo-pinned TypeScript always runs the build; the matrix TS then applies only to the test/typecheck phase.
- Cap the matrix at TypeScript 6 (\5.5\ and \6\) instead of \latest\. TS 6 still ships the JS compiler API, so zshy builds and \@zod/resolution\'s own zshy build both pass. This keeps broader coverage than pinning at 5, and the matrix can resume tracking \latest\ once zshy supports TS 7.
