### PR TITLE
fix(v4): let bundlers tree-shake locales out of the default import

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -323,7 +323,7 @@ async function loadLocale(locale: string) {
 await loadLocale("fr");
 ```
 
-For convenience, all locales are exported as `z.locales` from `"zod"`. In some bundlers, this may not be tree-shakable.
+For convenience, all locales are exported as `z.locales` from `"zod"`. Rollup and Webpack tree-shake this down to the locales you actually use. esbuild can't ([evanw/esbuild#1420](https://github.com/evanw/esbuild/issues/1420)) — with `import { z } from "zod"` or `import z from "zod"` it bundles every locale, so prefer `import * as z from "zod"` there.
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
 <Tab value="Zod">

--- a/packages/treeshake/locale-treeshake.test.ts
+++ b/packages/treeshake/locale-treeshake.test.ts
@@ -1,0 +1,59 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import resolve from "@rollup/plugin-node-resolve";
+import { type Plugin, rollup } from "rollup";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Strings unique to a single locale. Grepping the bundle for them proves inclusion
+// rather than inferring it from byte counts.
+const GERMAN = "Zu klein: erwartet";
+const JAPANESE = "小さすぎる値";
+
+// `import z from "zod"` used to pull all 53 locale modules into the bundle, because
+// `export default z` made the default export a fresh namespace value rather than a
+// re-export of the `z` binding — see #6050.
+function entry(code: string): Plugin {
+  const id = path.join(__dirname, "__entry__.mjs");
+  return {
+    name: "entry",
+    resolveId: (source) => (source === id ? id : null),
+    load: (loaded) => (loaded === id ? code : null),
+    options: (opts) => ({ ...opts, input: id }),
+  };
+}
+
+async function bundle(code: string): Promise<string> {
+  const build = await rollup({
+    input: "ignored",
+    plugins: [entry(code), resolve()],
+    treeshake: { preset: "smallest", annotations: true },
+    onwarn: () => {},
+  });
+  const { output } = await build.generate({ format: "esm" });
+  await build.close();
+  return output.map((chunk) => (chunk.type === "chunk" ? chunk.code : "")).join("");
+}
+
+describe("locale tree-shaking", () => {
+  it("drops unused locales from a default import", async () => {
+    const code = await bundle(`import z from "zod";\nconsole.log(z.string().min(5).safeParse("hi"));`);
+    expect(code).not.toContain(GERMAN);
+    expect(code).not.toContain(JAPANESE);
+  });
+
+  it("drops unused locales from a named import", async () => {
+    const code = await bundle(`import { z } from "zod";\nconsole.log(z.string().min(5).safeParse("hi"));`);
+    expect(code).not.toContain(GERMAN);
+    expect(code).not.toContain(JAPANESE);
+  });
+
+  it("keeps the one locale that is used, and only that one", async () => {
+    const code = await bundle(
+      `import z from "zod";\nz.config(z.locales.de());\nconsole.log(z.string().min(5).safeParse("hi"));`
+    );
+    expect(code).toContain(GERMAN);
+    expect(code).not.toContain(JAPANESE);
+  });
+});

--- a/packages/treeshake/locale-treeshake.test.ts
+++ b/packages/treeshake/locale-treeshake.test.ts
@@ -1,10 +1,18 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import resolve from "@rollup/plugin-node-resolve";
 import { type Plugin, rollup } from "rollup";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Unlike the rest of the suite, this file bundles the BUILT package: `resolve()` knows
+// nothing about vitest's `@zod/source` condition, so `zod` resolves through `exports` to
+// `packages/zod/index.js`. That is the faithful thing to measure — it is what consumers
+// actually bundle — but it means the assertions are stale until you `pnpm build`. CI is
+// fine, since `pnpm build` precedes `pnpm test`.
+const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
 
 // Strings unique to a single locale. Grepping the bundle for them proves inclusion
 // rather than inferring it from byte counts.
@@ -13,7 +21,15 @@ const JAPANESE = "小さすぎる値";
 
 // `import z from "zod"` used to pull all 53 locale modules into the bundle, because
 // `export default z` made the default export a fresh namespace value rather than a
-// re-export of the `z` binding — see #6050.
+// re-export of the `z` binding — see #6050. Rollup and Webpack share that blind spot and
+// were fixed by the same one-line change, so guarding Rollup guards both; esbuild cannot
+// shake a re-exported namespace at all (evanw/esbuild#1420) and is out of scope here.
+//
+// Both specifiers are covered because they were fixed in separate files — a regression in
+// `src/v4/index.ts` alone would otherwise go unnoticed. `zod/mini` and `zod/v4-mini` are
+// deliberately absent: they have no default export, so Rollup errors on `import z from`.
+const SPECIFIERS = ["zod", "zod/v4"];
+
 function entry(code: string): Plugin {
   const id = path.join(__dirname, "__entry__.mjs");
   return {
@@ -37,23 +53,29 @@ async function bundle(code: string): Promise<string> {
 }
 
 describe("locale tree-shaking", () => {
-  it("drops unused locales from a default import", async () => {
-    const code = await bundle(`import z from "zod";\nconsole.log(z.string().min(5).safeParse("hi"));`);
-    expect(code).not.toContain(GERMAN);
-    expect(code).not.toContain(JAPANESE);
+  beforeAll(() => {
+    if (!existsSync(BUILT_ENTRY)) throw new Error(`zod is not built — run \`pnpm build\` first (${BUILT_ENTRY})`);
   });
 
-  it("drops unused locales from a named import", async () => {
-    const code = await bundle(`import { z } from "zod";\nconsole.log(z.string().min(5).safeParse("hi"));`);
-    expect(code).not.toContain(GERMAN);
-    expect(code).not.toContain(JAPANESE);
-  });
+  for (const spec of SPECIFIERS) {
+    it(`drops unused locales from a default import of ${spec}`, async () => {
+      const code = await bundle(`import z from "${spec}";\nconsole.log(z.string().min(5).safeParse("hi"));`);
+      expect(code).not.toContain(GERMAN);
+      expect(code).not.toContain(JAPANESE);
+    });
 
-  it("keeps the one locale that is used, and only that one", async () => {
-    const code = await bundle(
-      `import z from "zod";\nz.config(z.locales.de());\nconsole.log(z.string().min(5).safeParse("hi"));`
-    );
-    expect(code).toContain(GERMAN);
-    expect(code).not.toContain(JAPANESE);
-  });
+    it(`drops unused locales from a named import of ${spec}`, async () => {
+      const code = await bundle(`import { z } from "${spec}";\nconsole.log(z.string().min(5).safeParse("hi"));`);
+      expect(code).not.toContain(GERMAN);
+      expect(code).not.toContain(JAPANESE);
+    });
+
+    it(`keeps the one locale used via ${spec}, and only that one`, async () => {
+      const code = await bundle(
+        `import z from "${spec}";\nz.config(z.locales.de());\nconsole.log(z.string().min(5).safeParse("hi"));`
+      );
+      expect(code).toContain(GERMAN);
+      expect(code).not.toContain(JAPANESE);
+    });
+  }
 });

--- a/packages/treeshake/zod-default-import.ts
+++ b/packages/treeshake/zod-default-import.ts
@@ -1,0 +1,4 @@
+import z from "zod";
+
+const schema = z.object({ title: z.string().min(5) });
+console.log(schema.safeParse({ title: "hi" }).error?.issues[0].message);

--- a/packages/treeshake/zod-named-import.ts
+++ b/packages/treeshake/zod-named-import.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+const schema = z.object({ title: z.string().min(5) });
+console.log(schema.safeParse({ title: "hi" }).error?.issues[0].message);

--- a/packages/zod/src/index.ts
+++ b/packages/zod/src/index.ts
@@ -1,4 +1,7 @@
 import * as z from "./v4/classic/external.js";
 export * from "./v4/classic/external.js";
-export { z };
-export default z;
+// Aliasing the binding, instead of `export default z`, keeps the default export a
+// re-export of `z` rather than a fresh namespace value. Rollup and Webpack can then
+// shake `import z from "zod"` as they already shake `import { z } from "zod"` — without
+// this they pull in every locale. See #6050.
+export { z, z as default };

--- a/packages/zod/src/v4/classic/index.ts
+++ b/packages/zod/src/v4/classic/index.ts
@@ -1,5 +1,5 @@
 import * as z from "./external.js";
 
-export { z };
 export * from "./external.js";
-export default z;
+// See the note in `src/index.ts` — aliasing keeps the default export shakable.
+export { z, z as default };

--- a/packages/zod/src/v4/index.ts
+++ b/packages/zod/src/v4/index.ts
@@ -1,3 +1,5 @@
+import z4 from "./classic/index.js";
 export * from "./classic/index.js";
-// See the note in `src/index.ts` — re-exporting the binding keeps it shakable.
-export { default } from "./classic/index.js";
+// See the note in `src/index.ts` — aliasing keeps the default export shakable.
+// Aliased rather than `export { default } from`, which emits a CJS getter.
+export { z4 as default };

--- a/packages/zod/src/v4/index.ts
+++ b/packages/zod/src/v4/index.ts
@@ -1,4 +1,3 @@
-import z4 from "./classic/index.js";
 export * from "./classic/index.js";
-
-export default z4;
+// See the note in `src/index.ts` — re-exporting the binding keeps it shakable.
+export { default } from "./classic/index.js";

--- a/packages/zod/src/v4/index.ts
+++ b/packages/zod/src/v4/index.ts
@@ -1,5 +1,6 @@
-import z4 from "./classic/index.js";
+import * as z4 from "./classic/external.js";
 export * from "./classic/index.js";
 // See the note in `src/index.ts` — aliasing keeps the default export shakable.
-// Aliased rather than `export { default } from`, which emits a CJS getter.
+// Aliased from the namespace, not from `./classic/index.js`'s default, so both the
+// tsc and Babel CJS outputs stay a plain `exports.default =` rather than a getter.
 export { z4 as default };


### PR DESCRIPTION
Partially addresses #6050. `import z from "zod"` was pulling all 53 locale modules into the bundle.

`export default z` made the default export a fresh namespace value rather than a re-export of the `z` binding. Rollup and Webpack both do property-level shaking on a re-exported namespace, but fall back to including everything when it's reached through a default export. Aliasing the binding — `export { z, z as default }` — makes them treat it like the named export they already handled. Applied to the three entries that have a default export; the mini entries have none.

Measured against the built package with a trivial `z.object({ title: z.string().min(5) })` consumer, grepping each bundle for strings unique to `de` and `ja` rather than inferring from byte counts. Re-measured after rebasing onto current `main`, since `z.creditCard()` grew every locale file:

| bundler | before | after |
|---|---|---|
| Rollup 4.62, `preset: "smallest"` | 591,761 (all locales) | **138,465 (none)** |
| Webpack 5.109, `mode: "production"` | 593,643 (all locales) | **295,761 (none)** |

`import z from "zod/v4"` moves the same way, 591,609 to 138,465. Shaking stays property-level rather than all-or-nothing: a fixture that calls `z.config(z.locales.de())` comes out at 300,420 under Webpack with German present and Japanese absent, against 593,643 with every locale before. That covers the Next.js report in [#6050](https://github.com/colinhacks/zod/issues/6050) where locales were 60% of the bundle — Next.js bundles with Webpack and the reported code is `import z from "zod"`.

Not an API change. `import z from "zod"` still yields the full namespace, and `z.config(z.locales.xx())` still resolves from `zod` (named, default and namespace import), `zod/v4`, `zod/mini`, `zod/v4-mini` and `zod/locales` — checked all eight.

**esbuild is unaffected and can't be fixed here.** It tracks imports through one level only and cannot shake a re-exported namespace at all — [evanw/esbuild#1420](https://github.com/evanw/esbuild/issues/1420), open, still reproducing on 0.28.2. `import { z } from "zod"` and `import z from "zod"` keep every locale there; `import * as z from "zod"` shakes them all out and always has. Getters, `/*@__PURE__*/`, `sideEffects` variations and `Proxy` were all tried and none of them drops the members. The docs caveat now names esbuild and points at the import form that works, instead of the previous "in some bundlers, this may not be tree-shakable".

Worth noting for #5953: nothing here touches `sideEffects`, `config(en())` or the stub generator. I ran this branch's fixture against #5959 and the locale byte count is identical, so the two compose — and #5959 is what makes the `import * as z` path actually usable, since today it's small but emits `Invalid input`.

`packages/treeshake/locale-treeshake.test.ts` guards the regression with Rollup's JS API, parameterized over `zod` and `zod/v4` — both were fixed in separate files, so a revert of either one alone fails two of the six cases. Each specifier also gets a case that configures `de` and asserts German present / Japanese absent, so a green run is evidence the grep works rather than evidence it matched nothing. Rollup and Webpack share the blind spot and were fixed by the same change, so guarding Rollup guards both.

**Verification across runtimes and bundlers.** `export { x as default }` is a real ESM semantic change, not a spelling change — the spec reclassifies it as an *indirect* export, and that reclassification is exactly what lets Rollup and Webpack shake it. Checked the observable surface is nonetheless unchanged, since all three aliased bindings are immutable import bindings:

| target | result |
|---|---|
| Node ESM + CJS through the real `exports` map | pass — no `.default.default` trap, identity preserved |
| Bun 1.3.14 runtime, Deno 2.8.1 | pass |
| Babel CJS transform (Jest / React Native) | pass — see below |
| Rollup 4.62, Webpack 5.109 | pass, plus the size win |
| esbuild 0.25.12 / 0.28.2, `bun build` | unchanged, upstream limitation |

That pass caught a real defect in the first attempt: re-exporting `zod/v4`'s default from `./classic/index.js`'s default binding is an indirect export, which **Babel** models as an `Object.defineProperty` getter. tsc emitted a plain assignment, but Jest and React Native go through Babel and would have seen the descriptor change. The last commit aliases the `external.js` namespace instead, so both toolchains emit `exports.default = z4;`. `zod/v4`'s default still compares `===` to `zod`'s and the export count matches at 240.

Incidental finding, unrelated to this PR: **webpack 4 cannot parse zod v4 at all**, by either entry, before or after this change — its acorn 6 rejects both `export * as` and `??`. Anyone on webpack 4 must already be transpiling zod.

The pattern is well-established in published ESM — `eventemitter3` ships `export{o as EventEmitter,o as default}`, the exact shape used here, and `magic-string`, `cac` and `tailwindcss` ship variants.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
