### PR TITLE
fix(fromJSONSchema): prefixItems/items arrays do not require omitted elements

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -465,8 +465,14 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
       const items = schema.items;
 
       if (prefixItems && Array.isArray(prefixItems)) {
-        // Tuple with prefixItems (draft-2020-12)
-        const tupleItems = prefixItems.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
+        // Tuple with prefixItems (draft-2020-12).
+        // Positional schemas constrain present elements, but without an
+        // explicit minItems they do not require the array to have that length.
+        const requiredCount = typeof schema.minItems === "number" ? schema.minItems : 0;
+        const tupleItems = prefixItems.map((item, i) => {
+          const converted = convertSchema(item as JSONSchema.JSONSchema, ctx);
+          return i < requiredCount ? converted : converted.optional();
+        });
         const rest =
           items && typeof items === "object" && !Array.isArray(items)
             ? convertSchema(items as JSONSchema.JSONSchema, ctx)
@@ -485,7 +491,11 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         }
       } else if (Array.isArray(items)) {
         // Tuple with items array (draft-7)
-        const tupleItems = items.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
+        const requiredCount = typeof schema.minItems === "number" ? schema.minItems : 0;
+        const tupleItems = items.map((item, i) => {
+          const converted = convertSchema(item as JSONSchema.JSONSchema, ctx);
+          return i < requiredCount ? converted : converted.optional();
+        });
         const rest =
           schema.additionalItems && typeof schema.additionalItems === "object"
             ? convertSchema(schema.additionalItems as JSONSchema.JSONSchema, ctx)

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -128,8 +128,21 @@ test("tuple with prefixItems (draft-2020-12)", () => {
     prefixItems: [{ type: "string" }, { type: "number" }],
   });
   expect(schema.parse(["hello", 42])).toEqual(["hello", 42]);
-  expect(() => schema.parse(["hello"])).toThrow();
+  expect(schema.parse([])).toEqual([]);
+  expect(schema.parse(["hello"])).toEqual(["hello"]);
   expect(() => schema.parse(["hello", "world"])).toThrow();
+});
+
+test("tuple with prefixItems and minItems (draft-2020-12)", () => {
+  const schema = fromJSONSchema({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "array",
+    prefixItems: [{ type: "string" }, { type: "number" }],
+    minItems: 2,
+  });
+  expect(schema.parse(["hello", 42])).toEqual(["hello", 42]);
+  expect(() => schema.parse(["hello"])).toThrow();
+  expect(() => schema.parse([])).toThrow();
 });
 
 test("tuple with items array (draft-7)", () => {
@@ -140,7 +153,30 @@ test("tuple with items array (draft-7)", () => {
     additionalItems: false,
   });
   expect(schema.parse(["hello", 42])).toEqual(["hello", 42]);
+  expect(schema.parse([])).toEqual([]);
+  expect(schema.parse(["hello"])).toEqual(["hello"]);
   expect(() => schema.parse(["hello", 42, "extra"])).toThrow();
+});
+
+test("prefixItems without minItems accepts shorter arrays", () => {
+  const schema = fromJSONSchema({
+    type: "array",
+    prefixItems: [{ type: "string" }],
+  });
+  expect(schema.safeParse([]).success).toBe(true);
+  expect(schema.safeParse(["ok"]).success).toBe(true);
+});
+
+test("draft-7 array items with additionalItems:false accepts shorter arrays", () => {
+  const schema = fromJSONSchema({
+    $schema: "http://json-schema.org/draft-07/schema#",
+    type: "array",
+    items: [{ type: "string" }],
+    additionalItems: false,
+  });
+  expect(schema.safeParse([]).success).toBe(true);
+  expect(schema.safeParse(["ok"]).success).toBe(true);
+  expect(schema.safeParse(["ok", "extra"]).success).toBe(false);
 });
 
 test("enum schema", () => {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -14,6 +14,16 @@ import {
 } from "./to-json-schema.js";
 import { getEnumValues } from "./util.js";
 
+function serializeDefault(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
+      throw new TypeError(`BigInt default value ${value} cannot be safely serialized to JSON`);
+    }
+    return Number(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
 const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> = {
   guid: "uuid",
   url: "uri",
@@ -498,7 +508,7 @@ export const defaultProcessor: Processor<schemas.$ZodDefault> = (schema, ctx, js
   process(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
-  json.default = JSON.parse(JSON.stringify(def.defaultValue));
+  json.default = serializeDefault(def.defaultValue);
 };
 
 export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, json, params) => {
@@ -506,7 +516,7 @@ export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, 
   process(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
-  if (ctx.io === "input") json._prefault = JSON.parse(JSON.stringify(def.defaultValue));
+  if (ctx.io === "input") json._prefault = serializeDefault(def.defaultValue);
 };
 
 export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, params) => {
@@ -523,7 +533,7 @@ export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, 
     }
     return;
   }
-  json.default = catchValue;
+  json.default = serializeDefault(catchValue);
 };
 
 export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, params) => {


### PR DESCRIPTION
Without an explicit \minItems\, positional array schemas (\prefixItems\ / draft-7 array-form \items\) constrain the elements that are *present* but do not require the array to have that length. The current conversion to \z.tuple(...)\ rejected shorter arrays (e.g. \[]\ for \prefixItems: [{ type: 'string' }]\).

When \minItems\ is absent, positional elements are now made optional so present elements are still validated against their positional schema while shorter arrays pass. When \minItems\ is set, the first \minItems\ positions remain required. Fixes #6200.