### PR TITLE
fix(v4): complete reserved-key hardening

### DIFF
--- a/packages/zod/src/v3/ZodError.ts
+++ b/packages/zod/src/v3/ZodError.ts
@@ -238,6 +238,14 @@ export class ZodError<T = any> extends Error {
             const el = issue.path[i]!;
             const terminal = i === issue.path.length - 1;
 
+            // `_errors` is reserved by this legacy format, so merge a matching
+            // path segment into the current node instead of treating its array as a child.
+            if (el === "_errors") {
+              if (terminal) curr._errors.push(mapper(issue));
+              i++;
+              continue;
+            }
+
             // Create `el` as an own data property. A segment naming an inherited member
             // ("toString", "constructor") would otherwise read through to the prototype, and
             // assigning "__proto__" would hit the setter and walk into Object.prototype.

--- a/packages/zod/src/v3/tests/error.test.ts
+++ b/packages/zod/src/v3/tests/error.test.ts
@@ -575,4 +575,12 @@ test("format() handles an input-derived _errors path", () => {
   if (!result.success) {
     expect(result.error.format().parent?._errors).toEqual(["Expected string, received number"]);
   }
+
+  const nested = z
+    .object({ parent: z.record(z.object({ child: z.string() })) })
+    .safeParse({ parent: { _errors: { child: 1 } } });
+  expect(nested.success).toEqual(false);
+  if (!nested.success) {
+    expect((nested.error.format() as any).parent.child._errors).toEqual(["Expected string, received number"]);
+  }
 });

--- a/packages/zod/src/v3/tests/error.test.ts
+++ b/packages/zod/src/v3/tests/error.test.ts
@@ -568,3 +568,11 @@ test("format() handles Object.prototype names in the issue path", () => {
     expect((inherited.error.format() as any).toString._errors).toHaveLength(1);
   }
 });
+
+test("format() handles an input-derived _errors path", () => {
+  const result = z.object({ parent: z.record(z.string()) }).safeParse({ parent: { _errors: 1 } });
+  expect(result.success).toEqual(false);
+  if (!result.success) {
+    expect(result.error.format().parent?._errors).toEqual(["Expected string, received number"]);
+  }
+});

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1817,11 +1817,11 @@ export function partialRecord<Key extends core.$ZodRecordKey, Value extends core
   params?: string | core.$ZodRecordParams
 ): ZodRecord<Key & core.$partial, Value> {
   const k = core.clone(keyType);
-  k._zod.values = undefined;
   return new ZodRecord({
     type: "record",
     keyType: k,
     valueType: valueType as any,
+    partial: true,
     ...util.normalizeParams(params),
   }) as any;
 }

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1816,13 +1816,12 @@ export function partialRecord<Key extends core.$ZodRecordKey, Value extends core
   valueType: Value,
   params?: string | core.$ZodRecordParams
 ): ZodRecord<Key & core.$partial, Value> {
-  const k = core.clone(keyType);
   return new ZodRecord({
     type: "record",
-    keyType: k,
+    keyType,
     valueType: valueType as any,
-    partial: true,
     ...util.normalizeParams(params),
+    partial: true,
   }) as any;
 }
 

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -692,3 +692,23 @@ test("encode with codec discriminator", () => {
   const encoded = z.encode(schema, { type: "one", value: "hello" });
   expect(encoded).toEqual({ type: 1, value: "hello" });
 });
+
+test.each(["__proto__", "constructor", "toString", "hasOwnProperty", "valueOf"])(
+  "Object.prototype discriminator name: %s",
+  (key) => {
+    const first = z.object({ [key]: z.literal("a"), value: z.string() });
+    const second = z.object({ [key]: z.literal("b"), value: z.number() });
+    const schema = z.discriminatedUnion(key, [first, second]);
+
+    expect(schema._zod.propValues?.[key]).toEqual(new Set(["a", "b"]));
+
+    const input = Object.fromEntries([
+      [key, "a"],
+      ["value", "ok"],
+    ]);
+    const parsed: any = schema.parse(input);
+    expect(Object.prototype.hasOwnProperty.call(parsed, key)).toBe(true);
+    expect(parsed[key]).toBe("a");
+    expect(parsed.value).toBe("ok");
+  }
+);

--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -878,3 +878,12 @@ test("error formatting leaves Object.prototype untouched for input-derived keys"
   expect(protoNode((z.treeifyError(result.error!) as any).properties).properties.pwn.errors).toHaveLength(1);
   expect(({} as any).pwn).toBeUndefined();
 });
+
+test("formatError handles an input-derived _errors path", () => {
+  const schema = z.object({ parent: z.record(z.string(), z.string()) });
+  const result = schema.safeParse({ parent: { _errors: 1 } });
+  expect(result.success).toBe(false);
+
+  const formatted = z.formatError(result.error!);
+  expect(formatted.parent?._errors).toEqual(["Invalid input: expected string, received number"]);
+});

--- a/packages/zod/src/v4/classic/tests/error-utils.test.ts
+++ b/packages/zod/src/v4/classic/tests/error-utils.test.ts
@@ -886,4 +886,12 @@ test("formatError handles an input-derived _errors path", () => {
 
   const formatted = z.formatError(result.error!);
   expect(formatted.parent?._errors).toEqual(["Invalid input: expected string, received number"]);
+
+  const nested = z
+    .object({ parent: z.record(z.string(), z.object({ child: z.string() })) })
+    .safeParse({ parent: { _errors: { child: 1 } } });
+  expect(nested.success).toBe(false);
+  expect((z.formatError(nested.error!) as any).parent.child._errors).toEqual([
+    "Invalid input: expected string, received number",
+  ]);
 });

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -672,8 +672,6 @@ test("safeExtend() on object with refinements should not throw", () => {
 
 // __proto__ in input must not replace the prototype of the parsed object via
 // the assignment setter on the result {}.
-// https://github.com/colinhacks/zod/security/advisories/GHSA-r34p-xfmx-58wv
-// https://github.com/colinhacks/zod/security/advisories/GHSA-84jv-fqfx-wxhr
 describe("__proto__ in object catchall paths", () => {
   const protoInput = () => JSON.parse('{"__proto__":{"isAdmin":true},"name":"alice"}');
 
@@ -732,7 +730,7 @@ describe("__proto__ as a declared shape key", () => {
     expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
     expect(parsed.__proto__).toEqual({ isAdmin: true });
     expect((parsed as any).isAdmin).toBeUndefined();
-    expect(Object.keys(parsed).sort()).toEqual(["__proto__", "name"]);
+    expect(Object.keys(parsed).sort()).toEqual(["__proto__", "name"].sort());
   };
 
   test("jit fastpass", () => {
@@ -763,8 +761,62 @@ describe("__proto__ as a declared shape key", () => {
     expect(schema.safeParse(JSON.parse('{"__proto__":123}')).success).toBe(false);
   });
 
+  test("an absent key uses own-property semantics", () => {
+    const shape = (schema: z.ZodType) => Object.fromEntries([["__proto__", schema]]) as Record<string, any>;
+
+    for (const jitless of [false, true]) {
+      const ctx = { jitless } as any;
+      expect(z.object(shape(z.unknown())).safeParse({}, ctx).success).toBe(false);
+      expect(z.object(shape(z.string().optional())).parse({}, ctx)).toEqual({});
+
+      const withDefault: any = z.object(shape(z.string().default("fallback"))).parse({}, ctx);
+      expect(Object.getOwnPropertyDescriptor(withDefault, "__proto__")!.value).toBe("fallback");
+    }
+  });
+
+  test("an own getter is still evaluated", () => {
+    let reads = 0;
+    const input = Object.defineProperty({}, "__proto__", {
+      get() {
+        reads++;
+        return "value";
+      },
+      enumerable: true,
+    });
+    const schema = z.object(Object.fromEntries([["__proto__", z.string()]]) as Record<string, any>);
+
+    expect(Object.getOwnPropertyDescriptor(schema.parse(input), "__proto__")!.value).toBe("value");
+    expect(reads).toBe(1);
+  });
+
+  test("pick keeps a declared key", () => {
+    const shape = Object.fromEntries([["__proto__", z.string()]]) as Record<string, any>;
+    const mask = Object.fromEntries([["__proto__", true]]) as Record<string, true>;
+    const picked = z.object(shape).pick(mask);
+
+    expect(Object.keys(picked.shape)).toEqual(["__proto__"]);
+    const parsed: any = picked.parse(Object.fromEntries([["__proto__", "value"]]));
+    expect(Object.getOwnPropertyDescriptor(parsed, "__proto__")!.value).toBe("value");
+    expect(() => z.object({ value: z.string() }).pick(mask as any).shape).toThrow('Unrecognized key: "__proto__"');
+  });
+
+  test.each(["omit", "partial", "required"] as const)("%s rejects an undeclared key", (method) => {
+    const mask = Object.fromEntries([["__proto__", true]]);
+    const schema = z.object({ value: z.string() });
+
+    expect(() => (schema[method] as any)(mask).shape).toThrow('Unrecognized key: "__proto__"');
+  });
+
   test("Object.prototype is untouched", () => {
     z.object(makeShape()).parse(protoInput());
     expect(({} as any).isAdmin).toBeUndefined();
   });
+});
+
+test("object parsing still reads ordinary inherited properties", () => {
+  const input = Object.create({ value: "inherited" });
+  const schema = z.object({ value: z.string() });
+
+  expect(schema.parse(input)).toEqual({ value: "inherited" });
+  expect(schema.parse(input, { jitless: true } as any)).toEqual({ value: "inherited" });
 });

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -730,7 +730,7 @@ describe("__proto__ as a declared shape key", () => {
     expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
     expect(parsed.__proto__).toEqual({ isAdmin: true });
     expect((parsed as any).isAdmin).toBeUndefined();
-    expect(Object.keys(parsed).sort()).toEqual(["__proto__", "name"].sort());
+    expect(Object.keys(parsed).sort()).toEqual(["__proto__", "name"]);
   };
 
   test("jit fastpass", () => {
@@ -805,6 +805,26 @@ describe("__proto__ as a declared shape key", () => {
     const schema = z.object({ value: z.string() });
 
     expect(() => (schema[method] as any)(mask).shape).toThrow('Unrecognized key: "__proto__"');
+  });
+
+  test("shape helpers preserve a declared key", () => {
+    const shape = () =>
+      Object.fromEntries([
+        ["__proto__", z.string()],
+        ["value", z.string()],
+      ]) as Record<string, any>;
+    const protoMask = Object.fromEntries([["__proto__", true]]);
+    const valueMask = { value: true } as const;
+    const shapes = [
+      z.object(shape()).omit(valueMask).shape,
+      z.object(shape()).partial(protoMask as any).shape,
+      z.object(shape()).required(protoMask as any).shape,
+    ];
+
+    for (const next of shapes) {
+      expect(Object.getPrototypeOf(next)).toBe(Object.prototype);
+      expect(Object.prototype.hasOwnProperty.call(next, "__proto__")).toBe(true);
+    }
   });
 
   test("Object.prototype is untouched", () => {

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -778,6 +778,26 @@ test("partialRecord preserves a declared __proto__ key", () => {
   expect(schema.safeParse({ other: "x" }).success).toBe(false);
 });
 
+test("partialRecord safely passes through a declared __proto__ key in loose mode", () => {
+  const key = z.enum(["__proto__"]).refine(() => false);
+  const schema = z.partialRecord(key, z.unknown(), { mode: "loose" });
+  const value = { marker: true };
+  const parsed: any = schema.parse(Object.fromEntries([["__proto__", value]]));
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+  expect(parsed.__proto__).toBe(value);
+  expect(parsed.marker).toBeUndefined();
+});
+
+test("partial is internal to partialRecord", () => {
+  // @ts-expect-error partial is not a public record parameter
+  z.record(z.enum(["a"]), z.string(), { partial: true });
+
+  const schema = z.partialRecord(z.enum(["a"]), z.string(), { partial: false } as any);
+  expect(schema.parse({})).toEqual({});
+});
+
 test("partialRecord still applies transforms to a declared __proto__ key", () => {
   const schema = z.partialRecord(
     z.literal("__proto__").transform(() => "safe" as const),

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -766,3 +766,31 @@ test("a raw __proto__ input key stays skipped in loose mode", () => {
   expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
   expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
 });
+
+test("partialRecord preserves a declared __proto__ key", () => {
+  const schema = z.partialRecord(z.enum(["__proto__", "b"]), z.string());
+  const parsed: any = schema.parse(Object.fromEntries([["__proto__", "declared"]]));
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+  expect(parsed.__proto__).toBe("declared");
+  expect(schema.parse({})).toEqual({});
+  expect(schema.safeParse({ other: "x" }).success).toBe(false);
+});
+
+test("partialRecord still applies transforms to a declared __proto__ key", () => {
+  const schema = z.partialRecord(
+    z.literal("__proto__").transform(() => "safe" as const),
+    z.string()
+  );
+
+  expect(schema.parse(Object.fromEntries([["__proto__", "value"]]))).toEqual({ safe: "value" });
+});
+
+test("a missing finite __proto__ key is parsed like any other finite key", () => {
+  const parsed: any = z.record(z.enum(["__proto__"]), z.unknown()).parse({});
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+  expect(parsed.__proto__).toBeUndefined();
+});

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -734,3 +734,35 @@ test("__proto__ in a finite key set becomes an own property", () => {
 
   expect(({} as any).a).toBeUndefined();
 });
+
+// The raw input key is what the __proto__ check sees, but the value is written under the key the
+// key schema emits. A normalizing key schema makes those two differ.
+test("__proto__ produced by a key transform becomes an own property", () => {
+  const schema = z.record(z.string().toLowerCase(), z.object({ a: z.string() }));
+  const parsed: any = schema.parse(JSON.parse('{"__PROTO__":{"a":"transformed"}}'));
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+  expect(parsed.__proto__).toEqual({ a: "transformed" });
+  expect(({} as any).a).toBeUndefined();
+});
+
+test("__proto__ from a key transform is an own property on the async path", async () => {
+  const schema = z.record(
+    z.string().toLowerCase(),
+    z.object({ a: z.string() }).refine(async () => true)
+  );
+  const parsed: any = await schema.parseAsync(JSON.parse('{"__PROTO__":{"a":"async"}}'));
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(parsed.__proto__).toEqual({ a: "async" });
+});
+
+// A raw __proto__ input key is skipped outright before the write; only a key the key schema
+// *produces* reaches it. Pinning that so the skip isn't mistaken for the same defect.
+test("a raw __proto__ input key stays skipped in loose mode", () => {
+  const parsed: any = z.looseRecord(z.iso.datetime(), z.unknown()).parse(JSON.parse('{"__proto__":{"a":1}}'));
+
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+});

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3182,10 +3182,9 @@ test("__proto__ metadata survives direct and wrapper metadata merges", () => {
 });
 
 test("partialRecord does not require finite keys", () => {
-  const key = z.enum(["__proto__", "b"]).meta({ description: "partial keys" });
-  const result = z.toJSONSchema(z.partialRecord(key, z.string()));
+  const result = z.toJSONSchema(z.partialRecord(z.enum(["__proto__", "b"]), z.string()));
 
   expect(result.required).toBeUndefined();
-  expect(result.propertyNames).toEqual({ type: "string", enum: ["__proto__", "b"], description: "partial keys" });
+  expect(result.propertyNames).toEqual({ type: "string", enum: ["__proto__", "b"] });
   expect(result.additionalProperties).toEqual({ type: "string" });
 });

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3182,9 +3182,10 @@ test("__proto__ metadata survives direct and wrapper metadata merges", () => {
 });
 
 test("partialRecord does not require finite keys", () => {
-  const result = z.toJSONSchema(z.partialRecord(z.enum(["__proto__", "b"]), z.string()));
+  const key = z.enum(["__proto__", "b"]).meta({ description: "partial keys" });
+  const result = z.toJSONSchema(z.partialRecord(key, z.string()));
 
   expect(result.required).toBeUndefined();
-  expect(result.propertyNames).toEqual({ type: "string", enum: ["__proto__", "b"] });
+  expect(result.propertyNames).toEqual({ type: "string", enum: ["__proto__", "b"], description: "partial keys" });
   expect(result.additionalProperties).toEqual({ type: "string" });
 });

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3159,3 +3159,32 @@ test("__proto__ def id emits a resolvable $ref", () => {
   expect(json.properties.a.$ref).toBe("#/$defs/__proto__");
   expect(json.$defs.__proto__).toBeDefined();
 });
+
+test("__proto__ patternProperties key is emitted as an own property", () => {
+  const result = z.toJSONSchema(z.looseRecord(z.string().regex(/__proto__/), z.string()));
+
+  expect(Object.getPrototypeOf(result.patternProperties)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(result.patternProperties, "__proto__")).toBe(true);
+  expect(result.patternProperties?.__proto__).toEqual({ type: "string" });
+});
+
+test("__proto__ metadata survives direct and wrapper metadata merges", () => {
+  for (const schema of [z.string(), z.readonly(z.string())]) {
+    const registry = z.registry<Record<string, unknown>>();
+    registry.add(schema, Object.fromEntries([["__proto__", { marker: true }]]));
+
+    const result: any = z.toJSONSchema(schema, { metadata: registry });
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(result, "__proto__")).toBe(true);
+    expect(result.__proto__).toEqual({ marker: true });
+    expect(JSON.parse(JSON.stringify(result)).__proto__).toEqual({ marker: true });
+  }
+});
+
+test("partialRecord does not require finite keys", () => {
+  const result = z.toJSONSchema(z.partialRecord(z.enum(["__proto__", "b"]), z.string()));
+
+  expect(result.required).toBeUndefined();
+  expect(result.propertyNames).toEqual({ type: "string", enum: ["__proto__", "b"] });
+  expect(result.additionalProperties).toEqual({ type: "string" });
+});

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1289,7 +1289,7 @@ export function _tuple(
 }
 
 // ZodRecord
-export type $ZodRecordParams = TypeParams<schemas.$ZodRecord, "keyType" | "valueType">;
+export type $ZodRecordParams = TypeParams<schemas.$ZodRecord, "keyType" | "valueType" | "partial">;
 // @__NO_SIDE_EFFECTS__
 export function _record<Key extends schemas.$ZodRecordKey, Value extends schemas.$ZodObject>(
   Class: util.SchemaClass<schemas.$ZodRecord>,

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -324,6 +324,14 @@ export function formatError<T, U>(error: $ZodError<T>, mapper = (issue: $ZodIssu
             const el = fullpath[i]!;
             const terminal = i === fullpath.length - 1;
 
+            // `_errors` is reserved by this legacy format, so merge a matching
+            // path segment into the current node instead of treating its array as a child.
+            if (el === "_errors") {
+              if (terminal) curr._errors.push(mapper(issue));
+              i++;
+              continue;
+            }
+
             curr = node(curr, el, () => ({ _errors: [] as U[] }));
             if (terminal) {
               curr._errors.push(mapper(issue));

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -451,7 +451,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
     });
     json.patternProperties = {};
     for (const pattern of patterns) {
-      json.patternProperties[pattern.source] = valueSchema;
+      assignProp(json.patternProperties, pattern.source, valueSchema);
     }
   } else {
     // Default behavior: use propertyNames + additionalProperties
@@ -469,7 +469,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
 
   // Add required for keys with discrete values (enum, literal, etc.)
   const keyValues = keyType._zod.values;
-  if (keyValues) {
+  if (keyValues && !def.partial) {
     const validKeyValues = [...keyValues].filter(
       (v): v is string | number => typeof v === "string" || typeof v === "number"
     );

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3021,7 +3021,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
         if (keyResult.issues.length) {
           if (def.mode === "loose") {
             // Pass through unchanged
-            payload.value[key] = input[key];
+            setProp(payload.value, key, input[key]);
           } else {
             // Default "strict" behavior: error on invalid key
             payload.issues.push({

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1752,10 +1752,18 @@ export type $InferObjectInput<T extends $ZodLooseShape, Extra extends Record<str
 // value; defineProperty creates the own data property the key was declared for.
 function setProp(target: any, key: PropertyKey, value: unknown): void {
   if (key === "__proto__") {
-    Object.defineProperty(target, key, { value, writable: true, enumerable: true, configurable: true });
+    util.assignProp(target, key, value);
   } else {
     target[key] = value;
   }
+}
+
+function getProperty(input: any, key: PropertyKey): unknown {
+  return key === "__proto__" && !Object.prototype.hasOwnProperty.call(input, key) ? undefined : input[key];
+}
+
+function isPropertyPresent(input: any, key: PropertyKey): boolean {
+  return key === "__proto__" ? Object.prototype.hasOwnProperty.call(input, key) : key in input;
 }
 
 function handlePropertyResult(
@@ -1766,7 +1774,7 @@ function handlePropertyResult(
   isOptionalIn: boolean,
   isOptionalOut: boolean
 ) {
-  const isPresent = key in input;
+  const isPresent = isPropertyPresent(input, key);
   if (result.issues.length) {
     // For optional-in/out schemas, ignore errors on absent keys.
     if (isOptionalIn && isOptionalOut && !isPresent) {
@@ -1938,7 +1946,9 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     for (const key in shape) {
       const field = shape[key]!._zod;
       if (field.values) {
-        propValues[key] ??= new Set();
+        if (!Object.prototype.hasOwnProperty.call(propValues, key)) {
+          util.assignProp(propValues, key, new Set());
+        }
         for (const v of field.values) propValues[key].add(v);
       }
     }
@@ -1973,7 +1983,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
       const isOptionalIn = el._zod.optin === "optional";
       const isOptionalOut = el._zod.optout === "optional";
 
-      const r = el._zod.run({ value: input[key], issues: [] }, ctx);
+      const r = el._zod.run({ value: getProperty(input, key), issues: [] }, ctx);
       if (r instanceof Promise) {
         proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut)));
       } else {
@@ -1999,12 +2009,23 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
     const _normalized = util.cached(() => normalizeDef(def));
 
     const generateFastpass = (shape: any) => {
-      const doc = new Doc(["shape", "payload", "ctx", "setProp"]);
       const normalized = _normalized.value;
+      const handlesProto = normalized.keySet.has("__proto__");
+      const doc = new Doc(
+        handlesProto
+          ? ["shape", "payload", "ctx", "setProp", "getProperty", "isPropertyPresent"]
+          : ["shape", "payload", "ctx"]
+      );
 
       const parseStr = (key: string) => {
         const k = util.esc(key);
-        return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
+        const value = key === "__proto__" ? `getProperty(input, ${k})` : `input[${k}]`;
+        return `shape[${k}]._zod.run({ value: ${value}, issues: [] }, ctx)`;
+      };
+
+      const presentStr = (key: string) => {
+        const k = util.esc(key);
+        return key === "__proto__" ? `isPropertyPresent(input, ${k})` : `${k} in input`;
       };
 
       // Keys are known here, so only a literal "__proto__" defers to setProp.
@@ -2026,6 +2047,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       for (const key of normalized.keys) {
         const id = ids[key];
         const k = util.esc(key);
+        const isPresent = presentStr(key);
         const schema = shape[key];
         const isOptionalIn = schema?._zod?.optin === "optional";
         const isOptionalOut = schema?._zod?.optout === "optional";
@@ -2036,7 +2058,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
           // For optional-in/out schemas, ignore errors on absent keys
           doc.write(`
         if (${id}.issues.length) {
-          if (${k} in input) {
+          if (${isPresent}) {
             payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
               ...iss,
               path: iss.path ? [${k}, ...iss.path] : [${k}]
@@ -2045,7 +2067,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         }
         
         if (${id}.value === undefined) {
-          if (${k} in input) {
+          if (${isPresent}) {
             ${setStr(key, "undefined")}
           }
         } else {
@@ -2055,7 +2077,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       `);
         } else if (!isOptionalIn) {
           doc.write(`
-        const ${id}_present = ${k} in input;
+        const ${id}_present = ${isPresent};
         if (${id}.issues.length) {
           payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
             ...iss,
@@ -2090,7 +2112,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         }
         
         if (${id}.value === undefined) {
-          if (${k} in input) {
+          if (${isPresent}) {
             ${setStr(key, "undefined")}
           }
         } else {
@@ -2104,7 +2126,9 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       doc.write(`payload.value = newResult;`);
       doc.write(`return payload;`);
       const fn = doc.compile();
-      return (payload: any, ctx: any) => fn(shape, payload, ctx, setProp);
+      return handlesProto
+        ? (payload: any, ctx: any) => fn(shape, payload, ctx, setProp, getProperty, isPropertyPresent)
+        : (payload: any, ctx: any) => fn(shape, payload, ctx);
     };
 
     let fastpass!: ReturnType<typeof generateFastpass>;
@@ -2389,7 +2413,9 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
         if (!pv || Object.keys(pv).length === 0)
           throw new Error(`Invalid discriminated union option at index "${def.options.indexOf(option)}"`);
         for (const [k, v] of Object.entries(pv!)) {
-          if (!propValues[k]) propValues[k] = new Set();
+          if (!Object.prototype.hasOwnProperty.call(propValues, k)) {
+            util.assignProp(propValues, k, new Set());
+          }
           for (const val of v) {
             propValues[k].add(val);
           }
@@ -2834,6 +2860,7 @@ export interface $ZodRecordDef<Key extends $ZodRecordKey = $ZodRecordKey, Value 
   valueType: Value;
   /** @default "strict" - errors on keys not matching keyType. "loose" passes through non-matching keys unchanged. */
   mode?: "strict" | "loose";
+  partial?: boolean;
 }
 
 // export type $InferZodRecordOutput<
@@ -2909,7 +2936,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
     const proms: Promise<any>[] = [];
 
     const values = def.keyType._zod.values;
-    if (values) {
+    if (values && !def.partial) {
       payload.value = {};
       const recordKeys = new Set<string | symbol>();
       for (const key of values) {
@@ -2931,7 +2958,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
             continue;
           }
           const outKey = keyResult.value as PropertyKey;
-          const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
+          const result = def.valueType._zod.run({ value: getProperty(input, key), issues: [] }, ctx);
 
           if (result instanceof Promise) {
             proms.push(
@@ -2971,7 +2998,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       payload.value = {};
       // Reflect.ownKeys for Symbol-key support; filter non-enumerable to match z.object()
       for (const key of Reflect.ownKeys(input)) {
-        if (key === "__proto__") continue;
+        if (key === "__proto__" && !(def.partial && values?.has(key))) continue;
         if (!Object.prototype.propertyIsEnumerable.call(input, key)) continue;
         let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
         if (keyResult instanceof Promise) {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3017,14 +3017,16 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
               if (result.issues.length) {
                 payload.issues.push(...util.prefixIssues(key, result.issues));
               }
-              payload.value[keyResult.value as PropertyKey] = result.value;
+              // keyResult.value is the key the key schema emitted, which the
+              // raw-key __proto__ guard above never saw.
+              setProp(payload.value, keyResult.value as PropertyKey, result.value);
             })
           );
         } else {
           if (result.issues.length) {
             payload.issues.push(...util.prefixIssues(key, result.issues));
           }
-          payload.value[keyResult.value as PropertyKey] = result.value;
+          setProp(payload.value, keyResult.value as PropertyKey, result.value);
         }
       }
     }

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -5,6 +5,17 @@ import type * as schemas from "./schemas.js";
 import type { StandardJSONSchemaV1, StandardSchemaWithJSONProps } from "./standard-schema.js";
 import { assignProp } from "./util.js";
 
+function assignProps<T extends object>(target: T, ...sources: object[]): T {
+  for (const source of sources) {
+    for (const key of Reflect.ownKeys(source)) {
+      if (Object.prototype.propertyIsEnumerable.call(source, key)) {
+        assignProp(target, key, (source as any)[key]);
+      }
+    }
+  }
+  return target;
+}
+
 export type Processor<T extends schemas.$ZodType = schemas.$ZodType> = (
   schema: T,
   ctx: ToJSONSchemaContext,
@@ -197,7 +208,7 @@ export function process<T extends schemas.$ZodType>(
 
   // metadata
   const meta = ctx.metadataRegistry.get(schema);
-  if (meta) Object.assign(result.schema, meta);
+  if (meta) assignProps(result.schema, meta);
 
   if (ctx.io === "input" && isTransforming(schema)) {
     // examples/defaults only apply to output type of pipe
@@ -389,10 +400,10 @@ export function finalize<T extends schemas.$ZodType>(
         schema.allOf = schema.allOf ?? [];
         schema.allOf.push(refSchema);
       } else {
-        Object.assign(schema, refSchema);
+        assignProps(schema, refSchema);
       }
       // restore child's own properties (child wins)
-      Object.assign(schema, _cached);
+      assignProps(schema, _cached);
 
       const isParentRef = zodSchema._zod.parent === ref;
 
@@ -470,7 +481,7 @@ export function finalize<T extends schemas.$ZodType>(
     result.$id = ctx.external.uri(id);
   }
 
-  Object.assign(result, root.def ?? root.schema);
+  assignProps(result, root.def ?? root.schema);
 
   // The `id` in `.meta()` is a Zod-specific registration tag used to extract
   // schemas into $defs — it is not user-facing JSON Schema metadata. Strip it

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -611,11 +611,11 @@ export function pick(schema: schemas.$ZodObject, mask: Record<string, unknown>):
     get shape() {
       const newShape: Writeable<schemas.$ZodShape> = {};
       for (const key in mask) {
-        if (!(key in currDef.shape)) {
+        if (!Object.prototype.hasOwnProperty.call(currDef.shape, key)) {
           throw new Error(`Unrecognized key: "${key}"`);
         }
         if (!mask[key]) continue;
-        newShape[key] = currDef.shape[key]!;
+        assignProp(newShape, key, currDef.shape[key]!);
       }
 
       assignProp(this, "shape", newShape); // self-caching
@@ -640,7 +640,7 @@ export function omit(schema: schemas.$ZodObject, mask: object): any {
     get shape() {
       const newShape: Writeable<schemas.$ZodShape> = { ...schema._zod.def.shape };
       for (const key in mask) {
-        if (!(key in currDef.shape)) {
+        if (!Object.prototype.hasOwnProperty.call(currDef.shape, key)) {
           throw new Error(`Unrecognized key: "${key}"`);
         }
         if (!(mask as any)[key]) continue;
@@ -736,7 +736,7 @@ export function partial(
 
       if (mask) {
         for (const key in mask) {
-          if (!(key in oldShape)) {
+          if (!Object.prototype.hasOwnProperty.call(oldShape, key)) {
             throw new Error(`Unrecognized key: "${key}"`);
           }
           if (!(mask as any)[key]) continue;
@@ -781,7 +781,7 @@ export function required(
 
       if (mask) {
         for (const key in mask) {
-          if (!(key in shape)) {
+          if (!Object.prototype.hasOwnProperty.call(shape, key)) {
             throw new Error(`Unrecognized key: "${key}"`);
           }
           if (!(mask as any)[key]) continue;

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1206,11 +1206,11 @@ export function partialRecord<Key extends core.$ZodRecordKey, Value extends Some
   params?: string | core.$ZodRecordParams
 ): ZodMiniRecord<Key & core.$partial, Value> {
   const k = core.clone(keyType);
-  k._zod.values = undefined;
   return new ZodMiniRecord({
     type: "record",
     keyType: k,
     valueType: valueType as any,
+    partial: true,
     ...util.normalizeParams(params),
   }) as any;
 }

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1205,13 +1205,12 @@ export function partialRecord<Key extends core.$ZodRecordKey, Value extends Some
   valueType: Value,
   params?: string | core.$ZodRecordParams
 ): ZodMiniRecord<Key & core.$partial, Value> {
-  const k = core.clone(keyType);
   return new ZodMiniRecord({
     type: "record",
-    keyType: k,
+    keyType,
     valueType: valueType as any,
-    partial: true,
     ...util.normalizeParams(params),
+    partial: true,
   }) as any;
 }
 

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -344,6 +344,15 @@ test("z.record", () => {
     [Enum.B]: "world",
   });
 
+  const partial = z.partialRecord(z.enum(["__proto__", "b"]), z.string());
+  type partial = z.output<typeof partial>;
+  expectTypeOf<partial>().toEqualTypeOf<Partial<Record<"__proto__" | "b", string>>>();
+  const parsed: any = z.parse(partial, Object.fromEntries([["__proto__", "declared"]]));
+  expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+  expect(parsed.__proto__).toBe("declared");
+  expect(z.parse(partial, {})).toEqual({});
+
   // v3-compat single-arg form: z.record(valueType) defaults keyType to z.string()
   const f = (z.record as any)(z.number());
   expect(f._zod.def.keyType._zod.def.type).toEqual("string");


### PR DESCRIPTION
This completes the reserved-key hardening pass in one reviewable change. It preserves declared `__proto__` fields across object, record, partial-record, discriminator, and shape-helper paths without changing ordinary inherited-property parsing. Keys normalized to `__proto__` remain rejected, matching #6355.

Legacy formatted errors now tolerate input paths named `_errors`, and JSON Schema conversion preserves generated `__proto__` keys through pattern and metadata merges. The public tests no longer name private advisories.

`pnpm test` passes all 3,911 tests with no type errors. `pnpm build`, `pnpm format:check`, `pnpm lint:check`, and `pnpm check:circular` also pass.

Supersedes #6356.
