### PR TITLE
perf(v4): share default `when` closures across size/length checks

### DIFF
--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -38,6 +38,18 @@ export const $ZodCheck: core.$constructor<$ZodCheck<any>> = /*@__PURE__*/ core.$
   }
 );
 
+/** Default `when` for size-based checks: run only on non-nullish values with a `size`. */
+const _whenHasSize = (payload: schemas.ParsePayload): boolean => {
+  const val = payload.value;
+  return !util.nullish(val) && (val as any).size !== undefined;
+};
+
+/** Default `when` for length-based checks: run only on non-nullish values with a `length`. */
+const _whenHasLength = (payload: schemas.ParsePayload): boolean => {
+  const val = payload.value;
+  return !util.nullish(val) && (val as any).length !== undefined;
+};
+
 ///////////////////////////////////////
 /////      $ZodCheckLessThan      /////
 ///////////////////////////////////////
@@ -457,10 +469,7 @@ export const $ZodCheckMaxSize: core.$constructor<$ZodCheckMaxSize> = /*@__PURE__
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).size !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasSize;
 
     inst._zod.onattach.push((inst) => {
       const curr = (inst._zod.bag.maximum ?? Number.POSITIVE_INFINITY) as number;
@@ -507,10 +516,7 @@ export const $ZodCheckMinSize: core.$constructor<$ZodCheckMinSize> = /*@__PURE__
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).size !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasSize;
 
     inst._zod.onattach.push((inst) => {
       const curr = (inst._zod.bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
@@ -557,10 +563,7 @@ export const $ZodCheckSizeEquals: core.$constructor<$ZodCheckSizeEquals> = /*@__
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).size !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasSize;
 
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag;
@@ -611,10 +614,7 @@ export const $ZodCheckMaxLength: core.$constructor<$ZodCheckMaxLength> = /*@__PU
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).length !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasLength;
 
     inst._zod.onattach.push((inst) => {
       const curr = (inst._zod.bag.maximum ?? Number.POSITIVE_INFINITY) as number;
@@ -662,10 +662,7 @@ export const $ZodCheckMinLength: core.$constructor<$ZodCheckMinLength> = /*@__PU
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).length !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasLength;
 
     inst._zod.onattach.push((inst) => {
       const curr = (inst._zod.bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
@@ -714,10 +711,7 @@ export const $ZodCheckLengthEquals: core.$constructor<$ZodCheckLengthEquals> = /
   (inst, def) => {
     $ZodCheck.init(inst, def);
 
-    inst._zod.def.when ??= (payload) => {
-      const val = payload.value;
-      return !util.nullish(val) && (val as any).length !== undefined;
-    };
+    inst._zod.def.when ??= _whenHasLength;
 
     inst._zod.onattach.push((inst) => {
       const bag = inst._zod.bag;


### PR DESCRIPTION
Follow-up to the suggestion on #6351: pulling the shared `when` closures out as their own change, rebased onto current `main`, with nothing else from that branch.

## What this does

Six checks (`maxSize`, `minSize`, `sizeEquals`, `maxLength`, `minLength`, `lengthEquals`) each defined the same default `when` inline, so every check instance allocated its own copy of one of two identical closures:

```ts
inst._zod.def.when ??= (payload) => {
  const val = payload.value;
  return !util.nullish(val) && (val as any).length !== undefined;
};
```

They now share two module-level functions, `_whenHasSize` and `_whenHasLength`.

The payoff is per-instance memory rather than bundle size, in the same direction as #6318: one shared function instead of one closure per check instance. Retaining 200,000 `z.string().min(5)` schemas goes from 3,600.4 to 3,544.4 bytes per schema, a 56 byte drop that is stable across runs since it counts allocations rather than time.

Bundle size is not the argument here and does not improve; those numbers are in #6351.

## Behaviour

Check instances now share one function reference where each previously held an identical closure. `def.when` stays user-overridable through the same `??=`, and nothing in the codebase or tests observes closure identity.
