### PR TITLE
feat: add .exclude() and .extract() to discriminated unions

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1881,6 +1881,27 @@ const MyResult = z.discriminatedUnion("status", [
 
 Each option should be an *object schema* whose discriminator prop (`status` in the example above) corresponds to some literal value or set of values, usually `z.enum()`, `z.literal()`, `z.null()`, or `z.undefined()`.
 
+### `.exclude()` and `.extract()`
+
+To derive a narrower union from an existing one, pass a set of discriminator values.
+
+<Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
+<Tab value="Zod">
+```ts
+const Success = MyResult.extract(["success"]); // { status: "success", data: string }
+const NotSuccess = MyResult.exclude(["success"]); // { status: "failed", error: string }
+```
+</Tab>
+<Tab value="Zod Mini">
+```ts
+// no equivalent
+
+```
+</Tab>
+</Tabs>
+
+Options are kept or dropped whole, so an option with several discriminator values must have all of them listed.
+
 <Accordions type="single">
 <Accordion title="Nesting discriminated unions">
 

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1900,7 +1900,7 @@ const NotSuccess = MyResult.exclude(["success"]); // { status: "failed", error: 
 </Tab>
 </Tabs>
 
-Options are kept or dropped whole, so an option with several discriminator values must have all of them listed.
+Options are kept or dropped whole, so an option with several discriminator values must have all of them listed. Like `.pick()` and `.omit()`, both methods throw if the union carries refinements.
 
 <Accordions type="single">
 <Accordion title="Nesting discriminated unions">

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1814,8 +1814,7 @@ export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /
         matched.add(option);
       }
 
-      // An option is kept or dropped whole, so a partial selection of its
-      // discriminator values would silently disagree with the inferred type.
+      // An option is kept or dropped whole, so a partial selection of its discriminator values would silently disagree with the inferred type.
       const selected = new Set(values);
       for (const [value, option] of byValue) {
         if (matched.has(option) && !selected.has(value))

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1781,11 +1781,11 @@ export interface ZodDiscriminatedUnion<
   extract<const U extends readonly util.DiscriminatorValues<Options[number], Disc>[]>(
     values: U,
     params?: string | core.$ZodDiscriminatedUnionParams
-  ): ZodDiscriminatedUnion<util.ExtractDiscriminated<Options, Disc, U[number]> & readonly core.SomeType[], Disc>;
+  ): ZodDiscriminatedUnion<util.ExtractDiscriminated<Options, Disc, U[number]>, Disc>;
   exclude<const U extends readonly util.DiscriminatorValues<Options[number], Disc>[]>(
     values: U,
     params?: string | core.$ZodDiscriminatedUnionParams
-  ): ZodDiscriminatedUnion<util.ExcludeDiscriminated<Options, Disc, U[number]> & readonly core.SomeType[], Disc>;
+  ): ZodDiscriminatedUnion<util.ExcludeDiscriminated<Options, Disc, U[number]>, Disc>;
 }
 export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /*@__PURE__*/ core.$constructor(
   "ZodDiscriminatedUnion",
@@ -1799,30 +1799,29 @@ export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /
         throw new Error(`.${method}() cannot be used on discriminated unions containing refinements`);
 
       const options = def.options as core.$ZodType[];
-      const valuesOf = (option: core.$ZodType, index: number) => {
+      const byValue = new Map<util.Primitive, core.$ZodType>();
+      options.forEach((option, index) => {
         const propValues = option._zod.propValues?.[def.discriminator];
         if (!propValues || propValues.size === 0)
           throw new Error(`Invalid discriminated union option at index "${index}"`);
-        return propValues;
-      };
+        for (const value of propValues) byValue.set(value, option);
+      });
 
       const matched = new Set<core.$ZodType>();
       for (const value of values) {
-        const index = options.findIndex((option, i) => valuesOf(option, i).has(value));
-        if (index === -1) throw new Error(`Discriminator value ${util.stringifyPrimitive(value)} not found in union`);
-        matched.add(options[index]);
+        const option = byValue.get(value);
+        if (!option) throw new Error(`Discriminator value ${util.stringifyPrimitive(value)} not found in union`);
+        matched.add(option);
       }
 
       // An option is kept or dropped whole, so a partial selection of its
       // discriminator values would silently disagree with the inferred type.
       const selected = new Set(values);
-      for (const option of matched) {
-        for (const value of valuesOf(option, options.indexOf(option))) {
-          if (!selected.has(value))
-            throw new Error(
-              `Discriminator value ${util.stringifyPrimitive(value)} belongs to the same option and must also be listed`
-            );
-        }
+      for (const [value, option] of byValue) {
+        if (matched.has(option) && !selected.has(value))
+          throw new Error(
+            `Discriminator value ${util.stringifyPrimitive(value)} belongs to the same option and must also be listed`
+          );
       }
 
       return new ZodDiscriminatedUnion({

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1794,6 +1794,10 @@ export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /
     core.$ZodDiscriminatedUnion.init(inst, def);
 
     const partition = (values: readonly util.Primitive[], keep: boolean, params: any) => {
+      const method = keep ? "extract" : "exclude";
+      if (def.checks?.length)
+        throw new Error(`.${method}() cannot be used on discriminated unions containing refinements`);
+
       const options = def.options as core.$ZodType[];
       const valuesOf = (option: core.$ZodType, index: number) => {
         const propValues = option._zod.propValues?.[def.discriminator];
@@ -1823,7 +1827,6 @@ export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /
 
       return new ZodDiscriminatedUnion({
         ...def,
-        checks: [],
         ...util.normalizeParams(params),
         options: options.filter((option) => matched.has(option) === keep),
       }) as any;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1777,12 +1777,60 @@ export interface ZodDiscriminatedUnion<
   "~standard": ZodStandardSchemaWithJSON<this>;
   _zod: core.$ZodDiscriminatedUnionInternals<Options, Disc>;
   def: core.$ZodDiscriminatedUnionDef<Options, Disc>;
+
+  extract<const U extends readonly util.DiscriminatorValues<Options[number], Disc>[]>(
+    values: U,
+    params?: string | core.$ZodDiscriminatedUnionParams
+  ): ZodDiscriminatedUnion<util.ExtractDiscriminated<Options, Disc, U[number]> & readonly core.SomeType[], Disc>;
+  exclude<const U extends readonly util.DiscriminatorValues<Options[number], Disc>[]>(
+    values: U,
+    params?: string | core.$ZodDiscriminatedUnionParams
+  ): ZodDiscriminatedUnion<util.ExcludeDiscriminated<Options, Disc, U[number]> & readonly core.SomeType[], Disc>;
 }
 export const ZodDiscriminatedUnion: core.$constructor<ZodDiscriminatedUnion> = /*@__PURE__*/ core.$constructor(
   "ZodDiscriminatedUnion",
   (inst, def) => {
     ZodUnion.init(inst, def);
     core.$ZodDiscriminatedUnion.init(inst, def);
+
+    const partition = (values: readonly util.Primitive[], keep: boolean, params: any) => {
+      const options = def.options as core.$ZodType[];
+      const valuesOf = (option: core.$ZodType, index: number) => {
+        const propValues = option._zod.propValues?.[def.discriminator];
+        if (!propValues || propValues.size === 0)
+          throw new Error(`Invalid discriminated union option at index "${index}"`);
+        return propValues;
+      };
+
+      const matched = new Set<core.$ZodType>();
+      for (const value of values) {
+        const index = options.findIndex((option, i) => valuesOf(option, i).has(value));
+        if (index === -1) throw new Error(`Discriminator value ${util.stringifyPrimitive(value)} not found in union`);
+        matched.add(options[index]);
+      }
+
+      // An option is kept or dropped whole, so a partial selection of its
+      // discriminator values would silently disagree with the inferred type.
+      const selected = new Set(values);
+      for (const option of matched) {
+        for (const value of valuesOf(option, options.indexOf(option))) {
+          if (!selected.has(value))
+            throw new Error(
+              `Discriminator value ${util.stringifyPrimitive(value)} belongs to the same option and must also be listed`
+            );
+        }
+      }
+
+      return new ZodDiscriminatedUnion({
+        ...def,
+        checks: [],
+        ...util.normalizeParams(params),
+        options: options.filter((option) => matched.has(option) === keep),
+      }) as any;
+    };
+
+    inst.extract = (values, params) => partition(values, true, params);
+    inst.exclude = (values, params) => partition(values, false, params);
   }
 );
 

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -866,7 +866,7 @@ test("exclude/extract through z.lazy() and undefined literals", () => {
 
   const NoUndef = z.discriminatedUnion("type", [z.lazy(() => Exact), Undef, Plain]).exclude([undefined]);
   expect(NoUndef.options.length).toEqual(2);
-  expectTypeOf<z.infer<typeof NoUndef>>().toEqualTypeOf<
-    { type?: "a" | undefined; x: string } | { type: "b"; y: number }
-  >();
+  // the lazy option survives in the type; TypeScript 6 flattens the union itself,
+  // so pin the discriminator rather than the whole shape
+  expectTypeOf<z.infer<typeof NoUndef>["type"]>().toEqualTypeOf<"a" | "b" | undefined>();
 });

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -808,3 +808,27 @@ test("exclude/extract match the discriminator input side", () => {
   expect(() => Wrapped.exclude(["a"])).toThrow(/must also be listed/);
   expect(Wrapped.exclude(["a", undefined]).options.length).toEqual(1);
 });
+
+test("exclude/extract with an optional-input discriminator", () => {
+  // `.default()` makes the key optional on the input side without accepting
+  // `undefined`, so it must not overlap with another option's `undefined`.
+  const U = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a").optional(), x: z.string() }),
+    z.object({ type: z.literal("b").default("b"), y: z.number() }),
+    z.object({ type: z.literal("c"), w: z.boolean() }),
+  ]);
+
+  const R = U.exclude(["a", undefined]);
+  expect(R.options.length).toEqual(2);
+  expectTypeOf<z.infer<typeof R>>().toEqualTypeOf<{ type: "b"; y: number } | { type: "c"; w: boolean }>();
+
+  const Defaulted = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a").default("a"), x: z.string() }),
+    z.object({ type: z.literal("b"), y: z.number() }),
+  ]);
+  // @ts-expect-error a defaulted discriminator does not accept undefined
+  expect(() => Defaulted.exclude([undefined])).toThrow(/not found in union/);
+
+  const OnlyB = Defaulted.exclude(["a"]);
+  expectTypeOf<z.infer<typeof OnlyB>>().toEqualTypeOf<{ type: "b"; y: number }>();
+});

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -782,8 +782,7 @@ test("exclude/extract on a union with refinements", () => {
 });
 
 test("exclude/extract match the discriminator input side", () => {
-  // propValues — and therefore the values these methods match on — come from the
-  // input side, so a codec discriminator is selected by its encoded value.
+  // propValues — and therefore the values these methods match on — come from the input side, so a codec discriminator is selected by its encoded value.
   const Coded = z.discriminatedUnion("type", [
     z.object({
       type: z.codec(z.literal("a"), z.literal(1), { decode: () => 1 as const, encode: () => "a" as const }),
@@ -810,8 +809,7 @@ test("exclude/extract match the discriminator input side", () => {
 });
 
 test("exclude/extract with an optional-input discriminator", () => {
-  // `.default()` makes the key optional on the input side without accepting
-  // `undefined`, so it must not overlap with another option's `undefined`.
+  // `.default()` makes the key optional on the input side without accepting `undefined`, so it must not overlap with another option's `undefined`.
   const U = z.discriminatedUnion("type", [
     z.object({ type: z.literal("a").optional(), x: z.string() }),
     z.object({ type: z.literal("b").default("b"), y: z.number() }),

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -711,3 +711,60 @@ test.each(["__proto__", "constructor", "toString", "hasOwnProperty", "valueOf"])
     expect(parsed.value).toBe("ok");
   }
 );
+
+const Action = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("added"), value: z.string() }),
+  z.object({ type: z.literal("removed"), id: z.number() }),
+  z.object({ type: z.literal("changed"), value: z.string(), id: z.number() }),
+]);
+
+test("exclude", () => {
+  const NoAdded = Action.exclude(["added"]);
+
+  expect(NoAdded.safeParse({ type: "removed", id: 1 }).success).toEqual(true);
+  expect(NoAdded.safeParse({ type: "added", value: "a" }).success).toEqual(false);
+  expect(NoAdded.options.length).toEqual(2);
+  expectTypeOf<z.infer<typeof NoAdded>>().toEqualTypeOf<
+    { type: "removed"; id: number } | { type: "changed"; value: string; id: number }
+  >();
+
+  const Empty = Action.exclude(["added", "removed", "changed"]);
+  expect(Empty.options.length).toEqual(0);
+  expectTypeOf<z.infer<typeof Empty>>().toEqualTypeOf<never>();
+});
+
+test("extract", () => {
+  const Mutations = Action.extract(["added", "removed"]);
+
+  expect(Mutations.safeParse({ type: "added", value: "a" }).success).toEqual(true);
+  expect(Mutations.safeParse({ type: "changed", value: "a", id: 1 }).success).toEqual(false);
+  expectTypeOf<z.infer<typeof Mutations>>().toEqualTypeOf<
+    { type: "added"; value: string } | { type: "removed"; id: number }
+  >();
+});
+
+test("exclude/extract error params", () => {
+  const NoAdded = Action.exclude(["added"], { error: () => "unsupported action" });
+  const result = NoAdded.safeParse({ type: "added", value: "a" });
+  expect(result.error!.issues[0].message).toEqual("unsupported action");
+});
+
+test("exclude/extract unknown discriminator value", () => {
+  expect(() => (Action as any).exclude(["renamed"])).toThrow(/not found in union/);
+  expect(() => (Action as any).extract(["renamed"])).toThrow(/not found in union/);
+});
+
+test("exclude/extract options with multiple discriminator values", () => {
+  const Multi = z.discriminatedUnion("type", [
+    z.object({ type: z.enum(["a", "b"]), value: z.string() }),
+    z.object({ type: z.literal("c"), id: z.number() }),
+  ]);
+
+  const NoAB = Multi.exclude(["a", "b"]);
+  expect(NoAB.options.length).toEqual(1);
+  expectTypeOf<z.infer<typeof NoAB>>().toEqualTypeOf<{ type: "c"; id: number }>();
+
+  // a partial selection would drop "b" without saying so
+  expect(() => Multi.exclude(["a"])).toThrow(/must also be listed/);
+  expect(() => Multi.extract(["a"])).toThrow(/must also be listed/);
+});

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -745,8 +745,10 @@ test("extract", () => {
 
 test("exclude/extract error params", () => {
   const NoAdded = Action.exclude(["added"], { error: () => "unsupported action" });
-  const result = NoAdded.safeParse({ type: "added", value: "a" });
-  expect(result.error!.issues[0].message).toEqual("unsupported action");
+  expect(NoAdded.safeParse({ type: "added", value: "a" }).error!.issues[0].message).toEqual("unsupported action");
+
+  const OnlyAdded = Action.extract(["added"], { error: () => "only additions" });
+  expect(OnlyAdded.safeParse({ type: "removed", id: 1 }).error!.issues[0].message).toEqual("only additions");
 });
 
 test("exclude/extract unknown discriminator value", () => {
@@ -767,4 +769,42 @@ test("exclude/extract options with multiple discriminator values", () => {
   // a partial selection would drop "b" without saying so
   expect(() => Multi.exclude(["a"])).toThrow(/must also be listed/);
   expect(() => Multi.extract(["a"])).toThrow(/must also be listed/);
+});
+
+test("exclude/extract on a union with refinements", () => {
+  const Refined = Action.check(z.refine((v) => v.type !== "added", "no additions"));
+  expect(() => Refined.exclude(["removed"])).toThrow(
+    /\.exclude\(\) cannot be used on discriminated unions containing refinements/
+  );
+  expect(() => Refined.extract(["removed"])).toThrow(
+    /\.extract\(\) cannot be used on discriminated unions containing refinements/
+  );
+});
+
+test("exclude/extract match the discriminator input side", () => {
+  // propValues — and therefore the values these methods match on — come from the
+  // input side, so a codec discriminator is selected by its encoded value.
+  const Coded = z.discriminatedUnion("type", [
+    z.object({
+      type: z.codec(z.literal("a"), z.literal(1), { decode: () => 1 as const, encode: () => "a" as const }),
+      x: z.string(),
+    }),
+    z.object({ type: z.literal("b"), y: z.number() }),
+  ]);
+
+  const OnlyB = Coded.exclude(["a"]);
+  expect(OnlyB.options.length).toEqual(1);
+  expect(OnlyB.safeParse({ type: "b", y: 1 }).success).toEqual(true);
+  expectTypeOf<z.infer<typeof OnlyB>>().toEqualTypeOf<{ type: "b"; y: number }>();
+
+  // @ts-expect-error the decoded value is not what the union matches on
+  expect(() => Coded.exclude([1])).toThrow(/not found in union/);
+
+  // wrapped discriminators contribute every value they accept
+  const Wrapped = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a").optional(), x: z.string() }),
+    z.object({ type: z.literal("b"), y: z.number() }),
+  ]);
+  expect(() => Wrapped.exclude(["a"])).toThrow(/must also be listed/);
+  expect(Wrapped.exclude(["a", undefined]).options.length).toEqual(1);
 });

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -842,4 +842,19 @@ test("exclude/extract with an optional-input discriminator", () => {
   const LayeredOnlyB = Layered.exclude(["a", undefined]);
   expect(LayeredOnlyB.options.length).toEqual(1);
   expectTypeOf<z.infer<typeof LayeredOnlyB>>().toEqualTypeOf<{ type: "b"; y: number }>();
+
+  // a default nested under another wrapper must not re-inherit that undefined
+  const A = z.object({ type: z.literal("a").default("a").nullable(), x: z.string() });
+  const T = z.object({
+    type: z
+      .literal("t")
+      .default("t")
+      .transform((v) => v),
+    w: z.boolean(),
+  });
+  const B = z.object({ type: z.literal("b").optional(), y: z.number() });
+
+  const Nested = z.discriminatedUnion("type", [A, T, B]).exclude(["b", undefined]);
+  expect(Nested.options.length).toEqual(2);
+  expectTypeOf<z.infer<typeof Nested>>().toEqualTypeOf<{ type: "a" | null; x: string } | { type: "t"; w: boolean }>();
 });

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -858,3 +858,15 @@ test("exclude/extract with an optional-input discriminator", () => {
   expect(Nested.options.length).toEqual(2);
   expectTypeOf<z.infer<typeof Nested>>().toEqualTypeOf<{ type: "a" | null; x: string } | { type: "t"; w: boolean }>();
 });
+
+test("exclude/extract through z.lazy() and undefined literals", () => {
+  const Exact = z.object({ type: z.literal("a").exactOptional(), x: z.string() });
+  const Undef = z.object({ type: z.literal(undefined), w: z.boolean() });
+  const Plain = z.object({ type: z.literal("b"), y: z.number() });
+
+  const NoUndef = z.discriminatedUnion("type", [z.lazy(() => Exact), Undef, Plain]).exclude([undefined]);
+  expect(NoUndef.options.length).toEqual(2);
+  expectTypeOf<z.infer<typeof NoUndef>>().toEqualTypeOf<
+    { type?: "a" | undefined; x: string } | { type: "b"; y: number }
+  >();
+});

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -831,4 +831,15 @@ test("exclude/extract with an optional-input discriminator", () => {
 
   const OnlyB = Defaulted.exclude(["a"]);
   expectTypeOf<z.infer<typeof OnlyB>>().toEqualTypeOf<{ type: "b"; y: number }>();
+
+  // layered wrappers: a default over an optional still accepts undefined
+  const Layered = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a").optional().default("a"), x: z.string() }),
+    z.object({ type: z.literal("b"), y: z.number() }),
+  ]);
+  expect(() => Layered.exclude(["a"])).toThrow(/must also be listed/);
+
+  const LayeredOnlyB = Layered.exclude(["a", undefined]);
+  expect(LayeredOnlyB.options.length).toEqual(1);
+  expectTypeOf<z.infer<typeof LayeredOnlyB>>().toEqualTypeOf<{ type: "b"; y: number }>();
 });

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -866,7 +866,5 @@ test("exclude/extract through z.lazy() and undefined literals", () => {
 
   const NoUndef = z.discriminatedUnion("type", [z.lazy(() => Exact), Undef, Plain]).exclude([undefined]);
   expect(NoUndef.options.length).toEqual(2);
-  // the lazy option survives in the type; TypeScript 6 flattens the union itself,
-  // so pin the discriminator rather than the whole shape
-  expectTypeOf<z.infer<typeof NoUndef>["type"]>().toEqualTypeOf<"a" | "b" | undefined>();
+  expectTypeOf<z.infer<typeof NoUndef>>().toEqualTypeOf<{ type?: "a"; x: string } | { type: "b"; y: number }>();
 });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -190,26 +190,48 @@ export type PrimitiveSet = Set<Primitive>;
 
 type PropAt<T, Disc extends string> = T extends unknown ? (Disc extends keyof T ? T[Disc] : never) : never;
 
-/** These wrappers report their inner type's `values` at runtime, but widen the input type with the
- * `undefined` they accept — so unwrap them before reading the input side. */
-type SchemaValues<S> = S extends {
-  _zod: { def: { type: "default" | "prefault" | "readonly" | "catch"; innerType: infer Inner } };
-}
-  ? SchemaValues<Inner>
-  : S extends { _zod: { input: infer I } }
-    ? I
-    : never;
+/** Whether a schema's runtime `values` contain `undefined`. Only `$ZodOptional` and `z.undefined()` add it,
+ * and only `.nonoptional()` takes it away; every other wrapper reports its inner type's values unchanged
+ * while still widening the input type, so they are followed rather than read. `z.exactOptional()` shares
+ * the `optional` def type but adds nothing, and is told apart by its narrowed output. */
+type AcceptsUndefined<S> = S extends { _zod: { def: { type: "nonoptional" } } }
+  ? false
+  : S extends { _zod: { def: { type: "undefined" } } }
+    ? true
+    : S extends { _zod: { output: infer O; def: { type: "optional"; innerType: infer Inner } } }
+      ? undefined extends O
+        ? true
+        : AcceptsUndefined<Inner>
+      : S extends { _zod: { def: { innerType: infer Inner } } }
+        ? AcceptsUndefined<Inner>
+        : S extends { _zod: { def: { in: infer In } } }
+          ? AcceptsUndefined<In>
+          : S extends { _zod: { def: { options: infer O extends readonly unknown[] } } }
+            ? true extends AcceptsUndefined<O[number]>
+              ? true
+              : false
+            : false;
+
+type SchemaValues<S> =
+  | Exclude<S extends { _zod: { input: infer I } } ? I : never, undefined>
+  | (AcceptsUndefined<S> extends true ? undefined : never);
 
 /** The discriminator values accepted by a single union option, matching its runtime `propValues`. They come
  * from the input side, since that is the side `propValues` is built from — so a codec discriminator matches
- * on its encoded values. Non-object options fall back to the option's own input and output types. */
+ * on its encoded values. Options that are not object schemas are followed to whatever they wrap. */
 export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { def: { shape: infer Shape } } }
   ? Disc extends keyof Shape
     ? SchemaValues<Shape[Disc]>
     : never
-  : T extends { _zod: { input: infer I; output: infer O } }
-    ? Exclude<PropAt<I, Disc>, undefined> | (undefined extends PropAt<O, Disc> ? undefined : never)
-    : never;
+  : T extends { _zod: { def: { options: infer O extends readonly unknown[] } } }
+    ? DiscriminatorValues<O[number], Disc>
+    : T extends { _zod: { def: { innerType: infer Inner } } }
+      ? DiscriminatorValues<Inner, Disc>
+      : T extends { _zod: { def: { in: infer In } } }
+        ? DiscriminatorValues<In, Disc>
+        : T extends { _zod: { input: infer I; output: infer O } }
+          ? Exclude<PropAt<I, Disc>, undefined> | (undefined extends PropAt<O, Disc> ? undefined : never)
+          : never;
 
 type Overlaps<T, Values> = [T & Values] extends [never] ? false : true;
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -190,13 +190,26 @@ export type PrimitiveSet = Set<Primitive>;
 
 type PropAt<T, Disc extends string> = T extends unknown ? (Disc extends keyof T ? T[Disc] : never) : never;
 
+/** These wrappers report their inner type's `values` at runtime, but widen the input type with the
+ * `undefined` they accept — so unwrap them before reading the input side. */
+type SchemaValues<S> = S extends {
+  _zod: { def: { type: "default" | "prefault" | "readonly" | "catch"; innerType: infer Inner } };
+}
+  ? SchemaValues<Inner>
+  : S extends { _zod: { input: infer I } }
+    ? I
+    : never;
+
 /** The discriminator values accepted by a single union option, matching its runtime `propValues`. They come
  * from the input side, since that is the side `propValues` is built from — so a codec discriminator matches
- * on its encoded values. An optional-input wrapper like `.default()` marks the key optional there without
- * accepting `undefined`, so `undefined` survives only when the output side has it too. */
-export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { input: infer I; output: infer O } }
-  ? Exclude<PropAt<I, Disc>, undefined> | (undefined extends PropAt<O, Disc> ? undefined : never)
-  : never;
+ * on its encoded values. Non-object options fall back to the option's own input and output types. */
+export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { def: { shape: infer Shape } } }
+  ? Disc extends keyof Shape
+    ? SchemaValues<Shape[Disc]>
+    : never
+  : T extends { _zod: { input: infer I; output: infer O } }
+    ? Exclude<PropAt<I, Disc>, undefined> | (undefined extends PropAt<O, Disc> ? undefined : never)
+    : never;
 
 type Overlaps<T, Values> = [T & Values] extends [never] ? false : true;
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -190,10 +190,12 @@ export type PrimitiveSet = Set<Primitive>;
 
 type PropAt<T, Disc extends string> = T extends unknown ? (Disc extends keyof T ? T[Disc] : never) : never;
 
-/** The discriminator values accepted by a single union option. Read off the input side, since that is
- * where `propValues` comes from — a codec discriminator matches on its encoded values. */
-export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { input: infer I } }
-  ? PropAt<I, Disc>
+/** The discriminator values accepted by a single union option, matching its runtime `propValues`. They come
+ * from the input side, since that is the side `propValues` is built from — so a codec discriminator matches
+ * on its encoded values. An optional-input wrapper like `.default()` marks the key optional there without
+ * accepting `undefined`, so `undefined` survives only when the output side has it too. */
+export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { input: infer I; output: infer O } }
+  ? Exclude<PropAt<I, Disc>, undefined> | (undefined extends PropAt<O, Disc> ? undefined : never)
   : never;
 
 type Overlaps<T, Values> = [T & Values] extends [never] ? false : true;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -188,6 +188,41 @@ export type SafeParseError<T> = {
 export type PropValues = Record<string, Set<Primitive>>;
 export type PrimitiveSet = Set<Primitive>;
 
+/** The discriminator values accepted by a single union option. */
+export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { output: infer O } }
+  ? O extends Record<Disc, infer V>
+    ? V
+    : never
+  : never;
+
+type Overlaps<T, Values> = [T & Values] extends [never] ? false : true;
+
+/** Drops every option whose discriminator values overlap `Values`. */
+export type ExcludeDiscriminated<
+  Options extends readonly unknown[],
+  Disc extends string,
+  Values,
+> = Options extends readonly [infer Head, ...infer Rest extends readonly unknown[]]
+  ? Overlaps<DiscriminatorValues<Head, Disc>, Values> extends true
+    ? ExcludeDiscriminated<Rest, Disc, Values>
+    : [Head, ...ExcludeDiscriminated<Rest, Disc, Values>]
+  : Options extends readonly []
+    ? []
+    : Options;
+
+/** Keeps only the options whose discriminator values overlap `Values`. */
+export type ExtractDiscriminated<
+  Options extends readonly unknown[],
+  Disc extends string,
+  Values,
+> = Options extends readonly [infer Head, ...infer Rest extends readonly unknown[]]
+  ? Overlaps<DiscriminatorValues<Head, Disc>, Values> extends true
+    ? [Head, ...ExtractDiscriminated<Rest, Disc, Values>]
+    : ExtractDiscriminated<Rest, Disc, Values>
+  : Options extends readonly []
+    ? []
+    : Options;
+
 // functions
 export function assertEqual<A, B>(val: AssertEqual<A, B>): AssertEqual<A, B> {
   return val;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -188,11 +188,12 @@ export type SafeParseError<T> = {
 export type PropValues = Record<string, Set<Primitive>>;
 export type PrimitiveSet = Set<Primitive>;
 
-/** The discriminator values accepted by a single union option. */
-export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { output: infer O } }
-  ? O extends Record<Disc, infer V>
-    ? V
-    : never
+type PropAt<T, Disc extends string> = T extends unknown ? (Disc extends keyof T ? T[Disc] : never) : never;
+
+/** The discriminator values accepted by a single union option. Read off the input side, since that is
+ * where `propValues` comes from — a codec discriminator matches on its encoded values. */
+export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { input: infer I } }
+  ? PropAt<I, Disc>
   : never;
 
 type Overlaps<T, Values> = [T & Values] extends [never] ? false : true;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -190,24 +190,28 @@ export type PrimitiveSet = Set<Primitive>;
 
 type PropAt<T, Disc extends string> = T extends unknown ? (Disc extends keyof T ? T[Disc] : never) : never;
 
-/** Whether a schema's runtime `values` contain `undefined`. Only `$ZodOptional` and `z.undefined()` add it,
- * and only `.nonoptional()` takes it away; every other wrapper reports its inner type's values unchanged
- * while still widening the input type, so they are followed rather than read. `z.exactOptional()` shares
- * the `optional` def type but adds nothing, and is told apart by its narrowed output. */
+/** Whether a schema's runtime `values` contain `undefined`. Wrappers widen their input type with the
+ * `undefined` they accept without adding it to `values`, so they are followed rather than read: only
+ * `.nonoptional()` removes it and only `$ZodOptional` adds it. `z.exactOptional()` shares the `optional`
+ * def type without adding it, and is told apart by its narrowed output. Leaves — `z.undefined()`,
+ * `z.literal(undefined)`, an enum with an `undefined` member — have no such widening, so their input side
+ * is read directly. */
 type AcceptsUndefined<S> = S extends { _zod: { def: { type: "nonoptional" } } }
   ? false
-  : S extends { _zod: { def: { type: "undefined" } } }
-    ? true
-    : S extends { _zod: { output: infer O; def: { type: "optional"; innerType: infer Inner } } }
-      ? undefined extends O
-        ? true
-        : AcceptsUndefined<Inner>
-      : S extends { _zod: { def: { innerType: infer Inner } } }
-        ? AcceptsUndefined<Inner>
-        : S extends { _zod: { def: { in: infer In } } }
-          ? AcceptsUndefined<In>
-          : S extends { _zod: { def: { options: infer O extends readonly unknown[] } } }
-            ? true extends AcceptsUndefined<O[number]>
+  : S extends { _zod: { output: infer O; def: { type: "optional"; innerType: infer Inner } } }
+    ? undefined extends O
+      ? true
+      : AcceptsUndefined<Inner>
+    : S extends { _zod: { def: { innerType: infer Inner } } }
+      ? AcceptsUndefined<Inner>
+      : S extends { _zod: { def: { in: infer In } } }
+        ? AcceptsUndefined<In>
+        : S extends { _zod: { def: { options: infer O extends readonly unknown[] } } }
+          ? true extends AcceptsUndefined<O[number]>
+            ? true
+            : false
+          : S extends { _zod: { input: infer I } }
+            ? undefined extends I
               ? true
               : false
             : false;
@@ -229,9 +233,11 @@ export type DiscriminatorValues<T, Disc extends string> = T extends { _zod: { de
       ? DiscriminatorValues<Inner, Disc>
       : T extends { _zod: { def: { in: infer In } } }
         ? DiscriminatorValues<In, Disc>
-        : T extends { _zod: { input: infer I; output: infer O } }
-          ? Exclude<PropAt<I, Disc>, undefined> | (undefined extends PropAt<O, Disc> ? undefined : never)
-          : never;
+        : T extends { _zod: { def: { getter: () => infer Inner } } }
+          ? DiscriminatorValues<Inner, Disc>
+          : T extends { _zod: { input: infer I; output: infer O } }
+            ? Exclude<PropAt<I, Disc>, undefined> | (undefined extends PropAt<O, Disc> ? undefined : never)
+            : never;
 
 type Overlaps<T, Values> = [T & Values] extends [never] ? false : true;
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -194,8 +194,8 @@ type PropAt<T, Disc extends string> = T extends unknown ? (Disc extends keyof T 
  * `undefined` they accept without adding it to `values`, so they are followed rather than read: only
  * `.nonoptional()` removes it and only `$ZodOptional` adds it. `z.exactOptional()` shares the `optional`
  * def type without adding it, and is told apart by its narrowed output. Leaves — `z.undefined()`,
- * `z.literal(undefined)`, an enum with an `undefined` member — have no such widening, so their input side
- * is read directly. */
+ * `z.literal(undefined)`, `z.literal(["a", undefined])` — have no such widening, so their input side is
+ * read directly. */
 type AcceptsUndefined<S> = S extends { _zod: { def: { type: "nonoptional" } } }
   ? false
   : S extends { _zod: { output: infer O; def: { type: "optional"; innerType: infer Inner } } }


### PR DESCRIPTION
Adds `.exclude()` and `.extract()` to `z.discriminatedUnion()`, mirroring the methods `z.enum()` already has. Both take a set of discriminator values and return a narrower discriminated union.

```ts
const MyResult = z.discriminatedUnion("status", [
  z.object({ status: z.literal("success"), data: z.string() }),
  z.object({ status: z.literal("failed"), error: z.string() }),
]);

const Success = MyResult.extract(["success"]); // { status: "success", data: string }
const NotSuccess = MyResult.exclude(["success"]); // { status: "failed", error: string }
```

This is the variant of the long-running "exclude" request that TypeScript can actually express — the ask in #829 is a tuple filter, not the arbitrary schema negation from #2862 that has no type-level representation. The inferred output type is exactly the surviving options, so it stays accurate.

Three construction-time guards, since none of these cases can be represented honestly in the result type:

- An unknown discriminator value throws, like the `Key X not found in enum` guard on `z.enum().exclude()`.
- An option whose discriminator is a `z.enum()` accepts several values. Selecting only some of them would silently drop the rest, so that throws.
- A union carrying refinements throws, matching `.pick()` and `.omit()`.

The accepted values come from the input side of each option's discriminator, which is what `propValues` is built from — so a codec discriminator is selected by its encoded value. For every other discriminator the two sides coincide.

Closes #829
