### PR TITLE
fix(v4): consistently strip __proto__ from parsed objects

### DIFF
--- a/packages/zod/src/v3/tests/intersection.test.ts
+++ b/packages/zod/src/v3/tests/intersection.test.ts
@@ -21,6 +21,24 @@ test("object intersection", () => {
   expect(() => z.intersection(BaseTeacher.strict(), HasID).parse({ ...data, extra: 12 })).toThrow();
 });
 
+test("object intersection strips __proto__ from pass-through operands", () => {
+  const cases = [
+    [
+      z.intersection(z.object({ name: z.string() }), z.unknown()),
+      JSON.parse('{"__proto__":{"isAdmin":true},"name":"alice"}'),
+      { name: "alice" },
+    ],
+    [z.intersection(z.record(z.string(), z.unknown()), z.any()), JSON.parse('{"__proto__":{},"a":1}'), { a: 1 }],
+  ] as const;
+
+  for (const [schema, input, expected] of cases) {
+    const parsed = schema.parse(input);
+    expect(parsed).toEqual(expected);
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+  }
+});
+
 test("deep intersection", () => {
   const Animal = z.object({
     properties: z.object({

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -3249,7 +3249,9 @@ function mergeValues(a: any, b: any): { valid: true; data: any } | { valid: fals
     const sharedKeys = util.objectKeys(a).filter((key) => bKeys.indexOf(key) !== -1);
 
     const newObj: any = { ...a, ...b };
+    if (Object.prototype.hasOwnProperty.call(newObj, "__proto__")) delete newObj.__proto__;
     for (const key of sharedKeys) {
+      if (key === "__proto__") continue;
       const sharedValue = mergeValues(a[key], b[key]);
       if (!sharedValue.valid) {
         return { valid: false };

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -707,8 +707,8 @@ test.each(["__proto__", "constructor", "toString", "hasOwnProperty", "valueOf"])
       ["value", "ok"],
     ]);
     const parsed: any = schema.parse(input);
-    expect(Object.prototype.hasOwnProperty.call(parsed, key)).toBe(true);
-    expect(parsed[key]).toBe("a");
+    expect(Object.prototype.hasOwnProperty.call(parsed, key)).toBe(key !== "__proto__");
+    if (key !== "__proto__") expect(parsed[key]).toBe("a");
     expect(parsed.value).toBe("ok");
   }
 );

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -897,7 +897,7 @@ test("Date default is coerced to its JSON string form", () => {
 // An object literal can't express an own "__proto__" key — `{ __proto__: x }`
 // sets the literal's prototype instead. JSON.parse is both the realistic source
 // of a JSON Schema and the only way to write these cases.
-test("required __proto__ property is kept and enforced", () => {
+test("required __proto__ property is represented in the shape but stripped during parsing", () => {
   const schema = fromJSONSchema(
     JSON.parse(`{
       "type": "object",
@@ -906,9 +906,10 @@ test("required __proto__ property is kept and enforced", () => {
     }`)
   );
 
-  expect(schema.safeParse({ role: "x" }).success).toBe(false);
-  expect(schema.safeParse(JSON.parse(`{ "role": "x", "__proto__": "wrong" }`)).success).toBe(false);
-  expect(schema.safeParse(JSON.parse(`{ "role": "x", "__proto__": "admin" }`)).success).toBe(true);
+  expect(Object.prototype.hasOwnProperty.call((schema as z.ZodObject).shape, "__proto__")).toBe(true);
+  expect(schema.parse({ role: "x" })).toEqual({ role: "x" });
+  expect(schema.parse(JSON.parse(`{ "role": "x", "__proto__": "wrong" }`))).toEqual({ role: "x" });
+  expect(schema.parse(JSON.parse(`{ "role": "x", "__proto__": "admin" }`))).toEqual({ role: "x" });
 });
 
 test("__proto__ annotation key reaches the registry", () => {

--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -67,6 +67,24 @@ test("object intersection: strict + strict", () => {
   `);
 });
 
+test("object intersection strips __proto__ from pass-through operands", () => {
+  const cases = [
+    [
+      z.intersection(z.object({ name: z.string() }), z.unknown()),
+      JSON.parse('{"__proto__":{"isAdmin":true},"name":"alice"}'),
+      { name: "alice" },
+    ],
+    [z.intersection(z.record(z.string(), z.unknown()), z.any()), JSON.parse('{"__proto__":{},"a":1}'), { a: 1 }],
+  ] as const;
+
+  for (const [schema, input, expected] of cases) {
+    const parsed = schema.parse(input);
+    expect(parsed).toEqual(expected);
+    expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+  }
+});
+
 test("deep intersection", () => {
   const Animal = z.object({
     properties: z.object({

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -717,7 +717,7 @@ describe("__proto__ in object catchall paths", () => {
     }
   });
 
-  test("strict still accepts a __proto__ key the shape declares", () => {
+  test("strict accepts but strips a __proto__ key the shape declares", () => {
     const shape: any = { name: z.string() };
     Object.defineProperty(shape, "__proto__", {
       value: z.string(),
@@ -731,7 +731,7 @@ describe("__proto__ in object catchall paths", () => {
       const result = schema.safeParse(input);
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(Object.keys(result.data)).toEqual(["name", "__proto__"]);
+        expect(Object.keys(result.data)).toEqual(["name"]);
         expect(Object.getPrototypeOf(result.data)).toBe(Object.prototype);
       }
     }
@@ -754,9 +754,7 @@ describe("__proto__ in object catchall paths", () => {
   });
 });
 
-// A __proto__ key declared in the shape is a field the caller asked for, so it must round-trip as
-// an own data property instead of hitting the inherited setter (which replaced the result
-// prototype and dropped the value).
+// Parsed objects always strip __proto__, including keys explicitly declared by the schema.
 describe("__proto__ as a declared shape key", () => {
   const protoInput = () => JSON.parse('{"__proto__":{"isAdmin":true},"name":"alice"}');
   const makeShape = () =>
@@ -765,20 +763,19 @@ describe("__proto__ as a declared shape key", () => {
       ["name", z.string()],
     ]) as Record<string, any>;
 
-  const expectOwnProp = (parsed: any) => {
+  const expectStripped = (parsed: any) => {
     expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
-    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
-    expect(parsed.__proto__).toEqual({ isAdmin: true });
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
     expect((parsed as any).isAdmin).toBeUndefined();
-    expect(Object.keys(parsed).sort()).toEqual(["__proto__", "name"]);
+    expect(Object.keys(parsed)).toEqual(["name"]);
   };
 
   test("jit fastpass", () => {
-    expectOwnProp(z.object(makeShape()).parse(protoInput()));
+    expectStripped(z.object(makeShape()).parse(protoInput()));
   });
 
   test("jitless", () => {
-    expectOwnProp(z.object(makeShape()).parse(protoInput(), { jitless: true } as any));
+    expectStripped(z.object(makeShape()).parse(protoInput(), { jitless: true } as any));
   });
 
   test("async", async () => {
@@ -786,35 +783,33 @@ describe("__proto__ as a declared shape key", () => {
       ["__proto__", z.object({ isAdmin: z.boolean() }).refine(async () => true)],
       ["name", z.string()],
     ]) as Record<string, any>;
-    expectOwnProp(await z.object(shape).parseAsync(protoInput()));
+    expectStripped(await z.object(shape).parseAsync(protoInput()));
   });
 
-  test("primitive value is not silently dropped", () => {
+  test("primitive value is stripped", () => {
     const schema = z.object(Object.fromEntries([["__proto__", z.string()]]) as Record<string, any>);
     const parsed: any = schema.parse(JSON.parse('{"__proto__":"hello"}'));
-    expect(parsed.__proto__).toBe("hello");
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
     expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
   });
 
-  test("validation still applies", () => {
+  test("declared key is not validated", () => {
     const schema = z.object(Object.fromEntries([["__proto__", z.string()]]) as Record<string, any>);
-    expect(schema.safeParse(JSON.parse('{"__proto__":123}')).success).toBe(false);
+    expect(schema.parse(JSON.parse('{"__proto__":123}'))).toEqual({});
   });
 
-  test("an absent key uses own-property semantics", () => {
+  test("required, optional, and defaulted declarations are all stripped", () => {
     const shape = (schema: z.ZodType) => Object.fromEntries([["__proto__", schema]]) as Record<string, any>;
 
     for (const jitless of [false, true]) {
       const ctx = { jitless } as any;
-      expect(z.object(shape(z.unknown())).safeParse({}, ctx).success).toBe(false);
+      expect(z.object(shape(z.unknown())).parse({}, ctx)).toEqual({});
       expect(z.object(shape(z.string().optional())).parse({}, ctx)).toEqual({});
-
-      const withDefault: any = z.object(shape(z.string().default("fallback"))).parse({}, ctx);
-      expect(Object.getOwnPropertyDescriptor(withDefault, "__proto__")!.value).toBe("fallback");
+      expect(z.object(shape(z.string().default("fallback"))).parse({}, ctx)).toEqual({});
     }
   });
 
-  test("an own getter is still evaluated", () => {
+  test("an own getter is not evaluated", () => {
     let reads = 0;
     const input = Object.defineProperty({}, "__proto__", {
       get() {
@@ -825,8 +820,8 @@ describe("__proto__ as a declared shape key", () => {
     });
     const schema = z.object(Object.fromEntries([["__proto__", z.string()]]) as Record<string, any>);
 
-    expect(Object.getOwnPropertyDescriptor(schema.parse(input), "__proto__")!.value).toBe("value");
-    expect(reads).toBe(1);
+    expect(schema.parse(input)).toEqual({});
+    expect(reads).toBe(0);
   });
 
   test("pick keeps a declared key", () => {
@@ -836,7 +831,7 @@ describe("__proto__ as a declared shape key", () => {
 
     expect(Object.keys(picked.shape)).toEqual(["__proto__"]);
     const parsed: any = picked.parse(Object.fromEntries([["__proto__", "value"]]));
-    expect(Object.getOwnPropertyDescriptor(parsed, "__proto__")!.value).toBe("value");
+    expect(parsed).toEqual({});
     expect(() => z.object({ value: z.string() }).pick(mask as any).shape).toThrow('Unrecognized key: "__proto__"');
   });
 

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -754,9 +754,7 @@ test("v3-compat single-arg form: z.record(valueType)", () => {
   });
 });
 
-// A finite key set that declares __proto__ writes through the same assignment as z.object(); the
-// key was declared by the schema, so it round-trips as an own data property.
-test("__proto__ in a finite key set becomes an own property", () => {
+test("__proto__ in a finite key set is stripped", () => {
   const data = JSON.parse('{"__proto__":{"a":"declared"},"b":{"a":"good"}}');
 
   for (const schema of [
@@ -765,8 +763,8 @@ test("__proto__ in a finite key set becomes an own property", () => {
   ]) {
     const parsed: any = schema.parse(data);
     expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
-    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
-    expect(parsed.__proto__).toEqual({ a: "declared" });
+    expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+    expect(Object.keys(parsed)).toEqual(["b"]);
     expect(parsed.a).toBeUndefined();
   }
 
@@ -780,26 +778,26 @@ test("a raw __proto__ input key stays skipped in loose mode", () => {
   expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
 });
 
-test("partialRecord preserves a declared __proto__ key", () => {
+test("partialRecord strips a declared __proto__ key", () => {
   const schema = z.partialRecord(z.enum(["__proto__", "b"]), z.string());
   const parsed: any = schema.parse(Object.fromEntries([["__proto__", "declared"]]));
 
   expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
-  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
-  expect(parsed.__proto__).toBe("declared");
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+  expect(parsed).toEqual({});
   expect(schema.parse({})).toEqual({});
   expect(schema.safeParse({ other: "x" }).success).toBe(false);
 });
 
-test("partialRecord safely passes through a declared __proto__ key in loose mode", () => {
+test("partialRecord strips a declared __proto__ key in loose mode", () => {
   const key = z.enum(["__proto__"]).refine(() => false);
   const schema = z.partialRecord(key, z.unknown(), { mode: "loose" });
   const value = { marker: true };
   const parsed: any = schema.parse(Object.fromEntries([["__proto__", value]]));
 
   expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
-  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
-  expect(parsed.__proto__).toBe(value);
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+  expect(parsed).toEqual({});
   expect(parsed.marker).toBeUndefined();
 });
 
@@ -811,19 +809,20 @@ test("partial is internal to partialRecord", () => {
   expect(schema.parse({})).toEqual({});
 });
 
-test("partialRecord still applies transforms to a declared __proto__ key", () => {
+test("partialRecord strips a declared __proto__ key before transforms", () => {
   const schema = z.partialRecord(
     z.literal("__proto__").transform(() => "safe" as const),
     z.string()
   );
 
-  expect(schema.parse(Object.fromEntries([["__proto__", "value"]]))).toEqual({ safe: "value" });
+  expect(schema.parse(Object.fromEntries([["__proto__", "value"]]))).toEqual({});
 });
 
-test("a missing finite __proto__ key is parsed like any other finite key", () => {
+test("a finite __proto__ key is ignored whether present or missing", () => {
+  const schema = z.record(z.enum(["__proto__"]), z.string());
   const parsed: any = z.record(z.enum(["__proto__"]), z.unknown()).parse({});
 
   expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
-  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
-  expect(parsed.__proto__).toBeUndefined();
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+  expect(schema.parse(Object.fromEntries([["__proto__", 123]]))).toEqual({});
 });

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -820,7 +820,7 @@ test("partialRecord strips a declared __proto__ key before transforms", () => {
 
 test("a finite __proto__ key is ignored whether present or missing", () => {
   const schema = z.record(z.enum(["__proto__"]), z.string());
-  const parsed: any = z.record(z.enum(["__proto__"]), z.unknown()).parse({});
+  const parsed: any = schema.parse({});
 
   expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
   expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1747,25 +1747,6 @@ export type $InferObjectInput<T extends $ZodLooseShape, Extra extends Record<str
         } & Extra
       >;
 
-// Writes a validated property onto the fresh {} we build results into. Plain assignment of
-// "__proto__" hits the inherited setter, which replaces the result prototype and drops the
-// value; defineProperty creates the own data property the key was declared for.
-function setProp(target: any, key: PropertyKey, value: unknown): void {
-  if (key === "__proto__") {
-    util.assignProp(target, key, value);
-  } else {
-    target[key] = value;
-  }
-}
-
-function getProperty(input: any, key: PropertyKey): unknown {
-  return key === "__proto__" && !Object.prototype.hasOwnProperty.call(input, key) ? undefined : input[key];
-}
-
-function isPropertyPresent(input: any, key: PropertyKey): boolean {
-  return key === "__proto__" ? Object.prototype.hasOwnProperty.call(input, key) : key in input;
-}
-
 function handlePropertyResult(
   result: ParsePayload,
   final: ParsePayload,
@@ -1774,7 +1755,7 @@ function handlePropertyResult(
   isOptionalIn: boolean,
   isOptionalOut: boolean
 ) {
-  const isPresent = isPropertyPresent(input, key);
+  const isPresent = key in input;
   if (result.issues.length) {
     // For optional-in/out schemas, ignore errors on absent keys.
     if (isOptionalIn && isOptionalOut && !isPresent) {
@@ -1797,10 +1778,10 @@ function handlePropertyResult(
 
   if (result.value === undefined) {
     if (isPresent) {
-      setProp(final.value, key, undefined);
+      (final.value as any)[key] = undefined;
     }
   } else {
-    setProp(final.value, key, result.value);
+    (final.value as any)[key] = result.value;
   }
 }
 
@@ -1887,8 +1868,8 @@ function handleCatchall(
   const isOptionalIn = _catchall.optin === "optional";
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
-    // must precede the __proto__ branch: a declared __proto__ field is handled by the
-    // shape loop, so reporting it here would reject input the schema explicitly allows
+    // Must precede the __proto__ branch: a declared key is not unrecognized, even though
+    // the shape loop deliberately strips __proto__ from the parsed output.
     if (keySet.has(key)) continue;
     // Don't copy an undeclared __proto__ into the result; assignment to a plain {} would
     // replace the result prototype. But in strict mode it is still an unknown key, so
@@ -1985,11 +1966,12 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     const shape = value.shape;
 
     for (const key of value.keys) {
+      if (key === "__proto__") continue;
       const el = shape[key]!;
       const isOptionalIn = el._zod.optin === "optional";
       const isOptionalOut = el._zod.optout === "optional";
 
-      const r = el._zod.run({ value: getProperty(input, key), issues: [] }, ctx);
+      const r = el._zod.run({ value: input[key], issues: [] }, ctx);
       if (r instanceof Promise) {
         proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut)));
       } else {
@@ -2016,28 +1998,11 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
 
     const generateFastpass = (shape: any) => {
       const normalized = _normalized.value;
-      const handlesProto = normalized.keySet.has("__proto__");
-      const doc = new Doc(
-        handlesProto
-          ? ["shape", "payload", "ctx", "setProp", "getProperty", "isPropertyPresent"]
-          : ["shape", "payload", "ctx"]
-      );
+      const doc = new Doc(["shape", "payload", "ctx"]);
 
       const parseStr = (key: string) => {
         const k = util.esc(key);
-        const value = key === "__proto__" ? `getProperty(input, ${k})` : `input[${k}]`;
-        return `shape[${k}]._zod.run({ value: ${value}, issues: [] }, ctx)`;
-      };
-
-      const presentStr = (key: string) => {
-        const k = util.esc(key);
-        return key === "__proto__" ? `isPropertyPresent(input, ${k})` : `${k} in input`;
-      };
-
-      // Keys are known here, so only a literal "__proto__" defers to setProp.
-      const setStr = (key: string, value: string) => {
-        const k = util.esc(key);
-        return key === "__proto__" ? `setProp(newResult, ${k}, ${value});` : `newResult[${k}] = ${value};`;
+        return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
       };
 
       doc.write(`const input = payload.value;`);
@@ -2051,9 +2016,10 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       // A: preserve key order {
       doc.write(`const newResult = {};`);
       for (const key of normalized.keys) {
+        if (key === "__proto__") continue;
         const id = ids[key];
         const k = util.esc(key);
-        const isPresent = presentStr(key);
+        const isPresent = `${k} in input`;
         const schema = shape[key];
         const isOptionalIn = schema?._zod?.optin === "optional";
         const isOptionalOut = schema?._zod?.optout === "optional";
@@ -2074,10 +2040,10 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         
         if (${id}.value === undefined) {
           if (${isPresent}) {
-            ${setStr(key, "undefined")}
+            newResult[${k}] = undefined;
           }
         } else {
-          ${setStr(key, `${id}.value`)}
+          newResult[${k}] = ${id}.value;
         }
 
       `);
@@ -2101,9 +2067,9 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
 
         if (${id}_present) {
           if (${id}.value === undefined) {
-            ${setStr(key, "undefined")}
+            newResult[${k}] = undefined;
           } else {
-            ${setStr(key, `${id}.value`)}
+            newResult[${k}] = ${id}.value;
           }
         }
 
@@ -2119,10 +2085,10 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         
         if (${id}.value === undefined) {
           if (${isPresent}) {
-            ${setStr(key, "undefined")}
+            newResult[${k}] = undefined;
           }
         } else {
-          ${setStr(key, `${id}.value`)}
+          newResult[${k}] = ${id}.value;
         }
 
       `);
@@ -2132,9 +2098,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       doc.write(`payload.value = newResult;`);
       doc.write(`return payload;`);
       const fn = doc.compile();
-      return handlesProto
-        ? (payload: any, ctx: any) => fn(shape, payload, ctx, setProp, getProperty, isPropertyPresent)
-        : (payload: any, ctx: any) => fn(shape, payload, ctx);
+      return (payload: any, ctx: any) => fn(shape, payload, ctx);
     };
 
     let fastpass!: ReturnType<typeof generateFastpass>;
@@ -2948,6 +2912,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       for (const key of values) {
         if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
           recordKeys.add(typeof key === "number" ? key.toString() : key);
+          if (key === "__proto__") continue;
           const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
             throw new Error("Async schemas not supported in object keys currently");
@@ -2964,7 +2929,8 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
             continue;
           }
           const outKey = keyResult.value as PropertyKey;
-          const result = def.valueType._zod.run({ value: getProperty(input, key), issues: [] }, ctx);
+          if (outKey === "__proto__") continue;
+          const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
 
           if (result instanceof Promise) {
             proms.push(
@@ -2972,14 +2938,14 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
                 if (result.issues.length) {
                   payload.issues.push(...util.prefixIssues(key, result.issues));
                 }
-                setProp(payload.value, outKey, result.value);
+                payload.value[outKey] = result.value;
               })
             );
           } else {
             if (result.issues.length) {
               payload.issues.push(...util.prefixIssues(key, result.issues));
             }
-            setProp(payload.value, outKey, result.value);
+            payload.value[outKey] = result.value;
           }
         }
       }
@@ -3004,7 +2970,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       payload.value = {};
       // Reflect.ownKeys for Symbol-key support; filter non-enumerable to match z.object()
       for (const key of Reflect.ownKeys(input)) {
-        if (key === "__proto__" && !(def.partial && values?.has(key))) continue;
+        if (key === "__proto__") continue;
         if (!Object.prototype.propertyIsEnumerable.call(input, key)) continue;
         let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
         if (keyResult instanceof Promise) {
@@ -3027,7 +2993,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
         if (keyResult.issues.length) {
           if (def.mode === "loose") {
             // Pass through unchanged
-            setProp(payload.value, key, input[key]);
+            payload.value[key] = input[key];
           } else {
             // Default "strict" behavior: error on invalid key
             payload.issues.push({
@@ -3045,7 +3011,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
         // the guard above tests the raw input key, but the key schema can normalize an
         // ordinary key into __proto__; re-check the key we actually write under
         const outKey = keyResult.value as PropertyKey;
-        if (outKey === "__proto__" && !(def.partial && key === "__proto__" && values?.has(key))) continue;
+        if (outKey === "__proto__") continue;
 
         const result = def.valueType._zod.run({ value: input[key], issues: [] }, ctx);
 
@@ -3055,14 +3021,14 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
               if (result.issues.length) {
                 payload.issues.push(...util.prefixIssues(key, result.issues));
               }
-              setProp(payload.value, outKey, result.value);
+              payload.value[outKey] = result.value;
             })
           );
         } else {
           if (result.issues.length) {
             payload.issues.push(...util.prefixIssues(key, result.issues));
           }
-          setProp(payload.value, outKey, result.value);
+          payload.value[outKey] = result.value;
         }
       }
     }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2523,7 +2523,9 @@ function mergeValues(
     const sharedKeys = Object.keys(a).filter((key) => bKeys.indexOf(key) !== -1);
 
     const newObj: any = { ...a, ...b };
+    if (Object.prototype.hasOwnProperty.call(newObj, "__proto__")) delete newObj.__proto__;
     for (const key of sharedKeys) {
+      if (key === "__proto__") continue;
       const sharedValue = mergeValues(a[key], b[key]);
       if (!sharedValue.valid) {
         return {
@@ -2912,6 +2914,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       for (const key of values) {
         if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
           recordKeys.add(typeof key === "number" ? key.toString() : key);
+          // A declared __proto__ is stripped but is not an unrecognized key.
           if (key === "__proto__") continue;
           const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -349,8 +349,8 @@ test("z.record", () => {
   expectTypeOf<partial>().toEqualTypeOf<Partial<Record<"__proto__" | "b", string>>>();
   const parsed: any = z.parse(partial, Object.fromEntries([["__proto__", "declared"]]));
   expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
-  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
-  expect(parsed.__proto__).toBe("declared");
+  expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
+  expect(parsed).toEqual({});
   expect(z.parse(partial, {})).toEqual({});
 
   // v3-compat single-arg form: z.record(valueType) defaults keyType to z.string()


### PR DESCRIPTION
Object and record parsers now strip `__proto__` whether the key comes directly from input, is declared by the schema, or is produced by a record key transform. This removes the safe-read/write helpers and JIT special casing added in #6371.

Object intersections in v3 and v4 also remove an own `__proto__` after merging their operands, preventing a pass-through side from reintroducing a key already stripped by the object or record side.

This deliberately means a schema-declared `__proto__` validator is not evaluated and the inferred result type can include a field absent at runtime. Released 4.4.x already stripped raw record and catchall keys, while declared object and finite-record paths wrote through the legacy setter; this change gives parsed-object assembly one policy.

Error formatting and JSON Schema conversion retain own-property writes because those APIs build error/schema artifacts where dropping the name would erase errors or break `required` and `$ref` entries.

The full suite passes all 3,927 tests with no type errors. Build, formatting, lint, and circular-dependency checks also pass.

Refs #6371.
