### PR TITLE
fix(v4): give z.xor() a distinct error when multiple options match

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1744,7 +1744,7 @@ If the input could match multiple options, `z.xor()` will fail. The resulting is
 ```ts
 const overlapping = z.xor([z.string(), z.any()]);
 overlapping.parse("hello"); // ❌ fails (matches both string and any)
-// ZodError: Invalid input: expected exactly one matching option, received 2 (options 0, 1)
+// ZodError: Invalid input: more than one option matched
 ```
 
 Object options overlap more often than you'd expect, since `z.object()` strips unknown keys instead of rejecting them. Below, an input with both keys matches *both* options — the first strips `version`, the second keeps it. Use `z.strictObject()` (or `.strict()`) on the narrower option to make the branches mutually exclusive:

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1739,11 +1739,22 @@ const payment = z.xor([
 payment.parse({ type: "card", cardNumber: "1234" }); // ✅ passes
 ```
 
-If the input could match multiple options, `z.xor()` will fail:
+If the input could match multiple options, `z.xor()` will fail. The resulting issue has `inclusive: false` and a `matches` array listing the indices of the options that matched:
 
 ```ts
 const overlapping = z.xor([z.string(), z.any()]);
 overlapping.parse("hello"); // ❌ fails (matches both string and any)
+// ZodError: Invalid input: expected exactly one matching option, received 2 (options 0, 1)
+```
+
+Object options overlap more often than you'd expect, since `z.object()` strips unknown keys instead of rejecting them. Below, an input with both keys matches *both* options — the first strips `version`, the second keeps it. Use `z.strictObject()` (or `.strict()`) on the narrower option to make the branches mutually exclusive:
+
+```ts
+const name = z.object({ name: z.string() });
+const version = name.extend({ version: z.string() });
+
+z.xor([name, version]).parse({ name: "zod", version: "4" });           // ❌ fails (matches both)
+z.xor([name.strict(), version]).parse({ name: "zod", version: "4" });  // ✅ passes
 ```
 
 

--- a/packages/zod/src/v4/classic/tests/union.test.ts
+++ b/packages/zod/src/v4/classic/tests/union.test.ts
@@ -208,7 +208,7 @@ test("z.xor() - multiple matches fails", () => {
             0,
             1,
           ],
-          "message": "Invalid input: expected exactly one matching option, received 2 (options 0, 1)",
+          "message": "Invalid input: more than one option matched",
           "path": [],
         },
       ]
@@ -226,9 +226,7 @@ test("z.xor() - multiple matches reports every matching option", () => {
     const issue = result.error.issues[0] as z.core.$ZodIssueInvalidUnion;
     expect(issue.inclusive).toBe(false);
     expect((issue as Extract<typeof issue, { inclusive: false }>).matches).toEqual([0, 1, 2]);
-    expect(issue.message).toMatchInlineSnapshot(
-      `"Invalid input: expected exactly one matching option, received 3 (options 0, 1, 2)"`
-    );
+    expect(issue.message).toBe("Invalid input: more than one option matched");
   }
 });
 

--- a/packages/zod/src/v4/classic/tests/union.test.ts
+++ b/packages/zod/src/v4/classic/tests/union.test.ts
@@ -198,8 +198,47 @@ test("z.xor() - multiple matches fails", () => {
   const result = schema.safeParse("hello");
   expect(result.success).toBe(false);
   if (!result.success) {
-    expect(result.error.issues[0].code).toBe("invalid_union");
-    expect((result.error.issues[0] as any).inclusive).toBe(false);
+    expect(result.error.issues).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "invalid_union",
+          "errors": [],
+          "inclusive": false,
+          "matches": [
+            0,
+            1,
+          ],
+          "message": "Invalid input: expected exactly one matching option, received 2 (options 0, 1)",
+          "path": [],
+        },
+      ]
+    `);
+  }
+});
+
+test("z.xor() - multiple matches reports every matching option", () => {
+  // non-strict objects strip unknown keys, so both branches accept the extra key
+  const name = z.object({ name: z.string() });
+  const version = name.extend({ version: z.string() });
+  const result = z.xor([name, version, z.unknown()]).safeParse({ name: "windows", version: "10" });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues[0] as z.core.$ZodIssueInvalidUnion;
+    expect(issue.inclusive).toBe(false);
+    expect((issue as Extract<typeof issue, { inclusive: false }>).matches).toEqual([0, 1, 2]);
+    expect(issue.message).toMatchInlineSnapshot(
+      `"Invalid input: expected exactly one matching option, received 3 (options 0, 1, 2)"`
+    );
+  }
+});
+
+test("z.xor() - zero matches keeps the per-option errors", () => {
+  const result = z.xor([z.string(), z.number()]).safeParse(true);
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues[0] as z.core.$ZodIssueInvalidUnion;
+    expect(issue.errors).toHaveLength(2);
+    expect(issue.message).toBe("Invalid input");
   }
 });
 

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -101,6 +101,8 @@ interface $ZodIssueInvalidUnionMultipleMatch extends $ZodIssueBase {
   readonly input?: unknown;
   readonly discriminator?: string | undefined;
   readonly inclusive: false;
+  /** Indices of the options that matched */
+  readonly matches: number[];
 }
 
 export type $ZodIssueInvalidUnion = $ZodIssueInvalidUnionNoMatch | $ZodIssueInvalidUnionMultipleMatch;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2271,14 +2271,17 @@ function handleExclusiveUnionResults(
   inst: $ZodUnion,
   ctx?: ParseContext
 ) {
-  const successes = results.filter((r) => r.issues.length === 0);
+  const matches: number[] = [];
+  for (let i = 0; i < results.length; i++) {
+    if (results[i].issues.length === 0) matches.push(i);
+  }
 
-  if (successes.length === 1) {
-    final.value = successes[0].value;
+  if (matches.length === 1) {
+    final.value = results[matches[0]].value;
     return final;
   }
 
-  if (successes.length === 0) {
+  if (matches.length === 0) {
     // No matches - same as regular union
     final.issues.push({
       code: "invalid_union",
@@ -2294,6 +2297,7 @@ function handleExclusiveUnionResults(
       inst,
       errors: [],
       inclusive: false,
+      matches,
     });
   }
 

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -107,6 +107,9 @@ const error: () => errors.$ZodErrorMap = () => {
           const opts = issue.options.map((o) => `'${o}'`).join(" | ");
           return `Invalid discriminator value. Expected ${opts}`;
         }
+        if (issue.inclusive === false && Array.isArray(issue.matches)) {
+          return `Invalid input: expected exactly one matching option, received ${issue.matches.length} (options ${issue.matches.join(", ")})`;
+        }
         return "Invalid input";
       case "invalid_element":
         return `Invalid value in ${issue.origin}`;

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -107,8 +107,8 @@ const error: () => errors.$ZodErrorMap = () => {
           const opts = issue.options.map((o) => `'${o}'`).join(" | ");
           return `Invalid discriminator value. Expected ${opts}`;
         }
-        if (issue.inclusive === false && Array.isArray(issue.matches)) {
-          return `Invalid input: expected exactly one matching option, received ${issue.matches.length} (options ${issue.matches.join(", ")})`;
+        if (issue.inclusive === false) {
+          return "Invalid input: more than one option matched";
         }
         return "Invalid input";
       case "invalid_element":


### PR DESCRIPTION
Closes #6342.

When `z.xor()` fails because *multiple* options matched, the issue is emitted with `errors: []` and `inclusive: false`. The English error map has no case for that shape, so it falls through to a bare `"Invalid input"` — nothing in the error points at the overlap that caused it.

`en` now names the overlap:

```
Invalid input: more than one option matched
```

The issue also carries `matches`, the indices of the options that matched, for callers that need to know *which* ones overlapped.

The zero-match path is untouched and still reports each option's own errors. Only `en` gets the new message; the other locales already fall back for the discriminator case the same way.

Also documents the trap behind #6342 in `api.mdx`: `z.object()` strips unknown keys rather than rejecting them, so two object options overlap on an input carrying both keys, and `z.strictObject()` on the narrower option disambiguates. That's the whole reason the reporter's `strictXor` worked and their `gentleXor` didn't.
