### PR TITLE
fix(v4): re-check the record key after the key schema runs

### DIFF
--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -402,6 +402,44 @@ test("is not vulnerable to prototype pollution", async () => {
   }
 });
 
+test("key schema cannot normalize an input key into __proto__", async () => {
+  const value = z.object({ a: z.string() });
+  const payload = { a: "evil" };
+  const wire = (key: string) => JSON.parse(JSON.stringify({ [key]: payload }));
+
+  const cases = [
+    [z.record(z.string().toLowerCase(), value), wire("__PROTO__")],
+    [z.record(z.string().trim(), value), wire(" __proto__ ")],
+    [z.record(z.string().normalize("NFKC"), value), wire("＿＿ｐｒｏｔｏ＿＿")],
+    [
+      z.record(
+        z.string().transform((s) => s.slice(2)),
+        value
+      ),
+      wire("x:__proto__"),
+    ],
+  ] as const;
+
+  for (const [schema, data] of cases) {
+    const result = schema.parse(data);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(Object.keys(result)).toEqual([]);
+    expect((result as any).a).toBeUndefined();
+
+    expect(Object.getPrototypeOf(await schema.parseAsync(data))).toBe(Object.prototype);
+  }
+
+  // an async value schema takes the promise write path
+  const asyncValue = z.record(
+    z.string().toLowerCase(),
+    value.refine(async () => true)
+  );
+  expect(Object.getPrototypeOf(await asyncValue.parseAsync(wire("__PROTO__")))).toBe(Object.prototype);
+
+  // ordinary normalization still lands as an own key
+  expect(z.record(z.string().toLowerCase(), value).parse({ KEY: payload })).toEqual({ key: payload });
+});
+
 test("dont remove undefined values", () => {
   const result1 = z.record(z.string(), z.any()).parse({ foo: undefined });
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2992,6 +2992,11 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
           continue;
         }
 
+        // the guard above tests the raw input key, but the key schema can normalize an
+        // ordinary key into __proto__; re-check the key we actually write under
+        const outKey = keyResult.value as PropertyKey;
+        if (outKey === "__proto__") continue;
+
         const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
 
         if (result instanceof Promise) {
@@ -3000,14 +3005,14 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
               if (result.issues.length) {
                 payload.issues.push(...util.prefixIssues(key, result.issues));
               }
-              payload.value[keyResult.value as PropertyKey] = result.value;
+              payload.value[outKey] = result.value;
             })
           );
         } else {
           if (result.issues.length) {
             payload.issues.push(...util.prefixIssues(key, result.issues));
           }
-          payload.value[keyResult.value as PropertyKey] = result.value;
+          payload.value[outKey] = result.value;
         }
       }
     }


### PR DESCRIPTION
`z.record()` skips an input key when the raw key is exactly `__proto__`, but it writes the parsed value under the key the *key schema* produced. A key schema that normalizes keys therefore walks straight past the guard.

```ts
const schema = z.record(z.string().toLowerCase(), z.object({ admin: z.boolean() }));
const result = schema.parse(JSON.parse('{"__PROTO__":{"admin":true}}'));

// before: Object.keys(result) is [] and JSON.stringify(result) is "{}",
//         but result.admin is true — the parsed value became the prototype
// after:  the entry is dropped, prototype intact
```

The guard at the top of the loop and the assignment at the bottom reason about different keys, so this is an ordering bug rather than a missing guard. Check the key actually written and drop it there, which is what the raw-key guard already does one line up. Zod 3 held the same invariant with a single guard on the post-transform key in `mergeObjectSync`; v4 has guarded the pre-transform key since 4.0.0.

Every key-transform mechanism reaches it — `toLowerCase`, `trim`, `normalize`, `transform`, `overwrite`, `preprocess`, `pipe`, `codec` — sync and async, classic and mini. A fullwidth key normalizing to `__proto__` under NFKC hits it too, and that one is the least likely to be caught by eye.

Declared `__proto__` keys are the opposite case and belong in #6354, which this does not overlap. The `.strict()` reporting gap in #6220 is separate and untouched.
