### PR TITLE
fix(v4): formatError and treeifyError handle inherited-name path elements

### DIFF
--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -806,6 +806,7 @@ test("z.treeifyError nested union with real schema", () => {
   }
 });
 
+<<<<<<< HEAD
 const prototypePropertyNames = ["__proto__", "constructor", "toString", "hasOwnProperty", "valueOf"] as const;
 
 test.each(prototypePropertyNames)("z.formatError handles Object.prototype property path: %s", (name) => {

--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -878,3 +878,24 @@ test("error formatting leaves Object.prototype untouched for input-derived keys"
   expect(protoNode((z.treeifyError(result.error!) as any).properties).properties.pwn.errors).toHaveLength(1);
   expect(({} as any).pwn).toBeUndefined();
 });
+
+test("error walkers handle path elements named after inherited methods", () => {
+  // "toString" and "constructor" are truthy on the prototype, so a plain lookup finds
+  // the inherited function instead of creating a node, and the push then throws.
+  for (const [schema, input] of [
+    [z.object({ toString: z.string() }), { toString: 1 }],
+    [z.object({ constructor: z.string() }), { constructor: 1 }],
+    [z.object({ toString: z.string(), constructor: z.string() }), { toString: 1, constructor: 2 }],
+  ] as const) {
+    const result = (schema as any).safeParse(input);
+    expect(result.success).toBe(false);
+
+    const formatted = z.formatError(result.error) as any;
+    const tree = z.treeifyError(result.error) as any;
+    for (const key of Object.keys(input)) {
+      expect(formatted[key]._errors).toHaveLength(1);
+      expect(tree.properties[key].errors).toHaveLength(1);
+      expect(Object.prototype.hasOwnProperty.call(formatted, key)).toBe(true);
+    }
+  }
+});

--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -806,7 +806,6 @@ test("z.treeifyError nested union with real schema", () => {
   }
 });
 
-<<<<<<< HEAD
 const prototypePropertyNames = ["__proto__", "constructor", "toString", "hasOwnProperty", "valueOf"] as const;
 
 test.each(prototypePropertyNames)("z.formatError handles Object.prototype property path: %s", (name) => {

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -338,9 +338,11 @@ export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssu
                 configurable: true,
               });
             }
+            const node = curr[el];
             if (terminal) {
-              curr[el]._errors.push(mapper(issue));
+              node._errors.push(mapper(issue));
             }
+            curr = node;
             i++;
           }
         }

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -324,9 +324,22 @@ export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssu
             const el = fullpath[i]!;
             const terminal = i === fullpath.length - 1;
 
-            curr = node(curr, el, () => ({ _errors: [] as U[] }));
+            // A path element may collide with an inherited property name such as
+            // "__proto__" or "constructor". Truthiness checks read the prototype
+            // (so no node is created, then ._errors.push throws), and bracket
+            // assignment of "__proto__" hits the setter instead of creating an
+            // own key. Guard the read with hasOwnProperty and create the node
+            // with defineProperty so any path element becomes a real own key.
+            if (!Object.prototype.hasOwnProperty.call(curr, el)) {
+              Object.defineProperty(curr, el, {
+                value: { _errors: [] },
+                enumerable: true,
+                writable: true,
+                configurable: true,
+              });
+            }
             if (terminal) {
-              curr._errors.push(mapper(issue));
+              curr[el]._errors.push(mapper(issue));
             }
             i++;
           }
@@ -379,7 +392,20 @@ export function treeifyError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIss
           const terminal = i === fullpath.length - 1;
           if (typeof el === "string") {
             curr.properties ??= {};
-            curr = node(curr.properties, el, () => ({ errors: [] as U[] }));
+            // el may collide with an inherited property name ("__proto__",
+            // "constructor", ...); ??= reads the prototype so the node is never
+            // created and curr.errors.push throws. Guard with hasOwnProperty and
+            // create the node with defineProperty so "__proto__" becomes a real
+            // own key rather than invoking the prototype setter.
+            if (!Object.prototype.hasOwnProperty.call(curr.properties, el)) {
+              Object.defineProperty(curr.properties, el, {
+                value: { errors: [] },
+                enumerable: true,
+                writable: true,
+                configurable: true,
+              });
+            }
+            curr = curr.properties[el];
           } else {
             curr.items ??= [];
             curr.items[el] ??= { errors: [] };


### PR DESCRIPTION
Fixes #6212. Guards against path elements that collide with Object.prototype property names.