### PR TITLE
fix(v4): correctly default on .default().transform() inside partial obj

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2099,12 +2099,10 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
       if (output instanceof Promise) {
         return output.then((output) => {
           payload.value = output;
-          payload.fallback = true;
           return payload;
         });
       }
       payload.value = output;
-      payload.fallback = true;
       return payload;
     };
   }

--- a/packages/zod/src/v4/classic/tests/default.test.ts
+++ b/packages/zod/src/v4/classic/tests/default.test.ts
@@ -312,6 +312,56 @@ test("partial should not clobber defaults", () => {
   `);
 });
 
+test("default().transform() in partial: absent key uses default, provided key uses value", () => {
+  const schema = z
+    .object({
+      tags: z
+        .string()
+        .default("")
+        .transform((v) => (v ? v.split(",") : [])),
+    })
+    .partial();
+
+  // absent key: default fires (""), transform produces []
+  expect(schema.parse({})).toEqual({ tags: [] });
+  // provided key: value flows through transform unchanged
+  expect(schema.parse({ tags: "a,b" })).toEqual({ tags: ["a", "b"] });
+  // explicit undefined: same as absent
+  expect(schema.parse({ tags: undefined })).toEqual({ tags: [] });
+});
+
+test("prefault().transform() in partial: absent key uses prefault, provided key uses value", () => {
+  const schema = z
+    .object({
+      tags: z
+        .string()
+        .prefault("")
+        .transform((v) => (v ? v.split(",") : [])),
+    })
+    .partial();
+
+  expect(schema.parse({})).toEqual({ tags: [] });
+  expect(schema.parse({ tags: "x,y" })).toEqual({ tags: ["x", "y"] });
+});
+
+test("transform() standalone: optional wrapper short-circuits when no default rescues the value", () => {
+  // preprocess(fn, T) = pipe(transform(fn), T): transform runs on undefined,
+  // no default clears fallback, so the outer optional short-circuits to undefined.
+  const preprocess = z.preprocess((v) => v ?? "fallback", z.string()).optional();
+  expect(preprocess.parse(undefined)).toBeUndefined();
+  expect(preprocess.parse("hello")).toBe("hello");
+
+  // default().transform(): default rescues undefined (clears fallback),
+  // so the outer optional does NOT short-circuit — it returns the transformed value.
+  const withDefault = z
+    .string()
+    .default("fallback")
+    .transform((v) => v.toUpperCase())
+    .optional();
+  expect(withDefault.parse(undefined)).toBe("FALLBACK");
+  expect(withDefault.parse("hello")).toBe("HELLO");
+});
+
 test("defaulted object schema returns shallow clone", () => {
   const schema = z
     .object({

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3433,7 +3433,6 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
         const output = _out instanceof Promise ? _out : Promise.resolve(_out);
         return output.then((output) => {
           payload.value = output;
-          payload.fallback = true;
           return payload;
         });
       }
@@ -3443,7 +3442,6 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
       }
 
       payload.value = _out;
-      payload.fallback = true;
       return payload;
     };
   }
@@ -3500,6 +3498,7 @@ export const $ZodOptional: core.$constructor<$ZodOptional> = /*@__PURE__*/ core.
     inst._zod.parse = (payload, ctx) => {
       if (def.innerType._zod.optin === "optional") {
         const input = payload.value;
+        if (input === undefined) payload.fallback = true;
         const result = def.innerType._zod.run(payload, ctx);
         if (result instanceof Promise) return result.then((r) => handleOptionalResult(r, input));
         return handleOptionalResult(result, input);
@@ -3646,6 +3645,7 @@ export const $ZodDefault: core.$constructor<$ZodDefault> = /*@__PURE__*/ core.$c
       // Forward direction (decode): apply defaults for undefined input
       if (payload.value === undefined) {
         payload.value = def.defaultValue;
+        payload.fallback = false;
         /**
          * $ZodDefault returns the default value immediately in forward direction.
          * It doesn't pass the default value into the validator ("prefault"). There's no reason to pass the default value through validation. The validity of the default is enforced by TypeScript statically. Otherwise, it's the responsibility of the user to ensure the default is valid. In the case of pipes with divergent in/out types, you can specify the default on the `in` schema of your ZodPipe to set a "prefault" for the pipe.   */
@@ -3712,6 +3712,7 @@ export const $ZodPrefault: core.$constructor<$ZodPrefault> = /*@__PURE__*/ core.
       // Forward direction (decode): apply prefault for undefined input
       if (payload.value === undefined) {
         payload.value = def.defaultValue;
+        payload.fallback = false;
       }
       return def.innerType._zod.run(payload, ctx);
     };


### PR DESCRIPTION
Fixes #6321 