### PR TITLE
perf(v4): dedupe factory def boilerplate in core/api.ts (-2.3% tree-shaken)

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2221,13 +2221,7 @@ export function _default<T extends core.SomeType>(
   innerType: T,
   defaultValue: util.NoUndefined<core.output<T>> | (() => util.NoUndefined<core.output<T>>)
 ): ZodDefault<T> {
-  return new ZodDefault({
-    type: "default",
-    innerType: innerType as any as core.$ZodType,
-    get defaultValue() {
-      return typeof defaultValue === "function" ? (defaultValue as Function)() : util.shallowClone(defaultValue);
-    },
-  }) as any;
+  return new ZodDefault(core._defaultDef("default", innerType as any, defaultValue)) as any;
 }
 
 // ZodPrefault
@@ -2251,13 +2245,7 @@ export function prefault<T extends core.SomeType>(
   innerType: T,
   defaultValue: core.input<T> | (() => core.input<T>)
 ): ZodPrefault<T> {
-  return new ZodPrefault({
-    type: "prefault",
-    innerType: innerType as any as core.$ZodType,
-    get defaultValue() {
-      return typeof defaultValue === "function" ? (defaultValue as Function)() : util.shallowClone(defaultValue);
-    },
-  }) as any;
+  return new ZodPrefault(core._defaultDef("prefault", innerType as any, defaultValue)) as any;
 }
 
 // ZodNonOptional

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1270,19 +1270,26 @@ export function _nullable<T extends schemas.$ZodObject>(
 
 // ZodDefault
 export type $ZodDefaultParams = TypeParams<schemas.$ZodDefault, "innerType" | "defaultValue">;
+
+/** Builds a default/prefault def whose `defaultValue` getter unwraps functions and clones static values. */
+// @__NO_SIDE_EFFECTS__
+export function _defaultDef(type: "default" | "prefault", innerType: schemas.$ZodType, defaultValue: unknown): any {
+  return {
+    type,
+    innerType,
+    get defaultValue() {
+      return typeof defaultValue === "function" ? (defaultValue as Function)() : util.shallowClone(defaultValue);
+    },
+  };
+}
+
 // @__NO_SIDE_EFFECTS__
 export function _default<T extends schemas.$ZodObject>(
   Class: util.SchemaClass<schemas.$ZodDefault>,
   innerType: T,
   defaultValue: util.NoUndefined<core.output<T>> | (() => util.NoUndefined<core.output<T>>)
 ): schemas.$ZodDefault<T> {
-  return new Class({
-    type: "default",
-    innerType,
-    get defaultValue() {
-      return typeof defaultValue === "function" ? (defaultValue as Function)() : util.shallowClone(defaultValue);
-    },
-  }) as any;
+  return new Class(_defaultDef("default", innerType as any, defaultValue)) as any;
 }
 
 // ZodNonOptional

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -89,6 +89,34 @@ export type $ZodStringFormatParams = CheckTypeParams<
 export type $ZodCheckStringFormatParams = CheckParams<checks.$ZodCheckStringFormat, "format">;
 // custom format
 
+/** Shared factory for string-format schemas. */
+// @__NO_SIDE_EFFECTS__
+function _sf<T extends schemas.$ZodStringFormat>(
+  Class: util.SchemaClass<T>,
+  format: string,
+  params?: unknown,
+  defaults?: object
+): T {
+  return new Class({
+    type: "string",
+    format,
+    check: "string_format",
+    ...defaults,
+    ...util.normalizeParams(params as any),
+  } as any);
+}
+
+/** Shared factory for string-format schemas that default to `abort: false`. */
+// @__NO_SIDE_EFFECTS__
+function _sfa<T extends schemas.$ZodStringFormat>(
+  Class: util.SchemaClass<T>,
+  format: string,
+  params?: unknown,
+  defaults?: object
+): T {
+  return _sf(Class, format, params, { abort: false, ...defaults });
+}
+
 // Email
 export type $ZodEmailParams = StringFormatParams<schemas.$ZodEmail, "when">;
 export type $ZodCheckEmailParams = CheckStringFormatParams<schemas.$ZodEmail, "when">;
@@ -97,13 +125,7 @@ export function _email<T extends schemas.$ZodEmail>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodEmailParams | $ZodCheckEmailParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "email",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "email", params);
 }
 
 // GUID
@@ -114,13 +136,7 @@ export function _guid<T extends schemas.$ZodGUID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodGUIDParams | $ZodCheckGUIDParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "guid",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "guid", params);
 }
 
 // UUID
@@ -131,13 +147,7 @@ export function _uuid<T extends schemas.$ZodUUID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodUUIDParams | $ZodCheckUUIDParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "uuid",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "uuid", params);
 }
 
 // UUIDv4
@@ -148,14 +158,7 @@ export function _uuidv4<T extends schemas.$ZodUUID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodUUIDv4Params | $ZodCheckUUIDv4Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "uuid",
-    check: "string_format",
-    abort: false,
-    version: "v4",
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "uuid", params, { version: "v4" });
 }
 
 // UUIDv6
@@ -166,14 +169,7 @@ export function _uuidv6<T extends schemas.$ZodUUID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodUUIDv6Params | $ZodCheckUUIDv6Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "uuid",
-    check: "string_format",
-    abort: false,
-    version: "v6",
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "uuid", params, { version: "v6" });
 }
 
 // UUIDv7
@@ -184,14 +180,7 @@ export function _uuidv7<T extends schemas.$ZodUUID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodUUIDv7Params | $ZodCheckUUIDv7Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "uuid",
-    check: "string_format",
-    abort: false,
-    version: "v7",
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "uuid", params, { version: "v7" });
 }
 
 // URL
@@ -202,13 +191,7 @@ export function _url<T extends schemas.$ZodURL>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodURLParams | $ZodCheckURLParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "url",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "url", params);
 }
 
 // Emoji
@@ -219,13 +202,7 @@ export function _emoji<T extends schemas.$ZodEmoji>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodEmojiParams | $ZodCheckEmojiParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "emoji",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "emoji", params);
 }
 
 // NanoID
@@ -236,13 +213,7 @@ export function _nanoid<T extends schemas.$ZodNanoID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodNanoIDParams | $ZodCheckNanoIDParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "nanoid",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "nanoid", params);
 }
 
 // CUID
@@ -268,13 +239,7 @@ export function _cuid<T extends schemas.$ZodCUID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodCUIDParams | $ZodCheckCUIDParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "cuid",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "cuid", params);
 }
 
 // CUID2
@@ -285,13 +250,7 @@ export function _cuid2<T extends schemas.$ZodCUID2>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodCUID2Params | $ZodCheckCUID2Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "cuid2",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "cuid2", params);
 }
 
 // ULID
@@ -302,13 +261,7 @@ export function _ulid<T extends schemas.$ZodULID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodULIDParams | $ZodCheckULIDParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "ulid",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "ulid", params);
 }
 
 // XID
@@ -319,13 +272,7 @@ export function _xid<T extends schemas.$ZodXID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodXIDParams | $ZodCheckXIDParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "xid",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "xid", params);
 }
 
 // KSUID
@@ -336,13 +283,7 @@ export function _ksuid<T extends schemas.$ZodKSUID>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodKSUIDParams | $ZodCheckKSUIDParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "ksuid",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "ksuid", params);
 }
 
 // IPv4
@@ -353,13 +294,7 @@ export function _ipv4<T extends schemas.$ZodIPv4>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodIPv4Params | $ZodCheckIPv4Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "ipv4",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "ipv4", params);
 }
 
 // IPv6
@@ -370,13 +305,7 @@ export function _ipv6<T extends schemas.$ZodIPv6>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodIPv6Params | $ZodCheckIPv6Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "ipv6",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "ipv6", params);
 }
 
 // MAC
@@ -387,13 +316,7 @@ export function _mac<T extends schemas.$ZodMAC>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodMACParams | $ZodCheckMACParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "mac",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "mac", params);
 }
 
 // CIDRv4
@@ -404,13 +327,7 @@ export function _cidrv4<T extends schemas.$ZodCIDRv4>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodCIDRv4Params | $ZodCheckCIDRv4Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "cidrv4",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "cidrv4", params);
 }
 
 // CIDRv6
@@ -421,13 +338,7 @@ export function _cidrv6<T extends schemas.$ZodCIDRv6>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodCIDRv6Params | $ZodCheckCIDRv6Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "cidrv6",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "cidrv6", params);
 }
 
 // Base64
@@ -438,13 +349,7 @@ export function _base64<T extends schemas.$ZodBase64>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodBase64Params | $ZodCheckBase64Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "base64",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "base64", params);
 }
 
 // base64url
@@ -455,13 +360,7 @@ export function _base64url<T extends schemas.$ZodBase64URL>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodBase64URLParams | $ZodCheckBase64URLParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "base64url",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "base64url", params);
 }
 
 // E164
@@ -472,13 +371,7 @@ export function _e164<T extends schemas.$ZodE164>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodE164Params | $ZodCheckE164Params
 ): T {
-  return new Class({
-    type: "string",
-    format: "e164",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "e164", params);
 }
 
 // JWT
@@ -489,13 +382,7 @@ export function _jwt<T extends schemas.$ZodJWT>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodJWTParams | $ZodCheckJWTParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "jwt",
-    check: "string_format",
-    abort: false,
-    ...util.normalizeParams(params),
-  });
+  return _sfa(Class, "jwt", params);
 }
 
 export const TimePrecision = {
@@ -513,15 +400,7 @@ export function _isoDateTime<T extends schemas.$ZodISODateTime>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodISODateTimeParams | $ZodCheckISODateTimeParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "datetime",
-    check: "string_format",
-    offset: false,
-    local: false,
-    precision: null,
-    ...util.normalizeParams(params),
-  });
+  return _sf(Class, "datetime", params, { offset: false, local: false, precision: null });
 }
 
 // ISODate
@@ -532,12 +411,7 @@ export function _isoDate<T extends schemas.$ZodISODate>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodISODateParams | $ZodCheckISODateParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "date",
-    check: "string_format",
-    ...util.normalizeParams(params),
-  });
+  return _sf(Class, "date", params);
 }
 
 // ISOTime
@@ -548,13 +422,7 @@ export function _isoTime<T extends schemas.$ZodISOTime>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodISOTimeParams | $ZodCheckISOTimeParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "time",
-    check: "string_format",
-    precision: null,
-    ...util.normalizeParams(params),
-  });
+  return _sf(Class, "time", params, { precision: null });
 }
 
 // ISODuration
@@ -565,12 +433,7 @@ export function _isoDuration<T extends schemas.$ZodISODuration>(
   Class: util.SchemaClass<T>,
   params?: string | $ZodISODurationParams | $ZodCheckISODurationParams
 ): T {
-  return new Class({
-    type: "string",
-    format: "duration",
-    check: "string_format",
-    ...util.normalizeParams(params),
-  });
+  return _sf(Class, "duration", params);
 }
 
 // Number

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -715,18 +715,34 @@ export function _nan<T extends schemas.$ZodNaN>(Class: util.SchemaClass<T>, para
 
 // export type $ZodCheckParams = CheckParams<checks.$ZodCheck, "abort" | "when">;
 
+/** Shared factory for check defs of the form `{ check, ...params, ...after }`; `after` fields cannot be overridden by params. */
+// @__NO_SIDE_EFFECTS__
+function _ck<T>(Class: new (def: any) => T, check: string, params?: unknown, after?: object): T {
+  return new Class({
+    check,
+    ...util.normalizeParams(params as any),
+    ...after,
+  });
+}
+
+/** Shared factory for string-format check defs. */
+// @__NO_SIDE_EFFECTS__
+function _ckf<T>(Class: new (def: any) => T, format: string, params?: unknown, after?: object): T {
+  return new Class({
+    check: "string_format",
+    format,
+    ...util.normalizeParams(params as any),
+    ...after,
+  });
+}
+
 export type $ZodCheckLessThanParams = CheckParams<checks.$ZodCheckLessThan, "inclusive" | "value" | "when">;
 // @__NO_SIDE_EFFECTS__
 export function _lt(
   value: util.Numeric,
   params?: string | $ZodCheckLessThanParams
 ): checks.$ZodCheckLessThan<util.Numeric> {
-  return new checks.$ZodCheckLessThan({
-    check: "less_than",
-    ...util.normalizeParams(params),
-    value,
-    inclusive: false,
-  });
+  return _ck(checks.$ZodCheckLessThan, "less_than", params, { value, inclusive: false });
 }
 
 // @__NO_SIDE_EFFECTS__
@@ -734,13 +750,7 @@ export function _lte(
   value: util.Numeric,
   params?: string | $ZodCheckLessThanParams
 ): checks.$ZodCheckLessThan<util.Numeric> {
-  return new checks.$ZodCheckLessThan({
-    check: "less_than",
-
-    ...util.normalizeParams(params),
-    value,
-    inclusive: true,
-  });
+  return _ck(checks.$ZodCheckLessThan, "less_than", params, { value, inclusive: true });
 }
 export {
   /** @deprecated Use `z.lte()` instead. */
@@ -751,23 +761,12 @@ export {
 export type $ZodCheckGreaterThanParams = CheckParams<checks.$ZodCheckGreaterThan, "inclusive" | "value" | "when">;
 // @__NO_SIDE_EFFECTS__
 export function _gt(value: util.Numeric, params?: string | $ZodCheckGreaterThanParams): checks.$ZodCheckGreaterThan {
-  return new checks.$ZodCheckGreaterThan({
-    check: "greater_than",
-
-    ...util.normalizeParams(params),
-    value,
-    inclusive: false,
-  });
+  return _ck(checks.$ZodCheckGreaterThan, "greater_than", params, { value, inclusive: false });
 }
 
 // @__NO_SIDE_EFFECTS__
 export function _gte(value: util.Numeric, params?: string | $ZodCheckGreaterThanParams): checks.$ZodCheckGreaterThan {
-  return new checks.$ZodCheckGreaterThan({
-    check: "greater_than",
-    ...util.normalizeParams(params),
-    value,
-    inclusive: true,
-  });
+  return _ck(checks.$ZodCheckGreaterThan, "greater_than", params, { value, inclusive: true });
 }
 
 export {
@@ -804,11 +803,7 @@ export function _multipleOf(
   value: number | bigint,
   params?: string | $ZodCheckMultipleOfParams
 ): checks.$ZodCheckMultipleOf {
-  return new checks.$ZodCheckMultipleOf({
-    check: "multiple_of",
-    ...util.normalizeParams(params),
-    value,
-  });
+  return _ck(checks.$ZodCheckMultipleOf, "multiple_of", params, { value });
 }
 
 export type $ZodCheckMaxSizeParams = CheckParams<checks.$ZodCheckMaxSize, "maximum" | "when">;
@@ -817,11 +812,7 @@ export function _maxSize(
   maximum: number,
   params?: string | $ZodCheckMaxSizeParams
 ): checks.$ZodCheckMaxSize<util.HasSize> {
-  return new checks.$ZodCheckMaxSize({
-    check: "max_size",
-    ...util.normalizeParams(params),
-    maximum,
-  });
+  return _ck(checks.$ZodCheckMaxSize, "max_size", params, { maximum });
 }
 
 export type $ZodCheckMinSizeParams = CheckParams<checks.$ZodCheckMinSize, "minimum" | "when">;
@@ -830,11 +821,7 @@ export function _minSize(
   minimum: number,
   params?: string | $ZodCheckMinSizeParams
 ): checks.$ZodCheckMinSize<util.HasSize> {
-  return new checks.$ZodCheckMinSize({
-    check: "min_size",
-    ...util.normalizeParams(params),
-    minimum,
-  });
+  return _ck(checks.$ZodCheckMinSize, "min_size", params, { minimum });
 }
 
 export type $ZodCheckSizeEqualsParams = CheckParams<checks.$ZodCheckSizeEquals, "size" | "when">;
@@ -843,11 +830,7 @@ export function _size(
   size: number,
   params?: string | $ZodCheckSizeEqualsParams
 ): checks.$ZodCheckSizeEquals<util.HasSize> {
-  return new checks.$ZodCheckSizeEquals({
-    check: "size_equals",
-    ...util.normalizeParams(params),
-    size,
-  });
+  return _ck(checks.$ZodCheckSizeEquals, "size_equals", params, { size });
 }
 
 export type $ZodCheckMaxLengthParams = CheckParams<checks.$ZodCheckMaxLength, "maximum" | "when">;
@@ -856,12 +839,7 @@ export function _maxLength(
   maximum: number,
   params?: string | $ZodCheckMaxLengthParams
 ): checks.$ZodCheckMaxLength<util.HasLength> {
-  const ch = new checks.$ZodCheckMaxLength({
-    check: "max_length",
-    ...util.normalizeParams(params),
-    maximum,
-  });
-  return ch;
+  return _ck(checks.$ZodCheckMaxLength, "max_length", params, { maximum });
 }
 
 export type $ZodCheckMinLengthParams = CheckParams<checks.$ZodCheckMinLength, "minimum" | "when">;
@@ -870,11 +848,7 @@ export function _minLength(
   minimum: number,
   params?: string | $ZodCheckMinLengthParams
 ): checks.$ZodCheckMinLength<util.HasLength> {
-  return new checks.$ZodCheckMinLength({
-    check: "min_length",
-    ...util.normalizeParams(params),
-    minimum,
-  });
+  return _ck(checks.$ZodCheckMinLength, "min_length", params, { minimum });
 }
 
 export type $ZodCheckLengthEqualsParams = CheckParams<checks.$ZodCheckLengthEquals, "length" | "when">;
@@ -883,54 +857,32 @@ export function _length(
   length: number,
   params?: string | $ZodCheckLengthEqualsParams
 ): checks.$ZodCheckLengthEquals<util.HasLength> {
-  return new checks.$ZodCheckLengthEquals({
-    check: "length_equals",
-    ...util.normalizeParams(params),
-    length,
-  });
+  return _ck(checks.$ZodCheckLengthEquals, "length_equals", params, { length });
 }
 
 export type $ZodCheckRegexParams = CheckParams<checks.$ZodCheckRegex, "format" | "pattern" | "when">;
 // @__NO_SIDE_EFFECTS__
 export function _regex(pattern: RegExp, params?: string | $ZodCheckRegexParams): checks.$ZodCheckRegex {
-  return new checks.$ZodCheckRegex({
-    check: "string_format",
-    format: "regex",
-    ...util.normalizeParams(params),
-    pattern,
-  });
+  return _ckf(checks.$ZodCheckRegex, "regex", params, { pattern });
 }
 
 export type $ZodCheckLowerCaseParams = CheckParams<checks.$ZodCheckLowerCase, "format" | "when">;
 // @__NO_SIDE_EFFECTS__
 export function _lowercase(params?: string | $ZodCheckLowerCaseParams): checks.$ZodCheckLowerCase {
-  return new checks.$ZodCheckLowerCase({
-    check: "string_format",
-    format: "lowercase",
-    ...util.normalizeParams(params),
-  });
+  return _ckf(checks.$ZodCheckLowerCase, "lowercase", params);
 }
 
 export type $ZodCheckUpperCaseParams = CheckParams<checks.$ZodCheckUpperCase, "format" | "when">;
 
 // @__NO_SIDE_EFFECTS__
 export function _uppercase(params?: string | $ZodCheckUpperCaseParams): checks.$ZodCheckUpperCase {
-  return new checks.$ZodCheckUpperCase({
-    check: "string_format",
-    format: "uppercase",
-    ...util.normalizeParams(params),
-  });
+  return _ckf(checks.$ZodCheckUpperCase, "uppercase", params);
 }
 
 export type $ZodCheckIncludesParams = CheckParams<checks.$ZodCheckIncludes, "includes" | "format" | "when" | "pattern">;
 // @__NO_SIDE_EFFECTS__
 export function _includes(includes: string, params?: string | $ZodCheckIncludesParams): checks.$ZodCheckIncludes {
-  return new checks.$ZodCheckIncludes({
-    check: "string_format",
-    format: "includes",
-    ...util.normalizeParams(params),
-    includes,
-  });
+  return _ckf(checks.$ZodCheckIncludes, "includes", params, { includes });
 }
 export type $ZodCheckStartsWithParams = CheckParams<
   checks.$ZodCheckStartsWith,
@@ -938,24 +890,14 @@ export type $ZodCheckStartsWithParams = CheckParams<
 >;
 // @__NO_SIDE_EFFECTS__
 export function _startsWith(prefix: string, params?: string | $ZodCheckStartsWithParams): checks.$ZodCheckStartsWith {
-  return new checks.$ZodCheckStartsWith({
-    check: "string_format",
-    format: "starts_with",
-    ...util.normalizeParams(params),
-    prefix,
-  });
+  return _ckf(checks.$ZodCheckStartsWith, "starts_with", params, { prefix });
 }
 
 export type $ZodCheckEndsWithParams = CheckParams<checks.$ZodCheckEndsWith, "suffix" | "format" | "pattern" | "when">;
 
 // @__NO_SIDE_EFFECTS__
 export function _endsWith(suffix: string, params?: string | $ZodCheckEndsWithParams): checks.$ZodCheckEndsWith {
-  return new checks.$ZodCheckEndsWith({
-    check: "string_format",
-    format: "ends_with",
-    ...util.normalizeParams(params),
-    suffix,
-  });
+  return _ckf(checks.$ZodCheckEndsWith, "ends_with", params, { suffix });
 }
 
 export type $ZodCheckPropertyParams = CheckParams<checks.$ZodCheckProperty, "property" | "schema" | "when">;

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1476,13 +1476,7 @@ export function _default<T extends SomeType>(
   innerType: T,
   defaultValue: util.NoUndefined<core.output<T>> | (() => util.NoUndefined<core.output<T>>)
 ): ZodMiniDefault<T> {
-  return new ZodMiniDefault({
-    type: "default",
-    innerType: innerType as any as core.$ZodType,
-    get defaultValue() {
-      return typeof defaultValue === "function" ? (defaultValue as Function)() : util.shallowClone(defaultValue);
-    },
-  }) as any;
+  return new ZodMiniDefault(core._defaultDef("default", innerType as any, defaultValue)) as any;
 }
 
 // ZodMiniPrefault
@@ -1502,13 +1496,7 @@ export function prefault<T extends SomeType>(
   innerType: T,
   defaultValue: util.NoUndefined<core.input<T>> | (() => util.NoUndefined<core.input<T>>)
 ): ZodMiniPrefault<T> {
-  return new ZodMiniPrefault({
-    type: "prefault",
-    innerType: innerType as any as core.$ZodType,
-    get defaultValue() {
-      return typeof defaultValue === "function" ? (defaultValue as Function)() : util.shallowClone(defaultValue);
-    },
-  }) as any;
+  return new ZodMiniPrefault(core._defaultDef("prefault", innerType as any, defaultValue)) as any;
 }
 
 // ZodMiniNonOptional


### PR DESCRIPTION
> **Context: bundle-size optimization campaign.** This is one of four PRs extracted from a systematic bundle-size campaign on the v4 core, run as an automated research loop: 30 isolated experiments, 24 kept, 6 discarded. Every candidate change was
>
> - measured with a **deterministic A/B size harness** that materialises two git revisions of `packages/zod/src` via `git archive` and bundles seven fixed entry cases with esbuild (`--bundle --minify --format=esm --target=es2020`), recording minified and gzipped (zlib 9) bytes plus esbuild metafiles for attribution. The verification below leads with the **standard consumer**: `import * as z from "zod"` + `z.object({ name: z.string(), age: z.number() }).safeParse(...)` (70.9 kB min at baseline; namespace property accesses tree-shake under esbuild). Also reported: `import { z }`, which defeats tree-shaking entirely under esbuild (the exported `z` binding is a namespace object that escapes as a value, pinning the full classic surface, 327.7 kB min at baseline, no matter how few methods are used), and named imports (`import { string }`), the best-case shaking scenario;
> - judged against an **exact-zero calibration**: identical revisions on both sides produce 0-byte deltas on every case (esbuild output is deterministic), so every reported delta is exact and there is no noise floor to argue about. Minified bytes is the judged metric; gzip is reported alongside;
> - verified behaviour-preserving by the **full test suite** (339 files, 3,811 tests including tsc typecheck; snapshot-heavy, so error messages, def shapes, and JSON Schema output are pinned), green after every commit. Experiments that changed observable behaviour or regressed a tree-shaken case were discarded; e.g. sharing regex source strings was rejected because esbuild cannot tree-shake `new RegExp` with a non-literal argument and the shared string would have been pinned into every `zod/mini` consumer;
> - **runtime-smoked** where a change touched construction or error paths (`packages/bench` `init` and `object-fail`), with results inside run-to-run noise;
> - cross-checked at the end against the **real build**: cumulative deltas re-measured on `zshy`-built package output bundled consumer-style matched the source-level harness byte-for-byte.
>
> The numbers below are fresh verification runs of **this branch in isolation against `main`**, first per commit (each against its parent), then the branch total. Negative = smaller.
>
> Sibling PRs from the same campaign: #6349, #6350, #6351.

## What this PR does

Dedupes the repeated def-literal boilerplate in the `core/api.ts` factory functions. Dozens of factories build near-identical def objects that the minifier cannot compress because property names are not mangled. Three commits, each preserving def key order and key presence byte-for-byte:

**1. String-format schema factories (`_sf`/`_sfa`).** 27 factories (`_email`, `_uuid`, `_ipv6`, the ISO family, ...) each spelled out `{ type: "string", format: X, check: "string_format", abort: false, ...normalizeParams(params) }`. They now delegate to two small helpers; `_sfa` supplies the `abort: false` default, `_sf` is used by the ISO factories that never set `abort`, and per-factory extras (`version: "v4"`, `precision: null`, ...) pass through a `defaults` argument in the original key position. Public signatures unchanged.

**2. Check factories (`_ck`/`_ckf`).** Same treatment for 17 check factories (`_lt`/`_gte`, `_minLength`-family, `_regex`/`_includes`/`_startsWith`/`_endsWith`, ...). Trailing fields still spread *after* `normalizeParams`, so user params cannot override `value`/`inclusive`/`pattern`, exactly as before.

**3. Shared `_defaultDef`.** The `defaultValue`-getter def literal (unwrap function values, `shallowClone` static ones) appeared five times across `core/api.ts`, `classic/schemas.ts`, and `mini/schemas.ts`; it is now built by one exported helper.

All three are construction-time only; no parse-path code is touched. The schema-init benchmark (`pnpm bench init`) was smoked around the round-1 factory change with results inside run-to-run noise.

## Verification (this branch vs `main`)

Per case, minified bytes (gzip tracked alongside; judged on minified):

| commit | namespace import `import * as z` (standard) | z-object import `import { z }` (full) | named imports `import { string }` |
|---|---|---|---|
| 1. `_sf`/`_sfa` string-format factories | **-1,409 (-1.99%)** | -1,465 | -1,412 |
| 2. `_ck`/`_ckf` check factories | -191 | -227 | -122 |
| 3. `_defaultDef` | -58 | -108 | -58 |
| **branch total** | **-1,658 (-2.34%)** | **-1,800 (-0.55%)** | **-1,592 (-2.78%)** |

Full suite green after every commit (3,847 tests + typecheck on current `main`). One trade-off to disclose: minimal `zod/mini` consumers retain the `_ck` helper once, +45 bytes on a 7.4 kB bundle (commit 2); classic consumers see no regression anywhere. Net source delta: 3 files, +111/-323.

## Reproducing the numbers

The harness below is the one used for the verification runs. From a checkout of this repo:

1. `pnpm install`
2. Save the file below as `sizecheck/compare.mts` (the directory must live **inside** the repo so the materialised trees resolve `node_modules`; `sizecheck/{a,b,meta}/` are created automatically and safe to delete).
3. Fetch this PR's head ref and compare it against `main`:

   ```sh
   git fetch origin pull/6348/head:pr-branch
   pnpm tsx sizecheck/compare.mts main pr-branch
   ```

A run takes ~15s and prints per-case minified/gzip bytes for both sides with exact deltas; the `namespace-import-classic` row is the standard `import * as z` consumer, `z-import-classic` the `import { z }` style, `named-import-classic` the `import { string }` style. A control run with the same rev on both sides (`pnpm tsx sizecheck/compare.mts main main`) prints all-zero deltas — the pipeline is deterministic, so single runs are conclusive.

<details>
<summary><code>sizecheck/compare.mts</code> — A/B bundle-size harness</summary>

```ts
/**
 * A/B bundle-size comparison between two git revisions of packages/zod.
 *
 * Usage: pnpm exec tsx sizecheck/compare.mts [revA] [revB]
 *   revA defaults to HEAD, revB defaults to WORK (the working tree).
 *
 * Each side is materialised under sizecheck/<side>/ via `git archive` (or a
 * straight copy for WORK), then a fixed set of entry files is bundled with
 * esbuild (--bundle --minify --format=esm, pinned target). Reports minified
 * and gzipped bytes per case plus deltas, and writes esbuild metafiles to
 * sizecheck/meta/.
 */
import { execSync } from "node:child_process";
import { gzipSync } from "node:zlib";
import * as fs from "node:fs";
import * as path from "node:path";
import { build } from "esbuild";

const root = path.resolve(import.meta.dirname, "..");
const work = path.join(root, "sizecheck");

const revA = process.argv[2] ?? "HEAD";
const revB = process.argv[3] ?? "WORK";

/** Entry cases. Files are written identically into each side's tree. */
const CASES: Array<{ name: string; code: string }> = [
  {
    name: "full-import-classic",
    code: `import * as z from "./packages/zod/src/index.ts";\nconsole.log(z);\n`,
  },
  {
    name: "full-import-mini",
    code: `import * as z from "./packages/zod/src/mini/index.ts";\nconsole.log(z);\n`,
  },
  {
    name: "named-import-mini",
    code: `import { string, minLength, safeParse } from "./packages/zod/src/mini/index.ts";\nconst schema = string().check(minLength(5));\nconsole.log(safeParse(schema, "hello"));\n`,
  },
  {
    name: "named-import-classic",
    code: `import { string } from "./packages/zod/src/index.ts";\nconst schema = string().min(5);\nconsole.log(schema.safeParse("hello"));\n`,
  },
  {
    name: "namespace-import-classic",
    code: `import * as z from "./packages/zod/src/index.ts";\nconst schema = z.object({ name: z.string(), age: z.number() });\nconsole.log(schema.safeParse({ name: "hello", age: 1 }));\n`,
  },
  {
    name: "z-import-classic",
    code: `import { z } from "./packages/zod/src/index.ts";\nconst schema = z.object({ name: z.string(), age: z.number() });\nconsole.log(schema.safeParse({ name: "hello", age: 1 }));\n`,
  },
  {
    name: "full-import-locales",
    code: `import * as locales from "./packages/zod/src/locales/index.ts";\nconsole.log(locales);\n`,
  },
];

function materialise(rev: string, dir: string): void {
  fs.rmSync(dir, { recursive: true, force: true });
  fs.mkdirSync(dir, { recursive: true });
  if (rev === "WORK") {
    fs.mkdirSync(path.join(dir, "packages/zod"), { recursive: true });
    fs.cpSync(path.join(root, "packages/zod/src"), path.join(dir, "packages/zod/src"), { recursive: true });
    fs.copyFileSync(path.join(root, "packages/zod/package.json"), path.join(dir, "packages/zod/package.json"));
  } else {
    execSync(`git archive ${rev} -- packages/zod/src packages/zod/package.json | tar -x -C ${JSON.stringify(dir)}`, {
      cwd: root,
      shell: "/bin/zsh",
    });
  }
  for (const c of CASES) {
    fs.writeFileSync(path.join(dir, `${c.name}.entry.ts`), c.code);
  }
}

interface Result {
  min: number;
  gzip: number;
}

async function measure(dir: string, side: string): Promise<Record<string, Result>> {
  const out: Record<string, Result> = {};
  for (const c of CASES) {
    const result = await build({
      entryPoints: [path.join(dir, `${c.name}.entry.ts`)],
      bundle: true,
      minify: true,
      format: "esm",
      target: "es2020",
      write: false,
      metafile: true,
      outfile: `${c.name}.js`,
      logLevel: "silent",
    });
    const contents = result.outputFiles[0].contents;
    out[c.name] = {
      min: contents.byteLength,
      gzip: gzipSync(contents, { level: 9 }).byteLength,
    };
    fs.mkdirSync(path.join(work, "meta"), { recursive: true });
    fs.writeFileSync(path.join(work, "meta", `${side}-${c.name}.json`), JSON.stringify(result.metafile));
  }
  return out;
}

function fmt(n: number): string {
  return n.toLocaleString("en-US");
}

const dirA = path.join(work, "a");
const dirB = path.join(work, "b");
materialise(revA, dirA);
materialise(revB, dirB);

const resA = await measure(dirA, "a");
const resB = await measure(dirB, "b");

console.log(`A = ${revA}, B = ${revB}\n`);
const pad = (s: string, n: number) => s.padStart(n);
console.log(
  "case".padEnd(16) +
    pad("A min", 10) +
    pad("B min", 10) +
    pad("Δ min", 9) +
    pad("Δ%", 8) +
    pad("A gz", 9) +
    pad("B gz", 9) +
    pad("Δ gz", 8)
);
let totMinA = 0;
let totMinB = 0;
let totGzA = 0;
let totGzB = 0;
for (const c of CASES) {
  const a = resA[c.name];
  const b = resB[c.name];
  totMinA += a.min;
  totMinB += b.min;
  totGzA += a.gzip;
  totGzB += b.gzip;
  const dMin = b.min - a.min;
  const dGz = b.gzip - a.gzip;
  const pct = a.min === 0 ? 0 : (dMin / a.min) * 100;
  console.log(
    c.name.padEnd(16) +
      pad(fmt(a.min), 10) +
      pad(fmt(b.min), 10) +
      pad((dMin >= 0 ? "+" : "") + fmt(dMin), 9) +
      pad(`${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%`, 8) +
      pad(fmt(a.gzip), 9) +
      pad(fmt(b.gzip), 9) +
      pad((dGz >= 0 ? "+" : "") + fmt(dGz), 8)
  );
}
const dTotMin = totMinB - totMinA;
const dTotGz = totGzB - totGzA;
console.log(
  "TOTAL".padEnd(16) +
    pad(fmt(totMinA), 10) +
    pad(fmt(totMinB), 10) +
    pad((dTotMin >= 0 ? "+" : "") + fmt(dTotMin), 9) +
    pad(`${totMinA ? ((dTotMin / totMinA) * 100).toFixed(2) : "0.00"}%`, 8) +
    pad(fmt(totGzA), 9) +
    pad(fmt(totGzB), 9) +
    pad((dTotGz >= 0 ? "+" : "") + fmt(dTotGz), 8)
);
```

</details>
