### PR TITLE
test(v4): stop redos tests failing on CPU contention

### DIFF
--- a/packages/zod/src/v4/classic/tests/redos.test.ts
+++ b/packages/zod/src/v4/classic/tests/redos.test.ts
@@ -41,7 +41,13 @@ test("no built-in pattern is ReDoS-vulnerable", () => {
     // Flags are load-bearing. Without "u" the checker reads `\p{...}` as a literal `p{...}`
     // and reports an exponential pattern as safe.
     const result = checkSync(pattern.source, pattern.flags);
-    if (result.status !== "safe") vulnerable.push(`${name} (${result.status}): ${pattern.source}`);
+    // "unknown" means the checker gave up, not that the pattern is vulnerable.
+    if (result.status !== "vulnerable") continue;
+    // The fuzz checker derives "vulnerable" from how long an attack string runs,
+    // so CPU contention from parallel test files can flip a safe pattern. Confirm
+    // with a budget large enough that only real backtracking can exhaust it.
+    const confirmed = checkSync(pattern.source, pattern.flags, { attackTimeout: 10_000 });
+    if (confirmed.status === "vulnerable") vulnerable.push(`${name}: ${pattern.source}`);
   }
   expect(vulnerable).toEqual([]);
 }, 60000);
@@ -50,7 +56,21 @@ test("emoji rejects a backtracking payload in linear time", () => {
   // U+1F9B0-U+1F9B3 are the only code points in both \p{Extended_Pictographic} and
   // \p{Emoji_Component}. A failing match over them used to backtrack exponentially:
   // 26 of them took ~1.9s, and each additional character roughly doubled it.
-  const start = performance.now();
-  expect(z.emoji().safeParse(`${"🦰".repeat(26)} `).success).toBe(false);
-  expect(performance.now() - start).toBeLessThan(100);
+  const schema = z.emoji();
+  const payload = `${"🦰".repeat(26)} `;
+
+  // Warm up first, then take the best of three: a cold first call is dominated by
+  // JIT and can cost hundreds of times the steady-state match on a loaded machine.
+  expect(schema.safeParse(payload).success).toBe(false);
+  let best = Number.POSITIVE_INFINITY;
+  for (let i = 0; i < 3; i++) {
+    const start = performance.now();
+    schema.safeParse(payload);
+    best = Math.min(best, performance.now() - start);
+  }
+
+  // The linear pattern matches in well under a millisecond, so this budget leaves
+  // three orders of magnitude of headroom for CPU contention while still catching
+  // the exponential regression.
+  expect(best).toBeLessThan(500);
 });


### PR DESCRIPTION
Fixes #6359.

Both tests in `redos.test.ts` decide pass/fail from wall-clock timing, so CPU contention from parallel test files flips them. On `ead9fcb3` the file failed in 2 of 6 full-suite runs and passed every time it ran alone, which also makes the pre-push hook reject unrelated pushes.

`no built-in pattern is ReDoS-vulnerable` treated any non-`safe` status as a failure. `unknown` only means the checker gave up, and `recheck`'s fuzz checker derives `vulnerable` from how long an attack string runs — so the verdict tracks available CPU rather than the pattern. Squeezing `attackTimeout` reproduces it on an idle machine, non-monotonically:

```
fuzz  extendedDuration  10000ms=unknown  1000ms=vulnerable  100ms=vulnerable  10ms=vulnerable
auto  email             10000ms=safe     1000ms=vulnerable  100ms=vulnerable  10ms=safe
```

The flagged patterns are fine — matched against adversarial input they scale linearly and stay under a millisecond out to 6.4KB. So this now ignores `unknown` and re-confirms a `vulnerable` verdict with a generous budget before failing. A genuinely exponential pattern exhausts any budget, so detection is unchanged: `^(a+)+$`, `^(a|a)*$`, `^([a-zA-Z0-9]+)*@x$` and `^(\w+\s?)*$` are all still caught.

`emoji rejects a backtracking payload in linear time` asserted a 100ms budget on a single cold call. The fixed pattern matches that payload in ~0.2ms and stays flat out to 200 emoji, so the threshold sat in JIT and scheduler noise while the regression it guards against took ~1.9s. It now warms up, takes the best of three, and allows 500ms — still three orders of magnitude below the exponential case.
