### PR TITLE
docs(v4): correct the version boundary on the coerce missing-key note

### DIFF
--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -380,15 +380,19 @@ type schemaInput = z.input<typeof schema>;
 // Zod 4: unknown;
 ```
 
-A missing key on an object schema with a `z.coerce.*` field now errors. Use `.default()` to declare the fallback explicitly.
+As of `zod@4.4.0`, a missing key on an object schema with a `z.coerce.*` field errors instead of coercing `undefined`. Use `.default()` to declare the fallback explicitly.
 
 ```ts
 const schema = z.object({ foo: z.coerce.boolean() });
 schema.parse({});
 
-// Zod 3: { foo: false }
-// Zod 4: ZodError: Invalid input: expected nonoptional, received undefined
+// Zod 3 through 4.3: { foo: false }
+// Zod 4.4:           ZodError: Invalid input: expected nonoptional, received undefined
+
+z.object({ foo: z.coerce.boolean().default(false) }).parse({}); // => { foo: false }
 ```
+
+The rule is general: an object key can be absent only when its schema is optional on the *input* side, which `z.coerce.*` is not. It matches the inferred input type, which has required the key since Zod 4.0.
 
 ## `.default()` updates
 

--- a/packages/zod/src/v4/classic/tests/coerce.test.ts
+++ b/packages/zod/src/v4/classic/tests/coerce.test.ts
@@ -158,3 +158,31 @@ test("override input type", () => {
   type output = z.infer<typeof a>;
   expectTypeOf<output>().toEqualTypeOf<string>();
 });
+
+test("absent object key is not coerced", () => {
+  // z.coerce.* is not optional on the input side, so an absent key is rejected
+  // rather than coerced from undefined.
+  for (const schema of [z.coerce.string(), z.coerce.number(), z.coerce.boolean(), z.coerce.bigint(), z.coerce.date()]) {
+    const obj = z.object({ foo: schema });
+    expect(obj.safeParse({}).success).toEqual(false);
+    expect(obj.safeParse({}, { jitless: true }).success).toEqual(false);
+  }
+
+  const bool = z.object({ foo: z.coerce.boolean() });
+  expect(bool.safeParse({}).error!.issues).toMatchInlineSnapshot(`
+    [
+      {
+        "code": "invalid_type",
+        "expected": "nonoptional",
+        "message": "Invalid input: expected nonoptional, received undefined",
+        "path": [
+          "foo",
+        ],
+      },
+    ]
+  `);
+
+  // an explicitly present undefined still coerces
+  expect(bool.parse({ foo: undefined })).toEqual({ foo: false });
+  expect(z.object({ foo: z.coerce.boolean().default(false) }).parse({})).toEqual({ foo: false });
+});


### PR DESCRIPTION
The coerce missing-key note that landed in #5964 dates the change to the v3 → v4 boundary:

```
// Zod 3: { foo: false }
// Zod 4: ZodError: Invalid input: expected nonoptional, received undefined
```

Zod 4.0, 4.1, 4.2 and 4.3 all return `{ foo: false }`, same as v3. The absent-key rejection landed in 4.4.0 with #5661, which made the object parser treat a key as absent-able only when the field schema is optional on the input side. As written the note tells a reader on 4.2 that their working code is broken, and gives someone upgrading 4.3 → 4.4 no signal that a minor bump moved behavior.

Names 4.4.0 as the boundary, inlines the `.default(false)` escape hatch, and states the general rule — it's an `optin` rule rather than a `z.coerce` rule, and the runtime now matches an inferred input type that has required the key since 4.0.

Also pins the behavior for all five coercers in `coerce.test.ts`. `optional.test.ts` covers `z.undefined()` and undefined-bearing unions, but nothing covered `z.coerce.*`, which is part of why the change reached users unannounced.

Refs #5957.
