### PR TITLE
fix: distinct error message when xor matches multiple options

### DIFF
--- a/packages/zod/src/v4/classic/tests/union.test.ts
+++ b/packages/zod/src/v4/classic/tests/union.test.ts
@@ -200,6 +200,7 @@ test("z.xor() - multiple matches fails", () => {
   if (!result.success) {
     expect(result.error.issues[0].code).toBe("invalid_union");
     expect((result.error.issues[0] as any).inclusive).toBe(false);
+    expect(result.error.issues[0].message).toBe("Invalid input: matches more than one exclusive option");
   }
 });
 

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -107,6 +107,9 @@ const error: () => errors.$ZodErrorMap = () => {
           const opts = issue.options.map((o) => `'${o}'`).join(" | ");
           return `Invalid discriminator value. Expected ${opts}`;
         }
+        if (issue.inclusive === false) {
+          return "Invalid input: matches more than one exclusive option";
+        }
         return "Invalid input";
       case "invalid_element":
         return `Invalid value in ${issue.origin}`;


### PR DESCRIPTION
Fixes #6342. z.xor() now reports a distinct error when multiple union options match instead of a generic one.