### PR TITLE
perf(v4): lazy ZodError construction (~40% faster failing safeParse)

### DIFF
--- a/packages/zod/src/v4/classic/errors.ts
+++ b/packages/zod/src/v4/classic/errors.ts
@@ -22,8 +22,10 @@ export interface ZodError<T = unknown> extends $ZodError<T> {
   isEmpty: boolean;
 }
 
-// Prototypes that already carry the lazy helper methods.
-const _installedErrorProtos = /* @__PURE__ */ new WeakSet<object>();
+/* Prototypes that already carry the lazy helper methods. Seeded with the
+ * intrinsics so that `init` on a foreign object — it accepts any object —
+ * can never install an accessor onto a prototype we do not own. */
+const _installedErrorProtos = /* @__PURE__ */ new WeakSet<object>([Object.prototype, Error.prototype]);
 
 /* Helper methods live as non-enumerable lazy getters on the shared
  * prototype instead of own properties on every instance. On first

--- a/packages/zod/src/v4/classic/errors.ts
+++ b/packages/zod/src/v4/classic/errors.ts
@@ -22,44 +22,54 @@ export interface ZodError<T = unknown> extends $ZodError<T> {
   isEmpty: boolean;
 }
 
+// Prototypes that already carry the lazy helper methods.
+const _installedErrorProtos = /* @__PURE__ */ new WeakSet<object>();
+
+/* Helper methods live as non-enumerable lazy getters on the shared
+ * prototype instead of own properties on every instance. On first
+ * access the getter allocates the per-instance closure and caches it
+ * as a non-enumerable own property, so detached usage still works and
+ * the allocation only happens for methods actually touched. */
+function _lazyMethod(proto: object, key: string, make: (self: ZodError) => unknown): void {
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    enumerable: false,
+    get(this: ZodError) {
+      const value = make(this);
+      Object.defineProperty(this, key, { value, configurable: true, writable: true });
+      return value;
+    },
+    set(this: ZodError, value: unknown) {
+      Object.defineProperty(this, key, { value, configurable: true, writable: true });
+    },
+  });
+}
+
 const initializer = (inst: ZodError, issues: core.$ZodIssue[]) => {
   $ZodError.init(inst, issues);
   inst.name = "ZodError";
-  Object.defineProperties(inst, {
-    format: {
-      value: (mapper: any) => core.formatError(inst, mapper),
-      // enumerable: false,
-    },
-    flatten: {
-      value: (mapper: any) => core.flattenError(inst, mapper),
-      // enumerable: false,
-    },
-    addIssue: {
-      value: (issue: any) => {
-        inst.issues.push(issue);
-        inst.message = JSON.stringify(inst.issues, util.jsonStringifyReplacer, 2);
-      },
-      // enumerable: false,
-    },
-    addIssues: {
-      value: (issues: any) => {
-        inst.issues.push(...issues);
-        inst.message = JSON.stringify(inst.issues, util.jsonStringifyReplacer, 2);
-      },
-      // enumerable: false,
-    },
-    isEmpty: {
-      get() {
-        return inst.issues.length === 0;
-      },
-      // enumerable: false,
+
+  const proto = Object.getPrototypeOf(inst);
+  if (_installedErrorProtos.has(proto)) return;
+  _installedErrorProtos.add(proto);
+
+  _lazyMethod(proto, "format", (self) => (mapper: any) => core.formatError(self, mapper));
+  _lazyMethod(proto, "flatten", (self) => (mapper: any) => core.flattenError(self, mapper));
+  _lazyMethod(proto, "addIssue", (self) => (issue: any) => {
+    self.issues.push(issue);
+    self.message = JSON.stringify(self.issues, util.jsonStringifyReplacer, 2);
+  });
+  _lazyMethod(proto, "addIssues", (self) => (issues: any) => {
+    self.issues.push(...issues);
+    self.message = JSON.stringify(self.issues, util.jsonStringifyReplacer, 2);
+  });
+  Object.defineProperty(proto, "isEmpty", {
+    configurable: true,
+    enumerable: false,
+    get(this: ZodError) {
+      return this.issues.length === 0;
     },
   });
-  // Object.defineProperty(inst, "isEmpty", {
-  //   get() {
-  //     return inst.issues.length === 0;
-  //   },
-  // });
 };
 export const ZodError: core.$constructor<ZodError> = /*@__PURE__*/ core.$constructor("ZodError", initializer);
 export const ZodRealError: core.$constructor<ZodError> = /*@__PURE__*/ core.$constructor("ZodError", initializer, {

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -709,3 +709,69 @@ test("error serialization", () => {
     `);
   }
 });
+
+test("message is lazy but stays own and enumerable", () => {
+  const err = z.object({ a: z.string() }).safeParse({ a: 1 }).error!;
+
+  expect(Object.keys(err)).toEqual(["name", "message"]);
+  expect(Object.keys({ ...err })).toEqual(["name", "message"]);
+  expect(JSON.parse(JSON.stringify(err)).message).toEqual(err.message);
+  expect(Object.getOwnPropertyDescriptor(err, "message")!.enumerable).toBe(true);
+  expect(Object.getOwnPropertyDescriptor(err, "issues")!.enumerable).toBe(false);
+
+  // computed once, then stable against later mutation of `.issues`
+  const computed = err.message;
+  err.issues.push({ code: "custom", message: "later", path: [], input: undefined });
+  expect(err.message).toEqual(computed);
+
+  // assignment wins over the computed value, and `toString` follows it
+  err.message = "overwritten";
+  expect(err.message).toEqual("overwritten");
+  expect(err.toString()).toEqual("overwritten");
+
+  // a second error computes its own message
+  expect(z.string().safeParse(1).error!.message).not.toEqual(computed);
+});
+
+test("error helpers survive detaching", () => {
+  const err = z.object({ a: z.string() }).safeParse({ a: 1 }).error!;
+  const { format, flatten } = err;
+  const stringify = err.toString;
+
+  expect(format().a?._errors).toEqual(["Invalid input: expected string, received number"]);
+  expect(flatten().fieldErrors.a).toEqual(["Invalid input: expected string, received number"]);
+  expect(stringify()).toEqual(err.message);
+  expect(err.isEmpty).toBe(false);
+  expect(new z.ZodError([]).isEmpty).toBe(true);
+
+  // addIssue refreshes a message that was already materialized
+  const empty = new z.ZodError([]);
+  expect(empty.message).toEqual("[]");
+  empty.addIssue({ code: "custom", message: "added", path: [], input: undefined });
+  expect(empty.message).toContain("added");
+});
+
+test("stack trace carries the message and the parse call site", () => {
+  function callSite() {
+    return z.string().safeParse(123).error!;
+  }
+  const stack = callSite().stack!;
+
+  expect(stack.startsWith("ZodError: [")).toBe(true);
+  expect(stack).toContain("invalid_type");
+  expect(stack).toContain("callSite");
+});
+
+test("error initializer never installs onto an intrinsic prototype", () => {
+  // `init` accepts any object; a foreign one must not leak accessors onto
+  // the prototype it happens to inherit from.
+  z.core.$ZodError.init({} as any, []);
+  z.ZodError.init({} as any, []);
+  z.core.$ZodError.init(new Error() as any, []);
+
+  expect(Object.getOwnPropertyDescriptor(Object.prototype, "toString")!.get).toBeUndefined();
+  expect(Object.getOwnPropertyDescriptor(Error.prototype, "toString")!.get).toBeUndefined();
+  expect(Object.getOwnPropertyNames(Object.prototype)).not.toContain("format");
+  expect({}.toString()).toEqual("[object Object]");
+  expect(String(new Error("boom"))).toEqual("Error: boom");
+});

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -237,7 +237,22 @@ const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
     value: def,
     enumerable: false,
   });
-  inst.message = JSON.stringify(def, util.jsonStringifyReplacer, 2);
+
+  // Computing the message eagerly is expensive (pretty-printed JSON of all
+  // issues), so defer it until first read. The setter preserves plain
+  // assignment semantics for consumers that overwrite `message`.
+  let message: string | undefined;
+  Object.defineProperty(inst, "message", {
+    get() {
+      message ??= JSON.stringify(def, util.jsonStringifyReplacer, 2);
+      return message;
+    },
+    set(value: string) {
+      message = value;
+    },
+    enumerable: true,
+    configurable: true,
+  });
 
   Object.defineProperty(inst, "toString", {
     value: () => inst.message,

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -250,8 +250,10 @@ const _messageDesc: PropertyDescriptor = {
 const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 const _issuesDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 
-// Prototypes that already carry the lazy `toString`.
-const _installedToString = /* @__PURE__ */ new WeakSet<object>();
+/* Prototypes that already carry the lazy `toString`. Seeded with the
+ * intrinsics so that `init` on a foreign object — it accepts any object —
+ * can never install an accessor onto a prototype we do not own. */
+const _installedToString = /* @__PURE__ */ new WeakSet<object>([Object.prototype, Error.prototype]);
 
 const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
   inst.name = "$ZodError";
@@ -259,6 +261,9 @@ const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
   Object.defineProperty(inst, "_zod", _zodDesc);
   _issuesDesc.value = def;
   Object.defineProperty(inst, "issues", _issuesDesc);
+  // Clear the shared slots; a retained `value` pins the last error's issues.
+  _zodDesc.value = undefined;
+  _issuesDesc.value = undefined;
   Object.defineProperty(inst, "message", _messageDesc);
 
   /* `toString` lives as a non-enumerable lazy getter on the shared

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -227,37 +227,59 @@ export interface $ZodError<T = unknown> extends Error {
   name: string;
 }
 
+/* Computing the message eagerly is expensive (pretty-printed JSON of all
+ * issues), so defer it until first read. The accessor functions and
+ * descriptors are shared across instances to keep error construction
+ * cheap; the computed message is cached on the internals object. The
+ * setter preserves plain assignment semantics for consumers that
+ * overwrite `message`. */
+function _getMessage(this: $ZodError): string {
+  const internals = this._zod as { def: $ZodIssue[]; message?: string };
+  internals.message ??= JSON.stringify(internals.def, util.jsonStringifyReplacer, 2);
+  return internals.message;
+}
+function _setMessage(this: $ZodError, value: string): void {
+  (this._zod as { message?: string }).message = value;
+}
+const _messageDesc: PropertyDescriptor = {
+  get: _getMessage,
+  set: _setMessage,
+  enumerable: true,
+  configurable: true,
+};
+const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
+const _issuesDesc: PropertyDescriptor = { value: undefined, enumerable: false };
+
+// Prototypes that already carry the lazy `toString`.
+const _installedToString = /* @__PURE__ */ new WeakSet<object>();
+
 const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
   inst.name = "$ZodError";
-  Object.defineProperty(inst, "_zod", {
-    value: inst._zod,
-    enumerable: false,
-  });
-  Object.defineProperty(inst, "issues", {
-    value: def,
-    enumerable: false,
-  });
+  _zodDesc.value = inst._zod;
+  Object.defineProperty(inst, "_zod", _zodDesc);
+  _issuesDesc.value = def;
+  Object.defineProperty(inst, "issues", _issuesDesc);
+  Object.defineProperty(inst, "message", _messageDesc);
 
-  // Computing the message eagerly is expensive (pretty-printed JSON of all
-  // issues), so defer it until first read. The setter preserves plain
-  // assignment semantics for consumers that overwrite `message`.
-  let message: string | undefined;
-  Object.defineProperty(inst, "message", {
-    get() {
-      message ??= JSON.stringify(def, util.jsonStringifyReplacer, 2);
-      return message;
-    },
-    set(value: string) {
-      message = value;
-    },
-    enumerable: true,
-    configurable: true,
-  });
-
-  Object.defineProperty(inst, "toString", {
-    value: () => inst.message,
-    enumerable: false,
-  });
+  /* `toString` lives as a non-enumerable lazy getter on the shared
+   * prototype; on first access it caches a per-instance closure so
+   * detached usage still works. */
+  const proto = Object.getPrototypeOf(inst);
+  if (!_installedToString.has(proto)) {
+    _installedToString.add(proto);
+    Object.defineProperty(proto, "toString", {
+      configurable: true,
+      enumerable: false,
+      get(this: $ZodError) {
+        const value = () => this.message;
+        Object.defineProperty(this, "toString", { value, configurable: true, writable: true });
+        return value;
+      },
+      set(this: $ZodError, value: unknown) {
+        Object.defineProperty(this, "toString", { value, configurable: true, writable: true });
+      },
+    });
+  }
 };
 
 export const $ZodError: $constructor<$ZodError> = $constructor("$ZodError", initializer);


### PR DESCRIPTION
> **Context: performance optimization campaign.** This is one of four PRs extracted from a systematic performance campaign on the v4 core, run as an automated research loop: 18 isolated experiments, 11 kept, 7 discarded. Every candidate change was
>
> - benchmarked with an A/B harness that loads **two git revisions of `packages/zod/src` into one process** and times 11 workloads in alternation, taking the minimum of 25 rep-scaled iterations. Module instances carry a stable load-order JIT bias of several percent, so the harness runs both load orders in separate child processes and combines them with a geometric mean;
> - measured on **11 deterministic workloads mirroring `packages/bench`** (simple object, the moltar `strictObject`, string/number leaf parses, union, discriminated union, failing `safeParse`, string formats, transform/pipe chain, schema construction). The repo's own benches compare zod against *other libraries* inside a single checkout and cannot load two zod revisions into one process, so using them for A/B would mean comparing two standalone runs — and run-to-run drift is larger than most effect sizes here. The mirrored cases use seeded PRNG data, so both revisions parse byte-identical inputs and the same workloads feed the characterisation guard below. The untouched `packages/bench` suite served as an external cross-check;
> - gated by a **calibrated noise floor** (~1.2% on the suite total, measured with identical code on both sides): changes under 2.5% total, or under 5% on a targeted case, were discarded, and every keep required a second confirming run;
> - verified behaviour-preserving by a **characterisation guard** (hashed parse outputs and error issues over all benchmark inputs) plus the full test suite (3811 tests + typecheck), both green after every commit. Discarded experiments — including several that looked plausible but regressed hot paths — are logged in the campaign notes.
>
> The numbers below are fresh verification runs of **this branch in isolation against `main`** (two independent runs each; an identical-source control run measured +0.56% total, i.e. pure noise). Negative = faster.

## What this PR does

Makes `$ZodError` construction lazy. A failing `safeParse` currently pays for work that is almost never consumed on that path. Three commits:

**1. Lazy `message` (`core/errors.ts`).** Every error construction ran `inst.message = JSON.stringify(def, jsonStringifyReplacer, 2)` — a pretty-printed JSON dump of *all issues* — even when `.message` is never read (the common `safeParse` flow reads `result.error.issues`). `message` is now an own get/set accessor: computed and cached on first read, with a setter preserving plain-assignment semantics (the deprecated `addIssue` reassigns it). It stays own and enumerable, so `Object.keys(err)`, `JSON.stringify(err)`, and spreads are unchanged.

**2. Helper methods on the prototype (`classic/errors.ts`).** The classic `ZodError` initializer ran `Object.defineProperties(inst, ...)` per instance: five descriptors and four closures for `format`/`flatten`/`addIssue`/`addIssues`/`isEmpty` — all deprecated methods. They are now one-time lazy getters on the shared prototype, the same lazy-bind pattern #5897 introduced for schema builder methods: first access allocates the bound closure and caches it as a non-enumerable own property, so detached usage (`const f = err.format; f()`) still works.

**3. Shared descriptors + lazy `toString` (`core/errors.ts`).** The remaining per-instance cost: the `message` accessor now uses one shared getter/setter pair (cache lives on `_zod`), the `_zod`/`issues` descriptor objects are module-level and reused, and `toString` moved from a per-instance closure to a lazy prototype accessor.

## Verification (this branch vs `main`)

| case | run 1 | run 2 | speed-up vs `main` |
|---|---|---|---|
| object-fail-safeparse | **-41.2%** | **-37.8%** | **1.65x** |
| string-formats (50% invalid inputs) | **-36.7%** | **-37.1%** | **1.59x** |
| all success-path cases | within noise | within noise | — |
| **suite TOTAL** | **-23.5%** | **-22.4%** | **1.30x** |

Cross-check on the repo's own benchmark, `packages/bench/error-handling.ts` (10k failing `safeParse` per iteration): `main` runs it at 95.9ms/iter (min 86.8ms), this branch at 45.0ms/iter (min 44.6ms) — **~2.1x faster than `main`**. One caveat: unlike the paired table above, this compares two standalone mitata runs from separate checkouts, which is normally too imprecise to quote; it is included only because the effect is far larger than any cross-run drift. (The remaining fail-path cost is dominated by `Error` stack capture; see below.)

## Observable surface

- `getOwnPropertyDescriptor(err, "message")` reports an accessor instead of a data property; enumeration and serialisation are identical.
- If `err.issues` is mutated *before* the first `.message` read, the lazy message now reflects the mutation (the eager one froze construction-time state). This matches the documented guidance to push directly to `.issues`.
- Helper methods and `toString` are inherited until first touched (`hasOwnProperty` flips); they were non-enumerable before and remain so.

After this change the dominant remaining cost of a failing `safeParse` is the `Error` constructor's stack capture (~70% of the profile). That is deliberately untouched here — suppressing it would change `error.stack` behaviour and deserves its own discussion.

## Reproducing the numbers

The harness below is the one used for the verification runs (one difference: each side is unpacked into its own directory, so `main main` works as a noise-control run). From a checkout of this repo:

1. `pnpm install`
2. Save the two files below as `perf/ab.mts` and `perf/cases.mts` (the directory must live **inside** the repo so the unpacked trees resolve `node_modules`; `perf/.trees/` is created automatically and safe to delete).
3. Noise control (identical source on both sides). Discard the very first run — it materialises the trees and runs with cold caches. Repeat runs should land within roughly ±2% on TOTAL; that is this machine-state's noise band and the yardstick for step 4:

   ```sh
   pnpm tsx perf/ab.mts main main
   ```

4. Measure this PR — fetch its head ref, then compare it against `main`:

   ```sh
   git fetch origin pull/6316/head:pr-6316
   pnpm tsx perf/ab.mts main pr-6316
   ```

One run takes ~5s: 11 deterministic workloads, both load orders in separate child processes, minimum of 25 rep-scaled iterations per case, geometric mean across orders. Negative delta = second revision is faster. Run each comparison at least twice and judge repeated results against your control band from step 3, never a single run. The `schema-init` case is the noisiest (GC-bound); the parse cases are much tighter.

<details>
<summary><code>perf/ab.mts</code> — A/B revision benchmark</summary>

```ts
/**
 * A/B benchmark of two git revisions of packages/zod/src.
 *
 *   pnpm tsx perf/ab.mts [revA] [revB]
 *
 * revA defaults to HEAD, revB defaults to WORKTREE (the working tree).
 * Revisions are materialised with `git archive` into perf/.trees/.
 *
 * Both variants are imported into one process and timed in alternation,
 * taking the minimum per case. Module instances carry a stable
 * positional (load-order) bias of several percent, so the parent runs
 * the measurement twice as child processes, once per load order, and
 * combines the two ratios with a geometric mean to cancel the bias.
 * Negative delta = B faster than A.
 */
import { execSync, spawnSync } from "node:child_process";
import * as fs from "node:fs";
import * as path from "node:path";
import { fileURLToPath, pathToFileURL } from "node:url";
import { type PerfCase, buildCases } from "./cases.mts";

const ROOT = path.join(import.meta.dirname, "..");
const TREES = path.join(import.meta.dirname, ".trees");

const WARMUP = 4;
const ITERS = 25;
const TARGET_NS = 1_500_000;

function materialise(rev: string, slot: string): string {
  if (rev === "WORKTREE") return path.join(ROOT, "packages/zod/src/index.ts");
  const sha = execSync(`git rev-parse ${rev}`, { cwd: ROOT }).toString().trim();
  const dir = path.join(TREES, `${sha}-${slot}`);
  if (!fs.existsSync(dir)) {
    fs.mkdirSync(dir, { recursive: true });
    execSync(`git archive ${sha} packages/zod/src | tar -x -C ${dir}`, { cwd: ROOT });
  }
  return path.join(dir, "packages/zod/src/index.ts");
}

interface Row {
  name: string;
  a: number;
  b: number;
}

async function measure(entryFirst: string, entrySecond: string): Promise<Array<Row>> {
  const zFirst = await import(pathToFileURL(entryFirst).href);
  const zSecond = await import(pathToFileURL(entrySecond).href);
  const casesFirst = buildCases(zFirst);
  const casesSecond = buildCases(zSecond);

  const time = (fn: () => void): number => {
    const start = process.hrtime.bigint();
    fn();
    return Number(process.hrtime.bigint() - start);
  };

  const rows: Array<Row> = [];
  for (let i = 0; i < casesFirst.length; i++) {
    const ca: PerfCase = casesFirst[i];
    const cb: PerfCase = casesSecond[i];

    /* JIT warmup on the raw bodies, then size the timed run to ~TARGET_NS;
     * both variants use the identical rep count. */
    let probe = Number.POSITIVE_INFINITY;
    for (let w = 0; w < 10; w++) {
      probe = Math.min(probe, time(ca.run));
      cb.run();
    }
    const reps = Math.max(1, Math.round(TARGET_NS / probe));
    const runA = () => {
      for (let r = 0; r < reps; r++) ca.run();
    };
    const runB = () => {
      for (let r = 0; r < reps; r++) cb.run();
    };

    for (let w = 0; w < WARMUP; w++) {
      runA();
      runB();
    }
    let minA = Number.POSITIVE_INFINITY;
    let minB = Number.POSITIVE_INFINITY;
    for (let iter = 0; iter < ITERS; iter++) {
      if (iter % 2 === 0) {
        minA = Math.min(minA, time(runA));
        minB = Math.min(minB, time(runB));
      } else {
        minB = Math.min(minB, time(runB));
        minA = Math.min(minA, time(runA));
      }
    }
    rows.push({ name: ca.name, a: minA / reps, b: minB / reps });
  }
  return rows;
}

if (process.env.AB_CHILD) {
  const rows = await measure(process.argv[2], process.argv[3]);
  console.log(JSON.stringify(rows));
} else {
  const revA = process.argv[2] ?? "HEAD";
  const revB = process.argv[3] ?? "WORKTREE";
  const entryA = materialise(revA, "a");
  const entryB = materialise(revB, "b");

  const self = fileURLToPath(import.meta.url);
  const child = (first: string, second: string): Array<Row> => {
    const res = spawnSync(process.execPath, ["--import", "tsx", self, first, second], {
      env: { ...process.env, AB_CHILD: "1" },
      encoding: "utf8",
      maxBuffer: 64 * 1024 * 1024,
    });
    if (res.status !== 0) {
      throw new Error(`child failed: ${res.stderr}`);
    }
    const lines = res.stdout.trim().split("\n");
    return JSON.parse(lines[lines.length - 1]);
  };

  /* Two children per load order; per-case minimum across same-order
   * children, then geometric mean across orders. */
  const minRows = (x: Array<Row>, y: Array<Row>): Array<Row> =>
    x.map((r, i) => ({ name: r.name, a: Math.min(r.a, y[i].a), b: Math.min(r.b, y[i].b) }));
  const run1 = minRows(child(entryA, entryB), child(entryA, entryB));
  const run2 = minRows(child(entryB, entryA), child(entryB, entryA));

  const fmt = (ns: number) => (ns / 1e6).toFixed(4).padStart(10);
  const pctFmt = (p: number) => `${p.toFixed(2).padStart(7)}%`;

  console.log(`A = ${revA}, B = ${revB} (min of ${ITERS} iters x 2 orders, ms)`);
  console.log(`${"case".padEnd(24)}${"A".padStart(10)}${"B".padStart(10)}${"delta".padStart(9)}`);
  let sumA = 0;
  let sumB = 0;
  let ratioTotal1 = 0;
  let ratioTotal2 = 0;
  const totals1 = { a: 0, b: 0 };
  const totals2 = { a: 0, b: 0 };
  for (let i = 0; i < run1.length; i++) {
    const r1 = run1[i];
    const r2 = run2[i];
    /* r1: a=A, b=B; r2: a=B, b=A */
    const ratio = Math.sqrt((r1.b / r1.a) * (r2.a / r2.b));
    const aAvg = (r1.a + r2.b) / 2;
    const bAvg = aAvg * ratio;
    sumA += aAvg;
    sumB += bAvg;
    totals1.a += r1.a;
    totals1.b += r1.b;
    totals2.a += r2.a;
    totals2.b += r2.b;
    console.log(`${r1.name.padEnd(24)}${fmt(aAvg)}${fmt(bAvg)} ${pctFmt((ratio - 1) * 100)}`);
  }
  ratioTotal1 = totals1.b / totals1.a;
  ratioTotal2 = totals2.a / totals2.b;
  const totalRatio = Math.sqrt(ratioTotal1 * ratioTotal2);
  console.log(`${"TOTAL".padEnd(24)}${fmt(sumA)}${fmt(sumA * totalRatio)} ${pctFmt((totalRatio - 1) * 100)}`);
}
```

</details>

<details>
<summary><code>perf/cases.mts</code> — deterministic workloads (mirroring <code>packages/bench</code>)</summary>

```ts
/**
 * Deterministic perf workloads mirroring packages/bench.
 * Each case exposes a timed body (`run`) and a serializable
 * behaviour sample (`collect`) used by the characterisation guard.
 */

export interface PerfCase {
  name: string;
  run: () => void;
  collect: () => unknown;
}

/** mulberry32 PRNG for reproducible inputs */
function rng(seed: number): () => number {
  let a = seed >>> 0;
  return () => {
    a = (a + 0x6d2b79f5) | 0;
    let t = Math.imul(a ^ (a >>> 15), 1 | a);
    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
  };
}

function randomString(rand: () => number, length: number): string {
  const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
  let out = "";
  for (let i = 0; i < length; i++) out += chars[Math.floor(rand() * chars.length)];
  return out;
}

const LONG_STRING = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor. ".repeat(12);

export function buildCases(z: any): Array<PerfCase> {
  const cases: Array<PerfCase> = [];

  {
    const rand = rng(1);
    const schema = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
    const data = Array.from({ length: 1000 }, () => ({
      number: rand(),
      string: `${rand()}`,
      boolean: rand() > 0.5,
    }));
    cases.push({
      name: "object-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.map((d) => schema.parse(d)),
    });
  }

  {
    const schema = z.strictObject({
      number: z.number(),
      negNumber: z.number(),
      maxNumber: z.number(),
      string: z.string(),
      longString: z.string(),
      boolean: z.boolean(),
      deeplyNested: z.strictObject({ foo: z.string(), num: z.number(), bool: z.boolean() }),
    });
    const data = Array.from({ length: 1000 }, (_, i) => ({
      number: i,
      negNumber: -i,
      maxNumber: Number.MAX_VALUE,
      string: "string",
      longString: LONG_STRING,
      boolean: true,
      deeplyNested: { foo: "bar", num: i, bool: false },
    }));
    cases.push({
      name: "strict-moltar",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 20).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(2);
    const schema = z.string();
    const data = Array.from({ length: 10_000 }, () => `${rand()}`);
    cases.push({
      name: "string-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(3);
    const schema = z.number();
    const data = Array.from({ length: 10_000 }, () => rand() * 1_000_000);
    cases.push({
      name: "number-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(4);
    const schema = z.array(z.string());
    const data = Array.from({ length: 200 }, () => Array.from({ length: 20 }, () => randomString(rand, 8)));
    cases.push({
      name: "array-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 10).map((d) => schema.parse(d)),
    });
  }

  {
    const schema = z.union([
      z.object({ type: z.literal("a") }),
      z.object({ type: z.literal("b") }),
      z.object({ type: z.literal("c") }),
    ]);
    const data = Array.from({ length: 1000 }, (_, i) => ({ type: "abc"[i % 3] }));
    cases.push({
      name: "union-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 9).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(5);
    const types = ["a", "b", "c", "d", "e", "f", "g"];
    const options = types.map((t) =>
      z.object({ type: z.literal(t), data1: z.string(), data2: z.string(), data3: z.string() })
    );
    const schema = z.discriminatedUnion("type", options);
    const data = Array.from({ length: 200 }, () => ({
      type: types[Math.floor(rand() * types.length)],
      data1: randomString(rand, 10),
      data2: randomString(rand, 10),
      data3: randomString(rand, 10),
    }));
    cases.push({
      name: "disc-union-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 14).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(6);
    const schema = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
    const bad: Array<unknown> = Array.from({ length: 200 }, (_, i) => {
      const kind = i % 5;
      if (kind === 0) return { string: rand(), boolean: "yes", number: `${rand()}` };
      if (kind === 1) return { string: "ok", boolean: true };
      if (kind === 2) return null;
      if (kind === 3) return { string: "ok", boolean: false, number: Number.NaN };
      return [1, 2, 3];
    });
    cases.push({
      name: "object-fail-safeparse",
      run: () => {
        for (const d of bad) schema.safeParse(d);
      },
      collect: () =>
        bad.map((d) => {
          const r = schema.safeParse(d);
          return r.success ? { success: true, data: r.data } : { success: false, issues: r.error.issues };
        }),
    });
  }

  {
    const rand = rng(7);
    const email = z.email();
    const uuid = z.uuid();
    const datetime = z.iso.datetime();
    const emails = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? `${randomString(rand, 8)}@example.com` : `${randomString(rand, 8)}example.com`
    );
    const uuids = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? "8a99219c-2a97-4a35-9fcf-5a5a4d3b1234" : randomString(rand, 36)
    );
    const datetimes = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? "2024-01-15T12:30:00Z" : `${randomString(rand, 10)}T99:99`
    );
    cases.push({
      name: "string-formats",
      run: () => {
        for (const d of emails) email.safeParse(d);
        for (const d of uuids) uuid.safeParse(d);
        for (const d of datetimes) datetime.safeParse(d);
      },
      collect: () => {
        const sample = (schema: any, inputs: Array<string>) =>
          inputs.slice(0, 6).map((d) => {
            const r = schema.safeParse(d);
            return r.success ? { success: true, data: r.data } : { success: false, issues: r.error.issues };
          });
        return [sample(email, emails), sample(uuid, uuids), sample(datetime, datetimes)];
      },
    });
  }

  {
    const rand = rng(8);
    const schema = z
      .string()
      .min(1)
      .transform((s: string) => s.length)
      .pipe(z.number().max(1000));
    const data = Array.from({ length: 2000 }, () => randomString(rand, 1 + Math.floor(rand() * 20)));
    cases.push({
      name: "chain-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const makeSchemas = () => {
      const simple = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
      const moltar = z.strictObject({
        number: z.number(),
        negNumber: z.number(),
        maxNumber: z.number(),
        string: z.string(),
        longString: z.string(),
        boolean: z.boolean(),
        deeplyNested: z.strictObject({ foo: z.string(), num: z.number(), bool: z.boolean() }),
      });
      return { simple, moltar };
    };
    cases.push({
      name: "schema-init",
      run: () => {
        for (let i = 0; i < 30; i++) makeSchemas();
      },
      collect: () => {
        const { simple, moltar } = makeSchemas();
        return [
          simple.parse({ string: "s", boolean: true, number: 1 }),
          moltar.parse({
            number: 1,
            negNumber: -1,
            maxNumber: Number.MAX_VALUE,
            string: "string",
            longString: LONG_STRING,
            boolean: true,
            deeplyNested: { foo: "bar", num: 1, bool: false },
          }),
        ];
      },
    });
  }

  return cases;
}
```

</details>

---

Companion PRs from the same campaign: #6317 #6318 #6319
