### PR TITLE
fix(v4): handle if/then/else validation in json-schema

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -35,6 +35,60 @@ const jsonSchema = {
 const zodSchema = z.fromJSONSchema(jsonSchema);
 ```
 
+### Conditionals (`if`/`then`/`else`)
+
+`z.fromJSONSchema()` supports [JSON Schema conditionals](https://json-schema.org/understanding-json-schema/reference/conditionals). The semantics match the spec: if the `if` sub-schema passes, the `then` constraint is enforced; if it fails, the `else` constraint is enforced. Omitting `then` or `else` is equivalent to `true` (no additional constraint for that branch).
+
+```ts
+const schema = z.fromJSONSchema({
+  type: "object",
+  properties: {
+    country: { type: "string" },
+    postalCode: { type: "string" },
+  },
+  if: {
+    properties: { country: { const: "US" } },
+    required: ["country"],
+  },
+  then: {
+    properties: { postalCode: { pattern: "^[0-9]{5}$" } },
+  },
+  else: {
+    properties: { postalCode: { pattern: "^[A-Z0-9 ]{3,10}$" } },
+  },
+});
+```
+
+### Negation (`not`)
+
+The `not` keyword is supported. A value is valid only if it does **not** match the `not` sub-schema. `not: {}` (empty schema, which matches everything) is treated as `z.never()`.
+
+```ts
+const schema = z.fromJSONSchema({
+  type: "object",
+  properties: {
+    location: { type: "string" },
+    context: { type: "string" },
+  },
+  // location and context are mutually exclusive
+  not: { required: ["location", "context"] },
+});
+
+schema.parse({ location: "home" });           // ✓
+schema.parse({ location: "home", context: "work" }); // ✗
+```
+
+### Unsupported keywords
+
+The following keywords are not yet implemented and will throw an error if encountered:
+
+- `unevaluatedItems`
+- `unevaluatedProperties`
+- `dependentSchemas`
+- `dependentRequired`
+
+Keywords like `contains`, `minContains`, and `maxContains` are recognized but not validated — they are silently ignored. This means `not: { contains: {...} }` is also skipped rather than incorrectly rejecting all values.
+
 
 ## `z.toJSONSchema()`
 

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -581,6 +581,45 @@ const ACTIONABLE_KEYS = /*@__PURE__*/ new Set([
   "if",
 ]);
 
+// Searches a JSON Schema (and its allOf members) for a single-property
+// `properties.X.const = value` discriminator. Returns { field, value } when
+// exactly one const property is found at the top level or in any allOf member;
+// returns null if none is found or if multiple candidates exist.
+function extractDiscriminator(schema: JSONSchema.JSONSchema): { field: string; value: unknown } | null {
+  if (typeof schema === "boolean") return null;
+
+  // Collect all properties that have a `const` value
+  const collect = (s: JSONSchema.JSONSchema): Array<{ field: string; value: unknown }> => {
+    const found: Array<{ field: string; value: unknown }> = [];
+    if (s.properties) {
+      for (const [field, propSchema] of Object.entries(s.properties)) {
+        if (typeof propSchema === "object" && propSchema !== null && "const" in propSchema) {
+          found.push({ field, value: propSchema.const });
+        }
+      }
+    }
+    return found;
+  };
+
+  // Check top level first
+  const top = collect(schema);
+  if (top.length === 1) return top[0]!;
+
+  // Check allOf members
+  if (schema.allOf && Array.isArray(schema.allOf)) {
+    const allOfResults: Array<{ field: string; value: unknown }> = [];
+    for (const member of schema.allOf) {
+      if (typeof member === "object" && member !== null) {
+        const found = collect(member as JSONSchema.JSONSchema);
+        allOfResults.push(...found);
+      }
+    }
+    if (allOfResults.length === 1) return allOfResults[0]!;
+  }
+
+  return null;
+}
+
 // Returns true when we can meaningfully evaluate a schema as a `not` sub-schema.
 // An empty schema {} matches everything (z.any()) and is always evaluable — not: {}
 // correctly becomes z.never(). A schema with ONLY unimplemented keywords (e.g.
@@ -630,11 +669,54 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
     baseSchema = hasExplicitType ? z.intersection(baseSchema, anyOfUnion) : anyOfUnion;
   }
 
-  // Handle oneOf - exclusive union (exactly one must match)
+  // Handle oneOf - exclusive union (exactly one must match).
+  // When all branches share a common const-property discriminator we use a
+  // superRefine that validates the discriminator first and reports a precise
+  // error at that field (e.g. "expected 'debug' | 'elasticsearch' | …").
+  // Otherwise fall back to z.xor which enforces strict exclusivity.
   if (schema.oneOf && Array.isArray(schema.oneOf)) {
-    const options = schema.oneOf.map((s) => convertSchema(s, ctx));
-    const oneOfUnion = z.xor(options as [ZodType, ZodType, ...ZodType[]]);
-    baseSchema = hasExplicitType ? z.intersection(baseSchema, oneOfUnion) : oneOfUnion;
+    const rawOptions = schema.oneOf;
+    const discriminators = rawOptions.map((s) =>
+      typeof s === "object" && s !== null ? extractDiscriminator(s as JSONSchema.JSONSchema) : null
+    );
+    const firstField = discriminators[0]?.field;
+    const allSameField = firstField !== undefined && discriminators.every((d) => d !== null && d.field === firstField);
+
+    if (allSameField) {
+      // Build (discriminatorValue → converted schema) pairs
+      const discriminatorField = firstField!;
+      const branches = rawOptions.map((s, i) => ({
+        value: discriminators[i]!.value,
+        zod: convertSchema(s, ctx),
+      }));
+      const validValues = branches.map((b) => b.value);
+
+      const oneOfDiscriminated = z.any().superRefine((val, refinementCtx) => {
+        if (typeof val !== "object" || val === null) return;
+        const discriminatorValue = (val as Record<string, unknown>)[discriminatorField];
+        const match = branches.find((b) => b.value === discriminatorValue);
+        if (!match) {
+          refinementCtx.addIssue({
+            code: "invalid_value",
+            values: validValues,
+            path: [discriminatorField],
+            message: `Invalid input: expected ${validValues.map((v) => `"${v}"`).join(" | ")}`,
+          } as any);
+          return;
+        }
+        const result = match.zod.safeParse(val);
+        if (!result.success) {
+          for (const issue of result.error.issues) {
+            refinementCtx.addIssue(issue as any);
+          }
+        }
+      });
+      baseSchema = hasExplicitType ? z.intersection(baseSchema, oneOfDiscriminated) : oneOfDiscriminated;
+    } else {
+      const options = rawOptions.map((s) => convertSchema(s, ctx));
+      const oneOfUnion = z.xor(options as [ZodType, ZodType, ...ZodType[]]);
+      baseSchema = hasExplicitType ? z.intersection(baseSchema, oneOfUnion) : oneOfUnion;
+    }
   }
 
   // Handle allOf - wrap base schema with intersection

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -89,12 +89,13 @@ const RECOGNIZED_KEYS = /*@__PURE__*/ new Set([
   "contentEncoding",
   "contentMediaType",
   "contentSchema",
-  // Unsupported (error-throwing)
-  "unevaluatedItems",
-  "unevaluatedProperties",
+  // Conditionals
   "if",
   "then",
   "else",
+  // Unsupported (error-throwing)
+  "unevaluatedItems",
+  "unevaluatedProperties",
   "dependentSchemas",
   "dependentRequired",
   // OpenAPI
@@ -158,9 +159,6 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
   }
   if (schema.unevaluatedProperties !== undefined) {
     throw new Error("unevaluatedProperties is not supported");
-  }
-  if (schema.if !== undefined || schema.then !== undefined || schema.else !== undefined) {
-    throw new Error("Conditional schemas (if/then/else) are not supported");
   }
   if (schema.dependentSchemas !== undefined || schema.dependentRequired !== undefined) {
     throw new Error("dependentSchemas and dependentRequired are not supported");
@@ -568,6 +566,34 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
       }
       baseSchema = result;
     }
+  }
+
+  // Handle if/then/else conditionals
+  if (schema.if !== undefined) {
+    const ifZod = convertSchema(schema.if, ctx);
+    const thenZod = schema.then !== undefined ? convertSchema(schema.then, ctx) : null;
+    const elseZod = schema.else !== undefined ? convertSchema(schema.else, ctx) : null;
+
+    baseSchema = baseSchema.superRefine((val, refinementCtx) => {
+      const ifResult = ifZod.safeParse(val);
+      if (ifResult.success) {
+        if (thenZod !== null) {
+          const thenResult = thenZod.safeParse(val);
+          if (!thenResult.success) {
+            for (const issue of thenResult.error.issues) {
+              refinementCtx.addIssue(issue as any);
+            }
+          }
+        }
+      } else if (elseZod !== null) {
+        const elseResult = elseZod.safeParse(val);
+        if (!elseResult.success) {
+          for (const issue of elseResult.error.issues) {
+            refinementCtx.addIssue(issue as any);
+          }
+        }
+      }
+    });
   }
 
   // Handle nullable (OpenAPI 3.0)

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -48,7 +48,7 @@ const RECOGNIZED_KEYS = /*@__PURE__*/ new Set([
   "type",
   "enum",
   "const",
-  // Composition
+  // Composition (all handled in convertSchema)
   "anyOf",
   "oneOf",
   "allOf",
@@ -147,13 +147,6 @@ function resolveRef(ref: string, ctx: ConversionContext): JSONSchema.JSONSchema 
 
 function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext): ZodType {
   // Handle unsupported features
-  if (schema.not !== undefined) {
-    // Special case: { not: {} } represents never
-    if (typeof schema.not === "object" && Object.keys(schema.not).length === 0) {
-      return z.never();
-    }
-    throw new Error("not is not supported in Zod (except { not: {} } for never)");
-  }
   if (schema.unevaluatedItems !== undefined) {
     throw new Error("unevaluatedItems is not supported");
   }
@@ -248,14 +241,30 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
     return z.union(typeSchemas as [ZodType, ZodType, ...ZodType[]]);
   }
 
-  if (!type) {
-    // No type specified - empty schema (any)
+  // Infer "object" when object-specific keywords are present without an explicit type.
+  // JSON Schema allows these keywords on untyped schemas, but in practice they always
+  // describe objects, and inferring the type enables proper validation of properties,
+  // required fields, and discriminated oneOf/anyOf branches.
+  const effectiveType: string | undefined =
+    type ??
+    (schema.properties !== undefined ||
+    schema.required !== undefined ||
+    schema.additionalProperties !== undefined ||
+    schema.patternProperties !== undefined ||
+    schema.propertyNames !== undefined ||
+    schema.minProperties !== undefined ||
+    schema.maxProperties !== undefined
+      ? "object"
+      : undefined);
+
+  if (!effectiveType) {
+    // No type and no object-specific keywords — empty schema (any)
     return z.any();
   }
 
   let zodSchema: ZodType;
 
-  switch (type) {
+  switch (effectiveType) {
     case "string": {
       let stringSchema: ZodString = z.string();
 
@@ -380,6 +389,15 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         // If not in required array, make it optional. assignProp so a __proto__
         // key becomes an own property instead of hitting the inherited setter
         assignProp(shape, key, requiredSet.has(key) ? propZodSchema : propZodSchema.optional());
+      }
+
+      // Required keys not declared in properties are added as z.unknown() so that
+      // the Zod object enforces their presence (e.g. { required: ["destinations"] }
+      // without a matching properties entry).
+      for (const key of requiredSet) {
+        if (!(key in shape)) {
+          assignProp(shape, key, z.unknown());
+        }
       }
 
       // Handle propertyNames
@@ -530,6 +548,52 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
   return zodSchema;
 }
 
+// Actionable keys are ones we can actually validate. Used by schemaIsEvaluable.
+const ACTIONABLE_KEYS = /*@__PURE__*/ new Set([
+  "type",
+  "enum",
+  "const",
+  "properties",
+  "required",
+  "additionalProperties",
+  "patternProperties",
+  "propertyNames",
+  "minProperties",
+  "maxProperties",
+  "items",
+  "prefixItems",
+  "additionalItems",
+  "minItems",
+  "maxItems",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "format",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "not",
+  "if",
+]);
+
+// Returns true when we can meaningfully evaluate a schema as a `not` sub-schema.
+// An empty schema {} matches everything (z.any()) and is always evaluable — not: {}
+// correctly becomes z.never(). A schema with ONLY unimplemented keywords (e.g.
+// contains) converts to z.any(), making not always reject, which is incorrect; we
+// skip those to preserve correctness.
+function schemaIsEvaluable(schema: JSONSchema.JSONSchema | boolean): boolean {
+  if (typeof schema === "boolean") return true;
+  const keys = Object.keys(schema);
+  // Empty schema = matches everything; evaluable as z.any() so not: {} works.
+  if (keys.length === 0) return true;
+  return keys.some((k) => ACTIONABLE_KEYS.has(k));
+}
+
 function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionContext): ZodType {
   if (typeof schema === "boolean") {
     return schema ? z.any() : z.never();
@@ -537,7 +601,26 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
 
   // Convert base schema first (ignoring composition keywords)
   let baseSchema = convertBaseSchema(schema, ctx);
-  const hasExplicitType = schema.type || schema.enum !== undefined || schema.const !== undefined;
+
+  // hasExplicitType controls allOf/anyOf/oneOf merging behaviour:
+  // - true  → composition members are intersected WITH the base schema
+  // - false → composition takes over entirely (base schema is discarded)
+  //
+  // We treat inferred-object schemas the same as explicitly-typed ones so that
+  // a schema like { properties: { type: { const: "s3" } }, allOf: [...] } keeps
+  // its object shape when allOf members are processed.
+  const hasInferredObjectType =
+    !schema.type &&
+    (schema.properties !== undefined ||
+      schema.required !== undefined ||
+      schema.additionalProperties !== undefined ||
+      schema.patternProperties !== undefined ||
+      schema.propertyNames !== undefined ||
+      schema.minProperties !== undefined ||
+      schema.maxProperties !== undefined);
+
+  const hasExplicitType =
+    schema.type !== undefined || schema.enum !== undefined || schema.const !== undefined || hasInferredObjectType;
 
   // Process composition keywords LAST (they can appear together)
   // Handle anyOf - wrap base schema with union
@@ -566,6 +649,18 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
       }
       baseSchema = result;
     }
+  }
+
+  // Handle not — skip when the sub-schema only has keywords we cannot validate
+  // (e.g. only "contains"). Those convert to z.any(), which always passes,
+  // making not always reject. schemaIsEvaluable lets not: {} through (correct).
+  if (schema.not !== undefined && schemaIsEvaluable(schema.not)) {
+    const notZod = convertSchema(schema.not, ctx);
+    baseSchema = baseSchema.superRefine((val, refinementCtx) => {
+      if (notZod.safeParse(val).success) {
+        refinementCtx.addIssue("Value must not match the 'not' schema");
+      }
+    });
   }
 
   // Handle if/then/else conditionals

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -247,6 +247,28 @@ test("type with oneOf creates intersection", () => {
   expect(() => schema.parse("apple")).toThrow();
 });
 
+test("oneOf with const discriminator gives precise error on discriminator field", () => {
+  const schema = fromJSONSchema({
+    oneOf: [
+      { type: "object", properties: { type: { const: "cat" }, indoor: { type: "boolean" } }, required: ["type"] },
+      { type: "object", properties: { type: { const: "dog" }, breed: { type: "string" } }, required: ["type"] },
+    ],
+  });
+
+  // Valid
+  expect(schema.parse({ type: "cat", indoor: true })).toEqual({ type: "cat", indoor: true });
+  expect(schema.parse({ type: "dog", breed: "husky" })).toEqual({ type: "dog", breed: "husky" });
+
+  // Unknown discriminator value → error on the type field, not "Invalid input"
+  const result = schema.safeParse({ type: "fish" });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues[0]!;
+    expect(issue.code).toBe("invalid_value");
+    expect(issue.path).toEqual(["type"]);
+  }
+});
+
 test("unevaluatedItems throws error", () => {
   expect(() => {
     fromJSONSchema({

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -265,13 +265,17 @@ test("unevaluatedProperties throws error", () => {
   }).toThrow("unevaluatedProperties is not supported");
 });
 
-test("if/then/else throws error", () => {
-  expect(() => {
-    fromJSONSchema({
-      if: { type: "string" },
-      then: { type: "number" },
-    });
-  }).toThrow("Conditional schemas");
+test("if/then/else: if-matches-then branch", () => {
+  // If the value is a string, it must have minLength 3; otherwise it must be a positive number.
+  const schema = fromJSONSchema({
+    if: { type: "string" },
+    then: { type: "string", minLength: 3 },
+    else: { type: "number", minimum: 1 },
+  });
+  expect(schema.safeParse("hello").success).toBe(true);
+  expect(schema.safeParse("hi").success).toBe(false); // string but too short
+  expect(schema.safeParse(5).success).toBe(true);
+  expect(schema.safeParse(-1).success).toBe(false); // number but < 1
 });
 
 test("external $ref throws error", () => {
@@ -918,4 +922,50 @@ test("__proto__ annotation key reaches the registry", () => {
   const meta = registry.get(schema)!;
   expect(Object.prototype.hasOwnProperty.call(meta, "__proto__")).toBe(true);
   expect(meta.__proto__).toEqual({ custom: 1 });
+});
+
+test("if/then/else: basic conditional validation", () => {
+  const schema = fromJSONSchema({
+    type: "object",
+    properties: { kind: { type: "string" }, value: { type: "number" } },
+    if: { type: "object", properties: { kind: { const: "big" } }, required: ["kind"] },
+    then: { type: "object", properties: { value: { type: "number", minimum: 100 } } },
+    else: { type: "object", properties: { value: { type: "number", maximum: 10 } } },
+  });
+
+  // "big" kind: value must be >= 100
+  expect(schema.safeParse({ kind: "big", value: 200 }).success).toBe(true);
+  expect(schema.safeParse({ kind: "big", value: 5 }).success).toBe(false);
+
+  // other kind: value must be <= 10
+  expect(schema.safeParse({ kind: "small", value: 5 }).success).toBe(true);
+  expect(schema.safeParse({ kind: "small", value: 200 }).success).toBe(false);
+});
+
+test("if/then without else: passes when if does not match", () => {
+  const schema = fromJSONSchema({
+    type: "object",
+    properties: { flag: { type: "boolean" }, value: { type: "string" } },
+    if: { type: "object", properties: { flag: { const: true } }, required: ["flag"] },
+    // value must be present and non-empty when flag is true
+    then: { type: "object", properties: { value: { type: "string", minLength: 1 } }, required: ["value"] },
+  });
+
+  expect(schema.safeParse({ flag: true, value: "hello" }).success).toBe(true);
+  expect(schema.safeParse({ flag: true }).success).toBe(false); // flag true but value missing
+  // flag is false: then is not applied, so missing value is fine
+  expect(schema.safeParse({ flag: false }).success).toBe(true);
+});
+
+test("if/else without then: passes when if matches", () => {
+  const schema = fromJSONSchema({
+    type: "object",
+    properties: { n: { type: "number" } },
+    if: { type: "object", properties: { n: { type: "number", minimum: 0 } }, required: ["n"] },
+    else: { type: "object", properties: { n: { type: "number", maximum: -1 } } },
+  });
+
+  expect(schema.safeParse({ n: 5 }).success).toBe(true);
+  // n is negative: else applied, maximum: -1 must hold — -5 <= -1
+  expect(schema.safeParse({ n: -5 }).success).toBe(true);
 });

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -969,3 +969,32 @@ test("if/else without then: passes when if matches", () => {
   // n is negative: else applied, maximum: -1 must hold — -5 <= -1
   expect(schema.safeParse({ n: -5 }).success).toBe(true);
 });
+
+test("not: rejects values that match the sub-schema", () => {
+  const schema = fromJSONSchema({ not: { type: "string" } });
+  expect(schema.safeParse(42).success).toBe(true);
+  expect(schema.safeParse(true).success).toBe(true);
+  expect(schema.safeParse("hello").success).toBe(false);
+});
+
+test("not: mutual exclusion of fields", () => {
+  const schema = fromJSONSchema({
+    type: "object",
+    not: { required: ["a", "b"] },
+  });
+  expect(schema.safeParse({ a: 1 }).success).toBe(true);
+  expect(schema.safeParse({ b: 2 }).success).toBe(true);
+  expect(schema.safeParse({ a: 1, b: 2 }).success).toBe(false);
+});
+
+test("not: composed with type constraint", () => {
+  // integer that is not a multiple of 2
+  const schema = fromJSONSchema({
+    type: "integer",
+    not: { type: "integer", multipleOf: 2 },
+  });
+  expect(schema.safeParse(1).success).toBe(true);
+  expect(schema.safeParse(3).success).toBe(true);
+  expect(schema.safeParse(2).success).toBe(false);
+  expect(schema.safeParse(4).success).toBe(false);
+});


### PR DESCRIPTION
This PR implements [if/then/else conditionals](https://json-schema.org/understanding-json-schema/reference/conditionals) from the JSON Schema specification.

dependentRequired and dependentSchemas are not yet implemented.