### PR TITLE
ci: build with pinned TypeScript, add TS 6 and 7 legs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,11 @@ jobs:
   test-node:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node: ["lts/*"]
-        typescript: ["5.5", "latest"]
+        typescript: ["5.5", "6", "latest"]
     name: Test with TypeScript ${{ matrix.typescript }} on Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v4
@@ -28,10 +29,14 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
+      # Build with the repo-pinned TypeScript: zshy uses the classic compiler API,
+      # which TypeScript 7 no longer ships. The matrix version applies to the tests.
       - run: pnpm build
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm test
+      # test-resolution.ts shells out to zshy, so it can't run under TypeScript 7.
       - run: pnpm run --filter @zod/resolution test:all
+        if: matrix.typescript != 'latest'
       - run: pnpm run --filter @zod/integration test:all
 
   lint:


### PR DESCRIPTION
Fixes #6185.

`typescript@latest` now resolves to 7.x, whose npm package no longer ships the classic compiler API — `require("typescript")` exposes exactly `version` and `versionMajorMinor`, and `ts.sys` is `undefined`. zshy reads tsconfigs through `ts.sys.readFile`, so `pnpm build` has crashed on every PR since with `TypeError: Cannot read properties of undefined (reading 'readFile')`. `fail-fast` then cancelled the 5.5 leg, so PRs have had no test signal at all — 114 open PRs are currently red for this one reason.

The build now runs before the matrix TypeScript is installed, using the repo-pinned version. That's what actually produces the published artifacts, so it's the more faithful thing to test anyway. The matrix version applies to `pnpm test` and the typecheck.

`@zod/resolution` is skipped on the `latest` leg because `test-resolution.ts` shells out to `zshy` directly, so reordering the root build doesn't save it.

Worth noting: zod's own types are fine on TS 7. Built with the pinned 5.5.4 and then swapped to 7.0.2, the suite is 339 files / 3811 tests with no type errors. Only the build tool is blocked, so capping the matrix at 5 (#6187) or 6 (#6312) would discard signal we currently pass. Both legs are kept instead, and `fail-fast: false` stops one red leg from hiding the others.

Supersedes #6187 and #6312.
