### PR TITLE
fix(v4): transform must not mark fallback when input came from a default

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2198,16 +2198,17 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
         }
       };
 
+      const input = payload.value;
       const output = def.transform(payload.value, payload);
       if (output instanceof Promise) {
         return output.then((output) => {
           payload.value = output;
-          payload.fallback = true;
+          if (input === undefined) payload.fallback = true;
           return payload;
         });
       }
       payload.value = output;
-      payload.fallback = true;
+      if (input === undefined) payload.fallback = true;
       return payload;
     };
   }

--- a/packages/zod/src/v4/classic/tests/default.test.ts
+++ b/packages/zod/src/v4/classic/tests/default.test.ts
@@ -312,6 +312,69 @@ test("partial should not clobber defaults", () => {
   `);
 });
 
+// A transform downstream of a default/prefault ran on a deliberate value, so an outer
+// optional must not clobber its output. Regression: #6321 (broke in 4.4.3 via #5941).
+test("optional respects a transform fed by default/prefault", () => {
+  const fromDefault = z
+    .string()
+    .default("")
+    .transform((v) => (v ? v.split(",") : []));
+  const fromPrefault = z
+    .string()
+    .prefault("hi")
+    .transform((v) => v.length);
+
+  expect(fromDefault.optional().parse(undefined)).toEqual([]);
+  expect(fromPrefault.optional().parse(undefined)).toBe(2);
+
+  const obj = z.object({ a: fromDefault }).partial();
+  expect(obj.parse({})).toEqual({ a: [] });
+  expect(obj.parse({ a: undefined })).toEqual({ a: [] });
+  expect(obj.parse({ a: "x,y" })).toEqual({ a: ["x", "y"] });
+});
+
+test("optional respects a transform fed by default/prefault (async)", async () => {
+  const schema = z
+    .string()
+    .default("")
+    .transform(async (v) => (v ? v.split(",") : []))
+    .optional();
+  await expect(schema.parseAsync(undefined)).resolves.toEqual([]);
+});
+
+// The other side of the same flag: with nothing upstream supplying a value, the
+// transform ran on undefined and the outer optional still wins. Pinned by #5941.
+test("optional still clobbers a transform that ran on undefined", () => {
+  expect(
+    z
+      .preprocess((v) => v ?? "X", z.string())
+      .optional()
+      .parse(undefined)
+  ).toBeUndefined();
+  expect(
+    z
+      .string()
+      .catch("X")
+      .transform((s) => `${s}!`)
+      .optional()
+      .parse(undefined)
+  ).toBeUndefined();
+  expect(
+    z
+      .transform(() => "T")
+      .optional()
+      .parse(undefined)
+  ).toBeUndefined();
+  // $ZodUnion runs its options against fresh payloads, so the flag has to be set by
+  // the transform itself to survive the trip out to the optional.
+  expect(
+    z
+      .union([z.preprocess((v) => v ?? "X", z.string()), z.number()])
+      .optional()
+      .parse(undefined)
+  ).toBeUndefined();
+});
+
 test("defaulted object schema returns shallow clone", () => {
   const schema = z
     .object({

--- a/packages/zod/src/v4/classic/tests/partial.test.ts
+++ b/packages/zod/src/v4/classic/tests/partial.test.ts
@@ -448,3 +448,13 @@ test("required - refinement is executed on required schema", () => {
   const validResult = requiredSchema.safeParse({ password: "abc", confirmPassword: "abc" });
   expect(validResult.success).toBe(true);
 });
+
+test("default with transform in partial object keeps transformed value", () => {
+  const arrayFromString = z
+    .string()
+    .default("")
+    .transform((val) => (val ? val.split(",").map((s) => s.trim()) : []));
+  const partialObj = z.object({ array: arrayFromString }).partial();
+  expect(arrayFromString.safeParse(undefined).data).toEqual([]);
+  expect(partialObj.safeParse({}).data?.array).toEqual([]);
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3576,12 +3576,13 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
         throw new core.$ZodEncodeError(inst.constructor.name);
       }
 
+      const input = payload.value;
       const _out = def.transform(payload.value, payload);
       if (ctx.async) {
         const output = _out instanceof Promise ? _out : Promise.resolve(_out);
         return output.then((output) => {
           payload.value = output;
-          payload.fallback = true;
+          if (input === undefined) payload.fallback = true;
           return payload;
         });
       }
@@ -3591,7 +3592,7 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
       }
 
       payload.value = _out;
-      payload.fallback = true;
+      if (input === undefined) payload.fallback = true;
       return payload;
     };
   }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -44,8 +44,8 @@ export interface ParsePayload<T = unknown> {
   aborted?: boolean;
   /** @internal Marks a value as a fallback that an outer wrapper (e.g.
    * $ZodOptional) may override with its own interpretation when input was
-   * undefined. Set by $ZodCatch when catchValue substitutes and by every
-   * $ZodTransform invocation. */
+   * undefined. Set by $ZodCatch when catchValue substitutes and by
+   * $ZodTransform when its own input was undefined. */
   fallback?: boolean | undefined;
   /** @internal Set when the value came from a repeat visit to a node still being
    * parsed. Its checks run on the node itself, against the finished value. */

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -12,7 +12,7 @@ Three runtime signals, each with a single consumer:
 |---|---|---|---|
 | `_zod.optin === "optional"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional` | "I accept absent input" |
 | `_zod.optout === "optional"` | optional, exact-optional, default-on-output cases | `$ZodObject`, `$ZodTuple` | "My output may legitimately be `undefined`; treat that as absent for length-shortening / key-omission" |
-| `payload.fallback === true` | catch (when `catchValue` substitutes), transform | `$ZodOptional` (in `handleOptionalResult`) | "This value is provisional; an outer wrapper may override it on undefined input" |
+| `payload.fallback === true` | catch (when `catchValue` substitutes), transform (when its own input was `undefined`) | `$ZodOptional` (in `handleOptionalResult`) | "This value is provisional; an outer wrapper may override it on undefined input" |
 
 Plus one bookkeeping flag:
 
@@ -149,7 +149,7 @@ interface ParsePayload<T> {
 | Schema | When | Why |
 |---|---|---|
 | `$ZodCatch` | When `catchValue` substitutes (i.e., the inner schema produced issues) | The substituted value is a recovery, not a deliberate output; an outer optional should be allowed to clobber it |
-| `$ZodTransform` | On every fn invocation (sync and async paths, both core and classic constructors) | The transform's output is provisional — for `undefined` input specifically, an outer optional should treat the transform's output as "what we got when input was missing" and replace with `undefined` |
+| `$ZodTransform` | When the value handed to the fn was `undefined` (sync and async paths, both core and classic constructors) | The transform's output is provisional *only* when the fn had nothing to work with — an outer optional should treat "what we got when input was missing" as overridable. When something upstream supplied a real value, the output is a real output |
 
 ### Who reads it
 
@@ -166,7 +166,9 @@ function handleOptionalResult(result: ParsePayload, input: unknown) {
 
 Translation: "If the *original* input to optional was `undefined`, and the inner either failed or produced a fallback value, override with `undefined`."
 
-The `input === undefined` gate is critical: when input was a defined value, the inner's output is the *real* output (e.g., a successful transform run), not a fallback, even if the flag happens to be set. This is what makes "always set on transform" safe — defined-input transforms have the flag set but it's never read.
+The `input === undefined` gate is critical: when input was a defined value, the inner's output is the *real* output (e.g., a successful transform run), not a fallback.
+
+Note that `input` here is the input to the **optional**, not to the transform that set the flag. Those are the same value only when nothing in between substitutes one. #5941 originally had `$ZodTransform` set the flag on *every* invocation, on the reasoning that a defined-input transform would have the flag set but never read. That holds right up until a `.default()` or `.prefault()` sits between the transform and the optional: optional's input is `undefined` (so the gate opens) while the transform's input was the substituted value (so its output is a real output). `z.string().default("").transform(fn).optional().parse(undefined)` returned `undefined` in 4.4.3 for exactly this reason — see #6321. `$ZodTransform` now sets the flag only when its own input was `undefined`, which is what the gate always assumed.
 
 ### Pipe propagation
 
@@ -195,7 +197,8 @@ So:
 |---|---|---|---|
 | valid value via normal path (default fired, prefault filled) | no | no | **respect** — return inner value |
 | recovery substitution (catch fired) | no (cleared) | yes | **clobber** — return undefined |
-| transform's output (preprocess, standalone transform, anything with a transform fn at the input side) | no | yes | **clobber** — return undefined |
+| transform's output, fn ran on `undefined` (preprocess, standalone transform, anything with a transform fn at the input side) | no | yes | **clobber** — return undefined |
+| transform's output, fn ran on a value a default/prefault supplied | no | no | **respect** — return inner value |
 | failed validation but no recovery | yes | no | **clobber** (issues swallowed) — return undefined |
 
 ### Why default and prefault aren't clobbered
@@ -211,6 +214,8 @@ Catch runs inner, and only fires when inner produces *issues*. The substitution 
 For preprocess, the user's fn runs on `undefined` because the *outer* schema invoked it (object accepting an absent key, or optional with `optin === "optional"` invoking the inner). The user's intent was "transform whatever input shows up," but they also wrapped in `.optional()` to say "absent input → absent output." `fallback` lets `.optional()` honor that.
 
 Standalone transform (rare) gets the same treatment by virtue of also being marked.
+
+The marking is conditional on the transform's own input being `undefined`. A `.default()` or `.prefault()` upstream of the transform means the fn ran on a deliberate value, so its output is deliberate too and `optional` respects it — `z.string().default("").transform(fn).optional().parse(undefined)` returns `fn("")`, not `undefined`.
 
 ## Walking through cases
 
@@ -389,12 +394,12 @@ This is technically unsound — the runtime accepts inputs the type rejects — 
 
 The schemas where the input stays strict at runtime — `coerce`, `unknown`, `any`, plain `string`/`number`/etc. — don't have a user-written escape hatch. There's no reason for them to claim to handle absence; they should reject and let the user opt in explicitly. So the rule is: **schemas with a user-written escape hatch (catch's recovery, transform's fn) accept `undefined` at runtime; schemas without one don't.**
 
-`fallback` is the runtime mechanism that makes this safe to combine with `optional`: when an outer wrapper *also* expresses an opinion about absent input ("missing → undefined"), the inner schema's escape-hatch output gets overridden. The user's explicit `.optional()` wins over the inner's "I happened to produce this value when called with undefined." Catch and transform both flag their output as fallback for this reason; default and prefault don't because their values are the deliberate output, not an escape-hatch output.
+`fallback` is the runtime mechanism that makes this safe to combine with `optional`: when an outer wrapper *also* expresses an opinion about absent input ("missing → undefined"), the inner schema's escape-hatch output gets overridden. The user's explicit `.optional()` wins over the inner's "I happened to produce this value when called with undefined." Catch and transform both flag their output as fallback for this reason; default and prefault don't because their values are the deliberate output, not an escape-hatch output. Transform flags only when the fn ran on `undefined` — once a default has supplied a value, there is no escape hatch left to mark.
 
 ## Mental model (one paragraph)
 
 A schema's `optin` declares whether it accepts absent input. Object and tuple parsers consult it before running. Optional consults it to decide whether to short-circuit or invoke the inner. Default, prefault, optional, and exact-optional all hardcode `optin = "optional"`. Catch and transform set it at runtime only — their static type doesn't claim to accept absence even though they do (flexible inputs, strict outputs). Preprocess inherits transform's runtime optin via pipe.
 
-When `optional` wraps something with `optin === "optional"` and the input is `undefined`, it has to decide: *trust the inner's output*, or *override with `undefined`*. The `fallback` payload flag is how the inner tells the outer "this value is a recovery / a transform's interpretation, not a deliberate handling of absence — feel free to override." Catch sets it on substitution; transform sets it on every invocation. Default and prefault don't, because their values *are* the deliberate handling.
+When `optional` wraps something with `optin === "optional"` and the input is `undefined`, it has to decide: *trust the inner's output*, or *override with `undefined`*. The `fallback` payload flag is how the inner tells the outer "this value is a recovery / a transform's interpretation, not a deliberate handling of absence — feel free to override." Catch sets it on substitution; transform sets it when its own input was `undefined`. Default and prefault don't, because their values *are* the deliberate handling — and because they hand the transform downstream of them a real value, they keep it from flagging too.
 
 For everything else — `coerce`, `string`, `unknown`, `any`, `transform.pipe` shapes where transform is on the OUT side — `optin` stays `undefined`. Object and tuple parsers reject absent input. Users opt in explicitly via `.optional()` or `.default(...)` when they want absence accepted.


### PR DESCRIPTION
$ZodTransform (and classic ZodTransform) unconditionally set payload.fallback = true, so when a .default().transform() chain sits inside a .partial() object, the outer $ZodOptional clobbers the transformed value back to undefined. Only mark fallback when the transform input was undefined (no default/catch supplied a value upstream). Fixes #6321.