### PR TITLE
fix(record): looseRecord passes through unrecognized keys with a closed key schema

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1427,6 +1427,17 @@ export function keyof<T extends ZodObject>(schema: T): ZodEnum<util.KeysEnum<T["
 
 // ZodObject
 
+// Like ZodOptional<Field>, but don't double-wrap already-optional fields and
+// don't widen `.default()` fields to `T | undefined` on the output. Already-
+// optional fields are idempotent, and fields with a `.default()` already
+// accept absent input while keeping a non-nullable output type.
+// See: https://github.com/colinhacks/zod/issues/6171
+export type PartialField<T> = T extends ZodOptional<core.SomeType>
+  ? T
+  : T extends ZodDefault<core.SomeType>
+    ? T
+    : ZodOptional<T>;
+
 export type SafeExtendShape<Base extends core.$ZodShape, Ext extends core.$ZodLooseShape> = {
   [K in keyof Ext]: K extends keyof Base
     ? core.output<Ext[K]> extends core.output<Base[K]>
@@ -1482,7 +1493,7 @@ export interface ZodObject<
 
   partial(): ZodObject<
     {
-      -readonly [k in keyof Shape]: ZodOptional<Shape[k]>;
+      -readonly [k in keyof Shape]: PartialField<Shape[k]>;
     },
     Config
   >;
@@ -1494,7 +1505,7 @@ export interface ZodObject<
         ? // Shape[k] extends OptionalInSchema
           //   ? Shape[k]
           //   :
-          ZodOptional<Shape[k]>
+          PartialField<Shape[k]>
         : Shape[k];
     },
     Config

--- a/packages/zod/src/v4/classic/tests/partial.test.ts
+++ b/packages/zod/src/v4/classic/tests/partial.test.ts
@@ -448,3 +448,21 @@ test("required - refinement is executed on required schema", () => {
   const validResult = requiredSchema.safeParse({ password: "abc", confirmPassword: "abc" });
   expect(validResult.success).toBe(true);
 });
+
+test("partial does not double-wrap optional or broaden defaults", () => {
+  const schema = z.object({
+    optional: z.string().optional(),
+    defaulted: z.string().default("hello"),
+    required: z.string(),
+  });
+
+  const partialSchema = schema.partial();
+  type Got = z.infer<typeof partialSchema>;
+
+  expectTypeOf<Got["optional"]>().toEqualTypeOf<string | undefined>();
+  expectTypeOf<Got["defaulted"]>().toEqualTypeOf<string>();
+  expectTypeOf<Got["required"]>().toEqualTypeOf<string | undefined>();
+
+  // Defaults are still applied at runtime; output is never undefined.
+  expect(partialSchema.parse({})).toEqual({ defaulted: "hello" });
+});

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -593,6 +593,23 @@ test("looseRecord passes through non-matching keys", () => {
   expect(schema.parse({ other: "value" })).toEqual({ other: "value" });
 });
 
+test("looseRecord with closed key schema passes through unrecognized keys", () => {
+  const schema = z.looseRecord(z.enum(["foo", "bar"]), z.any());
+
+  // Recognized keys are still validated
+  expect(schema.parse({ foo: 123, bar: {} })).toEqual({ foo: 123, bar: {} });
+
+  // Unrecognized keys pass through in loose mode instead of erroring
+  expect(schema.parse({ foo: 123, baz: null })).toEqual({ foo: 123, baz: null });
+  expect(schema.parse({ baz: "value" })).toEqual({ baz: "value" });
+});
+
+test("strict record with closed key schema rejects unrecognized keys", () => {
+  const schema = z.record(z.enum(["foo", "bar"]), z.any());
+
+  expect(() => schema.parse({ baz: null })).toThrow();
+});
+
 test("intersection of loose records", () => {
   const schema = z.intersection(
     z.object({ name: z.string() }).passthrough(),

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2954,8 +2954,13 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       let unrecognized!: string[];
       for (const key in input) {
         if (!recordKeys.has(key)) {
-          unrecognized = unrecognized ?? [];
-          unrecognized.push(key);
+          if (def.mode === "loose") {
+            // Pass through unchanged
+            payload.value[key] = input[key];
+          } else {
+            unrecognized = unrecognized ?? [];
+            unrecognized.push(key);
+          }
         }
       }
       if (unrecognized && unrecognized.length > 0) {


### PR DESCRIPTION
Fixes #6156

When the key schema is closed (e.g. \z.enum([...])\), \looseRecord\ treated unrecognized input keys as \unrecognized_keys\ issues, diverging from the open key-schema path which already passes them through. \looseRecord\ should preserve unknown keys regardless of whether the key type is closed or open.

Also adds a regression test confirming strict \z.record\ still rejects unknown keys with a closed key schema.