### PR TITLE
fix: support format hostname in fromJSONSchema

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -264,7 +264,9 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
       if (schema.format) {
         const format = schema.format;
         // Map common formats to Zod check functions
-        if (format === "email") {
+        if (format === "hostname") {
+          stringSchema = stringSchema.check(z.hostname());
+        } else if (format === "email") {
           stringSchema = stringSchema.check(z.email());
         } else if (format === "uri" || format === "uri-reference") {
           stringSchema = stringSchema.check(z.url());

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -448,6 +448,15 @@ test("string format - email", () => {
   expect(schema.parse("test@example.com")).toBe("test@example.com");
 });
 
+test("string format - hostname", () => {
+  const schema = fromJSONSchema({
+    type: "string",
+    format: "hostname",
+  });
+  expect(schema.parse("example.com")).toBe("example.com");
+  expect(() => schema.parse("not a hostname!")).toThrow();
+});
+
 test("string format - uuid", () => {
   const schema = fromJSONSchema({
     type: "string",

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -14,6 +14,16 @@ import {
 } from "./to-json-schema.js";
 import { getEnumValues } from "./util.js";
 
+function serializeDefault(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
+      throw new TypeError(`BigInt default value ${value} cannot be safely serialized to JSON`);
+    }
+    return Number(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
 const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> = {
   guid: "uuid",
   url: "uri",
@@ -498,7 +508,7 @@ export const defaultProcessor: Processor<schemas.$ZodDefault> = (schema, ctx, js
   process(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
-  json.default = JSON.parse(JSON.stringify(def.defaultValue));
+  json.default = serializeDefault(def.defaultValue);
 };
 
 export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, json, params) => {
@@ -506,7 +516,7 @@ export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, 
   process(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
-  if (ctx.io === "input") json._prefault = JSON.parse(JSON.stringify(def.defaultValue));
+  if (ctx.io === "input") json._prefault = serializeDefault(def.defaultValue);
 };
 
 export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, params) => {
@@ -523,7 +533,7 @@ export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, 
     }
     return;
   }
-  json.default = catchValue;
+  json.default = serializeDefault(catchValue);
 };
 
 export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, params) => {


### PR DESCRIPTION
Supports JSON Schema format "hostname" in fromJSONSchema by applying z.hostname(). Fixes #6304.