### PR TITLE
docs: add zod-form-action to ecosystem

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -125,6 +125,12 @@ const formIntegrations: ZodResource[] = [
     description: "Type-safe, Zod-first form library for Vue 3 and Nuxt.",
     slug: "attaform/Attaform",
   },
+  {
+    name: "zod-form-action",
+    url: "https://github.com/Vish05/zod-form-action",
+    description: "A tiny helper for wiring Zod validation into React's useActionState — typed field errors, zero boilerplate.",
+    slug: "Vish05/zod-form-action",
+  },
 ];
 
 const zodToXConverters: ZodResource[] = [


### PR DESCRIPTION
Adds `zod-form-action` to the Form Integrations list.

A small helper for wiring Zod schemas into React 19's `useActionState`, producing typed field errors with minimal boilerplate. No hard dependency on `zod` itself (structurally typed against `safeParse`), MIT licensed.

- npm: https://www.npmjs.com/package/zod-form-action
- GitHub: https://github.com/Vish05/zod-form-action
- Live demo: https://codesandbox.io/p/sandbox/zod-form-action-wcm26l