### PR TITLE
fix(v4): preserve key optionality through .transform()

### DIFF
--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -398,6 +398,60 @@ test("transform preserves optout from the in side", () => {
   expect(json.required).toEqual(undefined);
 });
 
+// When a property is optional on both axes and the key is absent, the issues it raised are
+// dropped — and so is its value. $ZodObjectJIT generates its own copy of that rule, so pin the
+// fastpass, the interpreted path, and async (which routes back through handlePropertyResult)
+// together: a fastpass that swallowed the issue but still assigned leaked the transform's
+// return value, `z.NEVER` included, into a successful result.
+test("absent optional key drops the issue and the value together", async () => {
+  const schema = z.object({
+    a: z
+      .string()
+      .optional()
+      .transform((_v, ctx) => {
+        ctx.addIssue({ code: "custom", message: "bad" });
+        return "leaked";
+      }),
+  });
+
+  // toStrictEqual, so a fastpass that regressed to assigning `a: undefined` is caught too.
+  expect(schema.parse({})).toStrictEqual({});
+  expect(schema.parse({}, { jitless: true })).toStrictEqual({});
+  await expect(schema.parseAsync({})).resolves.toStrictEqual({});
+
+  // A key that is actually present still reports the issue.
+  expect(schema.safeParse({ a: "x" }).success).toEqual(false);
+  expect(schema.safeParse({ a: "x" }, { jitless: true }).success).toEqual(false);
+
+  // The branch is reachable without a transform — a check that writes `ctx.value` alongside an
+  // issue hits it too, so this case pins the fastpass even if the pipe carve-out above ever goes.
+  const refined = z.object({
+    a: z
+      .string()
+      .optional()
+      .superRefine((_v, ctx) => {
+        ctx.addIssue({ code: "custom", message: "bad" });
+        ctx.value = "leaked";
+      }),
+  });
+  expect(refined.parse({})).toStrictEqual({});
+  expect(refined.parse({}, { jitless: true })).toStrictEqual({});
+
+  // handleTupleResults truncates for the tuple analog.
+  const tuple = z.tuple([
+    z.string(),
+    z
+      .number()
+      .optional()
+      .transform((_v, ctx) => {
+        ctx.addIssue({ code: "custom", message: "bad" });
+        return 1;
+      }),
+  ]);
+  expect(tuple.parse(["a"])).toEqual(["a"]);
+  expect(tuple.safeParse(["a", 2]).success).toEqual(false);
+});
+
 // Defensive: tuple optional-tail inference also reads optout. The PR that introduced
 // `"includeUndefined"` had to update TupleOutputTypeWithOptionals; pin the result so
 // any future flag change has to keep this contract.

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -113,11 +113,14 @@ test("pipe optionality inside objects", () => {
   }>();
 
   type SchemaOut = z.output<typeof schema>;
+  // `d` is optional-out but required-in, so an absent key is rejected outright (asserted in
+  // "object absent keys require optin optional" below). A key that can never be missing is not
+  // key-optional, whatever its value type.
   expectTypeOf<SchemaOut>().toEqualTypeOf<{
     a?: string | undefined;
     b: string;
     c: string;
-    d?: string | undefined;
+    d: string | undefined;
     e: string;
   }>();
 });
@@ -291,14 +294,14 @@ test("object key optionality through optout propagation", () => {
   const unionWithOpt = z.object({ k: z.union([z.string(), z.string().optional()]) });
   expectTypeOf<z.infer<typeof unionWithOpt>>().toEqualTypeOf<{ k?: string | undefined }>();
 
-  // pipe ending in optional()
+  // pipe ending in optional(), but required-in: the key is never absent, so it stays required
   const pipedToOpt = z.object({
     k: z
       .string()
       .transform((v) => (Math.random() ? v : undefined))
       .pipe(z.string().optional()),
   });
-  expectTypeOf<z.output<typeof pipedToOpt>>().toEqualTypeOf<{ k?: string | undefined }>();
+  expectTypeOf<z.output<typeof pipedToOpt>>().toEqualTypeOf<{ k: string | undefined }>();
 
   // mixed shape pinning required vs optional keys end-to-end
   const mixed = z.object({
@@ -315,6 +318,84 @@ test("object key optionality through optout propagation", () => {
     def: string;
     nullableOpt?: string | null | undefined;
   }>();
+});
+
+// `$ZodTransform` declares optout, and a key is only omissible when optin and optout agree.
+// Before that, the pipe read the transform's silence as "required" and `.transform()` dropped
+// key optionality the parser still honors at runtime.
+test("transform preserves optout from the in side", () => {
+  const transformed = z.object({
+    a: z
+      .string()
+      .nullish()
+      .transform((v) => v),
+  });
+  expectTypeOf<z.input<typeof transformed>>().toEqualTypeOf<{ a?: string | null | undefined }>();
+  expectTypeOf<z.output<typeof transformed>>().toEqualTypeOf<{ a?: string | null | undefined }>();
+  expect(transformed._zod.def.shape.a._zod.optout).toEqual("optional");
+
+  // The runtime the type now matches: absent in, absent out.
+  expect("a" in transformed.parse({})).toEqual(false);
+  expect("a" in transformed.parse({}, { jitless: true })).toEqual(false);
+  expect("a" in transformed.parse({ a: undefined })).toEqual(true);
+
+  // A required in side stays required — the transform doesn't invent optionality. It declares
+  // optout, but optin still comes from the leading schema, and a key needs both to be omissible.
+  const required = z.object({ a: z.string().transform((v) => v.length) });
+  expectTypeOf<z.output<typeof required>>().toEqualTypeOf<{ a: number }>();
+  expect(required._zod.def.shape.a._zod.optin).toEqual(undefined);
+  expect(required.safeParse({}).success).toEqual(false);
+
+  // A transform that fills the absent case still produces the key.
+  const filled = z.object({
+    a: z
+      .string()
+      .optional()
+      .transform((v) => v ?? "x"),
+  });
+  expect(filled.parse({})).toEqual({ a: "x" });
+
+  // Tuple tails apply the same conjunction, so the trailing slot trims like the untransformed one.
+  const tuple = z.tuple([
+    z.string(),
+    z
+      .number()
+      .optional()
+      .transform((v) => v),
+  ]);
+  expectTypeOf<z.output<typeof tuple>>().toEqualTypeOf<[string, (number | undefined)?]>();
+  expect(tuple.parse(["a"])).toEqual(["a"]);
+
+  // ...and a required-in transform tail stays required. The `.rest()` variant is the one that
+  // discriminates: without a rest the length precheck rejects a short array before `optout` is
+  // ever consulted, so only this shape reaches the trim branch.
+  const requiredTail = z.tuple([z.string(), z.string().transform((v) => v.length)]);
+  expectTypeOf<z.output<typeof requiredTail>>().toEqualTypeOf<[string, number]>();
+  expect(requiredTail.safeParse(["a"]).success).toEqual(false);
+
+  const withRest = z.tuple([z.string(), z.string().transform((v) => v)], z.string());
+  expect(withRest.safeParse(["a"]).success).toEqual(false);
+  expect(withRest.safeParse(["a"], { jitless: true }).success).toEqual(false);
+  expect(withRest.parse(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+
+  // The trailing-undefined trim is the other runtime reader. `z.any()` yields undefined without
+  // issues, so with a rest the absent tail reaches it; a required in side must keep the slot.
+  const anyTail = z.tuple([z.string(), z.any().transform((v) => v)], z.string());
+  expectTypeOf<z.output<typeof anyTail>>().toEqualTypeOf<[string, any, ...string[]]>();
+  expect(anyTail.parse(["a"])).toEqual(["a", undefined]);
+  expect(anyTail.parse(["a"], { jitless: true })).toEqual(["a", undefined]);
+
+  // JSON Schema `required` reads the same conjunction, so a required-in transform keeps its key.
+  const requiredInJson = z.toJSONSchema(z.object({ a: z.string().transform((v) => v.length) }), {
+    io: "output",
+    unrepresentable: "any",
+  });
+  expect(requiredInJson.required).toEqual(["a"]);
+
+  // JSON Schema `required` reads the same flag, so it moves in lockstep with the inferred type.
+  // Only reachable with `unrepresentable: "any"` — the default throws on a transform.
+  const json = z.toJSONSchema(transformed, { io: "output", unrepresentable: "any" });
+  expect(json.required).toEqual(undefined);
 });
 
 // Defensive: tuple optional-tail inference also reads optout. The PR that introduced

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -13,7 +13,7 @@ import {
   initializeContext,
   process,
 } from "./to-json-schema.js";
-import { assignProp, getEnumValues } from "./util.js";
+import { assignProp, getEnumValues, isOmissible } from "./util.js";
 
 const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> = {
   guid: "uuid",
@@ -283,12 +283,10 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
   const allKeys = new Set(Object.keys(shape));
   const requiredKeys = new Set(
     [...allKeys].filter((key) => {
-      const v = def.shape[key]!._zod;
       if (ctx.io === "input") {
-        return v.optin === undefined;
-      } else {
-        return v.optout === undefined;
+        return def.shape[key]!._zod.optin === undefined;
       }
+      return !isOmissible(def.shape[key]!);
     })
   );
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2038,23 +2038,25 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         doc.write(`const ${id} = ${parseStr(key)};`);
 
         if (isOptionalIn && isOptionalOut) {
-          // For optional-in/out schemas, ignore errors on absent keys
+          // For optional-in/out schemas, ignore errors on absent keys — and skip the
+          // assignment too, matching handlePropertyResult's early return. Otherwise the value
+          // produced alongside a swallowed issue lands in a successful result.
           doc.write(`
-        if (${id}.issues.length) {
-          if (${isPresent}) {
+        if (!${id}.issues.length || ${isPresent}) {
+          if (${id}.issues.length) {
             payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
               ...iss,
               path: iss.path ? [${k}, ...iss.path] : [${k}]
             })));
           }
-        }
-        
-        if (${id}.value === undefined) {
-          if (${isPresent}) {
-            newResult[${k}] = undefined;
+
+          if (${id}.value === undefined) {
+            if (${isPresent}) {
+              newResult[${k}] = undefined;
+            }
+          } else {
+            newResult[${k}] = ${id}.value;
           }
-        } else {
-          newResult[${k}] = ${id}.value;
         }
 
       `);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1697,6 +1697,8 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
 
 type OptionalOutSchema = { _zod: { optout: "optional" } };
 type OptionalInSchema = { _zod: { optin: "optional" } };
+/** A slot can be left out only if absence is legal going in and the output can be `undefined`. */
+type OmissibleSchema = { _zod: { optin: "optional"; optout: "optional" } };
 
 export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<string, unknown>> = string extends keyof T
   ? util.IsAny<T[keyof T]> extends true
@@ -1706,9 +1708,9 @@ export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<st
     ? Record<string, never>
     : util.Prettify<
         {
-          -readonly [k in keyof T as T[k] extends OptionalOutSchema ? never : k]: T[k]["_zod"]["output"];
+          -readonly [k in keyof T as T[k] extends OmissibleSchema ? never : k]: T[k]["_zod"]["output"];
         } & {
-          -readonly [k in keyof T as T[k] extends OptionalOutSchema ? k : never]?: T[k]["_zod"]["output"];
+          -readonly [k in keyof T as T[k] extends OmissibleSchema ? k : never]?: T[k]["_zod"]["output"];
         } & Extra
       >;
 
@@ -2664,7 +2666,7 @@ type TupleOutputTypeWithOptionals<T extends util.TupleItems> = T extends readonl
   ...infer Prefix extends SomeType[],
   infer Tail extends SomeType,
 ]
-  ? Tail["_zod"]["optout"] extends "optional"
+  ? Tail extends OmissibleSchema
     ? [...TupleOutputTypeWithOptionals<Prefix>, core.output<Tail>?]
     : TupleOutputTypeNoOptionals<T>
   : [];
@@ -2707,7 +2709,7 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
     const proms: Promise<any>[] = [];
 
     const optinStart = getTupleOptStart(items, "optin");
-    const optoutStart = getTupleOptStart(items, "optout");
+    const optoutStart = getTupleOptStart(items, "omissible");
 
     if (!def.rest) {
       if (input.length < optinStart) {
@@ -2772,9 +2774,11 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
   };
 });
 
-function getTupleOptStart(items: readonly $ZodType[], key: "optin" | "optout") {
+function getTupleOptStart(items: readonly $ZodType[], key: "optin" | "omissible") {
   for (let i = items.length - 1; i >= 0; i--) {
-    if (items[i]._zod[key] !== "optional") return i + 1;
+    const el = items[i]._zod;
+    const optional = key === "optin" ? el.optin === "optional" : util.isOmissible(items[i]);
+    if (!optional) return i + 1;
   }
   return 0;
 }
@@ -2816,7 +2820,7 @@ function handleTupleResults(
   // optional-out (e.g. `z.string().or(z.undefined())` accepting an
   // explicit undefined value).
   for (let i = final.value.length - 1; i >= input.length; i--) {
-    if (items[i]._zod.optout === "optional" && final.value[i] === undefined) {
+    if (util.isOmissible(items[i]!) && final.value[i] === undefined) {
       final.value.length = i;
     } else {
       break;
@@ -3445,6 +3449,7 @@ export interface $ZodTransformDef extends $ZodTypeDef {
 export interface $ZodTransformInternals<O = unknown, I = unknown> extends $ZodTypeInternals<O, I> {
   def: $ZodTransformDef;
   isst: never;
+  optout: "optional";
 }
 
 export interface $ZodTransform<O = unknown, I = unknown> extends $ZodType {
@@ -3456,6 +3461,7 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
   (inst, def) => {
     $ZodType.init(inst, def);
     inst._zod.optin = "optional";
+    inst._zod.optout = "optional";
     inst._zod.parse = (payload, ctx) => {
       if (ctx.direction === "backward") {
         throw new core.$ZodEncodeError(inst.constructor.name);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -571,10 +571,14 @@ export function stringifyPrimitive(value: any): string {
   return `${value}`;
 }
 
+/** Whether a slot can be left out entirely: absence must be legal going in, and the output
+ * must be able to be `undefined`. Neither flag answers this on its own. */
+export function isOmissible(schema: schemas.$ZodType): boolean {
+  return schema._zod.optin === "optional" && schema._zod.optout === "optional";
+}
+
 export function optionalKeys(shape: schemas.$ZodShape): string[] {
-  return Object.keys(shape).filter((k) => {
-    return shape[k]!._zod.optin === "optional" && shape[k]!._zod.optout === "optional";
-  });
+  return Object.keys(shape).filter((k) => isOmissible(shape[k]!));
 }
 
 export type CleanKey<T extends PropertyKey> = T extends `?${infer K}` ? K : T extends `${infer K}?` ? K : T;

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -123,9 +123,14 @@ A separate axis from `optin`. Set by:
 |---|---|
 | `$ZodOptional` | `"optional"` |
 | `$ZodExactOptional` | `"optional"` |
+| `$ZodTransform` | `"optional"` |
 | Everything else | inherited or `undefined` |
 
 `$ZodObject` uses it (combined with `optin` and `isPresent`) to decide whether to assign or skip. `$ZodTuple` uses it to decide whether to trim a trailing slot whose value came back as `undefined`.
+
+`$ZodTransform` sets it because a transform's output is whatever the user's fn returns, which may be `undefined`. It used to leave `optout` unset, and `$ZodPipe` — which reads `def.out`'s — read that silence as "required". That is what made `.transform()` erase key optionality: `X.transform(fn)` lowers to `pipe(X, transform(fn))`, so the pipe took its answer from a schema that had not given one.
+
+`optout` alone does not decide a key, though, and that is the other half. A key can only be omitted if absence is legal going in *and* the output can be `undefined` — so every consumer that decides omissibility reads `optin` and `optout` together: object and tuple output inference, `util.optionalKeys`, the tuple trim, and the JSON Schema `required` filter. `optin` alone still gates the questions that are genuinely one-axis — whether an absent key is legal, and the tuple `too_small` precheck. That keeps `z.string().transform(fn)` required (its `optin` comes from the leading `z.string()`) while `z.string().optional().transform(fn)` is key-optional, with no special-casing of the transform anywhere in `$ZodPipe`.
 
 The relevant observation for users: a schema can be **input-required, output-optional** (`z.string().nullable()` with some shapes), or **input-optional, output-required** (`z.string().default("d")` — accepts absence, never produces undefined). The `optin` × `optout` matrix has all four combinations and they all matter for object/tuple parsing.
 
@@ -375,6 +380,7 @@ z.object({ a: z.preprocess(fn, z.string().optional()) }).parse({})
 | [#5661](https://github.com/colinhacks/zod/pull/5661) | Made `$ZodObject` / `$ZodTuple` strict about absent slots — consult `optin`. Source of the 4.4 regressions. |
 | [#5917](https://github.com/colinhacks/zod/pull/5917) / [#5929](https://github.com/colinhacks/zod/pull/5929) | Made preprocess defer optionality to inner schema (so `preprocess(fn, X.optional())` worked again). Pure metadata-override subtype design. |
 | [#5937](https://github.com/colinhacks/zod/issues/5937) / [#5939](https://github.com/colinhacks/zod/pull/5939) | Restored `$ZodCatch.optin = "optional"` runtime + introduced the `caught` flag so an outer `$ZodOptional` could clobber catch's recovery. |
+| [#5178](https://github.com/colinhacks/zod/issues/5178) | Gave `$ZodTransform` its own `optout = "optional"` and made object output inference require `optin` *and* `optout`, matching `util.optionalKeys`. Restores the v3 key optionality that `.transform()` had been erasing. Also corrects `A.transform(fn).pipe(B.optional())`, which inferred a key-optional output for a key the parser rejects when absent. |
 | [#5941](https://github.com/colinhacks/zod/pull/5941) | Renamed `caught → fallback`; propagated through `$ZodPipe` boundaries; also makes `$ZodPreprocess.optin = "optional"` and `$ZodTransform` set `fallback` on every invocation. Restores the bare-`preprocess` regression. **Plus** prototype commit promoting `optin = "optional"` from preprocess to transform (under consideration). |
 
 ## Design principle: flexible inputs, strict outputs (at runtime)

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -68,7 +68,7 @@ The user-visible consequence: `z.input<typeof z.object({ a: z.preprocess(fn, T) 
 
 ### How the consumer reads it
 
-`$ZodObject.handlePropertyResult` (and the JIT codegen mirroring it):
+`$ZodObject.handlePropertyResult` (and the JIT codegen mirroring it — genuinely mirroring it only since the fix logged below; the fastpass used to swallow a property's issues without also skipping its assignment):
 
 ```ts
 const isPresent = key in input;
@@ -381,6 +381,7 @@ z.object({ a: z.preprocess(fn, z.string().optional()) }).parse({})
 | [#5917](https://github.com/colinhacks/zod/pull/5917) / [#5929](https://github.com/colinhacks/zod/pull/5929) | Made preprocess defer optionality to inner schema (so `preprocess(fn, X.optional())` worked again). Pure metadata-override subtype design. |
 | [#5937](https://github.com/colinhacks/zod/issues/5937) / [#5939](https://github.com/colinhacks/zod/pull/5939) | Restored `$ZodCatch.optin = "optional"` runtime + introduced the `caught` flag so an outer `$ZodOptional` could clobber catch's recovery. |
 | [#5178](https://github.com/colinhacks/zod/issues/5178) | Gave `$ZodTransform` its own `optout = "optional"` and made object output inference require `optin` *and* `optout`, matching `util.optionalKeys`. Restores the v3 key optionality that `.transform()` had been erasing. Also corrects `A.transform(fn).pipe(B.optional())`, which inferred a key-optional output for a key the parser rejects when absent. |
+| [#6382](https://github.com/colinhacks/zod/pull/6382) | Separate correctness fix. `$ZodObjectJIT`'s `isOptionalIn && isOptionalOut` branch swallowed a property's issues on an absent key but still ran the assignment, so a value produced alongside a swallowed issue leaked into a `success: true` result — on the default parse path only, with `jitless` and async both correct. Reachable without any transform, via a `.check()` / `.superRefine()` that writes `ctx.value`. |
 | [#5941](https://github.com/colinhacks/zod/pull/5941) | Renamed `caught → fallback`; propagated through `$ZodPipe` boundaries; also makes `$ZodPreprocess.optin = "optional"` and `$ZodTransform` set `fallback` on every invocation. Restores the bare-`preprocess` regression. **Plus** prototype commit promoting `optin = "optional"` from preprocess to transform (under consideration). |
 
 ## Design principle: flexible inputs, strict outputs (at runtime)


### PR DESCRIPTION
`$ZodTransform` never set `optout`, and `$ZodPipe` takes its own from `def.out`. Since `X.transform(fn)` lowers to `pipe(X, transform(fn))`, the pipe was reading a schema that had never given an answer, and read that silence as "required":

```ts
const schema = z.object({ a: z.string().nullish().transform((v) => v) });

type Out = z.output<typeof schema>;
// v3: { a?: string | null | undefined }
// v4: { a: string | null | undefined }

"a" in schema.parse({}); // false, in both
```

`handlePropertyResult` omits a key whose result is `undefined` and whose input key was absent, and does not consult `optout` to decide that — so the inferred type was claiming a key the parser does not emit. A type/runtime mismatch, not a disagreement with v4's optionality design.

### The fix

Two small changes, and `$ZodPipe` is untouched.

**The transform declares its own `optout`**, immediately beside the `optin` it already declares. Its output is whatever the user's fn returns, which may be `undefined`. Nothing else needs to know it is a transform.

**Every consumer that decides omissibility reads both axes.** That follows from the first change: `optout` is a statement about the *value*, not about the slot, so "can this slot be left out" needs `optin` too — absence must be legal going in and the output must be able to be `undefined`. `util.optionalKeys` already applied exactly that conjunction, so it becomes a shared `util.isOmissible`, and object inference, tuple tail inference, the tuple trim, and the JSON Schema `required` filter all adopt it. `optin` alone still gates the genuinely one-axis questions — whether an absent key is legal, and the tuple `too_small` precheck.

Without that second half, `z.string().transform(fn)` becomes omissible everywhere: `z.tuple([z.string(), z.string().transform(fn)], z.string()).parse(["a"])` is silently accepted, the trailing-`undefined` trim drops a required slot, and `io: "output"` JSON Schema loses its `required` entry. Each has a test that fails without the corresponding conjunction.

One accepted imprecision: `.catch()` wrapping a required-in transform infers `a?: T` and loses its `required` entry, though the parser always produces the key. `$ZodCatch` forwards its inner `optout`, and the transform cannot know at runtime what its fn returns. It is a weaker claim than reality rather than a wrong one. Narrowing the transform's declared `optout` by its output type fixes it but breaks schema assignability (`ZodTransform<string>` stops satisfying `$ZodTransform`), so it is not worth it.

### One pre-existing inference this corrects

`A.transform(fn).pipe(B.optional())` inferred a key-optional output for a key the parser rejects outright when absent — the existing `object absent keys require optin optional` test already asserts that `safeParse({})` fails for that shape. Two expectations move from `k?:` to `k:`.

### Second commit: an unrelated JIT correctness fix

`$ZodObjectJIT` generates its own copy of the "ignore errors on absent keys" rule. Its copy suppressed the issue but still ran the assignment, so a value produced alongside a swallowed issue landed in a successful result — default path only, with `jitless` and async correct. Any check that writes `ctx.value` reaches it, no transform required:

```ts
const schema = z.object({
  a: z.string().optional().superRefine((_v, ctx) => {
    ctx.addIssue({ code: "custom", message: "bad" });
    ctx.value = "leaked";
  }),
});

schema.safeParse({});                    // was: { success: true, data: { a: "leaked" } }
schema.safeParse({}, { jitless: true }); // was: { success: true, data: {} }
```

Fixes #5178
