### PR TITLE
fix: add offset option to z.iso.time() for timezone-aware time strings

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -525,12 +525,6 @@ z.iso.time({ precision: 2 });  // HH:MM:SS.ss (centisecond precision)
 z.iso.time({ precision: 3 });  // HH:MM:SS.sss (millisecond precision)
 ```
 
-The two combine, though `precision: -1` and `offset: true` no longer describe a `full-time`.
-
-```ts
-z.iso.time({ offset: true, precision: 0 }); // HH:MM:SS followed by an offset
-```
-
 ### IP addresses
 
 ```ts

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -497,11 +497,22 @@ time.parse("03:15:00"); // ✅
 time.parse("03:15:00.9999999"); // ✅ (arbitrary precision)
 ```
 
-No offsets of any kind are allowed.
+By default no offsets of any kind are allowed.
 
 ```ts
 time.parse("03:15:00Z"); // ❌ (no `Z` allowed)
 time.parse("03:15:00+02:00"); // ❌ (no offsets allowed)
+```
+
+Pass `offset: true` to require one. This is RFC 3339 `full-time`, so seconds become mandatory.
+
+```ts
+const fullTime = z.iso.time({ offset: true });
+
+fullTime.parse("03:15:00Z"); // ✅
+fullTime.parse("03:15:00.123+02:00"); // ✅
+fullTime.parse("03:15:00"); // ❌ (an offset is required)
+fullTime.parse("03:15Z"); // ❌ (seconds are required)
 ```
 
 Use the `precision` parameter to constrain the allowable decimal precision.
@@ -512,6 +523,12 @@ z.iso.time({ precision: 0 });  // HH:MM:SS (second precision)
 z.iso.time({ precision: 1 });  // HH:MM:SS.s (decisecond precision)
 z.iso.time({ precision: 2 });  // HH:MM:SS.ss (centisecond precision)
 z.iso.time({ precision: 3 });  // HH:MM:SS.sss (millisecond precision)
+```
+
+The two combine, though `precision: -1` and `offset: true` no longer describe a `full-time`.
+
+```ts
+z.iso.time({ offset: true, precision: 0 }); // HH:MM:SS followed by an offset
 ```
 
 ### IP addresses

--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -426,7 +426,7 @@ z.base64(); // => { type: "string", contentEncoding: "base64" }
 All other string formats are supported via `pattern`:
 
 ```ts
-z.iso.time(); // JSON Schema `format: "time"` requires an offset; plain `z.iso.time()` does not accept one
+z.iso.time(); // without an offset
 z.base64url();
 z.cuid();
 z.emoji();

--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -409,6 +409,7 @@ z.email(); // => { type: "string", format: "email" }
 z.iso.datetime(); // => { type: "string", format: "date-time" }
 z.iso.date(); // => { type: "string", format: "date" }
 z.iso.duration(); // => { type: "string", format: "duration" }
+z.iso.time({ offset: true }); // => { type: "string", format: "time" }
 z.ipv4(); // => { type: "string", format: "ipv4" }
 z.ipv6(); // => { type: "string", format: "ipv6" }
 z.uuid(); // => { type: "string", format: "uuid" }
@@ -425,7 +426,7 @@ z.base64(); // => { type: "string", contentEncoding: "base64" }
 All other string formats are supported via `pattern`:
 
 ```ts
-z.iso.time();
+z.iso.time(); // JSON Schema `format: "time"` requires an offset; plain `z.iso.time()` does not accept one
 z.base64url();
 z.cuid();
 z.emoji();

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -325,7 +325,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         } else if (format === "date") {
           stringSchema = stringSchema.check(z.iso.date());
         } else if (format === "time") {
-          stringSchema = stringSchema.check(z.iso.time());
+          stringSchema = stringSchema.check(z.iso.time({ offset: true }));
         } else if (format === "duration") {
           stringSchema = stringSchema.check(z.iso.duration());
         } else if (format === "hostname") {

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -825,6 +825,24 @@ test("string format - date-time", () => {
   expect(roundTripped.safeParse("2026-07-29T16:30:00+02:00").success).toBe(true);
 });
 
+test("string format - time", () => {
+  const schema = fromJSONSchema({
+    type: "string",
+    format: "time",
+  });
+  // JSON Schema `time` is RFC 3339 full-time, so an offset is required and a bare partial-time is not.
+  expect(schema.safeParse("14:30:00Z").success).toBe(true);
+  expect(schema.safeParse("16:30:00+02:00").success).toBe(true);
+  expect(schema.safeParse("16:30:00.123-05:30").success).toBe(true);
+  expect(schema.safeParse("14:30:00").success).toBe(false);
+  expect(schema.safeParse("14:30Z").success).toBe(false);
+  expect(schema.safeParse("16:30:00+0200").success).toBe(false);
+
+  const roundTripped = fromJSONSchema(z.toJSONSchema(z.iso.time({ offset: true })));
+  expect(roundTripped.safeParse("16:30:00+02:00").success).toBe(true);
+  expect(roundTripped.safeParse("16:30:00").success).toBe(false);
+});
+
 test("string format - hostname", () => {
   const schema = fromJSONSchema({
     type: "string",

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -841,6 +841,9 @@ test("string format - time", () => {
   const roundTripped = fromJSONSchema(z.toJSONSchema(z.iso.time({ offset: true })));
   expect(roundTripped.safeParse("16:30:00+02:00").success).toBe(true);
   expect(roundTripped.safeParse("16:30:00").success).toBe(false);
+
+  // The keyword has to survive the trip, not just the pattern it ships alongside.
+  expect(z.toJSONSchema(schema).format).toEqual("time");
 });
 
 test("string format - hostname", () => {

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -150,6 +150,14 @@ test("z.iso.time", () => {
   expect(z.safeParse(c, d1).success).toEqual(true);
   expect(z.safeParse(c, d2).success).toEqual(true);
   expect(z.safeParse(c, d3).success).toEqual(false);
+
+  // offset: true allows timezone suffixes (Z, +HH:MM, -HH:MM)
+  const withOffset = z.iso.time({ offset: true });
+  expect(z.safeParse(withOffset, "10:15:30Z").success).toEqual(true);
+  expect(z.safeParse(withOffset, "10:15:30+02:00").success).toEqual(true);
+  expect(z.safeParse(withOffset, "10:15:30-05:30").success).toEqual(true);
+  expect(z.safeParse(withOffset, "10:15:30").success).toEqual(false); // no offset ??? rejected when offset required
+  expect(z.safeParse(withOffset, "bad data").success).toEqual(false);
 });
 
 test("z.iso.duration", () => {

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -159,7 +159,9 @@ test("z.iso.time", () => {
   expect(z.safeParse(withOffset, "10:15:30").success).toEqual(false);
   expect(z.safeParse(withOffset, "10:15Z").success).toEqual(false);
   expect(z.safeParse(withOffset, "10:15:30z").success).toEqual(false);
+  expect(z.safeParse(withOffset, "10:15:30-00:00").success).toEqual(true);
   expect(z.safeParse(withOffset, "10:15:30+24:00").success).toEqual(false);
+  expect(z.safeParse(withOffset, "10:15:30+10:60").success).toEqual(false);
 
   // An explicit precision still wins, so the two compose.
   const offsetMinutes = z.iso.time({ offset: true, precision: -1 });

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -151,13 +151,28 @@ test("z.iso.time", () => {
   expect(z.safeParse(c, d2).success).toEqual(true);
   expect(z.safeParse(c, d3).success).toEqual(false);
 
-  // offset: true allows timezone suffixes (Z, +HH:MM, -HH:MM)
+  // `offset` selects RFC 3339 full-time: a `Z` or numeric offset is required, and so are seconds.
   const withOffset = z.iso.time({ offset: true });
   expect(z.safeParse(withOffset, "10:15:30Z").success).toEqual(true);
-  expect(z.safeParse(withOffset, "10:15:30+02:00").success).toEqual(true);
+  expect(z.safeParse(withOffset, "10:15:30.123456+02:00").success).toEqual(true);
   expect(z.safeParse(withOffset, "10:15:30-05:30").success).toEqual(true);
-  expect(z.safeParse(withOffset, "10:15:30").success).toEqual(false); // no offset ??? rejected when offset required
+  expect(z.safeParse(withOffset, "10:15:30").success).toEqual(false);
+  expect(z.safeParse(withOffset, "10:15Z").success).toEqual(false);
+  expect(z.safeParse(withOffset, "10:15:30z").success).toEqual(false);
+  expect(z.safeParse(withOffset, "10:15:30+24:00").success).toEqual(false);
   expect(z.safeParse(withOffset, "bad data").success).toEqual(false);
+
+  // An explicit precision still wins, so the two compose.
+  const offsetMinutes = z.iso.time({ offset: true, precision: -1 });
+  expect(z.safeParse(offsetMinutes, "10:15Z").success).toEqual(true);
+  expect(z.safeParse(offsetMinutes, "10:15:30Z").success).toEqual(false);
+
+  const offsetSeconds = z.iso.time({ offset: true, precision: 0 });
+  expect(z.safeParse(offsetSeconds, "10:15:30Z").success).toEqual(true);
+  expect(z.safeParse(offsetSeconds, "10:15:30.5Z").success).toEqual(false);
+
+  // Adding `offset` must not loosen the default, which still refuses every suffix.
+  expect(z.safeParse(a, "10:15:30Z").success).toEqual(false);
 });
 
 test("z.iso.duration", () => {

--- a/packages/zod/src/v4/classic/tests/index.test.ts
+++ b/packages/zod/src/v4/classic/tests/index.test.ts
@@ -160,7 +160,6 @@ test("z.iso.time", () => {
   expect(z.safeParse(withOffset, "10:15Z").success).toEqual(false);
   expect(z.safeParse(withOffset, "10:15:30z").success).toEqual(false);
   expect(z.safeParse(withOffset, "10:15:30+24:00").success).toEqual(false);
-  expect(z.safeParse(withOffset, "bad data").success).toEqual(false);
 
   // An explicit precision still wins, so the two compose.
   const offsetMinutes = z.iso.time({ offset: true, precision: -1 });

--- a/packages/zod/src/v4/classic/tests/redos.test.ts
+++ b/packages/zod/src/v4/classic/tests/redos.test.ts
@@ -22,6 +22,7 @@ function allPatterns(): [string, RegExp][] {
   for (const version of [1, 2, 3, 4, 5, 6, 7, 8]) patterns.push([`uuid(${version})`, regexes.uuid(version)]);
   for (const precision of [null, -1, 0, 3, 6]) {
     patterns.push([`time(${precision})`, regexes.time({ precision })]);
+    patterns.push([`time(${precision},offset)`, regexes.time({ precision, offset: true })]);
     for (const local of [false, true]) {
       for (const offset of [false, true]) {
         patterns.push([`datetime(${precision},${local},${offset})`, regexes.datetime({ precision, local, offset })]);

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -144,6 +144,9 @@ describe("toJSONSchema", () => {
         "type": "string",
       }
     `);
+    // The format has to survive being composed onto a string rather than constructed directly.
+    expect(z.toJSONSchema(z.string().check(z.iso.time({ offset: true }))).format).toEqual("time");
+    expect(z.toJSONSchema(z.string().check(z.iso.time())).format).toEqual(undefined);
     // Minute precision drops the seconds full-time requires, so the format goes away again.
     expect(z.toJSONSchema(z.iso.time({ offset: true, precision: -1 }))).toMatchInlineSnapshot(`
       {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -127,6 +127,31 @@ describe("toJSONSchema", () => {
         "type": "string",
       }
     `);
+    // `format: "time"` is RFC 3339 full-time, so it appears only once an offset is required.
+    expect(z.toJSONSchema(z.iso.time({ offset: true }))).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "time",
+        "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d+)?(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+        "type": "string",
+      }
+    `);
+    expect(z.toJSONSchema(z.iso.time({ offset: true, precision: 0 }))).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "time",
+        "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+        "type": "string",
+      }
+    `);
+    // Minute precision drops the seconds full-time requires, so the format goes away again.
+    expect(z.toJSONSchema(z.iso.time({ offset: true, precision: -1 }))).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "pattern": "^(?:[01]\\d|2[0-3]):[0-5]\\d(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$",
+        "type": "string",
+      }
+    `);
     expect(z.toJSONSchema(z.iso.duration())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -30,7 +30,7 @@ const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> =
 export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _json, _params) => {
   const json = _json as JSONSchema.StringSchema;
   json.type = "string";
-  const { minimum, maximum, format, patterns, contentEncoding } = schema._zod
+  const { minimum, maximum, format, patterns, contentEncoding, fullTime } = schema._zod
     .bag as schemas.$ZodStringInternals<unknown>["bag"];
   if (typeof minimum === "number") json.minLength = minimum;
   if (typeof maximum === "number") json.maxLength = maximum;
@@ -39,11 +39,8 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
     json.format = formatMap[format as checks.$ZodStringFormats] ?? format;
     if (json.format === "") delete json.format; // empty format is not valid
 
-    // JSON Schema format: "time" is RFC 3339 `full-time`, which requires a `Z` or numeric offset. Only `z.iso.time({ offset: true })` produces that, and only while the precision still admits seconds.
-    if (format === "time") {
-      const { offset, precision } = schema._zod.def as schemas.$ZodISOTimeDef;
-      if (!offset || precision === -1) delete json.format;
-    }
+    // JSON Schema format: "time" is RFC 3339 `full-time`, which requires a `Z` or numeric offset. Only `z.iso.time({ offset: true })` builds one, and it says so on the bag.
+    if (format === "time" && !fullTime) delete json.format;
   }
   if (contentEncoding) json.contentEncoding = contentEncoding;
   if (patterns && patterns.size > 0) {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -39,9 +39,10 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
     json.format = formatMap[format as checks.$ZodStringFormats] ?? format;
     if (json.format === "") delete json.format; // empty format is not valid
 
-    // JSON Schema format: "time" requires a full time with offset or Z. z.iso.time() does not include timezone information, so format: "time" should never be used
+    // JSON Schema format: "time" is RFC 3339 `full-time`, which requires a `Z` or numeric offset. Only `z.iso.time({ offset: true })` produces that, and only while the precision still admits seconds.
     if (format === "time") {
-      delete json.format;
+      const { offset, precision } = schema._zod.def as schemas.$ZodISOTimeDef;
+      if (!offset || precision === -1) delete json.format;
     }
   }
   if (contentEncoding) json.contentEncoding = contentEncoding;

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -128,8 +128,8 @@ export function time(args: {
   offset?: boolean;
   // local?: boolean;
 }): RegExp {
-  const t = timeSource(args);
-  return new RegExp(args.offset ? `^${t}(?:Z|${offsetSource})$` : `^${t}$`);
+  const source = timeSource(args);
+  return new RegExp(args.offset ? `^${source}(?:Z|${offsetSource})$` : `^${source}$`);
 }
 
 // Adapted from https://stackoverflow.com/a/3143231

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -120,9 +120,14 @@ function timeSource(args: { precision?: number | null | undefined }) {
 }
 export function time(args: {
   precision?: number | null;
+  offset?: boolean;
   // local?: boolean;
 }): RegExp {
-  return new RegExp(`^${timeSource(args)}$`);
+  const t = timeSource(args);
+  if (args.offset) {
+    return new RegExp(`^${t}(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$`);
+  }
+  return new RegExp(`^${t}$`);
 }
 
 // Adapted from https://stackoverflow.com/a/3143231

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -106,7 +106,9 @@ function anchor(source: string): RegExp {
 
 export const date: RegExp = /*@__PURE__*/ anchor(dateSource);
 
-function timeSource(args: { precision?: number | null | undefined }) {
+const offsetSource = `[+-](?:[01]\\d|2[0-3]):[0-5]\\d`;
+
+function timeSource(args: { precision?: number | null | undefined; offset?: boolean }) {
   const hhmm = `(?:[01]\\d|2[0-3]):[0-5]\\d`;
   const regex =
     typeof args.precision === "number"
@@ -115,7 +117,10 @@ function timeSource(args: { precision?: number | null | undefined }) {
         : args.precision === 0
           ? `${hhmm}:[0-5]\\d`
           : `${hhmm}:[0-5]\\d\\.\\d{${args.precision}}`
-      : `${hhmm}(?::[0-5]\\d(?:\\.\\d+)?)?`;
+      : // `offset` selects RFC 3339 `full-time`, whose `partial-time` makes seconds mandatory. An unspecified precision therefore means "seconds plus an arbitrary fraction" there, rather than the optional-seconds default that applies without an offset.
+        args.offset
+        ? `${hhmm}:[0-5]\\d(?:\\.\\d+)?`
+        : `${hhmm}(?::[0-5]\\d(?:\\.\\d+)?)?`;
   return regex;
 }
 export function time(args: {
@@ -124,10 +129,7 @@ export function time(args: {
   // local?: boolean;
 }): RegExp {
   const t = timeSource(args);
-  if (args.offset) {
-    return new RegExp(`^${t}(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$`);
-  }
-  return new RegExp(`^${t}$`);
+  return new RegExp(args.offset ? `^${t}(?:Z|${offsetSource})$` : `^${t}$`);
 }
 
 // Adapted from https://stackoverflow.com/a/3143231
@@ -139,7 +141,7 @@ export function datetime(args: {
   const time = timeSource({ precision: args.precision });
   const opts = ["Z"];
   // if (args.offset) opts.push(`([+-]\\d{2}:\\d{2})`);
-  if (args.offset) opts.push(`([+-](?:[01]\\d|2[0-3]):[0-5]\\d)`);
+  if (args.offset) opts.push(`(${offsetSource})`);
   const timeRegex = `${time}(?:${opts.join("|")})${args.local ? "?" : ""}`;
 
   return new RegExp(`^${dateSource}T(?:${timeRegex})$`);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -777,6 +777,7 @@ export const $ZodISODate: core.$constructor<$ZodISODate> = /*@__PURE__*/ core.$c
 
 export interface $ZodISOTimeDef extends $ZodStringFormatDef<"time"> {
   precision?: number | null;
+  offset?: boolean;
 }
 
 export interface $ZodISOTimeInternals extends $ZodStringFormatInternals<"time"> {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -368,6 +368,8 @@ export interface $ZodStringInternals<Input> extends $ZodTypeInternals<string, In
     patterns: Set<RegExp>;
     format: string;
     contentEncoding: string;
+    /** Set by `z.iso.time({ offset: true })` when its pattern is an RFC 3339 `full-time`. */
+    fullTime: boolean;
   }>;
 }
 
@@ -793,6 +795,14 @@ export const $ZodISOTime: core.$constructor<$ZodISOTime> = /*@__PURE__*/ core.$c
   (inst, def): void => {
     def.pattern ??= regexes.time(def);
     $ZodStringFormat.init(inst, def);
+
+    // Whether this is an RFC 3339 `full-time` is a fact only the ISO time def holds, but `toJSONSchema` asks it of the string the check ends up on — a different schema under `z.string().check(...)`. Publishing it makes both spellings answer the same; `init` has already run the attach list, so this schema is marked directly and any later host through the callback.
+    if (def.offset && (def.precision ?? 0) >= 0) {
+      inst._zod.bag.fullTime = true;
+      inst._zod.onattach.push((s) => {
+        (s._zod.bag as $ZodStringInternals<unknown>["bag"]).fullTime = true;
+      });
+    }
   }
 );
 

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -150,6 +150,12 @@ test("z.iso.time", () => {
   expect(z.safeParse(c, d1).success).toEqual(true);
   expect(z.safeParse(c, d2).success).toEqual(true);
   expect(z.safeParse(c, d3).success).toEqual(false);
+
+  const d = z.iso.time({ offset: true });
+  expect(z.safeParse(d, "00:00:00Z").success).toEqual(true);
+  expect(z.safeParse(d, "00:00:00.123+02:00").success).toEqual(true);
+  expect(z.safeParse(d, d1).success).toEqual(false);
+  expect(z.safeParse(d, "00:00Z").success).toEqual(false);
 });
 
 test("z.iso.duration", () => {


### PR DESCRIPTION
Fixes #6235. Adds an offset option to z.iso.time() to accept timezone-aware time strings.