### PR TITLE
perf(v4): reuse frozen default parse contexts (~15% faster leaf parses)

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -231,9 +231,19 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   // `const { parse } = schema`, etc.). Eager closures here mean callers pay
   // ~12 closure allocations per schema but get monomorphic call sites and
   // detached usage that "just works".
-  inst.parse = (data, params) => parse.parse(inst, data, params, { callee: inst.parse });
+  /* The `{ callee }` params object is constant per instance; allocate it
+   * lazily once instead of on every call. */
+  let parseParams: { callee: util.AnyFunc } | undefined;
+  let parseAsyncParams: { callee: util.AnyFunc } | undefined;
+  inst.parse = (data, params) => {
+    parseParams ??= { callee: inst.parse };
+    return parse.parse(inst, data, params, parseParams);
+  };
   inst.safeParse = (data, params) => parse.safeParse(inst, data, params);
-  inst.parseAsync = async (data, params) => parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
+  inst.parseAsync = async (data, params) => {
+    parseAsyncParams ??= { callee: inst.parseAsync };
+    return parse.parseAsync(inst, data, params, parseAsyncParams);
+  };
   inst.safeParseAsync = async (data, params) => parse.safeParseAsync(inst, data, params);
   inst.spa = inst.safeParseAsync;
   inst.encode = (data, params) => parse.encode(inst, data, params);

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -13,8 +13,14 @@ export type $Parse = <T extends schemas.$ZodType>(
   _params?: { callee?: util.AnyFunc; Err?: $ZodErrorClass }
 ) => core.output<T>;
 
+/* Shared default contexts for calls without an explicit `_ctx` (the
+ * overwhelmingly common case), frozen so accidental mutation throws
+ * instead of corrupting later parses. */
+const _syncCtx: schemas.ParseContextInternal = /* @__PURE__ */ Object.freeze({ async: false });
+const _asyncCtx: schemas.ParseContextInternal = /* @__PURE__ */ Object.freeze({ async: true });
+
 export const _parse: (_Err: $ZodErrorClass) => $Parse = (_Err) => (schema, value, _ctx, _params) => {
-  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
+  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : _syncCtx;
   const result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new core.$ZodAsyncError();
@@ -37,7 +43,7 @@ export type $ParseAsync = <T extends schemas.$ZodType>(
 ) => Promise<core.output<T>>;
 
 export const _parseAsync: (_Err: $ZodErrorClass) => $ParseAsync = (_Err) => async (schema, value, _ctx, params) => {
-  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
+  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : _asyncCtx;
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) result = await result;
   if (result.issues.length) {
@@ -57,7 +63,7 @@ export type $SafeParse = <T extends schemas.$ZodType>(
 ) => util.SafeParseResult<core.output<T>>;
 
 export const _safeParse: (_Err: $ZodErrorClass) => $SafeParse = (_Err) => (schema, value, _ctx) => {
-  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
+  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : _syncCtx;
   const result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) {
     throw new core.$ZodAsyncError();
@@ -79,7 +85,7 @@ export type $SafeParseAsync = <T extends schemas.$ZodType>(
 ) => Promise<util.SafeParseResult<core.output<T>>>;
 
 export const _safeParseAsync: (_Err: $ZodErrorClass) => $SafeParseAsync = (_Err) => async (schema, value, _ctx) => {
-  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
+  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : _asyncCtx;
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) result = await result;
 


### PR DESCRIPTION
> **Context: performance optimization campaign.** This is one of four PRs extracted from a systematic performance campaign on the v4 core, run as an automated research loop: 18 isolated experiments, 11 kept, 7 discarded. Every candidate change was
>
> - benchmarked with an A/B harness that loads **two git revisions of `packages/zod/src` into one process** and times 11 workloads in alternation, taking the minimum of 25 rep-scaled iterations. Module instances carry a stable load-order JIT bias of several percent, so the harness runs both load orders in separate child processes and combines them with a geometric mean;
> - measured on **11 deterministic workloads mirroring `packages/bench`** (simple object, the moltar `strictObject`, string/number leaf parses, union, discriminated union, failing `safeParse`, string formats, transform/pipe chain, schema construction). The repo's own benches compare zod against *other libraries* inside a single checkout and cannot load two zod revisions into one process, so using them for A/B would mean comparing two standalone runs — and run-to-run drift is larger than most effect sizes here. The mirrored cases use seeded PRNG data, so both revisions parse byte-identical inputs and the same workloads feed the characterisation guard below. The untouched `packages/bench` suite served as an external cross-check;
> - gated by a **calibrated noise floor** (~1.2% on the suite total, measured with identical code on both sides): changes under 2.5% total, or under 5% on a targeted case, were discarded, and every keep required a second confirming run;
> - verified behaviour-preserving by a **characterisation guard** (hashed parse outputs and error issues over all benchmark inputs) plus the full test suite (3811 tests + typecheck), both green after every commit. Discarded experiments — including several that looked plausible but regressed hot paths — are logged in the campaign notes.
>
> The numbers below are fresh verification runs of **this branch in isolation against `main`** (two independent runs each; an identical-source control run measured +0.56% total, i.e. pure noise). Negative = faster.

## What this PR does

Removes two per-call allocations from the parse entry points. At 13-18ns per leaf parse these paths are allocation-bound, so one object per call is a double-digit relative cost.

**Shared frozen default contexts (`core/parse.ts`).** `_parse`, `_parseAsync`, `_safeParse`, and `_safeParseAsync` allocated a fresh `{ async: ... }` context on every call without an explicit `_ctx` — the overwhelmingly common case. They now share two module-level contexts, frozen so any accidental mutation throws (all internal code is strict-mode ESM) instead of silently corrupting later parses. I verified nothing in the codebase writes to the parse context; `finalizeIssue` and `runChecks` only read it. Prior art: commit c7518e80 on the `perf-investigation` branch made exactly this change for `_safeParse` (frozen `_defaultSyncCtx`); it never landed on `main`.

**Cached `{ callee }` params (`classic/schemas.ts`).** Classic `.parse()` and `.parseAsync()` allocated `{ callee: inst.parse }` on every call, purely for `captureStackTrace` trimming on the throw path. The object is constant per instance, so it is now created lazily once and reused.

## Verification (this branch vs `main`)

| case | run 1 | run 2 | speed-up vs `main` |
|---|---|---|---|
| string-parse | **-14.8%** | **-15.4%** | **1.18x** |
| number-parse | **-14.3%** | **-14.6%** | **1.17x** |
| strict-moltar | -3.3% | -4.2% | 1.04x |
| chain-parse | -3.0% | -2.6% | 1.03x |
| **suite TOTAL** | -1.0% | -2.2% | 1.02x |

No repo-bench cross-check is quoted for this PR: a ~15% delta on a ~15ns leaf parse is below what two standalone `packages/bench` runs can resolve (their run-to-run drift exceeds the effect), which is precisely why the paired harness below exists. It reproduces the effect on demand.

The total is modest because leaf parses are a small slice of the mixed suite; the targeted cases improve ~15% consistently across four runs.

## Observable surface

None intended. The frozen context is never handed to user code with an expectation of mutability, and explicit `_ctx` arguments still get a fresh spread-copy exactly as before. Should any code path ever attempt to write to the default context, it now throws a `TypeError` instead of poisoning subsequent parses — arguably an improvement in failure mode.

## Reproducing the numbers

The harness below is the one used for the verification runs (one difference: each side is unpacked into its own directory, so `main main` works as a noise-control run). From a checkout of this repo:

1. `pnpm install`
2. Save the two files below as `perf/ab.mts` and `perf/cases.mts` (the directory must live **inside** the repo so the unpacked trees resolve `node_modules`; `perf/.trees/` is created automatically and safe to delete).
3. Noise control (identical source on both sides). Discard the very first run — it materialises the trees and runs with cold caches. Repeat runs should land within roughly ±2% on TOTAL; that is this machine-state's noise band and the yardstick for step 4:

   ```sh
   pnpm tsx perf/ab.mts main main
   ```

4. Measure this PR — fetch its head ref, then compare it against `main`:

   ```sh
   git fetch origin pull/6317/head:pr-6317
   pnpm tsx perf/ab.mts main pr-6317
   ```

One run takes ~5s: 11 deterministic workloads, both load orders in separate child processes, minimum of 25 rep-scaled iterations per case, geometric mean across orders. Negative delta = second revision is faster. Run each comparison at least twice and judge repeated results against your control band from step 3, never a single run. The `schema-init` case is the noisiest (GC-bound); the parse cases are much tighter.

<details>
<summary><code>perf/ab.mts</code> — A/B revision benchmark</summary>

```ts
/**
 * A/B benchmark of two git revisions of packages/zod/src.
 *
 *   pnpm tsx perf/ab.mts [revA] [revB]
 *
 * revA defaults to HEAD, revB defaults to WORKTREE (the working tree).
 * Revisions are materialised with `git archive` into perf/.trees/.
 *
 * Both variants are imported into one process and timed in alternation,
 * taking the minimum per case. Module instances carry a stable
 * positional (load-order) bias of several percent, so the parent runs
 * the measurement twice as child processes, once per load order, and
 * combines the two ratios with a geometric mean to cancel the bias.
 * Negative delta = B faster than A.
 */
import { execSync, spawnSync } from "node:child_process";
import * as fs from "node:fs";
import * as path from "node:path";
import { fileURLToPath, pathToFileURL } from "node:url";
import { type PerfCase, buildCases } from "./cases.mts";

const ROOT = path.join(import.meta.dirname, "..");
const TREES = path.join(import.meta.dirname, ".trees");

const WARMUP = 4;
const ITERS = 25;
const TARGET_NS = 1_500_000;

function materialise(rev: string, slot: string): string {
  if (rev === "WORKTREE") return path.join(ROOT, "packages/zod/src/index.ts");
  const sha = execSync(`git rev-parse ${rev}`, { cwd: ROOT }).toString().trim();
  const dir = path.join(TREES, `${sha}-${slot}`);
  if (!fs.existsSync(dir)) {
    fs.mkdirSync(dir, { recursive: true });
    execSync(`git archive ${sha} packages/zod/src | tar -x -C ${dir}`, { cwd: ROOT });
  }
  return path.join(dir, "packages/zod/src/index.ts");
}

interface Row {
  name: string;
  a: number;
  b: number;
}

async function measure(entryFirst: string, entrySecond: string): Promise<Array<Row>> {
  const zFirst = await import(pathToFileURL(entryFirst).href);
  const zSecond = await import(pathToFileURL(entrySecond).href);
  const casesFirst = buildCases(zFirst);
  const casesSecond = buildCases(zSecond);

  const time = (fn: () => void): number => {
    const start = process.hrtime.bigint();
    fn();
    return Number(process.hrtime.bigint() - start);
  };

  const rows: Array<Row> = [];
  for (let i = 0; i < casesFirst.length; i++) {
    const ca: PerfCase = casesFirst[i];
    const cb: PerfCase = casesSecond[i];

    /* JIT warmup on the raw bodies, then size the timed run to ~TARGET_NS;
     * both variants use the identical rep count. */
    let probe = Number.POSITIVE_INFINITY;
    for (let w = 0; w < 10; w++) {
      probe = Math.min(probe, time(ca.run));
      cb.run();
    }
    const reps = Math.max(1, Math.round(TARGET_NS / probe));
    const runA = () => {
      for (let r = 0; r < reps; r++) ca.run();
    };
    const runB = () => {
      for (let r = 0; r < reps; r++) cb.run();
    };

    for (let w = 0; w < WARMUP; w++) {
      runA();
      runB();
    }
    let minA = Number.POSITIVE_INFINITY;
    let minB = Number.POSITIVE_INFINITY;
    for (let iter = 0; iter < ITERS; iter++) {
      if (iter % 2 === 0) {
        minA = Math.min(minA, time(runA));
        minB = Math.min(minB, time(runB));
      } else {
        minB = Math.min(minB, time(runB));
        minA = Math.min(minA, time(runA));
      }
    }
    rows.push({ name: ca.name, a: minA / reps, b: minB / reps });
  }
  return rows;
}

if (process.env.AB_CHILD) {
  const rows = await measure(process.argv[2], process.argv[3]);
  console.log(JSON.stringify(rows));
} else {
  const revA = process.argv[2] ?? "HEAD";
  const revB = process.argv[3] ?? "WORKTREE";
  const entryA = materialise(revA, "a");
  const entryB = materialise(revB, "b");

  const self = fileURLToPath(import.meta.url);
  const child = (first: string, second: string): Array<Row> => {
    const res = spawnSync(process.execPath, ["--import", "tsx", self, first, second], {
      env: { ...process.env, AB_CHILD: "1" },
      encoding: "utf8",
      maxBuffer: 64 * 1024 * 1024,
    });
    if (res.status !== 0) {
      throw new Error(`child failed: ${res.stderr}`);
    }
    const lines = res.stdout.trim().split("\n");
    return JSON.parse(lines[lines.length - 1]);
  };

  /* Two children per load order; per-case minimum across same-order
   * children, then geometric mean across orders. */
  const minRows = (x: Array<Row>, y: Array<Row>): Array<Row> =>
    x.map((r, i) => ({ name: r.name, a: Math.min(r.a, y[i].a), b: Math.min(r.b, y[i].b) }));
  const run1 = minRows(child(entryA, entryB), child(entryA, entryB));
  const run2 = minRows(child(entryB, entryA), child(entryB, entryA));

  const fmt = (ns: number) => (ns / 1e6).toFixed(4).padStart(10);
  const pctFmt = (p: number) => `${p.toFixed(2).padStart(7)}%`;

  console.log(`A = ${revA}, B = ${revB} (min of ${ITERS} iters x 2 orders, ms)`);
  console.log(`${"case".padEnd(24)}${"A".padStart(10)}${"B".padStart(10)}${"delta".padStart(9)}`);
  let sumA = 0;
  let sumB = 0;
  let ratioTotal1 = 0;
  let ratioTotal2 = 0;
  const totals1 = { a: 0, b: 0 };
  const totals2 = { a: 0, b: 0 };
  for (let i = 0; i < run1.length; i++) {
    const r1 = run1[i];
    const r2 = run2[i];
    /* r1: a=A, b=B; r2: a=B, b=A */
    const ratio = Math.sqrt((r1.b / r1.a) * (r2.a / r2.b));
    const aAvg = (r1.a + r2.b) / 2;
    const bAvg = aAvg * ratio;
    sumA += aAvg;
    sumB += bAvg;
    totals1.a += r1.a;
    totals1.b += r1.b;
    totals2.a += r2.a;
    totals2.b += r2.b;
    console.log(`${r1.name.padEnd(24)}${fmt(aAvg)}${fmt(bAvg)} ${pctFmt((ratio - 1) * 100)}`);
  }
  ratioTotal1 = totals1.b / totals1.a;
  ratioTotal2 = totals2.a / totals2.b;
  const totalRatio = Math.sqrt(ratioTotal1 * ratioTotal2);
  console.log(`${"TOTAL".padEnd(24)}${fmt(sumA)}${fmt(sumA * totalRatio)} ${pctFmt((totalRatio - 1) * 100)}`);
}
```

</details>

<details>
<summary><code>perf/cases.mts</code> — deterministic workloads (mirroring <code>packages/bench</code>)</summary>

```ts
/**
 * Deterministic perf workloads mirroring packages/bench.
 * Each case exposes a timed body (`run`) and a serializable
 * behaviour sample (`collect`) used by the characterisation guard.
 */

export interface PerfCase {
  name: string;
  run: () => void;
  collect: () => unknown;
}

/** mulberry32 PRNG for reproducible inputs */
function rng(seed: number): () => number {
  let a = seed >>> 0;
  return () => {
    a = (a + 0x6d2b79f5) | 0;
    let t = Math.imul(a ^ (a >>> 15), 1 | a);
    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
  };
}

function randomString(rand: () => number, length: number): string {
  const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
  let out = "";
  for (let i = 0; i < length; i++) out += chars[Math.floor(rand() * chars.length)];
  return out;
}

const LONG_STRING = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor. ".repeat(12);

export function buildCases(z: any): Array<PerfCase> {
  const cases: Array<PerfCase> = [];

  {
    const rand = rng(1);
    const schema = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
    const data = Array.from({ length: 1000 }, () => ({
      number: rand(),
      string: `${rand()}`,
      boolean: rand() > 0.5,
    }));
    cases.push({
      name: "object-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.map((d) => schema.parse(d)),
    });
  }

  {
    const schema = z.strictObject({
      number: z.number(),
      negNumber: z.number(),
      maxNumber: z.number(),
      string: z.string(),
      longString: z.string(),
      boolean: z.boolean(),
      deeplyNested: z.strictObject({ foo: z.string(), num: z.number(), bool: z.boolean() }),
    });
    const data = Array.from({ length: 1000 }, (_, i) => ({
      number: i,
      negNumber: -i,
      maxNumber: Number.MAX_VALUE,
      string: "string",
      longString: LONG_STRING,
      boolean: true,
      deeplyNested: { foo: "bar", num: i, bool: false },
    }));
    cases.push({
      name: "strict-moltar",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 20).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(2);
    const schema = z.string();
    const data = Array.from({ length: 10_000 }, () => `${rand()}`);
    cases.push({
      name: "string-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(3);
    const schema = z.number();
    const data = Array.from({ length: 10_000 }, () => rand() * 1_000_000);
    cases.push({
      name: "number-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(4);
    const schema = z.array(z.string());
    const data = Array.from({ length: 200 }, () => Array.from({ length: 20 }, () => randomString(rand, 8)));
    cases.push({
      name: "array-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 10).map((d) => schema.parse(d)),
    });
  }

  {
    const schema = z.union([
      z.object({ type: z.literal("a") }),
      z.object({ type: z.literal("b") }),
      z.object({ type: z.literal("c") }),
    ]);
    const data = Array.from({ length: 1000 }, (_, i) => ({ type: "abc"[i % 3] }));
    cases.push({
      name: "union-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 9).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(5);
    const types = ["a", "b", "c", "d", "e", "f", "g"];
    const options = types.map((t) =>
      z.object({ type: z.literal(t), data1: z.string(), data2: z.string(), data3: z.string() })
    );
    const schema = z.discriminatedUnion("type", options);
    const data = Array.from({ length: 200 }, () => ({
      type: types[Math.floor(rand() * types.length)],
      data1: randomString(rand, 10),
      data2: randomString(rand, 10),
      data3: randomString(rand, 10),
    }));
    cases.push({
      name: "disc-union-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 14).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(6);
    const schema = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
    const bad: Array<unknown> = Array.from({ length: 200 }, (_, i) => {
      const kind = i % 5;
      if (kind === 0) return { string: rand(), boolean: "yes", number: `${rand()}` };
      if (kind === 1) return { string: "ok", boolean: true };
      if (kind === 2) return null;
      if (kind === 3) return { string: "ok", boolean: false, number: Number.NaN };
      return [1, 2, 3];
    });
    cases.push({
      name: "object-fail-safeparse",
      run: () => {
        for (const d of bad) schema.safeParse(d);
      },
      collect: () =>
        bad.map((d) => {
          const r = schema.safeParse(d);
          return r.success ? { success: true, data: r.data } : { success: false, issues: r.error.issues };
        }),
    });
  }

  {
    const rand = rng(7);
    const email = z.email();
    const uuid = z.uuid();
    const datetime = z.iso.datetime();
    const emails = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? `${randomString(rand, 8)}@example.com` : `${randomString(rand, 8)}example.com`
    );
    const uuids = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? "8a99219c-2a97-4a35-9fcf-5a5a4d3b1234" : randomString(rand, 36)
    );
    const datetimes = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? "2024-01-15T12:30:00Z" : `${randomString(rand, 10)}T99:99`
    );
    cases.push({
      name: "string-formats",
      run: () => {
        for (const d of emails) email.safeParse(d);
        for (const d of uuids) uuid.safeParse(d);
        for (const d of datetimes) datetime.safeParse(d);
      },
      collect: () => {
        const sample = (schema: any, inputs: Array<string>) =>
          inputs.slice(0, 6).map((d) => {
            const r = schema.safeParse(d);
            return r.success ? { success: true, data: r.data } : { success: false, issues: r.error.issues };
          });
        return [sample(email, emails), sample(uuid, uuids), sample(datetime, datetimes)];
      },
    });
  }

  {
    const rand = rng(8);
    const schema = z
      .string()
      .min(1)
      .transform((s: string) => s.length)
      .pipe(z.number().max(1000));
    const data = Array.from({ length: 2000 }, () => randomString(rand, 1 + Math.floor(rand() * 20)));
    cases.push({
      name: "chain-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const makeSchemas = () => {
      const simple = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
      const moltar = z.strictObject({
        number: z.number(),
        negNumber: z.number(),
        maxNumber: z.number(),
        string: z.string(),
        longString: z.string(),
        boolean: z.boolean(),
        deeplyNested: z.strictObject({ foo: z.string(), num: z.number(), bool: z.boolean() }),
      });
      return { simple, moltar };
    };
    cases.push({
      name: "schema-init",
      run: () => {
        for (let i = 0; i < 30; i++) makeSchemas();
      },
      collect: () => {
        const { simple, moltar } = makeSchemas();
        return [
          simple.parse({ string: "s", boolean: true, number: 1 }),
          moltar.parse({
            number: 1,
            negNumber: -1,
            maxNumber: Number.MAX_VALUE,
            string: "string",
            longString: LONG_STRING,
            boolean: true,
            deeplyNested: { foo: "bar", num: 1, bool: false },
          }),
        ];
      },
    });
  }

  return cases;
}
```

</details>

---

Companion PRs from the same campaign: #6316 #6318 #6319
