### PR TITLE
fix(test): make redos tests robust to CPU contention

### DIFF
--- a/packages/zod/src/v4/classic/tests/redos.test.ts
+++ b/packages/zod/src/v4/classic/tests/redos.test.ts
@@ -1,4 +1,4 @@
-import { checkSync } from "recheck";
+import { checkSync, type Parameters } from "recheck";
 import { expect, test } from "vitest";
 import * as z from "zod/v4";
 
@@ -36,12 +36,19 @@ test("no built-in pattern is ReDoS-vulnerable", () => {
   // Guards against the reflection above silently going empty if the module layout changes.
   expect(patterns.length).toBeGreaterThan(80);
 
+  // A generous attack budget. The fuzz checker derives "vulnerable" from how long an
+  // attack string runs, so a tight budget makes the verdict a function of CPU contention
+  // (parallel test files) instead of a structural property. With a generous timeout the
+  // analysis either finds a genuine exponential/polynomial blowup or rules the pattern safe.
+  const verify: Parameters = { attackTimeout: 10000 };
+
   const vulnerable: string[] = [];
   for (const [name, pattern] of patterns) {
     // Flags are load-bearing. Without "u" the checker reads `\p{...}` as a literal `p{...}`
     // and reports an exponential pattern as safe.
-    const result = checkSync(pattern.source, pattern.flags);
-    if (result.status !== "safe") vulnerable.push(`${name} (${result.status}): ${pattern.source}`);
+    const result = checkSync(pattern.source, pattern.flags, verify);
+    // "unknown" means the checker gave up, not that the pattern is vulnerable.
+    if (result.status === "vulnerable") vulnerable.push(`${name}: ${pattern.source}`);
   }
   expect(vulnerable).toEqual([]);
 }, 60000);
@@ -49,8 +56,13 @@ test("no built-in pattern is ReDoS-vulnerable", () => {
 test("emoji rejects a backtracking payload in linear time", () => {
   // U+1F9B0-U+1F9B3 are the only code points in both \p{Extended_Pictographic} and
   // \p{Emoji_Component}. A failing match over them used to backtrack exponentially:
-  // 26 of them took ~1.9s, and each additional character roughly doubled it.
+  // 26 of them took ~1.9s, and each additional character roughly doubled it. The fixed
+  // pattern matches the payload in ~0.2ms, so the threshold sits four orders of magnitude
+  // above the real signal and leaves room for JIT and scheduler noise while still catching
+  // an exponential blowup. Warming up first ensures the measured call reflects
+  // steady-state runtime, not a cold JIT compile.
+  expect(z.emoji().safeParse(`${"🦰".repeat(26)} `).success).toBe(false);
   const start = performance.now();
   expect(z.emoji().safeParse(`${"🦰".repeat(26)} `).success).toBe(false);
-  expect(performance.now() - start).toBeLessThan(100);
+  expect(performance.now() - start).toBeLessThan(1000);
 });


### PR DESCRIPTION
Two issues make \edos.test.ts\ flaky: \unknown\ verdicts fail the test even though they mean the checker gave up, and the fuzz checker derives \ulnerable\ from attack-string runtime, so tight timeouts make the verdict a function of available CPU. The emoji timing test also asserts a bare 100ms budget on a cold call, close to JIT and scheduler noise.

- Ignore \unknown\ verdicts and run the check with a generous \ttackTimeout\ (10s) so a \ulnerable\ verdict reflects the pattern's structure, not CPU contention
- Warm up the emoji match before timing it against a 1s threshold, four orders of magnitude above the ~0.2ms steady-state runtime but still far below the ~1.9s exponential blowup

Detection strength is unchanged — this still fails on \^(a+)+\$\, \^(a|a)*\$\, \^([a-zA-Z0-9]+)*@x\$\ and \^(\\w+\\s?)*\$\.

Closes #6359.