### PR TITLE
fix(v4): fromJSONSchema propertyNames enum keys should not be required

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -391,7 +391,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
             ? convertSchema(schema.additionalProperties as JSONSchema.JSONSchema, ctx)
             : z.any();
 
-       // Case A: No properties (pure record)
+        // Case A: No properties (pure record)
         if (Object.keys(shape).length === 0) {
           zodSchema = z.partialRecord(keySchema, valueSchema);
           break;

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -409,7 +409,8 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         });
         zodSchema = z.intersection(objectSchema, recordSchema);
         break;
-        
+      }
+      
       // Handle patternProperties
       if (schema.patternProperties) {
         // patternProperties: keys matching pattern must satisfy corresponding schema

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -1,3 +1,4 @@
+import * as core from "../core/index.js";
 import type * as JSONSchema from "../core/json-schema.js";
 import { type $ZodRegistry, globalRegistry } from "../core/registries.js";
 import * as _checks from "./checks.js";
@@ -390,19 +391,25 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
             ? convertSchema(schema.additionalProperties as JSONSchema.JSONSchema, ctx)
             : z.any();
 
-        // Case A: No properties (pure record)
+       // Case A: No properties (pure record)
         if (Object.keys(shape).length === 0) {
-          zodSchema = z.record(keySchema, valueSchema);
+          zodSchema = z.partialRecord(keySchema, valueSchema);
           break;
         }
 
-        // Case B: With properties (intersection of object and looseRecord)
+        // Case B: With properties (intersection of object and a partial+loose record)
         const objectSchema = z.object(shape).passthrough();
-        const recordSchema = z.looseRecord(keySchema, valueSchema);
+        const partialKeySchema = core.clone(keySchema);
+        (partialKeySchema as any)._zod.values = undefined;
+        const recordSchema = new z.ZodRecord({
+          type: "record",
+          keyType: partialKeySchema,
+          valueType: valueSchema,
+          mode: "loose",
+        });
         zodSchema = z.intersection(objectSchema, recordSchema);
         break;
-      }
-
+        
       // Handle patternProperties
       if (schema.patternProperties) {
         // patternProperties: keys matching pattern must satisfy corresponding schema


### PR DESCRIPTION
Fixes colinhacks#6323

`propertyNames` restricts which key names are allowed on an object — it does not
make any of them required. `fromJSONSchema` previously mapped `propertyNames` to
`z.record()` (no `properties`) or `z.looseRecord()` (with `properties`), and both
are exhaustive over enum key schemas, so every enum member became a required
property.

Fix:
- Case A (no `properties`): use `z.partialRecord()` instead of `z.record()`.
- Case B (with `properties`): needs a record that's both partial (non-required
  enum keys) and loose (unmatched keys still pass through to preserve existing
  `additionalProperties` behavior) — neither helper alone provides both, so it's
  constructed directly.

Verified:
- `{}`, `{a:"x"}`, `{a:"x",b:"y"}` now all pass; `{c:"z"}` still correctly fails
  with `invalid_key`
- `toJSONSchema` round-trip no longer injects a spurious `required` array
- Full existing test suite for `from-json-schema` / `to-json-schema` /
  `to-json-schema-methods` passes (336 tests), no regressions