### PR TITLE
perf(v4): halve schema construction cost; keep instances in fast-properties mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,44 @@ The project uses pnpm workspaces. Key commands:
 - Ask before generating new files
 - Use `util.defineLazy()` for computed properties to avoid circular dependencies
 - Performance is critical - parameter reassignment is allowed for optimization
+- Any change to `packages/zod/src` must be weighed on **all three axes: runtime performance, memory consumption, and bundle size** — see "The three axes" below. A change that improves one and is only checked on that one is not finished.
 - ALWAYS use the `gh` CLI to fetch GitHub information (issues, PRs, etc.) instead of relying on web search or assumptions
 - Keep JSDoc as minimal as possible. A self-explanatory type or symbol name needs no doc comment. When a comment is genuinely required, write one short sentence describing behavior — not history, rationale, or examples. Don't add interface-level JSDoc that just restates the interface name.
 - When you've modified a PR (or opened/closed/commented on one), include the PR URL liberally in summary messages — at minimum once at the end of any reply that touched it
 - When creating a PR, do not include a separate test plan section in the body. Link to any relevant issues under discussion, and use the same copywriting guidelines from "Commenting on issues and PRs": concise maintainer voice, prose over templates, and validation details only when they are material to the reader.
 - NEVER bump the version in `packages/zod/package.json` (or any package's `package.json`). A version bump is the only thing that triggers a release; everything else (including direct pushes to `main`) is recoverable until that happens. If a version bump is genuinely needed, ask first.
+
+## The three axes
+
+Zod is judged on **runtime performance**, **memory consumption**, and **bundle size** at once, and they trade against each other constantly. Optimizing one in isolation is how regressions land: a change that buys bundle bytes can cost construction speed, and one that saves memory can cost both. Any non-trivial change to `packages/zod/src` — and any change to `core/` at all, since every build ships it — needs a number on all three before it is done. Report them together, including the ones that got worse.
+
+`zod/mini` deserves its own line on the bundle axis: it is sold on size, so a fixed cost lands very differently there (~200 B is 6% of the smallest mini bundle and 1% of classic's).
+
+| axis    | how to measure                                                                                                                                    |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| runtime | `packages/bench/*.ts` via `pnpm bench <name>`, plus construction cost — parse and construction move independently                                 |
+| memory  | `packages/bench/memory/schema-footprint.ts` and `realworld.ts` (retained bytes per schema; run under `--expose-gc`)                               |
+| bundle  | bundle a `packages/treeshake` fixture with esbuild `--minify` under `--conditions=@zod/source` and gzip it, for both a classic and a mini fixture |
+
+### Benchmarking traps
+
+These produced hours of wrong conclusions; check them before believing a number.
+
+- **Check `uptime` first.** A loaded machine invents effects of ±16%. Numbers taken above a load average of ~8 are worthless.
+- **Interleave the two revisions.** Running all of A then all of B puts any drift entirely on whichever ran second. Alternating round-by-round took per-side spread from 2.5x to 4%.
+- **Loading two zod revisions into one process makes call sites polymorphic.** It is fine for comparing construction, unreliable for tight leaf parses.
+- **Allocating benchmarks can't be timed by a fixed-duration loop.** `z.array().parse()` allocates per call, so a time-boxed harness samples whatever the collector is doing — it gave +8.2% and −17.3% on consecutive identical runs. Use a fixed iteration count with `gc()` between samples and take the minimum.
+- **Make sure the work isn't optimized away.** If a micro-benchmark reports ~1e9 ops/sec, V8 eliminated the loop; consume the result.
+
+### Property placement, specifically
+
+Most of the memory in a schema is its own-property count, not its closures. V8 sizes an instance's backing store in steps and `$constructor` assigns nothing itself, so instances get no in-object slots: **≤12 own properties cost 128 bytes, 13–20 cost 848, ≥21 cost 1616** (`packages/bench/memory/prop-slack.ts` measures this). Members therefore live on the prototype and materialize per instance on first read.
+
+If you touch that machinery, three things bite:
+
+- **Moving a property between definition sites changes its descriptor**, and writability/enumerability/configurability are part of the public contract. `packages/bench/memory/` has a surface-diff approach for this: dump every descriptor, alias and assign/delete semantic on both revisions and diff them. It caught four real regressions that tests did not.
+- **Redefining an accessor demotes the object to dictionary mode**, which cost 2x on `z.object().parse` once. Run `packages/bench/memory/dict-mode.ts` after any change here — every instance must report `fast`.
+- **A bound function pays a call-time trampoline.** Fine for cold builder methods, measurably not fine on the parse path.
 
 ## Cutting a release
 
@@ -89,7 +122,8 @@ git push <contributor> pr-<N>:<headRefName> --force-with-lease   # for amends
 ```
 
 Notes:
-- Do NOT use `gh pr checkout --detach` for this — it moves your *current* working tree into detached HEAD instead of creating a worktree.
+
+- Do NOT use `gh pr checkout --detach` for this — it moves your _current_ working tree into detached HEAD instead of creating a worktree.
 - Husky pre-commit runs biome format/lint via lint-staged; pre-push runs the full vitest suite. Both are fast and act as a safety net — don't bypass with `--no-verify` unless you have a specific reason.
 - **Preserve contributor commits.** Never `git reset --hard` or otherwise rewrite history that erases the contributor's work, even if you're rewriting the actual change. They need to stay in the PR's commit list to get credit on the merged PR. If their approach was wrong, add a `Revert "..."` commit (or just a plain commit that undoes those lines) and then add your replacement commit on top. Force-pushing a single clobbering commit strips them from the GitHub contributors graph.
 - When done, clean up: `git worktree remove ~/.cursor/worktrees/zod/pr-<N>` and `git branch -D pr-<N>` (and optionally `git remote remove <contributor>`).

--- a/packages/bench/memory/breakdown.ts
+++ b/packages/bench/memory/breakdown.ts
@@ -1,0 +1,36 @@
+import * as z from "zod";
+import { fmtBytes, table } from "./harness.js";
+import { diffAllocation } from "./snapshot.js";
+
+const which = process.argv[2] ?? "string";
+
+const factories: Record<string, () => unknown> = {
+  string: () => z.string(),
+  number: () => z.number(),
+  "object-empty": () => z.object({}),
+  "object-3": () => z.object({ a: z.string(), b: z.number(), c: z.boolean() }),
+  "string-min": () => z.string().min(1),
+  optional: () => z.string().optional(),
+  union: () => z.union([z.string(), z.number()]),
+  array: () => z.array(z.string()),
+};
+
+const factory = factories[which];
+if (!factory) {
+  console.error(`unknown case "${which}"; try: ${Object.keys(factories).join(", ")}`);
+  process.exit(1);
+}
+
+const rows = diffAllocation(factory, 2_000, 8_000);
+const total = rows.reduce((sum, r) => sum + r.bytesEach, 0);
+
+console.log(`allocation breakdown for ${which} (per instance)\n`);
+table(
+  rows.map((r) => ({
+    node: r.what,
+    "per inst": r.countEach.toFixed(2),
+    bytes: r.bytesEach.toFixed(0),
+    human: fmtBytes(r.bytesEach),
+  }))
+);
+console.log(`\ntotal attributed: ${fmtBytes(total)}`);

--- a/packages/bench/memory/calibrate.ts
+++ b/packages/bench/memory/calibrate.ts
@@ -1,0 +1,38 @@
+/**
+ * Sanity-checks the measurement harness against allocations of known size.
+ * If these controls don't land near their theoretical sizes, no zod number
+ * produced by the same harness is trustworthy.
+ */
+import { fmtBytes, measureStable, table } from "./harness.js";
+
+const N = 20_000;
+
+const controls: Array<[string, string, (i: number) => unknown]> = [
+  ["{}", "~32 B", () => ({})],
+  ["{a:1,b:2,c:3}", "~56 B", () => ({ a: 1, b: 2, c: 3 })],
+  ["new Array(10)", "~120 B", () => new Array(10).fill(0)],
+  ["new Set()", "~100 B", () => new Set()],
+  ["new Set(['a','b','c'])", "~200 B", () => new Set(["a", "b", "c"])],
+  ["new Map()", "~100 B", () => new Map()],
+  ["closure over 1 var", "~100 B", (i) => () => i],
+  ["new Uint8Array(1024)", "~1088 B", () => new Uint8Array(1024)],
+  ["10-char string", "~40 B", (i) => `str-${i}-xxxx`.slice(0, 10) + String(i)],
+  [
+    "obj w/ getter (defineProperty)",
+    "~200 B",
+    () => {
+      const o: any = {};
+      Object.defineProperty(o, "x", { get: () => 1, configurable: true });
+      return o;
+    },
+  ],
+];
+
+console.log(`harness calibration, n=${N}\n`);
+
+table(
+  controls.map(([label, expected, factory]) => {
+    const m = measureStable(label, N, factory, 5);
+    return { control: label, expected, measured: fmtBytes(m.bytesEach), bytes: m.bytesEach.toFixed(0) };
+  })
+);

--- a/packages/bench/memory/dict-mode.ts
+++ b/packages/bench/memory/dict-mode.ts
@@ -1,0 +1,77 @@
+/**
+ * Reports whether schema instances and their `_zod` internals are in V8
+ * dictionary (slow) mode. A dictionary-mode object pays a NameDictionary
+ * backing store — roughly 900 B at these property counts — instead of inline
+ * slots, and every property read goes through a hash lookup.
+ *
+ * Run with: node --allow-natives-syntax --import tsx
+ */
+import * as z from "zod";
+import { table } from "./harness.js";
+
+// biome-ignore lint/security/noGlobalEval: V8 natives syntax is not valid in a module body.
+const hasFast: (o: object) => boolean = eval("(o) => %HasFastProperties(o)");
+
+const cases: Array<[string, () => any]> = [
+  ["z.string()", () => z.string()],
+  ["z.number()", () => z.number()],
+  ["z.boolean()", () => z.boolean()],
+  ["z.bigint()", () => z.bigint()],
+  ["z.object({a})", () => z.object({ a: z.string() })],
+  ["z.array(str)", () => z.array(z.string())],
+  ["z.string().min(1)", () => z.string().min(1)],
+  ["z.string().optional()", () => z.string().optional()],
+  ["z.email()", () => z.email()],
+  ["z.enum(['a'])", () => z.enum(["a"])],
+];
+
+// Reference points so the reader can see what fast/slow looks like.
+const plain: any = { a: 1, b: 2 };
+const forcedSlow: any = {};
+Object.defineProperty(forcedSlow, "x", { value: 1, enumerable: false });
+
+console.log(
+  `reference: plain literal fast=${hasFast(plain)}, non-enumerable defineProperty fast=${hasFast(forcedSlow)}\n`
+);
+
+table(
+  cases.map(([label, f]) => {
+    const s = f();
+    return {
+      schema: label,
+      "inst fast?": hasFast(s) ? "fast" : "DICT",
+      "inst props": Reflect.ownKeys(s).length,
+      "_zod fast?": hasFast(s._zod) ? "fast" : "DICT",
+      "_zod props": Reflect.ownKeys(s._zod).length,
+      "def fast?": hasFast(s._zod.def) ? "fast" : "DICT",
+    };
+  })
+);
+
+// Bisect: which operation in the constructor tips the instance over?
+console.log("\nwhat forces dictionary mode:");
+const probes: Array<[string, (o: any) => void]> = [
+  [
+    "plain assignment x25",
+    (o) => {
+      for (let i = 0; i < 25; i++) o[`p${i}`] = i;
+    },
+  ],
+  [
+    "defineProperty all-true x25",
+    (o) => {
+      for (let i = 0; i < 25; i++)
+        Object.defineProperty(o, `p${i}`, { value: i, writable: true, enumerable: true, configurable: true });
+    },
+  ],
+  ["defineProperty enumerable:false x1", (o) => Object.defineProperty(o, "z", { value: 1, enumerable: false })],
+  ["defineProperty value-only x1", (o) => Object.defineProperty(o, "z", { value: 1 })],
+  ["defineProperty getter x1", (o) => Object.defineProperty(o, "z", { get: () => 1, configurable: true })],
+];
+table(
+  probes.map(([label, apply]) => {
+    const o: any = {};
+    apply(o);
+    return { operation: label, result: hasFast(o) ? "fast" : "DICT" };
+  })
+);

--- a/packages/bench/memory/harness.ts
+++ b/packages/bench/memory/harness.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared measurement utilities for the memory benchmarks.
+ * Run everything under `node --expose-gc`.
+ */
+
+declare const gc: (() => void) | undefined;
+
+export function collect(): void {
+  if (typeof gc !== "function") {
+    throw new Error("run with --expose-gc");
+  }
+  // Repeated collections: the first pass frees the bulk, later passes catch
+  // objects that only became unreachable once the first pass ran.
+  for (let i = 0; i < 6; i++) gc();
+}
+
+export function heapUsed(): number {
+  collect();
+  return process.memoryUsage().heapUsed;
+}
+
+export interface Measurement {
+  label: string;
+  count: number;
+  totalBytes: number;
+  bytesEach: number;
+}
+
+/**
+ * Builds `count` instances via `factory`, holds them all live, and reports the
+ * retained heap delta. The sink array itself is subtracted out.
+ */
+export function measure(label: string, count: number, factory: (i: number) => unknown): Measurement {
+  // Warm up so lazily-initialized module state isn't attributed to the payload.
+  factory(0);
+
+  const sink: unknown[] = new Array(count);
+  const before = heapUsed();
+  for (let i = 0; i < count; i++) {
+    sink[i] = factory(i);
+  }
+  const after = heapUsed();
+
+  // Keep the sink reachable across the measurement.
+  if (sink.length !== count) throw new Error("unreachable");
+
+  const arrayOverhead = count * 8;
+  const totalBytes = after - before - arrayOverhead;
+  return { label, count, totalBytes, bytesEach: totalBytes / count };
+}
+
+/**
+ * Median-of-runs variant. Allocation measurements are noisy; taking the median
+ * of independent runs keeps a single unlucky GC from dominating the number.
+ */
+export function measureStable(label: string, count: number, factory: (i: number) => unknown, runs = 5): Measurement {
+  const samples: number[] = [];
+  for (let r = 0; r < runs; r++) {
+    samples.push(measure(label, count, factory).bytesEach);
+  }
+  samples.sort((a, b) => a - b);
+  const bytesEach = samples[Math.floor(samples.length / 2)]!;
+  return { label, count, totalBytes: bytesEach * count, bytesEach };
+}
+
+export function fmtBytes(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1024 * 1024) return `${(n / 1024 / 1024).toFixed(2)} MB`;
+  if (abs >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n.toFixed(0)} B`;
+}
+
+export function table(rows: Array<Record<string, string | number>>): void {
+  if (rows.length === 0) return;
+  const cols = Object.keys(rows[0]!);
+  const widths = cols.map((c) => Math.max(c.length, ...rows.map((r) => String(r[c]).length)));
+  const line = (cells: string[]) => cells.map((cell, i) => cell.padEnd(widths[i]!)).join("  ");
+  console.log(line(cols));
+  console.log(widths.map((w) => "-".repeat(w)).join("  "));
+  for (const row of rows) {
+    console.log(line(cols.map((c) => String(row[c]))));
+  }
+}

--- a/packages/bench/memory/leaks.ts
+++ b/packages/bench/memory/leaks.ts
@@ -1,0 +1,145 @@
+/**
+ * Empirical leak detection.
+ *
+ * Each scenario runs a workload that creates schemas and/or parses data and
+ * then DROPS every reference it created. A correct scenario returns to its
+ * starting heap. Anything that grows linearly with iteration count is
+ * retaining something it shouldn't.
+ *
+ * Growth is measured across two batches of different sizes so a fixed
+ * one-time cost (module init, lazily-installed prototypes) doesn't read as a
+ * leak: only the SLOPE matters.
+ */
+import * as z from "zod";
+import { collect, fmtBytes, table } from "./harness.js";
+
+interface Scenario {
+  label: string;
+  /** Must leave nothing reachable behind. */
+  run: (i: number) => void;
+  /** Known-leaky scenarios we assert ON, to prove the detector works. */
+  expectLeak?: boolean;
+}
+
+const scenarios: Scenario[] = [
+  // --- controls: these MUST show a leak, proving the detector is sensitive ---
+  {
+    label: "CONTROL: push to module array",
+    run: (i) => void leakSink.push(z.string().min(i % 5)),
+    expectLeak: true,
+  },
+  {
+    label: "CONTROL: no-op",
+    run: () => {},
+  },
+
+  // --- schema construction, all references dropped ---
+  { label: "z.string()", run: () => void z.string() },
+  { label: "z.string().min(1)", run: () => void z.string().min(1) },
+  { label: "z.object({...})", run: () => void z.object({ a: z.string(), b: z.number() }) },
+  { label: "z.object().extend()", run: () => void z.object({ a: z.string() }).extend({ b: z.number() }) },
+  { label: "z.object().partial()", run: () => void z.object({ a: z.string() }).partial() },
+  {
+    label: "z.discriminatedUnion",
+    run: () => void z.discriminatedUnion("t", [z.object({ t: z.literal("a") }), z.object({ t: z.literal("b") })]),
+  },
+  {
+    label: "z.lazy recursive",
+    run: () => {
+      const s: any = z.lazy(() => z.object({ v: z.string(), next: s.optional() }));
+      void s.safeParse({ v: "x", next: { v: "y" } });
+    },
+  },
+
+  // --- registry / metadata ---
+  { label: ".describe()", run: (i) => void z.string().describe(`d${i}`) },
+  { label: ".meta() no id", run: (i) => void z.string().meta({ title: `t${i}` }) },
+  { label: ".meta() WITH id", run: (i) => void z.string().meta({ id: `id-${i}` }) },
+  { label: "custom registry .add() w/ id", run: (i) => void localRegistry.add(z.string(), { id: `r-${i}` }) },
+
+  // --- parsing: input data must not be retained ---
+  { label: "parse (fresh schema each time)", run: (i) => void z.object({ a: z.string() }).parse({ a: `v${i}` }) },
+  { label: "parse big payload (shared schema)", run: (i) => void bigSchema.parse(makeBig(i)) },
+  {
+    label: "safeParse FAILURE (shared schema)",
+    run: (i) => void bigSchema.safeParse({ ...makeBig(i), n: "not-a-number" }),
+  },
+  {
+    label: "parse throw+catch (shared schema)",
+    run: (i) => {
+      try {
+        bigSchema.parse({ ...makeBig(i), n: "not-a-number" });
+      } catch {}
+    },
+  },
+  { label: "refine failure (shared schema)", run: (i) => void refined.safeParse(`x${i}`) },
+
+  // --- JSON schema generation ---
+  { label: "toJSONSchema (shared schema)", run: () => void z.toJSONSchema(bigSchema) },
+  { label: "toJSONSchema (fresh schema)", run: () => void z.toJSONSchema(z.object({ a: z.string() })) },
+
+  // --- standard-schema surface ---
+  { label: "~standard.validate", run: (i) => void bigSchema["~standard"].validate(makeBig(i)) },
+];
+
+const leakSink: unknown[] = [];
+const localRegistry = z.registry<{ id: string }>();
+const bigSchema = z.object({
+  s: z.string(),
+  n: z.number(),
+  arr: z.array(z.string()),
+  nested: z.object({ deep: z.object({ deeper: z.string() }) }),
+});
+const refined = z.string().refine((s) => s.length > 1000, "too short");
+
+function makeBig(i: number) {
+  return {
+    s: `string-value-${i}`,
+    n: i,
+    arr: Array.from({ length: 20 }, (_, k) => `item-${i}-${k}-padding-padding-padding`),
+    nested: { deep: { deeper: `deep-${i}` } },
+  };
+}
+
+function heapAfter(run: (i: number) => void, iterations: number, offset: number): number {
+  for (let i = 0; i < iterations; i++) run(offset + i);
+  collect();
+  return process.memoryUsage().heapUsed;
+}
+
+const SMALL = 2_000;
+const LARGE = 10_000;
+
+const rows = scenarios.map((s) => {
+  // Warm everything (lazy prototype installs, JIT compilation) so one-time
+  // costs land before the first measurement.
+  for (let i = 0; i < 500; i++) s.run(i);
+  collect();
+
+  const base = process.memoryUsage().heapUsed;
+  const afterSmall = heapAfter(s.run, SMALL, 1_000_000);
+  const afterLarge = heapAfter(s.run, LARGE, 2_000_000);
+
+  // Bytes retained per iteration, from the slope between the two batches.
+  // Using the slope cancels any fixed cost captured in `base`.
+  const slope = (afterLarge - afterSmall) / LARGE;
+  const totalGrowth = afterLarge - base;
+  const leaking = slope > 24; // below ~1 pointer/iteration is noise
+
+  return {
+    scenario: s.label,
+    "bytes/iter": slope.toFixed(1),
+    "total growth": fmtBytes(totalGrowth),
+    verdict: leaking ? "LEAK" : "ok",
+    expected: s.expectLeak ? "leak" : "ok",
+    agree: leaking === !!s.expectLeak ? "" : "  <-- MISMATCH",
+  };
+});
+
+table(rows);
+
+const mismatches = rows.filter((r) => r.agree !== "");
+console.log(
+  `\n${mismatches.length === 0 ? "all scenarios matched expectations" : `${mismatches.length} MISMATCH(ES)`}`
+);
+if (leakSink.length === 0) throw new Error("unreachable");

--- a/packages/bench/memory/own-props.ts
+++ b/packages/bench/memory/own-props.ts
@@ -1,0 +1,49 @@
+/**
+ * Enumerates exactly what each schema instance owns: own properties on the
+ * instance and on `_zod`, split by whether the value is a per-instance
+ * function (a closure allocated at construction) or shared/data.
+ */
+import * as z from "zod";
+import { table } from "./harness.js";
+
+function describe(label: string, a: any, b: any): void {
+  const report: Array<{ where: string; key: string; kind: string; perInstance: string }> = [];
+
+  for (const [where, objA, objB] of [
+    ["inst", a, b],
+    ["_zod", a._zod, b._zod],
+  ] as const) {
+    for (const key of Reflect.ownKeys(objA)) {
+      const d = Object.getOwnPropertyDescriptor(objA, key)!;
+      const dB = Object.getOwnPropertyDescriptor(objB, key);
+      let kind: string;
+      let perInstance: string;
+      if (d.get || d.set) {
+        kind = `accessor${d.get ? " get" : ""}${d.set ? " set" : ""}`;
+        // Accessor pairs defined per-instance are distinct function objects.
+        perInstance = dB && (d.get !== dB.get || d.set !== dB.set) ? "YES" : "no";
+      } else {
+        const v = d.value;
+        kind = typeof v === "function" ? "function" : Array.isArray(v) ? `array[${v.length}]` : typeof v;
+        perInstance = dB && typeof v === "object" && v !== null ? (v !== dB.value ? "YES" : "no") : "";
+        if (typeof v === "function") perInstance = dB && v !== dB.value ? "YES" : "no";
+      }
+      report.push({ where, key: String(key), kind, perInstance });
+    }
+  }
+
+  const closures = report.filter(
+    (r) => (r.kind === "function" || r.kind.startsWith("accessor")) && r.perInstance === "YES"
+  );
+  const objects = report.filter((r) => r.kind === "object" && r.perInstance === "YES");
+
+  console.log(`\n=== ${label} ===`);
+  console.log(
+    `own props: inst=${Reflect.ownKeys(a).length}, _zod=${Reflect.ownKeys(a._zod).length}` +
+      `  |  per-instance functions: ${closures.length}, per-instance objects: ${objects.length}`
+  );
+  table(report);
+}
+
+describe("z.string()", z.string(), z.string());
+describe("z.object({a: string})", z.object({ a: z.string() }), z.object({ a: z.string() }));

--- a/packages/bench/memory/prop-arrays.ts
+++ b/packages/bench/memory/prop-arrays.ts
@@ -1,0 +1,62 @@
+/**
+ * Attributes `(object properties)` backing stores to the objects that own
+ * them. These showed up as the single largest line in the per-instance
+ * breakdown, so this answers *whose* they are and how big.
+ */
+import * as fs from "node:fs";
+import * as z from "zod";
+import { fmtBytes, table } from "./harness.js";
+import { loadGraph, snapshotNow } from "./retainers.js";
+
+const which = process.argv[2] ?? "string";
+const factories: Record<string, () => unknown> = {
+  string: () => z.string(),
+  "string-min": () => z.string().min(1),
+  "object-3": () => z.object({ a: z.string(), b: z.number(), c: z.boolean() }),
+  number: () => z.number(),
+};
+
+const N = 5_000;
+const sink: unknown[] = [];
+for (let i = 0; i < N; i++) sink.push(factories[which]!());
+
+const file = snapshotNow("props");
+const g = loadGraph(file);
+
+// For every node that owns an "(object properties)" child, record the owner's
+// kind and the child's size.
+const byOwner = new Map<string, { count: number; bytes: number }>();
+for (let i = 0; i < g.count; i++) {
+  for (const e of g.edgesOf(i)) {
+    if (e.type !== "internal" || e.name !== "properties") continue;
+    const child = e.to;
+    if (g.name(child) !== "(object properties)") continue;
+    const key = `${g.type(i)}::${g.name(i)}`;
+    let rec = byOwner.get(key);
+    if (!rec) {
+      rec = { count: 0, bytes: 0 };
+      byOwner.set(key, rec);
+    }
+    rec.count++;
+    rec.bytes += g.selfSize(child);
+  }
+}
+
+const rows = [...byOwner.entries()]
+  .map(([owner, r]) => ({
+    owner,
+    count: r.count,
+    "per schema": (r.count / N).toFixed(2),
+    "total bytes": r.bytes,
+    "avg size": fmtBytes(r.bytes / r.count),
+    "bytes/schema": (r.bytes / N).toFixed(0),
+  }))
+  .filter((r) => r.count >= N * 0.2)
+  .sort((a, b) => Number(b["bytes/schema"]) - Number(a["bytes/schema"]));
+
+console.log(`(object properties) backing stores, ${which}, n=${N}\n`);
+table(rows);
+console.log(`\ntotal: ${rows.reduce((s, r) => s + Number(r["bytes/schema"]), 0).toFixed(0)} bytes/schema`);
+
+if (sink.length !== N) throw new Error("unreachable");
+fs.unlinkSync(file);

--- a/packages/bench/memory/prop-slack.ts
+++ b/packages/bench/memory/prop-slack.ts
@@ -1,0 +1,45 @@
+/**
+ * How much does an own property actually cost when it's added by assignment
+ * to an object V8 couldn't slack-track (created by a generic constructor that
+ * assigns nothing itself)? This is the shape every zod schema instance has,
+ * so it sets the payoff for moving methods to the prototype.
+ */
+import { fmtBytes, measureStable, table } from "./harness.js";
+
+// A constructor that assigns nothing, so V8 infers zero in-object slots and
+// every property lands in a growable backing store — same as $constructor.
+function Empty(this: any) {}
+
+function withProps(n: number): () => unknown {
+  return () => {
+    const o: any = new (Empty as any)();
+    for (let i = 0; i < n; i++) o[`p${i}`] = i;
+    return o;
+  };
+}
+
+// Same, but properties defined all at once from a literal (fast path).
+function literalProps(n: number): () => unknown {
+  const keys = Array.from({ length: n }, (_, i) => `p${i}`);
+  return () => {
+    const o: any = {};
+    for (const k of keys) o[k] = 0;
+    return o;
+  };
+}
+
+const counts = [0, 4, 8, 12, 16, 20, 23, 25, 30, 40];
+
+table(
+  counts.map((n) => {
+    const a = measureStable(`ctor+${n}`, 20_000, withProps(n), 5);
+    const b = measureStable(`lit+${n}`, 20_000, literalProps(n), 5);
+    return {
+      "own props": n,
+      "via generic ctor": fmtBytes(a.bytesEach),
+      bytes: a.bytesEach.toFixed(0),
+      "via plain literal": fmtBytes(b.bytesEach),
+      "per prop": n ? (a.bytesEach / n).toFixed(0) : "-",
+    };
+  })
+);

--- a/packages/bench/memory/realworld.ts
+++ b/packages/bench/memory/realworld.ts
@@ -1,0 +1,76 @@
+/**
+ * Whole-application memory: how much heap does a realistically-sized schema
+ * catalogue cost? This is the number a service actually pays — a few hundred
+ * schemas held for the process lifetime, each with nested objects, unions,
+ * arrays and refinements.
+ */
+import * as z from "zod";
+import { collect, fmtBytes, table } from "./harness.js";
+
+/** One "resource" the way an API codebase tends to define them. */
+function makeResource(i: number) {
+  const Address = z.object({
+    street: z.string().min(1).max(200),
+    city: z.string().min(1),
+    postalCode: z.string().regex(/^\d{5}$/),
+    country: z.string().length(2),
+  });
+
+  const Contact = z.object({
+    email: z.email(),
+    phone: z.string().optional(),
+    address: Address.optional(),
+  });
+
+  const Status = z.enum(["active", "pending", "archived", "deleted"]);
+
+  const Event = z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("created"), at: z.iso.datetime(), by: z.uuid() }),
+    z.object({ kind: z.literal("updated"), at: z.iso.datetime(), fields: z.array(z.string()) }),
+    z.object({ kind: z.literal("deleted"), at: z.iso.datetime(), reason: z.string().nullable() }),
+  ]);
+
+  return z
+    .object({
+      id: z.uuid(),
+      slug: z.string().regex(/^[a-z0-9-]+$/),
+      title: z.string().min(1).max(300),
+      description: z.string().max(5000).optional(),
+      status: Status,
+      count: z.number().int().nonnegative(),
+      score: z.number().min(0).max(100),
+      tags: z.array(z.string().min(1)).max(50),
+      contact: Contact,
+      history: z.array(Event),
+      metadata: z.record(z.string(), z.unknown()).optional(),
+      createdAt: z.iso.datetime(),
+      updatedAt: z.iso.datetime().nullable(),
+    })
+    .refine((v) => v.createdAt <= (v.updatedAt ?? v.createdAt), `resource ${i}: updatedAt precedes createdAt`);
+}
+
+const COUNTS = [50, 200, 500];
+
+const rows = COUNTS.map((n) => {
+  // Warm the lazily-installed prototypes so they aren't billed to the payload.
+  makeResource(-1);
+  collect();
+  const before = process.memoryUsage().heapUsed;
+
+  const catalogue: unknown[] = [];
+  for (let i = 0; i < n; i++) catalogue.push(makeResource(i));
+
+  collect();
+  const after = process.memoryUsage().heapUsed;
+  if (catalogue.length !== n) throw new Error("unreachable");
+
+  return {
+    "resource schemas": n,
+    "heap held": fmtBytes(after - before),
+    "per resource": fmtBytes((after - before) / n),
+    bytes: (after - before).toFixed(0),
+  };
+});
+
+console.log("realistic schema catalogue (each resource is ~40 schema nodes)\n");
+table(rows);

--- a/packages/bench/memory/retainers.ts
+++ b/packages/bench/memory/retainers.ts
@@ -1,0 +1,122 @@
+/**
+ * Walks a V8 heap snapshot and reports, for every node kind that scales with
+ * the live schema population, the exact edge path that retains it.
+ *
+ * The population is anchored under a single global array so the walk has a
+ * known root; paths are reported relative to one sample instance.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as v8 from "node:v8";
+
+declare const gc: (() => void) | undefined;
+
+interface RawSnapshot {
+  snapshot: {
+    meta: { node_fields: string[]; node_types: (string[] | string)[]; edge_fields: string[]; edge_types: string[][] };
+    node_count: number;
+    edge_count: number;
+  };
+  nodes: number[];
+  edges: number[];
+  strings: string[];
+}
+
+export interface Graph {
+  count: number;
+  type: (i: number) => string;
+  name: (i: number) => string;
+  selfSize: (i: number) => number;
+  /** [toNodeIndex, edgeType, edgeNameOrIndex][] */
+  edgesOf: (i: number) => Array<{ to: number; type: string; name: string }>;
+}
+
+export function loadGraph(file: string): Graph {
+  const snap: RawSnapshot = JSON.parse(fs.readFileSync(file, "utf8"));
+  const meta = snap.snapshot.meta;
+  const nf = meta.node_fields;
+  const ef = meta.edge_fields;
+  const nStride = nf.length;
+  const eStride = ef.length;
+
+  const nTypeIdx = nf.indexOf("type");
+  const nNameIdx = nf.indexOf("name");
+  const nSizeIdx = nf.indexOf("self_size");
+  const nEdgeCountIdx = nf.indexOf("edge_count");
+  const eTypeIdx = ef.indexOf("type");
+  const eNameIdx = ef.indexOf("name_or_index");
+  const eToIdx = ef.indexOf("to_node");
+
+  const nodeTypes = meta.node_types[nTypeIdx] as string[];
+  const edgeTypes = meta.edge_types[eTypeIdx] as string[];
+  const { nodes, edges, strings } = snap;
+  const count = snap.snapshot.node_count;
+
+  // Prefix-sum of edge counts so edges of node i are locatable in O(1).
+  const edgeStart = new Uint32Array(count + 1);
+  for (let i = 0; i < count; i++) {
+    edgeStart[i + 1] = edgeStart[i]! + nodes[i * nStride + nEdgeCountIdx]!;
+  }
+
+  return {
+    count,
+    type: (i) => nodeTypes[nodes[i * nStride + nTypeIdx]!]!,
+    name: (i) => strings[nodes[i * nStride + nNameIdx]!]!,
+    selfSize: (i) => nodes[i * nStride + nSizeIdx]!,
+    edgesOf: (i) => {
+      const out: Array<{ to: number; type: string; name: string }> = [];
+      for (let e = edgeStart[i]!; e < edgeStart[i + 1]!; e++) {
+        const base = e * eStride;
+        const type = edgeTypes[edges[base + eTypeIdx]!]!;
+        const nameOrIndex = edges[base + eNameIdx]!;
+        out.push({
+          to: edges[base + eToIdx]! / nStride,
+          type,
+          // Element/hidden edges carry a numeric index; others carry a string id.
+          name: type === "element" || type === "hidden" ? String(nameOrIndex) : (strings[nameOrIndex] ?? "?"),
+        });
+      }
+      return out;
+    },
+  };
+}
+
+export function snapshotNow(tag: string): string {
+  if (typeof gc !== "function") throw new Error("run with --expose-gc");
+  for (let i = 0; i < 6; i++) gc();
+  const file = path.join(os.tmpdir(), `zod-ret-${tag}-${process.pid}.heapsnapshot`);
+  v8.writeHeapSnapshot(file);
+  return file;
+}
+
+/**
+ * BFS outward from `roots`, recording for each visited node the shortest edge
+ * path that reached it. Nodes in `stopAt` are not traversed through.
+ */
+export function shortestPaths(g: Graph, roots: number[], maxDepth = 12): Map<number, string[]> {
+  const paths = new Map<number, string[]>();
+  let frontier = roots.slice();
+  for (const r of roots) paths.set(r, []);
+
+  for (let depth = 0; depth < maxDepth && frontier.length > 0; depth++) {
+    const next: number[] = [];
+    for (const from of frontier) {
+      const fromPath = paths.get(from)!;
+      for (const e of g.edgesOf(from)) {
+        if (paths.has(e.to)) continue;
+        if (e.type === "weak") continue;
+        paths.set(e.to, [...fromPath, `${e.type === "element" ? `[${e.name}]` : e.name}`]);
+        next.push(e.to);
+      }
+    }
+    frontier = next;
+  }
+  return paths;
+}
+
+export function findNodes(g: Graph, pred: (i: number) => boolean): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < g.count; i++) if (pred(i)) out.push(i);
+  return out;
+}

--- a/packages/bench/memory/schema-footprint.ts
+++ b/packages/bench/memory/schema-footprint.ts
@@ -1,0 +1,79 @@
+import * as z from "zod";
+import * as zm from "zod/mini";
+import { fmtBytes, measureStable, table } from "./harness.js";
+
+const N = 20_000;
+
+const cases: Array<[string, (i: number) => unknown]> = [
+  ["z.string()", () => z.string()],
+  ["z.number()", () => z.number()],
+  ["z.boolean()", () => z.boolean()],
+  ["z.literal('a')", () => z.literal("a")],
+  ["z.string().min(1)", () => z.string().min(1)],
+  ["z.string().min(1).max(5)", () => z.string().min(1).max(5)],
+  ["z.string().optional()", () => z.string().optional()],
+  ["z.email()", () => z.email()],
+  ["z.uuid()", () => z.uuid()],
+  ["z.iso.datetime()", () => z.iso.datetime()],
+  ["z.array(z.string())", () => z.array(z.string())],
+  ["z.enum(['a','b','c'])", () => z.enum(["a", "b", "c"])],
+  ["z.object({}) empty", () => z.object({})],
+  [
+    "z.object() 3 keys",
+    () =>
+      z.object({
+        a: z.string(),
+        b: z.number(),
+        c: z.boolean(),
+      }),
+  ],
+  [
+    "z.object() 10 keys",
+    () => {
+      const shape: Record<string, z.ZodType> = {};
+      for (let k = 0; k < 10; k++) shape[`k${k}`] = z.string();
+      return z.object(shape);
+    },
+  ],
+  [
+    "z.object() 10 keys (shared leaf)",
+    (() => {
+      const leaf = z.string();
+      return () => {
+        const shape: Record<string, z.ZodType> = {};
+        for (let k = 0; k < 10; k++) shape[`k${k}`] = leaf;
+        return z.object(shape);
+      };
+    })(),
+  ],
+  ["z.union([str,num])", () => z.union([z.string(), z.number()])],
+  [
+    "z.discriminatedUnion 2",
+    () =>
+      z.discriminatedUnion("t", [
+        z.object({ t: z.literal("a"), a: z.string() }),
+        z.object({ t: z.literal("b"), b: z.number() }),
+      ]),
+  ],
+  ["z.record(str, num)", () => z.record(z.string(), z.number())],
+  ["z.tuple([str,num])", () => z.tuple([z.string(), z.number()])],
+  ["z.lazy(() => str)", () => z.lazy(() => z.string())],
+  ["z.string().refine(fn)", () => z.string().refine((s) => s.length > 0)],
+  ["z.string().transform(fn)", () => z.string().transform((s) => s.length)],
+  ["z.string().default('x')", () => z.string().default("x")],
+  ["z.string().brand<'x'>()", () => z.string().brand<"x">()],
+  ["z.string().nullable()", () => z.string().nullable()],
+  ["z.pipe(str, num-ish)", () => z.string().pipe(z.string())],
+  // mini variants for contrast (no method-chaining surface)
+  ["mini z.string()", () => zm.string()],
+  ["mini z.object() 3 keys", () => zm.object({ a: zm.string(), b: zm.number(), c: zm.boolean() })],
+];
+
+console.log(`per-instance retained heap, n=${N}\n`);
+
+const rows = cases.map(([label, factory]) => {
+  const m = measureStable(label, N, factory, 5);
+  return { schema: label, bytes: m.bytesEach.toFixed(0), human: fmtBytes(m.bytesEach) };
+});
+
+table(rows);

--- a/packages/bench/memory/snapshot.ts
+++ b/packages/bench/memory/snapshot.ts
@@ -1,0 +1,133 @@
+/**
+ * Attributes per-instance heap cost by diffing two V8 heap snapshots: one with
+ * a baseline population of schemas live, one with `delta` more. Grouping the
+ * difference by node type/name shows exactly which allocations scale with the
+ * number of schemas.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as v8 from "node:v8";
+
+declare const gc: (() => void) | undefined;
+
+interface Snapshot {
+  snapshot: {
+    meta: {
+      node_fields: string[];
+      node_types: (string[] | string)[];
+      edge_fields: string[];
+      edge_types: (string[] | string)[];
+    };
+    node_count: number;
+    edge_count: number;
+  };
+  nodes: number[];
+  edges: number[];
+  strings: string[];
+}
+
+export interface NodeRow {
+  type: string;
+  name: string;
+  selfSize: number;
+}
+
+function collect(): void {
+  if (typeof gc !== "function") throw new Error("run with --expose-gc");
+  for (let i = 0; i < 6; i++) gc();
+}
+
+function takeSnapshot(tag: string): string {
+  collect();
+  const file = path.join(os.tmpdir(), `zod-mem-${tag}-${process.pid}.heapsnapshot`);
+  v8.writeHeapSnapshot(file);
+  return file;
+}
+
+function readNodes(file: string): NodeRow[] {
+  const snap: Snapshot = JSON.parse(fs.readFileSync(file, "utf8"));
+  const { node_fields, node_types } = snap.snapshot.meta;
+  const typeIdx = node_fields.indexOf("type");
+  const nameIdx = node_fields.indexOf("name");
+  const sizeIdx = node_fields.indexOf("self_size");
+  const stride = node_fields.length;
+  const typeNames = node_types[typeIdx] as string[];
+  const { nodes, strings } = snap;
+
+  const out: NodeRow[] = new Array(snap.snapshot.node_count);
+  for (let i = 0, n = 0; i < nodes.length; i += stride, n++) {
+    out[n] = {
+      type: typeNames[nodes[i + typeIdx]!]!,
+      name: strings[nodes[i + nameIdx]!]!,
+      selfSize: nodes[i + sizeIdx]!,
+    };
+  }
+  return out;
+}
+
+function key(r: NodeRow): string {
+  return `${r.type}::${r.name}`;
+}
+
+function tally(rows: NodeRow[]): Map<string, { count: number; bytes: number }> {
+  const m = new Map<string, { count: number; bytes: number }>();
+  for (const r of rows) {
+    const k = key(r);
+    let e = m.get(k);
+    if (!e) {
+      e = { count: 0, bytes: 0 };
+      m.set(k, e);
+    }
+    e.count++;
+    e.bytes += r.selfSize;
+  }
+  return m;
+}
+
+export interface DiffRow {
+  what: string;
+  count: number;
+  bytes: number;
+  countEach: number;
+  bytesEach: number;
+}
+
+/**
+ * Runs `factory` `delta` extra times on top of `baseline` live instances and
+ * reports which node kinds grew, normalized per added instance.
+ */
+export function diffAllocation(factory: () => unknown, baseline = 2_000, delta = 8_000): DiffRow[] {
+  const sink: unknown[] = [];
+  for (let i = 0; i < baseline; i++) sink.push(factory());
+
+  const fileA = takeSnapshot("a");
+  const before = tally(readNodes(fileA));
+  fs.unlinkSync(fileA);
+
+  for (let i = 0; i < delta; i++) sink.push(factory());
+
+  const fileB = takeSnapshot("b");
+  const after = tally(readNodes(fileB));
+  fs.unlinkSync(fileB);
+
+  if (sink.length !== baseline + delta) throw new Error("unreachable");
+
+  const rows: DiffRow[] = [];
+  for (const [k, a] of after) {
+    const b = before.get(k) ?? { count: 0, bytes: 0 };
+    const dCount = a.count - b.count;
+    const dBytes = a.bytes - b.bytes;
+    // Ignore noise that doesn't scale with the population.
+    if (dCount < delta * 0.2) continue;
+    rows.push({
+      what: k,
+      count: dCount,
+      bytes: dBytes,
+      countEach: dCount / delta,
+      bytesEach: dBytes / delta,
+    });
+  }
+  rows.sort((x, y) => y.bytes - x.bytes);
+  return rows;
+}

--- a/packages/bench/memory/survey.ts
+++ b/packages/bench/memory/survey.ts
@@ -1,0 +1,80 @@
+/**
+ * Per-instance own-property census across every schema type. `funcs` counts
+ * own properties whose value is a distinct function per instance — i.e. a
+ * closure allocated at construction time that could live on the prototype.
+ *
+ * V8 switches an object to dictionary mode past ~30 dynamically-added
+ * properties, so `own` is also a proxy for whether instances pay for a
+ * NameDictionary instead of inline slots.
+ */
+import * as z from "zod";
+import { table } from "./harness.js";
+
+function census(a: any, b: any): { own: number; zod: number; funcs: number; accessors: number } {
+  let funcs = 0;
+  let accessors = 0;
+  for (const [objA, objB] of [
+    [a, b],
+    [a._zod, b._zod],
+  ] as const) {
+    for (const key of Reflect.ownKeys(objA)) {
+      const d = Object.getOwnPropertyDescriptor(objA, key)!;
+      const dB = objB && Object.getOwnPropertyDescriptor(objB, key);
+      if (d.get || d.set) {
+        if (dB && (d.get !== dB.get || d.set !== dB.set)) accessors++;
+      } else if (typeof d.value === "function" && dB && d.value !== dB.value) {
+        funcs++;
+      }
+    }
+  }
+  return { own: Reflect.ownKeys(a).length, zod: Reflect.ownKeys(a._zod).length, funcs, accessors };
+}
+
+const cases: Array<[string, () => any]> = [
+  ["string", () => z.string()],
+  ["number", () => z.number()],
+  ["boolean", () => z.boolean()],
+  ["bigint", () => z.bigint()],
+  ["date", () => z.date()],
+  ["file", () => z.file()],
+  ["symbol", () => z.symbol()],
+  ["literal", () => z.literal("a")],
+  ["enum", () => z.enum(["a", "b"])],
+  ["array", () => z.array(z.string())],
+  ["object", () => z.object({ a: z.string() })],
+  ["record", () => z.record(z.string(), z.string())],
+  ["map", () => z.map(z.string(), z.string())],
+  ["set", () => z.set(z.string())],
+  ["tuple", () => z.tuple([z.string()])],
+  ["union", () => z.union([z.string(), z.number()])],
+  ["intersection", () => z.intersection(z.object({}), z.object({}))],
+  ["optional", () => z.string().optional()],
+  ["nullable", () => z.string().nullable()],
+  ["default", () => z.string().default("x")],
+  ["catch", () => z.string().catch("x")],
+  ["pipe", () => z.string().pipe(z.string())],
+  ["lazy", () => z.lazy(() => z.string())],
+  ["promise", () => z.promise(z.string())],
+  ["readonly", () => z.string().readonly()],
+  ["success", () => z.success(z.string())],
+  ["transform", () => z.transform((x) => x)],
+  ["email (fmt)", () => z.email()],
+  ["custom", () => z.custom(() => true)],
+];
+
+const rows = cases.map(([label, f]) => {
+  const c = census(f(), f());
+  return {
+    schema: label,
+    "own(inst)": c.own,
+    "own(_zod)": c.zod,
+    "per-inst fns": c.funcs,
+    "per-inst accessors": c.accessors,
+    "dict mode?": c.own > 30 ? "LIKELY" : "",
+  };
+});
+rows.sort((a, b) => (b["per-inst fns"] as number) - (a["per-inst fns"] as number));
+table(rows);
+
+const total = rows.reduce((s, r) => s + (r["per-inst fns"] as number), 0);
+console.log(`\ntotal per-instance closures across ${rows.length} types: ${total}`);

--- a/packages/bench/memory/throughput.ts
+++ b/packages/bench/memory/throughput.ts
@@ -1,0 +1,79 @@
+/**
+ * Construction and parse throughput, so memory work can be shown not to cost
+ * speed. Reports ops/sec; compare runs across commits.
+ */
+import * as z from "zod";
+import { table } from "./harness.js";
+
+function timeOnce(fn: () => void, ms: number): number {
+  let ops = 0;
+  const start = process.hrtime.bigint();
+  const budget = BigInt(ms) * 1_000_000n;
+  while (process.hrtime.bigint() - start < budget) {
+    for (let i = 0; i < 200; i++) fn();
+    ops += 200;
+  }
+  return ops / (Number(process.hrtime.bigint() - start) / 1e9);
+}
+
+const ROUNDS = 7;
+const CASES: Array<[string, () => void]> = [];
+function bench(label: string, fn: () => void): void {
+  CASES.push([label, fn]);
+}
+
+/**
+ * Rounds are interleaved across all cases rather than run case-by-case, so a
+ * transient (thermal, GC, other processes) hits every case roughly equally
+ * instead of ruining one. Reported value is the median round.
+ */
+function runAll(ms = 400): Array<{ label: string; opsPerSec: number; spreadPct: number }> {
+  for (const [, fn] of CASES) for (let i = 0; i < 5_000; i++) fn();
+
+  const samples = new Map<string, number[]>(CASES.map(([l]) => [l, []]));
+  for (let r = 0; r < ROUNDS; r++) {
+    for (const [label, fn] of CASES) {
+      samples.get(label)!.push(timeOnce(fn, ms));
+    }
+  }
+  return CASES.map(([label]) => {
+    const s = samples.get(label)!.sort((a, b) => a - b);
+    const median = s[Math.floor(s.length / 2)]!;
+    return { label, opsPerSec: median, spreadPct: ((s.at(-1)! - s[0]!) / median) * 100 };
+  });
+}
+
+const shape = { a: z.string(), b: z.number(), c: z.boolean() };
+const objSchema = z.object(shape);
+const strSchema = z.string();
+const minSchema = z.string().min(1);
+const arrSchema = z.array(z.string());
+const unionSchema = z.union([z.string(), z.number()]);
+const data = { a: "x", b: 1, c: true };
+const arrData = ["a", "b", "c", "d"];
+
+// construction
+bench("construct z.string()", () => void z.string());
+bench("construct z.number()", () => void z.number());
+bench("construct z.bigint()", () => void z.bigint());
+bench("construct z.object(3)", () => void z.object({ a: z.string(), b: z.number(), c: z.boolean() }));
+bench("construct z.array(str)", () => void z.array(z.string()));
+bench("construct .min(1)", () => void z.string().min(1));
+// parsing (hot path must not regress)
+bench("parse string", () => void strSchema.parse("hello"));
+bench("parse string.min", () => void minSchema.parse("hello"));
+bench("parse object(3)", () => void objSchema.parse(data));
+bench("parse array(4)", () => void arrSchema.parse(arrData));
+bench("parse union", () => void unionSchema.parse("hi"));
+bench("safeParse object", () => void objSchema.safeParse(data));
+// method access (the lazy-bind getters)
+bench("first .optional() on new", () => void z.string().optional());
+bench("first .email() on new", () => void z.string().email());
+
+table(
+  runAll().map((r) => ({
+    bench: r.label,
+    "ops/sec": Math.round(r.opsPerSec).toLocaleString(),
+    "spread%": r.spreadPct.toFixed(0),
+  }))
+);

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -185,7 +185,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   // directly — every interior node of a large schema graph — allocates none
   // of them.
   _installLazyMethods(inst, "check", _zodTypeMethods);
-  _installLazyProps(inst, "_def", _zodTypeParseProps);
+  _installLazyProps(inst, "parse", _zodTypeParseProps);
   // `description` reads through to the registry on every access, so unlike the
   // rest it must not cache onto the instance.
   const proto = Object.getPrototypeOf(inst);
@@ -194,6 +194,14 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
       configurable: true,
       get(this: ZodType) {
         return core.globalRegistry.get(this)?.description;
+      },
+    });
+    // Getter with no setter, so `schema._def = x` still throws in strict mode
+    // as it did when `_def` was a non-writable own property.
+    Object.defineProperty(proto, "_def", {
+      configurable: true,
+      get(this: ZodType) {
+        return this._zod.def;
       },
     });
   }
@@ -2391,9 +2399,6 @@ export function preprocess<A, U extends core.SomeType, B = unknown>(
  */
 function _zodTypeParseProps(): _LazyPropsOf<ZodType> {
   return {
-    // `_def` derives purely from the instance, so it is materialized on read
-    // rather than assigned at construction. It is also this group's sentinel.
-    _def: (self) => self._zod.def,
     // Overrides core's prototype-level `~standard` with the classic one, which
     // also carries `jsonSchema`. It must stay a prototype entry: reading
     // `~standard` to attach `jsonSchema` forced every schema to build it, and

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -13,7 +13,6 @@ import * as parse from "./parse.js";
 // `util.installLazyMethods` / `installLazyProps` for why this matters.
 const _installLazyMethods = util.installLazyMethods;
 const _installLazyProps = util.installLazyProps;
-const _installProtoAccessors = util.installProtoAccessors;
 type _LazyMethodsOf<T> = util.LazyMethodsOf<T>;
 type _LazyPropsOf<T> = util.LazyPropsOf<T>;
 
@@ -185,27 +184,20 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   // `arr.map(schema.parse)` still work, and a schema that is never parsed
   // directly — every interior node of a large schema graph — allocates none
   // of them.
-  _installLazyMethods(inst, "ZodType", _zodTypeMethods);
-  _installLazyProps(inst, "ZodTypeParse", _zodTypeParseProps);
-  _installProtoAccessors(inst, "ZodTypeAccessors", _zodTypeAccessors);
-
-  // Overrides core's prototype-level `~standard` with the classic one, which
-  // also carries `jsonSchema`. It must stay a prototype entry: reading
-  // `~standard` to attach `jsonSchema` forced every schema to build it, and
-  // redefining it per instance demoted instances to dictionary mode.
-  _installLazyProps(inst, "ZodType~standard", _zodTypeStandard);
-  return inst;
-});
-
-const _zodTypeStandard = (): _LazyPropsOf<ZodType> => ({
-  "~standard": (self) =>
-    ({
-      ...core.standardProps(self),
-      jsonSchema: {
-        input: createStandardJSONSchemaMethod(self, "input"),
-        output: createStandardJSONSchemaMethod(self, "output"),
+  _installLazyMethods(inst, "check", _zodTypeMethods);
+  _installLazyProps(inst, "_def", _zodTypeParseProps);
+  // `description` reads through to the registry on every access, so unlike the
+  // rest it must not cache onto the instance.
+  const proto = Object.getPrototypeOf(inst);
+  if (!Object.prototype.hasOwnProperty.call(proto, "description")) {
+    Object.defineProperty(proto, "description", {
+      configurable: true,
+      get(this: ZodType) {
+        return core.globalRegistry.get(this)?.description;
       },
-    }) as ZodType["~standard"],
+    });
+  }
+  return inst;
 });
 
 // ZodString
@@ -247,7 +239,7 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
   inst.minLength = bag.minimum ?? null;
   inst.maxLength = bag.maximum ?? null;
 
-  _installLazyMethods(inst, "_ZodString", _zodStringBaseMethods);
+  _installLazyMethods(inst, "regex", _zodStringBaseMethods);
 });
 
 export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> {
@@ -331,7 +323,7 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   core.$ZodString.init(inst, def);
   _ZodString.init(inst, def);
 
-  _installLazyMethods(inst, "ZodString", _zodStringMethods);
+  _installLazyMethods(inst, "email", _zodStringMethods);
 });
 
 export function string(params?: string | core.$ZodStringParams): ZodString;
@@ -837,7 +829,7 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
 
   inst._zod.processJSONSchema = (ctx, json, params) => processors.numberProcessor(inst, ctx, json, params);
 
-  _installLazyMethods(inst, "ZodNumber", _zodNumberMethods);
+  _installLazyMethods(inst, "gt", _zodNumberMethods);
 
   const bag = inst._zod.bag;
   inst.minValue =
@@ -935,7 +927,7 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.bigintProcessor(inst, ctx, json, params);
 
-  _installLazyMethods(inst, "ZodBigInt", _zodBigIntMethods);
+  _installLazyMethods(inst, "gte", _zodBigIntMethods);
 
   const bag = inst._zod.bag;
   inst.minValue = bag.minimum ?? null;
@@ -1108,7 +1100,7 @@ export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constru
   inst._zod.processJSONSchema = (ctx, json, params) => processors.arrayProcessor(inst, ctx, json, params);
 
   inst.element = def.element;
-  _installLazyMethods(inst, "ZodArray", _zodArrayMethods);
+  _installLazyMethods(inst, "min", _zodArrayMethods);
 });
 
 export function array<T extends core.SomeType>(element: T, params?: string | core.$ZodArrayParams): ZodArray<T> {
@@ -1222,7 +1214,7 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
     return def.shape;
   });
 
-  _installLazyMethods(inst, "ZodObject", _zodObjectMethods);
+  _installLazyMethods(inst, "keyof", _zodObjectMethods);
 });
 
 export function object<T extends core.$ZodLooseShape = Partial<Record<never, core.SomeType>>>(
@@ -2400,8 +2392,20 @@ export function preprocess<A, U extends core.SomeType, B = unknown>(
 function _zodTypeParseProps(): _LazyPropsOf<ZodType> {
   return {
     // `_def` derives purely from the instance, so it is materialized on read
-    // rather than assigned at construction.
+    // rather than assigned at construction. It is also this group's sentinel.
     _def: (self) => self._zod.def,
+    // Overrides core's prototype-level `~standard` with the classic one, which
+    // also carries `jsonSchema`. It must stay a prototype entry: reading
+    // `~standard` to attach `jsonSchema` forced every schema to build it, and
+    // redefining it per instance demoted instances to dictionary mode.
+    "~standard": (self) =>
+      ({
+        ...core.standardProps(self),
+        jsonSchema: {
+          input: createStandardJSONSchemaMethod(self, "input"),
+          output: createStandardJSONSchemaMethod(self, "output"),
+        },
+      }) as ZodType["~standard"],
     parse: (self) => {
       const fn: ZodType["parse"] = (data, params) => parse.parse(self, data, params, { callee: fn });
       return fn;
@@ -2423,14 +2427,6 @@ function _zodTypeParseProps(): _LazyPropsOf<ZodType> {
     safeEncodeAsync: (self) => async (data, params) => parse.safeEncodeAsync(self, data, params),
     safeDecodeAsync: (self) => async (data, params) => parse.safeDecodeAsync(self, data, params),
     toJSONSchema: (self) => createToJSONSchemaMethod(self, {}),
-  };
-}
-
-function _zodTypeAccessors(): Record<string, (this: ZodType) => unknown> {
-  return {
-    description(this: ZodType) {
-      return core.globalRegistry.get(this)?.description;
-    },
   };
 }
 

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -189,7 +189,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   // `description` reads through to the registry on every access, so unlike the
   // rest it must not cache onto the instance.
   const proto = Object.getPrototypeOf(inst);
-  if (!Object.prototype.hasOwnProperty.call(proto, "description")) {
+  if (!("description" in proto)) {
     Object.defineProperty(proto, "description", {
       configurable: true,
       get(this: ZodType) {

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -576,35 +576,88 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   core.$ZodString.init(inst, def);
   _ZodString.init(inst, def);
 
-  inst.email = (params) => inst.check(core._email(ZodEmail, params));
-  inst.url = (params) => inst.check(core._url(ZodURL, params));
-  inst.jwt = (params) => inst.check(core._jwt(ZodJWT, params));
-  inst.emoji = (params) => inst.check(core._emoji(ZodEmoji, params));
-  inst.guid = (params) => inst.check(core._guid(ZodGUID, params));
-  inst.uuid = (params) => inst.check(core._uuid(ZodUUID, params));
-  inst.uuidv4 = (params) => inst.check(core._uuidv4(ZodUUID, params));
-  inst.uuidv6 = (params) => inst.check(core._uuidv6(ZodUUID, params));
-  inst.uuidv7 = (params) => inst.check(core._uuidv7(ZodUUID, params));
-  inst.nanoid = (params) => inst.check(core._nanoid(ZodNanoID, params));
-  inst.guid = (params) => inst.check(core._guid(ZodGUID, params));
-  inst.cuid = (params) => inst.check(core._cuid(ZodCUID, params));
-  inst.cuid2 = (params) => inst.check(core._cuid2(ZodCUID2, params));
-  inst.ulid = (params) => inst.check(core._ulid(ZodULID, params));
-  inst.base64 = (params) => inst.check(core._base64(ZodBase64, params));
-  inst.base64url = (params) => inst.check(core._base64url(ZodBase64URL, params));
-  inst.xid = (params) => inst.check(core._xid(ZodXID, params));
-  inst.ksuid = (params) => inst.check(core._ksuid(ZodKSUID, params));
-  inst.ipv4 = (params) => inst.check(core._ipv4(ZodIPv4, params));
-  inst.ipv6 = (params) => inst.check(core._ipv6(ZodIPv6, params));
-  inst.cidrv4 = (params) => inst.check(core._cidrv4(ZodCIDRv4, params));
-  inst.cidrv6 = (params) => inst.check(core._cidrv6(ZodCIDRv6, params));
-  inst.e164 = (params) => inst.check(core._e164(ZodE164, params));
+  _installLazyMethods(inst, "ZodStringFormats", {
+    email(params) {
+      return this.check(core._email(ZodEmail, params));
+    },
+    url(params) {
+      return this.check(core._url(ZodURL, params));
+    },
+    jwt(params) {
+      return this.check(core._jwt(ZodJWT, params));
+    },
+    emoji(params) {
+      return this.check(core._emoji(ZodEmoji, params));
+    },
+    guid(params) {
+      return this.check(core._guid(ZodGUID, params));
+    },
+    uuid(params) {
+      return this.check(core._uuid(ZodUUID, params));
+    },
+    uuidv4(params) {
+      return this.check(core._uuidv4(ZodUUID, params));
+    },
+    uuidv6(params) {
+      return this.check(core._uuidv6(ZodUUID, params));
+    },
+    uuidv7(params) {
+      return this.check(core._uuidv7(ZodUUID, params));
+    },
+    nanoid(params) {
+      return this.check(core._nanoid(ZodNanoID, params));
+    },
+    cuid(params) {
+      return this.check(core._cuid(ZodCUID, params));
+    },
+    cuid2(params) {
+      return this.check(core._cuid2(ZodCUID2, params));
+    },
+    ulid(params) {
+      return this.check(core._ulid(ZodULID, params));
+    },
+    base64(params) {
+      return this.check(core._base64(ZodBase64, params));
+    },
+    base64url(params) {
+      return this.check(core._base64url(ZodBase64URL, params));
+    },
+    xid(params) {
+      return this.check(core._xid(ZodXID, params));
+    },
+    ksuid(params) {
+      return this.check(core._ksuid(ZodKSUID, params));
+    },
+    ipv4(params) {
+      return this.check(core._ipv4(ZodIPv4, params));
+    },
+    ipv6(params) {
+      return this.check(core._ipv6(ZodIPv6, params));
+    },
+    cidrv4(params) {
+      return this.check(core._cidrv4(ZodCIDRv4, params));
+    },
+    cidrv6(params) {
+      return this.check(core._cidrv6(ZodCIDRv6, params));
+    },
+    e164(params) {
+      return this.check(core._e164(ZodE164, params));
+    },
 
-  // iso
-  inst.datetime = (params) => inst.check(core._isoDateTime(ZodISODateTime, params as any));
-  inst.date = (params) => inst.check(core._isoDate(ZodISODate, params as any));
-  inst.time = (params) => inst.check(core._isoTime(ZodISOTime, params as any));
-  inst.duration = (params) => inst.check(core._isoDuration(ZodISODuration, params as any));
+    // iso
+    datetime(params) {
+      return this.check(core._isoDateTime(ZodISODateTime, params as any));
+    },
+    date(params) {
+      return this.check(core._isoDate(ZodISODate, params as any));
+    },
+    time(params) {
+      return this.check(core._isoTime(ZodISOTime, params as any));
+    },
+    duration(params) {
+      return this.check(core._isoDuration(ZodISODuration, params as any));
+    },
+  });
 });
 
 export function string(params?: string | core.$ZodStringParams): ZodString;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -30,6 +30,30 @@ type _LazyMethodsOf<T> = Partial<{
   [K in keyof T]: T[K] extends (...args: infer A) => infer R ? (this: T, ...args: A) => R : never;
 }>;
 
+/* `description` and `_def` derive purely from `this`, so they live as
+ * shared getters on the prototype instead of per-instance descriptors. */
+const _installedAccessorProtos = /* @__PURE__ */ new WeakSet<object>();
+function _installSharedAccessors(inst: object): void {
+  const proto = Object.getPrototypeOf(inst);
+  if (_installedAccessorProtos.has(proto)) return;
+  _installedAccessorProtos.add(proto);
+  Object.defineProperty(proto, "description", {
+    configurable: true,
+    get(this: ZodType) {
+      return core.globalRegistry.get(this)?.description;
+    },
+  });
+  Object.defineProperty(proto, "_def", {
+    configurable: true,
+    get(this: ZodType) {
+      return this._zod.def;
+    },
+    set(this: ZodType, value: unknown) {
+      Object.defineProperty(this, "_def", { value, configurable: true, writable: true });
+    },
+  });
+}
+
 function _installLazyMethods<T extends object>(inst: T, group: string, methods: _LazyMethodsOf<T>): void {
   const proto = Object.getPrototypeOf(inst);
   let installed = _installedGroups.get(proto);
@@ -212,19 +236,22 @@ export interface ZodType<
 export interface _ZodType<out Internals extends core.$ZodTypeInternals = core.$ZodTypeInternals>
   extends ZodType<any, any, Internals> {}
 
+/* Attaches the JSON Schema methods when the lazily created standard-schema
+ * object is first accessed, instead of forcing its creation per instance. */
+function _onStandard(inst: core.$ZodType, standard: object): void {
+  (standard as { jsonSchema: unknown }).jsonSchema = {
+    input: createStandardJSONSchemaMethod(inst, "input"),
+    output: createStandardJSONSchemaMethod(inst, "output"),
+  };
+}
+
 export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$constructor("ZodType", (inst, def) => {
   core.$ZodType.init(inst, def);
-  Object.assign(inst["~standard"], {
-    jsonSchema: {
-      input: createStandardJSONSchemaMethod(inst, "input"),
-      output: createStandardJSONSchemaMethod(inst, "output"),
-    },
-  });
+  inst._zod.onStandard = _onStandard;
   inst.toJSONSchema = createToJSONSchemaMethod(inst, {});
 
   inst.def = def;
   inst.type = def.type;
-  Object.defineProperty(inst, "_def", { value: def });
 
   // Parse-family is intentionally kept as per-instance closures: these are
   // the hot path AND the most-detached methods (`arr.map(schema.parse)`,
@@ -376,12 +403,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
       return fn(this);
     },
   });
-  Object.defineProperty(inst, "description", {
-    get() {
-      return core.globalRegistry.get(inst)?.description;
-    },
-    configurable: true,
-  });
+  _installSharedAccessors(inst);
   return inst;
 });
 

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -236,14 +236,35 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   inst.parseAsync = async (data, params) => parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
   inst.safeParseAsync = async (data, params) => parse.safeParseAsync(inst, data, params);
   inst.spa = inst.safeParseAsync;
-  inst.encode = (data, params) => parse.encode(inst, data, params);
-  inst.decode = (data, params) => parse.decode(inst, data, params);
-  inst.encodeAsync = async (data, params) => parse.encodeAsync(inst, data, params);
-  inst.decodeAsync = async (data, params) => parse.decodeAsync(inst, data, params);
-  inst.safeEncode = (data, params) => parse.safeEncode(inst, data, params);
-  inst.safeDecode = (data, params) => parse.safeDecode(inst, data, params);
-  inst.safeEncodeAsync = async (data, params) => parse.safeEncodeAsync(inst, data, params);
-  inst.safeDecodeAsync = async (data, params) => parse.safeDecodeAsync(inst, data, params);
+
+  // The codec family is far off the hot path, so it uses the same
+  // lazy-bind treatment as the builder methods below.
+  _installLazyMethods(inst, "ZodTypeCodecs", {
+    encode(data, params) {
+      return parse.encode(this, data, params);
+    },
+    decode(data, params) {
+      return parse.decode(this, data, params);
+    },
+    async encodeAsync(data, params) {
+      return parse.encodeAsync(this, data, params);
+    },
+    async decodeAsync(data, params) {
+      return parse.decodeAsync(this, data, params);
+    },
+    safeEncode(data, params) {
+      return parse.safeEncode(this, data, params);
+    },
+    safeDecode(data, params) {
+      return parse.safeDecode(this, data, params);
+    },
+    async safeEncodeAsync(data, params) {
+      return parse.safeEncodeAsync(this, data, params);
+    },
+    async safeDecodeAsync(data, params) {
+      return parse.safeDecodeAsync(this, data, params);
+    },
+  });
 
   // All builder methods are placed on the internal prototype as lazy-bind
   // getters. On first access per-instance, a bound thunk is allocated and

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -7,88 +7,15 @@ import { createStandardJSONSchemaMethod, createToJSONSchemaMethod } from "../cor
 import * as checks from "./checks.js";
 import * as parse from "./parse.js";
 
-// Lazy-bind builder methods.
-//
-// Builder methods (`.optional`, `.array`, `.refine`, ...) live as
-// non-enumerable getters on each concrete schema constructor's
-// prototype. On first access from an instance the getter allocates
-// `fn.bind(this)` and caches it as an own property on that instance,
-// so detached usage (`const m = schema.optional; m()`) still works
-// and the per-instance allocation only happens for methods actually
-// touched.
-//
-// One install per (prototype, group), memoized by `_installedGroups`.
-const _installedGroups = /* @__PURE__ */ new WeakMap<object, Set<string>>();
-
-/**
- * Methods of `T` reshaped so each body has `this: T` and matches the
- * declared (args, return) of the corresponding interface method. Allows
- * us to type-check inline method-shorthand bodies against the
- * `ZodType` / `_ZodString` / etc. interface declarations.
- */
-type _LazyMethodsOf<T> = Partial<{
-  [K in keyof T]: T[K] extends (...args: infer A) => infer R ? (this: T, ...args: A) => R : never;
-}>;
-
-/* `description` and `_def` derive purely from `this`, so they live as
- * shared getters on the prototype instead of per-instance descriptors. */
-const _installedAccessorProtos = /* @__PURE__ */ new WeakSet<object>();
-function _installSharedAccessors(inst: object): void {
-  const proto = Object.getPrototypeOf(inst);
-  if (_installedAccessorProtos.has(proto)) return;
-  _installedAccessorProtos.add(proto);
-  Object.defineProperty(proto, "description", {
-    configurable: true,
-    get(this: ZodType) {
-      return core.globalRegistry.get(this)?.description;
-    },
-  });
-  Object.defineProperty(proto, "_def", {
-    configurable: true,
-    get(this: ZodType) {
-      return this._zod.def;
-    },
-    set(this: ZodType, value: unknown) {
-      Object.defineProperty(this, "_def", { value, configurable: true, writable: true });
-    },
-  });
-}
-
-function _installLazyMethods<T extends object>(inst: T, group: string, methods: _LazyMethodsOf<T>): void {
-  const proto = Object.getPrototypeOf(inst);
-  let installed = _installedGroups.get(proto);
-  if (!installed) {
-    installed = new Set();
-    _installedGroups.set(proto, installed);
-  }
-  if (installed.has(group)) return;
-  installed.add(group);
-  for (const key in methods) {
-    const fn = methods[key]!;
-    Object.defineProperty(proto, key, {
-      configurable: true,
-      enumerable: false,
-      get(this: any) {
-        const bound = fn.bind(this);
-        Object.defineProperty(this, key, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: bound,
-        });
-        return bound;
-      },
-      set(this: any, v: unknown) {
-        Object.defineProperty(this, key, {
-          configurable: true,
-          writable: true,
-          enumerable: true,
-          value: v,
-        });
-      },
-    });
-  }
-}
+// Builder methods and the parse family live on each concrete schema
+// constructor's prototype and materialize per instance on first access, so a
+// schema only pays for what it is actually asked for. See
+// `util.installLazyMethods` / `installLazyProps` for why this matters.
+const _installLazyMethods = util.installLazyMethods;
+const _installLazyProps = util.installLazyProps;
+const _installProtoAccessors = util.installProtoAccessors;
+type _LazyMethodsOf<T> = util.LazyMethodsOf<T>;
+type _LazyPropsOf<T> = util.LazyPropsOf<T>;
 
 ///////////////////////////////////////////
 ///////////////////////////////////////////
@@ -236,175 +163,49 @@ export interface ZodType<
 export interface _ZodType<out Internals extends core.$ZodTypeInternals = core.$ZodTypeInternals>
   extends ZodType<any, any, Internals> {}
 
-/* Attaches the JSON Schema methods when the lazily created standard-schema
- * object is first accessed, instead of forcing its creation per instance. */
-function _onStandard(inst: core.$ZodType, standard: object): void {
-  (standard as { jsonSchema: unknown }).jsonSchema = {
-    input: createStandardJSONSchemaMethod(inst, "input"),
-    output: createStandardJSONSchemaMethod(inst, "output"),
-  };
-}
-
 export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$constructor("ZodType", (inst, def) => {
   core.$ZodType.init(inst, def);
-  inst._zod.onStandard = _onStandard;
-  inst.toJSONSchema = createToJSONSchemaMethod(inst, {});
 
   inst.def = def;
   inst.type = def.type;
 
-  // Parse-family is intentionally kept as per-instance closures: these are
-  // the hot path AND the most-detached methods (`arr.map(schema.parse)`,
-  // `const { parse } = schema`, etc.). Eager closures here mean callers pay
-  // ~12 closure allocations per schema but get monomorphic call sites and
-  // detached usage that "just works".
-  inst.parse = (data, params) => parse.parse(inst, data, params, { callee: inst.parse });
-  inst.safeParse = (data, params) => parse.safeParse(inst, data, params);
-  inst.parseAsync = async (data, params) => parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
-  inst.safeParseAsync = async (data, params) => parse.safeParseAsync(inst, data, params);
-  inst.spa = inst.safeParseAsync;
+  // Everything else — the parse family, the builder methods, `_def`,
+  // `~standard` and `toJSONSchema` — is installed on the prototype rather
+  // than the instance.
+  //
+  // Own-property count is the dominant cost of a schema. V8 sizes an
+  // instance's property backing store in steps, and a constructor like this
+  // one (which assigns nothing itself, so there is nothing to slack-track)
+  // gets no in-object slots: 12 own properties cost 128 bytes, 13 cost 848,
+  // and 21 cost 1616. Keeping instances under the first cliff is worth more
+  // than the closures themselves.
+  //
+  // Detachability is preserved: the getters bind on first access and cache
+  // the bound function as an own property, so `const { parse } = schema` and
+  // `arr.map(schema.parse)` still work, and a schema that is never parsed
+  // directly — every interior node of a large schema graph — allocates none
+  // of them.
+  _installLazyMethods(inst, "ZodType", _zodTypeMethods);
+  _installLazyProps(inst, "ZodTypeParse", _zodTypeParseProps);
+  _installProtoAccessors(inst, "ZodTypeAccessors", _zodTypeAccessors);
 
-  // The codec family is far off the hot path, so it uses the same
-  // lazy-bind treatment as the builder methods below.
-  _installLazyMethods(inst, "ZodTypeCodecs", {
-    encode(data, params) {
-      return parse.encode(this, data, params);
-    },
-    decode(data, params) {
-      return parse.decode(this, data, params);
-    },
-    async encodeAsync(data, params) {
-      return parse.encodeAsync(this, data, params);
-    },
-    async decodeAsync(data, params) {
-      return parse.decodeAsync(this, data, params);
-    },
-    safeEncode(data, params) {
-      return parse.safeEncode(this, data, params);
-    },
-    safeDecode(data, params) {
-      return parse.safeDecode(this, data, params);
-    },
-    async safeEncodeAsync(data, params) {
-      return parse.safeEncodeAsync(this, data, params);
-    },
-    async safeDecodeAsync(data, params) {
-      return parse.safeDecodeAsync(this, data, params);
-    },
-  });
-
-  // All builder methods are placed on the internal prototype as lazy-bind
-  // getters. On first access per-instance, a bound thunk is allocated and
-  // cached as an own property; subsequent accesses skip the getter. This
-  // means: no per-instance allocation for unused methods, full
-  // detachability preserved (`const m = schema.optional; m()` works), and
-  // shared underlying function references across all instances.
-  _installLazyMethods(inst, "ZodType", {
-    check(...chks) {
-      const def = this.def;
-      return this.clone(
-        util.mergeDefs(def, {
-          checks: [
-            ...(def.checks ?? []),
-            ...chks.map((ch) =>
-              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
-            ),
-          ],
-        }),
-        { parent: true }
-      );
-    },
-    with(...chks) {
-      return this.check(...chks);
-    },
-    clone(def, params) {
-      return core.clone(this, def, params);
-    },
-    brand() {
-      return this;
-    },
-    register(reg, meta) {
-      reg.add(this, meta);
-      return this;
-    },
-    refine(check, params) {
-      return this.check(refine(check, params));
-    },
-    superRefine(refinement, params) {
-      return this.check(superRefine(refinement, params));
-    },
-    overwrite(fn) {
-      return this.check(checks.overwrite(fn));
-    },
-    optional() {
-      return optional(this);
-    },
-    exactOptional() {
-      return exactOptional(this);
-    },
-    nullable() {
-      return nullable(this);
-    },
-    nullish() {
-      return optional(nullable(this));
-    },
-    nonoptional(params) {
-      return nonoptional(this, params);
-    },
-    array() {
-      return array(this);
-    },
-    or(arg) {
-      return union([this, arg]);
-    },
-    and(arg) {
-      return intersection(this, arg);
-    },
-    transform(tx) {
-      return pipe(this, transform(tx));
-    },
-    default(d) {
-      return _default(this, d);
-    },
-    prefault(d) {
-      return prefault(this, d);
-    },
-    catch(params) {
-      return _catch(this, params);
-    },
-    pipe(target) {
-      return pipe(this, target);
-    },
-    readonly() {
-      return readonly(this);
-    },
-    describe(description) {
-      const cl = this.clone();
-      core.globalRegistry.add(cl, { description });
-      return cl;
-    },
-    meta(...args: any[]): any {
-      // overloaded: meta() returns the registered metadata, meta(data)
-      // returns a clone with `data` registered. The mapped type picks
-      // up the second overload, so we accept variadic any-args and
-      // return `any` to satisfy both at runtime.
-      if (args.length === 0) return core.globalRegistry.get(this);
-      const cl = this.clone();
-      core.globalRegistry.add(cl, args[0]);
-      return cl;
-    },
-    isOptional() {
-      return this.safeParse(undefined).success;
-    },
-    isNullable() {
-      return this.safeParse(null).success;
-    },
-    apply(fn) {
-      return fn(this);
-    },
-  });
-  _installSharedAccessors(inst);
+  // Overrides core's prototype-level `~standard` with the classic one, which
+  // also carries `jsonSchema`. It must stay a prototype entry: reading
+  // `~standard` to attach `jsonSchema` forced every schema to build it, and
+  // redefining it per instance demoted instances to dictionary mode.
+  _installLazyProps(inst, "ZodType~standard", _zodTypeStandard);
   return inst;
+});
+
+const _zodTypeStandard = (): _LazyPropsOf<ZodType> => ({
+  "~standard": (self) =>
+    ({
+      ...core.standardProps(self),
+      jsonSchema: {
+        input: createStandardJSONSchemaMethod(self, "input"),
+        output: createStandardJSONSchemaMethod(self, "output"),
+      },
+    }) as ZodType["~standard"],
 });
 
 // ZodString
@@ -446,53 +247,7 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
   inst.minLength = bag.minimum ?? null;
   inst.maxLength = bag.maximum ?? null;
 
-  _installLazyMethods(inst, "_ZodString", {
-    regex(...args) {
-      return this.check((checks.regex as any)(...args));
-    },
-    includes(...args) {
-      return this.check((checks.includes as any)(...args));
-    },
-    startsWith(...args) {
-      return this.check((checks.startsWith as any)(...args));
-    },
-    endsWith(...args) {
-      return this.check((checks.endsWith as any)(...args));
-    },
-    min(...args) {
-      return this.check((checks.minLength as any)(...args));
-    },
-    max(...args) {
-      return this.check((checks.maxLength as any)(...args));
-    },
-    length(...args) {
-      return this.check((checks.length as any)(...args));
-    },
-    nonempty(...args) {
-      return this.check((checks.minLength as any)(1, ...args));
-    },
-    lowercase(params) {
-      return this.check(checks.lowercase(params));
-    },
-    uppercase(params) {
-      return this.check(checks.uppercase(params));
-    },
-    trim() {
-      return this.check(checks.trim());
-    },
-    normalize(...args) {
-      return this.check(checks.normalize(...args));
-    },
-    toLowerCase() {
-      return this.check(checks.toLowerCase());
-    },
-    toUpperCase() {
-      return this.check(checks.toUpperCase());
-    },
-    slugify() {
-      return this.check(checks.slugify());
-    },
-  });
+  _installLazyMethods(inst, "_ZodString", _zodStringBaseMethods);
 });
 
 export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> {
@@ -576,88 +331,7 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   core.$ZodString.init(inst, def);
   _ZodString.init(inst, def);
 
-  _installLazyMethods(inst, "ZodStringFormats", {
-    email(params) {
-      return this.check(core._email(ZodEmail, params));
-    },
-    url(params) {
-      return this.check(core._url(ZodURL, params));
-    },
-    jwt(params) {
-      return this.check(core._jwt(ZodJWT, params));
-    },
-    emoji(params) {
-      return this.check(core._emoji(ZodEmoji, params));
-    },
-    guid(params) {
-      return this.check(core._guid(ZodGUID, params));
-    },
-    uuid(params) {
-      return this.check(core._uuid(ZodUUID, params));
-    },
-    uuidv4(params) {
-      return this.check(core._uuidv4(ZodUUID, params));
-    },
-    uuidv6(params) {
-      return this.check(core._uuidv6(ZodUUID, params));
-    },
-    uuidv7(params) {
-      return this.check(core._uuidv7(ZodUUID, params));
-    },
-    nanoid(params) {
-      return this.check(core._nanoid(ZodNanoID, params));
-    },
-    cuid(params) {
-      return this.check(core._cuid(ZodCUID, params));
-    },
-    cuid2(params) {
-      return this.check(core._cuid2(ZodCUID2, params));
-    },
-    ulid(params) {
-      return this.check(core._ulid(ZodULID, params));
-    },
-    base64(params) {
-      return this.check(core._base64(ZodBase64, params));
-    },
-    base64url(params) {
-      return this.check(core._base64url(ZodBase64URL, params));
-    },
-    xid(params) {
-      return this.check(core._xid(ZodXID, params));
-    },
-    ksuid(params) {
-      return this.check(core._ksuid(ZodKSUID, params));
-    },
-    ipv4(params) {
-      return this.check(core._ipv4(ZodIPv4, params));
-    },
-    ipv6(params) {
-      return this.check(core._ipv6(ZodIPv6, params));
-    },
-    cidrv4(params) {
-      return this.check(core._cidrv4(ZodCIDRv4, params));
-    },
-    cidrv6(params) {
-      return this.check(core._cidrv6(ZodCIDRv6, params));
-    },
-    e164(params) {
-      return this.check(core._e164(ZodE164, params));
-    },
-
-    // iso
-    datetime(params) {
-      return this.check(core._isoDateTime(ZodISODateTime, params as any));
-    },
-    date(params) {
-      return this.check(core._isoDate(ZodISODate, params as any));
-    },
-    time(params) {
-      return this.check(core._isoTime(ZodISOTime, params as any));
-    },
-    duration(params) {
-      return this.check(core._isoDuration(ZodISODuration, params as any));
-    },
-  });
+  _installLazyMethods(inst, "ZodString", _zodStringMethods);
 });
 
 export function string(params?: string | core.$ZodStringParams): ZodString;
@@ -1163,53 +837,7 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
 
   inst._zod.processJSONSchema = (ctx, json, params) => processors.numberProcessor(inst, ctx, json, params);
 
-  _installLazyMethods(inst, "ZodNumber", {
-    gt(value, params) {
-      return this.check(checks.gt(value, params));
-    },
-    gte(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    min(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    lt(value, params) {
-      return this.check(checks.lt(value, params));
-    },
-    lte(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    max(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    int(params) {
-      return this.check(int(params));
-    },
-    safe(params) {
-      return this.check(int(params));
-    },
-    positive(params) {
-      return this.check(checks.gt(0, params));
-    },
-    nonnegative(params) {
-      return this.check(checks.gte(0, params));
-    },
-    negative(params) {
-      return this.check(checks.lt(0, params));
-    },
-    nonpositive(params) {
-      return this.check(checks.lte(0, params));
-    },
-    multipleOf(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-    step(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-    finite() {
-      return this;
-    },
-  });
+  _installLazyMethods(inst, "ZodNumber", _zodNumberMethods);
 
   const bag = inst._zod.bag;
   inst.minValue =
@@ -1307,19 +935,7 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.bigintProcessor(inst, ctx, json, params);
 
-  inst.gte = (value, params) => inst.check(checks.gte(value, params));
-  inst.min = (value, params) => inst.check(checks.gte(value, params));
-  inst.gt = (value, params) => inst.check(checks.gt(value, params));
-  inst.gte = (value, params) => inst.check(checks.gte(value, params));
-  inst.min = (value, params) => inst.check(checks.gte(value, params));
-  inst.lt = (value, params) => inst.check(checks.lt(value, params));
-  inst.lte = (value, params) => inst.check(checks.lte(value, params));
-  inst.max = (value, params) => inst.check(checks.lte(value, params));
-  inst.positive = (params) => inst.check(checks.gt(BigInt(0), params));
-  inst.negative = (params) => inst.check(checks.lt(BigInt(0), params));
-  inst.nonpositive = (params) => inst.check(checks.lte(BigInt(0), params));
-  inst.nonnegative = (params) => inst.check(checks.gte(BigInt(0), params));
-  inst.multipleOf = (value, params) => inst.check(checks.multipleOf(value, params));
+  _installLazyMethods(inst, "ZodBigInt", _zodBigIntMethods);
 
   const bag = inst._zod.bag;
   inst.minValue = bag.minimum ?? null;
@@ -1492,23 +1108,7 @@ export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constru
   inst._zod.processJSONSchema = (ctx, json, params) => processors.arrayProcessor(inst, ctx, json, params);
 
   inst.element = def.element;
-  _installLazyMethods(inst, "ZodArray", {
-    min(n, params) {
-      return this.check(checks.minLength(n, params));
-    },
-    nonempty(params) {
-      return this.check(checks.minLength(1, params));
-    },
-    max(n, params) {
-      return this.check(checks.maxLength(n, params));
-    },
-    length(n, params) {
-      return this.check(checks.length(n, params));
-    },
-    unwrap() {
-      return this.element;
-    },
-  });
+  _installLazyMethods(inst, "ZodArray", _zodArrayMethods);
 });
 
 export function array<T extends core.SomeType>(element: T, params?: string | core.$ZodArrayParams): ZodArray<T> {
@@ -1622,47 +1222,7 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
     return def.shape;
   });
 
-  _installLazyMethods(inst, "ZodObject", {
-    keyof() {
-      return _enum(Object.keys(this._zod.def.shape));
-    },
-    catchall(catchall) {
-      return this.clone({ ...this._zod.def, catchall: catchall as any });
-    },
-    passthrough() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
-    },
-    loose() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
-    },
-    strict() {
-      return this.clone({ ...this._zod.def, catchall: never() });
-    },
-    strip() {
-      return this.clone({ ...this._zod.def, catchall: undefined });
-    },
-    extend(incoming) {
-      return util.extend(this, incoming);
-    },
-    safeExtend(incoming) {
-      return util.safeExtend(this, incoming);
-    },
-    merge(other) {
-      return util.merge(this, other);
-    },
-    pick(mask) {
-      return util.pick(this, mask);
-    },
-    omit(mask) {
-      return util.omit(this, mask);
-    },
-    partial(...args) {
-      return util.partial(ZodOptional, this, args[0]);
-    },
-    required(...args) {
-      return util.required(ZodNonOptional, this, args[0]);
-    },
-  });
+  _installLazyMethods(inst, "ZodObject", _zodObjectMethods);
 });
 
 export function object<T extends core.$ZodLooseShape = Partial<Record<never, core.SomeType>>>(
@@ -2830,4 +2390,440 @@ export function preprocess<A, U extends core.SomeType, B = unknown>(
     in: transform(fn as any) as any as core.$ZodTransform,
     out: schema as any as core.$ZodType,
   }) as any;
+}
+
+/**
+ * The parse family, built lazily but as the exact closures the eager version
+ * used — same shape, same monomorphic call sites, allocated only for schemas
+ * something actually parses through directly.
+ */
+function _zodTypeParseProps(): _LazyPropsOf<ZodType> {
+  return {
+    // `_def` derives purely from the instance, so it is materialized on read
+    // rather than assigned at construction.
+    _def: (self) => self._zod.def,
+    parse: (self) => {
+      const fn: ZodType["parse"] = (data, params) => parse.parse(self, data, params, { callee: fn });
+      return fn;
+    },
+    parseAsync: (self) => {
+      const fn: ZodType["parseAsync"] = async (data, params) => parse.parseAsync(self, data, params, { callee: fn });
+      return fn;
+    },
+    safeParse: (self) => (data, params) => parse.safeParse(self, data, params),
+    safeParseAsync: (self) => async (data, params) => parse.safeParseAsync(self, data, params),
+    // `spa` is an alias: same function object as `safeParseAsync`, as before.
+    spa: (self) => self.safeParseAsync,
+    encode: (self) => (data, params) => parse.encode(self, data, params),
+    decode: (self) => (data, params) => parse.decode(self, data, params),
+    encodeAsync: (self) => async (data, params) => parse.encodeAsync(self, data, params),
+    decodeAsync: (self) => async (data, params) => parse.decodeAsync(self, data, params),
+    safeEncode: (self) => (data, params) => parse.safeEncode(self, data, params),
+    safeDecode: (self) => (data, params) => parse.safeDecode(self, data, params),
+    safeEncodeAsync: (self) => async (data, params) => parse.safeEncodeAsync(self, data, params),
+    safeDecodeAsync: (self) => async (data, params) => parse.safeDecodeAsync(self, data, params),
+    toJSONSchema: (self) => createToJSONSchemaMethod(self, {}),
+  };
+}
+
+function _zodTypeAccessors(): Record<string, (this: ZodType) => unknown> {
+  return {
+    description(this: ZodType) {
+      return core.globalRegistry.get(this)?.description;
+    },
+  };
+}
+
+function _zodTypeMethods(): _LazyMethodsOf<ZodType> {
+  return {
+    check(...chks) {
+      const def = this.def;
+      return this.clone(
+        util.mergeDefs(def, {
+          checks: [
+            ...(def.checks ?? []),
+            ...chks.map((ch) =>
+              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+            ),
+          ],
+        }),
+        { parent: true }
+      );
+    },
+    with(...chks) {
+      return this.check(...chks);
+    },
+    clone(def, params) {
+      return core.clone(this, def, params);
+    },
+    brand() {
+      return this;
+    },
+    register(reg, meta) {
+      reg.add(this, meta);
+      return this;
+    },
+    refine(check, params) {
+      return this.check(refine(check, params));
+    },
+    superRefine(refinement, params) {
+      return this.check(superRefine(refinement, params));
+    },
+    overwrite(fn) {
+      return this.check(checks.overwrite(fn));
+    },
+    optional() {
+      return optional(this);
+    },
+    exactOptional() {
+      return exactOptional(this);
+    },
+    nullable() {
+      return nullable(this);
+    },
+    nullish() {
+      return optional(nullable(this));
+    },
+    nonoptional(params) {
+      return nonoptional(this, params);
+    },
+    array() {
+      return array(this);
+    },
+    or(arg) {
+      return union([this, arg]);
+    },
+    and(arg) {
+      return intersection(this, arg);
+    },
+    transform(tx) {
+      return pipe(this, transform(tx));
+    },
+    default(d) {
+      return _default(this, d);
+    },
+    prefault(d) {
+      return prefault(this, d);
+    },
+    catch(params) {
+      return _catch(this, params);
+    },
+    pipe(target) {
+      return pipe(this, target);
+    },
+    readonly() {
+      return readonly(this);
+    },
+    describe(description) {
+      const cl = this.clone();
+      core.globalRegistry.add(cl, { description });
+      return cl;
+    },
+    meta(...args: any[]): any {
+      // overloaded: meta() returns the registered metadata, meta(data)
+      // returns a clone with `data` registered. The mapped type picks
+      // up the second overload, so we accept variadic any-args and
+      // return `any` to satisfy both at runtime.
+      if (args.length === 0) return core.globalRegistry.get(this);
+      const cl = this.clone();
+      core.globalRegistry.add(cl, args[0]);
+      return cl;
+    },
+    isOptional() {
+      return this.safeParse(undefined).success;
+    },
+    isNullable() {
+      return this.safeParse(null).success;
+    },
+    apply(fn) {
+      return fn(this);
+    },
+  };
+}
+
+function _zodStringBaseMethods(): _LazyMethodsOf<_ZodString> {
+  return {
+    regex(...args) {
+      return this.check((checks.regex as any)(...args));
+    },
+    includes(...args) {
+      return this.check((checks.includes as any)(...args));
+    },
+    startsWith(...args) {
+      return this.check((checks.startsWith as any)(...args));
+    },
+    endsWith(...args) {
+      return this.check((checks.endsWith as any)(...args));
+    },
+    min(...args) {
+      return this.check((checks.minLength as any)(...args));
+    },
+    max(...args) {
+      return this.check((checks.maxLength as any)(...args));
+    },
+    length(...args) {
+      return this.check((checks.length as any)(...args));
+    },
+    nonempty(...args) {
+      return this.check((checks.minLength as any)(1, ...args));
+    },
+    lowercase(params) {
+      return this.check(checks.lowercase(params));
+    },
+    uppercase(params) {
+      return this.check(checks.uppercase(params));
+    },
+    trim() {
+      return this.check(checks.trim());
+    },
+    normalize(...args) {
+      return this.check(checks.normalize(...args));
+    },
+    toLowerCase() {
+      return this.check(checks.toLowerCase());
+    },
+    toUpperCase() {
+      return this.check(checks.toUpperCase());
+    },
+    slugify() {
+      return this.check(checks.slugify());
+    },
+  };
+}
+
+function _zodStringMethods(): _LazyMethodsOf<ZodString> {
+  return {
+    email(params) {
+      return this.check(core._email(ZodEmail, params));
+    },
+    url(params) {
+      return this.check(core._url(ZodURL, params));
+    },
+    jwt(params) {
+      return this.check(core._jwt(ZodJWT, params));
+    },
+    emoji(params) {
+      return this.check(core._emoji(ZodEmoji, params));
+    },
+    guid(params) {
+      return this.check(core._guid(ZodGUID, params));
+    },
+    uuid(params) {
+      return this.check(core._uuid(ZodUUID, params));
+    },
+    uuidv4(params) {
+      return this.check(core._uuidv4(ZodUUID, params));
+    },
+    uuidv6(params) {
+      return this.check(core._uuidv6(ZodUUID, params));
+    },
+    uuidv7(params) {
+      return this.check(core._uuidv7(ZodUUID, params));
+    },
+    nanoid(params) {
+      return this.check(core._nanoid(ZodNanoID, params));
+    },
+    cuid(params) {
+      return this.check(core._cuid(ZodCUID, params));
+    },
+    cuid2(params) {
+      return this.check(core._cuid2(ZodCUID2, params));
+    },
+    ulid(params) {
+      return this.check(core._ulid(ZodULID, params));
+    },
+    base64(params) {
+      return this.check(core._base64(ZodBase64, params));
+    },
+    base64url(params) {
+      return this.check(core._base64url(ZodBase64URL, params));
+    },
+    xid(params) {
+      return this.check(core._xid(ZodXID, params));
+    },
+    ksuid(params) {
+      return this.check(core._ksuid(ZodKSUID, params));
+    },
+    ipv4(params) {
+      return this.check(core._ipv4(ZodIPv4, params));
+    },
+    ipv6(params) {
+      return this.check(core._ipv6(ZodIPv6, params));
+    },
+    cidrv4(params) {
+      return this.check(core._cidrv4(ZodCIDRv4, params));
+    },
+    cidrv6(params) {
+      return this.check(core._cidrv6(ZodCIDRv6, params));
+    },
+    e164(params) {
+      return this.check(core._e164(ZodE164, params));
+    },
+
+    // iso
+    datetime(params) {
+      return this.check(core._isoDateTime(ZodISODateTime, params as any));
+    },
+    date(params) {
+      return this.check(core._isoDate(ZodISODate, params as any));
+    },
+    time(params) {
+      return this.check(core._isoTime(ZodISOTime, params as any));
+    },
+    duration(params) {
+      return this.check(core._isoDuration(ZodISODuration, params as any));
+    },
+  };
+}
+
+function _zodNumberMethods(): _LazyMethodsOf<ZodNumber> {
+  return {
+    gt(value, params) {
+      return this.check(checks.gt(value, params));
+    },
+    gte(value, params) {
+      return this.check(checks.gte(value, params));
+    },
+    min(value, params) {
+      return this.check(checks.gte(value, params));
+    },
+    lt(value, params) {
+      return this.check(checks.lt(value, params));
+    },
+    lte(value, params) {
+      return this.check(checks.lte(value, params));
+    },
+    max(value, params) {
+      return this.check(checks.lte(value, params));
+    },
+    int(params) {
+      return this.check(int(params));
+    },
+    safe(params) {
+      return this.check(int(params));
+    },
+    positive(params) {
+      return this.check(checks.gt(0, params));
+    },
+    nonnegative(params) {
+      return this.check(checks.gte(0, params));
+    },
+    negative(params) {
+      return this.check(checks.lt(0, params));
+    },
+    nonpositive(params) {
+      return this.check(checks.lte(0, params));
+    },
+    multipleOf(value, params) {
+      return this.check(checks.multipleOf(value, params));
+    },
+    step(value, params) {
+      return this.check(checks.multipleOf(value, params));
+    },
+    finite() {
+      return this;
+    },
+  };
+}
+
+function _zodBigIntMethods(): _LazyMethodsOf<ZodBigInt> {
+  return {
+    gte(value, params) {
+      return this.check(checks.gte(value, params));
+    },
+    min(value, params) {
+      return this.check(checks.gte(value, params));
+    },
+    gt(value, params) {
+      return this.check(checks.gt(value, params));
+    },
+    lt(value, params) {
+      return this.check(checks.lt(value, params));
+    },
+    lte(value, params) {
+      return this.check(checks.lte(value, params));
+    },
+    max(value, params) {
+      return this.check(checks.lte(value, params));
+    },
+    positive(params) {
+      return this.check(checks.gt(BigInt(0), params));
+    },
+    negative(params) {
+      return this.check(checks.lt(BigInt(0), params));
+    },
+    nonpositive(params) {
+      return this.check(checks.lte(BigInt(0), params));
+    },
+    nonnegative(params) {
+      return this.check(checks.gte(BigInt(0), params));
+    },
+    multipleOf(value, params) {
+      return this.check(checks.multipleOf(value, params));
+    },
+  };
+}
+
+function _zodArrayMethods(): _LazyMethodsOf<ZodArray> {
+  return {
+    min(n, params) {
+      return this.check(checks.minLength(n, params));
+    },
+    nonempty(params) {
+      return this.check(checks.minLength(1, params));
+    },
+    max(n, params) {
+      return this.check(checks.maxLength(n, params));
+    },
+    length(n, params) {
+      return this.check(checks.length(n, params));
+    },
+    unwrap() {
+      return this.element;
+    },
+  };
+}
+
+function _zodObjectMethods(): _LazyMethodsOf<ZodObject> {
+  return {
+    keyof() {
+      return _enum(Object.keys(this._zod.def.shape));
+    },
+    catchall(catchall) {
+      return this.clone({ ...this._zod.def, catchall: catchall as any });
+    },
+    passthrough() {
+      return this.clone({ ...this._zod.def, catchall: unknown() });
+    },
+    loose() {
+      return this.clone({ ...this._zod.def, catchall: unknown() });
+    },
+    strict() {
+      return this.clone({ ...this._zod.def, catchall: never() });
+    },
+    strip() {
+      return this.clone({ ...this._zod.def, catchall: undefined });
+    },
+    extend(incoming) {
+      return util.extend(this, incoming);
+    },
+    safeExtend(incoming) {
+      return util.safeExtend(this, incoming);
+    },
+    merge(other) {
+      return util.merge(this, other);
+    },
+    pick(mask) {
+      return util.pick(this, mask);
+    },
+    omit(mask) {
+      return util.omit(this, mask);
+    },
+    partial(...args) {
+      return util.partial(ZodOptional, this, args[0]);
+    },
+    required(...args) {
+      return util.required(ZodNonOptional, this, args[0]);
+    },
+  };
 }

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -7,10 +7,8 @@ import { createStandardJSONSchemaMethod, createToJSONSchemaMethod } from "../cor
 import * as checks from "./checks.js";
 import * as parse from "./parse.js";
 
-// Builder methods and the parse family live on each concrete schema
-// constructor's prototype and materialize per instance on first access, so a
-// schema only pays for what it is actually asked for. See
-// `util.installLazyMethods` / `installLazyProps` for why this matters.
+// Methods live on each concrete constructor's prototype and materialize per
+// instance on first access, so a schema only pays for what it is asked for.
 const _installLazyMethods = util.installLazyMethods;
 const _installLazyProps = util.installLazyProps;
 type _LazyMethodsOf<T> = util.LazyMethodsOf<T>;
@@ -168,26 +166,9 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   inst.def = def;
   inst.type = def.type;
 
-  // Everything else — the parse family, the builder methods, `_def`,
-  // `~standard` and `toJSONSchema` — is installed on the prototype rather
-  // than the instance.
-  //
-  // Own-property count is the dominant cost of a schema. V8 sizes an
-  // instance's property backing store in steps, and a constructor like this
-  // one (which assigns nothing itself, so there is nothing to slack-track)
-  // gets no in-object slots: 12 own properties cost 128 bytes, 13 cost 848,
-  // and 21 cost 1616. Keeping instances under the first cliff is worth more
-  // than the closures themselves.
-  //
-  // Detachability is preserved: the getters bind on first access and cache
-  // the bound function as an own property, so `const { parse } = schema` and
-  // `arr.map(schema.parse)` still work, and a schema that is never parsed
-  // directly — every interior node of a large schema graph — allocates none
-  // of them.
   _installLazyMethods(inst, "check", _zodTypeMethods);
   _installLazyProps(inst, "parse", _zodTypeParseProps);
-  // `description` reads through to the registry on every access, so unlike the
-  // rest it must not cache onto the instance.
+  // Reads through to the registry on every access, so it must not cache.
   const proto = Object.getPrototypeOf(inst);
   if (!("description" in proto)) {
     Object.defineProperty(proto, "description", {
@@ -196,8 +177,8 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
         return core.globalRegistry.get(this)?.description;
       },
     });
-    // Getter with no setter, so `schema._def = x` still throws in strict mode
-    // as it did when `_def` was a non-writable own property.
+    // No setter: `schema._def = x` throws, as it did when `_def` was a
+    // non-writable own property.
     Object.defineProperty(proto, "_def", {
       configurable: true,
       get(this: ZodType) {
@@ -207,6 +188,149 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   }
   return inst;
 });
+
+function _zodTypeMethods(): _LazyMethodsOf<ZodType> {
+  return {
+    check(...chks) {
+      const def = this.def;
+      return this.clone(
+        util.mergeDefs(def, {
+          checks: [
+            ...(def.checks ?? []),
+            ...chks.map((ch) =>
+              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+            ),
+          ],
+        }),
+        { parent: true }
+      );
+    },
+    with(...chks) {
+      return this.check(...chks);
+    },
+    clone(def, params) {
+      return core.clone(this, def, params);
+    },
+    brand() {
+      return this;
+    },
+    register(reg, meta) {
+      reg.add(this, meta);
+      return this;
+    },
+    refine(check, params) {
+      return this.check(refine(check, params));
+    },
+    superRefine(refinement, params) {
+      return this.check(superRefine(refinement, params));
+    },
+    overwrite(fn) {
+      return this.check(checks.overwrite(fn));
+    },
+    optional() {
+      return optional(this);
+    },
+    exactOptional() {
+      return exactOptional(this);
+    },
+    nullable() {
+      return nullable(this);
+    },
+    nullish() {
+      return optional(nullable(this));
+    },
+    nonoptional(params) {
+      return nonoptional(this, params);
+    },
+    array() {
+      return array(this);
+    },
+    or(arg) {
+      return union([this, arg]);
+    },
+    and(arg) {
+      return intersection(this, arg);
+    },
+    transform(tx) {
+      return pipe(this, transform(tx));
+    },
+    default(d) {
+      return _default(this, d);
+    },
+    prefault(d) {
+      return prefault(this, d);
+    },
+    catch(params) {
+      return _catch(this, params);
+    },
+    pipe(target) {
+      return pipe(this, target);
+    },
+    readonly() {
+      return readonly(this);
+    },
+    describe(description) {
+      const cl = this.clone();
+      core.globalRegistry.add(cl, { description });
+      return cl;
+    },
+    meta(...args: any[]): any {
+      // overloaded: meta() returns the registered metadata, meta(data)
+      // returns a clone with `data` registered. The mapped type picks
+      // up the second overload, so we accept variadic any-args and
+      // return `any` to satisfy both at runtime.
+      if (args.length === 0) return core.globalRegistry.get(this);
+      const cl = this.clone();
+      core.globalRegistry.add(cl, args[0]);
+      return cl;
+    },
+    isOptional() {
+      return this.safeParse(undefined).success;
+    },
+    isNullable() {
+      return this.safeParse(null).success;
+    },
+    apply(fn) {
+      return fn(this);
+    },
+  };
+}
+
+function _zodTypeParseProps(): _LazyPropsOf<ZodType> {
+  return {
+    // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype
+    // entry: redefining it per instance demotes instances to dictionary mode.
+    "~standard": (self) =>
+      ({
+        ...core.standardProps(self),
+        jsonSchema: {
+          input: createStandardJSONSchemaMethod(self, "input"),
+          output: createStandardJSONSchemaMethod(self, "output"),
+        },
+      }) as ZodType["~standard"],
+    parse: (self) => {
+      const fn: ZodType["parse"] = (data, params) => parse.parse(self, data, params, { callee: fn });
+      return fn;
+    },
+    parseAsync: (self) => {
+      const fn: ZodType["parseAsync"] = async (data, params) => parse.parseAsync(self, data, params, { callee: fn });
+      return fn;
+    },
+    safeParse: (self) => (data, params) => parse.safeParse(self, data, params),
+    safeParseAsync: (self) => async (data, params) => parse.safeParseAsync(self, data, params),
+    // `spa` is an alias: same function object as `safeParseAsync`, as before.
+    spa: (self) => self.safeParseAsync,
+    encode: (self) => (data, params) => parse.encode(self, data, params),
+    decode: (self) => (data, params) => parse.decode(self, data, params),
+    encodeAsync: (self) => async (data, params) => parse.encodeAsync(self, data, params),
+    decodeAsync: (self) => async (data, params) => parse.decodeAsync(self, data, params),
+    safeEncode: (self) => (data, params) => parse.safeEncode(self, data, params),
+    safeDecode: (self) => (data, params) => parse.safeDecode(self, data, params),
+    safeEncodeAsync: (self) => async (data, params) => parse.safeEncodeAsync(self, data, params),
+    safeDecodeAsync: (self) => async (data, params) => parse.safeDecodeAsync(self, data, params),
+    toJSONSchema: (self) => createToJSONSchemaMethod(self, {}),
+  };
+}
 
 // ZodString
 export interface _ZodString<T extends core.$ZodStringInternals<unknown> = core.$ZodStringInternals<unknown>>
@@ -249,6 +373,56 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
 
   _installLazyMethods(inst, "regex", _zodStringBaseMethods);
 });
+
+function _zodStringBaseMethods(): _LazyMethodsOf<_ZodString> {
+  return {
+    regex(...args) {
+      return this.check((checks.regex as any)(...args));
+    },
+    includes(...args) {
+      return this.check((checks.includes as any)(...args));
+    },
+    startsWith(...args) {
+      return this.check((checks.startsWith as any)(...args));
+    },
+    endsWith(...args) {
+      return this.check((checks.endsWith as any)(...args));
+    },
+    min(...args) {
+      return this.check((checks.minLength as any)(...args));
+    },
+    max(...args) {
+      return this.check((checks.maxLength as any)(...args));
+    },
+    length(...args) {
+      return this.check((checks.length as any)(...args));
+    },
+    nonempty(...args) {
+      return this.check((checks.minLength as any)(1, ...args));
+    },
+    lowercase(params) {
+      return this.check(checks.lowercase(params));
+    },
+    uppercase(params) {
+      return this.check(checks.uppercase(params));
+    },
+    trim() {
+      return this.check(checks.trim());
+    },
+    normalize(...args) {
+      return this.check(checks.normalize(...args));
+    },
+    toLowerCase() {
+      return this.check(checks.toLowerCase());
+    },
+    toUpperCase() {
+      return this.check(checks.toUpperCase());
+    },
+    slugify() {
+      return this.check(checks.slugify());
+    },
+  };
+}
 
 export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> {
   // string format checks
@@ -333,6 +507,91 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
 
   _installLazyMethods(inst, "email", _zodStringMethods);
 });
+
+function _zodStringMethods(): _LazyMethodsOf<ZodString> {
+  return {
+    email(params) {
+      return this.check(core._email(ZodEmail, params));
+    },
+    url(params) {
+      return this.check(core._url(ZodURL, params));
+    },
+    jwt(params) {
+      return this.check(core._jwt(ZodJWT, params));
+    },
+    emoji(params) {
+      return this.check(core._emoji(ZodEmoji, params));
+    },
+    guid(params) {
+      return this.check(core._guid(ZodGUID, params));
+    },
+    uuid(params) {
+      return this.check(core._uuid(ZodUUID, params));
+    },
+    uuidv4(params) {
+      return this.check(core._uuidv4(ZodUUID, params));
+    },
+    uuidv6(params) {
+      return this.check(core._uuidv6(ZodUUID, params));
+    },
+    uuidv7(params) {
+      return this.check(core._uuidv7(ZodUUID, params));
+    },
+    nanoid(params) {
+      return this.check(core._nanoid(ZodNanoID, params));
+    },
+    cuid(params) {
+      return this.check(core._cuid(ZodCUID, params));
+    },
+    cuid2(params) {
+      return this.check(core._cuid2(ZodCUID2, params));
+    },
+    ulid(params) {
+      return this.check(core._ulid(ZodULID, params));
+    },
+    base64(params) {
+      return this.check(core._base64(ZodBase64, params));
+    },
+    base64url(params) {
+      return this.check(core._base64url(ZodBase64URL, params));
+    },
+    xid(params) {
+      return this.check(core._xid(ZodXID, params));
+    },
+    ksuid(params) {
+      return this.check(core._ksuid(ZodKSUID, params));
+    },
+    ipv4(params) {
+      return this.check(core._ipv4(ZodIPv4, params));
+    },
+    ipv6(params) {
+      return this.check(core._ipv6(ZodIPv6, params));
+    },
+    cidrv4(params) {
+      return this.check(core._cidrv4(ZodCIDRv4, params));
+    },
+    cidrv6(params) {
+      return this.check(core._cidrv6(ZodCIDRv6, params));
+    },
+    e164(params) {
+      return this.check(core._e164(ZodE164, params));
+    },
+
+    // iso
+    datetime(params) {
+      return this.check(core._isoDateTime(ZodISODateTime, params as any));
+    },
+    date(params) {
+      return this.check(core._isoDate(ZodISODate, params as any));
+    },
+    time(params) {
+      return this.check(core._isoTime(ZodISOTime, params as any));
+    },
+    duration(params) {
+      return this.check(core._isoDuration(ZodISODuration, params as any));
+    },
+  };
+}
 
 export function string(params?: string | core.$ZodStringParams): ZodString;
 export function string<T extends string>(params?: string | core.$ZodStringParams): core.$ZodType<T, T>;
@@ -849,6 +1108,56 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
   inst.format = bag.format ?? null;
 });
 
+function _zodNumberMethods(): _LazyMethodsOf<ZodNumber> {
+  return {
+    gt(value, params) {
+      return this.check(checks.gt(value, params));
+    },
+    gte(value, params) {
+      return this.check(checks.gte(value, params));
+    },
+    min(value, params) {
+      return this.check(checks.gte(value, params));
+    },
+    lt(value, params) {
+      return this.check(checks.lt(value, params));
+    },
+    lte(value, params) {
+      return this.check(checks.lte(value, params));
+    },
+    max(value, params) {
+      return this.check(checks.lte(value, params));
+    },
+    int(params) {
+      return this.check(int(params));
+    },
+    safe(params) {
+      return this.check(int(params));
+    },
+    positive(params) {
+      return this.check(checks.gt(0, params));
+    },
+    nonnegative(params) {
+      return this.check(checks.gte(0, params));
+    },
+    negative(params) {
+      return this.check(checks.lt(0, params));
+    },
+    nonpositive(params) {
+      return this.check(checks.lte(0, params));
+    },
+    multipleOf(value, params) {
+      return this.check(checks.multipleOf(value, params));
+    },
+    step(value, params) {
+      return this.check(checks.multipleOf(value, params));
+    },
+    finite() {
+      return this;
+    },
+  };
+}
+
 export function number(params?: string | core.$ZodNumberParams): ZodNumber {
   return core._number(ZodNumber, params);
 }
@@ -942,6 +1251,44 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
   inst.maxValue = bag.maximum ?? null;
   inst.format = bag.format ?? null;
 });
+
+function _zodBigIntMethods(): _LazyMethodsOf<ZodBigInt> {
+  return {
+    gte(value, params) {
+      return this.check(checks.gte(value, params));
+    },
+    min(value, params) {
+      return this.check(checks.gte(value, params));
+    },
+    gt(value, params) {
+      return this.check(checks.gt(value, params));
+    },
+    lt(value, params) {
+      return this.check(checks.lt(value, params));
+    },
+    lte(value, params) {
+      return this.check(checks.lte(value, params));
+    },
+    max(value, params) {
+      return this.check(checks.lte(value, params));
+    },
+    positive(params) {
+      return this.check(checks.gt(BigInt(0), params));
+    },
+    negative(params) {
+      return this.check(checks.lt(BigInt(0), params));
+    },
+    nonpositive(params) {
+      return this.check(checks.lte(BigInt(0), params));
+    },
+    nonnegative(params) {
+      return this.check(checks.gte(BigInt(0), params));
+    },
+    multipleOf(value, params) {
+      return this.check(checks.multipleOf(value, params));
+    },
+  };
+}
 
 export function bigint(params?: string | core.$ZodBigIntParams): ZodBigInt {
   return core._bigint(ZodBigInt, params);
@@ -1111,6 +1458,26 @@ export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constru
   _installLazyMethods(inst, "min", _zodArrayMethods);
 });
 
+function _zodArrayMethods(): _LazyMethodsOf<ZodArray> {
+  return {
+    min(n, params) {
+      return this.check(checks.minLength(n, params));
+    },
+    nonempty(params) {
+      return this.check(checks.minLength(1, params));
+    },
+    max(n, params) {
+      return this.check(checks.maxLength(n, params));
+    },
+    length(n, params) {
+      return this.check(checks.length(n, params));
+    },
+    unwrap() {
+      return this.element;
+    },
+  };
+}
+
 export function array<T extends core.SomeType>(element: T, params?: string | core.$ZodArrayParams): ZodArray<T> {
   return core._array(ZodArray, element as any, params) as any;
 }
@@ -1224,6 +1591,50 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
 
   _installLazyMethods(inst, "keyof", _zodObjectMethods);
 });
+
+function _zodObjectMethods(): _LazyMethodsOf<ZodObject> {
+  return {
+    keyof() {
+      return _enum(Object.keys(this._zod.def.shape));
+    },
+    catchall(catchall) {
+      return this.clone({ ...this._zod.def, catchall: catchall as any });
+    },
+    passthrough() {
+      return this.clone({ ...this._zod.def, catchall: unknown() });
+    },
+    loose() {
+      return this.clone({ ...this._zod.def, catchall: unknown() });
+    },
+    strict() {
+      return this.clone({ ...this._zod.def, catchall: never() });
+    },
+    strip() {
+      return this.clone({ ...this._zod.def, catchall: undefined });
+    },
+    extend(incoming) {
+      return util.extend(this, incoming);
+    },
+    safeExtend(incoming) {
+      return util.safeExtend(this, incoming);
+    },
+    merge(other) {
+      return util.merge(this, other);
+    },
+    pick(mask) {
+      return util.pick(this, mask);
+    },
+    omit(mask) {
+      return util.omit(this, mask);
+    },
+    partial(...args) {
+      return util.partial(ZodOptional, this, args[0]);
+    },
+    required(...args) {
+      return util.required(ZodNonOptional, this, args[0]);
+    },
+  };
+}
 
 export function object<T extends core.$ZodLooseShape = Partial<Record<never, core.SomeType>>>(
   shape?: T,
@@ -2392,439 +2803,4 @@ export function preprocess<A, U extends core.SomeType, B = unknown>(
   }) as any;
 }
 
-/**
- * The parse family, built lazily but as the exact closures the eager version
- * used — same shape, same monomorphic call sites, allocated only for schemas
- * something actually parses through directly.
- */
-function _zodTypeParseProps(): _LazyPropsOf<ZodType> {
-  return {
-    // Overrides core's prototype-level `~standard` with the classic one, which
-    // also carries `jsonSchema`. It must stay a prototype entry: reading
-    // `~standard` to attach `jsonSchema` forced every schema to build it, and
-    // redefining it per instance demoted instances to dictionary mode.
-    "~standard": (self) =>
-      ({
-        ...core.standardProps(self),
-        jsonSchema: {
-          input: createStandardJSONSchemaMethod(self, "input"),
-          output: createStandardJSONSchemaMethod(self, "output"),
-        },
-      }) as ZodType["~standard"],
-    parse: (self) => {
-      const fn: ZodType["parse"] = (data, params) => parse.parse(self, data, params, { callee: fn });
-      return fn;
-    },
-    parseAsync: (self) => {
-      const fn: ZodType["parseAsync"] = async (data, params) => parse.parseAsync(self, data, params, { callee: fn });
-      return fn;
-    },
-    safeParse: (self) => (data, params) => parse.safeParse(self, data, params),
-    safeParseAsync: (self) => async (data, params) => parse.safeParseAsync(self, data, params),
-    // `spa` is an alias: same function object as `safeParseAsync`, as before.
-    spa: (self) => self.safeParseAsync,
-    encode: (self) => (data, params) => parse.encode(self, data, params),
-    decode: (self) => (data, params) => parse.decode(self, data, params),
-    encodeAsync: (self) => async (data, params) => parse.encodeAsync(self, data, params),
-    decodeAsync: (self) => async (data, params) => parse.decodeAsync(self, data, params),
-    safeEncode: (self) => (data, params) => parse.safeEncode(self, data, params),
-    safeDecode: (self) => (data, params) => parse.safeDecode(self, data, params),
-    safeEncodeAsync: (self) => async (data, params) => parse.safeEncodeAsync(self, data, params),
-    safeDecodeAsync: (self) => async (data, params) => parse.safeDecodeAsync(self, data, params),
-    toJSONSchema: (self) => createToJSONSchemaMethod(self, {}),
-  };
-}
-
-function _zodTypeMethods(): _LazyMethodsOf<ZodType> {
-  return {
-    check(...chks) {
-      const def = this.def;
-      return this.clone(
-        util.mergeDefs(def, {
-          checks: [
-            ...(def.checks ?? []),
-            ...chks.map((ch) =>
-              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
-            ),
-          ],
-        }),
-        { parent: true }
-      );
-    },
-    with(...chks) {
-      return this.check(...chks);
-    },
-    clone(def, params) {
-      return core.clone(this, def, params);
-    },
-    brand() {
-      return this;
-    },
-    register(reg, meta) {
-      reg.add(this, meta);
-      return this;
-    },
-    refine(check, params) {
-      return this.check(refine(check, params));
-    },
-    superRefine(refinement, params) {
-      return this.check(superRefine(refinement, params));
-    },
-    overwrite(fn) {
-      return this.check(checks.overwrite(fn));
-    },
-    optional() {
-      return optional(this);
-    },
-    exactOptional() {
-      return exactOptional(this);
-    },
-    nullable() {
-      return nullable(this);
-    },
-    nullish() {
-      return optional(nullable(this));
-    },
-    nonoptional(params) {
-      return nonoptional(this, params);
-    },
-    array() {
-      return array(this);
-    },
-    or(arg) {
-      return union([this, arg]);
-    },
-    and(arg) {
-      return intersection(this, arg);
-    },
-    transform(tx) {
-      return pipe(this, transform(tx));
-    },
-    default(d) {
-      return _default(this, d);
-    },
-    prefault(d) {
-      return prefault(this, d);
-    },
-    catch(params) {
-      return _catch(this, params);
-    },
-    pipe(target) {
-      return pipe(this, target);
-    },
-    readonly() {
-      return readonly(this);
-    },
-    describe(description) {
-      const cl = this.clone();
-      core.globalRegistry.add(cl, { description });
-      return cl;
-    },
-    meta(...args: any[]): any {
-      // overloaded: meta() returns the registered metadata, meta(data)
-      // returns a clone with `data` registered. The mapped type picks
-      // up the second overload, so we accept variadic any-args and
-      // return `any` to satisfy both at runtime.
-      if (args.length === 0) return core.globalRegistry.get(this);
-      const cl = this.clone();
-      core.globalRegistry.add(cl, args[0]);
-      return cl;
-    },
-    isOptional() {
-      return this.safeParse(undefined).success;
-    },
-    isNullable() {
-      return this.safeParse(null).success;
-    },
-    apply(fn) {
-      return fn(this);
-    },
-  };
-}
-
-function _zodStringBaseMethods(): _LazyMethodsOf<_ZodString> {
-  return {
-    regex(...args) {
-      return this.check((checks.regex as any)(...args));
-    },
-    includes(...args) {
-      return this.check((checks.includes as any)(...args));
-    },
-    startsWith(...args) {
-      return this.check((checks.startsWith as any)(...args));
-    },
-    endsWith(...args) {
-      return this.check((checks.endsWith as any)(...args));
-    },
-    min(...args) {
-      return this.check((checks.minLength as any)(...args));
-    },
-    max(...args) {
-      return this.check((checks.maxLength as any)(...args));
-    },
-    length(...args) {
-      return this.check((checks.length as any)(...args));
-    },
-    nonempty(...args) {
-      return this.check((checks.minLength as any)(1, ...args));
-    },
-    lowercase(params) {
-      return this.check(checks.lowercase(params));
-    },
-    uppercase(params) {
-      return this.check(checks.uppercase(params));
-    },
-    trim() {
-      return this.check(checks.trim());
-    },
-    normalize(...args) {
-      return this.check(checks.normalize(...args));
-    },
-    toLowerCase() {
-      return this.check(checks.toLowerCase());
-    },
-    toUpperCase() {
-      return this.check(checks.toUpperCase());
-    },
-    slugify() {
-      return this.check(checks.slugify());
-    },
-  };
-}
-
-function _zodStringMethods(): _LazyMethodsOf<ZodString> {
-  return {
-    email(params) {
-      return this.check(core._email(ZodEmail, params));
-    },
-    url(params) {
-      return this.check(core._url(ZodURL, params));
-    },
-    jwt(params) {
-      return this.check(core._jwt(ZodJWT, params));
-    },
-    emoji(params) {
-      return this.check(core._emoji(ZodEmoji, params));
-    },
-    guid(params) {
-      return this.check(core._guid(ZodGUID, params));
-    },
-    uuid(params) {
-      return this.check(core._uuid(ZodUUID, params));
-    },
-    uuidv4(params) {
-      return this.check(core._uuidv4(ZodUUID, params));
-    },
-    uuidv6(params) {
-      return this.check(core._uuidv6(ZodUUID, params));
-    },
-    uuidv7(params) {
-      return this.check(core._uuidv7(ZodUUID, params));
-    },
-    nanoid(params) {
-      return this.check(core._nanoid(ZodNanoID, params));
-    },
-    cuid(params) {
-      return this.check(core._cuid(ZodCUID, params));
-    },
-    cuid2(params) {
-      return this.check(core._cuid2(ZodCUID2, params));
-    },
-    ulid(params) {
-      return this.check(core._ulid(ZodULID, params));
-    },
-    base64(params) {
-      return this.check(core._base64(ZodBase64, params));
-    },
-    base64url(params) {
-      return this.check(core._base64url(ZodBase64URL, params));
-    },
-    xid(params) {
-      return this.check(core._xid(ZodXID, params));
-    },
-    ksuid(params) {
-      return this.check(core._ksuid(ZodKSUID, params));
-    },
-    ipv4(params) {
-      return this.check(core._ipv4(ZodIPv4, params));
-    },
-    ipv6(params) {
-      return this.check(core._ipv6(ZodIPv6, params));
-    },
-    cidrv4(params) {
-      return this.check(core._cidrv4(ZodCIDRv4, params));
-    },
-    cidrv6(params) {
-      return this.check(core._cidrv6(ZodCIDRv6, params));
-    },
-    e164(params) {
-      return this.check(core._e164(ZodE164, params));
-    },
-
-    // iso
-    datetime(params) {
-      return this.check(core._isoDateTime(ZodISODateTime, params as any));
-    },
-    date(params) {
-      return this.check(core._isoDate(ZodISODate, params as any));
-    },
-    time(params) {
-      return this.check(core._isoTime(ZodISOTime, params as any));
-    },
-    duration(params) {
-      return this.check(core._isoDuration(ZodISODuration, params as any));
-    },
-  };
-}
-
-function _zodNumberMethods(): _LazyMethodsOf<ZodNumber> {
-  return {
-    gt(value, params) {
-      return this.check(checks.gt(value, params));
-    },
-    gte(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    min(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    lt(value, params) {
-      return this.check(checks.lt(value, params));
-    },
-    lte(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    max(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    int(params) {
-      return this.check(int(params));
-    },
-    safe(params) {
-      return this.check(int(params));
-    },
-    positive(params) {
-      return this.check(checks.gt(0, params));
-    },
-    nonnegative(params) {
-      return this.check(checks.gte(0, params));
-    },
-    negative(params) {
-      return this.check(checks.lt(0, params));
-    },
-    nonpositive(params) {
-      return this.check(checks.lte(0, params));
-    },
-    multipleOf(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-    step(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-    finite() {
-      return this;
-    },
-  };
-}
-
-function _zodBigIntMethods(): _LazyMethodsOf<ZodBigInt> {
-  return {
-    gte(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    min(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    gt(value, params) {
-      return this.check(checks.gt(value, params));
-    },
-    lt(value, params) {
-      return this.check(checks.lt(value, params));
-    },
-    lte(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    max(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    positive(params) {
-      return this.check(checks.gt(BigInt(0), params));
-    },
-    negative(params) {
-      return this.check(checks.lt(BigInt(0), params));
-    },
-    nonpositive(params) {
-      return this.check(checks.lte(BigInt(0), params));
-    },
-    nonnegative(params) {
-      return this.check(checks.gte(BigInt(0), params));
-    },
-    multipleOf(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-  };
-}
-
-function _zodArrayMethods(): _LazyMethodsOf<ZodArray> {
-  return {
-    min(n, params) {
-      return this.check(checks.minLength(n, params));
-    },
-    nonempty(params) {
-      return this.check(checks.minLength(1, params));
-    },
-    max(n, params) {
-      return this.check(checks.maxLength(n, params));
-    },
-    length(n, params) {
-      return this.check(checks.length(n, params));
-    },
-    unwrap() {
-      return this.element;
-    },
-  };
-}
-
-function _zodObjectMethods(): _LazyMethodsOf<ZodObject> {
-  return {
-    keyof() {
-      return _enum(Object.keys(this._zod.def.shape));
-    },
-    catchall(catchall) {
-      return this.clone({ ...this._zod.def, catchall: catchall as any });
-    },
-    passthrough() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
-    },
-    loose() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
-    },
-    strict() {
-      return this.clone({ ...this._zod.def, catchall: never() });
-    },
-    strip() {
-      return this.clone({ ...this._zod.def, catchall: undefined });
-    },
-    extend(incoming) {
-      return util.extend(this, incoming);
-    },
-    safeExtend(incoming) {
-      return util.safeExtend(this, incoming);
-    },
-    merge(other) {
-      return util.merge(this, other);
-    },
-    pick(mask) {
-      return util.pick(this, mask);
-    },
-    omit(mask) {
-      return util.omit(this, mask);
-    },
-    partial(...args) {
-      return util.partial(ZodOptional, this, args[0]);
-    },
-    required(...args) {
-      return util.required(ZodNonOptional, this, args[0]);
-    },
-  };
-}
+/** Built as closures rather than bound methods; see `installLazyProps`. */

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -28,6 +28,8 @@ test("schema instances stay under V8's property-count step", () => {
     ["optional", z.string().optional()],
     ["pipe", z.string().pipe(z.string())],
     ["email", z.email()],
+    ["mini string", zm.string()],
+    ["mini object", zm.object({ a: zm.string() })],
   ];
 
   const over = cases
@@ -35,29 +37,6 @@ test("schema instances stay under V8's property-count step", () => {
     .filter(([, count]) => count > MAX_OWN_PROPS);
 
   expect(over).toEqual([]);
-});
-
-// zod/mini deliberately keeps its methods as per-instance closures. Moving
-// them to the prototype would cost ~180 bytes gzipped of installer machinery,
-// which is ~6% of the smallest mini bundle — too much for a package sold on
-// size. Mini instances therefore sit above the step; this bound just stops
-// them drifting further.
-const MINI_MAX_OWN_PROPS = 14;
-
-test("zod/mini keeps its methods per-instance, and does not grow", () => {
-  const cases: Array<[string, object]> = [
-    ["mini string", zm.string()],
-    ["mini object", zm.object({ a: zm.string() })],
-    ["mini array", zm.array(zm.string())],
-  ];
-
-  const over = cases
-    .map(([name, schema]) => [name, Reflect.ownKeys(schema).length] as const)
-    .filter(([, count]) => count > MINI_MAX_OWN_PROPS);
-
-  expect(over).toEqual([]);
-  // The methods must remain own properties, not inherited accessors.
-  expect(Object.prototype.hasOwnProperty.call(zm.string(), "parse")).toEqual(true);
 });
 
 test("prototype-installed members survive detaching", () => {

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -72,6 +72,37 @@ test("~standard is lazy but complete", () => {
   expect(Object.prototype.hasOwnProperty.call(schema, "~standard")).toEqual(true);
 });
 
+test("reading a lazy member does not change the instance's enumerable surface", () => {
+  const schema = z.string();
+  const before = Object.keys(schema);
+
+  void schema["~standard"];
+  void schema.parse;
+  void schema.optional;
+
+  // The cache is an implementation detail: `Object.keys` and `JSON.stringify`
+  // must not depend on which members happen to have been touched.
+  expect(Object.keys(schema)).toEqual(before);
+  expect(Object.keys(schema)).not.toContain("~standard");
+
+  // An explicit assignment still behaves like one.
+  const other: any = z.string();
+  other.parse = () => "x";
+  expect(Object.keys(other)).toContain("parse");
+});
+
+test("_def stays read-only", () => {
+  expect(() => {
+    (z.string() as any)._def = {};
+  }).toThrow(TypeError);
+  expect(() => {
+    (z.function({ input: [z.string()], output: z.number() }) as any)._def = {};
+  }).toThrow(TypeError);
+  const schema = z.string();
+  expect(schema._def).toBe(schema._zod.def);
+  expect(z.object({ a: z.string() })._def.type).toEqual("object");
+});
+
 test("deferred initializers are released after construction", () => {
   expect(z.string()._zod.deferred).toEqual(undefined);
   expect(z.object({ a: z.string() })._zod.deferred).toEqual(undefined);

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "vitest";
+
+import * as zm from "zod/mini";
+import * as z from "zod/v4";
+
+// V8 sizes an instance's property backing store in steps, and schema
+// instances get no in-object slots (their constructor assigns nothing itself):
+// 12 own properties cost 128 bytes, 13 cost 848, 21 cost 1616. Methods
+// therefore live on the prototype and materialize per instance on first read.
+// These bounds are what keeps a schema graph small; crossing one silently
+// multiplies its memory by 6x.
+const MAX_OWN_PROPS = 12;
+
+test("schema instances stay under V8's property-count step", () => {
+  const cases: Array<[string, object]> = [
+    ["string", z.string()],
+    ["number", z.number()],
+    ["bigint", z.bigint()],
+    ["boolean", z.boolean()],
+    ["date", z.date()],
+    ["enum", z.enum(["a", "b"])],
+    ["array", z.array(z.string())],
+    ["object", z.object({ a: z.string() })],
+    ["record", z.record(z.string(), z.string())],
+    ["map", z.map(z.string(), z.string())],
+    ["set", z.set(z.string())],
+    ["union", z.union([z.string(), z.number()])],
+    ["optional", z.string().optional()],
+    ["pipe", z.string().pipe(z.string())],
+    ["email", z.email()],
+    ["mini string", zm.string()],
+    ["mini object", zm.object({ a: zm.string() })],
+  ];
+
+  const over = cases
+    .map(([name, schema]) => [name, Reflect.ownKeys(schema).length] as const)
+    .filter(([, count]) => count > MAX_OWN_PROPS);
+
+  expect(over).toEqual([]);
+});
+
+test("prototype-installed members survive detaching", () => {
+  const schema = z.string();
+  const { parse, safeParse, spa } = schema;
+
+  expect(parse("hi")).toEqual("hi");
+  expect(safeParse("hi").success).toEqual(true);
+  expect(["a", "b"].map((v) => parse(v))).toEqual(["a", "b"]);
+  expect(spa).toBe(schema.safeParseAsync);
+
+  const email = schema.email;
+  expect(email().safeParse("a@b.co").success).toEqual(true);
+});
+
+test("prototype-installed members can be overwritten per instance", () => {
+  const schema: any = z.string();
+  schema.parse = () => "overridden";
+
+  expect(schema.parse("anything")).toEqual("overridden");
+  expect(z.string().parse("untouched")).toEqual("untouched");
+});
+
+test("~standard is lazy but complete", () => {
+  const schema = z.string();
+
+  expect(Object.prototype.hasOwnProperty.call(schema, "~standard")).toEqual(false);
+  expect(schema["~standard"].vendor).toEqual("zod");
+  expect(schema["~standard"].version).toEqual(1);
+  expect(schema["~standard"].validate("hi")).toEqual({ value: "hi" });
+  expect((schema["~standard"] as any).jsonSchema.input()).toMatchObject({ type: "string" });
+  // Reading it caches on the instance, so the getter runs once.
+  expect(Object.prototype.hasOwnProperty.call(schema, "~standard")).toEqual(true);
+});
+
+test("deferred initializers are released after construction", () => {
+  expect(z.string()._zod.deferred).toEqual(undefined);
+  expect(z.object({ a: z.string() })._zod.deferred).toEqual(undefined);
+});

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -28,8 +28,6 @@ test("schema instances stay under V8's property-count step", () => {
     ["optional", z.string().optional()],
     ["pipe", z.string().pipe(z.string())],
     ["email", z.email()],
-    ["mini string", zm.string()],
-    ["mini object", zm.object({ a: zm.string() })],
   ];
 
   const over = cases
@@ -37,6 +35,29 @@ test("schema instances stay under V8's property-count step", () => {
     .filter(([, count]) => count > MAX_OWN_PROPS);
 
   expect(over).toEqual([]);
+});
+
+// zod/mini deliberately keeps its methods as per-instance closures. Moving
+// them to the prototype would cost ~180 bytes gzipped of installer machinery,
+// which is ~6% of the smallest mini bundle — too much for a package sold on
+// size. Mini instances therefore sit above the step; this bound just stops
+// them drifting further.
+const MINI_MAX_OWN_PROPS = 14;
+
+test("zod/mini keeps its methods per-instance, and does not grow", () => {
+  const cases: Array<[string, object]> = [
+    ["mini string", zm.string()],
+    ["mini object", zm.object({ a: zm.string() })],
+    ["mini array", zm.array(zm.string())],
+  ];
+
+  const over = cases
+    .map(([name, schema]) => [name, Reflect.ownKeys(schema).length] as const)
+    .filter(([, count]) => count > MINI_MAX_OWN_PROPS);
+
+  expect(over).toEqual([]);
+  // The methods must remain own properties, not inherited accessors.
+  expect(Object.prototype.hasOwnProperty.call(zm.string(), "parse")).toEqual(true);
 });
 
 test("prototype-installed members survive detaching", () => {

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -72,23 +72,26 @@ test("~standard is lazy but complete", () => {
   expect(Object.prototype.hasOwnProperty.call(schema, "~standard")).toEqual(true);
 });
 
-test("reading a lazy member does not change the instance's enumerable surface", () => {
+test("caching a lazy member preserves its original enumerability", () => {
   const schema = z.string();
-  const before = Object.keys(schema);
 
-  void schema["~standard"];
+  // Methods were enumerable own properties before they moved to the prototype,
+  // so touching one still surfaces it to `Object.keys`.
   void schema.parse;
   void schema.optional;
+  expect(Object.keys(schema)).toContain("parse");
+  expect(Object.keys(schema)).toContain("optional");
 
-  // The cache is an implementation detail: `Object.keys` and `JSON.stringify`
-  // must not depend on which members happen to have been touched.
-  expect(Object.keys(schema)).toEqual(before);
+  // `~standard` never was an own data property, so caching it must not add it
+  // to `Object.keys` or to `JSON.stringify` of a schema.
+  void schema["~standard"];
   expect(Object.keys(schema)).not.toContain("~standard");
+  expect(JSON.stringify(schema)).not.toContain("~standard");
 
-  // An explicit assignment still behaves like one.
+  // An explicit assignment behaves like one, as before.
   const other: any = z.string();
-  other.parse = () => "x";
-  expect(Object.keys(other)).toContain("parse");
+  other["~standard"] = { vendor: "x" };
+  expect(Object.keys(other)).toContain("~standard");
 });
 
 test("_def stays read-only", () => {

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -30,8 +30,13 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
         constr: _,
         traits: new Set(),
       };
-      Object.defineProperty(inst, "_zod", _zodDesc);
-      _zodDesc.value = undefined;
+      try {
+        Object.defineProperty(inst, "_zod", _zodDesc);
+      } finally {
+        // Must clear even if the define throws, or the shared descriptor would
+        // carry this instance's internals into the next construction.
+        _zodDesc.value = undefined;
+      }
     }
 
     if (inst._zod.traits.has(name)) {

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -66,6 +66,9 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
       for (const fn of deferred) {
         fn();
       }
+      // Initializers run exactly once; holding the list afterwards keeps an
+      // array and its closures alive for the schema's whole lifetime.
+      inst._zod.deferred = undefined;
     }
     return inst;
   }

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -33,8 +33,8 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
       try {
         Object.defineProperty(inst, "_zod", _zodDesc);
       } finally {
-        // Must clear even if the define throws, or the shared descriptor would
-        // carry this instance's internals into the next construction.
+        // Cleared even on throw, so the shared descriptor never leaks one
+        // instance's internals into the next.
         _zodDesc.value = undefined;
       }
     }
@@ -71,8 +71,8 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
       for (const fn of deferred) {
         fn();
       }
-      // Initializers run exactly once; holding the list afterwards keeps an
-      // array and its closures alive for the schema's whole lifetime.
+      // Released: initializers run once, and the list would otherwise be
+      // retained for the schema's lifetime.
       inst._zod.deferred = undefined;
     }
     return inst;

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -14,6 +14,10 @@ export const NEVER: never = /*@__PURE__*/ Object.freeze({
   status: "aborted",
 }) as never;
 
+/* Shared descriptor for installing `_zod`; defineProperty reads it
+ * synchronously, so reusing one object avoids a per-instance allocation. */
+const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
+
 export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T["_zod"]["def"]>(
   name: string,
   initializer: (inst: T, def: D) => void,
@@ -21,14 +25,13 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
 ): $constructor<T, D> {
   function init(inst: T, def: D) {
     if (!inst._zod) {
-      Object.defineProperty(inst, "_zod", {
-        value: {
-          def,
-          constr: _,
-          traits: new Set(),
-        },
-        enumerable: false,
-      });
+      _zodDesc.value = {
+        def,
+        constr: _,
+        traits: new Set(),
+      };
+      Object.defineProperty(inst, "_zod", _zodDesc);
+      _zodDesc.value = undefined;
     }
 
     if (inst._zod.traits.has(name)) {
@@ -58,9 +61,11 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
   function _(this: any, def: D) {
     const inst = params?.Parent ? new Definition() : this;
     init(inst, def);
-    inst._zod.deferred ??= [];
-    for (const fn of inst._zod.deferred) {
-      fn();
+    const deferred = inst._zod.deferred;
+    if (deferred) {
+      for (const fn of deferred) {
+        fn();
+      }
     }
     return inst;
   }

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -39,11 +39,11 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
 
     initializer(inst, def);
 
-    // support prototype modifications
+    // support prototype modifications; for-in avoids the array
+    // allocation of Object.keys on the (usually empty) prototype
     const proto = _.prototype;
-    const keys = Object.keys(proto);
-    for (let i = 0; i < keys.length; i++) {
-      const k = keys[i]!;
+    for (const k in proto) {
+      if (!Object.prototype.hasOwnProperty.call(proto, k)) continue;
       if (!(k in inst)) {
         (inst as any)[k] = proto[k].bind(inst);
       }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -153,9 +153,6 @@ export interface _$ZodTypeInternals {
   /** @internal The set of issues this schema might throw during type checking. */
   isst: errors.$ZodIssueBase;
 
-  /** @internal Extends the lazily created standard-schema object right after construction. */
-  onStandard?: ((inst: $ZodType, standard: $ZodStandardSchema<unknown>) => void) | undefined;
-
   /** @internal Subject to change, not a public API. */
   processJSONSchema?:
     | ((ctx: ToJSONSchemaContext, json: JSONSchema.BaseSchema, params: ProcessParams) => void)
@@ -189,9 +186,6 @@ export interface $ZodType<
 }
 export interface _$ZodType<T extends $ZodTypeInternals = $ZodTypeInternals>
   extends $ZodType<T["output"], T["input"], T> {}
-
-// Prototypes that already carry the lazy "~standard" accessor.
-const _installedStandardProtos = /* @__PURE__ */ new WeakSet<object>();
 
 export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constructor("$ZodType", (inst, def) => {
   inst ??= {} as any;
@@ -311,40 +305,30 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
     };
   }
 
-  // Lazy initialize ~standard via a shared prototype accessor so schema
-  // construction pays neither the object nor a per-instance descriptor;
-  // the built object is cached as an own property on first access.
-  const proto = Object.getPrototypeOf(inst);
-  if (!_installedStandardProtos.has(proto)) {
-    _installedStandardProtos.add(proto);
-    Object.defineProperty(proto, "~standard", {
-      configurable: true,
-      enumerable: false,
-      get(this: $ZodType) {
-        const standard = {
-          validate: (value: unknown) => {
-            try {
-              const r = safeParse(this, value);
-              return r.success ? { value: r.data } : { issues: r.error?.issues };
-            } catch (_) {
-              return safeParseAsync(this, value).then((r) =>
-                r.success ? { value: r.data } : { issues: r.error?.issues }
-              );
-            }
-          },
-          vendor: "zod",
-          version: 1 as const,
-        };
-        this._zod.onStandard?.(this, standard as $ZodStandardSchema<unknown>);
-        Object.defineProperty(this, "~standard", { value: standard, configurable: true });
-        return standard;
-      },
-      set(this: $ZodType, value: unknown) {
-        Object.defineProperty(this, "~standard", { value, configurable: true });
-      },
-    });
-  }
+  // `~standard` lives on the prototype and materializes per instance on first
+  // read, so construction pays neither the object nor a per-instance
+  // descriptor. Wrappers extend it by installing their own richer factory
+  // over this one (see the classic build) rather than reading it eagerly.
+  util.installLazyProps<any>(inst, "$ZodType~standard", standardPropsTable);
 });
+
+const standardPropsTable = () => ({ "~standard": standardProps });
+
+/** The Standard Schema surface for `inst`. Shared so wrappers can extend it without forcing it. */
+export function standardProps(inst: $ZodType): StandardSchemaV1.Props<any, any> {
+  return {
+    validate: (value: unknown) => {
+      try {
+        const r = safeParse(inst, value);
+        return r.success ? { value: r.data } : { issues: r.error?.issues };
+      } catch (_) {
+        return safeParseAsync(inst, value).then((r) => (r.success ? { value: r.data } : { issues: r.error?.issues }));
+      }
+    },
+    vendor: "zod",
+    version: 1 as const,
+  };
+}
 
 export { clone } from "./util.js";
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -190,6 +190,9 @@ export interface $ZodType<
 export interface _$ZodType<T extends $ZodTypeInternals = $ZodTypeInternals>
   extends $ZodType<T["output"], T["input"], T> {}
 
+// Prototypes that already carry the lazy "~standard" accessor.
+const _installedStandardProtos = /* @__PURE__ */ new WeakSet<object>();
+
 export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constructor("$ZodType", (inst, def) => {
   inst ??= {} as any;
 
@@ -197,12 +200,13 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   inst._zod.bag = inst._zod.bag || {}; // initialize _bag object
   inst._zod.version = version;
 
-  const checks = [...(inst._zod.def.checks ?? [])];
-
+  const defChecks = inst._zod.def.checks;
   // if inst is itself a checks.$ZodCheck, run it as a check
-  if (inst._zod.traits.has("$ZodCheck")) {
-    checks.unshift(inst as any);
-  }
+  const checks: checks.$ZodCheck<never>[] = inst._zod.traits.has("$ZodCheck")
+    ? [inst as any, ...(defChecks ?? [])]
+    : defChecks?.length
+      ? [...defChecks]
+      : [];
 
   for (const ch of checks) {
     for (const fn of ch._zod.onattach) {
@@ -307,23 +311,39 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
     };
   }
 
-  // Lazy initialize ~standard to avoid creating objects for every schema
-  util.defineLazy(inst, "~standard", () => {
-    const standard = {
-      validate: (value: unknown) => {
-        try {
-          const r = safeParse(inst, value);
-          return r.success ? { value: r.data } : { issues: r.error?.issues };
-        } catch (_) {
-          return safeParseAsync(inst, value).then((r) => (r.success ? { value: r.data } : { issues: r.error?.issues }));
-        }
+  // Lazy initialize ~standard via a shared prototype accessor so schema
+  // construction pays neither the object nor a per-instance descriptor;
+  // the built object is cached as an own property on first access.
+  const proto = Object.getPrototypeOf(inst);
+  if (!_installedStandardProtos.has(proto)) {
+    _installedStandardProtos.add(proto);
+    Object.defineProperty(proto, "~standard", {
+      configurable: true,
+      enumerable: false,
+      get(this: $ZodType) {
+        const standard = {
+          validate: (value: unknown) => {
+            try {
+              const r = safeParse(this, value);
+              return r.success ? { value: r.data } : { issues: r.error?.issues };
+            } catch (_) {
+              return safeParseAsync(this, value).then((r) =>
+                r.success ? { value: r.data } : { issues: r.error?.issues }
+              );
+            }
+          },
+          vendor: "zod",
+          version: 1 as const,
+        };
+        this._zod.onStandard?.(this, standard as $ZodStandardSchema<unknown>);
+        Object.defineProperty(this, "~standard", { value: standard, configurable: true });
+        return standard;
       },
-      vendor: "zod",
-      version: 1 as const,
-    };
-    inst._zod.onStandard?.(inst, standard as $ZodStandardSchema<unknown>);
-    return standard;
-  });
+      set(this: $ZodType, value: unknown) {
+        Object.defineProperty(this, "~standard", { value, configurable: true });
+      },
+    });
+  }
 });
 
 export { clone } from "./util.js";

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -309,29 +309,10 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   // read, so construction pays neither the object nor a per-instance
   // descriptor. Wrappers extend it by installing their own richer factory
   // over this one (see the classic build) rather than reading it eagerly.
-  //
-  // Written out here rather than routed through `util.installLazyProps` so
-  // that zod/mini — whose only use of this machinery is `~standard` — does not
-  // pull the generic installers into its bundle.
-  const proto = Object.getPrototypeOf(inst);
-  if (!installedStandardProtos.has(proto)) {
-    installedStandardProtos.add(proto);
-    Object.defineProperty(proto, "~standard", {
-      configurable: true,
-      enumerable: false,
-      get(this: $ZodType) {
-        const standard = standardProps(this);
-        Object.defineProperty(this, "~standard", { value: standard, writable: true, configurable: true });
-        return standard;
-      },
-      set(this: $ZodType, value: unknown) {
-        Object.defineProperty(this, "~standard", { value, writable: true, configurable: true });
-      },
-    });
-  }
+  util.installLazyProps<any>(inst, "$ZodType~standard", standardPropsTable);
 });
 
-const installedStandardProtos = /* @__PURE__ */ new WeakSet<object>();
+const standardPropsTable = () => ({ "~standard": standardProps });
 
 /** The Standard Schema surface for `inst`. Shared so wrappers can extend it without forcing it. */
 export function standardProps(inst: $ZodType): StandardSchemaV1.Props<any, any> {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -309,20 +309,20 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   // read, so construction pays neither the object nor a per-instance
   // descriptor. Wrappers extend it by installing their own richer factory
   // over this one (see the classic build) rather than reading it eagerly.
-  util.installLazyProps<any>(inst, "$ZodType~standard", standardPropsTable);
+  util.installLazyProp(inst, "~standard", standardProps);
 });
 
-const standardPropsTable = () => ({ "~standard": standardProps });
-
 /** The Standard Schema surface for `inst`. Shared so wrappers can extend it without forcing it. */
+const toStandardResult = (r: util.SafeParseResult<unknown>) =>
+  r.success ? { value: r.data } : { issues: r.error?.issues };
+
 export function standardProps(inst: $ZodType): StandardSchemaV1.Props<any, any> {
   return {
     validate: (value: unknown) => {
       try {
-        const r = safeParse(inst, value);
-        return r.success ? { value: r.data } : { issues: r.error?.issues };
+        return toStandardResult(safeParse(inst, value));
       } catch (_) {
-        return safeParseAsync(inst, value).then((r) => (r.success ? { value: r.data } : { issues: r.error?.issues }));
+        return safeParseAsync(inst, value).then(toStandardResult);
       }
     },
     vendor: "zod",

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -153,6 +153,9 @@ export interface _$ZodTypeInternals {
   /** @internal The set of issues this schema might throw during type checking. */
   isst: errors.$ZodIssueBase;
 
+  /** @internal Extends the lazily created standard-schema object right after construction. */
+  onStandard?: ((inst: $ZodType, standard: $ZodStandardSchema<unknown>) => void) | undefined;
+
   /** @internal Subject to change, not a public API. */
   processJSONSchema?:
     | ((ctx: ToJSONSchemaContext, json: JSONSchema.BaseSchema, params: ProcessParams) => void)
@@ -305,18 +308,22 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   }
 
   // Lazy initialize ~standard to avoid creating objects for every schema
-  util.defineLazy(inst, "~standard", () => ({
-    validate: (value: unknown) => {
-      try {
-        const r = safeParse(inst, value);
-        return r.success ? { value: r.data } : { issues: r.error?.issues };
-      } catch (_) {
-        return safeParseAsync(inst, value).then((r) => (r.success ? { value: r.data } : { issues: r.error?.issues }));
-      }
-    },
-    vendor: "zod",
-    version: 1 as const,
-  }));
+  util.defineLazy(inst, "~standard", () => {
+    const standard = {
+      validate: (value: unknown) => {
+        try {
+          const r = safeParse(inst, value);
+          return r.success ? { value: r.data } : { issues: r.error?.issues };
+        } catch (_) {
+          return safeParseAsync(inst, value).then((r) => (r.success ? { value: r.data } : { issues: r.error?.issues }));
+        }
+      },
+      vendor: "zod",
+      version: 1 as const,
+    };
+    inst._zod.onStandard?.(inst, standard as $ZodStandardSchema<unknown>);
+    return standard;
+  });
 });
 
 export { clone } from "./util.js";

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -309,10 +309,29 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   // read, so construction pays neither the object nor a per-instance
   // descriptor. Wrappers extend it by installing their own richer factory
   // over this one (see the classic build) rather than reading it eagerly.
-  util.installLazyProps<any>(inst, "$ZodType~standard", standardPropsTable);
+  //
+  // Written out here rather than routed through `util.installLazyProps` so
+  // that zod/mini — whose only use of this machinery is `~standard` — does not
+  // pull the generic installers into its bundle.
+  const proto = Object.getPrototypeOf(inst);
+  if (!installedStandardProtos.has(proto)) {
+    installedStandardProtos.add(proto);
+    Object.defineProperty(proto, "~standard", {
+      configurable: true,
+      enumerable: false,
+      get(this: $ZodType) {
+        const standard = standardProps(this);
+        Object.defineProperty(this, "~standard", { value: standard, writable: true, configurable: true });
+        return standard;
+      },
+      set(this: $ZodType, value: unknown) {
+        Object.defineProperty(this, "~standard", { value, writable: true, configurable: true });
+      },
+    });
+  }
 });
 
-const standardPropsTable = () => ({ "~standard": standardProps });
+const installedStandardProtos = /* @__PURE__ */ new WeakSet<object>();
 
 /** The Standard Schema surface for `inst`. Shared so wrappers can extend it without forcing it. */
 export function standardProps(inst: $ZodType): StandardSchemaV1.Props<any, any> {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4435,7 +4435,10 @@ export const $ZodFunction: core.$constructor<$ZodFunction> = /*@__PURE__*/ core.
   "$ZodFunction",
   (inst, def) => {
     $ZodType.init(inst, def);
-    inst._def = def;
+    // Own, non-writable — matching what the classic build used to install on
+    // every instance. Defined rather than assigned because the classic
+    // prototype now exposes `_def` as a getter with no setter.
+    Object.defineProperty(inst, "_def", { value: def });
     inst._zod.def = def;
 
     inst.implement = (func) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -305,10 +305,8 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
     };
   }
 
-  // `~standard` lives on the prototype and materializes per instance on first
-  // read, so construction pays neither the object nor a per-instance
-  // descriptor. Wrappers extend it by installing their own richer factory
-  // over this one (see the classic build) rather than reading it eagerly.
+  // Wrappers extend this by installing a richer factory over it; reading it
+  // eagerly would defeat the laziness.
   util.installLazyProp(inst, "~standard", standardProps);
 });
 
@@ -4435,9 +4433,8 @@ export const $ZodFunction: core.$constructor<$ZodFunction> = /*@__PURE__*/ core.
   "$ZodFunction",
   (inst, def) => {
     $ZodType.init(inst, def);
-    // Own, non-writable — matching what the classic build used to install on
-    // every instance. Defined rather than assigned because the classic
-    // prototype now exposes `_def` as a getter with no setter.
+    // Defined, not assigned: the classic prototype exposes `_def` as a
+    // getter with no setter.
     Object.defineProperty(inst, "_def", { value: def });
     inst._zod.def = def;
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1001,19 +1001,20 @@ function claim(inst: object, sentinel: string): object | undefined {
 }
 
 function defineCached(proto: object, key: string, compute: (self: any) => unknown): void {
+  // Every relocated member except `~standard` used to be an enumerable own
+  // property, so its cache stays enumerable and `Object.keys` still reports it
+  // once touched. `~standard` was never an own data property — the old
+  // `defineLazy` cached into a closure — so caching it enumerably would newly
+  // add it to `Object.keys` and `JSON.stringify` of a schema.
+  const enumerable = key !== "~standard";
   Object.defineProperty(proto, key, {
     configurable: true,
     get(this: any) {
       const value = compute(this);
-      // The cache is an implementation detail, so it is written NON-enumerable:
-      // reading a member must not change `Object.keys`/`JSON.stringify` of the
-      // schema. Otherwise a schema's serialized shape would depend on which
-      // members happened to have been touched.
-      Object.defineProperty(this, key, { configurable: true, writable: true, value });
+      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable, value });
       return value;
     },
     set(this: any, value: unknown) {
-      // An explicit assignment behaves like one, i.e. enumerable, as before.
       Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
     },
   });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -984,42 +984,22 @@ export abstract class Class {
 
 //////////    PROTOTYPE INSTALLERS     //////////
 //
-// Own-property count is the dominant per-instance cost of a schema. V8 sizes
-// the property backing store in steps, and `$constructor` assigns nothing
-// itself, so instances get no in-object slots: 12 own properties cost 128
-// bytes, 13 cost 848, 21 cost 1616. Keeping methods on the prototype and
-// materializing them per instance only when touched keeps instances under the
-// first step.
-//
-// Each install runs once per prototype, so a prototype must not be modified
-// after the first instance of its type is built — later changes are never
-// picked up.
-//
-// The guard is a sentinel key the table itself owns: if the prototype already
-// has it, this table is installed. It must be checked BEFORE building the
-// table, since building it allocates every method in the group. A
-// WeakMap-of-key-sets is ~3% faster for classic construction but costs bundle
-// size everywhere and is slower for mini, so the sentinel wins on balance.
-//
-// Changing anything here means re-measuring runtime, memory AND bundle size —
-// they trade against each other and several plausible simplifications here
-// have measured worse. See "The three axes" in AGENTS.md, and run
-// `packages/bench/memory/{prop-slack,dict-mode}.ts`.
+// Members live on the prototype and materialize per instance on first read,
+// which keeps own-property count under the step where V8 stops using inline
+// slots. Changing anything here means re-measuring runtime, memory and bundle
+// size together — see "The three axes" in AGENTS.md.
+
+/** Returns the prototype to install on, or `undefined` if this group is already installed on it. */
 function claim(inst: object, sentinel: string): object | undefined {
   const proto = Object.getPrototypeOf(inst);
-  // `in` rather than `hasOwnProperty.call`: this runs once per install group on
-  // EVERY construction, and the builtin call is measurably more expensive than
-  // the operator. Safe because every sentinel is a key the group itself defines
-  // and none collide with anything on `Object.prototype`.
+  // Runs on every construction, so `in` rather than the costlier
+  // `hasOwnProperty.call`. Sentinels are keys the group itself defines.
   return sentinel in proto ? undefined : proto;
 }
 
 function defineCached(proto: object, key: string, compute: (self: any) => unknown): void {
-  // Every relocated member except `~standard` used to be an enumerable own
-  // property, so its cache stays enumerable and `Object.keys` still reports it
-  // once touched. `~standard` was never an own data property — the old
-  // `defineLazy` cached into a closure — so caching it enumerably would newly
-  // add it to `Object.keys` and `JSON.stringify` of a schema.
+  // `~standard` was never an own data property, so caching it must not add it
+  // to `Object.keys`. Everything else here was enumerable and stays so.
   const enumerable = key !== "~standard";
   Object.defineProperty(proto, key, {
     configurable: true,
@@ -1034,10 +1014,7 @@ function defineCached(proto: object, key: string, compute: (self: any) => unknow
   });
 }
 
-/**
- * Methods of `T` reshaped so each body has `this: T` and matches the declared
- * (args, return) of the corresponding interface method.
- */
+/** Methods of `T` reshaped so each body has `this: T`. */
 export type LazyMethodsOf<T> = Partial<{
   [K in keyof T]: T[K] extends (...args: infer A) => infer R ? (this: T, ...args: A) => R : never;
 }>;
@@ -1046,12 +1023,9 @@ export type LazyMethodsOf<T> = Partial<{
 export type LazyPropsOf<T> = Partial<{ [K in keyof T]: (self: T) => T[K] }>;
 
 /**
- * Installs methods as lazy-bind getters: on first access an instance gets
- * `fn.bind(this)` cached as an own property, so detached use (`const m =
- * schema.optional; m()`) still works.
- *
- * Not for hot-path functions — a bound function pays a call-time trampoline.
- * Use `installLazyProps` there and build the closure directly.
+ * Installs methods that bind to the instance on first access. Not for hot-path
+ * functions — a bound function pays a call-time trampoline; use
+ * `installLazyProps` there.
  */
 export function installLazyMethods<T extends object>(inst: T, sentinel: string, methods: () => LazyMethodsOf<T>): void {
   const proto = claim(inst, sentinel);
@@ -1073,10 +1047,7 @@ export function installLazyProps<T extends object>(inst: T, sentinel: string, pr
   }
 }
 
-/**
- * Single-property variant. The key doubles as the sentinel, so installing one
- * lazy member costs no table and no loop.
- */
+/** Single-property variant; the key doubles as the sentinel. */
 export function installLazyProp(inst: object, key: string, make: (self: any) => unknown): void {
   const proto = claim(inst, key);
   if (proto) defineCached(proto, key, make);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -991,10 +991,20 @@ export abstract class Class {
 // materializing them per instance only when touched keeps instances under the
 // first step.
 //
-// Each install runs once per prototype. The guard is a sentinel key that the
-// table itself owns: if the prototype already has it, this table is installed.
-// That is cheaper than a WeakMap of key-sets, and it has to be checked BEFORE
-// building the table, since building it allocates every method in the group.
+// Each install runs once per prototype, so a prototype must not be modified
+// after the first instance of its type is built — later changes are never
+// picked up.
+//
+// The guard is a sentinel key the table itself owns: if the prototype already
+// has it, this table is installed. It must be checked BEFORE building the
+// table, since building it allocates every method in the group. A
+// WeakMap-of-key-sets is ~3% faster for classic construction but costs bundle
+// size everywhere and is slower for mini, so the sentinel wins on balance.
+//
+// Changing anything here means re-measuring runtime, memory AND bundle size —
+// they trade against each other and several plausible simplifications here
+// have measured worse. See "The three axes" in AGENTS.md, and run
+// `packages/bench/memory/{prop-slack,dict-mode}.ts`.
 function claim(inst: object, sentinel: string): object | undefined {
   const proto = Object.getPrototypeOf(inst);
   // `in` rather than `hasOwnProperty.call`: this runs once per install group on

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1005,12 +1005,15 @@ function defineCached(proto: object, key: string, compute: (self: any) => unknow
     configurable: true,
     get(this: any) {
       const value = compute(this);
-      // Routes through the setter below, so the own-property descriptor is
-      // written in one place rather than duplicated here.
-      this[key] = value;
+      // The cache is an implementation detail, so it is written NON-enumerable:
+      // reading a member must not change `Object.keys`/`JSON.stringify` of the
+      // schema. Otherwise a schema's serialized shape would depend on which
+      // members happened to have been touched.
+      Object.defineProperty(this, key, { configurable: true, writable: true, value });
       return value;
     },
     set(this: any, value: unknown) {
+      // An explicit assignment behaves like one, i.e. enumerable, as before.
       Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
     },
   });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -997,7 +997,11 @@ export abstract class Class {
 // building the table, since building it allocates every method in the group.
 function claim(inst: object, sentinel: string): object | undefined {
   const proto = Object.getPrototypeOf(inst);
-  return Object.prototype.hasOwnProperty.call(proto, sentinel) ? undefined : proto;
+  // `in` rather than `hasOwnProperty.call`: this runs once per install group on
+  // EVERY construction, and the builtin call is measurably more expensive than
+  // the operator. Safe because every sentinel is a key the group itself defines
+  // and none collide with anything on `Object.prototype`.
+  return sentinel in proto ? undefined : proto;
 }
 
 function defineCached(proto: object, key: string, compute: (self: any) => unknown): void {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -981,3 +981,95 @@ export function uint8ArrayToHex(bytes: Uint8Array): string {
 export abstract class Class {
   constructor(..._args: any[]) {}
 }
+
+//////////    PROTOTYPE INSTALLERS     //////////
+//
+// Own-property count is the dominant per-instance cost of a schema. V8 sizes
+// the property backing store in steps, and `$constructor` assigns nothing
+// itself, so instances get no in-object slots: 12 own properties cost 128
+// bytes, 13 cost 848, 21 cost 1616. Keeping methods on the prototype and
+// materializing them per instance only when touched keeps instances under the
+// first step.
+//
+// Each installer runs once per (prototype, group), memoized here.
+const installedGroups = /* @__PURE__ */ new WeakMap<object, Set<string>>();
+
+function claimGroup(inst: object, group: string): object | undefined {
+  const proto = Object.getPrototypeOf(inst);
+  let installed = installedGroups.get(proto);
+  if (!installed) {
+    installed = new Set();
+    installedGroups.set(proto, installed);
+  }
+  if (installed.has(group)) return undefined;
+  installed.add(group);
+  return proto;
+}
+
+function defineCached(proto: object, key: string, compute: (self: any) => unknown): void {
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    enumerable: false,
+    get(this: any) {
+      const value = compute(this);
+      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
+      return value;
+    },
+    set(this: any, v: unknown) {
+      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value: v });
+    },
+  });
+}
+
+/**
+ * Methods of `T` reshaped so each body has `this: T` and matches the declared
+ * (args, return) of the corresponding interface method.
+ */
+export type LazyMethodsOf<T> = Partial<{
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R ? (this: T, ...args: A) => R : never;
+}>;
+
+/** Factories for properties whose value is built per instance on first read. */
+export type LazyPropsOf<T> = Partial<{ [K in keyof T]: (self: T) => T[K] }>;
+
+/**
+ * Installs methods as lazy-bind getters: on first access an instance gets
+ * `fn.bind(this)` cached as an own property, so detached use (`const m =
+ * schema.optional; m()`) still works.
+ *
+ * Not for hot-path functions — a bound function pays a call-time trampoline.
+ * Use `installLazyProps` there and build the closure directly.
+ */
+export function installLazyMethods<T extends object>(inst: T, group: string, methods: () => LazyMethodsOf<T>): void {
+  const proto = claimGroup(inst, group);
+  if (!proto) return;
+  const built = methods();
+  for (const key in built) {
+    const fn = built[key]!;
+    defineCached(proto, key, (self) => (fn as AnyFunc).bind(self));
+  }
+}
+
+/** Like `installLazyMethods`, but the factory builds the value instead of binding a shared function. */
+export function installLazyProps<T extends object>(inst: T, group: string, props: () => LazyPropsOf<T>): void {
+  const proto = claimGroup(inst, group);
+  if (!proto) return;
+  const built = props();
+  for (const key in built) {
+    defineCached(proto, key, built[key] as AnyFunc);
+  }
+}
+
+/** Installs plain (non-caching) prototype accessors, for values that must be recomputed on every read. */
+export function installProtoAccessors<T extends object>(
+  inst: T,
+  group: string,
+  accessors: () => Record<string, (this: T) => unknown>
+): void {
+  const proto = claimGroup(inst, group);
+  if (!proto) return;
+  const built = accessors();
+  for (const key in built) {
+    Object.defineProperty(proto, key, { configurable: true, enumerable: false, get: built[key]! });
+  }
+}

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -991,32 +991,27 @@ export abstract class Class {
 // materializing them per instance only when touched keeps instances under the
 // first step.
 //
-// Each installer runs once per (prototype, group), memoized here.
-const installedGroups = /* @__PURE__ */ new WeakMap<object, Set<string>>();
-
-function claimGroup(inst: object, group: string): object | undefined {
+// Each install runs once per prototype. The guard is a sentinel key that the
+// table itself owns: if the prototype already has it, this table is installed.
+// That is cheaper than a WeakMap of key-sets, and it has to be checked BEFORE
+// building the table, since building it allocates every method in the group.
+function claim(inst: object, sentinel: string): object | undefined {
   const proto = Object.getPrototypeOf(inst);
-  let installed = installedGroups.get(proto);
-  if (!installed) {
-    installed = new Set();
-    installedGroups.set(proto, installed);
-  }
-  if (installed.has(group)) return undefined;
-  installed.add(group);
-  return proto;
+  return Object.prototype.hasOwnProperty.call(proto, sentinel) ? undefined : proto;
 }
 
 function defineCached(proto: object, key: string, compute: (self: any) => unknown): void {
   Object.defineProperty(proto, key, {
     configurable: true,
-    enumerable: false,
     get(this: any) {
       const value = compute(this);
-      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
+      // Routes through the setter below, so the own-property descriptor is
+      // written in one place rather than duplicated here.
+      this[key] = value;
       return value;
     },
-    set(this: any, v: unknown) {
-      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value: v });
+    set(this: any, value: unknown) {
+      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
     },
   });
 }
@@ -1040,8 +1035,8 @@ export type LazyPropsOf<T> = Partial<{ [K in keyof T]: (self: T) => T[K] }>;
  * Not for hot-path functions — a bound function pays a call-time trampoline.
  * Use `installLazyProps` there and build the closure directly.
  */
-export function installLazyMethods<T extends object>(inst: T, group: string, methods: () => LazyMethodsOf<T>): void {
-  const proto = claimGroup(inst, group);
+export function installLazyMethods<T extends object>(inst: T, sentinel: string, methods: () => LazyMethodsOf<T>): void {
+  const proto = claim(inst, sentinel);
   if (!proto) return;
   const built = methods();
   for (const key in built) {
@@ -1051,8 +1046,8 @@ export function installLazyMethods<T extends object>(inst: T, group: string, met
 }
 
 /** Like `installLazyMethods`, but the factory builds the value instead of binding a shared function. */
-export function installLazyProps<T extends object>(inst: T, group: string, props: () => LazyPropsOf<T>): void {
-  const proto = claimGroup(inst, group);
+export function installLazyProps<T extends object>(inst: T, sentinel: string, props: () => LazyPropsOf<T>): void {
+  const proto = claim(inst, sentinel);
   if (!proto) return;
   const built = props();
   for (const key in built) {
@@ -1060,16 +1055,11 @@ export function installLazyProps<T extends object>(inst: T, group: string, props
   }
 }
 
-/** Installs plain (non-caching) prototype accessors, for values that must be recomputed on every read. */
-export function installProtoAccessors<T extends object>(
-  inst: T,
-  group: string,
-  accessors: () => Record<string, (this: T) => unknown>
-): void {
-  const proto = claimGroup(inst, group);
-  if (!proto) return;
-  const built = accessors();
-  for (const key in built) {
-    Object.defineProperty(proto, key, { configurable: true, enumerable: false, get: built[key]! });
-  }
+/**
+ * Single-property variant. The key doubles as the sentinel, so installing one
+ * lazy member costs no table and no loop.
+ */
+export function installLazyProp(inst: object, key: string, make: (self: any) => unknown): void {
+  const proto = claim(inst, key);
+  if (proto) defineCached(proto, key, make);
 }

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -55,7 +55,7 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
     // — allocates none of them. Keeps instances at 3 own properties instead
     // of 14, which is the difference between one and two steps of V8's
     // property backing store.
-    util.installLazyMethods<ZodMiniType>(inst, "ZodMiniType", _zodMiniTypeMethods);
+    util.installLazyMethods<ZodMiniType>(inst, "parse", _zodMiniTypeMethods);
   }
 );
 

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -50,14 +50,8 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
     inst.def = def;
     inst.type = def.type;
 
-    // Installed on the prototype and built per instance on first read, so an
-    // interior node of a schema graph — one nothing parses through or clones
-    // — allocates none of them. Keeps instances at 3 own properties instead
-    // of 14, which is the difference between one and two steps of V8's
-    // property backing store.
     util.installLazyMethods<ZodMiniType>(inst, "parse", _zodMiniTypeMethods);
-    // `with` was an alias for `check` — the same function object, not a
-    // delegating wrapper — so it is installed as a prop that resolves to it.
+    // `with` is an alias for `check`: the same function object, not a wrapper.
     util.installLazyProp(inst, "with", (self: ZodMiniType) => self.check);
   }
 );

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -49,38 +49,63 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
 
     inst.def = def;
     inst.type = def.type;
-    inst.parse = (data, params) => parse.parse(inst, data, params, { callee: inst.parse });
-    inst.safeParse = (data, params) => parse.safeParse(inst, data, params);
-    inst.parseAsync = async (data, params) => parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
-    inst.safeParseAsync = async (data, params) => parse.safeParseAsync(inst, data, params);
-    inst.check = (...checks) => {
-      return inst.clone(
+
+    // Installed on the prototype and built per instance on first read, so an
+    // interior node of a schema graph — one nothing parses through or clones
+    // — allocates none of them. Keeps instances at 3 own properties instead
+    // of 14, which is the difference between one and two steps of V8's
+    // property backing store.
+    util.installLazyMethods<ZodMiniType>(inst, "ZodMiniType", _zodMiniTypeMethods);
+  }
+);
+
+function _zodMiniTypeMethods(): util.LazyMethodsOf<ZodMiniType> {
+  return {
+    parse(data, params) {
+      return parse.parse(this, data, params, { callee: this.parse });
+    },
+    parseAsync(data, params) {
+      return parse.parseAsync(this, data, params, { callee: this.parseAsync });
+    },
+    safeParse(data, params) {
+      return parse.safeParse(this, data, params);
+    },
+    safeParseAsync(data, params) {
+      return parse.safeParseAsync(this, data, params);
+    },
+    check(...checks) {
+      const def = this.def;
+      return this.clone(
         {
           ...def,
           checks: [
             ...(def.checks ?? []),
             ...checks.map((ch) =>
-              typeof ch === "function"
-                ? {
-                    _zod: { check: ch, def: { check: "custom" }, onattach: [] },
-                  }
-                : ch
+              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
             ),
           ],
         },
         { parent: true }
       );
-    };
-    inst.with = inst.check;
-    inst.clone = (_def, params) => core.clone(inst, _def, params);
-    inst.brand = () => inst as any;
-    inst.register = ((reg: any, meta: any) => {
-      reg.add(inst, meta);
-      return inst;
-    }) as any;
-    inst.apply = (fn) => fn(inst);
-  }
-);
+    },
+    with(...checks) {
+      return this.check(...checks);
+    },
+    clone(_def, params) {
+      return core.clone(this, _def, params);
+    },
+    brand() {
+      return this as any;
+    },
+    register(reg: any, meta: any) {
+      reg.add(this, meta);
+      return this;
+    },
+    apply(fn) {
+      return fn(this);
+    },
+  };
+}
 
 export interface _ZodMiniString<T extends core.$ZodStringInternals<unknown> = core.$ZodStringInternals<unknown>>
   extends _ZodMiniType<T>,

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -49,63 +49,38 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
 
     inst.def = def;
     inst.type = def.type;
-
-    // Installed on the prototype and built per instance on first read, so an
-    // interior node of a schema graph — one nothing parses through or clones
-    // — allocates none of them. Keeps instances at 3 own properties instead
-    // of 14, which is the difference between one and two steps of V8's
-    // property backing store.
-    util.installLazyMethods<ZodMiniType>(inst, "ZodMiniType", _zodMiniTypeMethods);
-  }
-);
-
-function _zodMiniTypeMethods(): util.LazyMethodsOf<ZodMiniType> {
-  return {
-    parse(data, params) {
-      return parse.parse(this, data, params, { callee: this.parse });
-    },
-    parseAsync(data, params) {
-      return parse.parseAsync(this, data, params, { callee: this.parseAsync });
-    },
-    safeParse(data, params) {
-      return parse.safeParse(this, data, params);
-    },
-    safeParseAsync(data, params) {
-      return parse.safeParseAsync(this, data, params);
-    },
-    check(...checks) {
-      const def = this.def;
-      return this.clone(
+    inst.parse = (data, params) => parse.parse(inst, data, params, { callee: inst.parse });
+    inst.safeParse = (data, params) => parse.safeParse(inst, data, params);
+    inst.parseAsync = async (data, params) => parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
+    inst.safeParseAsync = async (data, params) => parse.safeParseAsync(inst, data, params);
+    inst.check = (...checks) => {
+      return inst.clone(
         {
           ...def,
           checks: [
             ...(def.checks ?? []),
             ...checks.map((ch) =>
-              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+              typeof ch === "function"
+                ? {
+                    _zod: { check: ch, def: { check: "custom" }, onattach: [] },
+                  }
+                : ch
             ),
           ],
         },
         { parent: true }
       );
-    },
-    with(...checks) {
-      return this.check(...checks);
-    },
-    clone(_def, params) {
-      return core.clone(this, _def, params);
-    },
-    brand() {
-      return this as any;
-    },
-    register(reg: any, meta: any) {
-      reg.add(this, meta);
-      return this;
-    },
-    apply(fn) {
-      return fn(this);
-    },
-  };
-}
+    };
+    inst.with = inst.check;
+    inst.clone = (_def, params) => core.clone(inst, _def, params);
+    inst.brand = () => inst as any;
+    inst.register = ((reg: any, meta: any) => {
+      reg.add(inst, meta);
+      return inst;
+    }) as any;
+    inst.apply = (fn) => fn(inst);
+  }
+);
 
 export interface _ZodMiniString<T extends core.$ZodStringInternals<unknown> = core.$ZodStringInternals<unknown>>
   extends _ZodMiniType<T>,

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -56,6 +56,9 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
     // of 14, which is the difference between one and two steps of V8's
     // property backing store.
     util.installLazyMethods<ZodMiniType>(inst, "parse", _zodMiniTypeMethods);
+    // `with` was an alias for `check` — the same function object, not a
+    // delegating wrapper — so it is installed as a prop that resolves to it.
+    util.installLazyProp(inst, "with", (self: ZodMiniType) => self.check);
   }
 );
 
@@ -87,9 +90,6 @@ function _zodMiniTypeMethods(): util.LazyMethodsOf<ZodMiniType> {
         },
         { parent: true }
       );
-    },
-    with(...checks) {
-      return this.check(...checks);
     },
     clone(_def, params) {
       return core.clone(this, _def, params);


### PR DESCRIPTION
> **Context: performance optimization campaign.** This is one of four PRs extracted from a systematic performance campaign on the v4 core, run as an automated research loop: 18 isolated experiments, 11 kept, 7 discarded. Every candidate change was
>
> - benchmarked with an A/B harness that loads **two git revisions of `packages/zod/src` into one process** and times 11 workloads in alternation, taking the minimum of 25 rep-scaled iterations. Module instances carry a stable load-order JIT bias of several percent, so the harness runs both load orders in separate child processes and combines them with a geometric mean;
> - measured on **11 deterministic workloads mirroring `packages/bench`** (simple object, the moltar `strictObject`, string/number leaf parses, union, discriminated union, failing `safeParse`, string formats, transform/pipe chain, schema construction). The repo's own benches compare zod against *other libraries* inside a single checkout and cannot load two zod revisions into one process, so using them for A/B would mean comparing two standalone runs — and run-to-run drift is larger than most effect sizes here. The mirrored cases use seeded PRNG data, so both revisions parse byte-identical inputs and the same workloads feed the characterisation guard below. The untouched `packages/bench` suite served as an external cross-check;
> - gated by a **calibrated noise floor** (~1.2% on the suite total, measured with identical code on both sides): changes under 2.5% total, or under 5% on a targeted case, were discarded, and every keep required a second confirming run;
> - verified behaviour-preserving by a **characterisation guard** (hashed parse outputs and error issues over all benchmark inputs) plus the full test suite (3811 tests + typecheck), both green after every commit. Discarded experiments — including several that looked plausible but regressed hot paths — are logged in the campaign notes.
>
> The numbers below are fresh verification runs of **this branch in isolation against `main`** (two independent runs each; an identical-source control run measured +0.56% total, i.e. pure noise). Negative = faster.

## What this PR does

Cuts schema construction cost roughly in half, and — unexpectedly but reproducibly — speeds up *parse* hot paths as well, by keeping schema instances in V8's fast-properties representation. Four commits:

**1. Lazy-bind codec methods; drop `Object.keys` in init.** Eight of the thirteen eager per-instance closures in the `ZodType` initializer were the codec family (`encode`, `decode`, `safeEncode`, ...) — far off the hot path. They join the lazy-bind prototype groups from #5897. (The five parse-family closures stay eager: converting them was tried and regressed hot paths 11-38%, empirically confirming the existing code comment.) Separately, `$constructor.init`'s prototype-modification loop ran `Object.keys(proto)` per instance per trait level on almost-always-empty prototypes; a `for...in` + `hasOwnProperty` loop visits the identical key set with zero allocation.

**2. Defer standard-schema and JSON Schema method creation.** The core initializer creates `"~standard"` lazily on purpose ("avoid creating objects for every schema") — but the classic `ZodType` initializer immediately forced it via `Object.assign(inst["~standard"], { jsonSchema: ... })`, allocating the standard object, its `validate` closure, and two JSON Schema method closures for every schema ever constructed. Core now exposes an `@internal` `_zod.onStandard` hook that classic uses to attach the `jsonSchema` methods when `"~standard"` is first accessed. `description` and `_def` — pure functions of `this` — move from per-instance descriptors to shared prototype getters (`_def` keeps a setter because core `$ZodFunction` assigns it).

**3. `"~standard"` as a shared prototype accessor.** The per-instance `defineLazy` accessor for `"~standard"` was the last *accessor* among instance own properties. Moving it to a one-time prototype getter (caching as an own non-enumerable data property on first access, same semantics as `defineLazy`) keeps instances in fast-properties mode — which is why this commit alone measured -58% on array parsing and double digits on other parse paths that never touch `"~standard"` at all. `defineProperty` calls per `strictObject` tree of 13 schemas drop from 77 to 25.

**4. Lazy-bind the 26 `ZodString` format methods.** `z.string()` allocated 26 eager closures (`.email()`, `.uuid()`, `.ipv4()`, `.datetime()`, ...) per instance — the only method group in the file still eager after #5897. Converted to the same lazy-bind group as everything else. (`ZodBigInt`/`ZodDate`/`ZodSet`/`ZodMap` have the same pattern and could get the same treatment in a follow-up.)

## Verification (this branch vs `main`)

| case | run 1 | run 2 | speed-up vs `main` |
|---|---|---|---|
| schema-init (construction) | **-47.7%** | **-47.7%** | **1.91x** |
| array-parse | **-58.4%** | **-57.9%** | **2.39x** |
| strict-moltar parse | **-22.7%** | **-22.6%** | **1.29x** |
| string-parse | -16.0% | -17.0% | 1.20x |
| number-parse | -15.3% | -17.7% | 1.20x |
| chain-parse | -14.7% | -15.6% | 1.18x |
| **suite TOTAL** | **-13.5%** | **-13.4%** | **1.16x** |

Cross-check on the repo's own `packages/bench/object-moltar.ts`: the bench runs the npm build of zod **4.0.8** (its `zod4` alias) in the same process as the workspace code, so the workspace-vs-npm ratio is paired within a single run and robust to machine drift. That ratio moves from 0.96x on `main` to **1.39x on this branch** — a ~1.4x relative shift, in line with the paired moltar measurement above (1.29x) given single-run bench variance. Read the *shift*, not the absolute multiplier: the absolute number also bakes in the version gap (npm 4.0.8 vs current source) and the build-format gap (compiled npm JS vs TypeScript source loaded through tsx), neither of which has anything to do with this PR.

## Observable surface

- `"~standard"`, `description`, `_def`, and the codec/format methods are inherited until first touched; after first access they cache as own properties with the same enumerability as before. `Object.keys` / `JSON.stringify` / spread behaviour of schemas is unchanged (all moved properties were non-enumerable or are methods).
- `_zod.onStandard` is a new `@internal` field on the internals interface.
- Assigning `schema._def = x` still works via the accessor's setter (used by core `$ZodFunction`).

The fast-properties effect is the key finding here: during the campaign, the *inverse* experiments (adding accessors to instances or to `_zod`) regressed object parsing by +57% to +142%, which is what pinned the mechanism.

## Reproducing the numbers

The harness below is the one used for the verification runs (one difference: each side is unpacked into its own directory, so `main main` works as a noise-control run). From a checkout of this repo:

1. `pnpm install`
2. Save the two files below as `perf/ab.mts` and `perf/cases.mts` (the directory must live **inside** the repo so the unpacked trees resolve `node_modules`; `perf/.trees/` is created automatically and safe to delete).
3. Noise control (identical source on both sides). Discard the very first run — it materialises the trees and runs with cold caches. Repeat runs should land within roughly ±2% on TOTAL; that is this machine-state's noise band and the yardstick for step 4:

   ```sh
   pnpm tsx perf/ab.mts main main
   ```

4. Measure this PR — fetch its head ref, then compare it against `main`:

   ```sh
   git fetch origin pull/6318/head:pr-6318
   pnpm tsx perf/ab.mts main pr-6318
   ```

One run takes ~5s: 11 deterministic workloads, both load orders in separate child processes, minimum of 25 rep-scaled iterations per case, geometric mean across orders. Negative delta = second revision is faster. Run each comparison at least twice and judge repeated results against your control band from step 3, never a single run. The `schema-init` case is the noisiest (GC-bound); the parse cases are much tighter.

<details>
<summary><code>perf/ab.mts</code> — A/B revision benchmark</summary>

```ts
/**
 * A/B benchmark of two git revisions of packages/zod/src.
 *
 *   pnpm tsx perf/ab.mts [revA] [revB]
 *
 * revA defaults to HEAD, revB defaults to WORKTREE (the working tree).
 * Revisions are materialised with `git archive` into perf/.trees/.
 *
 * Both variants are imported into one process and timed in alternation,
 * taking the minimum per case. Module instances carry a stable
 * positional (load-order) bias of several percent, so the parent runs
 * the measurement twice as child processes, once per load order, and
 * combines the two ratios with a geometric mean to cancel the bias.
 * Negative delta = B faster than A.
 */
import { execSync, spawnSync } from "node:child_process";
import * as fs from "node:fs";
import * as path from "node:path";
import { fileURLToPath, pathToFileURL } from "node:url";
import { type PerfCase, buildCases } from "./cases.mts";

const ROOT = path.join(import.meta.dirname, "..");
const TREES = path.join(import.meta.dirname, ".trees");

const WARMUP = 4;
const ITERS = 25;
const TARGET_NS = 1_500_000;

function materialise(rev: string, slot: string): string {
  if (rev === "WORKTREE") return path.join(ROOT, "packages/zod/src/index.ts");
  const sha = execSync(`git rev-parse ${rev}`, { cwd: ROOT }).toString().trim();
  const dir = path.join(TREES, `${sha}-${slot}`);
  if (!fs.existsSync(dir)) {
    fs.mkdirSync(dir, { recursive: true });
    execSync(`git archive ${sha} packages/zod/src | tar -x -C ${dir}`, { cwd: ROOT });
  }
  return path.join(dir, "packages/zod/src/index.ts");
}

interface Row {
  name: string;
  a: number;
  b: number;
}

async function measure(entryFirst: string, entrySecond: string): Promise<Array<Row>> {
  const zFirst = await import(pathToFileURL(entryFirst).href);
  const zSecond = await import(pathToFileURL(entrySecond).href);
  const casesFirst = buildCases(zFirst);
  const casesSecond = buildCases(zSecond);

  const time = (fn: () => void): number => {
    const start = process.hrtime.bigint();
    fn();
    return Number(process.hrtime.bigint() - start);
  };

  const rows: Array<Row> = [];
  for (let i = 0; i < casesFirst.length; i++) {
    const ca: PerfCase = casesFirst[i];
    const cb: PerfCase = casesSecond[i];

    /* JIT warmup on the raw bodies, then size the timed run to ~TARGET_NS;
     * both variants use the identical rep count. */
    let probe = Number.POSITIVE_INFINITY;
    for (let w = 0; w < 10; w++) {
      probe = Math.min(probe, time(ca.run));
      cb.run();
    }
    const reps = Math.max(1, Math.round(TARGET_NS / probe));
    const runA = () => {
      for (let r = 0; r < reps; r++) ca.run();
    };
    const runB = () => {
      for (let r = 0; r < reps; r++) cb.run();
    };

    for (let w = 0; w < WARMUP; w++) {
      runA();
      runB();
    }
    let minA = Number.POSITIVE_INFINITY;
    let minB = Number.POSITIVE_INFINITY;
    for (let iter = 0; iter < ITERS; iter++) {
      if (iter % 2 === 0) {
        minA = Math.min(minA, time(runA));
        minB = Math.min(minB, time(runB));
      } else {
        minB = Math.min(minB, time(runB));
        minA = Math.min(minA, time(runA));
      }
    }
    rows.push({ name: ca.name, a: minA / reps, b: minB / reps });
  }
  return rows;
}

if (process.env.AB_CHILD) {
  const rows = await measure(process.argv[2], process.argv[3]);
  console.log(JSON.stringify(rows));
} else {
  const revA = process.argv[2] ?? "HEAD";
  const revB = process.argv[3] ?? "WORKTREE";
  const entryA = materialise(revA, "a");
  const entryB = materialise(revB, "b");

  const self = fileURLToPath(import.meta.url);
  const child = (first: string, second: string): Array<Row> => {
    const res = spawnSync(process.execPath, ["--import", "tsx", self, first, second], {
      env: { ...process.env, AB_CHILD: "1" },
      encoding: "utf8",
      maxBuffer: 64 * 1024 * 1024,
    });
    if (res.status !== 0) {
      throw new Error(`child failed: ${res.stderr}`);
    }
    const lines = res.stdout.trim().split("\n");
    return JSON.parse(lines[lines.length - 1]);
  };

  /* Two children per load order; per-case minimum across same-order
   * children, then geometric mean across orders. */
  const minRows = (x: Array<Row>, y: Array<Row>): Array<Row> =>
    x.map((r, i) => ({ name: r.name, a: Math.min(r.a, y[i].a), b: Math.min(r.b, y[i].b) }));
  const run1 = minRows(child(entryA, entryB), child(entryA, entryB));
  const run2 = minRows(child(entryB, entryA), child(entryB, entryA));

  const fmt = (ns: number) => (ns / 1e6).toFixed(4).padStart(10);
  const pctFmt = (p: number) => `${p.toFixed(2).padStart(7)}%`;

  console.log(`A = ${revA}, B = ${revB} (min of ${ITERS} iters x 2 orders, ms)`);
  console.log(`${"case".padEnd(24)}${"A".padStart(10)}${"B".padStart(10)}${"delta".padStart(9)}`);
  let sumA = 0;
  let sumB = 0;
  let ratioTotal1 = 0;
  let ratioTotal2 = 0;
  const totals1 = { a: 0, b: 0 };
  const totals2 = { a: 0, b: 0 };
  for (let i = 0; i < run1.length; i++) {
    const r1 = run1[i];
    const r2 = run2[i];
    /* r1: a=A, b=B; r2: a=B, b=A */
    const ratio = Math.sqrt((r1.b / r1.a) * (r2.a / r2.b));
    const aAvg = (r1.a + r2.b) / 2;
    const bAvg = aAvg * ratio;
    sumA += aAvg;
    sumB += bAvg;
    totals1.a += r1.a;
    totals1.b += r1.b;
    totals2.a += r2.a;
    totals2.b += r2.b;
    console.log(`${r1.name.padEnd(24)}${fmt(aAvg)}${fmt(bAvg)} ${pctFmt((ratio - 1) * 100)}`);
  }
  ratioTotal1 = totals1.b / totals1.a;
  ratioTotal2 = totals2.a / totals2.b;
  const totalRatio = Math.sqrt(ratioTotal1 * ratioTotal2);
  console.log(`${"TOTAL".padEnd(24)}${fmt(sumA)}${fmt(sumA * totalRatio)} ${pctFmt((totalRatio - 1) * 100)}`);
}
```

</details>

<details>
<summary><code>perf/cases.mts</code> — deterministic workloads (mirroring <code>packages/bench</code>)</summary>

```ts
/**
 * Deterministic perf workloads mirroring packages/bench.
 * Each case exposes a timed body (`run`) and a serializable
 * behaviour sample (`collect`) used by the characterisation guard.
 */

export interface PerfCase {
  name: string;
  run: () => void;
  collect: () => unknown;
}

/** mulberry32 PRNG for reproducible inputs */
function rng(seed: number): () => number {
  let a = seed >>> 0;
  return () => {
    a = (a + 0x6d2b79f5) | 0;
    let t = Math.imul(a ^ (a >>> 15), 1 | a);
    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
  };
}

function randomString(rand: () => number, length: number): string {
  const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
  let out = "";
  for (let i = 0; i < length; i++) out += chars[Math.floor(rand() * chars.length)];
  return out;
}

const LONG_STRING = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor. ".repeat(12);

export function buildCases(z: any): Array<PerfCase> {
  const cases: Array<PerfCase> = [];

  {
    const rand = rng(1);
    const schema = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
    const data = Array.from({ length: 1000 }, () => ({
      number: rand(),
      string: `${rand()}`,
      boolean: rand() > 0.5,
    }));
    cases.push({
      name: "object-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.map((d) => schema.parse(d)),
    });
  }

  {
    const schema = z.strictObject({
      number: z.number(),
      negNumber: z.number(),
      maxNumber: z.number(),
      string: z.string(),
      longString: z.string(),
      boolean: z.boolean(),
      deeplyNested: z.strictObject({ foo: z.string(), num: z.number(), bool: z.boolean() }),
    });
    const data = Array.from({ length: 1000 }, (_, i) => ({
      number: i,
      negNumber: -i,
      maxNumber: Number.MAX_VALUE,
      string: "string",
      longString: LONG_STRING,
      boolean: true,
      deeplyNested: { foo: "bar", num: i, bool: false },
    }));
    cases.push({
      name: "strict-moltar",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 20).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(2);
    const schema = z.string();
    const data = Array.from({ length: 10_000 }, () => `${rand()}`);
    cases.push({
      name: "string-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(3);
    const schema = z.number();
    const data = Array.from({ length: 10_000 }, () => rand() * 1_000_000);
    cases.push({
      name: "number-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(4);
    const schema = z.array(z.string());
    const data = Array.from({ length: 200 }, () => Array.from({ length: 20 }, () => randomString(rand, 8)));
    cases.push({
      name: "array-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 10).map((d) => schema.parse(d)),
    });
  }

  {
    const schema = z.union([
      z.object({ type: z.literal("a") }),
      z.object({ type: z.literal("b") }),
      z.object({ type: z.literal("c") }),
    ]);
    const data = Array.from({ length: 1000 }, (_, i) => ({ type: "abc"[i % 3] }));
    cases.push({
      name: "union-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 9).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(5);
    const types = ["a", "b", "c", "d", "e", "f", "g"];
    const options = types.map((t) =>
      z.object({ type: z.literal(t), data1: z.string(), data2: z.string(), data3: z.string() })
    );
    const schema = z.discriminatedUnion("type", options);
    const data = Array.from({ length: 200 }, () => ({
      type: types[Math.floor(rand() * types.length)],
      data1: randomString(rand, 10),
      data2: randomString(rand, 10),
      data3: randomString(rand, 10),
    }));
    cases.push({
      name: "disc-union-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 14).map((d) => schema.parse(d)),
    });
  }

  {
    const rand = rng(6);
    const schema = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
    const bad: Array<unknown> = Array.from({ length: 200 }, (_, i) => {
      const kind = i % 5;
      if (kind === 0) return { string: rand(), boolean: "yes", number: `${rand()}` };
      if (kind === 1) return { string: "ok", boolean: true };
      if (kind === 2) return null;
      if (kind === 3) return { string: "ok", boolean: false, number: Number.NaN };
      return [1, 2, 3];
    });
    cases.push({
      name: "object-fail-safeparse",
      run: () => {
        for (const d of bad) schema.safeParse(d);
      },
      collect: () =>
        bad.map((d) => {
          const r = schema.safeParse(d);
          return r.success ? { success: true, data: r.data } : { success: false, issues: r.error.issues };
        }),
    });
  }

  {
    const rand = rng(7);
    const email = z.email();
    const uuid = z.uuid();
    const datetime = z.iso.datetime();
    const emails = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? `${randomString(rand, 8)}@example.com` : `${randomString(rand, 8)}example.com`
    );
    const uuids = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? "8a99219c-2a97-4a35-9fcf-5a5a4d3b1234" : randomString(rand, 36)
    );
    const datetimes = Array.from({ length: 200 }, (_, i) =>
      i % 2 === 0 ? "2024-01-15T12:30:00Z" : `${randomString(rand, 10)}T99:99`
    );
    cases.push({
      name: "string-formats",
      run: () => {
        for (const d of emails) email.safeParse(d);
        for (const d of uuids) uuid.safeParse(d);
        for (const d of datetimes) datetime.safeParse(d);
      },
      collect: () => {
        const sample = (schema: any, inputs: Array<string>) =>
          inputs.slice(0, 6).map((d) => {
            const r = schema.safeParse(d);
            return r.success ? { success: true, data: r.data } : { success: false, issues: r.error.issues };
          });
        return [sample(email, emails), sample(uuid, uuids), sample(datetime, datetimes)];
      },
    });
  }

  {
    const rand = rng(8);
    const schema = z
      .string()
      .min(1)
      .transform((s: string) => s.length)
      .pipe(z.number().max(1000));
    const data = Array.from({ length: 2000 }, () => randomString(rand, 1 + Math.floor(rand() * 20)));
    cases.push({
      name: "chain-parse",
      run: () => {
        for (const d of data) schema.parse(d);
      },
      collect: () => data.slice(0, 50).map((d) => schema.parse(d)),
    });
  }

  {
    const makeSchemas = () => {
      const simple = z.object({ string: z.string(), boolean: z.boolean(), number: z.number() });
      const moltar = z.strictObject({
        number: z.number(),
        negNumber: z.number(),
        maxNumber: z.number(),
        string: z.string(),
        longString: z.string(),
        boolean: z.boolean(),
        deeplyNested: z.strictObject({ foo: z.string(), num: z.number(), bool: z.boolean() }),
      });
      return { simple, moltar };
    };
    cases.push({
      name: "schema-init",
      run: () => {
        for (let i = 0; i < 30; i++) makeSchemas();
      },
      collect: () => {
        const { simple, moltar } = makeSchemas();
        return [
          simple.parse({ string: "s", boolean: true, number: 1 }),
          moltar.parse({
            number: 1,
            negNumber: -1,
            maxNumber: Number.MAX_VALUE,
            string: "string",
            longString: LONG_STRING,
            boolean: true,
            deeplyNested: { foo: "bar", num: 1, bool: false },
          }),
        ];
      },
    });
  }

  return cases;
}
```

</details>

---

Companion PRs from the same campaign: #6316 #6317 #6319
