### PR TITLE
perf(v4): let three dead declarations tree-shake under esbuild

### DIFF
--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -77,7 +77,7 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
 }
 
 //////////////////////////////   UTILITIES   ///////////////////////////////////////
-export const $brand: unique symbol = Symbol("zod_brand");
+export const $brand: unique symbol = /*@__PURE__*/ Symbol("zod_brand");
 export type $brand<T extends string | number | symbol = string | number | symbol> = {
   [$brand]: { [k in T]: true };
 };

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -94,9 +94,16 @@ export const httpProtocol: RegExp = /^https?$/;
 // E.164: leading digit must be 1-9; total digits (excluding '+') between 7-15
 export const e164: RegExp = /^\+[1-9]\d{6,14}$/;
 
-// const dateSource = `((\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-((0[13578]|1[02])-(0[1-9]|[12]\\d|3[01])|(0[469]|11)-(0[1-9]|[12]\\d|30)|(02)-(0[1-9]|1\\d|2[0-8])))`;
 const dateSource = `(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))`;
-export const date: RegExp = /*@__PURE__*/ new RegExp(`^${dateSource}$`);
+
+/** Anchors a pattern source. The interpolation lives here rather than at the call site because
+ * esbuild will not drop a `@__PURE__` call whose own argument interpolates a variable, but it
+ * will drop `anchor(dateSource)`. Keeping it inline pinned `date` into every bundle. */
+function anchor(source: string): RegExp {
+  return new RegExp(`^${source}$`);
+}
+
+export const date: RegExp = /*@__PURE__*/ anchor(dateSource);
 
 function timeSource(args: { precision?: number | null | undefined }) {
   const hhmm = `(?:[01]\\d|2[0-3]):[0-5]\\d`;

--- a/packages/zod/src/v4/core/registries.ts
+++ b/packages/zod/src/v4/core/registries.ts
@@ -1,9 +1,9 @@
 import type * as core from "./core.js";
 import type { $ZodType } from "./schemas.js";
 
-export const $output: unique symbol = Symbol("ZodOutput");
+export const $output: unique symbol = /*@__PURE__*/ Symbol("ZodOutput");
 export type $output = typeof $output;
-export const $input: unique symbol = Symbol("ZodInput");
+export const $input: unique symbol = /*@__PURE__*/ Symbol("ZodInput");
 export type $input = typeof $input;
 
 export type $replace<Meta, S extends $ZodType> = Meta extends $output

--- a/packages/zod/src/v4/core/tests/treeshake.test.ts
+++ b/packages/zod/src/v4/core/tests/treeshake.test.ts
@@ -1,0 +1,57 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { expect, test } from "vitest";
+
+// These declarations are unreachable from a minimal schema, but esbuild only drops them
+// because of details that read as noise: `@__PURE__` annotations, and the `anchor()` helper
+// in regexes.ts that exists solely because esbuild will not drop an annotated call whose
+// argument interpolates a variable. Inlining the helper or deleting an annotation silently
+// puts them back with no other test going red.
+//
+// Rollup drops all of these regardless, so a rollup fixture would report no difference and
+// prove nothing. This has to run under esbuild.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const MINI = path.resolve(here, "../../../mini/index.ts");
+const CLASSIC = path.resolve(here, "../../../index.ts");
+
+async function bundle(entrypoint: string, source: string): Promise<string> {
+  const result = await build({
+    stdin: {
+      contents: source.replace("%ENTRY%", entrypoint),
+      loader: "ts",
+      resolveDir: here,
+    },
+    bundle: true,
+    minify: true,
+    format: "esm",
+    target: "es2020",
+    treeShaking: true,
+    write: false,
+    logLevel: "silent",
+  });
+  return result.outputFiles[0]!.text;
+}
+
+test("a minimal zod/mini schema drops the declarations it cannot reach", async () => {
+  const out = await bundle(MINI, `import * as z from "%ENTRY%";\nconsole.log(z.boolean().parse(true));`);
+
+  // Sanity check: the schema itself is present, so an empty bundle cannot pass this test.
+  expect(out).toContain("boolean");
+
+  expect(out, "core.ts `$brand` lost its @__PURE__ annotation").not.toContain("zod_brand");
+  expect(out, "util.ts `NUMBER_FORMAT_RANGES` escaped its @__PURE__ IIFE").not.toContain("MAX_SAFE_INTEGER");
+  expect(out, "regexes.ts `date` is pinned again — was `anchor()` inlined?").not.toContain("02-29");
+}, 30000);
+
+// `registries.ts` is dropped from the mini module graph entirely, so its two symbols are
+// absent there before and after. Classic is the entrypoint that exercises them.
+test("a minimal classic schema drops the registry symbols", async () => {
+  const out = await bundle(CLASSIC, `import * as z from "%ENTRY%";\nconsole.log(z.boolean().parse(true));`);
+
+  expect(out).toContain("boolean");
+
+  expect(out, "registries.ts `$output` lost its @__PURE__ annotation").not.toContain("ZodOutput");
+  expect(out, "registries.ts `$input` lost its @__PURE__ annotation").not.toContain("ZodInput");
+}, 30000);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -585,13 +585,15 @@ export type FromCleanMap<T extends schemas.$ZodLooseShape> = {
   [k in keyof T as k extends `?${infer K}` ? K : k extends `${infer K}?` ? K : k]: k;
 };
 
-export const NUMBER_FORMAT_RANGES: Record<checks.$ZodNumberFormats, [number, number]> = {
+// Wrapped in a `@__PURE__` IIFE: esbuild never tree-shakes a top-level initializer that
+// contains a member access on `Number`, so the bare object literal survived into every bundle.
+export const NUMBER_FORMAT_RANGES: Record<checks.$ZodNumberFormats, [number, number]> = /*@__PURE__*/ (() => ({
   safeint: [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
   int32: [-2147483648, 2147483647],
   uint32: [0, 4294967295],
   float32: [-3.4028234663852886e38, 3.4028234663852886e38],
   float64: [-Number.MAX_VALUE, Number.MAX_VALUE],
-};
+}))();
 
 export const BIGINT_FORMAT_RANGES: Record<checks.$ZodBigIntFormats, [bigint, bigint]> = {
   int64: [/* @__PURE__*/ BigInt("-9223372036854775808"), /* @__PURE__*/ BigInt("9223372036854775807")],


### PR DESCRIPTION
Three declarations survive tree-shaking into every minimal `zod/mini` bundle despite being unreachable. All three are esbuild-specific — Rollup already drops them, and Rollup output is byte-identical before and after this change.

**`regexes.date`** was `/*@__PURE__*/ new RegExp(`^${dateSource}$`)`. esbuild will not drop an annotated call whose argument interpolates a variable, so `date` and the `dateSource` string were pinned into every bundle, including a bare `z.boolean()`. Moving the interpolation into an `anchor()` helper restores shakeability — a bare identifier argument is fine, it is specifically the template substitution that blocks the drop. `datetime()` still builds from `dateSource` exactly as before.

**`NUMBER_FORMAT_RANGES`** reads `Number.MIN_SAFE_INTEGER` / `Number.MAX_VALUE`. esbuild's known-pure-globals table covers `Math`, `Object`, `Symbol` and `JSON` but not `Number`, so the literal was never dropped even though only `checks.ts` reads it. A `@__PURE__` IIFE sidesteps that without touching the values. Plain numeric literals also work, but they regress `z.int32()` by ~25 bytes gzipped — the repeated `Number.MAX_VALUE` text compresses better than distinct literals.

**`$brand`**, plus `$output` and `$input` in `registries.ts`, are unannotated `Symbol()` calls.

esbuild, gzipped: `z.boolean()` 2632 → 2336 (−11.2%), `z.string()` −9.6%, a 3-key object −7.5%, a two-field form schema −6.7%, a 10-key mixed object −5.1%. Rollup: 0 bytes on every scenario. So the win lands on esbuild-native pipelines — Bun, tsup, Deno, esbuild-based Workers builds, Vite dev — and Vite production users see no change.

The `date` rewrite is the only part that touches a pattern, so it is worth being explicit: `date.source` and `date.flags` are unchanged, verified by string equality against the previous value and by a differential test over 90,007 inputs (every 4-digit year against leap-day, 30/31-day and out-of-range suffixes, plus malformed strings) with zero divergences.

One note on measurement, since it cuts against how bundle-size changes here have been judged recently: a reduction in minified bytes does not reliably survive compression. Refactors that merely remove duplicated text tend to be gzip-neutral or slightly negative, because LZ77 already encodes the repetition almost for free while the new helper names are fresh bytes. This change is a real removal rather than a dedup, which is why it survives compression at all.

Related: [#6050](https://github.com/colinhacks/zod/issues/6050), [#4433](https://github.com/colinhacks/zod/issues/4433).
