### PR TITLE
feat(v4): parse input containing reference cycles

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1477,6 +1477,7 @@ export interface ZodArray<T extends core.SomeType = core.$ZodType>
   "~standard": ZodStandardSchemaWithJSON<this>;
 }
 export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constructor("ZodArray", (inst, def) => {
+  core.attachMemoizer(inst);
   core.$ZodArray.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.arrayProcessor(inst, ctx, json, params);
@@ -1608,6 +1609,7 @@ export interface ZodObject<
 }
 
 export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$constructor("ZodObject", (inst, def) => {
+  core.attachMemoizer(inst);
   core.$ZodObjectJIT.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.objectProcessor(inst, ctx, json, params);
@@ -1828,6 +1830,7 @@ export interface ZodTuple<
   rest<Rest extends core.SomeType = core.$ZodType>(rest: Rest): ZodTuple<T, Rest>;
 }
 export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constructor("ZodTuple", (inst, def) => {
+  core.attachMemoizer(inst);
   core.$ZodTuple.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.tupleProcessor(inst, ctx, json, params);
@@ -1875,6 +1878,7 @@ export interface ZodRecord<
   valueType: Value;
 }
 export const ZodRecord: core.$constructor<ZodRecord> = /*@__PURE__*/ core.$constructor("ZodRecord", (inst, def) => {
+  core.attachMemoizer(inst);
   core.$ZodRecord.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.recordProcessor(inst, ctx, json, params);
@@ -1946,6 +1950,7 @@ export interface ZodMap<Key extends core.SomeType = core.$ZodType, Value extends
   size(size: number, params?: string | core.$ZodCheckSizeEqualsParams): this;
 }
 export const ZodMap: core.$constructor<ZodMap> = /*@__PURE__*/ core.$constructor("ZodMap", (inst, def) => {
+  core.attachMemoizer(inst);
   core.$ZodMap.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.mapProcessor(inst, ctx, json, params);
@@ -1981,6 +1986,7 @@ export interface ZodSet<T extends core.SomeType = core.$ZodType>
   size(size: number, params?: string | core.$ZodCheckSizeEqualsParams): this;
 }
 export const ZodSet: core.$constructor<ZodSet> = /*@__PURE__*/ core.$constructor("ZodSet", (inst, def) => {
+  core.attachMemoizer(inst);
   core.$ZodSet.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.setProcessor(inst, ctx, json, params);
@@ -2171,6 +2177,10 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
       if (_ctx.direction === "backward") {
         throw new core.$ZodEncodeError(inst.constructor.name);
       }
+
+      // The value is a placeholder a back-edge is still waiting on, so the cycle
+      // closes through this transform. Its output can't exist in time to bind.
+      if (core.isBackEdge(_ctx, payload.value)) throw new core.$ZodCyclicError();
 
       (payload as core.$RefinementCtx).addIssue = (issue) => {
         if (typeof issue === "string") {

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -1,0 +1,627 @@
+import { expect, test } from "vitest";
+import * as z from "zod/v4";
+
+test("parses a self-referential object and preserves identity", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return Node;
+    },
+  });
+
+  const input: any = { id: 1 };
+  input.self = input;
+
+  const result = Node.parse(input);
+  expect(result.id).toBe(1);
+  expect(result.self).toBe(result);
+  expect(result).not.toBe(input);
+});
+
+test("validates a node against every schema that reaches it", () => {
+  const A: any = z.object({
+    x: z.string(),
+    get b() {
+      return B;
+    },
+  });
+  const B: any = z.object({
+    y: z.number(),
+    get a() {
+      return A;
+    },
+  });
+
+  const input: any = { x: "s", y: 1 };
+  input.b = input;
+  input.a = input;
+
+  const result = A.parse(input);
+  expect(Object.keys(result).sort()).toEqual(["b", "x"]);
+  expect(Object.keys(result.b).sort()).toEqual(["a", "y"]);
+  expect(result.b.y).toBe(1);
+  expect(result.b.a).toBe(result);
+
+  const bad: any = { x: "s", y: "not a number" };
+  bad.b = bad;
+  bad.a = bad;
+  expect(A.safeParse(bad).success).toBe(false);
+});
+
+test("breaks cycles through every container", () => {
+  const cases: [string, () => { schema: any; input: any }][] = [
+    [
+      "array",
+      () => {
+        const S: any = z.object({
+          id: z.number(),
+          get kids() {
+            return z.array(S);
+          },
+        });
+        const a: any = { id: 1, kids: [] };
+        a.kids.push(a);
+        return { schema: S, input: a };
+      },
+    ],
+    [
+      "record",
+      () => {
+        const S: any = z.object({
+          id: z.number(),
+          get kids() {
+            return z.record(z.string(), S);
+          },
+        });
+        const a: any = { id: 1, kids: {} };
+        a.kids.self = a;
+        return { schema: S, input: a };
+      },
+    ],
+    [
+      "tuple",
+      () => {
+        const S: any = z.object({
+          id: z.number(),
+          get pair() {
+            return z.tuple([z.number(), S]);
+          },
+        });
+        const a: any = { id: 1 };
+        a.pair = [1, a];
+        return { schema: S, input: a };
+      },
+    ],
+    [
+      "set",
+      () => {
+        const S: any = z.object({
+          id: z.number(),
+          get peers() {
+            return z.set(S);
+          },
+        });
+        const a: any = { id: 1, peers: new Set() };
+        a.peers.add(a);
+        return { schema: S, input: a };
+      },
+    ],
+    [
+      "map",
+      () => {
+        const S: any = z.object({
+          id: z.number(),
+          get links() {
+            return z.map(z.string(), S);
+          },
+        });
+        const a: any = { id: 1, links: new Map() };
+        a.links.set("s", a);
+        return { schema: S, input: a };
+      },
+    ],
+    [
+      "union",
+      () => {
+        const S: any = z.object({
+          id: z.number(),
+          get self() {
+            return z.union([z.string(), S]);
+          },
+        });
+        const a: any = { id: 1 };
+        a.self = a;
+        return { schema: S, input: a };
+      },
+    ],
+    [
+      "discriminated union",
+      () => {
+        const S: any = z.discriminatedUnion("kind", [
+          z.object({ kind: z.literal("leaf"), v: z.number() }),
+          z.object({
+            kind: z.literal("branch"),
+            get next() {
+              return S;
+            },
+          }),
+        ]);
+        const a: any = { kind: "branch" };
+        a.next = a;
+        return { schema: S, input: a };
+      },
+    ],
+    [
+      "lazy",
+      () => {
+        const S: any = z.object({ id: z.number(), self: z.lazy(() => S) });
+        const a: any = { id: 1 };
+        a.self = a;
+        return { schema: S, input: a };
+      },
+    ],
+    [
+      "mutual recursion five hops apart",
+      () => {
+        const A: any = z.object({
+          get b() {
+            return B;
+          },
+        });
+        const B: any = z.object({
+          get c() {
+            return C;
+          },
+        });
+        const C: any = z.object({
+          get d() {
+            return D;
+          },
+        });
+        const D: any = z.object({
+          get e() {
+            return E;
+          },
+        });
+        const E: any = z.object({
+          get a() {
+            return A;
+          },
+        });
+        const a: any = {};
+        a.b = { c: { d: { e: { a } } } };
+        return { schema: A, input: a };
+      },
+    ],
+  ];
+
+  for (const [name, build] of cases) {
+    for (const jitless of [false, true]) {
+      const { schema, input } = build();
+      expect(() => schema.parse(input, { jitless }), `${name} (jitless: ${jitless})`).not.toThrow();
+    }
+  }
+});
+
+test("checks run once per node and never against a half-built object", () => {
+  const seen: number[] = [];
+  const Node: any = z
+    .object({
+      id: z.number(),
+      get self() {
+        return Node;
+      },
+    })
+    .refine((value: any) => {
+      seen.push(Object.keys(value).length);
+      return true;
+    });
+
+  const input: any = { id: 1 };
+  input.self = input;
+  Node.parse(input);
+
+  expect(seen).toEqual([2]);
+});
+
+test("reports a failing check inside a cycle", () => {
+  const Node: any = z
+    .object({
+      id: z.number(),
+      get self() {
+        return Node;
+      },
+    })
+    .refine((value: any) => value.id > 100, "too small");
+
+  const input: any = { id: 1 };
+  input.self = input;
+  expect(Node.safeParse(input).success).toBe(false);
+});
+
+test("reports an invalid value inside a cycle once, at its own path", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return Node;
+    },
+  });
+
+  const input: any = { id: "nope" };
+  input.self = input;
+
+  const result = Node.safeParse(input);
+  expect(result.success).toBe(false);
+  expect(result.error!.issues).toHaveLength(1);
+  expect(result.error!.issues[0].path).toEqual(["id"]);
+});
+
+test("rejects a cycle that closes through a transform", () => {
+  const Inner: any = z.object({
+    name: z.string(),
+    get self() {
+      return Wrapped;
+    },
+  });
+  const Wrapped: any = Inner.transform((value: any) => ({ wrapped: value }));
+
+  const input: any = { name: "x" };
+  input.self = input;
+
+  expect(() => Wrapped.parse(input)).toThrow(/reference cycle/);
+});
+
+test("leaves a transform that is not on the cycle alone", () => {
+  const Node: any = z.object({
+    n: z.number().transform((value: number) => value * 2),
+    get self() {
+      return Node;
+    },
+  });
+
+  const input: any = { n: 21 };
+  input.self = input;
+
+  const result = Node.parse(input);
+  expect(result.n).toBe(42);
+  expect(result.self).toBe(result);
+});
+
+test("encodes through a cycle", () => {
+  const Stringified = z.codec(z.string(), z.number(), {
+    decode: (value) => Number(value),
+    encode: (value) => String(value),
+  });
+  const Node: any = z.object({
+    n: Stringified,
+    get self() {
+      return Node;
+    },
+  });
+
+  const input: any = { n: 5 };
+  input.self = input;
+
+  const result: any = z.encode(Node, input);
+  expect(result.n).toBe("5");
+  expect(result.self).toBe(result);
+});
+
+test("keeps separate parses independent", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return Node;
+    },
+  });
+
+  const input: any = { id: 1 };
+  input.self = input;
+
+  const first = Node.parse(input);
+  const second = Node.parse(input);
+  expect(first).not.toBe(second);
+  expect(first.self).toBe(first);
+  expect(second.self).toBe(second);
+
+  const bad: any = { id: "x" };
+  bad.self = bad;
+  expect(Node.safeParse(bad).success).toBe(false);
+  expect(Node.safeParse(input).success).toBe(true);
+});
+
+test("parses a cycle asynchronously", async () => {
+  const Node: any = z.object({
+    id: z.number().refine(async (value: number) => value > 0),
+    get self() {
+      return Node;
+    },
+  });
+
+  const input: any = { id: 1 };
+  input.self = input;
+
+  const result = await Node.parseAsync(input);
+  expect(result.self).toBe(result);
+
+  const bad: any = { id: -1 };
+  bad.self = bad;
+  expect((await Node.safeParseAsync(bad)).success).toBe(false);
+});
+
+test("a non-recursive schema still copies a shared reference twice", () => {
+  const Leaf = z.object({ v: z.number() });
+  const Pair = z.object({ a: Leaf, b: Leaf });
+
+  const shared = { v: 1 };
+  const result = Pair.parse({ a: shared, b: shared });
+
+  expect(result.a).not.toBe(result.b);
+  expect(result.a.v).toBe(1);
+  expect(result.b.v).toBe(1);
+});
+
+test("a recursive schema shares one output node per input node", () => {
+  const Node: any = z.object({
+    v: z.number(),
+    get kids() {
+      return z.array(Node);
+    },
+  });
+
+  const shared: any = { v: 1, kids: [] };
+  const result = Node.parse({ v: 0, kids: [shared, shared] });
+
+  expect(result.kids[0]).toBe(result.kids[1]);
+});
+
+test("sync and async agree on a shared reference", async () => {
+  const build = (asyncCheck: boolean) => {
+    const Node: any = z.object({
+      v: asyncCheck ? z.number().refine(async (n: number) => n >= 0) : z.number(),
+      get kids() {
+        return z.array(Node);
+      },
+    });
+    return Node;
+  };
+
+  const shared: any = { v: 1, kids: [] };
+  const input = { v: 0, kids: [shared, shared] };
+
+  const syncResult = build(false).parse(input);
+  const asyncResult = await build(true).parseAsync(input);
+
+  expect(syncResult.kids[0]).toBe(syncResult.kids[1]);
+  expect(asyncResult.kids[0]).toBe(asyncResult.kids[1]);
+});
+
+test("a cycle through .readonly() keeps the node intact", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return Node.readonly();
+    },
+  });
+
+  const input: any = { id: 1 };
+  input.self = input;
+
+  // Freezing a node that is still being built would make its remaining keys
+  // fail to assign, silently, because generated code is not strict mode.
+  const result = Node.parse(input);
+  expect(Object.keys(result).sort()).toEqual(["id", "self"]);
+  expect(result.self).toBe(result);
+});
+
+test("a cycle through z.intersection validates but does not mirror the graph", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return z.intersection(Node, z.object({ id: z.number() }));
+    },
+  });
+
+  const input: any = { id: 7 };
+  input.self = input;
+
+  // The merged value is built after both sides are parsed, so it cannot be the
+  // object a back-edge already resolved to. Values are right, the graph is not.
+  const result = Node.parse(input);
+  expect(result.id).toBe(7);
+  expect(result.self.id).toBe(7);
+  expect(result.self).not.toBe(result);
+  expect(result.self.self).toBeUndefined();
+
+  const bad: any = { id: "nope" };
+  bad.self = bad;
+  expect(Node.safeParse(bad).success).toBe(false);
+});
+
+test("keeps two cycles and a shared node distinct in one input", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get kids() {
+      return z.array(Node);
+    },
+  });
+
+  const shared: any = { id: 9, kids: [] };
+  const root: any = { id: 0, kids: [shared, shared] };
+  root.kids.push(root);
+
+  const result = Node.parse(root);
+  expect(result.kids[0]).toBe(result.kids[1]);
+  expect(result.kids[2]).toBe(result);
+});
+
+test("closes a cycle through a Map key and a Set member", () => {
+  const Keyed: any = z.object({
+    id: z.number(),
+    get keyed() {
+      return z.map(Keyed, z.string());
+    },
+  });
+  const k: any = { id: 1, keyed: new Map() };
+  k.keyed.set(k, "v");
+  const keyedOut = Keyed.parse(k);
+  expect([...keyedOut.keyed.keys()][0]).toBe(keyedOut);
+
+  const Peered: any = z.object({
+    id: z.number(),
+    get peers() {
+      return z.set(Peered);
+    },
+  });
+  const p: any = { id: 1, peers: new Set() };
+  p.peers.add(p);
+  const peeredOut = Peered.parse(p);
+  expect([...peeredOut.peers][0]).toBe(peeredOut);
+});
+
+test("does not mutate the input, and tolerates a frozen one", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return Node;
+    },
+  });
+
+  const input: any = { id: 1 };
+  input.self = input;
+  Object.freeze(input);
+
+  const result = Node.parse(input);
+  expect(result).not.toBe(input);
+  expect(result.self).toBe(result);
+  expect(Reflect.ownKeys(input)).toEqual(["id", "self"]);
+});
+
+test("keys identity on the schema, not just the input", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return Node.optional();
+    },
+  });
+  const Partial: any = Node.partial();
+
+  const input: any = { id: 1 };
+  input.self = input;
+
+  // `Partial` and `Node` are different schemas, so the root and the node its
+  // cycle points back to are different output objects. Same rule that lets one
+  // input node be validated against two schemas in mutual recursion.
+  const result = Partial.parse(input);
+  expect(result.self).not.toBe(result);
+  expect(result.self.self).toBe(result.self);
+  expect(result.id).toBe(1);
+  expect(result.self.id).toBe(1);
+});
+
+test("keeps concurrent async parses of one schema independent", async () => {
+  const Node: any = z.object({
+    id: z.number().refine(async (n: number) => {
+      await new Promise((r) => setTimeout(r, 5 + (n % 3)));
+      return true;
+    }),
+    get self() {
+      return Node;
+    },
+  });
+
+  const make = (id: number) => {
+    const o: any = { id };
+    o.self = o;
+    return o;
+  };
+
+  const [a, b, c] = await Promise.all([Node.parseAsync(make(1)), Node.parseAsync(make(2)), Node.parseAsync(make(3))]);
+
+  expect([a.id, b.id, c.id]).toEqual([1, 2, 3]);
+  expect(a.self).toBe(a);
+  expect(b.self).toBe(b);
+  expect(c.self).toBe(c);
+});
+
+test("runs checks once per reference, as it does without a cycle", () => {
+  let calls = 0;
+  const Node: any = z
+    .object({
+      id: z.number(),
+      get kids() {
+        return z.array(Node);
+      },
+    })
+    .refine(() => {
+      calls++;
+      return true;
+    });
+
+  const shared: any = { id: 1, kids: [] };
+  Node.parse({ id: 0, kids: [shared, shared] });
+
+  // Memoization skips the container's parse, not the checks layered on it.
+  expect(calls).toBe(3);
+});
+
+test("a schema wrapped at the root adds one node and no more", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return Node.optional();
+    },
+  });
+
+  const input: any = { id: 1 };
+  input.self = input;
+
+  // The root is keyed on the wrapper, everything under it on `Node`, so the
+  // graph closes one level down rather than at the root. It does not compound:
+  // stacking wrappers still yields exactly two nodes.
+  const count = (root: any) => {
+    const seen: any[] = [];
+    let n = root;
+    while (n && !seen.includes(n)) {
+      seen.push(n);
+      n = n.self;
+    }
+    return seen.length;
+  };
+
+  expect(count(Node.parse(input))).toBe(1);
+  expect(count(Node.partial().parse(input))).toBe(2);
+  expect(count(Node.partial().partial().parse(input))).toBe(2);
+  expect(count(Node.extend({ extra: z.string().optional() }).parse(input))).toBe(2);
+});
+
+test("resolves a recursive reference once, however it is written", () => {
+  // This is what bounds the above: core caches a shape getter and a lazy
+  // getter, so a getter returning a fresh clone still yields a finite schema
+  // graph rather than a new schema per node.
+  let getterCalls = 0;
+  const ViaGetter: any = z.object({
+    id: z.number(),
+    get self() {
+      getterCalls++;
+      return ViaGetter.partial();
+    },
+  });
+
+  let lazyCalls = 0;
+  const ViaLazy: any = z.object({
+    id: z.number(),
+    self: z.lazy(() => {
+      lazyCalls++;
+      return ViaLazy.partial();
+    }),
+  });
+
+  const input: any = { id: 1 };
+  input.self = input;
+
+  expect(() => ViaGetter.parse(input)).not.toThrow();
+  expect(() => ViaLazy.parse(input)).not.toThrow();
+  expect(getterCalls).toBe(1);
+  expect(lazyCalls).toBe(1);
+});

--- a/packages/zod/src/v4/core/index.ts
+++ b/packages/zod/src/v4/core/index.ts
@@ -2,6 +2,7 @@ export * from "./core.js";
 export * from "./parse.js";
 export * from "./errors.js";
 export * from "./schemas.js";
+export * from "./memoizer.js";
 export * from "./checks.js";
 export * from "./versions.js";
 export * as util from "./util.js";

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -1,0 +1,191 @@
+import type * as errors from "./errors.js";
+import type { $ZodMemoizer, $ZodType, ParseContextInternal, ParsePayload } from "./schemas.js";
+import type * as util from "./util.js";
+
+export class $ZodCyclicError extends Error {
+  constructor() {
+    super(`Cannot parse a reference cycle that closes through a transform`);
+    this.name = "ZodCyclicError";
+  }
+}
+
+interface Entry {
+  value: unknown;
+  /** `null` until the node's children are parsed. */
+  issues: errors.$ZodRawIssue[] | null;
+}
+
+interface State {
+  buckets: Map<$ZodType, Map<object, Entry>>;
+  /** Nodes a back-edge resolved to before they finished. */
+  backEdges: Set<object> | undefined;
+}
+
+/** Keyed off the context object every schema in one parse call already shares. */
+const STATE = "~memo";
+type WithState = { [STATE]?: State };
+
+const NO_ISSUES: errors.$ZodRawIssue[] = [];
+
+interface Memoizer extends $ZodMemoizer {
+  recursive: boolean | undefined;
+  /** Set immediately before delegating to core and cleared immediately after, so
+   * `alloc` registers only for a visit this module is driving. */
+  handoff: Map<object, Entry> | undefined;
+  /** `bucket` memoized for one parse; a recursive schema is re-entered many
+   * times and its bucket never changes. */
+  ctx: object | undefined;
+  bucket: Map<object, Entry> | undefined;
+  /** Allocated but unfinished entries. `alloc` and the matching pop both happen
+   * in the synchronous part of a parse, so they nest even when children are async. */
+  open: Entry[];
+}
+
+const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
+
+/** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */
+function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
+  const cached = recursive.get(inst);
+  if (cached !== undefined) return cached;
+  // Relative to the walk in progress, so not cached.
+  if (stack.has(inst)) return true;
+  stack.add(inst);
+
+  let result = false;
+  const check = (child: any) => {
+    if (!result && child?._zod && isRecursive(child, stack)) result = true;
+  };
+
+  const def = inst._zod.def as any;
+  if (def.type === "lazy") {
+    check((inst as any)._zod.innerType);
+  } else {
+    // $ZodObject redefines `shape` as a non-enumerable accessor, so `for...in` misses it.
+    const shape = def.shape;
+    if (shape) for (const key in shape) check(shape[key]);
+    for (const key in def) {
+      const value = def[key];
+      if (!value || typeof value !== "object") continue;
+      if (value._zod) check(value);
+      else if (Array.isArray(value)) for (const el of value) check(el);
+    }
+  }
+
+  stack.delete(inst);
+  recursive.set(inst, result);
+  return result;
+}
+
+function bucketFor(state: State, inst: $ZodType): Map<object, Entry> {
+  let bucket = state.buckets.get(inst);
+  if (!bucket) {
+    bucket = new Map();
+    state.buckets.set(inst, bucket);
+  }
+  return bucket;
+}
+
+/**
+ * Gives a container cycle support. Call before the container's `init`, which
+ * reads the memoizer once and closes over it.
+ */
+export function attachMemoizer(inst: $ZodType): void {
+  const m: Memoizer = {
+    recursive: undefined,
+    handoff: undefined,
+    ctx: undefined,
+    bucket: undefined,
+    open: [],
+    alloc(_inst, payload, empty) {
+      const bucket = m.handoff;
+      if (!bucket) return empty;
+      m.handoff = undefined;
+      const entry: Entry = { value: empty, issues: null };
+      bucket.set(payload.value as object, entry);
+      m.open.push(entry);
+      return empty;
+    },
+  };
+  inst._zod.memoizer = m;
+
+  // Wraps `parse`, not `run`. `run` is assigned by a deferred of core's own that
+  // would replace anything installed here first; wrapping `parse` reaches both
+  // ways core builds `run` — it copies `parse` when there are no checks, and
+  // reads it dynamically when there are.
+  inst._zod.deferred ??= [];
+  inst._zod.deferred.push(() => {
+    const base = inst._zod.parse;
+
+    const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload> => {
+      if (m.recursive === undefined) {
+        m.recursive = isRecursive(inst, new Set());
+        if (!m.recursive) {
+          // Nothing here can ever fire, so take it back out. `run` has to be
+          // checked too: with no checks on the schema, core copies `parse` into
+          // it rather than reading it each time.
+          inst._zod.parse = base;
+          if (inst._zod.run === wrapped) inst._zod.run = base;
+          return base(payload, ctx);
+        }
+      }
+
+      const input = payload.value;
+      if (input === null || typeof input !== "object") return base(payload, ctx);
+
+      let state = (ctx as WithState)[STATE];
+      if (!state) {
+        state = { buckets: new Map(), backEdges: undefined };
+        (ctx as WithState)[STATE] = state;
+      }
+
+      let bucket: Map<object, Entry>;
+      if (m.ctx === ctx) {
+        bucket = m.bucket!;
+      } else {
+        bucket = bucketFor(state, inst);
+        m.ctx = ctx;
+        m.bucket = bucket;
+      }
+
+      const hit = bucket.get(input);
+      if (hit) {
+        payload.value = hit.value;
+        if (hit.issues) {
+          payload.issues.push(...hit.issues);
+        } else {
+          // Still being parsed: its own checks cover it, so skip them here.
+          payload.memo = true;
+          state.backEdges ??= new Set();
+          state.backEdges.add(hit.value as object);
+        }
+        return payload;
+      }
+
+      m.handoff = bucket;
+      const depth = m.open.length;
+      const result = base(payload, ctx);
+      m.handoff = undefined;
+      // A container that rejected its input outright allocated nothing.
+      const entry = m.open.length > depth ? m.open.pop()! : undefined;
+
+      // Both paths written out so the sync one allocates no closure. It runs once
+      // per node, and capturing here cost more than everything else combined.
+      if (result instanceof Promise) {
+        return result.then((r) => {
+          if (entry) entry.issues = r.issues.length ? r.issues.slice() : NO_ISSUES;
+          return r;
+        });
+      }
+      if (entry) entry.issues = result.issues.length ? result.issues.slice() : NO_ISSUES;
+      return result;
+    };
+
+    inst._zod.parse = wrapped;
+  });
+}
+
+/** Whether this value is a node a back-edge resolved to before it finished. */
+export function isBackEdge(ctx: object, value: unknown): boolean {
+  const backEdges = (ctx as WithState)[STATE]?.backEdges;
+  return backEdges !== undefined && value !== null && typeof value === "object" && backEdges.has(value);
+}

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -31,6 +31,12 @@ export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> ex
   readonly skipChecks?: boolean;
 }
 
+/** @internal Supplies the object a container builds into, registered before any
+ * child is parsed so a reference back to the same input resolves to it. */
+export interface $ZodMemoizer {
+  alloc<T extends object>(inst: $ZodType, payload: ParsePayload, empty: T, ctx: ParseContextInternal): T;
+}
+
 export interface ParsePayload<T = unknown> {
   value: T;
   issues: errors.$ZodRawIssue[];
@@ -41,6 +47,9 @@ export interface ParsePayload<T = unknown> {
    * undefined. Set by $ZodCatch when catchValue substitutes and by every
    * $ZodTransform invocation. */
   fallback?: boolean | undefined;
+  /** @internal Set when the value came from a repeat visit to a node still being
+   * parsed. Its checks run on the node itself, against the finished value. */
+  memo?: boolean | undefined;
 }
 
 export type CheckFn<T> = (input: ParsePayload<T>) => util.MaybeAsync<void>;
@@ -124,6 +133,9 @@ export interface _$ZodTypeInternals {
   optin?: "optional" | undefined;
   /** @internal */
   optout?: "optional" | undefined;
+
+  /** @internal */
+  memoizer?: $ZodMemoizer | undefined;
 
   /** @internal The set of literal values that will pass validation. Must be an exhaustive set. Used to determine optionality in z.record().
    *
@@ -221,6 +233,8 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
       checks: checks.$ZodCheck<never>[],
       ctx?: ParseContextInternal | undefined
     ): util.MaybeAsync<ParsePayload> => {
+      if (payload.memo) return payload;
+
       let isAborted = util.aborted(payload);
 
       let asyncResult!: Promise<unknown> | undefined;
@@ -1697,6 +1711,8 @@ function handleArrayResult(result: ParsePayload<any>, final: ParsePayload<any[]>
 export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$constructor("$ZodArray", (inst, def) => {
   $ZodType.init(inst, def);
 
+  const memo = inst._zod.memoizer;
+
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
 
@@ -1711,7 +1727,7 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
       return payload;
     }
 
-    payload.value = Array(input.length);
+    payload.value = memo ? memo.alloc(inst, payload, Array(input.length), ctx) : Array(input.length);
     const proms: Promise<any>[] = [];
     for (let i = 0; i < input.length; i++) {
       const item = input[i];
@@ -2010,6 +2026,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
   const catchall = def.catchall;
 
   let value!: typeof _normalized.value;
+  const memo = inst._zod.memoizer;
 
   inst._zod.parse = (payload, ctx) => {
     value ??= _normalized.value;
@@ -2024,7 +2041,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
       return payload;
     }
 
-    payload.value = {};
+    payload.value = memo ? memo.alloc(inst, payload, {}, ctx) : {};
 
     const proms: Promise<any>[] = [];
     const shape = value.shape;
@@ -2060,9 +2077,11 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
     const superParse = inst._zod.parse;
     const _normalized = util.cached(() => normalizeDef(def));
 
+    const memo = inst._zod.memoizer;
+
     const generateFastpass = (shape: any) => {
       const normalized = _normalized.value;
-      const doc = new Doc(["shape", "payload", "ctx"]);
+      const doc = new Doc(memo ? ["shape", "payload", "ctx", "inst", "memo"] : ["shape", "payload", "ctx"]);
 
       const parseStr = (key: string) => {
         const k = util.esc(key);
@@ -2078,7 +2097,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       }
 
       // A: preserve key order {
-      doc.write(`const newResult = {};`);
+      doc.write(memo ? `const newResult = memo.alloc(inst, payload, {}, ctx);` : `const newResult = {};`);
       for (const key of normalized.keys) {
         if (key === "__proto__") continue;
         const id = ids[key];
@@ -2156,6 +2175,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       doc.write(`payload.value = newResult;`);
       doc.write(`return payload;`);
       const fn = doc.compile();
+      if (memo) return (payload: any, ctx: any) => fn(shape, payload, ctx, inst, memo);
       return (payload: any, ctx: any) => fn(shape, payload, ctx);
     };
 
@@ -2754,6 +2774,7 @@ export interface $ZodTuple<
 export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$constructor("$ZodTuple", (inst, def) => {
   $ZodType.init(inst, def);
   const items = def.items;
+  const memo = inst._zod.memoizer;
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -2767,7 +2788,7 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       return payload;
     }
 
-    payload.value = [];
+    payload.value = memo ? memo.alloc(inst, payload, [] as unknown[], ctx) : [];
     const proms: Promise<any>[] = [];
 
     const optinStart = getTupleOptStart(items, "optin");
@@ -2963,6 +2984,7 @@ export interface $ZodRecord<Key extends $ZodRecordKey = $ZodRecordKey, Value ext
 
 export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$constructor("$ZodRecord", (inst, def) => {
   $ZodType.init(inst, def);
+  const memo = inst._zod.memoizer;
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -2982,7 +3004,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
 
     const values = def.keyType._zod.values;
     if (values && !def.partial) {
-      payload.value = {};
+      payload.value = memo ? memo.alloc(inst, payload, {}, ctx) : {};
       const recordKeys = new Set<string | symbol>();
       for (const key of values) {
         if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
@@ -3051,7 +3073,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
         });
       }
     } else {
-      payload.value = {};
+      payload.value = memo ? memo.alloc(inst, payload, {}, ctx) : {};
       // An enumerable key schema declares which keys the record owns, so a key outside
       // the set is unrecognized. A non-enumerable one (regex, refine) is a constraint
       // every key must satisfy, so a failing key is invalid. Only the former is
@@ -3170,6 +3192,7 @@ export interface $ZodMap<Key extends SomeType = $ZodType, Value extends SomeType
 
 export const $ZodMap: core.$constructor<$ZodMap> = /*@__PURE__*/ core.$constructor("$ZodMap", (inst, def) => {
   $ZodType.init(inst, def);
+  const memo = inst._zod.memoizer;
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -3185,7 +3208,7 @@ export const $ZodMap: core.$constructor<$ZodMap> = /*@__PURE__*/ core.$construct
     }
 
     const proms: Promise<any>[] = [];
-    payload.value = new Map();
+    payload.value = memo ? memo.alloc(inst, payload, new Map(), ctx) : new Map();
 
     for (const [key, value] of input) {
       const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
@@ -3274,6 +3297,7 @@ export interface $ZodSet<T extends SomeType = $ZodType> extends $ZodType {
 
 export const $ZodSet: core.$constructor<$ZodSet> = /*@__PURE__*/ core.$constructor("$ZodSet", (inst, def) => {
   $ZodType.init(inst, def);
+  const memo = inst._zod.memoizer;
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -3288,7 +3312,7 @@ export const $ZodSet: core.$constructor<$ZodSet> = /*@__PURE__*/ core.$construct
     }
 
     const proms: Promise<any>[] = [];
-    payload.value = new Set();
+    payload.value = memo ? memo.alloc(inst, payload, new Set(), ctx) : new Set();
     for (const item of input) {
       const result = def.valueType._zod.run({ value: item, issues: [] }, ctx);
       if (result instanceof Promise) {
@@ -4338,7 +4362,9 @@ export const $ZodReadonly: core.$constructor<$ZodReadonly> = /*@__PURE__*/ core.
 );
 
 function handleReadonlyResult(payload: ParsePayload): ParsePayload {
-  payload.value = Object.freeze(payload.value);
+  // A repeat visit hands back a node that is still being built; freezing it here
+  // would make the rest of its keys fail to assign.
+  if (!payload.memo) payload.value = Object.freeze(payload.value);
   return payload;
 }
 


### PR DESCRIPTION
Parses input that contains reference cycles. Today this is a `RangeError` — `safeParse` included, so it isn't even catchable through the result. Fixes #5346.

```ts
const Node = z.object({
  id: z.number(),
  get self() { return Node; },
});

const input: any = { id: 1 };
input.self = input;

const out = Node.parse(input);
out.self === out; // true
```

**`zod/mini` doesn't get this**, and pays 34 gzipped bytes for not getting it.

## Shape

Core gains one seam:

```ts
export interface $ZodMemoizer {
  alloc<T extends object>(inst: $ZodType, payload: ParsePayload, empty: T, ctx: ParseContextInternal): T;
}
```

A container hands the memoizer the object it is about to build into. That is core's entire share of the mechanism: the interface, one `_zod.memoizer` field, and one changed line per container —

```ts
payload.value = memo ? memo.alloc(inst, payload, {}, ctx) : {};
```

`memo` is read **once, at construction**, into a closure constant, so a schema that was never given one runs exactly the code it runs today. In the JIT the same constant decides which of two strings gets emitted, so non-injected schemas produce byte-identical generated code.

The memoizer itself is `core/memoizer.ts`. Nothing outside that module references it unless a layer asks for it, so it shakes out completely: `zod/mini` links none of it and the string `isRecursive` doesn't appear in its bundle. Classic opts a container in with one line before its `init`:

```ts
core.attachMemoizer(inst);
core.$ZodObjectJIT.init(inst, def);
```

The one other core line is in `runChecks`, so a repeat visit doesn't re-run the node's checks against a value that is still being built.

## What the memoizer does

It registers the real output object before any child is parsed, so a reference back to the same input resolves to the object the caller will actually receive — nothing is copied afterwards. The lookup is keyed on `(schema, input)`, not on the input alone, and that is what makes mutual recursion sound: one node validated against two schemas needs an output per schema.

```ts
const A = z.object({ x: z.string(), get b() { return B; } });
const B = z.object({ y: z.number(), get a() { return A; } });

const n: any = { x: "s", y: 1 };
n.b = n; n.a = n;

const out = A.parse(n);
Object.keys(out);      // ["x", "b"]   — the A view
Object.keys(out.b);    // ["y", "a"]   — the B view, separately validated
out.b.a === out;       // true
```

A repeat visit returns without ever reaching core, which is also what stops the node's checks running a second time against a half-built value. A cycle that closes through a `.transform()` throws `ZodCyclicError` — the transform's output can't exist at the moment the back-edge needs to bind, so the alternatives are a clear error or a silently wrong graph. Transforms that aren't on the cycle are unaffected.

A schema that can't re-enter itself disarms both halves on its first parse: the wrapper puts the original `run` back and `alloc` becomes a single field read.

## Cost

Bundle, esbuild `--minify` / `gzip -9`:

| bundle | main | this PR | delta |
|---|---|---|---|
| **`zod-mini-object`** | 3928 | 3962 | **+34 (+0.9%)** |
| **`zod-mini-full`** | 3925 | 3959 | **+34 (+0.9%)** |
| `zod-object` (classic) | 21205 | 21978 | +773 (+3.6%) |
| `zod-full` (classic) | 21201 | 21974 | +773 (+3.6%) |

Neither mini bundle contains any of the memoizer — `isRecursive`, `backEdges` and the error message are all absent.

Runtime, best-of-3 processes per side, both pinned to the same base:

| workload | main | this PR |
|---|---|---|
| flat object | 23.9 ns | −10.0% |
| nested object | 122.1 ns | +8.4% |
| refined object | 243.5 ns | +0.5% |
| array of 20 objects | 749.5 ns | +3.7% |
| record, 5 keys | 435.2 ns | +0.8% |
| flat object, jitless | 152.2 ns | +3.9% |
| build + first parse, wide schema | 1.67 ms | +0.6% |
| **recursive schema, 364-node tree** | 27.0 µs | **+171%** |

Non-recursive parsing is unchanged — those rows are run-to-run noise.

The last row is the price: a recursive schema over ordinary acyclic data pays ~2.7×, for the memo lookup and insert on every node. That is not a consequence of skipping the JIT — the fastpass is still generated and used, and the jitless path carries the same absolute per-node overhead, which it wouldn't if the JIT were being bypassed. Putting the same logic inside core's containers instead measured ~2.6×, so this shape costs essentially nothing over that while keeping `zod/mini` at 34 bytes.

## Behavior change

Under a recursive schema, two positions holding the same input object now produce the same output object:

```ts
const shared = { v: 1, kids: [] };
const out = Node.parse({ v: 0, kids: [shared, shared] });
out.kids[0] === out.kids[1]; // true — previously two independent copies
```

The output graph mirrors the input graph, which is also what arktype does. Non-recursive schemas are untouched and still copy.

The alternative — scoping entries to the parse stack so acyclic input is bit-for-bit unchanged — diverges between sync and async. Under `parseAsync` sibling subtrees are in flight together, so the second occurrence of a shared node finds the first one's in-progress entry and binds to it, while `parse` walks siblings sequentially and doesn't. "Currently being parsed" only equals "is my ancestor" when parsing is sequential. Keeping entries for the whole parse makes the two agree.

What does **not** change: memoization skips the container's parse, not the checks and transforms layered on top of it. A `.refine()` or `.transform()` on a shared node still runs once per reference, exactly as it does on a non-recursive schema, so side effects keep their existing counts.

## Limits

Measured, and worth knowing before merging:

- **Maximum recursion depth drops from ~3400 to ~1100 levels.** The interceptor adds a stack frame per container, so a deeply nested chain that parses today can overflow. Binary-searched, with `zod/mini` (which has no memoizer) as the control.
- **`z.intersection` on a cycle produces a truncated graph.** `mergeValues` builds a fresh object after both sides are parsed, so it can never be the object a back-edge already resolved to. Values validate correctly and invalid input is still rejected, but the cycle is replaced by a copy. Same class as transform-on-a-cycle, which throws; this one doesn't yet.
- **Identity is keyed on `(schema, input)`, not on input alone.** That is what keeps mutual recursion sound, but it means `Node.partial().parse(cyclic)` gives a root that is *not* the node its own cycle points back to — the root is keyed on the partial clone, the cycled node on the original.
- **`.readonly()` on a cycled node doesn't freeze it.** Freezing a node that is still being built would make its remaining keys fail to assign, silently.

Supersedes #5347 and #5664.
