### PR TITLE
ci: build with pinned TypeScript in the release workflow too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   test-node:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node: ["lts/*"]
@@ -26,10 +27,14 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: pnpm/action-setup@v4
       - run: pnpm install
-      - run: pnpm add typescript@${{ matrix.typescript }} -w
+      # Build with the repo-pinned TypeScript: zshy uses the classic compiler API,
+      # which TypeScript 7 no longer ships. The matrix version applies to the tests.
       - run: pnpm build
+      - run: pnpm add typescript@${{ matrix.typescript }} -w
       - run: pnpm test
+      # test-resolution.ts shells out to zshy, so it can't run under TypeScript 7.
       - run: pnpm run --filter @zod/resolution test:all
+        if: matrix.typescript != 'latest'
       - run: pnpm run --filter @zod/integration test:all
 
   lint:


### PR DESCRIPTION
The release workflow has been failing on every push to `main` that touches `packages/zod/src`, which skips `build_and_publish` and blocks releases.

#6345 fixed this in `test.yml` and left `release.yml` alone. Both files still had the same step order, so `release.yml` still installs `typescript@latest` — now 7.0.2 — before it builds, and `zshy` crashes reading tsconfigs through `ts.sys.readFile`:

```
│ └── ✕ unmet peer typescript@^5.4.4: found 7.0.2
»  Build failed: TypeError: Cannot read properties of undefined (reading 'readFile')
```

Three runs have failed this way so far — 573fcb75, e6c213ec and f238fbd2 — the first `packages/zod/src` merges since #6345. I reran the last one to rule out a transient failure; it failed identically.

This applies the same reordering: build with the repo-pinned TypeScript, then swap in the matrix version for the tests, and skip the resolution suite on the `latest` leg because `test-resolution.ts` shells out to `zshy`. After this change the `test-node` job is step-for-step identical to the one in `test.yml`.

Also sets `fail-fast: false`. Without it the failing `latest` leg cancelled the `5.5` leg, so a failed run gave no signal about whether anything else was broken — the same reason #6345 added it.

Two things worth knowing before merging:

- Workflow changes only take effect once they are on `main`, and `release.yml` does not run on pull requests, so this PR's own checks do not exercise it. The evidence that the ordering works is that the identical steps in `test.yml` passed their TypeScript `latest` leg on #6347.
- Merging this restores canary publishing. Once `test-node` passes again, `build_and_publish` runs, finds the version already on npm, and publishes a `4.5.0-canary.<timestamp>` under the `canary` tag. That is the designed behavior; the most recent canary is from 2026-05-04.

The matrix here is still `["5.5", "latest"]` while `test.yml` now runs `["5.5", "6", "latest"]`. I left that alone — say the word and I will add the TypeScript 6 leg here too.
