### PR TITLE
perf(v4): dedupe class-init boilerplate in classic/core schemas (-3.6% tree-shaken)

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -30,12 +30,14 @@ function _setProcessor(inst: core.$ZodType, processor: core.Processor<any>): voi
 function _initFrom(
   Sup: { init: (inst: any, def: any) => void },
   Base: { init: (inst: any, def: any) => void },
-  processor?: core.Processor<any>
+  processor?: core.Processor<any>,
+  unwrap?: boolean
 ): (inst: any, def: any) => void {
   return (inst, def) => {
     Sup.init(inst, def);
     Base.init(inst, def);
     if (processor) _setProcessor(inst, processor);
+    if (unwrap) inst.unwrap = () => inst._zod.def.innerType;
   };
 }
 
@@ -2123,13 +2125,7 @@ export interface ZodOptional<T extends core.SomeType = core.$ZodType>
 }
 export const ZodOptional: core.$constructor<ZodOptional> = /*@__PURE__*/ core.$constructor(
   "ZodOptional",
-  (inst, def) => {
-    core.$ZodOptional.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.optionalProcessor);
-
-    inst.unwrap = () => inst._zod.def.innerType;
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodOptional, ZodType, processors.optionalProcessor, true)
 );
 
 export function optional<T extends core.SomeType>(innerType: T): ZodOptional<T> {
@@ -2148,13 +2144,7 @@ export interface ZodExactOptional<T extends core.SomeType = core.$ZodType>
 }
 export const ZodExactOptional: core.$constructor<ZodExactOptional> = /*@__PURE__*/ core.$constructor(
   "ZodExactOptional",
-  (inst, def) => {
-    core.$ZodExactOptional.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.optionalProcessor);
-
-    inst.unwrap = () => inst._zod.def.innerType;
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodExactOptional, ZodType, processors.optionalProcessor, true)
 );
 
 export function exactOptional<T extends core.SomeType>(innerType: T): ZodExactOptional<T> {
@@ -2173,13 +2163,7 @@ export interface ZodNullable<T extends core.SomeType = core.$ZodType>
 }
 export const ZodNullable: core.$constructor<ZodNullable> = /*@__PURE__*/ core.$constructor(
   "ZodNullable",
-  (inst, def) => {
-    core.$ZodNullable.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.nullableProcessor);
-
-    inst.unwrap = () => inst._zod.def.innerType;
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodNullable, ZodType, processors.nullableProcessor, true)
 );
 
 export function nullable<T extends core.SomeType>(innerType: T): ZodNullable<T> {
@@ -2234,12 +2218,7 @@ export interface ZodPrefault<T extends core.SomeType = core.$ZodType>
 }
 export const ZodPrefault: core.$constructor<ZodPrefault> = /*@__PURE__*/ core.$constructor(
   "ZodPrefault",
-  (inst, def) => {
-    core.$ZodPrefault.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.prefaultProcessor);
-    inst.unwrap = () => inst._zod.def.innerType;
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodPrefault, ZodType, processors.prefaultProcessor, true)
 );
 
 export function prefault<T extends core.SomeType>(
@@ -2264,13 +2243,7 @@ export interface ZodNonOptional<T extends core.SomeType = core.$ZodType>
 }
 export const ZodNonOptional: core.$constructor<ZodNonOptional> = /*@__PURE__*/ core.$constructor(
   "ZodNonOptional",
-  (inst, def) => {
-    core.$ZodNonOptional.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.nonoptionalProcessor);
-
-    inst.unwrap = () => inst._zod.def.innerType;
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodNonOptional, ZodType, processors.nonoptionalProcessor, true)
 );
 
 export function nonoptional<T extends core.SomeType>(
@@ -2291,13 +2264,10 @@ export interface ZodSuccess<T extends core.SomeType = core.$ZodType>
   "~standard": ZodStandardSchemaWithJSON<this>;
   unwrap(): T;
 }
-export const ZodSuccess: core.$constructor<ZodSuccess> = /*@__PURE__*/ core.$constructor("ZodSuccess", (inst, def) => {
-  core.$ZodSuccess.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.successProcessor);
-
-  inst.unwrap = () => inst._zod.def.innerType;
-});
+export const ZodSuccess: core.$constructor<ZodSuccess> = /*@__PURE__*/ core.$constructor(
+  "ZodSuccess",
+  /* @__PURE__ */ _initFrom(core.$ZodSuccess, ZodType, processors.successProcessor, true)
+);
 
 export function success<T extends core.SomeType>(innerType: T): ZodSuccess<T> {
   return new ZodSuccess({
@@ -2447,13 +2417,7 @@ export interface ZodReadonly<T extends core.SomeType = core.$ZodType>
 }
 export const ZodReadonly: core.$constructor<ZodReadonly> = /*@__PURE__*/ core.$constructor(
   "ZodReadonly",
-  (inst, def) => {
-    core.$ZodReadonly.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.readonlyProcessor);
-
-    inst.unwrap = () => inst._zod.def.innerType;
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodReadonly, ZodType, processors.readonlyProcessor, true)
 );
 
 export function readonly<T extends core.SomeType>(innerType: T): ZodReadonly<T> {
@@ -2514,13 +2478,10 @@ export interface ZodPromise<T extends core.SomeType = core.$ZodType>
   "~standard": ZodStandardSchemaWithJSON<this>;
   unwrap(): T;
 }
-export const ZodPromise: core.$constructor<ZodPromise> = /*@__PURE__*/ core.$constructor("ZodPromise", (inst, def) => {
-  core.$ZodPromise.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.promiseProcessor);
-
-  inst.unwrap = () => inst._zod.def.innerType;
-});
+export const ZodPromise: core.$constructor<ZodPromise> = /*@__PURE__*/ core.$constructor(
+  "ZodPromise",
+  /* @__PURE__ */ _initFrom(core.$ZodPromise, ZodType, processors.promiseProcessor, true)
+);
 
 export function promise<T extends core.SomeType>(innerType: T): ZodPromise<T> {
   return new ZodPromise({

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -25,6 +25,20 @@ function _setProcessor(inst: core.$ZodType, processor: core.Processor<any>): voi
   inst._zod.processJSONSchema = (ctx, json, params) => processor(inst, ctx, json, params);
 }
 
+/** Init body for classes that layer a core schema class under a classic base class. */
+// @__NO_SIDE_EFFECTS__
+function _initFrom(
+  Sup: { init: (inst: any, def: any) => void },
+  Base: { init: (inst: any, def: any) => void },
+  processor?: core.Processor<any>
+): (inst: any, def: any) => void {
+  return (inst, def) => {
+    Sup.init(inst, def);
+    Base.init(inst, def);
+    if (processor) _setProcessor(inst, processor);
+  };
+}
+
 /**
  * Methods of `T` reshaped so each body has `this: T` and matches the
  * declared (args, return) of the corresponding interface method. Allows
@@ -580,10 +594,7 @@ export interface ZodStringFormat<Format extends string = string>
   extends _ZodString<core.$ZodStringFormatInternals<Format>> {}
 export const ZodStringFormat: core.$constructor<ZodStringFormat> = /*@__PURE__*/ core.$constructor(
   "ZodStringFormat",
-  (inst, def) => {
-    core.$ZodStringFormat.init(inst, def);
-    _ZodString.init(inst, def);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodStringFormat, _ZodString)
 );
 
 //////////////////////////////////////////////
@@ -598,10 +609,7 @@ export interface ZodISODateTime extends ZodStringFormat {
 }
 export const ZodISODateTime: core.$constructor<ZodISODateTime> = /*@__PURE__*/ core.$constructor(
   "ZodISODateTime",
-  (inst, def) => {
-    core.$ZodISODateTime.init(inst, def);
-    ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodISODateTime, ZodStringFormat)
 );
 
 //////////////////////////////////////////
@@ -614,10 +622,10 @@ export const ZodISODateTime: core.$constructor<ZodISODateTime> = /*@__PURE__*/ c
 export interface ZodISODate extends ZodStringFormat {
   _zod: core.$ZodISODateInternals;
 }
-export const ZodISODate: core.$constructor<ZodISODate> = /*@__PURE__*/ core.$constructor("ZodISODate", (inst, def) => {
-  core.$ZodISODate.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodISODate: core.$constructor<ZodISODate> = /*@__PURE__*/ core.$constructor(
+  "ZodISODate",
+  /* @__PURE__ */ _initFrom(core.$ZodISODate, ZodStringFormat)
+);
 
 //////////////////////////////////////////
 //////////////////////////////////////////
@@ -629,10 +637,10 @@ export const ZodISODate: core.$constructor<ZodISODate> = /*@__PURE__*/ core.$con
 export interface ZodISOTime extends ZodStringFormat {
   _zod: core.$ZodISOTimeInternals;
 }
-export const ZodISOTime: core.$constructor<ZodISOTime> = /*@__PURE__*/ core.$constructor("ZodISOTime", (inst, def) => {
-  core.$ZodISOTime.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodISOTime: core.$constructor<ZodISOTime> = /*@__PURE__*/ core.$constructor(
+  "ZodISOTime",
+  /* @__PURE__ */ _initFrom(core.$ZodISOTime, ZodStringFormat)
+);
 
 //////////////////////////////////////////////
 //////////////////////////////////////////////
@@ -646,10 +654,7 @@ export interface ZodISODuration extends ZodStringFormat {
 }
 export const ZodISODuration: core.$constructor<ZodISODuration> = /*@__PURE__*/ core.$constructor(
   "ZodISODuration",
-  (inst, def) => {
-    core.$ZodISODuration.init(inst, def);
-    ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodISODuration, ZodStringFormat)
 );
 
 // ZodEmail
@@ -905,10 +910,10 @@ export function ipv6(params?: string | core.$ZodIPv6Params): ZodIPv6 {
 export interface ZodCIDRv4 extends ZodStringFormat<"cidrv4"> {
   _zod: core.$ZodCIDRv4Internals;
 }
-export const ZodCIDRv4: core.$constructor<ZodCIDRv4> = /*@__PURE__*/ core.$constructor("ZodCIDRv4", (inst, def) => {
-  core.$ZodCIDRv4.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodCIDRv4: core.$constructor<ZodCIDRv4> = /*@__PURE__*/ core.$constructor(
+  "ZodCIDRv4",
+  /* @__PURE__ */ _initFrom(core.$ZodCIDRv4, ZodStringFormat)
+);
 
 export function cidrv4(params?: string | core.$ZodCIDRv4Params): ZodCIDRv4 {
   return core._cidrv4(ZodCIDRv4, params);
@@ -918,10 +923,10 @@ export function cidrv4(params?: string | core.$ZodCIDRv4Params): ZodCIDRv4 {
 export interface ZodCIDRv6 extends ZodStringFormat<"cidrv6"> {
   _zod: core.$ZodCIDRv6Internals;
 }
-export const ZodCIDRv6: core.$constructor<ZodCIDRv6> = /*@__PURE__*/ core.$constructor("ZodCIDRv6", (inst, def) => {
-  core.$ZodCIDRv6.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodCIDRv6: core.$constructor<ZodCIDRv6> = /*@__PURE__*/ core.$constructor(
+  "ZodCIDRv6",
+  /* @__PURE__ */ _initFrom(core.$ZodCIDRv6, ZodStringFormat)
+);
 
 export function cidrv6(params?: string | core.$ZodCIDRv6Params): ZodCIDRv6 {
   return core._cidrv6(ZodCIDRv6, params);
@@ -1140,10 +1145,7 @@ export interface ZodNumberFormat extends ZodNumber {
 }
 export const ZodNumberFormat: core.$constructor<ZodNumberFormat> = /*@__PURE__*/ core.$constructor(
   "ZodNumberFormat",
-  (inst, def) => {
-    core.$ZodNumberFormat.init(inst, def);
-    ZodNumber.init(inst, def);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodNumberFormat, ZodNumber)
 );
 
 // int
@@ -1179,11 +1181,10 @@ export function uint32(params?: string | core.$ZodCheckNumberFormatParams): ZodU
 // boolean
 export interface _ZodBoolean<T extends core.$ZodBooleanInternals = core.$ZodBooleanInternals> extends _ZodType<T> {}
 export interface ZodBoolean extends _ZodBoolean<core.$ZodBooleanInternals<boolean>> {}
-export const ZodBoolean: core.$constructor<ZodBoolean> = /*@__PURE__*/ core.$constructor("ZodBoolean", (inst, def) => {
-  core.$ZodBoolean.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.booleanProcessor);
-});
+export const ZodBoolean: core.$constructor<ZodBoolean> = /*@__PURE__*/ core.$constructor(
+  "ZodBoolean",
+  /* @__PURE__ */ _initFrom(core.$ZodBoolean, ZodType, processors.booleanProcessor)
+);
 
 export function boolean(params?: string | core.$ZodBooleanParams): ZodBoolean {
   return core._boolean(ZodBoolean, params);
@@ -1247,10 +1248,7 @@ export interface ZodBigIntFormat extends ZodBigInt {
 }
 export const ZodBigIntFormat: core.$constructor<ZodBigIntFormat> = /*@__PURE__*/ core.$constructor(
   "ZodBigIntFormat",
-  (inst, def) => {
-    core.$ZodBigIntFormat.init(inst, def);
-    ZodBigInt.init(inst, def);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodBigIntFormat, ZodBigInt)
 );
 
 // int64
@@ -1265,11 +1263,10 @@ export function uint64(params?: string | core.$ZodBigIntFormatParams): ZodBigInt
 
 // symbol
 export interface ZodSymbol extends _ZodType<core.$ZodSymbolInternals> {}
-export const ZodSymbol: core.$constructor<ZodSymbol> = /*@__PURE__*/ core.$constructor("ZodSymbol", (inst, def) => {
-  core.$ZodSymbol.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.symbolProcessor);
-});
+export const ZodSymbol: core.$constructor<ZodSymbol> = /*@__PURE__*/ core.$constructor(
+  "ZodSymbol",
+  /* @__PURE__ */ _initFrom(core.$ZodSymbol, ZodType, processors.symbolProcessor)
+);
 
 export function symbol(params?: string | core.$ZodSymbolParams): ZodSymbol {
   return core._symbol(ZodSymbol, params);
@@ -1279,11 +1276,7 @@ export function symbol(params?: string | core.$ZodSymbolParams): ZodSymbol {
 export interface ZodUndefined extends _ZodType<core.$ZodUndefinedInternals> {}
 export const ZodUndefined: core.$constructor<ZodUndefined> = /*@__PURE__*/ core.$constructor(
   "ZodUndefined",
-  (inst, def) => {
-    core.$ZodUndefined.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.undefinedProcessor);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodUndefined, ZodType, processors.undefinedProcessor)
 );
 
 function _undefined(params?: string | core.$ZodUndefinedParams): ZodUndefined {
@@ -1293,11 +1286,10 @@ export { _undefined as undefined };
 
 // ZodNull
 export interface ZodNull extends _ZodType<core.$ZodNullInternals> {}
-export const ZodNull: core.$constructor<ZodNull> = /*@__PURE__*/ core.$constructor("ZodNull", (inst, def) => {
-  core.$ZodNull.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.nullProcessor);
-});
+export const ZodNull: core.$constructor<ZodNull> = /*@__PURE__*/ core.$constructor(
+  "ZodNull",
+  /* @__PURE__ */ _initFrom(core.$ZodNull, ZodType, processors.nullProcessor)
+);
 
 function _null(params?: string | core.$ZodNullParams): ZodNull {
   return core._null(ZodNull, params);
@@ -1306,11 +1298,10 @@ export { _null as null };
 
 // ZodAny
 export interface ZodAny extends _ZodType<core.$ZodAnyInternals> {}
-export const ZodAny: core.$constructor<ZodAny> = /*@__PURE__*/ core.$constructor("ZodAny", (inst, def) => {
-  core.$ZodAny.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.anyProcessor);
-});
+export const ZodAny: core.$constructor<ZodAny> = /*@__PURE__*/ core.$constructor(
+  "ZodAny",
+  /* @__PURE__ */ _initFrom(core.$ZodAny, ZodType, processors.anyProcessor)
+);
 
 export function any(): ZodAny {
   return core._any(ZodAny);
@@ -1318,11 +1309,10 @@ export function any(): ZodAny {
 
 // ZodUnknown
 export interface ZodUnknown extends _ZodType<core.$ZodUnknownInternals> {}
-export const ZodUnknown: core.$constructor<ZodUnknown> = /*@__PURE__*/ core.$constructor("ZodUnknown", (inst, def) => {
-  core.$ZodUnknown.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.unknownProcessor);
-});
+export const ZodUnknown: core.$constructor<ZodUnknown> = /*@__PURE__*/ core.$constructor(
+  "ZodUnknown",
+  /* @__PURE__ */ _initFrom(core.$ZodUnknown, ZodType, processors.unknownProcessor)
+);
 
 export function unknown(): ZodUnknown {
   return core._unknown(ZodUnknown);
@@ -1330,11 +1320,10 @@ export function unknown(): ZodUnknown {
 
 // ZodNever
 export interface ZodNever extends _ZodType<core.$ZodNeverInternals> {}
-export const ZodNever: core.$constructor<ZodNever> = /*@__PURE__*/ core.$constructor("ZodNever", (inst, def) => {
-  core.$ZodNever.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.neverProcessor);
-});
+export const ZodNever: core.$constructor<ZodNever> = /*@__PURE__*/ core.$constructor(
+  "ZodNever",
+  /* @__PURE__ */ _initFrom(core.$ZodNever, ZodType, processors.neverProcessor)
+);
 
 export function never(params?: string | core.$ZodNeverParams): ZodNever {
   return core._never(ZodNever, params);
@@ -1342,11 +1331,10 @@ export function never(params?: string | core.$ZodNeverParams): ZodNever {
 
 // ZodVoid
 export interface ZodVoid extends _ZodType<core.$ZodVoidInternals> {}
-export const ZodVoid: core.$constructor<ZodVoid> = /*@__PURE__*/ core.$constructor("ZodVoid", (inst, def) => {
-  core.$ZodVoid.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.voidProcessor);
-});
+export const ZodVoid: core.$constructor<ZodVoid> = /*@__PURE__*/ core.$constructor(
+  "ZodVoid",
+  /* @__PURE__ */ _initFrom(core.$ZodVoid, ZodType, processors.voidProcessor)
+);
 
 function _void(params?: string | core.$ZodVoidParams): ZodVoid {
   return core._void(ZodVoid, params);
@@ -1711,11 +1699,7 @@ export interface ZodIntersection<A extends core.SomeType = core.$ZodType, B exte
 }
 export const ZodIntersection: core.$constructor<ZodIntersection> = /*@__PURE__*/ core.$constructor(
   "ZodIntersection",
-  (inst, def) => {
-    core.$ZodIntersection.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.intersectionProcessor);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodIntersection, ZodType, processors.intersectionProcessor)
 );
 
 export function intersection<T extends core.SomeType, U extends core.SomeType>(
@@ -2352,11 +2336,10 @@ export { _catch as catch };
 export interface ZodNaN extends _ZodType<core.$ZodNaNInternals>, core.$ZodNaN {
   "~standard": ZodStandardSchemaWithJSON<this>;
 }
-export const ZodNaN: core.$constructor<ZodNaN> = /*@__PURE__*/ core.$constructor("ZodNaN", (inst, def) => {
-  core.$ZodNaN.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.nanProcessor);
-});
+export const ZodNaN: core.$constructor<ZodNaN> = /*@__PURE__*/ core.$constructor(
+  "ZodNaN",
+  /* @__PURE__ */ _initFrom(core.$ZodNaN, ZodType, processors.nanProcessor)
+);
 
 export function nan(params?: string | core.$ZodNaNParams): ZodNaN {
   return core._nan(ZodNaN, params);
@@ -2482,11 +2465,7 @@ export interface ZodTemplateLiteral<Template extends string = string>
 }
 export const ZodTemplateLiteral: core.$constructor<ZodTemplateLiteral> = /*@__PURE__*/ core.$constructor(
   "ZodTemplateLiteral",
-  (inst, def) => {
-    core.$ZodTemplateLiteral.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.templateLiteralProcessor);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodTemplateLiteral, ZodType, processors.templateLiteralProcessor)
 );
 
 export function templateLiteral<const Parts extends core.$ZodTemplateLiteralPart[]>(
@@ -2567,11 +2546,7 @@ export interface ZodFunction<
 
 export const ZodFunction: core.$constructor<ZodFunction> = /*@__PURE__*/ core.$constructor(
   "ZodFunction",
-  (inst, def) => {
-    core.$ZodFunction.init(inst, def);
-    ZodType.init(inst, def);
-    _setProcessor(inst, processors.functionProcessor);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodFunction, ZodType, processors.functionProcessor)
 );
 
 export function _function(): ZodFunction;
@@ -2617,11 +2592,10 @@ export interface ZodCustom<O = unknown, I = unknown>
     core.$ZodCustom<O, I> {
   "~standard": ZodStandardSchemaWithJSON<this>;
 }
-export const ZodCustom: core.$constructor<ZodCustom> = /*@__PURE__*/ core.$constructor("ZodCustom", (inst, def) => {
-  core.$ZodCustom.init(inst, def);
-  ZodType.init(inst, def);
-  _setProcessor(inst, processors.customProcessor);
-});
+export const ZodCustom: core.$constructor<ZodCustom> = /*@__PURE__*/ core.$constructor(
+  "ZodCustom",
+  /* @__PURE__ */ _initFrom(core.$ZodCustom, ZodType, processors.customProcessor)
+);
 
 // custom checks
 export function check<O = unknown>(fn: core.CheckFn<O>): core.$ZodCheck<O> {

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -669,11 +669,10 @@ export const ZodISODuration: core.$constructor<ZodISODuration> = /*@__PURE__*/ c
 export interface ZodEmail extends ZodStringFormat<"email"> {
   _zod: core.$ZodEmailInternals;
 }
-export const ZodEmail: core.$constructor<ZodEmail> = /*@__PURE__*/ core.$constructor("ZodEmail", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodEmail.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodEmail: core.$constructor<ZodEmail> = /*@__PURE__*/ core.$constructor(
+  "ZodEmail",
+  /* @__PURE__ */ _initFrom(core.$ZodEmail, ZodStringFormat)
+);
 
 export function email(params?: string | core.$ZodEmailParams): ZodEmail {
   return core._email(ZodEmail, params);
@@ -683,11 +682,10 @@ export function email(params?: string | core.$ZodEmailParams): ZodEmail {
 export interface ZodGUID extends ZodStringFormat<"guid"> {
   _zod: core.$ZodGUIDInternals;
 }
-export const ZodGUID: core.$constructor<ZodGUID> = /*@__PURE__*/ core.$constructor("ZodGUID", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodGUID.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodGUID: core.$constructor<ZodGUID> = /*@__PURE__*/ core.$constructor(
+  "ZodGUID",
+  /* @__PURE__ */ _initFrom(core.$ZodGUID, ZodStringFormat)
+);
 
 export function guid(params?: string | core.$ZodGUIDParams): ZodGUID {
   return core._guid(ZodGUID, params);
@@ -697,11 +695,10 @@ export function guid(params?: string | core.$ZodGUIDParams): ZodGUID {
 export interface ZodUUID extends ZodStringFormat<"uuid"> {
   _zod: core.$ZodUUIDInternals;
 }
-export const ZodUUID: core.$constructor<ZodUUID> = /*@__PURE__*/ core.$constructor("ZodUUID", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodUUID.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodUUID: core.$constructor<ZodUUID> = /*@__PURE__*/ core.$constructor(
+  "ZodUUID",
+  /* @__PURE__ */ _initFrom(core.$ZodUUID, ZodStringFormat)
+);
 
 export function uuid(params?: string | core.$ZodUUIDParams): ZodUUID {
   return core._uuid(ZodUUID, params);
@@ -727,11 +724,10 @@ export function uuidv7(params?: string | core.$ZodUUIDv7Params): ZodUUID {
 export interface ZodURL extends ZodStringFormat<"url"> {
   _zod: core.$ZodURLInternals;
 }
-export const ZodURL: core.$constructor<ZodURL> = /*@__PURE__*/ core.$constructor("ZodURL", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodURL.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodURL: core.$constructor<ZodURL> = /*@__PURE__*/ core.$constructor(
+  "ZodURL",
+  /* @__PURE__ */ _initFrom(core.$ZodURL, ZodStringFormat)
+);
 
 export function url(params?: string | core.$ZodURLParams): ZodURL {
   return core._url(ZodURL, params);
@@ -749,11 +745,10 @@ export function httpUrl(params?: string | Omit<core.$ZodURLParams, "protocol" | 
 export interface ZodEmoji extends ZodStringFormat<"emoji"> {
   _zod: core.$ZodEmojiInternals;
 }
-export const ZodEmoji: core.$constructor<ZodEmoji> = /*@__PURE__*/ core.$constructor("ZodEmoji", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodEmoji.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodEmoji: core.$constructor<ZodEmoji> = /*@__PURE__*/ core.$constructor(
+  "ZodEmoji",
+  /* @__PURE__ */ _initFrom(core.$ZodEmoji, ZodStringFormat)
+);
 
 export function emoji(params?: string | core.$ZodEmojiParams): ZodEmoji {
   return core._emoji(ZodEmoji, params);
@@ -763,11 +758,10 @@ export function emoji(params?: string | core.$ZodEmojiParams): ZodEmoji {
 export interface ZodNanoID extends ZodStringFormat<"nanoid"> {
   _zod: core.$ZodNanoIDInternals;
 }
-export const ZodNanoID: core.$constructor<ZodNanoID> = /*@__PURE__*/ core.$constructor("ZodNanoID", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodNanoID.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodNanoID: core.$constructor<ZodNanoID> = /*@__PURE__*/ core.$constructor(
+  "ZodNanoID",
+  /* @__PURE__ */ _initFrom(core.$ZodNanoID, ZodStringFormat)
+);
 
 export function nanoid(params?: string | core.$ZodNanoIDParams): ZodNanoID {
   return core._nanoid(ZodNanoID, params);
@@ -787,11 +781,10 @@ export interface ZodCUID extends ZodStringFormat<"cuid"> {
  * (timestamps embedded in the id). Use {@link ZodCUID2} instead.
  * See https://github.com/paralleldrive/cuid.
  */
-export const ZodCUID: core.$constructor<ZodCUID> = /*@__PURE__*/ core.$constructor("ZodCUID", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodCUID.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodCUID: core.$constructor<ZodCUID> = /*@__PURE__*/ core.$constructor(
+  "ZodCUID",
+  /* @__PURE__ */ _initFrom(core.$ZodCUID, ZodStringFormat)
+);
 
 /**
  * Validates a CUID v1 string.
@@ -808,11 +801,10 @@ export function cuid(params?: string | core.$ZodCUIDParams): ZodCUID {
 export interface ZodCUID2 extends ZodStringFormat<"cuid2"> {
   _zod: core.$ZodCUID2Internals;
 }
-export const ZodCUID2: core.$constructor<ZodCUID2> = /*@__PURE__*/ core.$constructor("ZodCUID2", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodCUID2.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodCUID2: core.$constructor<ZodCUID2> = /*@__PURE__*/ core.$constructor(
+  "ZodCUID2",
+  /* @__PURE__ */ _initFrom(core.$ZodCUID2, ZodStringFormat)
+);
 
 export function cuid2(params?: string | core.$ZodCUID2Params): ZodCUID2 {
   return core._cuid2(ZodCUID2, params);
@@ -822,11 +814,10 @@ export function cuid2(params?: string | core.$ZodCUID2Params): ZodCUID2 {
 export interface ZodULID extends ZodStringFormat<"ulid"> {
   _zod: core.$ZodULIDInternals;
 }
-export const ZodULID: core.$constructor<ZodULID> = /*@__PURE__*/ core.$constructor("ZodULID", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodULID.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodULID: core.$constructor<ZodULID> = /*@__PURE__*/ core.$constructor(
+  "ZodULID",
+  /* @__PURE__ */ _initFrom(core.$ZodULID, ZodStringFormat)
+);
 
 export function ulid(params?: string | core.$ZodULIDParams): ZodULID {
   return core._ulid(ZodULID, params);
@@ -836,11 +827,10 @@ export function ulid(params?: string | core.$ZodULIDParams): ZodULID {
 export interface ZodXID extends ZodStringFormat<"xid"> {
   _zod: core.$ZodXIDInternals;
 }
-export const ZodXID: core.$constructor<ZodXID> = /*@__PURE__*/ core.$constructor("ZodXID", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodXID.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodXID: core.$constructor<ZodXID> = /*@__PURE__*/ core.$constructor(
+  "ZodXID",
+  /* @__PURE__ */ _initFrom(core.$ZodXID, ZodStringFormat)
+);
 
 export function xid(params?: string | core.$ZodXIDParams): ZodXID {
   return core._xid(ZodXID, params);
@@ -850,11 +840,10 @@ export function xid(params?: string | core.$ZodXIDParams): ZodXID {
 export interface ZodKSUID extends ZodStringFormat<"ksuid"> {
   _zod: core.$ZodKSUIDInternals;
 }
-export const ZodKSUID: core.$constructor<ZodKSUID> = /*@__PURE__*/ core.$constructor("ZodKSUID", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodKSUID.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodKSUID: core.$constructor<ZodKSUID> = /*@__PURE__*/ core.$constructor(
+  "ZodKSUID",
+  /* @__PURE__ */ _initFrom(core.$ZodKSUID, ZodStringFormat)
+);
 
 export function ksuid(params?: string | core.$ZodKSUIDParams): ZodKSUID {
   return core._ksuid(ZodKSUID, params);
@@ -878,11 +867,10 @@ export function ksuid(params?: string | core.$ZodKSUIDParams): ZodKSUID {
 export interface ZodIPv4 extends ZodStringFormat<"ipv4"> {
   _zod: core.$ZodIPv4Internals;
 }
-export const ZodIPv4: core.$constructor<ZodIPv4> = /*@__PURE__*/ core.$constructor("ZodIPv4", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodIPv4.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodIPv4: core.$constructor<ZodIPv4> = /*@__PURE__*/ core.$constructor(
+  "ZodIPv4",
+  /* @__PURE__ */ _initFrom(core.$ZodIPv4, ZodStringFormat)
+);
 
 export function ipv4(params?: string | core.$ZodIPv4Params): ZodIPv4 {
   return core._ipv4(ZodIPv4, params);
@@ -892,11 +880,10 @@ export function ipv4(params?: string | core.$ZodIPv4Params): ZodIPv4 {
 export interface ZodMAC extends ZodStringFormat<"mac"> {
   _zod: core.$ZodMACInternals;
 }
-export const ZodMAC: core.$constructor<ZodMAC> = /*@__PURE__*/ core.$constructor("ZodMAC", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodMAC.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodMAC: core.$constructor<ZodMAC> = /*@__PURE__*/ core.$constructor(
+  "ZodMAC",
+  /* @__PURE__ */ _initFrom(core.$ZodMAC, ZodStringFormat)
+);
 export function mac(params?: string | core.$ZodMACParams): ZodMAC {
   return core._mac(ZodMAC, params);
 }
@@ -905,11 +892,10 @@ export function mac(params?: string | core.$ZodMACParams): ZodMAC {
 export interface ZodIPv6 extends ZodStringFormat<"ipv6"> {
   _zod: core.$ZodIPv6Internals;
 }
-export const ZodIPv6: core.$constructor<ZodIPv6> = /*@__PURE__*/ core.$constructor("ZodIPv6", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodIPv6.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodIPv6: core.$constructor<ZodIPv6> = /*@__PURE__*/ core.$constructor(
+  "ZodIPv6",
+  /* @__PURE__ */ _initFrom(core.$ZodIPv6, ZodStringFormat)
+);
 export function ipv6(params?: string | core.$ZodIPv6Params): ZodIPv6 {
   return core._ipv6(ZodIPv6, params);
 }
@@ -944,11 +930,10 @@ export function cidrv6(params?: string | core.$ZodCIDRv6Params): ZodCIDRv6 {
 export interface ZodBase64 extends ZodStringFormat<"base64"> {
   _zod: core.$ZodBase64Internals;
 }
-export const ZodBase64: core.$constructor<ZodBase64> = /*@__PURE__*/ core.$constructor("ZodBase64", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodBase64.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodBase64: core.$constructor<ZodBase64> = /*@__PURE__*/ core.$constructor(
+  "ZodBase64",
+  /* @__PURE__ */ _initFrom(core.$ZodBase64, ZodStringFormat)
+);
 export function base64(params?: string | core.$ZodBase64Params): ZodBase64 {
   return core._base64(ZodBase64, params);
 }
@@ -959,11 +944,7 @@ export interface ZodBase64URL extends ZodStringFormat<"base64url"> {
 }
 export const ZodBase64URL: core.$constructor<ZodBase64URL> = /*@__PURE__*/ core.$constructor(
   "ZodBase64URL",
-  (inst, def) => {
-    // ZodStringFormat.init(inst, def);
-    core.$ZodBase64URL.init(inst, def);
-    ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodBase64URL, ZodStringFormat)
 );
 export function base64url(params?: string | core.$ZodBase64URLParams): ZodBase64URL {
   return core._base64url(ZodBase64URL, params);
@@ -973,11 +954,10 @@ export function base64url(params?: string | core.$ZodBase64URLParams): ZodBase64
 export interface ZodE164 extends ZodStringFormat<"e164"> {
   _zod: core.$ZodE164Internals;
 }
-export const ZodE164: core.$constructor<ZodE164> = /*@__PURE__*/ core.$constructor("ZodE164", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodE164.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodE164: core.$constructor<ZodE164> = /*@__PURE__*/ core.$constructor(
+  "ZodE164",
+  /* @__PURE__ */ _initFrom(core.$ZodE164, ZodStringFormat)
+);
 
 export function e164(params?: string | core.$ZodE164Params): ZodE164 {
   return core._e164(ZodE164, params);
@@ -987,11 +967,10 @@ export function e164(params?: string | core.$ZodE164Params): ZodE164 {
 export interface ZodJWT extends ZodStringFormat<"jwt"> {
   _zod: core.$ZodJWTInternals;
 }
-export const ZodJWT: core.$constructor<ZodJWT> = /*@__PURE__*/ core.$constructor("ZodJWT", (inst, def) => {
-  // ZodStringFormat.init(inst, def);
-  core.$ZodJWT.init(inst, def);
-  ZodStringFormat.init(inst, def);
-});
+export const ZodJWT: core.$constructor<ZodJWT> = /*@__PURE__*/ core.$constructor(
+  "ZodJWT",
+  /* @__PURE__ */ _initFrom(core.$ZodJWT, ZodStringFormat)
+);
 
 export function jwt(params?: string | core.$ZodJWTParams): ZodJWT {
   return core._jwt(ZodJWT, params);
@@ -1006,11 +985,7 @@ export interface ZodCustomStringFormat<Format extends string = string>
 }
 export const ZodCustomStringFormat: core.$constructor<ZodCustomStringFormat> = /*@__PURE__*/ core.$constructor(
   "ZodCustomStringFormat",
-  (inst, def) => {
-    // ZodStringFormat.init(inst, def);
-    core.$ZodCustomStringFormat.init(inst, def);
-    ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _initFrom(core.$ZodCustomStringFormat, ZodStringFormat)
 );
 export function stringFormat<Format extends string>(
   format: Format,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -20,6 +20,11 @@ import * as parse from "./parse.js";
 // One install per (prototype, group), memoized by `_installedGroups`.
 const _installedGroups = /* @__PURE__ */ new WeakMap<object, Set<string>>();
 
+/** Wires a JSON Schema processor to an instance's `processJSONSchema` hook. */
+function _setProcessor(inst: core.$ZodType, processor: core.Processor<any>): void {
+  inst._zod.processJSONSchema = (ctx, json, params) => processor(inst, ctx, json, params);
+}
+
 /**
  * Methods of `T` reshaped so each body has `this: T` and matches the
  * declared (args, return) of the corresponding interface method. Allows
@@ -396,7 +401,7 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
   core.$ZodString.init(inst, def);
   ZodType.init(inst, def);
 
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.stringProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.stringProcessor);
 
   const bag = inst._zod.bag;
   inst.format = bag.format ?? null;
@@ -1065,7 +1070,7 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
 
   ZodType.init(inst, def);
 
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.numberProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.numberProcessor);
 
   _installLazyMethods(inst, "ZodNumber", {
     gt(value, params) {
@@ -1177,7 +1182,7 @@ export interface ZodBoolean extends _ZodBoolean<core.$ZodBooleanInternals<boolea
 export const ZodBoolean: core.$constructor<ZodBoolean> = /*@__PURE__*/ core.$constructor("ZodBoolean", (inst, def) => {
   core.$ZodBoolean.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.booleanProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.booleanProcessor);
 });
 
 export function boolean(params?: string | core.$ZodBooleanParams): ZodBoolean {
@@ -1209,7 +1214,7 @@ export interface ZodBigInt extends _ZodBigInt<core.$ZodBigIntInternals<bigint>> 
 export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$constructor("ZodBigInt", (inst, def) => {
   core.$ZodBigInt.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.bigintProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.bigintProcessor);
 
   inst.gte = (value, params) => inst.check(checks.gte(value, params));
   inst.min = (value, params) => inst.check(checks.gte(value, params));
@@ -1263,7 +1268,7 @@ export interface ZodSymbol extends _ZodType<core.$ZodSymbolInternals> {}
 export const ZodSymbol: core.$constructor<ZodSymbol> = /*@__PURE__*/ core.$constructor("ZodSymbol", (inst, def) => {
   core.$ZodSymbol.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.symbolProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.symbolProcessor);
 });
 
 export function symbol(params?: string | core.$ZodSymbolParams): ZodSymbol {
@@ -1277,7 +1282,7 @@ export const ZodUndefined: core.$constructor<ZodUndefined> = /*@__PURE__*/ core.
   (inst, def) => {
     core.$ZodUndefined.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.undefinedProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.undefinedProcessor);
   }
 );
 
@@ -1291,7 +1296,7 @@ export interface ZodNull extends _ZodType<core.$ZodNullInternals> {}
 export const ZodNull: core.$constructor<ZodNull> = /*@__PURE__*/ core.$constructor("ZodNull", (inst, def) => {
   core.$ZodNull.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.nullProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.nullProcessor);
 });
 
 function _null(params?: string | core.$ZodNullParams): ZodNull {
@@ -1304,7 +1309,7 @@ export interface ZodAny extends _ZodType<core.$ZodAnyInternals> {}
 export const ZodAny: core.$constructor<ZodAny> = /*@__PURE__*/ core.$constructor("ZodAny", (inst, def) => {
   core.$ZodAny.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.anyProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.anyProcessor);
 });
 
 export function any(): ZodAny {
@@ -1316,7 +1321,7 @@ export interface ZodUnknown extends _ZodType<core.$ZodUnknownInternals> {}
 export const ZodUnknown: core.$constructor<ZodUnknown> = /*@__PURE__*/ core.$constructor("ZodUnknown", (inst, def) => {
   core.$ZodUnknown.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.unknownProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.unknownProcessor);
 });
 
 export function unknown(): ZodUnknown {
@@ -1328,7 +1333,7 @@ export interface ZodNever extends _ZodType<core.$ZodNeverInternals> {}
 export const ZodNever: core.$constructor<ZodNever> = /*@__PURE__*/ core.$constructor("ZodNever", (inst, def) => {
   core.$ZodNever.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.neverProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.neverProcessor);
 });
 
 export function never(params?: string | core.$ZodNeverParams): ZodNever {
@@ -1340,7 +1345,7 @@ export interface ZodVoid extends _ZodType<core.$ZodVoidInternals> {}
 export const ZodVoid: core.$constructor<ZodVoid> = /*@__PURE__*/ core.$constructor("ZodVoid", (inst, def) => {
   core.$ZodVoid.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.voidProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.voidProcessor);
 });
 
 function _void(params?: string | core.$ZodVoidParams): ZodVoid {
@@ -1363,7 +1368,7 @@ export interface ZodDate extends _ZodDate<core.$ZodDateInternals<Date>> {}
 export const ZodDate: core.$constructor<ZodDate> = /*@__PURE__*/ core.$constructor("ZodDate", (inst, def) => {
   core.$ZodDate.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.dateProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.dateProcessor);
 
   inst.min = (value, params) => inst.check(checks.gte(value, params));
   inst.max = (value, params) => inst.check(checks.lte(value, params));
@@ -1393,7 +1398,7 @@ export interface ZodArray<T extends core.SomeType = core.$ZodType>
 export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constructor("ZodArray", (inst, def) => {
   core.$ZodArray.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.arrayProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.arrayProcessor);
 
   inst.element = def.element;
   _installLazyMethods(inst, "ZodArray", {
@@ -1520,7 +1525,7 @@ export interface ZodObject<
 export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$constructor("ZodObject", (inst, def) => {
   core.$ZodObjectJIT.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.objectProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.objectProcessor);
 
   util.defineLazy(inst, "shape", () => {
     return def.shape;
@@ -1619,7 +1624,7 @@ export interface ZodUnion<T extends readonly core.SomeType[] = readonly core.$Zo
 export const ZodUnion: core.$constructor<ZodUnion> = /*@__PURE__*/ core.$constructor("ZodUnion", (inst, def) => {
   core.$ZodUnion.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.unionProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.unionProcessor);
   inst.options = def.options;
 });
 
@@ -1644,7 +1649,7 @@ export interface ZodXor<T extends readonly core.SomeType[] = readonly core.$ZodT
 export const ZodXor: core.$constructor<ZodXor> = /*@__PURE__*/ core.$constructor("ZodXor", (inst, def) => {
   ZodUnion.init(inst, def);
   core.$ZodXor.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.unionProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.unionProcessor);
   inst.options = def.options;
 });
 
@@ -1709,7 +1714,7 @@ export const ZodIntersection: core.$constructor<ZodIntersection> = /*@__PURE__*/
   (inst, def) => {
     core.$ZodIntersection.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.intersectionProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.intersectionProcessor);
   }
 );
 
@@ -1736,7 +1741,7 @@ export interface ZodTuple<
 export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constructor("ZodTuple", (inst, def) => {
   core.$ZodTuple.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.tupleProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.tupleProcessor);
   inst.rest = (rest) =>
     inst.clone({
       ...inst._zod.def,
@@ -1783,7 +1788,7 @@ export interface ZodRecord<
 export const ZodRecord: core.$constructor<ZodRecord> = /*@__PURE__*/ core.$constructor("ZodRecord", (inst, def) => {
   core.$ZodRecord.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.recordProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.recordProcessor);
 
   inst.keyType = def.keyType;
   inst.valueType = def.valueType;
@@ -1855,7 +1860,7 @@ export interface ZodMap<Key extends core.SomeType = core.$ZodType, Value extends
 export const ZodMap: core.$constructor<ZodMap> = /*@__PURE__*/ core.$constructor("ZodMap", (inst, def) => {
   core.$ZodMap.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.mapProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.mapProcessor);
   inst.keyType = def.keyType;
   inst.valueType = def.valueType;
   inst.min = (...args) => inst.check(core._minSize(...args));
@@ -1890,7 +1895,7 @@ export interface ZodSet<T extends core.SomeType = core.$ZodType>
 export const ZodSet: core.$constructor<ZodSet> = /*@__PURE__*/ core.$constructor("ZodSet", (inst, def) => {
   core.$ZodSet.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.setProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.setProcessor);
 
   inst.min = (...args) => inst.check(core._minSize(...args));
   inst.nonempty = (params) => inst.check(core._minSize(1, params));
@@ -1931,7 +1936,7 @@ export interface ZodEnum<
 export const ZodEnum: core.$constructor<ZodEnum> = /*@__PURE__*/ core.$constructor("ZodEnum", (inst, def) => {
   core.$ZodEnum.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.enumProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.enumProcessor);
 
   inst.enum = def.entries;
   inst.options = Object.values(def.entries);
@@ -2012,7 +2017,7 @@ export interface ZodLiteral<T extends util.Literal = util.Literal>
 export const ZodLiteral: core.$constructor<ZodLiteral> = /*@__PURE__*/ core.$constructor("ZodLiteral", (inst, def) => {
   core.$ZodLiteral.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.literalProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.literalProcessor);
   inst.values = new Set(def.values);
   Object.defineProperty(inst, "value", {
     get() {
@@ -2050,7 +2055,7 @@ export interface ZodFile extends _ZodType<core.$ZodFileInternals>, core.$ZodFile
 export const ZodFile: core.$constructor<ZodFile> = /*@__PURE__*/ core.$constructor("ZodFile", (inst, def) => {
   core.$ZodFile.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.fileProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.fileProcessor);
 
   inst.min = (size, params) => inst.check(core._minSize(size, params));
   inst.max = (size, params) => inst.check(core._maxSize(size, params));
@@ -2072,7 +2077,7 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
   (inst, def) => {
     core.$ZodTransform.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.transformProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.transformProcessor);
 
     inst._zod.parse = (payload, _ctx) => {
       if (_ctx.direction === "backward") {
@@ -2131,7 +2136,7 @@ export const ZodOptional: core.$constructor<ZodOptional> = /*@__PURE__*/ core.$c
   (inst, def) => {
     core.$ZodOptional.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.optionalProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.optionalProcessor);
 
     inst.unwrap = () => inst._zod.def.innerType;
   }
@@ -2156,7 +2161,7 @@ export const ZodExactOptional: core.$constructor<ZodExactOptional> = /*@__PURE__
   (inst, def) => {
     core.$ZodExactOptional.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.optionalProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.optionalProcessor);
 
     inst.unwrap = () => inst._zod.def.innerType;
   }
@@ -2181,7 +2186,7 @@ export const ZodNullable: core.$constructor<ZodNullable> = /*@__PURE__*/ core.$c
   (inst, def) => {
     core.$ZodNullable.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.nullableProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.nullableProcessor);
 
     inst.unwrap = () => inst._zod.def.innerType;
   }
@@ -2211,7 +2216,7 @@ export interface ZodDefault<T extends core.SomeType = core.$ZodType>
 export const ZodDefault: core.$constructor<ZodDefault> = /*@__PURE__*/ core.$constructor("ZodDefault", (inst, def) => {
   core.$ZodDefault.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.defaultProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.defaultProcessor);
 
   inst.unwrap = () => inst._zod.def.innerType;
   inst.removeDefault = inst.unwrap;
@@ -2242,7 +2247,7 @@ export const ZodPrefault: core.$constructor<ZodPrefault> = /*@__PURE__*/ core.$c
   (inst, def) => {
     core.$ZodPrefault.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.prefaultProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.prefaultProcessor);
     inst.unwrap = () => inst._zod.def.innerType;
   }
 );
@@ -2272,7 +2277,7 @@ export const ZodNonOptional: core.$constructor<ZodNonOptional> = /*@__PURE__*/ c
   (inst, def) => {
     core.$ZodNonOptional.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.nonoptionalProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.nonoptionalProcessor);
 
     inst.unwrap = () => inst._zod.def.innerType;
   }
@@ -2299,7 +2304,7 @@ export interface ZodSuccess<T extends core.SomeType = core.$ZodType>
 export const ZodSuccess: core.$constructor<ZodSuccess> = /*@__PURE__*/ core.$constructor("ZodSuccess", (inst, def) => {
   core.$ZodSuccess.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.successProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.successProcessor);
 
   inst.unwrap = () => inst._zod.def.innerType;
 });
@@ -2323,7 +2328,7 @@ export interface ZodCatch<T extends core.SomeType = core.$ZodType>
 export const ZodCatch: core.$constructor<ZodCatch> = /*@__PURE__*/ core.$constructor("ZodCatch", (inst, def) => {
   core.$ZodCatch.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.catchProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.catchProcessor);
 
   inst.unwrap = () => inst._zod.def.innerType;
   inst.removeCatch = inst.unwrap;
@@ -2350,7 +2355,7 @@ export interface ZodNaN extends _ZodType<core.$ZodNaNInternals>, core.$ZodNaN {
 export const ZodNaN: core.$constructor<ZodNaN> = /*@__PURE__*/ core.$constructor("ZodNaN", (inst, def) => {
   core.$ZodNaN.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.nanProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.nanProcessor);
 });
 
 export function nan(params?: string | core.$ZodNaNParams): ZodNaN {
@@ -2368,7 +2373,7 @@ export interface ZodPipe<A extends core.SomeType = core.$ZodType, B extends core
 export const ZodPipe: core.$constructor<ZodPipe> = /*@__PURE__*/ core.$constructor("ZodPipe", (inst, def) => {
   core.$ZodPipe.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.pipeProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.pipeProcessor);
 
   inst.in = def.in;
   inst.out = def.out;
@@ -2456,7 +2461,7 @@ export const ZodReadonly: core.$constructor<ZodReadonly> = /*@__PURE__*/ core.$c
   (inst, def) => {
     core.$ZodReadonly.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.readonlyProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.readonlyProcessor);
 
     inst.unwrap = () => inst._zod.def.innerType;
   }
@@ -2480,7 +2485,7 @@ export const ZodTemplateLiteral: core.$constructor<ZodTemplateLiteral> = /*@__PU
   (inst, def) => {
     core.$ZodTemplateLiteral.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.templateLiteralProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.templateLiteralProcessor);
   }
 );
 
@@ -2505,7 +2510,7 @@ export interface ZodLazy<T extends core.SomeType = core.$ZodType>
 export const ZodLazy: core.$constructor<ZodLazy> = /*@__PURE__*/ core.$constructor("ZodLazy", (inst, def) => {
   core.$ZodLazy.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.lazyProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.lazyProcessor);
 
   inst.unwrap = () => inst._zod.def.getter();
 });
@@ -2527,7 +2532,7 @@ export interface ZodPromise<T extends core.SomeType = core.$ZodType>
 export const ZodPromise: core.$constructor<ZodPromise> = /*@__PURE__*/ core.$constructor("ZodPromise", (inst, def) => {
   core.$ZodPromise.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.promiseProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.promiseProcessor);
 
   inst.unwrap = () => inst._zod.def.innerType;
 });
@@ -2565,7 +2570,7 @@ export const ZodFunction: core.$constructor<ZodFunction> = /*@__PURE__*/ core.$c
   (inst, def) => {
     core.$ZodFunction.init(inst, def);
     ZodType.init(inst, def);
-    inst._zod.processJSONSchema = (ctx, json, params) => processors.functionProcessor(inst, ctx, json, params);
+    _setProcessor(inst, processors.functionProcessor);
   }
 );
 
@@ -2615,7 +2620,7 @@ export interface ZodCustom<O = unknown, I = unknown>
 export const ZodCustom: core.$constructor<ZodCustom> = /*@__PURE__*/ core.$constructor("ZodCustom", (inst, def) => {
   core.$ZodCustom.init(inst, def);
   ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.customProcessor(inst, ctx, json, params);
+  _setProcessor(inst, processors.customProcessor);
 });
 
 // custom checks

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -548,39 +548,45 @@ export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> 
   duration(params?: string | core.$ZodCheckISODurationParams): this;
 }
 
+/** Built on first ZodString construction; the format classes are declared later in this module. */
+let _stringFormatMethodTable: Array<[string, (Class: any, params?: any) => any, unknown]> | undefined;
+
 export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$constructor("ZodString", (inst, def) => {
   core.$ZodString.init(inst, def);
   _ZodString.init(inst, def);
 
-  inst.email = (params) => inst.check(core._email(ZodEmail, params));
-  inst.url = (params) => inst.check(core._url(ZodURL, params));
-  inst.jwt = (params) => inst.check(core._jwt(ZodJWT, params));
-  inst.emoji = (params) => inst.check(core._emoji(ZodEmoji, params));
-  inst.guid = (params) => inst.check(core._guid(ZodGUID, params));
-  inst.uuid = (params) => inst.check(core._uuid(ZodUUID, params));
-  inst.uuidv4 = (params) => inst.check(core._uuidv4(ZodUUID, params));
-  inst.uuidv6 = (params) => inst.check(core._uuidv6(ZodUUID, params));
-  inst.uuidv7 = (params) => inst.check(core._uuidv7(ZodUUID, params));
-  inst.nanoid = (params) => inst.check(core._nanoid(ZodNanoID, params));
-  inst.guid = (params) => inst.check(core._guid(ZodGUID, params));
-  inst.cuid = (params) => inst.check(core._cuid(ZodCUID, params));
-  inst.cuid2 = (params) => inst.check(core._cuid2(ZodCUID2, params));
-  inst.ulid = (params) => inst.check(core._ulid(ZodULID, params));
-  inst.base64 = (params) => inst.check(core._base64(ZodBase64, params));
-  inst.base64url = (params) => inst.check(core._base64url(ZodBase64URL, params));
-  inst.xid = (params) => inst.check(core._xid(ZodXID, params));
-  inst.ksuid = (params) => inst.check(core._ksuid(ZodKSUID, params));
-  inst.ipv4 = (params) => inst.check(core._ipv4(ZodIPv4, params));
-  inst.ipv6 = (params) => inst.check(core._ipv6(ZodIPv6, params));
-  inst.cidrv4 = (params) => inst.check(core._cidrv4(ZodCIDRv4, params));
-  inst.cidrv6 = (params) => inst.check(core._cidrv6(ZodCIDRv6, params));
-  inst.e164 = (params) => inst.check(core._e164(ZodE164, params));
-
-  // iso
-  inst.datetime = (params) => inst.check(core._isoDateTime(ZodISODateTime, params as any));
-  inst.date = (params) => inst.check(core._isoDate(ZodISODate, params as any));
-  inst.time = (params) => inst.check(core._isoTime(ZodISOTime, params as any));
-  inst.duration = (params) => inst.check(core._isoDuration(ZodISODuration, params as any));
+  _stringFormatMethodTable ??= [
+    ["email", core._email, ZodEmail],
+    ["url", core._url, ZodURL],
+    ["jwt", core._jwt, ZodJWT],
+    ["emoji", core._emoji, ZodEmoji],
+    ["guid", core._guid, ZodGUID],
+    ["uuid", core._uuid, ZodUUID],
+    ["uuidv4", core._uuidv4, ZodUUID],
+    ["uuidv6", core._uuidv6, ZodUUID],
+    ["uuidv7", core._uuidv7, ZodUUID],
+    ["nanoid", core._nanoid, ZodNanoID],
+    ["cuid", core._cuid, ZodCUID],
+    ["cuid2", core._cuid2, ZodCUID2],
+    ["ulid", core._ulid, ZodULID],
+    ["base64", core._base64, ZodBase64],
+    ["base64url", core._base64url, ZodBase64URL],
+    ["xid", core._xid, ZodXID],
+    ["ksuid", core._ksuid, ZodKSUID],
+    ["ipv4", core._ipv4, ZodIPv4],
+    ["ipv6", core._ipv6, ZodIPv6],
+    ["cidrv4", core._cidrv4, ZodCIDRv4],
+    ["cidrv6", core._cidrv6, ZodCIDRv6],
+    ["e164", core._e164, ZodE164],
+    // iso
+    ["datetime", core._isoDateTime, ZodISODateTime],
+    ["date", core._isoDate, ZodISODate],
+    ["time", core._isoTime, ZodISOTime],
+    ["duration", core._isoDuration, ZodISODuration],
+  ];
+  for (const [name, factory, Class] of _stringFormatMethodTable) {
+    (inst as any)[name] = (params: any) => inst.check(factory(Class, params));
+  }
 });
 
 export function string(params?: string | core.$ZodStringParams): ZodString;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1910,35 +1910,24 @@ export const ZodEnum: core.$constructor<ZodEnum> = /*@__PURE__*/ core.$construct
 
   const keys = new Set(Object.keys(def.entries));
 
-  inst.extract = (values, params) => {
-    const newEntries: Record<string, any> = {};
+  const subEnum = (values: readonly string[], params: unknown, remove: boolean) => {
+    const newEntries: Record<string, any> = remove ? { ...def.entries } : {};
     for (const value of values) {
       if (keys.has(value)) {
-        newEntries[value] = def.entries[value];
+        if (remove) delete newEntries[value];
+        else newEntries[value] = def.entries[value];
       } else throw new Error(`Key ${value} not found in enum`);
     }
     return new ZodEnum({
       ...def,
       checks: [],
-      ...util.normalizeParams(params),
+      ...util.normalizeParams(params as any),
       entries: newEntries,
     }) as any;
   };
 
-  inst.exclude = (values, params) => {
-    const newEntries: Record<string, any> = { ...def.entries };
-    for (const value of values) {
-      if (keys.has(value)) {
-        delete newEntries[value];
-      } else throw new Error(`Key ${value} not found in enum`);
-    }
-    return new ZodEnum({
-      ...def,
-      checks: [],
-      ...util.normalizeParams(params),
-      entries: newEntries,
-    }) as any;
-  };
+  inst.extract = (values, params) => subEnum(values, params, false);
+  inst.exclude = (values, params) => subEnum(values, params, true);
 });
 
 function _enum<const T extends readonly string[]>(

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -400,6 +400,15 @@ export const $ZodStringFormat: core.$constructor<$ZodStringFormat> = /*@__PURE__
   }
 );
 
+/** Init body for string-format classes whose only extra step is a default pattern. */
+// @__NO_SIDE_EFFECTS__
+function _formatInit(pattern: RegExp): (inst: any, def: any) => void {
+  return (inst, def) => {
+    def.pattern ??= pattern;
+    $ZodStringFormat.init(inst, def);
+  };
+}
+
 //////////////////////////////   ZodGUID   //////////////////////////////
 export interface $ZodGUIDDef extends $ZodStringFormatDef<"guid"> {}
 export interface $ZodGUIDInternals extends $ZodStringFormatInternals<"guid"> {}
@@ -408,10 +417,10 @@ export interface $ZodGUID extends $ZodType {
   _zod: $ZodGUIDInternals;
 }
 
-export const $ZodGUID: core.$constructor<$ZodGUID> = /*@__PURE__*/ core.$constructor("$ZodGUID", (inst, def): void => {
-  def.pattern ??= regexes.guid;
-  $ZodStringFormat.init(inst, def);
-});
+export const $ZodGUID: core.$constructor<$ZodGUID> = /*@__PURE__*/ core.$constructor(
+  "$ZodGUID",
+  /* @__PURE__ */ _formatInit(regexes.guid)
+);
 
 //////////////////////////////   ZodUUID   //////////////////////////////
 
@@ -456,10 +465,7 @@ export interface $ZodEmail extends $ZodType {
 
 export const $ZodEmail: core.$constructor<$ZodEmail> = /*@__PURE__*/ core.$constructor(
   "$ZodEmail",
-  (inst, def): void => {
-    def.pattern ??= regexes.email;
-    $ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _formatInit(regexes.email)
 );
 
 //////////////////////////////   ZodURL   //////////////////////////////
@@ -583,10 +589,7 @@ export interface $ZodNanoID extends $ZodType {
 
 export const $ZodNanoID: core.$constructor<$ZodNanoID> = /*@__PURE__*/ core.$constructor(
   "$ZodNanoID",
-  (inst, def): void => {
-    def.pattern ??= regexes.nanoid;
-    $ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _formatInit(regexes.nanoid)
 );
 
 //////////////////////////////   ZodCUID   //////////////////////////////
@@ -618,10 +621,10 @@ export interface $ZodCUID extends $ZodType {
  * (timestamps embedded in the id). Use {@link $ZodCUID2} instead.
  * See https://github.com/paralleldrive/cuid.
  */
-export const $ZodCUID: core.$constructor<$ZodCUID> = /*@__PURE__*/ core.$constructor("$ZodCUID", (inst, def): void => {
-  def.pattern ??= regexes.cuid;
-  $ZodStringFormat.init(inst, def);
-});
+export const $ZodCUID: core.$constructor<$ZodCUID> = /*@__PURE__*/ core.$constructor(
+  "$ZodCUID",
+  /* @__PURE__ */ _formatInit(regexes.cuid)
+);
 
 //////////////////////////////   ZodCUID2   //////////////////////////////
 
@@ -634,10 +637,7 @@ export interface $ZodCUID2 extends $ZodType {
 
 export const $ZodCUID2: core.$constructor<$ZodCUID2> = /*@__PURE__*/ core.$constructor(
   "$ZodCUID2",
-  (inst, def): void => {
-    def.pattern ??= regexes.cuid2;
-    $ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _formatInit(regexes.cuid2)
 );
 
 //////////////////////////////   ZodULID   //////////////////////////////
@@ -649,10 +649,10 @@ export interface $ZodULID extends $ZodType {
   _zod: $ZodULIDInternals;
 }
 
-export const $ZodULID: core.$constructor<$ZodULID> = /*@__PURE__*/ core.$constructor("$ZodULID", (inst, def): void => {
-  def.pattern ??= regexes.ulid;
-  $ZodStringFormat.init(inst, def);
-});
+export const $ZodULID: core.$constructor<$ZodULID> = /*@__PURE__*/ core.$constructor(
+  "$ZodULID",
+  /* @__PURE__ */ _formatInit(regexes.ulid)
+);
 
 //////////////////////////////   ZodXID   //////////////////////////////
 
@@ -663,10 +663,10 @@ export interface $ZodXID extends $ZodType {
   _zod: $ZodXIDInternals;
 }
 
-export const $ZodXID: core.$constructor<$ZodXID> = /*@__PURE__*/ core.$constructor("$ZodXID", (inst, def): void => {
-  def.pattern ??= regexes.xid;
-  $ZodStringFormat.init(inst, def);
-});
+export const $ZodXID: core.$constructor<$ZodXID> = /*@__PURE__*/ core.$constructor(
+  "$ZodXID",
+  /* @__PURE__ */ _formatInit(regexes.xid)
+);
 
 //////////////////////////////   ZodKSUID   //////////////////////////////
 
@@ -679,10 +679,7 @@ export interface $ZodKSUID extends $ZodType {
 
 export const $ZodKSUID: core.$constructor<$ZodKSUID> = /*@__PURE__*/ core.$constructor(
   "$ZodKSUID",
-  (inst, def): void => {
-    def.pattern ??= regexes.ksuid;
-    $ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _formatInit(regexes.ksuid)
 );
 
 //////////////////////////////   ZodISODateTime   //////////////////////////////
@@ -720,10 +717,7 @@ export interface $ZodISODate extends $ZodType {
 
 export const $ZodISODate: core.$constructor<$ZodISODate> = /*@__PURE__*/ core.$constructor(
   "$ZodISODate",
-  (inst, def): void => {
-    def.pattern ??= regexes.date;
-    $ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _formatInit(regexes.date)
 );
 
 //////////////////////////////   ZodISOTime   //////////////////////////////
@@ -759,10 +753,7 @@ export interface $ZodISODuration extends $ZodType {
 
 export const $ZodISODuration: core.$constructor<$ZodISODuration> = /*@__PURE__*/ core.$constructor(
   "$ZodISODuration",
-  (inst, def): void => {
-    def.pattern ??= regexes.duration;
-    $ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _formatInit(regexes.duration)
 );
 
 //////////////////////////////   ZodIPv4   //////////////////////////////
@@ -859,10 +850,7 @@ export interface $ZodCIDRv4 extends $ZodType {
 
 export const $ZodCIDRv4: core.$constructor<$ZodCIDRv4> = /*@__PURE__*/ core.$constructor(
   "$ZodCIDRv4",
-  (inst, def): void => {
-    def.pattern ??= regexes.cidrv4;
-    $ZodStringFormat.init(inst, def);
-  }
+  /* @__PURE__ */ _formatInit(regexes.cidrv4)
 );
 
 //////////////////////////////   ZodCIDRv6   //////////////////////////////
@@ -999,10 +987,10 @@ export interface $ZodE164 extends $ZodType {
   _zod: $ZodE164Internals;
 }
 
-export const $ZodE164: core.$constructor<$ZodE164> = /*@__PURE__*/ core.$constructor("$ZodE164", (inst, def): void => {
-  def.pattern ??= regexes.e164;
-  $ZodStringFormat.init(inst, def);
-});
+export const $ZodE164: core.$constructor<$ZodE164> = /*@__PURE__*/ core.$constructor(
+  "$ZodE164",
+  /* @__PURE__ */ _formatInit(regexes.e164)
+);
 
 //////////////////////////////   ZodJWT   //////////////////////////////
 


### PR DESCRIPTION
> **Context: bundle-size optimization campaign.** This is one of four PRs extracted from a systematic bundle-size campaign on the v4 core, run as an automated research loop: 30 isolated experiments, 24 kept, 6 discarded. Every candidate change was
>
> - measured with a **deterministic A/B size harness** that materialises two git revisions of `packages/zod/src` via `git archive` and bundles seven fixed entry cases with esbuild (`--bundle --minify --format=esm --target=es2020`), recording minified and gzipped (zlib 9) bytes plus esbuild metafiles for attribution. The verification below leads with the **standard consumer**: `import * as z from "zod"` + `z.object({ name: z.string(), age: z.number() }).safeParse(...)` (70.9 kB min at baseline; namespace property accesses tree-shake under esbuild). Also reported: `import { z }`, which defeats tree-shaking entirely under esbuild (the exported `z` binding is a namespace object that escapes as a value, pinning the full classic surface, 327.7 kB min at baseline, no matter how few methods are used), and named imports (`import { string }`), the best-case shaking scenario;
> - judged against an **exact-zero calibration**: identical revisions on both sides produce 0-byte deltas on every case (esbuild output is deterministic), so every reported delta is exact and there is no noise floor to argue about. Minified bytes is the judged metric; gzip is reported alongside;
> - verified behaviour-preserving by the **full test suite** (339 files, 3,811 tests including tsc typecheck; snapshot-heavy, so error messages, def shapes, and JSON Schema output are pinned), green after every commit. Experiments that changed observable behaviour or regressed a tree-shaken case were discarded; e.g. sharing regex source strings was rejected because esbuild cannot tree-shake `new RegExp` with a non-literal argument and the shared string would have been pinned into every `zod/mini` consumer;
> - **runtime-smoked** where a change touched construction or error paths (`packages/bench` `init` and `object-fail`), with results inside run-to-run noise;
> - cross-checked at the end against the **real build**: cumulative deltas re-measured on `zshy`-built package output bundled consumer-style matched the source-level harness byte-for-byte.
>
> The numbers below are fresh verification runs of **this branch in isolation against `main`**, first per commit (each against its parent), then the branch total. Negative = smaller.
>
> Sibling PRs from the same campaign: #6348, #6350, #6351.

## What this PR does

Dedupes the per-class wiring boilerplate in `classic/schemas.ts` and `core/schemas.ts`. Because every classic class is registered with `core.$constructor("Name", (inst, def) => { ... })`, dozens of initializer bodies are structurally identical, and property-name-heavy code like this survives minification at full size. Seven commits:

**1. `_setProcessor`.** 41 classes wired their JSON Schema hook with the identical line `inst._zod.processJSONSchema = (ctx, json, params) => processors.xProcessor(inst, ctx, json, params);`. One helper now creates that closure; the closure itself is unchanged.

**2-3. `_initFrom` (classic) and `_formatInit` (core).** Classic classes whose body is exactly "init core class, init base class, maybe `_setProcessor`" collapse onto one parametrised initializer; 12 core string-format classes whose body is exactly "default the pattern, init `$ZodStringFormat`" collapse onto another. Each call site carries its own `/* @__PURE__ */` annotation (free in output, comments are stripped) so esbuild/rollup still drop unused classes (verified: tree-shaking of unused classes is unchanged).

**4. Table-driven `ZodString` format methods.** `ZodString`'s initializer assigned 27 uniform closures one by one (`inst.email = (params) => inst.check(core._email(ZodEmail, params));` etc., including a duplicated `guid` line). A lazily-built `[name, factory, Class]` table plus a loop installs the same closures; the table is built on first construction because the format classes are declared later in the module. Same closure count per instance.

**5-6. `_initFrom` extensions.** The 8 wrapper classes that also set `inst.unwrap = () => inst._zod.def.innerType;` fold that into the helper via a flag, and 26 more format classes whose bodies had been hidden behind a stale `// ZodStringFormat.init(inst, def);` comment (also removed) convert as well.

**7. `ZodEnum.extract/exclude`.** Both methods shared the loop-with-guard and the `new ZodEnum({...def, checks: [], ...normalizeParams(params), entries })` closer; one `subEnum` closure now serves both.

All construction-time; no parse-path code touched. The schema-init benchmark (`pnpm bench init`) was smoked around commits 1 and 4: 30.8ms baseline vs 31.3/33.5ms after, inside run-to-run noise (the unchanged npm-package anchor swung 39-62ms across the same runs).

## Verification (this branch vs `main`)

Per case, minified bytes:

| commit | namespace import `import * as z` (standard) | z-object import `import { z }` (full) | named imports `import { string }` |
|---|---|---|---|
| 1. `_setProcessor` (41 sites) | **-694** | -1,487 | -505 |
| 2. `_initFrom` classic (22 classes) | -260 | -561 | -173 |
| 3. `_formatInit` core (12 classes) | -417 | -413 | -417 |
| 4. `ZodString` method table | -308 | -308 | -308 |
| 5. `_initFrom` + unwrap (8 classes) | -331 | -455 | -331 |
| 6. remaining format classes (26) | -442 | -494 | -442 |
| 7. `subEnum` | -117 | -117 | 0 |
| **branch total** | **-2,569 (-3.62%)** | **-3,834 (-1.17%)** | **-2,176 (-3.80%)** |

`zod/mini` cases: unchanged or improved (full-import-mini -416, minimal mini consumer 0). Full suite green after every commit (3,847 tests + typecheck on current `main`). Net source delta: 2 files, +264/-366.

## Reproducing the numbers

The harness below is the one used for the verification runs. From a checkout of this repo:

1. `pnpm install`
2. Save the file below as `sizecheck/compare.mts` (the directory must live **inside** the repo so the materialised trees resolve `node_modules`; `sizecheck/{a,b,meta}/` are created automatically and safe to delete).
3. Fetch this PR's head ref and compare it against `main`:

   ```sh
   git fetch origin pull/6349/head:pr-branch
   pnpm tsx sizecheck/compare.mts main pr-branch
   ```

A run takes ~15s and prints per-case minified/gzip bytes for both sides with exact deltas; the `namespace-import-classic` row is the standard `import * as z` consumer, `z-import-classic` the `import { z }` style, `named-import-classic` the `import { string }` style. A control run with the same rev on both sides (`pnpm tsx sizecheck/compare.mts main main`) prints all-zero deltas — the pipeline is deterministic, so single runs are conclusive.

<details>
<summary><code>sizecheck/compare.mts</code> — A/B bundle-size harness</summary>

```ts
/**
 * A/B bundle-size comparison between two git revisions of packages/zod.
 *
 * Usage: pnpm exec tsx sizecheck/compare.mts [revA] [revB]
 *   revA defaults to HEAD, revB defaults to WORK (the working tree).
 *
 * Each side is materialised under sizecheck/<side>/ via `git archive` (or a
 * straight copy for WORK), then a fixed set of entry files is bundled with
 * esbuild (--bundle --minify --format=esm, pinned target). Reports minified
 * and gzipped bytes per case plus deltas, and writes esbuild metafiles to
 * sizecheck/meta/.
 */
import { execSync } from "node:child_process";
import { gzipSync } from "node:zlib";
import * as fs from "node:fs";
import * as path from "node:path";
import { build } from "esbuild";

const root = path.resolve(import.meta.dirname, "..");
const work = path.join(root, "sizecheck");

const revA = process.argv[2] ?? "HEAD";
const revB = process.argv[3] ?? "WORK";

/** Entry cases. Files are written identically into each side's tree. */
const CASES: Array<{ name: string; code: string }> = [
  {
    name: "full-import-classic",
    code: `import * as z from "./packages/zod/src/index.ts";\nconsole.log(z);\n`,
  },
  {
    name: "full-import-mini",
    code: `import * as z from "./packages/zod/src/mini/index.ts";\nconsole.log(z);\n`,
  },
  {
    name: "named-import-mini",
    code: `import { string, minLength, safeParse } from "./packages/zod/src/mini/index.ts";\nconst schema = string().check(minLength(5));\nconsole.log(safeParse(schema, "hello"));\n`,
  },
  {
    name: "named-import-classic",
    code: `import { string } from "./packages/zod/src/index.ts";\nconst schema = string().min(5);\nconsole.log(schema.safeParse("hello"));\n`,
  },
  {
    name: "namespace-import-classic",
    code: `import * as z from "./packages/zod/src/index.ts";\nconst schema = z.object({ name: z.string(), age: z.number() });\nconsole.log(schema.safeParse({ name: "hello", age: 1 }));\n`,
  },
  {
    name: "z-import-classic",
    code: `import { z } from "./packages/zod/src/index.ts";\nconst schema = z.object({ name: z.string(), age: z.number() });\nconsole.log(schema.safeParse({ name: "hello", age: 1 }));\n`,
  },
  {
    name: "full-import-locales",
    code: `import * as locales from "./packages/zod/src/locales/index.ts";\nconsole.log(locales);\n`,
  },
];

function materialise(rev: string, dir: string): void {
  fs.rmSync(dir, { recursive: true, force: true });
  fs.mkdirSync(dir, { recursive: true });
  if (rev === "WORK") {
    fs.mkdirSync(path.join(dir, "packages/zod"), { recursive: true });
    fs.cpSync(path.join(root, "packages/zod/src"), path.join(dir, "packages/zod/src"), { recursive: true });
    fs.copyFileSync(path.join(root, "packages/zod/package.json"), path.join(dir, "packages/zod/package.json"));
  } else {
    execSync(`git archive ${rev} -- packages/zod/src packages/zod/package.json | tar -x -C ${JSON.stringify(dir)}`, {
      cwd: root,
      shell: "/bin/zsh",
    });
  }
  for (const c of CASES) {
    fs.writeFileSync(path.join(dir, `${c.name}.entry.ts`), c.code);
  }
}

interface Result {
  min: number;
  gzip: number;
}

async function measure(dir: string, side: string): Promise<Record<string, Result>> {
  const out: Record<string, Result> = {};
  for (const c of CASES) {
    const result = await build({
      entryPoints: [path.join(dir, `${c.name}.entry.ts`)],
      bundle: true,
      minify: true,
      format: "esm",
      target: "es2020",
      write: false,
      metafile: true,
      outfile: `${c.name}.js`,
      logLevel: "silent",
    });
    const contents = result.outputFiles[0].contents;
    out[c.name] = {
      min: contents.byteLength,
      gzip: gzipSync(contents, { level: 9 }).byteLength,
    };
    fs.mkdirSync(path.join(work, "meta"), { recursive: true });
    fs.writeFileSync(path.join(work, "meta", `${side}-${c.name}.json`), JSON.stringify(result.metafile));
  }
  return out;
}

function fmt(n: number): string {
  return n.toLocaleString("en-US");
}

const dirA = path.join(work, "a");
const dirB = path.join(work, "b");
materialise(revA, dirA);
materialise(revB, dirB);

const resA = await measure(dirA, "a");
const resB = await measure(dirB, "b");

console.log(`A = ${revA}, B = ${revB}\n`);
const pad = (s: string, n: number) => s.padStart(n);
console.log(
  "case".padEnd(16) +
    pad("A min", 10) +
    pad("B min", 10) +
    pad("Δ min", 9) +
    pad("Δ%", 8) +
    pad("A gz", 9) +
    pad("B gz", 9) +
    pad("Δ gz", 8)
);
let totMinA = 0;
let totMinB = 0;
let totGzA = 0;
let totGzB = 0;
for (const c of CASES) {
  const a = resA[c.name];
  const b = resB[c.name];
  totMinA += a.min;
  totMinB += b.min;
  totGzA += a.gzip;
  totGzB += b.gzip;
  const dMin = b.min - a.min;
  const dGz = b.gzip - a.gzip;
  const pct = a.min === 0 ? 0 : (dMin / a.min) * 100;
  console.log(
    c.name.padEnd(16) +
      pad(fmt(a.min), 10) +
      pad(fmt(b.min), 10) +
      pad((dMin >= 0 ? "+" : "") + fmt(dMin), 9) +
      pad(`${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%`, 8) +
      pad(fmt(a.gzip), 9) +
      pad(fmt(b.gzip), 9) +
      pad((dGz >= 0 ? "+" : "") + fmt(dGz), 8)
  );
}
const dTotMin = totMinB - totMinA;
const dTotGz = totGzB - totGzA;
console.log(
  "TOTAL".padEnd(16) +
    pad(fmt(totMinA), 10) +
    pad(fmt(totMinB), 10) +
    pad((dTotMin >= 0 ? "+" : "") + fmt(dTotMin), 9) +
    pad(`${totMinA ? ((dTotMin / totMinA) * 100).toFixed(2) : "0.00"}%`, 8) +
    pad(fmt(totGzA), 9) +
    pad(fmt(totGzB), 9) +
    pad((dTotGz >= 0 ? "+" : "") + fmt(dTotGz), 8)
);
```

</details>
