### PR TITLE
perf(v4): merge duplicated cold-path logic in core (-1.7% tree-shaken)

### DIFF
--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -326,31 +326,17 @@ export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /
           // });
         }
         if (!Number.isSafeInteger(input)) {
-          if (input > 0) {
-            // too_big
-            payload.issues.push({
-              input,
-              code: "too_big",
-              maximum: Number.MAX_SAFE_INTEGER,
-              note: "Integers must be within the safe integer range.",
-              inst,
-              origin,
-              inclusive: true,
-              continue: !def.abort,
-            });
-          } else {
-            // too_small
-            payload.issues.push({
-              input,
-              code: "too_small",
-              minimum: Number.MIN_SAFE_INTEGER,
-              note: "Integers must be within the safe integer range.",
-              inst,
-              origin,
-              inclusive: true,
-              continue: !def.abort,
-            });
-          }
+          payload.issues.push({
+            input,
+            ...(input > 0
+              ? { code: "too_big" as const, maximum: Number.MAX_SAFE_INTEGER }
+              : { code: "too_small" as const, minimum: Number.MIN_SAFE_INTEGER }),
+            note: "Integers must be within the safe integer range.",
+            inst,
+            origin,
+            inclusive: true,
+            continue: !def.abort,
+          } as never);
 
           return;
         }

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -938,6 +938,15 @@ export const $ZodCheckUpperCase: core.$constructor<$ZodCheckUpperCase> = /*@__PU
   }
 );
 
+/** Registers an onattach hook that records `pattern` in the schema's bag. */
+function _attachPattern(inst: $ZodCheck<never>, pattern: RegExp): void {
+  inst._zod.onattach.push((inst) => {
+    const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
+    bag.patterns ??= new Set();
+    bag.patterns.add(pattern);
+  });
+}
+
 ///////////////////////////////////
 /////    $ZodCheckIncludes    /////
 ///////////////////////////////////
@@ -963,11 +972,7 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     const escapedRegex = util.escapeRegex(def.includes);
     const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position}}${escapedRegex}` : escapedRegex);
     def.pattern = pattern;
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      bag.patterns ??= new Set();
-      bag.patterns.add(pattern);
-    });
+    _attachPattern(inst, pattern);
 
     inst._zod.check = (payload) => {
       if (payload.value.includes(def.includes, def.position)) return;
@@ -1007,11 +1012,7 @@ export const $ZodCheckStartsWith: core.$constructor<$ZodCheckStartsWith> = /*@__
 
     const pattern = new RegExp(`^${util.escapeRegex(def.prefix)}.*`);
     def.pattern ??= pattern;
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      bag.patterns ??= new Set();
-      bag.patterns.add(pattern);
-    });
+    _attachPattern(inst, pattern);
 
     inst._zod.check = (payload) => {
       if (payload.value.startsWith(def.prefix)) return;
@@ -1051,11 +1052,7 @@ export const $ZodCheckEndsWith: core.$constructor<$ZodCheckEndsWith> = /*@__PURE
 
     const pattern = new RegExp(`.*${util.escapeRegex(def.suffix)}$`);
     def.pattern ??= pattern;
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      bag.patterns ??= new Set();
-      bag.patterns.add(pattern);
-    });
+    _attachPattern(inst, pattern);
 
     inst._zod.check = (payload) => {
       if (payload.value.endsWith(def.suffix)) return;

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -38,6 +38,18 @@ export const $ZodCheck: core.$constructor<$ZodCheck<any>> = /*@__PURE__*/ core.$
   }
 );
 
+/** Default `when` for size-based checks: run only on non-nullish values with a `size`. */
+const _whenHasSize = (payload: schemas.ParsePayload): boolean => {
+  const val = payload.value;
+  return !util.nullish(val) && (val as any).size !== undefined;
+};
+
+/** Default `when` for length-based checks: run only on non-nullish values with a `length`. */
+const _whenHasLength = (payload: schemas.ParsePayload): boolean => {
+  const val = payload.value;
+  return !util.nullish(val) && (val as any).length !== undefined;
+};
+
 ///////////////////////////////////////
 /////      $ZodCheckLessThan      /////
 ///////////////////////////////////////
@@ -457,10 +469,7 @@ export const $ZodCheckMaxSize: core.$constructor<$ZodCheckMaxSize> = /*@__PURE__
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).size !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasSize;
 
     inst._zod.onattach.push((inst) => {
       const curr = (inst._zod.bag.maximum ?? Number.POSITIVE_INFINITY) as number;
@@ -507,10 +516,7 @@ export const $ZodCheckMinSize: core.$constructor<$ZodCheckMinSize> = /*@__PURE__
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).size !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasSize;
 
     inst._zod.onattach.push((inst) => {
       const curr = (inst._zod.bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
@@ -557,10 +563,7 @@ export const $ZodCheckSizeEquals: core.$constructor<$ZodCheckSizeEquals> = /*@__
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).size !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasSize;
 
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag;
@@ -611,10 +614,7 @@ export const $ZodCheckMaxLength: core.$constructor<$ZodCheckMaxLength> = /*@__PU
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).length !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasLength;
 
     inst._zod.onattach.push((inst) => {
       const curr = (inst._zod.bag.maximum ?? Number.POSITIVE_INFINITY) as number;
@@ -662,10 +662,7 @@ export const $ZodCheckMinLength: core.$constructor<$ZodCheckMinLength> = /*@__PU
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).length !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasLength;
 
     inst._zod.onattach.push((inst) => {
       const curr = (inst._zod.bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
@@ -714,10 +711,7 @@ export const $ZodCheckLengthEquals: core.$constructor<$ZodCheckLengthEquals> = /
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).length !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasLength;
 
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag;

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -301,40 +301,40 @@ export type $ZodFormattedError<T, U = string> = {
   _errors: U[];
 } & util.Flatten<_ZodFormattedError<T, U>>;
 
-export function formatError<T>(error: $ZodError<T>): $ZodFormattedError<T>;
-export function formatError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodFormattedError<T, U>;
-export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
-  const fieldErrors: $ZodFormattedError<T> = { _errors: [] } as any;
+/** Walks issues recursively, flattening nested union/key/element issues, and calls `onLeaf` with each terminal issue and its full path. */
+function _walkIssues(error: { issues: $ZodIssue[] }, onLeaf: (issue: $ZodIssue, fullpath: PropertyKey[]) => void) {
   const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
     for (const issue of error.issues) {
       if (issue.code === "invalid_union" && issue.errors.length) {
         issue.errors.map((issues) => processError({ issues }, [...path, ...issue.path]));
-      } else if (issue.code === "invalid_key") {
-        processError({ issues: issue.issues }, [...path, ...issue.path]);
-      } else if (issue.code === "invalid_element") {
+      } else if (issue.code === "invalid_key" || issue.code === "invalid_element") {
         processError({ issues: issue.issues }, [...path, ...issue.path]);
       } else {
-        const fullpath = [...path, ...issue.path];
-        if (fullpath.length === 0) {
-          (fieldErrors as any)._errors.push(mapper(issue));
-        } else {
-          let curr: any = fieldErrors;
-          let i = 0;
-          while (i < fullpath.length) {
-            const el = fullpath[i]!;
-            const terminal = i === fullpath.length - 1;
-
-            curr = node(curr, el, () => ({ _errors: [] as U[] }));
-            if (terminal) {
-              curr._errors.push(mapper(issue));
-            }
-            i++;
-          }
-        }
+        onLeaf(issue, [...path, ...issue.path]);
       }
     }
   };
   processError(error);
+}
+
+export function formatError<T>(error: $ZodError<T>): $ZodFormattedError<T>;
+export function formatError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodFormattedError<T, U>;
+export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
+  const fieldErrors: $ZodFormattedError<T> = { _errors: [] } as any;
+  _walkIssues(error, (issue, fullpath) => {
+    if (fullpath.length === 0) {
+      (fieldErrors as any)._errors.push(mapper(issue));
+    } else {
+      let curr: any = fieldErrors;
+      for (let i = 0; i < fullpath.length; i++) {
+        const el = fullpath[i]!;
+        curr = node(curr, el, () => ({ _errors: [] as U[] }));
+        if (i === fullpath.length - 1) {
+          curr._errors.push(mapper(issue));
+        }
+      }
+    }
+  });
   return fieldErrors;
 }
 
@@ -355,47 +355,30 @@ export function treeifyError<T>(error: $ZodError<T>): $ZodErrorTree<T>;
 export function treeifyError<T, U>(error: $ZodError<T>, mapper?: (issue: $ZodIssue) => U): $ZodErrorTree<T, U>;
 export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssue) => issue.message as U) {
   const result: $ZodErrorTree<T, U> = { errors: [] } as any;
-  const processError = (error: { issues: $ZodIssue[] }, path: PropertyKey[] = []) => {
-    for (const issue of error.issues) {
-      if (issue.code === "invalid_union" && issue.errors.length) {
-        // regular union error
-        issue.errors.map((issues) => processError({ issues }, [...path, ...issue.path]));
-      } else if (issue.code === "invalid_key") {
-        processError({ issues: issue.issues }, [...path, ...issue.path]);
-      } else if (issue.code === "invalid_element") {
-        processError({ issues: issue.issues }, [...path, ...issue.path]);
+  _walkIssues(error, (issue, fullpath) => {
+    if (fullpath.length === 0) {
+      result.errors.push(mapper(issue));
+      return;
+    }
+
+    let curr: any = result;
+    for (let i = 0; i < fullpath.length; i++) {
+      const el = fullpath[i]!;
+
+      if (typeof el === "string") {
+        curr.properties ??= {};
+        curr = node(curr.properties, el, () => ({ errors: [] as U[] }));
       } else {
-        const fullpath = [...path, ...issue.path];
-        if (fullpath.length === 0) {
-          result.errors.push(mapper(issue));
-          continue;
-        }
+        curr.items ??= [];
+        curr.items[el] ??= { errors: [] };
+        curr = curr.items[el];
+      }
 
-        let curr: any = result;
-        let i = 0;
-        while (i < fullpath.length) {
-          const el = fullpath[i]!;
-
-          const terminal = i === fullpath.length - 1;
-          if (typeof el === "string") {
-            curr.properties ??= {};
-            curr = node(curr.properties, el, () => ({ errors: [] as U[] }));
-          } else {
-            curr.items ??= [];
-            curr.items[el] ??= { errors: [] };
-            curr = curr.items[el];
-          }
-
-          if (terminal) {
-            curr.errors.push(mapper(issue));
-          }
-
-          i++;
-        }
+      if (i === fullpath.length - 1) {
+        curr.errors.push(mapper(issue));
       }
     }
-  };
-  processError(error);
+  });
   return result;
 }
 

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -5,6 +5,23 @@ import * as util from "./util.js";
 
 export type $ZodErrorClass = { new (issues: errors.$ZodIssue[]): errors.$ZodError };
 
+/** Finalizes the raw issues of a failed parse result. */
+function _finalizeIssues(result: schemas.ParsePayload, ctx: schemas.ParseContextInternal): errors.$ZodIssue[] {
+  return result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config()));
+}
+
+/** Builds and throws the parse error for a failed result. */
+function _throwParseError(
+  result: schemas.ParsePayload,
+  ctx: schemas.ParseContextInternal,
+  _Err: $ZodErrorClass,
+  _params?: { callee?: util.AnyFunc; Err?: $ZodErrorClass }
+): never {
+  const e = new (_params?.Err ?? _Err)(_finalizeIssues(result, ctx));
+  util.captureStackTrace(e, _params?.callee);
+  throw e;
+}
+
 ///////////        METHODS       ///////////
 export type $Parse = <T extends schemas.$ZodType>(
   schema: T,
@@ -20,9 +37,7 @@ export const _parse: (_Err: $ZodErrorClass) => $Parse = (_Err) => (schema, value
     throw new core.$ZodAsyncError();
   }
   if (result.issues.length) {
-    const e = new (_params?.Err ?? _Err)(result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())));
-    util.captureStackTrace(e, _params?.callee);
-    throw e;
+    _throwParseError(result, ctx, _Err, _params);
   }
   return result.value as core.output<typeof schema>;
 };
@@ -41,9 +56,7 @@ export const _parseAsync: (_Err: $ZodErrorClass) => $ParseAsync = (_Err) => asyn
   let result = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) result = await result;
   if (result.issues.length) {
-    const e = new (params?.Err ?? _Err)(result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())));
-    util.captureStackTrace(e, params?.callee);
-    throw e;
+    _throwParseError(result, ctx, _Err, params);
   }
   return result.value as core.output<typeof schema>;
 };
@@ -66,7 +79,7 @@ export const _safeParse: (_Err: $ZodErrorClass) => $SafeParse = (_Err) => (schem
   return result.issues.length
     ? {
         success: false,
-        error: new (_Err ?? errors.$ZodError)(result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config()))),
+        error: new (_Err ?? errors.$ZodError)(_finalizeIssues(result, ctx)),
       }
     : ({ success: true, data: result.value } as any);
 };
@@ -86,7 +99,7 @@ export const _safeParseAsync: (_Err: $ZodErrorClass) => $SafeParseAsync = (_Err)
   return result.issues.length
     ? {
         success: false,
-        error: new _Err(result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config()))),
+        error: new _Err(_finalizeIssues(result, ctx)),
       }
     : ({ success: true, data: result.value } as any);
 };

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1996,6 +1996,22 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
       };
 
+      const concatIssues = (id: string, k: string) => `payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
+            ...iss,
+            path: iss.path ? [${k}, ...iss.path] : [${k}]
+          })));`;
+
+      const assignValue = (id: string, k: string) => `
+        if (${id}.value === undefined) {
+          if (${k} in input) {
+            newResult[${k}] = undefined;
+          }
+        } else {
+          newResult[${k}] = ${id}.value;
+        }
+
+      `;
+
       doc.write(`const input = payload.value;`);
 
       const ids: any = Object.create(null);
@@ -2020,30 +2036,16 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
           doc.write(`
         if (${id}.issues.length) {
           if (${k} in input) {
-            payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-              ...iss,
-              path: iss.path ? [${k}, ...iss.path] : [${k}]
-            })));
+            ${concatIssues(id, k)}
           }
         }
-        
-        if (${id}.value === undefined) {
-          if (${k} in input) {
-            newResult[${k}] = undefined;
-          }
-        } else {
-          newResult[${k}] = ${id}.value;
-        }
-        
+        ${assignValue(id, k)}
       `);
         } else if (!isOptionalIn) {
           doc.write(`
         const ${id}_present = ${k} in input;
         if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
+          ${concatIssues(id, k)}
         }
         if (!${id}_present && !${id}.issues.length) {
           payload.issues.push({
@@ -2066,20 +2068,9 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         } else {
           doc.write(`
         if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
+          ${concatIssues(id, k)}
         }
-        
-        if (${id}.value === undefined) {
-          if (${k} in input) {
-            newResult[${k}] = undefined;
-          }
-        } else {
-          newResult[${k}] = ${id}.value;
-        }
-        
+        ${assignValue(id, k)}
       `);
         }
       }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3898,41 +3898,32 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
     // Forward direction (decode): apply catch logic
     const result = def.innerType._zod.run(payload, ctx);
     if (result instanceof Promise) {
-      return result.then((result) => {
-        payload.value = result.value;
-        if (result.issues.length) {
-          payload.value = def.catchValue({
-            ...payload,
-            error: {
-              issues: result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())),
-            },
-            input: payload.value,
-          });
-          payload.issues = [];
-          payload.fallback = true;
-        }
-
-        return payload;
-      });
+      return result.then((result) => handleCatchResult(result, payload, ctx, def));
     }
-
-    payload.value = result.value;
-    if (result.issues.length) {
-      payload.value = def.catchValue({
-        ...payload,
-        error: {
-          issues: result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())),
-        },
-        input: payload.value,
-      });
-
-      payload.issues = [];
-      payload.fallback = true;
-    }
-
-    return payload;
+    return handleCatchResult(result, payload, ctx, def);
   };
 });
+
+function handleCatchResult(
+  result: ParsePayload,
+  payload: ParsePayload,
+  ctx: ParseContextInternal,
+  def: $ZodCatchDef
+): ParsePayload {
+  payload.value = result.value;
+  if (result.issues.length) {
+    payload.value = def.catchValue({
+      ...payload,
+      error: {
+        issues: result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())),
+      },
+      input: payload.value,
+    });
+    payload.issues = [];
+    payload.fallback = true;
+  }
+  return payload;
+}
 
 ////////////////////////////////////////////
 ////////////////////////////////////////////

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -598,14 +598,16 @@ export const BIGINT_FORMAT_RANGES: Record<checks.$ZodBigIntFormats, [bigint, big
   uint64: [/* @__PURE__*/ BigInt(0), /* @__PURE__*/ BigInt("18446744073709551615")],
 };
 
+/** Throws if the def carries refinement checks; `method` names the caller in the message. */
+function _assertNoChecks(checks: unknown[] | undefined, method: string, suffix = ""): void {
+  if (checks && checks.length > 0) {
+    throw new Error(`.${method}() cannot be used on object schemas containing refinements${suffix}`);
+  }
+}
+
 export function pick(schema: schemas.$ZodObject, mask: Record<string, unknown>): any {
   const currDef = schema._zod.def;
-
-  const checks = currDef.checks;
-  const hasChecks = checks && checks.length > 0;
-  if (hasChecks) {
-    throw new Error(".pick() cannot be used on object schemas containing refinements");
-  }
+  _assertNoChecks(currDef.checks, "pick");
 
   const def = mergeDefs(schema._zod.def, {
     get shape() {
@@ -629,12 +631,7 @@ export function pick(schema: schemas.$ZodObject, mask: Record<string, unknown>):
 
 export function omit(schema: schemas.$ZodObject, mask: object): any {
   const currDef = schema._zod.def;
-
-  const checks = currDef.checks;
-  const hasChecks = checks && checks.length > 0;
-  if (hasChecks) {
-    throw new Error(".omit() cannot be used on object schemas containing refinements");
-  }
+  _assertNoChecks(currDef.checks, "omit");
 
   const def = mergeDefs(schema._zod.def, {
     get shape() {
@@ -699,9 +696,7 @@ export function safeExtend(schema: schemas.$ZodObject, shape: schemas.$ZodShape)
 }
 
 export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
-  if (a._zod.def.checks?.length) {
-    throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
-  }
+  _assertNoChecks(a._zod.def.checks, "merge", ". Use .safeExtend() instead.");
   const def = mergeDefs(a._zod.def, {
     get shape() {
       const _shape = { ...a._zod.def.shape, ...b._zod.def.shape };
@@ -723,11 +718,7 @@ export function partial(
   mask: object | undefined
 ): any {
   const currDef = schema._zod.def;
-  const checks = currDef.checks;
-  const hasChecks = checks && checks.length > 0;
-  if (hasChecks) {
-    throw new Error(".partial() cannot be used on object schemas containing refinements");
-  }
+  _assertNoChecks(currDef.checks, "partial");
 
   const def = mergeDefs(schema._zod.def, {
     get shape() {


### PR DESCRIPTION
> **Context: bundle-size optimization campaign.** This is one of four PRs extracted from a systematic bundle-size campaign on the v4 core, run as an automated research loop: 30 isolated experiments, 24 kept, 6 discarded. Every candidate change was
>
> - measured with a **deterministic A/B size harness** that materialises two git revisions of `packages/zod/src` via `git archive` and bundles seven fixed entry cases with esbuild (`--bundle --minify --format=esm --target=es2020`), recording minified and gzipped (zlib 9) bytes plus esbuild metafiles for attribution. The verification below leads with the **standard consumer**: `import * as z from "zod"` + `z.object({ name: z.string(), age: z.number() }).safeParse(...)` (70.9 kB min at baseline; namespace property accesses tree-shake under esbuild). Also reported: `import { z }`, which defeats tree-shaking entirely under esbuild (the exported `z` binding is a namespace object that escapes as a value, pinning the full classic surface, 327.7 kB min at baseline, no matter how few methods are used), and named imports (`import { string }`), the best-case shaking scenario;
> - judged against an **exact-zero calibration**: identical revisions on both sides produce 0-byte deltas on every case (esbuild output is deterministic), so every reported delta is exact and there is no noise floor to argue about. Minified bytes is the judged metric; gzip is reported alongside;
> - verified behaviour-preserving by the **full test suite** (339 files, 3,811 tests including tsc typecheck; snapshot-heavy, so error messages, def shapes, and JSON Schema output are pinned), green after every commit. Experiments that changed observable behaviour or regressed a tree-shaken case were discarded; e.g. sharing regex source strings was rejected because esbuild cannot tree-shake `new RegExp` with a non-literal argument and the shared string would have been pinned into every `zod/mini` consumer;
> - **runtime-smoked** where a change touched construction or error paths (`packages/bench` `init` and `object-fail`), with results inside run-to-run noise;
> - cross-checked at the end against the **real build**: cumulative deltas re-measured on `zshy`-built package output bundled consumer-style matched the source-level harness byte-for-byte.
>
> The numbers below are fresh verification runs of **this branch in isolation against `main`**, first per commit (each against its parent), then the branch total. Negative = smaller.
>
> Sibling PRs from the same campaign: #6348, #6349, #6350.

## What this PR does

Merges duplicated cold-path logic across `core/`: blocks that exist twice byte-for-byte, mostly on error/derivation paths. Eight commits:

**1. `ZodObjectJIT` codegen templates.** The three per-key code-generation branches in `generateFastpass` shared two large template chunks (the issues-concat snippet appeared 3x, the value-assignment block 2x); they are now built by two local template helpers. The *generated* runtime code differs only in whitespace, so parse behaviour and JIT output semantics are identical.

**2. `_walkIssues`.** `formatError` and `treeifyError` shared an identical recursive walker (invalid_union/invalid_key/invalid_element flattening); only the leaf accumulation differs and stays per-function. Builds on #6213, which reworked the leaf accumulation to own-property semantics via `node()` but left the walker skeleton duplicated; the extracted leaves use `node()` exactly as #6213 wrote them.

**3. Shared default `when` clauses.** The six size/length checks each defined an identical `def.when ??= (payload) => ...` closure ("non-nullish and has `size`"/"has `length`"); two shared module-level functions replace them. Instances now share one function reference instead of each owning an identical closure; nothing observes closure identity.

**4. `handleCatchResult`.** `$ZodCatch.parse` duplicated its entire catch-value block for the promise and non-promise branches; extracted into a module-level handler, the same shape as the existing `handleDefaultResult`/`handleOptionalResult` helpers in the file.

**5. `_assertNoChecks`.** `.pick()`/`.omit()`/`.merge()`/`.partial()` each carried the same refinement guard and long message; messages stay byte-identical including `.merge()`'s "Use .safeExtend() instead." suffix.

**6. `_attachPattern`.** `includes`/`startsWith`/`endsWith` checks each registered an identical onattach hook recording their pattern in the schema bag.

**7. `parse.ts` error path.** `result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config()))` appeared four times and the throw-with-stack-capture block twice; extracted `_finalizeIssues`/`_throwParseError`. Only failure paths call them; the success path and per-call ctx construction are untouched. Smoked with `pnpm bench object-fail`: 13.4µs vs 12.5µs baseline with fully overlapping ranges (noise).

**8. Safe-integer branches.** The number-format check's too_big/too_small pushes for unsafe integers merge via the conditional-spread idiom `$ZodCheckLengthEquals` already uses, preserving issue key order.

## Verification (this branch vs `main`)

Per case, minified bytes:

| commit | namespace import `import * as z` (standard) | z-object import `import { z }` (full) | named imports `import { string }` |
|---|---|---|---|
| 1. JIT codegen templates | **-448** | -448 | 0 |
| 2. `_walkIssues` | -29 | -323 | -29 |
| 3. shared `when` clauses | -85 | -176 | -84 |
| 4. `handleCatchResult` | -101 | -97 | -101 |
| 5. `_assertNoChecks` | -223 | -223 | -225 |
| 6. `_attachPattern` | -145 | -145 | -145 |
| 7. parse.ts error path | -43 | -43 | -42 |
| 8. safe-integer branches | -120 | -120 | 0 |
| **branch total** | **-1,194 (-1.68%)** | **-1,575 (-0.48%)** | **-626 (-1.09%)** |

`zod/mini` improves too (minimal mini consumer -35, full-import-mini -1,574). Full suite green after every commit (3,847 tests + typecheck on current `main`, including the new #6213 error-walker tests). Net source delta: 5 files, +160/-214.

## Reproducing the numbers

The harness below is the one used for the verification runs. From a checkout of this repo:

1. `pnpm install`
2. Save the file below as `sizecheck/compare.mts` (the directory must live **inside** the repo so the materialised trees resolve `node_modules`; `sizecheck/{a,b,meta}/` are created automatically and safe to delete).
3. Fetch this PR's head ref and compare it against `main`:

   ```sh
   git fetch origin pull/6351/head:pr-branch
   pnpm tsx sizecheck/compare.mts main pr-branch
   ```

A run takes ~15s and prints per-case minified/gzip bytes for both sides with exact deltas; the `namespace-import-classic` row is the standard `import * as z` consumer, `z-import-classic` the `import { z }` style, `named-import-classic` the `import { string }` style. A control run with the same rev on both sides (`pnpm tsx sizecheck/compare.mts main main`) prints all-zero deltas — the pipeline is deterministic, so single runs are conclusive.

<details>
<summary><code>sizecheck/compare.mts</code> — A/B bundle-size harness</summary>

```ts
/**
 * A/B bundle-size comparison between two git revisions of packages/zod.
 *
 * Usage: pnpm exec tsx sizecheck/compare.mts [revA] [revB]
 *   revA defaults to HEAD, revB defaults to WORK (the working tree).
 *
 * Each side is materialised under sizecheck/<side>/ via `git archive` (or a
 * straight copy for WORK), then a fixed set of entry files is bundled with
 * esbuild (--bundle --minify --format=esm, pinned target). Reports minified
 * and gzipped bytes per case plus deltas, and writes esbuild metafiles to
 * sizecheck/meta/.
 */
import { execSync } from "node:child_process";
import { gzipSync } from "node:zlib";
import * as fs from "node:fs";
import * as path from "node:path";
import { build } from "esbuild";

const root = path.resolve(import.meta.dirname, "..");
const work = path.join(root, "sizecheck");

const revA = process.argv[2] ?? "HEAD";
const revB = process.argv[3] ?? "WORK";

/** Entry cases. Files are written identically into each side's tree. */
const CASES: Array<{ name: string; code: string }> = [
  {
    name: "full-import-classic",
    code: `import * as z from "./packages/zod/src/index.ts";\nconsole.log(z);\n`,
  },
  {
    name: "full-import-mini",
    code: `import * as z from "./packages/zod/src/mini/index.ts";\nconsole.log(z);\n`,
  },
  {
    name: "named-import-mini",
    code: `import { string, minLength, safeParse } from "./packages/zod/src/mini/index.ts";\nconst schema = string().check(minLength(5));\nconsole.log(safeParse(schema, "hello"));\n`,
  },
  {
    name: "named-import-classic",
    code: `import { string } from "./packages/zod/src/index.ts";\nconst schema = string().min(5);\nconsole.log(schema.safeParse("hello"));\n`,
  },
  {
    name: "namespace-import-classic",
    code: `import * as z from "./packages/zod/src/index.ts";\nconst schema = z.object({ name: z.string(), age: z.number() });\nconsole.log(schema.safeParse({ name: "hello", age: 1 }));\n`,
  },
  {
    name: "z-import-classic",
    code: `import { z } from "./packages/zod/src/index.ts";\nconst schema = z.object({ name: z.string(), age: z.number() });\nconsole.log(schema.safeParse({ name: "hello", age: 1 }));\n`,
  },
  {
    name: "full-import-locales",
    code: `import * as locales from "./packages/zod/src/locales/index.ts";\nconsole.log(locales);\n`,
  },
];

function materialise(rev: string, dir: string): void {
  fs.rmSync(dir, { recursive: true, force: true });
  fs.mkdirSync(dir, { recursive: true });
  if (rev === "WORK") {
    fs.mkdirSync(path.join(dir, "packages/zod"), { recursive: true });
    fs.cpSync(path.join(root, "packages/zod/src"), path.join(dir, "packages/zod/src"), { recursive: true });
    fs.copyFileSync(path.join(root, "packages/zod/package.json"), path.join(dir, "packages/zod/package.json"));
  } else {
    execSync(`git archive ${rev} -- packages/zod/src packages/zod/package.json | tar -x -C ${JSON.stringify(dir)}`, {
      cwd: root,
      shell: "/bin/zsh",
    });
  }
  for (const c of CASES) {
    fs.writeFileSync(path.join(dir, `${c.name}.entry.ts`), c.code);
  }
}

interface Result {
  min: number;
  gzip: number;
}

async function measure(dir: string, side: string): Promise<Record<string, Result>> {
  const out: Record<string, Result> = {};
  for (const c of CASES) {
    const result = await build({
      entryPoints: [path.join(dir, `${c.name}.entry.ts`)],
      bundle: true,
      minify: true,
      format: "esm",
      target: "es2020",
      write: false,
      metafile: true,
      outfile: `${c.name}.js`,
      logLevel: "silent",
    });
    const contents = result.outputFiles[0].contents;
    out[c.name] = {
      min: contents.byteLength,
      gzip: gzipSync(contents, { level: 9 }).byteLength,
    };
    fs.mkdirSync(path.join(work, "meta"), { recursive: true });
    fs.writeFileSync(path.join(work, "meta", `${side}-${c.name}.json`), JSON.stringify(result.metafile));
  }
  return out;
}

function fmt(n: number): string {
  return n.toLocaleString("en-US");
}

const dirA = path.join(work, "a");
const dirB = path.join(work, "b");
materialise(revA, dirA);
materialise(revB, dirB);

const resA = await measure(dirA, "a");
const resB = await measure(dirB, "b");

console.log(`A = ${revA}, B = ${revB}\n`);
const pad = (s: string, n: number) => s.padStart(n);
console.log(
  "case".padEnd(16) +
    pad("A min", 10) +
    pad("B min", 10) +
    pad("Δ min", 9) +
    pad("Δ%", 8) +
    pad("A gz", 9) +
    pad("B gz", 9) +
    pad("Δ gz", 8)
);
let totMinA = 0;
let totMinB = 0;
let totGzA = 0;
let totGzB = 0;
for (const c of CASES) {
  const a = resA[c.name];
  const b = resB[c.name];
  totMinA += a.min;
  totMinB += b.min;
  totGzA += a.gzip;
  totGzB += b.gzip;
  const dMin = b.min - a.min;
  const dGz = b.gzip - a.gzip;
  const pct = a.min === 0 ? 0 : (dMin / a.min) * 100;
  console.log(
    c.name.padEnd(16) +
      pad(fmt(a.min), 10) +
      pad(fmt(b.min), 10) +
      pad((dMin >= 0 ? "+" : "") + fmt(dMin), 9) +
      pad(`${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%`, 8) +
      pad(fmt(a.gzip), 9) +
      pad(fmt(b.gzip), 9) +
      pad((dGz >= 0 ? "+" : "") + fmt(dGz), 8)
  );
}
const dTotMin = totMinB - totMinA;
const dTotGz = totGzB - totGzA;
console.log(
  "TOTAL".padEnd(16) +
    pad(fmt(totMinA), 10) +
    pad(fmt(totMinB), 10) +
    pad((dTotMin >= 0 ? "+" : "") + fmt(dTotMin), 9) +
    pad(`${totMinA ? ((dTotMin / totMinA) * 100).toFixed(2) : "0.00"}%`, 8) +
    pad(fmt(totGzA), 9) +
    pad(fmt(totGzB), 9) +
    pad((dTotGz >= 0 ? "+" : "") + fmt(dTotGz), 8)
);
```

</details>
