### PR TITLE
fix(v4): never write __proto__ into parse output

### DIFF
--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -734,3 +734,35 @@ test("__proto__ in a finite key set becomes an own property", () => {
 
   expect(({} as any).a).toBeUndefined();
 });
+
+// The raw input key is what the __proto__ check sees, but the value is written under the key the
+// key schema emits. A normalizing key schema makes those two differ.
+test("__proto__ produced by a key transform becomes an own property", () => {
+  const schema = z.record(z.string().toLowerCase(), z.object({ a: z.string() }));
+  const parsed: any = schema.parse(JSON.parse('{"__PROTO__":{"a":"transformed"}}'));
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+  expect(parsed.__proto__).toEqual({ a: "transformed" });
+  expect(({} as any).a).toBeUndefined();
+});
+
+test("__proto__ from a key transform is an own property on the async path", async () => {
+  const schema = z.record(
+    z.string().toLowerCase(),
+    z.object({ a: z.string() }).refine(async () => true)
+  );
+  const parsed: any = await schema.parseAsync(JSON.parse('{"__PROTO__":{"a":"async"}}'));
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(parsed.__proto__).toEqual({ a: "async" });
+});
+
+// A raw __proto__ input key is skipped outright before the write; only a key the key schema
+// *produces* reaches it. Pinning that so the skip isn't mistaken for the same defect.
+test("a raw __proto__ input key stays skipped in loose mode", () => {
+  const parsed: any = z.looseRecord(z.iso.datetime(), z.unknown()).parse(JSON.parse('{"__proto__":{"a":1}}'));
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3017,14 +3017,16 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
               if (result.issues.length) {
                 payload.issues.push(...util.prefixIssues(key, result.issues));
               }
-              payload.value[keyResult.value as PropertyKey] = result.value;
+              // keyResult.value is the key the key schema emitted, which the
+              // raw-key __proto__ guard above never saw.
+              setProp(payload.value, keyResult.value as PropertyKey, result.value);
             })
           );
         } else {
           if (result.issues.length) {
             payload.issues.push(...util.prefixIssues(key, result.issues));
           }
-          payload.value[keyResult.value as PropertyKey] = result.value;
+          setProp(payload.value, keyResult.value as PropertyKey, result.value);
         }
       }
     }


### PR DESCRIPTION
Adopts one rule across every assembly point: **`__proto__` does not land in a parse result**, however the key got there — declared in a shape, named by a finite record key, produced by a key transform, or read off the input. The field still validates; only the write is suppressed.

```ts
const schema = z.object({ ["__proto__"]: z.object({ admin: z.boolean() }), name: z.string() });
const parsed = schema.parse(JSON.parse('{"__proto__":{"admin":true},"name":"a"}'));

Object.keys(parsed);                              // ["name"]
Object.getPrototypeOf(parsed) === Object.prototype; // true
```

This is what every released version already does for the key itself — the unguarded assignment invoked the inherited setter, so the key never reached output. What it *also* did, when the value was an object rather than a primitive, was replace the result's prototype. Skipping the write keeps output shape identical to 4.4.3 and removes the prototype replacement.

#6354 fixed the same defect by preserving the key as an own data property instead. That changed output shape for a declared `__proto__` field and split the codebase between preserve and skip, so this replaces it. The JIT knows the key set at generation time, so it now emits no write at all for `__proto__` and the `setProp` plumbing is gone from the compiled path.

Schema *internals* are the other side of the rule and keep `__proto__`: shapes carry it as a real validator, and JSON Schema documents emit it as a real property (#6346). Only parse results drop it.

### `util.pick`

Separate defect on the shape side, fixed here because it is the same policy boundary. The mask guard used `key in shape`, which answers true for every `Object.prototype` member:

```ts
const src = z.object({ ["__proto__"]: z.string().min(5), safe: z.string() });

src.pick(JSON.parse('{"__proto__":true}'));  // before: schema with zero fields, accepts {}
z.object({ name: z.string() }).pick(JSON.parse('{"toString":true}'));
// before: installed Function.prototype.toString as a validator, then threw at parse time
```

Now an own-key check, so an undeclared key throws `Unrecognized key` as intended, and the selected entry is written with `assignProp` so a declared `__proto__` validator survives selection. Same guard applied to `omit`, `partial` and `required`.

Refs #6354, #6346
