### PR TITLE
fix(json-schema): keep __proto__ keys as own properties in schema conversion

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -1,5 +1,6 @@
 import type * as JSONSchema from "../core/json-schema.js";
 import { type $ZodRegistry, globalRegistry } from "../core/registries.js";
+import { assignProp } from "../core/util.js";
 import * as _checks from "./checks.js";
 import * as _iso from "./iso.js";
 import * as _schemas from "./schemas.js";
@@ -378,8 +379,9 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
       // Convert properties - mark optional ones
       for (const [key, propSchema] of Object.entries(properties)) {
         const propZodSchema = convertSchema(propSchema as JSONSchema.JSONSchema, ctx);
-        // If not in required array, make it optional
-        shape[key] = requiredSet.has(key) ? propZodSchema : propZodSchema.optional();
+        // If not in required array, make it optional. assignProp so a __proto__
+        // key becomes an own property instead of hitting the inherited setter
+        assignProp(shape, key, requiredSet.has(key) ? propZodSchema : propZodSchema.optional());
       }
 
       // Handle propertyNames
@@ -606,7 +608,7 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
 
   for (const key of Object.keys(schema)) {
     if (!RECOGNIZED_KEYS.has(key)) {
-      extraMeta[key] = schema[key];
+      assignProp(extraMeta, key, schema[key]);
     }
   }
 

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -893,3 +893,29 @@ test("Date default is coerced to its JSON string form", () => {
   const schema = fromJSONSchema({ type: "string", default: date as any });
   expect(schema.parse(undefined)).toBe(date.toISOString());
 });
+
+// An object literal can't express an own "__proto__" key — `{ __proto__: x }`
+// sets the literal's prototype instead. JSON.parse is both the realistic source
+// of a JSON Schema and the only way to write these cases.
+test("required __proto__ property is kept and enforced", () => {
+  const schema = fromJSONSchema(
+    JSON.parse(`{
+      "type": "object",
+      "properties": { "__proto__": { "type": "string", "const": "admin" }, "role": { "type": "string" } },
+      "required": ["__proto__", "role"]
+    }`)
+  );
+
+  expect(schema.safeParse({ role: "x" }).success).toBe(false);
+  expect(schema.safeParse(JSON.parse(`{ "role": "x", "__proto__": "wrong" }`)).success).toBe(false);
+  expect(schema.safeParse(JSON.parse(`{ "role": "x", "__proto__": "admin" }`)).success).toBe(true);
+});
+
+test("__proto__ annotation key reaches the registry", () => {
+  const registry = z.registry<Record<string, unknown>>();
+  const schema = fromJSONSchema(JSON.parse(`{ "type": "string", "__proto__": { "custom": 1 } }`), { registry });
+
+  const meta = registry.get(schema)!;
+  expect(Object.prototype.hasOwnProperty.call(meta, "__proto__")).toBe(true);
+  expect(meta.__proto__).toEqual({ custom: 1 });
+});

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3129,3 +3129,33 @@ test("recursive lazy with describe does not stack overflow", () => {
   expect(result).toBeDefined();
   expect(result.$defs).toBeDefined();
 });
+
+test("__proto__ shape key is emitted as an own property", () => {
+  const schema = z.object({ ["__proto__"]: z.literal("admin"), role: z.string() });
+  const result = z.toJSONSchema(schema, { io: "input" });
+
+  expect(result.required).toEqual(["__proto__", "role"]);
+  // every required key needs a matching entry in properties
+  for (const key of result.required!) {
+    expect(Object.prototype.hasOwnProperty.call(result.properties, key)).toBe(true);
+  }
+  expect(JSON.parse(JSON.stringify(result)).properties.__proto__).toEqual({ type: "string", const: "admin" });
+});
+
+test("__proto__ registry id is emitted as an own entry", () => {
+  const myRegistry = z.registry<{ id: string }>();
+  myRegistry.add(z.object({ a: z.string() }), { id: "__proto__" });
+  myRegistry.add(z.object({ b: z.string() }), { id: "normal" });
+
+  expect(Object.keys(z.toJSONSchema(myRegistry).schemas)).toEqual(["__proto__", "normal"]);
+});
+
+test("__proto__ def id emits a resolvable $ref", () => {
+  const myRegistry = z.registry<{ id: string }>();
+  const Inner = z.object({ x: z.string() });
+  myRegistry.add(Inner, { id: "__proto__" });
+
+  const json = JSON.parse(JSON.stringify(z.toJSONSchema(z.object({ a: Inner, b: Inner }), { metadata: myRegistry })));
+  expect(json.properties.a.$ref).toBe("#/$defs/__proto__");
+  expect(json.$defs.__proto__).toBeDefined();
+});

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -12,7 +12,7 @@ import {
   initializeContext,
   process,
 } from "./to-json-schema.js";
-import { getEnumValues } from "./util.js";
+import { assignProp, getEnumValues } from "./util.js";
 
 const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> = {
   guid: "uuid",
@@ -295,10 +295,16 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
   const shape = def.shape;
 
   for (const key in shape) {
-    json.properties[key] = process(shape[key]!, ctx as any, {
-      ...params,
-      path: [...params.path, "properties", key],
-    });
+    // assignProp so a __proto__ key becomes an own property instead of hitting
+    // the inherited setter on the plain {} we build into
+    assignProp(
+      json.properties,
+      key,
+      process(shape[key]!, ctx as any, {
+        ...params,
+        path: [...params.path, "properties", key],
+      })
+    );
   }
 
   // required keys
@@ -648,7 +654,7 @@ export function toJSONSchema(
     for (const entry of registry._idmap.entries()) {
       const [key, schema] = entry;
       extractDefs(ctx as any, schema);
-      schemas[key] = finalize(ctx as any, schema);
+      assignProp(schemas, key, finalize(ctx as any, schema));
     }
 
     if (Object.keys(defs).length > 0) {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -3,6 +3,7 @@ import type * as JSONSchema from "./json-schema.js";
 import { type $ZodRegistry, globalRegistry } from "./registries.js";
 import type * as schemas from "./schemas.js";
 import type { StandardJSONSchemaV1, StandardSchemaWithJSONProps } from "./standard-schema.js";
+import { assignProp } from "./util.js";
 
 export type Processor<T extends schemas.$ZodType = schemas.$ZodType> = (
   schema: T,
@@ -484,7 +485,7 @@ export function finalize<T extends schemas.$ZodType>(
     const seen = entry[1];
     if (seen.def && seen.defId) {
       if (seen.def.id === seen.defId) delete seen.def.id;
-      defs[seen.defId] = seen.def;
+      assignProp(defs, seen.defId, seen.def);
     }
   }
 


### PR DESCRIPTION
Both JSON Schema converters build plain object dictionaries and fill them with `obj[key] = value`. When the key is `__proto__`, that invokes the inherited setter instead of creating an own property, so the entry is silently lost.

```ts
const schema = z.object({ ["__proto__"]: z.literal("admin"), role: z.string() });

z.toJSONSchema(schema, { io: "input" });
// { properties: { role: {...} }, required: ["__proto__", "role"] }
//   ^ required names a property that isn't there — Ajv accepts input zod rejects

const rebuilt = z.fromJSONSchema(JSON.parse(`{
  "type": "object",
  "properties": { "__proto__": { "type": "string" } },
  "required": ["__proto__"]
}`));
rebuilt.safeParse({}).success; // true — the constraint is gone
```

Four sinks, one line each, all fixed with the existing `util.assignProp`:

| Site | Before |
| --- | --- |
| `from-json-schema.ts` shape build | a required `__proto__` property is dropped, so the schema accepts `{}` |
| `json-schema-processors.ts` object processor | `properties` omits the key while `required` still lists it |
| `json-schema-processors.ts` registry overload | a schema registered under the id `__proto__` vanishes from the catalog |
| `to-json-schema.ts` defs builder | the `$def` is dropped while `$ref`s to it are still emitted, so the reference is unresolvable |

The last one is the sharpest: Ajv throws `can't resolve reference #/$defs/__proto__` on the emitted schema.

Also covers the unrecognized-annotation path in `fromJSONSchema`, which fed the same unsafe write into the metadata registry.

Parsing has tolerated a `__proto__` shape key since #4359 — only the converters were left behind. No global prototype pollution is involved anywhere here; every write lands on a local dictionary.

One note for reviewers: an object literal cannot express these cases. Writing `{ __proto__: x }` sets the literal's own prototype and yields zero own keys, so the tests use a computed key and `JSON.parse` — which is also the realistic source of a JSON Schema.

Refs #4359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
