### PR TITLE
docs: document that any/unknown object keys are required

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1067,6 +1067,14 @@ z.any(); // inferred type: `any`
 z.unknown(); // inferred type: `unknown`
 ```
 
+As object properties, their keys are required, matching `{ a: any }` in TypeScript.
+
+```ts
+z.object({ a: z.any() }).parse({}); // ❌
+z.object({ a: z.any() }).parse({ a: undefined }); // ✅
+z.object({ a: z.any().optional() }).parse({}); // ✅
+```
+
 ## Never
 
 No value will pass validation.

--- a/packages/docs/content/v4/changelog.mdx
+++ b/packages/docs/content/v4/changelog.mdx
@@ -479,6 +479,16 @@ const mySchema = z.object({
 // Zod 4: { a: any; b: unknown };
 ```
 
+As of `v4.4.0`, the key is required at parse time too. Zod 4.0–4.3 accepted a missing key despite the inferred type above; requiring it is a soundness fix.
+
+```ts
+mySchema.parse({}); // ❌ (✅ in v4.3 and earlier)
+mySchema.parse({ a: undefined, b: undefined }); // ✅
+
+// use .optional() for a key that may be absent
+z.object({ a: z.any().optional() }).parse({}); // ✅
+```
+
 ### deprecates `.merge()`
 
 The `.merge()` method on `ZodObject` has been deprecated in favor of `.extend()`. The `.extend()` method provides the same functionality, avoids ambiguity around strictness inheritance, and has better TypeScript performance.


### PR DESCRIPTION
`z.any()` and `z.unknown()` infer as required object keys. The v4 migration guide already covers that, but only as a type-level change. As of 4.4.0 the key is required at parse time too — 4.0–4.3 accepted a missing key despite the inferred type, and #5661 closed that gap.

That runtime half isn't documented anywhere user-facing, which is what #5997, #5957 and #5993 are all reporting. The rule is written up in `wiki/optionality.md`, but that's an internal reference.

Two edits: note the parse-time behavior in the migration guide next to the existing type change, and add the object-property case to the `z.any()` / `z.unknown()` API section.
