### PR TITLE
perf(v4): dedupe JSON Schema pipeline internals (pinned in every bundle)

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -466,37 +466,27 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
       const prefixItems = schema.prefixItems;
       const items = schema.items;
 
+      let tupleItems: ZodType[] | undefined;
+      let rest: ZodType | undefined;
       if (prefixItems && Array.isArray(prefixItems)) {
         // Tuple with prefixItems (draft-2020-12)
-        const tupleItems = prefixItems.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
-        const rest =
+        tupleItems = prefixItems.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
+        rest =
           items && typeof items === "object" && !Array.isArray(items)
             ? convertSchema(items as JSONSchema.JSONSchema, ctx)
             : undefined;
-        if (rest) {
-          zodSchema = z.tuple(tupleItems as [ZodType, ...ZodType[]]).rest(rest);
-        } else {
-          zodSchema = z.tuple(tupleItems as [ZodType, ...ZodType[]]);
-        }
-        // Apply minItems/maxItems constraints to tuples
-        if (typeof schema.minItems === "number") {
-          zodSchema = zodSchema.check(z.minLength(schema.minItems));
-        }
-        if (typeof schema.maxItems === "number") {
-          zodSchema = zodSchema.check(z.maxLength(schema.maxItems));
-        }
       } else if (Array.isArray(items)) {
         // Tuple with items array (draft-7)
-        const tupleItems = items.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
-        const rest =
+        tupleItems = items.map((item) => convertSchema(item as JSONSchema.JSONSchema, ctx));
+        rest =
           schema.additionalItems && typeof schema.additionalItems === "object"
             ? convertSchema(schema.additionalItems as JSONSchema.JSONSchema, ctx)
             : undefined; // additionalItems: false means no rest, handled by default tuple behavior
-        if (rest) {
-          zodSchema = z.tuple(tupleItems as [ZodType, ...ZodType[]]).rest(rest);
-        } else {
-          zodSchema = z.tuple(tupleItems as [ZodType, ...ZodType[]]);
-        }
+      }
+
+      if (tupleItems) {
+        const tuple = z.tuple(tupleItems as [ZodType, ...ZodType[]]);
+        zodSchema = rest ? tuple.rest(rest) : tuple;
         // Apply minItems/maxItems constraints to tuples
         if (typeof schema.minItems === "number") {
           zodSchema = zodSchema.check(z.minLength(schema.minItems));

--- a/packages/zod/src/v4/core/json-schema-generator.ts
+++ b/packages/zod/src/v4/core/json-schema-generator.ts
@@ -81,14 +81,10 @@ export class JSONSchemaGenerator {
   }
 
   constructor(params?: JSONSchemaGeneratorConstructorParams) {
-    // Normalize target for internal context
-    let normalizedTarget: ToJSONSchemaContext["target"] = params?.target ?? "draft-2020-12";
-    if (normalizedTarget === "draft-4") normalizedTarget = "draft-04";
-    if (normalizedTarget === "draft-7") normalizedTarget = "draft-07";
-
+    // Target normalization (draft-4/draft-7 aliases) happens in initializeContext.
     this.ctx = initializeContext({
       processors: allProcessors,
-      target: normalizedTarget,
+      target: params?.target,
       ...(params?.metadata && { metadata: params.metadata }),
       ...(params?.unrepresentable && { unrepresentable: params.unrepresentable }),
       ...(params?.override && { override: params.override as any }),

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -24,6 +24,15 @@ const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> =
 
 // ==================== SIMPLE TYPE PROCESSORS ====================
 
+/** Processor factory for types that cannot be represented in JSON Schema. */
+const _unrepresentable =
+  (name: string): Processor<any> =>
+  (_schema, ctx, _json, _params) => {
+    if (ctx.unrepresentable === "throw") {
+      throw new Error(`${name} cannot be represented in JSON Schema`);
+    }
+  };
+
 export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _json, _params) => {
   const json = _json as JSONSchema.StringSchema;
   json.type = "string";
@@ -99,17 +108,9 @@ export const booleanProcessor: Processor<schemas.$ZodBoolean> = (_schema, _ctx, 
   (json as JSONSchema.BooleanSchema).type = "boolean";
 };
 
-export const bigintProcessor: Processor<schemas.$ZodBigInt> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("BigInt cannot be represented in JSON Schema");
-  }
-};
+export const bigintProcessor: Processor<schemas.$ZodBigInt> = /* @__PURE__ */ _unrepresentable("BigInt");
 
-export const symbolProcessor: Processor<schemas.$ZodSymbol> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Symbols cannot be represented in JSON Schema");
-  }
-};
+export const symbolProcessor: Processor<schemas.$ZodSymbol> = /* @__PURE__ */ _unrepresentable("Symbols");
 
 export const nullProcessor: Processor<schemas.$ZodNull> = (_schema, ctx, json, _params) => {
   if (ctx.target === "openapi-3.0") {
@@ -121,17 +122,9 @@ export const nullProcessor: Processor<schemas.$ZodNull> = (_schema, ctx, json, _
   }
 };
 
-export const undefinedProcessor: Processor<schemas.$ZodUndefined> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Undefined cannot be represented in JSON Schema");
-  }
-};
+export const undefinedProcessor: Processor<schemas.$ZodUndefined> = /* @__PURE__ */ _unrepresentable("Undefined");
 
-export const voidProcessor: Processor<schemas.$ZodVoid> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Void cannot be represented in JSON Schema");
-  }
-};
+export const voidProcessor: Processor<schemas.$ZodVoid> = /* @__PURE__ */ _unrepresentable("Void");
 
 export const neverProcessor: Processor<schemas.$ZodNever> = (_schema, _ctx, json, _params) => {
   json.not = {};
@@ -145,11 +138,7 @@ export const unknownProcessor: Processor<schemas.$ZodUnknown> = (_schema, _ctx, 
   // empty schema accepts anything
 };
 
-export const dateProcessor: Processor<schemas.$ZodDate> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Date cannot be represented in JSON Schema");
-  }
-};
+export const dateProcessor: Processor<schemas.$ZodDate> = /* @__PURE__ */ _unrepresentable("Date");
 
 export const enumProcessor: Processor<schemas.$ZodEnum> = (schema, _ctx, json, _params) => {
   const def = schema._zod.def as schemas.$ZodEnumDef;
@@ -199,11 +188,7 @@ export const literalProcessor: Processor<schemas.$ZodLiteral> = (schema, ctx, js
   }
 };
 
-export const nanProcessor: Processor<schemas.$ZodNaN> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("NaN cannot be represented in JSON Schema");
-  }
-};
+export const nanProcessor: Processor<schemas.$ZodNaN> = /* @__PURE__ */ _unrepresentable("NaN");
 
 export const templateLiteralProcessor: Processor<schemas.$ZodTemplateLiteral> = (schema, _ctx, json, _params) => {
   const _json = json as JSONSchema.StringSchema;
@@ -241,35 +226,15 @@ export const successProcessor: Processor<schemas.$ZodSuccess> = (_schema, _ctx, 
   (json as JSONSchema.BooleanSchema).type = "boolean";
 };
 
-export const customProcessor: Processor<schemas.$ZodCustom> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Custom types cannot be represented in JSON Schema");
-  }
-};
+export const customProcessor: Processor<schemas.$ZodCustom> = /* @__PURE__ */ _unrepresentable("Custom types");
 
-export const functionProcessor: Processor<schemas.$ZodFunction> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Function types cannot be represented in JSON Schema");
-  }
-};
+export const functionProcessor: Processor<schemas.$ZodFunction> = /* @__PURE__ */ _unrepresentable("Function types");
 
-export const transformProcessor: Processor<schemas.$ZodTransform> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Transforms cannot be represented in JSON Schema");
-  }
-};
+export const transformProcessor: Processor<schemas.$ZodTransform> = /* @__PURE__ */ _unrepresentable("Transforms");
 
-export const mapProcessor: Processor<schemas.$ZodMap> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Map cannot be represented in JSON Schema");
-  }
-};
+export const mapProcessor: Processor<schemas.$ZodMap> = /* @__PURE__ */ _unrepresentable("Map");
 
-export const setProcessor: Processor<schemas.$ZodSet> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Set cannot be represented in JSON Schema");
-  }
-};
+export const setProcessor: Processor<schemas.$ZodSet> = /* @__PURE__ */ _unrepresentable("Set");
 
 // ==================== COMPOSITE TYPE PROCESSORS ====================
 

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -134,9 +134,7 @@ export const anyProcessor: Processor<schemas.$ZodAny> = (_schema, _ctx, _json, _
   // empty schema accepts anything
 };
 
-export const unknownProcessor: Processor<schemas.$ZodUnknown> = (_schema, _ctx, _json, _params) => {
-  // empty schema accepts anything
-};
+export const unknownProcessor: Processor<schemas.$ZodUnknown> = anyProcessor as Processor<any>;
 
 export const dateProcessor: Processor<schemas.$ZodDate> = /* @__PURE__ */ _unrepresentable("Date");
 
@@ -222,9 +220,7 @@ export const fileProcessor: Processor<schemas.$ZodFile> = (schema, _ctx, json, _
   }
 };
 
-export const successProcessor: Processor<schemas.$ZodSuccess> = (_schema, _ctx, json, _params) => {
-  (json as JSONSchema.BooleanSchema).type = "boolean";
-};
+export const successProcessor: Processor<schemas.$ZodSuccess> = booleanProcessor as Processor<any>;
 
 export const customProcessor: Processor<schemas.$ZodCustom> = /* @__PURE__ */ _unrepresentable("Custom types");
 
@@ -445,6 +441,13 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
   }
 };
 
+/** Processes the wrapped inner type and points this schema's ref at it. */
+const _refInner: Processor<any> = (schema, ctx, _json, params) => {
+  const innerType = (schema._zod.def as { innerType: schemas.$ZodType }).innerType;
+  process(innerType, ctx, params);
+  ctx.seen.get(schema)!.ref = innerType;
+};
+
 export const nullableProcessor: Processor<schemas.$ZodNullable> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodNullableDef;
   const inner = process(def.innerType, ctx as any, params);
@@ -457,34 +460,21 @@ export const nullableProcessor: Processor<schemas.$ZodNullable> = (schema, ctx, 
   }
 };
 
-export const nonoptionalProcessor: Processor<schemas.$ZodNonOptional> = (schema, ctx, _json, params) => {
-  const def = schema._zod.def as schemas.$ZodNonOptionalDef;
-  process(def.innerType, ctx as any, params);
-  const seen = ctx.seen.get(schema)!;
-  seen.ref = def.innerType;
-};
+export const nonoptionalProcessor: Processor<schemas.$ZodNonOptional> = _refInner;
 
 export const defaultProcessor: Processor<schemas.$ZodDefault> = (schema, ctx, json, params) => {
-  const def = schema._zod.def as schemas.$ZodDefaultDef;
-  process(def.innerType, ctx as any, params);
-  const seen = ctx.seen.get(schema)!;
-  seen.ref = def.innerType;
-  json.default = JSON.parse(JSON.stringify(def.defaultValue));
+  _refInner(schema, ctx, json, params);
+  json.default = JSON.parse(JSON.stringify(schema._zod.def.defaultValue));
 };
 
 export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, json, params) => {
-  const def = schema._zod.def as schemas.$ZodPrefaultDef;
-  process(def.innerType, ctx as any, params);
-  const seen = ctx.seen.get(schema)!;
-  seen.ref = def.innerType;
-  if (ctx.io === "input") json._prefault = JSON.parse(JSON.stringify(def.defaultValue));
+  _refInner(schema, ctx, json, params);
+  if (ctx.io === "input") json._prefault = JSON.parse(JSON.stringify(schema._zod.def.defaultValue));
 };
 
 export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, params) => {
-  const def = schema._zod.def as schemas.$ZodCatchDef;
-  process(def.innerType, ctx as any, params);
-  const seen = ctx.seen.get(schema)!;
-  seen.ref = def.innerType;
+  _refInner(schema, ctx, json, params);
+  const def = schema._zod.def;
   let catchValue: any;
   try {
     catchValue = def.catchValue(undefined as any);
@@ -507,26 +497,13 @@ export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, p
 };
 
 export const readonlyProcessor: Processor<schemas.$ZodReadonly> = (schema, ctx, json, params) => {
-  const def = schema._zod.def as schemas.$ZodReadonlyDef;
-  process(def.innerType, ctx as any, params);
-  const seen = ctx.seen.get(schema)!;
-  seen.ref = def.innerType;
+  _refInner(schema, ctx, json, params);
   json.readOnly = true;
 };
 
-export const promiseProcessor: Processor<schemas.$ZodPromise> = (schema, ctx, _json, params) => {
-  const def = schema._zod.def as schemas.$ZodPromiseDef;
-  process(def.innerType, ctx as any, params);
-  const seen = ctx.seen.get(schema)!;
-  seen.ref = def.innerType;
-};
+export const promiseProcessor: Processor<schemas.$ZodPromise> = _refInner;
 
-export const optionalProcessor: Processor<schemas.$ZodOptional> = (schema, ctx, _json, params) => {
-  const def = schema._zod.def as schemas.$ZodOptionalDef;
-  process(def.innerType, ctx as any, params);
-  const seen = ctx.seen.get(schema)!;
-  seen.ref = def.innerType;
-};
+export const optionalProcessor: Processor<schemas.$ZodOptional> = _refInner;
 
 export const lazyProcessor: Processor<schemas.$ZodLazy> = (schema, ctx, _json, params) => {
   const innerType = (schema as schemas.$ZodLazy)._zod.innerType;

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -215,15 +215,20 @@ export function process<T extends schemas.$ZodType>(
   return _result.schema;
 }
 
+/** Returns the Seen entry for a processed schema, throwing if process() was never called. */
+function _getRoot(ctx: ToJSONSchemaContext, schema: schemas.$ZodType): Seen {
+  const root = ctx.seen.get(schema);
+  if (!root) throw new Error("Unprocessed schema. This is a bug in Zod.");
+  return root;
+}
+
 export function extractDefs<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
   // params: EmitParams
 ): void {
   // iterate over seen map;
-  const root = ctx.seen.get(schema);
-
-  if (!root) throw new Error("Unprocessed schema. This is a bug in Zod.");
+  const root = _getRoot(ctx, schema);
 
   // Track ids to detect duplicates across different schemas
   const idToSchema = new Map<string, schemas.$ZodType>();
@@ -371,8 +376,7 @@ export function finalize<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
 ): ZodStandardJSONSchemaPayload<T> {
-  const root = ctx.seen.get(schema);
-  if (!root) throw new Error("Unprocessed schema. This is a bug in Zod.");
+  const root = _getRoot(ctx, schema);
 
   // flatten refs - inherit properties from parent schemas
   const flattenRef = (zodSchema: schemas.$ZodType) => {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -357,6 +357,16 @@ export function extractDefs<T extends schemas.$ZodType>(
   }
 }
 
+/** Deletes keys (except `$ref`/`allOf`) whose value deep-equals the same key in `def`. */
+function _deleteMatchingDefKeys(schema: JSONSchema.BaseSchema, def: JSONSchema.BaseSchema): void {
+  for (const key in schema) {
+    if (key === "$ref" || key === "allOf") continue;
+    if (key in def && JSON.stringify(schema[key]) === JSON.stringify(def[key])) {
+      delete schema[key];
+    }
+  }
+}
+
 export function finalize<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
@@ -408,12 +418,7 @@ export function finalize<T extends schemas.$ZodType>(
 
       // When ref was extracted to $defs, remove properties that match the definition
       if (refSchema.$ref && refSeen.def) {
-        for (const key in schema) {
-          if (key === "$ref" || key === "allOf") continue;
-          if (key in refSeen.def && JSON.stringify(schema[key]) === JSON.stringify(refSeen.def[key])) {
-            delete schema[key];
-          }
-        }
+        _deleteMatchingDefKeys(schema, refSeen.def);
       }
     }
 
@@ -429,12 +434,7 @@ export function finalize<T extends schemas.$ZodType>(
         schema.$ref = parentSeen.schema.$ref;
         // De-duplicate with parent's definition
         if (parentSeen.def) {
-          for (const key in schema) {
-            if (key === "$ref" || key === "allOf") continue;
-            if (key in parentSeen.def && JSON.stringify(schema[key]) === JSON.stringify(parentSeen.def[key])) {
-              delete schema[key];
-            }
-          }
+          _deleteMatchingDefKeys(schema, parentSeen.def);
         }
       }
     }


### PR DESCRIPTION
> **Context: bundle-size optimization campaign.** This is one of four PRs extracted from a systematic bundle-size campaign on the v4 core, run as an automated research loop: 30 isolated experiments, 24 kept, 6 discarded. Every candidate change was
>
> - measured with a **deterministic A/B size harness** that materialises two git revisions of `packages/zod/src` via `git archive` and bundles seven fixed entry cases with esbuild (`--bundle --minify --format=esm --target=es2020`), recording minified and gzipped (zlib 9) bytes plus esbuild metafiles for attribution. The verification below leads with the **standard consumer**: `import * as z from "zod"` + `z.object({ name: z.string(), age: z.number() }).safeParse(...)` (70.9 kB min at baseline; namespace property accesses tree-shake under esbuild). Also reported: `import { z }`, which defeats tree-shaking entirely under esbuild (the exported `z` binding is a namespace object that escapes as a value, pinning the full classic surface, 327.7 kB min at baseline, no matter how few methods are used), and named imports (`import { string }`), the best-case shaking scenario;
> - judged against an **exact-zero calibration**: identical revisions on both sides produce 0-byte deltas on every case (esbuild output is deterministic), so every reported delta is exact and there is no noise floor to argue about. Minified bytes is the judged metric; gzip is reported alongside;
> - verified behaviour-preserving by the **full test suite** (339 files, 3,811 tests including tsc typecheck; snapshot-heavy, so error messages, def shapes, and JSON Schema output are pinned), green after every commit. Experiments that changed observable behaviour or regressed a tree-shaken case were discarded; e.g. sharing regex source strings was rejected because esbuild cannot tree-shake `new RegExp` with a non-literal argument and the shared string would have been pinned into every `zod/mini` consumer;
> - **runtime-smoked** where a change touched construction or error paths (`packages/bench` `init` and `object-fail`), with results inside run-to-run noise;
> - cross-checked at the end against the **real build**: cumulative deltas re-measured on `zshy`-built package output bundled consumer-style matched the source-level harness byte-for-byte.
>
> The numbers below are fresh verification runs of **this branch in isolation against `main`**, first per commit (each against its parent), then the branch total. Negative = smaller.
>
> Sibling PRs from the same campaign: #6348, #6349, #6351.

## What this PR does

Dedupes internals of the JSON Schema pipeline. This code is not optional for consumers: every `ZodType` instance gets a `toJSONSchema` method and `~standard.jsonSchema` wiring at construction, so `to-json-schema.ts` and parts of `json-schema-processors.ts` are pinned into every tree-shaken bundle. Six commits:

**1. `_unrepresentable` factory.** Eleven processors (`bigint`, `symbol`, `undefined`, `void`, `date`, `nan`, `custom`, `function`, `transform`, `map`, `set`) were the identical function differing only in the error-message noun. All eleven messages fit `` `${name} cannot be represented in JSON Schema` `` byte-for-byte (snapshot-verified), so they collapse onto one PURE-annotated factory.

**2. `_refInner` + aliases.** Seven wrapper processors shared the body "process `def.innerType`, point `seen.ref` at it". `optional`/`nonoptional`/`promise` become direct references to the shared function; `readonly`/`default`/`prefault`/`catch` call it and keep their one distinctive line. `successProcessor` and `unknownProcessor` were literal duplicates of `booleanProcessor`/`anyProcessor` and become aliases.

**3. Tuple-branch merge in `from-json-schema.ts`.** The draft-2020-12 (`prefixItems`) and draft-7 (`items` array) tuple branches were identical after computing `tupleItems`/`rest`; the shared tail (tuple construction, `minItems`/`maxItems` checks) now runs once.

**4. Redundant normalization deleted.** `JSONSchemaGenerator`'s constructor normalized `draft-4`/`draft-7` aliases and then passed the result to `initializeContext`, which performs the same normalization. Pure deletion.

**5. `_deleteMatchingDefKeys`.** `finalize()` contained the same "delete keys (except `$ref`/`allOf`) whose value deep-equals the def" loop twice (ref dedup and parent dedup).

**6. `_getRoot`.** The `"Unprocessed schema. This is a bug in Zod."` guard appeared in both `extractDefs` and `finalize`.

All cold-path (JSON Schema generation); no parse-path code touched.

## Verification (this branch vs `main`)

Per case, minified bytes:

| commit | namespace import `import * as z` (standard) | z-object import `import { z }` (full) | named imports `import { string }` |
|---|---|---|---|
| 1. `_unrepresentable` (11 processors) | -77 | **-924** | -77 |
| 2. `_refInner` + aliases | **-313** | -435 | -316 |
| 3. tuple-branch merge | 0 | -177 | 0 |
| 4. delete redundant normalization | 0 | -85 | 0 |
| 5. `_deleteMatchingDefKeys` | -84 | -84 | -84 |
| 6. `_getRoot` | -41 | -41 | -41 |
| **branch total** | **-515 (-0.73%)** | **-1,746 (-0.53%)** | **-518 (-0.90%)** |

`zod/mini` cases: full-import-mini -1,574, minimal mini consumer 0. Full suite green after every commit (JSON Schema output is heavily snapshot-tested, so message strings and emitted schemas are pinned). Net source delta: 4 files, +73/-141.

## Reproducing the numbers

The harness below is the one used for the verification runs. From a checkout of this repo:

1. `pnpm install`
2. Save the file below as `sizecheck/compare.mts` (the directory must live **inside** the repo so the materialised trees resolve `node_modules`; `sizecheck/{a,b,meta}/` are created automatically and safe to delete).
3. Fetch this PR's head ref and compare it against `main`:

   ```sh
   git fetch origin pull/6350/head:pr-branch
   pnpm tsx sizecheck/compare.mts main pr-branch
   ```

A run takes ~15s and prints per-case minified/gzip bytes for both sides with exact deltas; the `namespace-import-classic` row is the standard `import * as z` consumer, `z-import-classic` the `import { z }` style, `named-import-classic` the `import { string }` style. A control run with the same rev on both sides (`pnpm tsx sizecheck/compare.mts main main`) prints all-zero deltas — the pipeline is deterministic, so single runs are conclusive.

<details>
<summary><code>sizecheck/compare.mts</code> — A/B bundle-size harness</summary>

```ts
/**
 * A/B bundle-size comparison between two git revisions of packages/zod.
 *
 * Usage: pnpm exec tsx sizecheck/compare.mts [revA] [revB]
 *   revA defaults to HEAD, revB defaults to WORK (the working tree).
 *
 * Each side is materialised under sizecheck/<side>/ via `git archive` (or a
 * straight copy for WORK), then a fixed set of entry files is bundled with
 * esbuild (--bundle --minify --format=esm, pinned target). Reports minified
 * and gzipped bytes per case plus deltas, and writes esbuild metafiles to
 * sizecheck/meta/.
 */
import { execSync } from "node:child_process";
import { gzipSync } from "node:zlib";
import * as fs from "node:fs";
import * as path from "node:path";
import { build } from "esbuild";

const root = path.resolve(import.meta.dirname, "..");
const work = path.join(root, "sizecheck");

const revA = process.argv[2] ?? "HEAD";
const revB = process.argv[3] ?? "WORK";

/** Entry cases. Files are written identically into each side's tree. */
const CASES: Array<{ name: string; code: string }> = [
  {
    name: "full-import-classic",
    code: `import * as z from "./packages/zod/src/index.ts";\nconsole.log(z);\n`,
  },
  {
    name: "full-import-mini",
    code: `import * as z from "./packages/zod/src/mini/index.ts";\nconsole.log(z);\n`,
  },
  {
    name: "named-import-mini",
    code: `import { string, minLength, safeParse } from "./packages/zod/src/mini/index.ts";\nconst schema = string().check(minLength(5));\nconsole.log(safeParse(schema, "hello"));\n`,
  },
  {
    name: "named-import-classic",
    code: `import { string } from "./packages/zod/src/index.ts";\nconst schema = string().min(5);\nconsole.log(schema.safeParse("hello"));\n`,
  },
  {
    name: "namespace-import-classic",
    code: `import * as z from "./packages/zod/src/index.ts";\nconst schema = z.object({ name: z.string(), age: z.number() });\nconsole.log(schema.safeParse({ name: "hello", age: 1 }));\n`,
  },
  {
    name: "z-import-classic",
    code: `import { z } from "./packages/zod/src/index.ts";\nconst schema = z.object({ name: z.string(), age: z.number() });\nconsole.log(schema.safeParse({ name: "hello", age: 1 }));\n`,
  },
  {
    name: "full-import-locales",
    code: `import * as locales from "./packages/zod/src/locales/index.ts";\nconsole.log(locales);\n`,
  },
];

function materialise(rev: string, dir: string): void {
  fs.rmSync(dir, { recursive: true, force: true });
  fs.mkdirSync(dir, { recursive: true });
  if (rev === "WORK") {
    fs.mkdirSync(path.join(dir, "packages/zod"), { recursive: true });
    fs.cpSync(path.join(root, "packages/zod/src"), path.join(dir, "packages/zod/src"), { recursive: true });
    fs.copyFileSync(path.join(root, "packages/zod/package.json"), path.join(dir, "packages/zod/package.json"));
  } else {
    execSync(`git archive ${rev} -- packages/zod/src packages/zod/package.json | tar -x -C ${JSON.stringify(dir)}`, {
      cwd: root,
      shell: "/bin/zsh",
    });
  }
  for (const c of CASES) {
    fs.writeFileSync(path.join(dir, `${c.name}.entry.ts`), c.code);
  }
}

interface Result {
  min: number;
  gzip: number;
}

async function measure(dir: string, side: string): Promise<Record<string, Result>> {
  const out: Record<string, Result> = {};
  for (const c of CASES) {
    const result = await build({
      entryPoints: [path.join(dir, `${c.name}.entry.ts`)],
      bundle: true,
      minify: true,
      format: "esm",
      target: "es2020",
      write: false,
      metafile: true,
      outfile: `${c.name}.js`,
      logLevel: "silent",
    });
    const contents = result.outputFiles[0].contents;
    out[c.name] = {
      min: contents.byteLength,
      gzip: gzipSync(contents, { level: 9 }).byteLength,
    };
    fs.mkdirSync(path.join(work, "meta"), { recursive: true });
    fs.writeFileSync(path.join(work, "meta", `${side}-${c.name}.json`), JSON.stringify(result.metafile));
  }
  return out;
}

function fmt(n: number): string {
  return n.toLocaleString("en-US");
}

const dirA = path.join(work, "a");
const dirB = path.join(work, "b");
materialise(revA, dirA);
materialise(revB, dirB);

const resA = await measure(dirA, "a");
const resB = await measure(dirB, "b");

console.log(`A = ${revA}, B = ${revB}\n`);
const pad = (s: string, n: number) => s.padStart(n);
console.log(
  "case".padEnd(16) +
    pad("A min", 10) +
    pad("B min", 10) +
    pad("Δ min", 9) +
    pad("Δ%", 8) +
    pad("A gz", 9) +
    pad("B gz", 9) +
    pad("Δ gz", 8)
);
let totMinA = 0;
let totMinB = 0;
let totGzA = 0;
let totGzB = 0;
for (const c of CASES) {
  const a = resA[c.name];
  const b = resB[c.name];
  totMinA += a.min;
  totMinB += b.min;
  totGzA += a.gzip;
  totGzB += b.gzip;
  const dMin = b.min - a.min;
  const dGz = b.gzip - a.gzip;
  const pct = a.min === 0 ? 0 : (dMin / a.min) * 100;
  console.log(
    c.name.padEnd(16) +
      pad(fmt(a.min), 10) +
      pad(fmt(b.min), 10) +
      pad((dMin >= 0 ? "+" : "") + fmt(dMin), 9) +
      pad(`${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%`, 8) +
      pad(fmt(a.gzip), 9) +
      pad(fmt(b.gzip), 9) +
      pad((dGz >= 0 ? "+" : "") + fmt(dGz), 8)
  );
}
const dTotMin = totMinB - totMinA;
const dTotGz = totGzB - totGzA;
console.log(
  "TOTAL".padEnd(16) +
    pad(fmt(totMinA), 10) +
    pad(fmt(totMinB), 10) +
    pad((dTotMin >= 0 ? "+" : "") + fmt(dTotMin), 9) +
    pad(`${totMinA ? ((dTotMin / totMinA) * 100).toFixed(2) : "0.00"}%`, 8) +
    pad(fmt(totGzA), 9) +
    pad(fmt(totGzB), 9) +
    pad((dTotGz >= 0 ? "+" : "") + fmt(dTotGz), 8)
);
```

</details>
