### PR TITLE
test(v4): cover mini object shape manipulation

### DIFF
--- a/packages/zod/src/v4/mini/tests/partial.test.ts
+++ b/packages/zod/src/v4/mini/tests/partial.test.ts
@@ -1,0 +1,146 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as z from "zod/mini";
+
+const nested = z.object({
+  name: z.string(),
+  age: z.number(),
+  outer: z.object({ inner: z.string() }),
+  array: z.array(z.object({ asdf: z.string() })),
+});
+
+test("z.partial - shallow inference", () => {
+  const shallow = z.partial(nested);
+  expectTypeOf<z.infer<typeof shallow>>().toEqualTypeOf<{
+    name?: string | undefined;
+    age?: number | undefined;
+    outer?: { inner: string } | undefined;
+    array?: { asdf: string }[] | undefined;
+  }>();
+});
+
+test("z.partial - shallow parse", () => {
+  const shallow = z.partial(nested);
+  expect(z.parse(shallow, {})).toEqual({});
+  expect(z.parse(shallow, { name: "asdf", age: 23143 })).toEqual({ name: "asdf", age: 23143 });
+});
+
+test("z.required - wraps every key in ZodMiniNonOptional", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.optional(z.number()),
+    field: z._default(z.optional(z.string()), "asdf"),
+    nullableField: z.nullable(z.number()),
+    nullishField: z.nullish(z.string()),
+  });
+
+  const requiredObject = z.required(object);
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodMiniNonOptional);
+  expect(requiredObject.shape.name._zod.def.innerType).toBeInstanceOf(z.ZodMiniString);
+  expect(requiredObject.shape.age._zod.def.innerType).toBeInstanceOf(z.ZodMiniOptional);
+  expect(requiredObject.shape.field._zod.def.innerType).toBeInstanceOf(z.ZodMiniDefault);
+  expect(requiredObject.shape.nullableField._zod.def.innerType).toBeInstanceOf(z.ZodMiniNullable);
+  expect(requiredObject.shape.nullishField._zod.def.innerType).toBeInstanceOf(z.ZodMiniOptional);
+  expect(requiredObject.shape.nullishField._zod.def.innerType._zod.def.innerType).toBeInstanceOf(z.ZodMiniNullable);
+});
+
+test("z.required - inference", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.optional(z.number()),
+    field: z._default(z.optional(z.string()), "asdf"),
+    nullableField: z.nullable(z.number()),
+    nullishField: z.nullish(z.string()),
+  });
+
+  const requiredObject = z.required(object);
+  expectTypeOf<z.infer<typeof requiredObject>>().toEqualTypeOf<{
+    name: string;
+    age: number;
+    field: string;
+    nullableField: number | null;
+    nullishField: string | null;
+  }>();
+});
+
+test("z.required - with mask", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.optional(z.number()),
+    field: z._default(z.optional(z.string()), "asdf"),
+    country: z.optional(z.string()),
+  });
+
+  const requiredObject = z.required(object, { age: true });
+  expect(requiredObject.shape.name).toBeInstanceOf(z.ZodMiniString);
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodMiniNonOptional);
+  expect(requiredObject.shape.field).toBeInstanceOf(z.ZodMiniDefault);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodMiniOptional);
+});
+
+test("z.required - mask ignores falsy values", () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.optional(z.number()),
+    country: z.optional(z.string()),
+  });
+
+  // @ts-expect-error falsy mask values are not assignable
+  const requiredObject = z.required(object, { age: true, country: false });
+  expect(requiredObject.shape.age).toBeInstanceOf(z.ZodMiniNonOptional);
+  expect(requiredObject.shape.country).toBeInstanceOf(z.ZodMiniOptional);
+});
+
+test("z.partial - with mask", async () => {
+  const object = z.object({
+    name: z.string(),
+    age: z.optional(z.number()),
+    field: z._default(z.optional(z.string()), "asdf"),
+    country: z.string(),
+  });
+
+  const masked = z.partial(object, { age: true, field: true, name: true });
+  expect(masked.shape.name).toBeInstanceOf(z.ZodMiniOptional);
+  expect(masked.shape.age).toBeInstanceOf(z.ZodMiniOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodMiniOptional);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodMiniString);
+
+  // a masked key wrapping a default still emits that default when absent
+  expect(z.parse(masked, { country: "US" })).toEqual({ field: "asdf", country: "US" });
+  await expect(z.parseAsync(masked, { country: "US" })).resolves.toEqual({ field: "asdf", country: "US" });
+});
+
+test("z.partial - mask ignores falsy values", () => {
+  const object = z.object({
+    name: z.string(),
+    field: z._default(z.optional(z.string()), "asdf"),
+    country: z.string(),
+  });
+
+  // @ts-expect-error falsy mask values are not assignable
+  const masked = z.partial(object, { name: true, country: false });
+  expect(masked.shape.name).toBeInstanceOf(z.ZodMiniOptional);
+  expect(masked.shape.field).toBeInstanceOf(z.ZodMiniDefault);
+  expect(masked.shape.country).toBeInstanceOf(z.ZodMiniString);
+});
+
+test("z.partial - rejects schemas containing refinements", () => {
+  const base = z.object({ password: z.string(), confirmPassword: z.string() });
+  const refined = base.check(z.refine((data) => data.password === data.confirmPassword, "Passwords must match"));
+
+  expect(() => z.partial(refined)).toThrow(".partial() cannot be used on object schemas containing refinements");
+});
+
+test("z.required - preserves refinements", () => {
+  const base = z.object({ name: z.optional(z.string()), age: z.optional(z.number()) });
+  const refined = base.check(
+    z.superRefine((val, ctx) => {
+      if (val.name === "admin") ctx.issues.push({ code: "custom", input: val, message: "Name cannot be admin" });
+    })
+  );
+
+  const requiredSchema = z.required(refined);
+  const result = z.safeParse(requiredSchema, { name: "admin", age: 25 });
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0].message).toBe("Name cannot be admin");
+  expect(z.safeParse(requiredSchema, { name: "user", age: 25 }).success).toBe(true);
+});

--- a/packages/zod/src/v4/mini/tests/pickomit.test.ts
+++ b/packages/zod/src/v4/mini/tests/pickomit.test.ts
@@ -1,0 +1,97 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as z from "zod/mini";
+
+const fish = z.object({
+  name: z.string(),
+  age: z.number(),
+  nested: z.object({}),
+});
+
+test("z.pick - inference and parse", () => {
+  const nameonly = z.pick(fish, { name: true });
+  expectTypeOf<z.infer<typeof nameonly>>().toEqualTypeOf<{ name: string }>();
+  expect(z.parse(nameonly, { name: "bob" })).toEqual({ name: "bob" });
+  // unknown keys are stripped, not rejected
+  expect(z.parse(nameonly, { name: "bob", age: 12 } as any)).toEqual({ name: "bob" });
+  expect(() => z.parse(nameonly, { age: 12 } as any)).toThrow();
+});
+
+test("z.pick - falsy mask values are ignored at runtime", () => {
+  // @ts-expect-error falsy mask values are not assignable
+  const picked = z.pick(fish, { name: true, age: false });
+  expect(Object.keys(picked._zod.def.shape)).toEqual(["name"]);
+});
+
+test("z.pick - drops unpicked keys from the shape", () => {
+  const schema = z.object({ a: z.string(), b: z.optional(z.string()) });
+  const picked = z.pick(schema, { a: true });
+  expect("a" in picked._zod.def.shape).toBe(true);
+  expect("b" in picked._zod.def.shape).toBe(false);
+});
+
+test("z.omit - inference and parse", () => {
+  const noname = z.omit(fish, { name: true });
+  expectTypeOf<z.infer<typeof noname>>().toEqualTypeOf<{ age: number; nested: Record<string, never> }>();
+  expect(z.parse(noname, { age: 12, nested: {} })).toEqual({ age: 12, nested: {} });
+  expect(() => z.parse(noname, { age: 12 } as any)).toThrow();
+  expect(() => z.parse(noname, {} as any)).toThrow();
+});
+
+test("z.omit - drops the omitted key from the shape", () => {
+  const schema = z.object({ a: z.string(), b: z.optional(z.string()) });
+  const omitted = z.omit(schema, { a: true });
+  expect("a" in omitted._zod.def.shape).toBe(false);
+  expect("b" in omitted._zod.def.shape).toBe(true);
+});
+
+test("z.pick - preserves catchall", () => {
+  const lax = z.pick(z.catchall(fish, z.any()), { name: true });
+  expectTypeOf<z.infer<typeof lax>>().toEqualTypeOf<{ name: string; [k: string]: any }>();
+  expect(z.parse(lax, { name: "asdf", whatever: "asdf" })).toEqual({ name: "asdf", whatever: "asdf" });
+  expect(() => z.parse(lax, { whatever: "asdf" } as any)).toThrow();
+});
+
+test("pick/omit/partial/required - reject unknown mask keys", () => {
+  const schema = z.object({ name: z.string(), age: z.number() });
+
+  // @ts-expect-error unknown key
+  expect(() => z.safeParse(z.pick(schema, { name: true, asdf: true }), {})).toThrow('Unrecognized key: "asdf"');
+  // @ts-expect-error unknown key
+  expect(() => z.safeParse(z.omit(schema, { name: true, asdf: true }), {})).toThrow('Unrecognized key: "asdf"');
+  // @ts-expect-error unknown key
+  expect(() => z.safeParse(z.partial(schema, { name: true, asdf: true }), {})).toThrow('Unrecognized key: "asdf"');
+  // @ts-expect-error unknown key
+  expect(() => z.safeParse(z.required(schema, { name: true, asdf: true }), {})).toThrow('Unrecognized key: "asdf"');
+  // @ts-expect-error unknown key
+  expect(() => z.safeParse(z.pick(schema, { $unknown: true }), {})).toThrow('Unrecognized key: "$unknown"');
+});
+
+test("z.pick / z.omit - reject schemas containing refinements", () => {
+  const base = z.object({ id: z.string(), name: z.string() });
+  const refined = base.check(z.refine((val) => val.id.length > 0, "Must have an id"));
+
+  expect(() => z.pick(refined, { name: true })).toThrow(
+    ".pick() cannot be used on object schemas containing refinements"
+  );
+  expect(() => z.omit(refined, { id: true })).toThrow(
+    ".omit() cannot be used on object schemas containing refinements"
+  );
+});
+
+test("z.extend - only rejects refined schemas when a key is overwritten", () => {
+  const base = z.object({ id: z.string(), name: z.string() });
+  const refined = base.check(z.refine((val) => val.id.length > 0, "Must have an id"));
+
+  expect(() => z.extend(refined, { name: z.number() })).toThrow(
+    "Cannot overwrite keys on object schemas containing refinements"
+  );
+  expect(Object.keys(z.extend(refined, { extra: z.number() })._zod.def.shape)).toEqual(["id", "name", "extra"]);
+
+  // safeExtend permits the overwrite that extend rejects, but only when the
+  // replacement narrows the original type
+  const narrowed = z.safeExtend(refined, { name: z.literal("bob") });
+  expect(Object.keys(narrowed._zod.def.shape)).toEqual(["id", "name"]);
+  expect(z.parse(narrowed, { id: "1", name: "bob" })).toEqual({ id: "1", name: "bob" });
+  // @ts-expect-error a widening replacement is rejected at the type level
+  z.safeExtend(refined, { name: z.number() });
+});


### PR DESCRIPTION
`zod/mini` has no tests for `partial`, `required`, `pick`, `omit`, `extend` or `safeExtend`, even though `classic` covers all of them. Since both APIs delegate to the same helpers in `core/util.ts`, the mini side is only exercised through its own type signatures — which is exactly where #6302 slipped through (`merge()` declares a schema-to-schema signature but forwards to `util.extend()`, so the call that typechecks throws and the call that runs is a type error).

This ports that coverage to the mini function-style API:

- `partial` / `required`, with and without a mask, including the `ZodMiniNonOptional` wrapper chain and falsy mask values
- the `Unrecognized key` guard on all four mask-taking helpers — `pick`, `omit`, `partial`, `required` — which only fires on shape access and had no mini coverage at all
- the refinement guards on `pick` and `omit`, and `extend`'s narrower rule that it only rejects a refined schema when a key is actually overwritten
- `safeExtend` accepting a narrowing overwrite that `extend` rejects, and still rejecting a widening one

No behavior changes. I went looking for runtime divergence first and found none — the shared `core/util.ts` path makes mini and classic agree on all of the above, so this is coverage rather than a fix.
