### PR TITLE
fix: report date origin for numeric min/max on date schemas

### DIFF
--- a/packages/zod/src/v4/classic/tests/date.test.ts
+++ b/packages/zod/src/v4/classic/tests/date.test.ts
@@ -60,3 +60,32 @@ test("min max getters", () => {
   expect(maxCheck.maxDate).toEqual(benchmarkDate);
   expect(maxCheck.max(beforeBenchmarkDate).maxDate).toEqual(beforeBenchmarkDate);
 });
+
+test("numeric min/max arguments still report date origin", () => {
+  const resultMin = z.date().min(benchmarkDate.getTime()).safeParse(beforeBenchmarkDate);
+  const resultMax = z.date().max(benchmarkDate.getTime()).safeParse(afterBenchmarkDate);
+
+  expect(resultMin.success).toEqual(false);
+  expect(resultMin.error!.issues[0]).toMatchInlineSnapshot(`
+    {
+      "code": "too_small",
+      "inclusive": true,
+      "message": "Too small: expected date to be >=1667606400000",
+      "minimum": 1667606400000,
+      "origin": "date",
+      "path": [],
+    }
+  `);
+
+  expect(resultMax.success).toEqual(false);
+  expect(resultMax.error!.issues[0]).toMatchInlineSnapshot(`
+    {
+      "code": "too_big",
+      "inclusive": true,
+      "maximum": 1667606400000,
+      "message": "Too big: expected date to be <=1667606400000",
+      "origin": "date",
+      "path": [],
+    }
+  `);
+});

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -65,7 +65,7 @@ export const $ZodCheckLessThan: core.$constructor<$ZodCheckLessThan> = /*@__PURE
   "$ZodCheckLessThan",
   (inst, def) => {
     $ZodCheck.init(inst, def);
-    const origin = numericOriginMap[typeof def.value as "number" | "bigint" | "object"];
+    let origin = numericOriginMap[typeof def.value as "number" | "bigint" | "object"];
 
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag;
@@ -74,6 +74,8 @@ export const $ZodCheckLessThan: core.$constructor<$ZodCheckLessThan> = /*@__PURE
         if (def.inclusive) bag.maximum = def.value;
         else bag.exclusiveMaximum = def.value;
       }
+      const type = inst._zod.def.type;
+      if (type === "date" || type === "bigint" || type === "number") origin = type;
     });
 
     inst._zod.check = (payload) => {
@@ -116,7 +118,7 @@ export const $ZodCheckGreaterThan: core.$constructor<$ZodCheckGreaterThan> = /*@
   "$ZodCheckGreaterThan",
   (inst, def) => {
     $ZodCheck.init(inst, def);
-    const origin = numericOriginMap[typeof def.value as "number" | "bigint" | "object"];
+    let origin = numericOriginMap[typeof def.value as "number" | "bigint" | "object"];
 
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag;
@@ -125,6 +127,8 @@ export const $ZodCheckGreaterThan: core.$constructor<$ZodCheckGreaterThan> = /*@
         if (def.inclusive) bag.minimum = def.value;
         else bag.exclusiveMinimum = def.value;
       }
+      const type = inst._zod.def.type;
+      if (type === "date" || type === "bigint" || type === "number") origin = type;
     });
 
     inst._zod.check = (payload) => {


### PR DESCRIPTION
Fixes #5980.