### PR TITLE
fix(from-json-schema): accept RFC 3339 numeric offsets for date-time format

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -271,7 +271,10 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         } else if (format === "uuid" || format === "guid") {
           stringSchema = stringSchema.check(z.uuid());
         } else if (format === "date-time") {
-          stringSchema = stringSchema.check(z.iso.datetime());
+          // JSON Schema's "date-time" format is RFC 3339 date-time, which allows both "Z"
+          // and numeric UTC offsets (e.g. "+02:00"). z.iso.datetime() only accepts "Z" by
+          // default, so pass offset: true to accept the full RFC 3339 grammar.
+          stringSchema = stringSchema.check(z.iso.datetime({ offset: true }));
         } else if (format === "date") {
           stringSchema = stringSchema.check(z.iso.date());
         } else if (format === "time") {

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -457,6 +457,17 @@ test("string format - uuid", () => {
   expect(schema.parse(uuid)).toBe(uuid);
 });
 
+test("string format - date-time accepts RFC 3339 numeric offsets", () => {
+  const schema = fromJSONSchema({
+    type: "string",
+    format: "date-time",
+  });
+  expect(schema.parse("2026-07-29T14:30:00Z")).toBe("2026-07-29T14:30:00Z");
+  expect(schema.parse("2026-07-29T16:30:00+02:00")).toBe("2026-07-29T16:30:00+02:00");
+  expect(schema.parse("2026-07-29T09:30:00-05:00")).toBe("2026-07-29T09:30:00-05:00");
+  expect(() => schema.parse("2026-07-29T14:30:00")).toThrow();
+});
+
 test("exclusiveMinimum and exclusiveMaximum", () => {
   const schema = fromJSONSchema({
     type: "number",


### PR DESCRIPTION
Closes #6296

## Problem

`fromJSONSchema({ type: "string", format: "date-time" })` maps to `z.iso.datetime()`, which only accepts the `Z` suffix by default:

```ts
const schema = z.fromJSONSchema({ type: "string", format: "date-time" });

schema.parse("2026-07-29T14:30:00Z");        // accepted
schema.parse("2026-07-29T16:30:00+02:00");   // rejected — but should be valid
```

JSON Schema's `date-time` format is defined against the full RFC 3339 `date-time` grammar, which permits both `Z` and numeric UTC offsets. The generated Zod schema is therefore stricter than the source JSON Schema.

## Fix

Pass `offset: true` to `z.iso.datetime()` in `packages/zod/src/v4/classic/from-json-schema.ts`. This accepts both `Z` and numeric offsets while still correctly rejecting a bare local timestamp with no offset at all (`z.iso.datetime`'s `local` option, which would allow that, is intentionally left `false`).

## Testing

Added a test in `from-json-schema.test.ts` covering `Z`, a positive offset, a negative offset, and confirming a local timestamp with no offset still throws.

Full test suite (`vitest run`) passes: 3813/3813.