### PR TITLE
feat(v4): expose stringbool truthy/falsy/case via _zod.bag

### DIFF
--- a/packages/zod/src/v4/classic/tests/stringbool.test.ts
+++ b/packages/zod/src/v4/classic/tests/stringbool.test.ts
@@ -104,3 +104,21 @@ test("z.stringbool codec round trip", () => {
   const encodedFalse = z.encode(schema, decodedFalse);
   expect(encodedFalse).toEqual("disabled"); // First element of falsy array
 });
+
+test("z.stringbool exposes truthy/falsy/case via _zod.bag", () => {
+  const a = z.stringbool();
+  expect(a._zod.bag.truthy).toEqual(["true", "1", "yes", "on", "y", "enabled"]);
+  expect(a._zod.bag.falsy).toEqual(["false", "0", "no", "off", "n", "disabled"]);
+  expect(a._zod.bag.case).toEqual("insensitive");
+
+  // values are normalized when case-insensitive
+  const b = z.stringbool({ truthy: ["Y", "yes"], falsy: ["N"] });
+  expect(b._zod.bag.truthy).toEqual(["y", "yes"]);
+  expect(b._zod.bag.falsy).toEqual(["n"]);
+  expect(b._zod.bag.case).toEqual("insensitive");
+
+  const c = z.stringbool({ truthy: ["Y"], falsy: ["N"], case: "sensitive" });
+  expect(c._zod.bag.truthy).toEqual(["Y"]);
+  expect(c._zod.bag.falsy).toEqual(["N"]);
+  expect(c._zod.bag.case).toEqual("sensitive");
+});

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1795,6 +1795,10 @@ export function _stringbool(
     error: params.error,
   }) as any;
 
+  codec._zod.bag.truthy = truthyArray;
+  codec._zod.bag.falsy = falsyArray;
+  codec._zod.bag.case = params.case ?? "insensitive";
+
   return codec;
 }
 

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -871,12 +871,15 @@ test("z.stringbool", () => {
   expect(z.parse(b, "n")).toEqual(false);
   expect(z.safeParse(b, "true")).toMatchObject({ success: false });
   expect(z.safeParse(b, "false")).toMatchObject({ success: false });
+  expect(b._zod.bag.truthy).toEqual(["y"]);
+  expect(b._zod.bag.falsy).toEqual(["n"]);
 
   const c = z.stringbool({
     case: "sensitive",
   });
   expect(z.parse(c, "true")).toEqual(true);
   expect(z.safeParse(c, "TRUE")).toMatchObject({ success: false });
+  expect(c._zod.bag.case).toEqual("sensitive");
 });
 
 // promise


### PR DESCRIPTION
Implements the `._zod.bag` metadata suggested in #5011.

`z.stringbool()` builds a `$ZodCodec` whose transform closes over the resolved `truthy`/`falsy` values, so there is no way to read them back off the schema at runtime. Tools that introspect schemas currently have to regex the output of `transform.toString()` just to detect a stringbool, and even then the values stay out of reach.

This change writes the resolved config onto `._zod.bag` after construction, the same way `z.instanceof` exposes `bag.Class`:

```ts
const schema = z.stringbool({ truthy: ["y"], falsy: ["N"] });
schema._zod.bag; // { truthy: ["y"], falsy: ["n"], case: "insensitive" }
```

The stored arrays are the normalized ones (lowercased unless `case: "sensitive"`), so they match what the validator actually accepts. One change in core `_stringbool` covers both `zod` and `zod/mini`. Tests cover defaults, custom values, and case-sensitive mode.

The `superRefine` gap mentioned later in #5011 is a separate problem and not part of this change.
