### PR TITLE
feat(json-schema): run `override` before the unrepresentable error

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -233,6 +233,8 @@ You can change this behavior by setting the `unrepresentable` option to `"any"`.
 z.toJSONSchema(z.bigint(), { unrepresentable: "any" });
 // => {}
 ```
+
+To represent some of these types but keep the error for the rest, use [`override`](#override) instead. It runs first, and only the types it doesn't handle throw.
 ### `cycles`
 
 How to handle cycles. If a cycle is encountered as `z.toJSONSchema()` traverses the schema, it will be represented using `$ref`. 
@@ -319,12 +321,11 @@ z.toJSONSchema(mySchema, {
 });
 ```
 
-Note that unrepresentable types will throw an `Error` before this function is called. If you are trying to define custom behavior for an unrepresentable type, you'll need to set the `unrepresentable: "any"` alongside `override`.
+`override` runs before the [`unrepresentable`](#unrepresentable) error is thrown, so you can represent an unrepresentable type here without disabling the error for the others.
 
 ```ts
 // support z.date() as ISO datetime strings
 const result = z.toJSONSchema(z.date(), {
-  unrepresentable: "any",
   override: (ctx) => {
     const def = ctx.zodSchema._zod.def;
     if(def.type ==="date"){
@@ -333,6 +334,21 @@ const result = z.toJSONSchema(z.date(), {
     }
   },
 });
+```
+
+Any unrepresentable type your `override` doesn't give a JSON Schema still throws. Annotations don't count as handling one — adding a `description` to every schema won't suppress the error.
+
+```ts
+z.toJSONSchema(z.object({ createdAt: z.date(), id: z.bigint() }), {
+  override: (ctx) => {
+    const def = ctx.zodSchema._zod.def;
+    if(def.type ==="date"){
+      ctx.jsonSchema.type = "string";
+      ctx.jsonSchema.format = "date-time";
+    }
+  },
+});
+// => throws Error (BigInt cannot be represented in JSON Schema)
 ```
 
 

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3305,6 +3305,29 @@ describe("override runs before the unrepresentable error", () => {
     );
   });
 
+  test("applies through wrappers that clone the schema", () => {
+    // .describe()/.meta() clone the schema and set `_zod.parent`, so the node is visited twice
+    expect(z.toJSONSchema(z.date().describe("x"), { override: dateOverride })).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "description": "x",
+        "format": "date-time",
+        "type": "string",
+      }
+    `);
+    expect(z.toJSONSchema(z.optional(z.date()), { override: dateOverride })).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "format": "date-time",
+        "type": "string",
+      }
+    `);
+    expect(() => z.toJSONSchema(z.bigint().describe("x"), { override: dateOverride })).toThrow(
+      "BigInt cannot be represented in JSON Schema"
+    );
+    expect(() => z.toJSONSchema(z.date().describe("x"))).toThrow("Date cannot be represented in JSON Schema");
+  });
+
   test("emits a valid OpenAPI 3.0 schema", async () => {
     const jsonSchema = z.toJSONSchema(z.object({ when: z.date() }), {
       target: "openapi-3.0",

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3188,3 +3188,143 @@ test("partialRecord does not require finite keys", () => {
   expect(result.propertyNames).toEqual({ type: "string", enum: ["__proto__", "b"] });
   expect(result.additionalProperties).toEqual({ type: "string" });
 });
+
+describe("override runs before the unrepresentable error", () => {
+  const dateOverride: z.core.ToJSONSchemaParams["override"] = (ctx) => {
+    const def = ctx.zodSchema._zod.def;
+    if (def.type === "date") {
+      ctx.jsonSchema.type = "string";
+      ctx.jsonSchema.format = "date-time";
+    }
+  };
+
+  test("an override can represent one type while the rest still throw", () => {
+    expect(z.toJSONSchema(z.object({ when: z.date() }), { override: dateOverride })).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "when": {
+            "format": "date-time",
+            "type": "string",
+          },
+        },
+        "required": [
+          "when",
+        ],
+        "type": "object",
+      }
+    `);
+    expect(() => z.toJSONSchema(z.object({ id: z.bigint() }), { override: dateOverride })).toThrow(
+      "BigInt cannot be represented in JSON Schema"
+    );
+  });
+
+  test("applies through nesting, reuse and $defs extraction", () => {
+    const When = z.date().meta({ id: "When" });
+    expect(
+      z.toJSONSchema(z.object({ a: When, b: When, list: z.array(z.date()) }), { override: dateOverride })
+    ).toMatchInlineSnapshot(`
+      {
+        "$defs": {
+          "When": {
+            "format": "date-time",
+            "type": "string",
+          },
+        },
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "additionalProperties": false,
+        "properties": {
+          "a": {
+            "$ref": "#/$defs/When",
+          },
+          "b": {
+            "$ref": "#/$defs/When",
+          },
+          "list": {
+            "items": {
+              "format": "date-time",
+              "type": "string",
+            },
+            "type": "array",
+          },
+        },
+        "required": [
+          "a",
+          "b",
+          "list",
+        ],
+        "type": "object",
+      }
+    `);
+    // an unrepresentable type extracted into $defs still throws
+    const Big = z.bigint().meta({ id: "Big" });
+    expect(() => z.toJSONSchema(z.object({ a: Big, b: Big }), { override: dateOverride })).toThrow(
+      "BigInt cannot be represented in JSON Schema"
+    );
+  });
+
+  test("annotations alone do not count as handling the type", () => {
+    // a blanket override must not silently disable every unrepresentable error
+    expect(() =>
+      z.toJSONSchema(z.bigint(), {
+        override: (ctx) => {
+          ctx.jsonSchema.description ??= "docs";
+        },
+      })
+    ).toThrow("BigInt cannot be represented in JSON Schema");
+    // nor does metadata already on the schema
+    expect(() => z.toJSONSchema(z.date().meta({ description: "when" }))).toThrow(
+      "Date cannot be represented in JSON Schema"
+    );
+  });
+
+  test("value-level cases still throw even though their node has a form", () => {
+    // the node is a `string`; only the dynamic catch value is unrepresentable
+    expect(() =>
+      z.toJSONSchema(
+        z.string().catch(() => {
+          throw new Error("dynamic");
+        }),
+        { override: dateOverride }
+      )
+    ).toThrow("Dynamic catch values are not supported in JSON Schema");
+    // the node still carries "a"; only the `undefined` member is unrepresentable
+    expect(() => z.toJSONSchema(z.literal([undefined, "a"]), { override: dateOverride })).toThrow(
+      "Literal `undefined` cannot be represented in JSON Schema"
+    );
+  });
+
+  test('`unrepresentable: "any"` is unaffected', () => {
+    expect(z.toJSONSchema(z.bigint(), { unrepresentable: "any", override: dateOverride })).toMatchInlineSnapshot(
+      `
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+      }
+    `
+    );
+  });
+
+  test("emits a valid OpenAPI 3.0 schema", async () => {
+    const jsonSchema = z.toJSONSchema(z.object({ when: z.date() }), {
+      target: "openapi-3.0",
+      override: dateOverride,
+    });
+    expect(jsonSchema).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "when": {
+            "format": "date-time",
+            "type": "string",
+          },
+        },
+        "required": [
+          "when",
+        ],
+        "type": "object",
+      }
+    `);
+    await expect(validateOpenAPI30Schema(jsonSchema)).resolves.toBe(true);
+  });
+});

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -9,6 +9,7 @@ import {
   type ZodStandardJSONSchemaPayload,
   extractDefs,
   finalize,
+  handleUnrepresentable,
   initializeContext,
   process,
 } from "./to-json-schema.js";
@@ -99,16 +100,12 @@ export const booleanProcessor: Processor<schemas.$ZodBoolean> = (_schema, _ctx, 
   (json as JSONSchema.BooleanSchema).type = "boolean";
 };
 
-export const bigintProcessor: Processor<schemas.$ZodBigInt> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("BigInt cannot be represented in JSON Schema");
-  }
+export const bigintProcessor: Processor<schemas.$ZodBigInt> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "BigInt cannot be represented in JSON Schema");
 };
 
-export const symbolProcessor: Processor<schemas.$ZodSymbol> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Symbols cannot be represented in JSON Schema");
-  }
+export const symbolProcessor: Processor<schemas.$ZodSymbol> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Symbols cannot be represented in JSON Schema");
 };
 
 export const nullProcessor: Processor<schemas.$ZodNull> = (_schema, ctx, json, _params) => {
@@ -121,16 +118,12 @@ export const nullProcessor: Processor<schemas.$ZodNull> = (_schema, ctx, json, _
   }
 };
 
-export const undefinedProcessor: Processor<schemas.$ZodUndefined> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Undefined cannot be represented in JSON Schema");
-  }
+export const undefinedProcessor: Processor<schemas.$ZodUndefined> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Undefined cannot be represented in JSON Schema");
 };
 
-export const voidProcessor: Processor<schemas.$ZodVoid> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Void cannot be represented in JSON Schema");
-  }
+export const voidProcessor: Processor<schemas.$ZodVoid> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Void cannot be represented in JSON Schema");
 };
 
 export const neverProcessor: Processor<schemas.$ZodNever> = (_schema, _ctx, json, _params) => {
@@ -145,10 +138,8 @@ export const unknownProcessor: Processor<schemas.$ZodUnknown> = (_schema, _ctx, 
   // empty schema accepts anything
 };
 
-export const dateProcessor: Processor<schemas.$ZodDate> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Date cannot be represented in JSON Schema");
-  }
+export const dateProcessor: Processor<schemas.$ZodDate> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Date cannot be represented in JSON Schema");
 };
 
 export const enumProcessor: Processor<schemas.$ZodEnum> = (schema, _ctx, json, _params) => {
@@ -165,17 +156,10 @@ export const literalProcessor: Processor<schemas.$ZodLiteral> = (schema, ctx, js
   const vals: (string | number | boolean | null)[] = [];
   for (const val of def.values) {
     if (val === undefined) {
-      if (ctx.unrepresentable === "throw") {
-        throw new Error("Literal `undefined` cannot be represented in JSON Schema");
-      } else {
-        // do not add to vals
-      }
+      handleUnrepresentable(schema, ctx, "Literal `undefined` cannot be represented in JSON Schema");
     } else if (typeof val === "bigint") {
-      if (ctx.unrepresentable === "throw") {
-        throw new Error("BigInt literals cannot be represented in JSON Schema");
-      } else {
-        vals.push(Number(val));
-      }
+      handleUnrepresentable(schema, ctx, "BigInt literals cannot be represented in JSON Schema");
+      vals.push(Number(val));
     } else {
       vals.push(val);
     }
@@ -199,10 +183,8 @@ export const literalProcessor: Processor<schemas.$ZodLiteral> = (schema, ctx, js
   }
 };
 
-export const nanProcessor: Processor<schemas.$ZodNaN> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("NaN cannot be represented in JSON Schema");
-  }
+export const nanProcessor: Processor<schemas.$ZodNaN> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "NaN cannot be represented in JSON Schema");
 };
 
 export const templateLiteralProcessor: Processor<schemas.$ZodTemplateLiteral> = (schema, _ctx, json, _params) => {
@@ -241,34 +223,24 @@ export const successProcessor: Processor<schemas.$ZodSuccess> = (_schema, _ctx, 
   (json as JSONSchema.BooleanSchema).type = "boolean";
 };
 
-export const customProcessor: Processor<schemas.$ZodCustom> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Custom types cannot be represented in JSON Schema");
-  }
+export const customProcessor: Processor<schemas.$ZodCustom> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Custom types cannot be represented in JSON Schema");
 };
 
-export const functionProcessor: Processor<schemas.$ZodFunction> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Function types cannot be represented in JSON Schema");
-  }
+export const functionProcessor: Processor<schemas.$ZodFunction> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Function types cannot be represented in JSON Schema");
 };
 
-export const transformProcessor: Processor<schemas.$ZodTransform> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Transforms cannot be represented in JSON Schema");
-  }
+export const transformProcessor: Processor<schemas.$ZodTransform> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Transforms cannot be represented in JSON Schema");
 };
 
-export const mapProcessor: Processor<schemas.$ZodMap> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Map cannot be represented in JSON Schema");
-  }
+export const mapProcessor: Processor<schemas.$ZodMap> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Map cannot be represented in JSON Schema");
 };
 
-export const setProcessor: Processor<schemas.$ZodSet> = (_schema, ctx, _json, _params) => {
-  if (ctx.unrepresentable === "throw") {
-    throw new Error("Set cannot be represented in JSON Schema");
-  }
+export const setProcessor: Processor<schemas.$ZodSet> = (schema, ctx, _json, _params) => {
+  handleUnrepresentable(schema, ctx, "Set cannot be represented in JSON Schema");
 };
 
 // ==================== COMPOSITE TYPE PROCESSORS ====================
@@ -524,9 +496,7 @@ export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, 
   try {
     catchValue = def.catchValue(undefined as any);
   } catch {
-    if (ctx.unrepresentable === "throw") {
-      throw new Error("Dynamic catch values are not supported in JSON Schema");
-    }
+    handleUnrepresentable(schema, ctx, "Dynamic catch values are not supported in JSON Schema");
     return;
   }
   json.default = catchValue;

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -87,6 +87,8 @@ export interface Seen {
   /** Cycle path */
   cycle?: (string | number)[] | undefined;
   isParent?: boolean | undefined;
+  /** Deferred `unrepresentable: "throw"` error, thrown after `override` gets a chance to handle it */
+  unrepresentable?: string | undefined;
   /** Schema to inherit JSON Schema properties from (set by processor for wrappers) */
   ref?: schemas.$ZodType | null;
   /** JSON Schema property path for this schema */
@@ -146,6 +148,17 @@ export function initializeContext(params: JSONSchemaGeneratorParams): ToJSONSche
     reused: params?.reused ?? "inline",
     external: params?.external ?? undefined,
   };
+}
+
+/** Applies the `unrepresentable` setting at a site with no JSON Schema equivalent. Under `"throw"`
+ * the error is deferred: it is recorded on the seen entry and thrown in `finalize`, but only if
+ * `override` did not give the node a JSON Schema form of its own. */
+export function handleUnrepresentable(schema: schemas.$ZodType, ctx: ToJSONSchemaContext, message: string): void {
+  if (ctx.unrepresentable === "throw") {
+    const seen = ctx.seen.get(schema);
+    if (seen) seen.unrepresentable = message;
+    else throw new Error(message);
+  }
 }
 
 export function process<T extends schemas.$ZodType>(
@@ -368,6 +381,28 @@ export function extractDefs<T extends schemas.$ZodType>(
   }
 }
 
+const ANNOTATION_KEYS = /*@__PURE__*/ new Set([
+  "title",
+  "description",
+  "default",
+  "examples",
+  "deprecated",
+  "readOnly",
+  "writeOnly",
+  "$comment",
+  "id",
+  "$id",
+  "_prefault",
+]);
+
+function structuralSnapshot(schema: JSONSchema.BaseSchema): string {
+  const structural: Record<string, unknown> = {};
+  for (const key in schema) {
+    if (!ANNOTATION_KEYS.has(key)) structural[key] = schema[key];
+  }
+  return JSON.stringify(structural);
+}
+
 export function finalize<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
@@ -451,11 +486,23 @@ export function finalize<T extends schemas.$ZodType>(
     }
 
     // execute overrides
+    // Snapshot the structural (non-annotation) half so we can tell whether `override` actually
+    // gave this node a JSON Schema form.
+    const before = seen.unrepresentable !== undefined ? structuralSnapshot(schema) : "";
+
     ctx.override({
       zodSchema: zodSchema as schemas.$ZodTypes,
       jsonSchema: schema,
       path: seen.path ?? [],
     });
+
+    // An unrepresentable node survives only if `override` changed something structural about it.
+    // Annotations don't count, so a blanket `description` override can't silently disable every
+    // unrepresentable error; and requiring a *change* keeps value-level cases (an `undefined`
+    // literal member, a dynamic `.catch()`) throwing even though their node already has a form.
+    if (seen.unrepresentable !== undefined && structuralSnapshot(schema) === before) {
+      throw new Error(seen.unrepresentable);
+    }
   };
 
   for (const entry of [...ctx.seen.entries()].reverse()) {


### PR DESCRIPTION
An alternative to #6380 for the same issue. Rather than teaching `unrepresentable` a callback, this lets `override` run first, so it can represent the types it cares about and everything else still throws.

Today, representing one unrepresentable type means setting `unrepresentable: "any"` and losing the error for all of them — `z.date()` becomes a date-time string only by also letting `z.map()`, `z.symbol()` and the rest silently become `{}`. The docs currently tell you to do exactly that.

```ts
z.toJSONSchema(z.object({ when: z.date(), id: z.bigint() }), {
  // no `unrepresentable: "any"` needed
  override: (ctx) => {
    const def = ctx.zodSchema._zod.def;
    if (def.type === "date") {
      ctx.jsonSchema.type = "string";
      ctx.jsonSchema.format = "date-time";
    }
  },
});
// when => { type: "string", format: "date-time" }
// id   => throws "BigInt cannot be represented in JSON Schema"
```

The old ordering wasn't deliberate. `override` has run in the emit phase since the first Zod 4 commit because it needs the flattened schema, while the unrepresentable checks throw during traversal — nothing depended on the throw landing first. Moving `override` earlier isn't an option (it would see an empty object), so instead the throw is deferred: `unrepresentable: "throw"` records the message on the seen entry, and `finalize` throws it after `override` runs.

"Handled" means `override` changed a non-annotation key on that node. Both halves of that are load-bearing:

- Requiring a **non-annotation** key stops a blanket `override` that adds a `description` to everything from silently disabling every unrepresentable error.
- Requiring a **change** keeps the value-level cases throwing. Those nodes already have a JSON Schema form of their own — a dynamic `.catch()` node is still a `string`, and `z.literal([undefined, "a"])` still carries `"a"` — so they can't be recognized by shape alone.

I tried each half on its own first; each one breaks one of those two groups, and the tests here cover both.

Behavior changes worth flagging: the error now surfaces after traversal instead of during it, so with both a cycle and an unrepresentable type the cycle error wins, and when several types are unrepresentable the reported one follows emit order rather than traversal order. `unrepresentable: "any"` and the default strict behavior are otherwise unchanged.

Closes #5234
