### PR TITLE
fix: ZodFlattenedError accepts a schema, matching inferFlattenedErrors

### DIFF
--- a/packages/zod/src/v4/classic/errors.ts
+++ b/packages/zod/src/v4/classic/errors.ts
@@ -79,11 +79,17 @@ export const ZodRealError: core.$constructor<ZodError> = /*@__PURE__*/ core.$con
 });
 
 /** @deprecated Use `z.core.$ZodFlattenedError` instead. */
-export type ZodFlattenedError<T, U = string> = core.$ZodFlattenedError<T, U>;
-/** @deprecated Use `z.core.$ZodFormattedError` instead. */
-export type ZodFormattedError<T, U = string> = core.$ZodFormattedError<T, U>;
-/** @deprecated Use `z.core.$ZodErrorMap` instead. */
-export type ZodErrorMap<T extends core.$ZodIssueBase = core.$ZodIssue> = core.$ZodErrorMap<T>;
+/** @deprecated Use `z.core.$ZodFlattenedError` instead. */
+export type ZodFlattenedError<T, U = string> = T extends core.$ZodType
+  ? core.$ZodFlattenedError<core.output<T>, U>
+  : core.$ZodFlattenedError<T, U>;
+
+export type {
+  /** @deprecated Use `z.core.$ZodFormattedError` instead. */
+  $ZodFormattedError as ZodFormattedError,
+  /** @deprecated Use `z.core.$ZodErrorMap` instead. */
+  $ZodErrorMap as ZodErrorMap,
+} from "../core/index.js";
 
 /** @deprecated Use `z.core.$ZodRawIssue` instead. */
 export type IssueData = core.$ZodRawIssue;

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1,5 +1,5 @@
 import { inspect } from "node:util";
-import { expect, test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 import * as z from "zod/v4";
 
 test("error creation", () => {
@@ -498,6 +498,18 @@ test("inferFlattenedErrors", () => {
       "formErrors": [],
     }
   `);
+});
+
+test("ZodFlattenedError accepts a schema like inferFlattenedErrors", () => {
+  const schemaWithTransform = z.object({ foo: z.string() }).transform((o) => ({ bar: o.foo }));
+
+  type FromSchema = z.ZodFlattenedError<typeof schemaWithTransform>["fieldErrors"];
+  type FromOutput = z.ZodFlattenedError<z.output<typeof schemaWithTransform>>["fieldErrors"];
+  type Legacy = z.inferFlattenedErrors<typeof schemaWithTransform>["fieldErrors"];
+
+  // Passing a schema unwraps to the output type, matching `inferFlattenedErrors`.
+  expectTypeOf<FromSchema>().toEqualTypeOf<FromOutput>();
+  expectTypeOf<FromSchema>().toEqualTypeOf<Legacy>();
 });
 
 const stringWithCustomError = z.string({


### PR DESCRIPTION
Fixes #5029.

`z.ZodFlattenedError` was a direct alias of `core.$ZodFlattenedError`, which takes the schema's **output type** as its generic. The v3 `z.inferFlattenedErrors` it's meant to replace takes a **schema**. So a straight migration — `inferFlattenedErrors<typeof schema>` → `ZodFlattenedError<typeof schema>` — keyed `fieldErrors` over the schema's internals (`_zod`, `def`, `type`, ...) instead of the actual fields.

This makes the deprecated alias accept both:

```ts
// both now resolve to the same type
type A = z.ZodFlattenedError<typeof schema>["fieldErrors"];
type B = z.ZodFlattenedError<z.output<typeof schema>>["fieldErrors"];
type C = z.inferFlattenedErrors<typeof schema>["fieldErrors"];
```

When passed a `$ZodType`, it unwraps to `output<T>`; otherwise it's treated as a plain output type, so existing callers passing `z.output<typeof schema>` keep their current typing. Added a type test asserting `ZodFlattenedError<typeof schema>` is equal to both `ZodFlattenedError<output<typeof schema>>` and `inferFlattenedErrors<typeof schema>`.
