### PR TITLE
fix(v4): write a declared __proto__ key as an own property

### DIFF
--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -715,3 +715,56 @@ describe("__proto__ in object catchall paths", () => {
     expect(result.success).toBe(true);
   });
 });
+
+// A __proto__ key declared in the shape is a field the caller asked for, so it must round-trip as
+// an own data property instead of hitting the inherited setter (which replaced the result
+// prototype and dropped the value).
+describe("__proto__ as a declared shape key", () => {
+  const protoInput = () => JSON.parse('{"__proto__":{"isAdmin":true},"name":"alice"}');
+  const makeShape = () =>
+    Object.fromEntries([
+      ["__proto__", z.object({ isAdmin: z.boolean() })],
+      ["name", z.string()],
+    ]) as Record<string, any>;
+
+  const expectOwnProp = (parsed: any) => {
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+    expect(parsed.__proto__).toEqual({ isAdmin: true });
+    expect((parsed as any).isAdmin).toBeUndefined();
+    expect(Object.keys(parsed).sort()).toEqual(["__proto__", "name"]);
+  };
+
+  test("jit fastpass", () => {
+    expectOwnProp(z.object(makeShape()).parse(protoInput()));
+  });
+
+  test("jitless", () => {
+    expectOwnProp(z.object(makeShape()).parse(protoInput(), { jitless: true } as any));
+  });
+
+  test("async", async () => {
+    const shape = Object.fromEntries([
+      ["__proto__", z.object({ isAdmin: z.boolean() }).refine(async () => true)],
+      ["name", z.string()],
+    ]) as Record<string, any>;
+    expectOwnProp(await z.object(shape).parseAsync(protoInput()));
+  });
+
+  test("primitive value is not silently dropped", () => {
+    const schema = z.object(Object.fromEntries([["__proto__", z.string()]]) as Record<string, any>);
+    const parsed: any = schema.parse(JSON.parse('{"__proto__":"hello"}'));
+    expect(parsed.__proto__).toBe("hello");
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  });
+
+  test("validation still applies", () => {
+    const schema = z.object(Object.fromEntries([["__proto__", z.string()]]) as Record<string, any>);
+    expect(schema.safeParse(JSON.parse('{"__proto__":123}')).success).toBe(false);
+  });
+
+  test("Object.prototype is untouched", () => {
+    z.object(makeShape()).parse(protoInput());
+    expect(({} as any).isAdmin).toBeUndefined();
+  });
+});

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -715,3 +715,22 @@ test("v3-compat single-arg form: z.record(valueType)", () => {
     additionalProperties: { type: "number" },
   });
 });
+
+// A finite key set that declares __proto__ writes through the same assignment as z.object(); the
+// key was declared by the schema, so it round-trips as an own data property.
+test("__proto__ in a finite key set becomes an own property", () => {
+  const data = JSON.parse('{"__proto__":{"a":"declared"},"b":{"a":"good"}}');
+
+  for (const schema of [
+    z.record(z.enum(["__proto__", "b"]), z.object({ a: z.string() })),
+    z.record(z.literal(["__proto__", "b"]), z.object({ a: z.string() })),
+  ]) {
+    const parsed: any = schema.parse(data);
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+    expect(parsed.__proto__).toEqual({ a: "declared" });
+    expect(parsed.a).toBeUndefined();
+  }
+
+  expect(({} as any).a).toBeUndefined();
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1747,6 +1747,17 @@ export type $InferObjectInput<T extends $ZodLooseShape, Extra extends Record<str
         } & Extra
       >;
 
+// Writes a validated property onto the fresh {} we build results into. Plain assignment of
+// "__proto__" hits the inherited setter, which replaces the result prototype and drops the
+// value; defineProperty creates the own data property the key was declared for.
+function setProp(target: any, key: PropertyKey, value: unknown): void {
+  if (key === "__proto__") {
+    Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
+  } else {
+    target[key] = value;
+  }
+}
+
 function handlePropertyResult(
   result: ParsePayload,
   final: ParsePayload,
@@ -1778,10 +1789,10 @@ function handlePropertyResult(
 
   if (result.value === undefined) {
     if (isPresent) {
-      (final.value as any)[key] = undefined;
+      setProp(final.value, key, undefined);
     }
   } else {
-    (final.value as any)[key] = result.value;
+    setProp(final.value, key, result.value);
   }
 }
 
@@ -1988,12 +1999,18 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
     const _normalized = util.cached(() => normalizeDef(def));
 
     const generateFastpass = (shape: any) => {
-      const doc = new Doc(["shape", "payload", "ctx"]);
+      const doc = new Doc(["shape", "payload", "ctx", "setProp"]);
       const normalized = _normalized.value;
 
       const parseStr = (key: string) => {
         const k = util.esc(key);
         return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
+      };
+
+      // Keys are known here, so only a literal "__proto__" defers to setProp.
+      const setStr = (key: string, value: string) => {
+        const k = util.esc(key);
+        return key === "__proto__" ? `setProp(newResult, ${k}, ${value});` : `newResult[${k}] = ${value};`;
       };
 
       doc.write(`const input = payload.value;`);
@@ -2029,12 +2046,12 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         
         if (${id}.value === undefined) {
           if (${k} in input) {
-            newResult[${k}] = undefined;
+            ${setStr(key, "undefined")}
           }
         } else {
-          newResult[${k}] = ${id}.value;
+          ${setStr(key, `${id}.value`)}
         }
-        
+
       `);
         } else if (!isOptionalIn) {
           doc.write(`
@@ -2056,9 +2073,9 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
 
         if (${id}_present) {
           if (${id}.value === undefined) {
-            newResult[${k}] = undefined;
+            ${setStr(key, "undefined")}
           } else {
-            newResult[${k}] = ${id}.value;
+            ${setStr(key, `${id}.value`)}
           }
         }
 
@@ -2074,12 +2091,12 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         
         if (${id}.value === undefined) {
           if (${k} in input) {
-            newResult[${k}] = undefined;
+            ${setStr(key, "undefined")}
           }
         } else {
-          newResult[${k}] = ${id}.value;
+          ${setStr(key, `${id}.value`)}
         }
-        
+
       `);
         }
       }
@@ -2087,7 +2104,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       doc.write(`payload.value = newResult;`);
       doc.write(`return payload;`);
       const fn = doc.compile();
-      return (payload: any, ctx: any) => fn(shape, payload, ctx);
+      return (payload: any, ctx: any) => fn(shape, payload, ctx, setProp);
     };
 
     let fastpass!: ReturnType<typeof generateFastpass>;
@@ -2922,14 +2939,14 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
                 if (result.issues.length) {
                   payload.issues.push(...util.prefixIssues(key, result.issues));
                 }
-                payload.value[outKey] = result.value;
+                setProp(payload.value, outKey, result.value);
               })
             );
           } else {
             if (result.issues.length) {
               payload.issues.push(...util.prefixIssues(key, result.issues));
             }
-            payload.value[outKey] = result.value;
+            setProp(payload.value, outKey, result.value);
           }
         }
       }


### PR DESCRIPTION
Object and record parsing builds the result into a fresh `{}` and assigns with `output[key] = value`. When the schema declares `__proto__` as a shape key or as a finite record key, that assignment invokes the inherited setter instead of creating an own property: the value is discarded and the result's prototype becomes the parsed value.

```ts
const schema = z.object(Object.fromEntries([["__proto__", z.string()]]));
schema.parse(JSON.parse('{"__proto__":"hello"}'));
// before: {}                       — reports success, drops the field
// after:  { __proto__: "hello" }
```

PR #5898 guarded the two paths where the key comes from the *input* — `handleCatchall` and the record `Reflect.ownKeys` branch — where dropping it is correct, since it was never declared. Three paths where the key **is** declared still assigned directly: the shape loop in `handlePropertyResult`, the JIT fastpass codegen, and the `$ZodRecord` finite-key branch. Those now go through `setProp`.

Zod 3 held this invariant with a single guard in `mergeObjectSync`; v4 split that assembly point into five and kept the guard at two.

Input-derived `__proto__` keys are unchanged — passthrough, catchall, loose objects and `z.record(z.string())` still drop them.

### Cost

The fastpass branches at generation time, where the key set is already known, so a normal key still compiles to a bare `newResult[k] = v` and pays nothing at runtime. Only a literal `__proto__` key emits a `setProp` call, and `setProp` is passed into the compiled function rather than inlined as a `defineProperty` string, so the descriptor appears once in the bundle instead of once per generated call site.

Measured on a tree-shaken `esbuild --minify` bundle of `z.object` + `z.record` + `safeParse`:

| | minified | gzipped |
| --- | --- | --- |
| `main` | 74,300 | 20,202 |
| this PR | 74,483 | 20,274 (+0.36%) |

For reference, the cheaper semantics — silently dropping a declared `__proto__` key, mirroring #5898 — measures 20,243 gzipped. So preserving the field costs 31 bytes over dropping it, which did not seem worth the silent data loss.

Refs #5898. The `.strict()` reporting gap in #6220 is separate and untouched here.
