### PR TITLE
feat(enum): add extend method to ZodEnum

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2035,6 +2035,10 @@ export interface ZodEnum<
     values: U,
     params?: string | core.$ZodEnumParams
   ): ZodEnum<util.Flatten<Omit<T, U[number]>>>;
+  extend<const U extends readonly string[]>(
+    values: U,
+    params?: string | core.$ZodEnumParams
+  ): ZodEnum<util.Flatten<T & Record<U[number], U[number]>>>;
 }
 export const ZodEnum: core.$constructor<ZodEnum> = /*@__PURE__*/ core.$constructor("ZodEnum", (inst, def) => {
   core.$ZodEnum.init(inst, def);
@@ -2067,6 +2071,19 @@ export const ZodEnum: core.$constructor<ZodEnum> = /*@__PURE__*/ core.$construct
       if (keys.has(value)) {
         delete newEntries[value];
       } else throw new Error(`Key ${value} not found in enum`);
+    }
+    return new ZodEnum({
+      ...def,
+      checks: [],
+      ...util.normalizeParams(params),
+      entries: newEntries,
+    }) as any;
+  };
+
+  inst.extend = (values, params) => {
+    const newEntries: Record<string, any> = { ...def.entries };
+    for (const value of values) {
+      newEntries[value] = value;
     }
     return new ZodEnum({
       ...def,

--- a/packages/zod/src/v4/classic/tests/enum.test.ts
+++ b/packages/zod/src/v4/classic/tests/enum.test.ts
@@ -160,6 +160,19 @@ test("exclude", () => {
   expectTypeOf<z.infer<typeof EmptyFoodEnum>>().toEqualTypeOf<never>();
 });
 
+test("extend", () => {
+  const directions = ["north", "south", "east", "west"] as const;
+  const BaseDirections = z.enum(directions);
+  const EightDirections = BaseDirections.extend(["northwest", "northeast"]);
+
+  expect(EightDirections.safeParse("north").success).toEqual(true);
+  expect(EightDirections.safeParse("northeast").success).toEqual(true);
+  expect(EightDirections.safeParse("up").success).toEqual(false);
+  expectTypeOf<z.infer<typeof EightDirections>>().toEqualTypeOf<
+    "north" | "south" | "east" | "west" | "northwest" | "northeast"
+  >();
+});
+
 test("error map inheritance", () => {
   const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
   const FoodEnum = z.enum(foods, { error: () => "This is not food!" });


### PR DESCRIPTION
Adds ZodEnum.prototype.extend(), mirroring extract/exclude. Users who need to reuse a base enum with additional values currently must fall back to z.union, losing the enum property they use to build a record. Fixes #6276.