### PR TITLE
fix: remove exponential backtracking from the emoji regex

### DIFF
--- a/packages/zod/src/v3/tests/string.test.ts
+++ b/packages/zod/src/v3/tests/string.test.ts
@@ -323,6 +323,7 @@ test("url error overrides", () => {
 test("emoji validations", () => {
   const emoji = z.string().emoji();
 
+  emoji.parse("🦰🦱🦲🦳"); // both Extended_Pictographic and Emoji_Component
   emoji.parse("👋👋👋👋");
   emoji.parse("🍺👩‍🚀🫡");
   emoji.parse("💚💙💜💛❤️");
@@ -335,6 +336,11 @@ test("emoji validations", () => {
   expect(() => emoji.parse("😀 is an emoji")).toThrow();
   expect(() => emoji.parse("😀stuff")).toThrow();
   expect(() => emoji.parse("stuff😀")).toThrow();
+
+  // a failing match over the overlapping code points used to backtrack exponentially
+  const start = performance.now();
+  expect(emoji.safeParse(`${"🦰".repeat(26)} `).success).toBe(false);
+  expect(performance.now() - start).toBeLessThan(100);
 });
 
 test("uuid", () => {

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -619,7 +619,7 @@ const emailRegex = /^(?!\.)(?!.*\.\.)([A-Z0-9_'+\-\.]*)[A-Z0-9_+-]@([A-Z0-9][A-Z
 //   /^[a-z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9\-]+)*$/i;
 
 // from https://thekevinscott.com/emojis-in-javascript/#writing-a-regular-expression
-const _emojiRegex = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`;
+const _emojiRegex = `^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$`;
 let emojiRegex: RegExp;
 
 // faster, simpler, safer

--- a/packages/zod/src/v4/classic/tests/continuability.test.ts
+++ b/packages/zod/src/v4/classic/tests/continuability.test.ts
@@ -230,7 +230,7 @@ test("continuability", () => {
         "message": "Invalid emoji",
         "origin": "string",
         "path": [],
-        "pattern": "/^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$/u",
+        "pattern": "/^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$/u",
       },
       {
         "code": "custom",

--- a/packages/zod/src/v4/classic/tests/datetime.test.ts
+++ b/packages/zod/src/v4/classic/tests/datetime.test.ts
@@ -1,4 +1,3 @@
-import { checkSync } from "recheck";
 import { expect, test } from "vitest";
 import * as z from "zod/v4";
 
@@ -286,17 +285,3 @@ test("duration", () => {
     expect(result.error.issues[0].message).toEqual("Invalid ISO duration");
   }
 });
-
-test("redos checker", () => {
-  const a = z.iso.datetime();
-  const b = z.string().datetime({ offset: true });
-  const c = z.string().datetime({ local: true });
-  const d = z.string().datetime({ local: true, offset: true, precision: 3 });
-  const e = z.string().date();
-  const f = z.string().time();
-  const g = z.string().duration();
-  for (const schema of [a, b, c, d, e, f, g]) {
-    const result = checkSync(schema._zod.pattern.source, "");
-    if (result.status !== "safe") throw Error("ReDoS issue");
-  }
-}, 10000);

--- a/packages/zod/src/v4/classic/tests/redos.test.ts
+++ b/packages/zod/src/v4/classic/tests/redos.test.ts
@@ -1,0 +1,56 @@
+import { checkSync } from "recheck";
+import { expect, test } from "vitest";
+import * as z from "zod/v4";
+
+const { regexes } = z.core;
+
+/** Every pattern `core/regexes.ts` ships, with the parameterized ones materialized across their argument space. */
+function allPatterns(): [string, RegExp][] {
+  const patterns: [string, RegExp][] = [];
+  for (const [name, value] of Object.entries(regexes)) {
+    if (value instanceof RegExp) patterns.push([name, value]);
+  }
+
+  patterns.push(
+    ["emoji()", regexes.emoji()],
+    ["mac()", regexes.mac()],
+    ["mac('-')", regexes.mac("-")],
+    ["uuid()", regexes.uuid()],
+    ["string()", regexes.string()],
+    ["string({min,max})", regexes.string({ minimum: 1, maximum: 10 })]
+  );
+  for (const version of [1, 2, 3, 4, 5, 6, 7, 8]) patterns.push([`uuid(${version})`, regexes.uuid(version)]);
+  for (const precision of [null, -1, 0, 3, 6]) {
+    patterns.push([`time(${precision})`, regexes.time({ precision })]);
+    for (const local of [false, true]) {
+      for (const offset of [false, true]) {
+        patterns.push([`datetime(${precision},${local},${offset})`, regexes.datetime({ precision, local, offset })]);
+      }
+    }
+  }
+  return patterns;
+}
+
+test("no built-in pattern is ReDoS-vulnerable", () => {
+  const patterns = allPatterns();
+  // Guards against the reflection above silently going empty if the module layout changes.
+  expect(patterns.length).toBeGreaterThan(80);
+
+  const vulnerable: string[] = [];
+  for (const [name, pattern] of patterns) {
+    // Flags are load-bearing. Without "u" the checker reads `\p{...}` as a literal `p{...}`
+    // and reports an exponential pattern as safe.
+    const result = checkSync(pattern.source, pattern.flags);
+    if (result.status !== "safe") vulnerable.push(`${name} (${result.status}): ${pattern.source}`);
+  }
+  expect(vulnerable).toEqual([]);
+}, 60000);
+
+test("emoji rejects a backtracking payload in linear time", () => {
+  // U+1F9B0-U+1F9B3 are the only code points in both \p{Extended_Pictographic} and
+  // \p{Emoji_Component}. A failing match over them used to backtrack exponentially:
+  // 26 of them took ~1.9s, and each additional character roughly doubled it.
+  const start = performance.now();
+  expect(z.emoji().safeParse(`${"🦰".repeat(26)} `).success).toBe(false);
+  expect(performance.now() - start).toBeLessThan(100);
+});

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -493,6 +493,7 @@ test("url error overrides", () => {
 test("emoji validations", () => {
   const emoji = z.string().emoji();
 
+  emoji.parse("🦰🦱🦲🦳"); // both Extended_Pictographic and Emoji_Component
   emoji.parse("👋👋👋👋");
   emoji.parse("🍺👩‍🚀🫡");
   emoji.parse("💚💙💜💛❤️");

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -221,7 +221,7 @@ describe("toJSONSchema", () => {
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "emoji",
-        "pattern": "^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$",
+        "pattern": "^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$",
         "type": "string",
       }
     `);

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -57,7 +57,9 @@ export const browserEmail: RegExp =
   /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 // from https://thekevinscott.com/emojis-in-javascript/#writing-a-regular-expression
 
-const _emoji: string = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`;
+// Single character class, not an alternation: the two properties overlap (U+1F9B0-U+1F9B3),
+// so `(A|B)+` backtracks exponentially on a failed match.
+const _emoji: string = `^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$`;
 export function emoji(): RegExp {
   return new RegExp(_emoji, "u");
 }


### PR DESCRIPTION
The emoji format validator backtracks exponentially on a failed match.

```ts
const _emoji: string = `^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$`;
```

The two Unicode properties overlap on exactly four code points — U+1F9B0 through U+1F9B3, the emoji hair components. Quantifying an ambiguous alternation with `+` means that when the anchor fails, the engine re-explores up to 2^n ways of attributing the already-consumed characters between the two branches. Measured on `z.emoji().safeParse()`:

| input | payload | time |
| --- | --- | --- |
| 22 hair components + a space | 90 B | 145 ms |
| 24 hair components + a space | 98 B | 498 ms |
| 26 hair components + a space | 106 B | 2846 ms |

That is 2.11× per added character. A 126-byte string buys a 60-second stall, and `RegExp.test()` is uninterruptible, so a request timeout does not help. The same string ships from `zod`, `zod/mini`, `zod/v4-mini` and the bundled `zod/v3`.

## The fix

Collapse the alternation into one character class, which is the same move #2824 made on the email regex:

```ts
const _emoji: string = `^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$`;
```

Both patterns are `X+` over a per-character set, so equal single-character sets imply equal languages. Iterating every code point (surrogates excluded), the old and new patterns agree on all 2,990 members with zero disagreements — no valid emoji string changes acceptance. The dev-dependency ReDoS checker reports the new pattern **linear** via its automaton checker, and a 20,000-character payload now returns in 0 ms.

## Regression coverage

The existing `redos checker` test had two holes. It covered only the date/time family, and it passed an empty flags string:

```ts
const result = checkSync(schema._zod.pattern.source, "");
```

Without `u`, the checker does not read `\p{...}` as a Unicode property escape at all — it sees a literal `p{...}` and reports this pattern as safe. Adding emoji to that loop would have produced a green test over a live exponential regex.

The test moves to `redos.test.ts`, sweeps every pattern `core/regexes.ts` exports with the parameterized ones materialized across their argument space (89 patterns, up from 7), and passes the real flags. It also asserts a floor on the pattern count so a future refactor cannot silently empty the sweep. Runtime is about 4 seconds.

A companion test pins the fix behaviorally in both v4 and v3: 26 hair components followed by a space must be rejected in under 100 ms. Against the old pattern that assertion fails at roughly 2–17 seconds depending on the machine. The payload is deliberately 26 and should not be raised — at 64 the old pattern does not fail the assertion, it hangs the worker forever and vitest cannot interrupt it.

## Note for consumers

The pattern string is emitted as the JSON Schema `pattern` and in `invalid_format` issues, so `z.toJSONSchema(z.emoji())` output changes. It is semantically equivalent; two inline snapshots are updated.
