### PR TITLE
fix: report __proto__ as unrecognized key in strict mode

### DIFF
--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -14,6 +14,16 @@ import {
 } from "./to-json-schema.js";
 import { assignProp, getEnumValues } from "./util.js";
 
+function serializeDefault(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
+      throw new TypeError(`BigInt default value ${value} cannot be safely serialized to JSON`);
+    }
+    return Number(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
 const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> = {
   guid: "uuid",
   url: "uri",
@@ -504,7 +514,7 @@ export const defaultProcessor: Processor<schemas.$ZodDefault> = (schema, ctx, js
   process(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
-  json.default = JSON.parse(JSON.stringify(def.defaultValue));
+  json.default = serializeDefault(def.defaultValue);
 };
 
 export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, json, params) => {
@@ -512,7 +522,7 @@ export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, 
   process(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
-  if (ctx.io === "input") json._prefault = JSON.parse(JSON.stringify(def.defaultValue));
+  if (ctx.io === "input") json._prefault = serializeDefault(def.defaultValue);
 };
 
 export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, params) => {
@@ -529,7 +539,7 @@ export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, 
     }
     return;
   }
-  json.default = catchValue;
+  json.default = serializeDefault(catchValue);
 };
 
 export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, params) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1881,7 +1881,12 @@ function handleCatchall(
   for (const key in input) {
     // skip __proto__ so it can't replace the result prototype via the
     // assignment setter on the plain {} we build into
-    if (key === "__proto__") continue;
+    if (key === "__proto__") {
+      if (t === "never") {
+        unrecognized.push(key);
+      }
+      continue;
+    }
     if (keySet.has(key)) continue;
     if (t === "never") {
       unrecognized.push(key);


### PR DESCRIPTION
Fixes #6220. z.object().strict() now reports an own __proto__ input key as unrecognized_keys instead of silently accepting it.