### PR TITLE
ci: fix release matrix broken by TypeScript 7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,14 @@ jobs:
   test-node:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node: ["lts/*"]
-        typescript: ["5.5", "latest"]
+        # Deliberately narrower than test.yml, which also runs a "latest" leg. This
+        # matrix gates publishing, so a regression in a bleeding-edge compiler must
+        # not be able to block a release. test.yml carries the TypeScript 7 signal.
+        typescript: ["5.5", "6"]
     name: Test with TypeScript ${{ matrix.typescript }} on Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
       - uses: actions/checkout@v4
@@ -26,8 +30,10 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
+      # Build with the repo-pinned TypeScript, which is what actually ships. zshy
+      # uses the classic compiler API, which TypeScript 7 no longer provides.
       - run: pnpm build
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm test
       - run: pnpm run --filter @zod/resolution test:all
       - run: pnpm run --filter @zod/integration test:all


### PR DESCRIPTION
Follow-up to #6345, which fixed the same bug in `test.yml`.

`release.yml` carries its own copy of the `test-node` job, and it had the identical defect: the matrix TypeScript was installed before `pnpm build`, so the `latest` leg crashed in zshy with `TypeError: Cannot read properties of undefined (reading 'readFile')`.

The consequence is worse here than in `test.yml`. `build_and_publish` gates on `test-node` through `needs`, so it has been **skipped on every qualifying push since TypeScript 7.0.2 became `latest`**. Canary publishing has been silently dead — the last canary on npm is `4.5.0-canary.20260504T180558` — and three release runs failed that way today alone. A real version bump would have failed before publishing anything.

The build now runs with the repo-pinned TypeScript, which is what actually produces the published artifacts.

One deliberate difference from `test.yml`: this matrix is capped at `["5.5", "6"]` and does not track `latest`. This job gates publishing, so a regression in a bleeding-edge compiler shouldn't be able to block a release. `test.yml` keeps the TypeScript 7 leg and carries that signal on every PR.

Note that merging this restores canary publishing, so the next qualifying push to `main` will publish one again.
