### PR TITLE
fix(docs-v3): serve the docsify SPA fallback on Vercel

### DIFF
--- a/packages/docs-v3/_redirects
+++ b/packages/docs-v3/_redirects
@@ -1,2 +1,0 @@
-/blog/* /blog/index.html 200
-/*            /   200

--- a/packages/docs-v3/vercel.json
+++ b/packages/docs-v3/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/blog/:path*", "destination": "/blog/index.html" },
+    { "source": "/:path*", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
The v3 docs run docsify with `routerMode: "history"`, so every in-page link resolves to an extensionless path. Nothing rewrites those to `index.html`, so a direct load, a refresh, or a shared link hits Vercel's `NOT_FOUND` page:

```
404  https://v3.zod.dev/ERROR_HANDLING
404  https://v3.zod.dev/MIGRATION
404  https://v3.zod.dev/CHANGELOG
404  https://v3.zod.dev/README_ZH
404  https://v3.zod.dev/README_KO
404  https://v3.zod.dev/CONTRIBUTING
404  https://v3.zod.dev/CODE_OF_CONDUCT
404  https://v3.zod.dev/blog/clerk-fellowship
```

Clicking those links from the sidebar works, because docsify handles them with `pushState` and never touches the network. Refreshing, opening in a new tab, or following a link from outside 404s — which is why the report reads as intermittent.

The fallback was already written down, in `_redirects` — Netlify syntax that Vercel ignores. That is also why `/README.md` 404ing took the whole homepage down instead of falling back, and why 6f5e99fd had to rename the homepage to `home.md` to bring it back.

This replaces it with the equivalent `vercel.json` rewrites, keeping the separate `/blog/*` shell. Vercel matches the filesystem before rewrites, so `home.md`, the rest of the markdown, and `static/` keep serving as plain files.

Verified by serving `packages/docs-v3` through a router that mimics Vercel's order. Every path above returns 200 with the right docsify shell, and in a browser `/ERROR_HANDLING` and `/blog/clerk-fellowship` both render on a cold direct load. `/?id=ecosystem` still resolves on the homepage and the static assets still serve as files.

One note for after the merge, since `zod-v3` only builds production from `main` and has no preview deployments to check against: Vercel reads `vercel.json` from the project's Root Directory, which this assumes is `packages/docs-v3`. Every deployment in the project's history builds in 1–4s, which means Vercel is skipping install — consistent with a root directory that has no `package.json`. Worth confirming with one curl once the deploy lands:

```bash
curl -sI -o /dev/null -w '%{http_code}\n' https://v3.zod.dev/ERROR_HANDLING   # want 200
```

Related: #6009
