### PR TITLE
fix: count Unicode code points in string length checks

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -869,6 +869,22 @@ test("boundary cases with zero length", () => {
   expect(() => maxZero.parse("hello")).toThrow();
 });
 
+test("length checks count Unicode code points", () => {
+  const fiveEmoji = "😀😀😀😀😀";
+
+  expect(z.string().max(5).safeParse(fiveEmoji).success).toBe(true);
+  expect(z.string().max(5).safeParse(fiveEmoji + "😀").success).toBe(false);
+
+  expect(z.string().min(1).safeParse("😀").success).toBe(true);
+  expect(z.string().min(1).safeParse("").success).toBe(false);
+
+  expect(z.string().length(5).safeParse(fiveEmoji).success).toBe(true);
+  expect(z.string().length(5).safeParse(fiveEmoji + "😀").success).toBe(false);
+
+  // arrays still count elements
+  expect(z.array(z.string()).max(2).safeParse(["a", "b", "c"]).success).toBe(false);
+});
+
 test("trim", () => {
   expect(z.string().trim().min(2).parse(" 12 ")).toEqual("12");
 

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -873,13 +873,23 @@ test("length checks count Unicode code points", () => {
   const fiveEmoji = "😀😀😀😀😀";
 
   expect(z.string().max(5).safeParse(fiveEmoji).success).toBe(true);
-  expect(z.string().max(5).safeParse(fiveEmoji + "😀").success).toBe(false);
+  expect(
+    z
+      .string()
+      .max(5)
+      .safeParse(fiveEmoji + "😀").success
+  ).toBe(false);
 
   expect(z.string().min(1).safeParse("😀").success).toBe(true);
   expect(z.string().min(1).safeParse("").success).toBe(false);
 
   expect(z.string().length(5).safeParse(fiveEmoji).success).toBe(true);
-  expect(z.string().length(5).safeParse(fiveEmoji + "😀").success).toBe(false);
+  expect(
+    z
+      .string()
+      .length(5)
+      .safeParse(fiveEmoji + "😀").success
+  ).toBe(false);
 
   // arrays still count elements
   expect(z.array(z.string()).max(2).safeParse(["a", "b", "c"]).success).toBe(false);

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -623,7 +623,7 @@ export const $ZodCheckMaxLength: core.$constructor<$ZodCheckMaxLength> = /*@__PU
 
     inst._zod.check = (payload) => {
       const input = payload.value;
-      const length = input.length;
+      const length = typeof input === "string" ? util.stringLength(input) : input.length;
 
       if (length <= def.maximum) return;
       const origin = util.getLengthableOrigin(input);
@@ -674,7 +674,7 @@ export const $ZodCheckMinLength: core.$constructor<$ZodCheckMinLength> = /*@__PU
 
     inst._zod.check = (payload) => {
       const input = payload.value;
-      const length = input.length;
+      const length = typeof input === "string" ? util.stringLength(input) : input.length;
 
       if (length >= def.minimum) return;
       const origin = util.getLengthableOrigin(input);
@@ -728,7 +728,7 @@ export const $ZodCheckLengthEquals: core.$constructor<$ZodCheckLengthEquals> = /
 
     inst._zod.check = (payload) => {
       const input = payload.value;
-      const length = input.length;
+      const length = typeof input === "string" ? util.stringLength(input) : input.length;
       if (length === def.length) return;
       const origin = util.getLengthableOrigin(input);
       const tooBig = length > def.length;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -361,6 +361,14 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
   return typeof data === "object" && data !== null && !Array.isArray(data);
 }
 
+export function stringLength(str: string): number {
+  // Count Unicode code points instead of UTF-16 code units so that
+  // surrogate pairs (emoji, etc.) are each counted as one character.
+  let count = 0;
+  for (const _ch of str) count++;
+  return count;
+}
+
 export const allowsEval: { value: boolean } = /* @__PURE__*/ cached(() => {
   // Skip the probe under `jitless`: strict CSPs report the caught `new Function` as a `securitypolicyviolation` even though the throw is swallowed.
   if (globalConfig.jitless) {


### PR DESCRIPTION
﻿Counts string length in `max`/`min`/`length` checks by Unicode code points instead of UTF-16 code units, so surrogate pairs (emoji, etc.) are counted as a single character. Non-string lengthables (arrays, etc.) are unaffected.

Fixes #3355.
