### PR TITLE
fix(v4): preserve input defaults through transforms in toJSONSchema

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2633,6 +2633,59 @@ test("defaults/prefaults", () => {
   `);
 });
 
+test("input defaults preserved when transform preserves the input type", () => {
+  // identity transform: default is a valid input, so it should survive
+  const a = z
+    .string()
+    .transform((s) => s)
+    .default("hello");
+  expect(z.toJSONSchema(a, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": "hello",
+      "type": "string",
+    }
+  `);
+
+  // default inside a union with a transforming option
+  const b = z.union([z.boolean(), z.object({ a: z.string().transform((x) => x) })]).default(false);
+  expect(z.toJSONSchema(b, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "anyOf": [
+        {
+          "type": "boolean",
+        },
+        {
+          "properties": {
+            "a": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "a",
+          ],
+          "type": "object",
+        },
+      ],
+      "default": false,
+    }
+  `);
+
+  // divergent transform: default is not a valid input, so it stays dropped
+  const c = z
+    .string()
+    .transform((val) => val.length)
+    .pipe(z.number())
+    .default(5);
+  expect(z.toJSONSchema(c, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+    }
+  `);
+});
+
 test("falsy prefaults (false, 0, empty string)", () => {
   // boolean prefault false
   const a = z.boolean().prefault(false);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -201,8 +201,17 @@ export function process<T extends schemas.$ZodType>(
 
   if (ctx.io === "input" && isTransforming(schema)) {
     // examples/defaults only apply to output type of pipe
-    delete result.schema.examples;
-    delete result.schema.default;
+    if (result.schema.examples !== undefined) {
+      if (
+        !Array.isArray(result.schema.examples) ||
+        !result.schema.examples.every((example) => isValidInput(schema, example))
+      ) {
+        delete result.schema.examples;
+      }
+    }
+    if (result.schema.default !== undefined && !isValidInput(schema, result.schema.default)) {
+      delete result.schema.default;
+    }
   }
 
   // set prefault as default
@@ -587,6 +596,16 @@ function isTransforming(
   }
 
   return false;
+}
+
+function isValidInput(schema: schemas.$ZodType, value: unknown): boolean {
+  try {
+    const result = schema._zod.run({ value, issues: [] }, { async: false });
+    if (result instanceof Promise) return false;
+    return result.issues.length === 0;
+  } catch {
+    return false;
+  }
 }
 
 export type ZodStandardSchemaWithJSON<T> = StandardSchemaWithJSONProps<core.input<T>, core.output<T>>;


### PR DESCRIPTION
﻿When a defaulted schema contains a transform, `io: "input"` emission dropped the `default` (and `examples`) even when the value is a valid input — an identity transform, or a default drawn from a non-transforming union arm, both produced schemas missing the `default` keyword.

Now the value is validated as input first, and only dropped when it isn't a valid input (e.g. a number default on a string-input transform).

Fixes #6049.