### PR TITLE
fix(v4): reject ASCII tab/newline in url, ipv6 and cidrv6

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -386,6 +386,26 @@ test("url trims whitespace", () => {
   expect(url.parse("https://example.com/path")).toBe("https://example.com/path");
 });
 
+// The WHATWG URL parser deletes ASCII tab/newline instead of failing, so `new URL()` reports a
+// different URL than the one that was passed in and the formats backed by it accepted the input.
+test("url, ipv6 and cidrv6 reject ASCII tab and newline", () => {
+  for (const c of ["\t", "\n", "\r"]) {
+    expect(z.url().safeParse(`https://exa${c}mple.com`).success).toBe(false);
+    expect(z.url({ normalize: true }).safeParse(`https://example.com/a${c}b`).success).toBe(false);
+    expect(z.httpUrl().safeParse(`https://exa${c}mple.com`).success).toBe(false);
+    expect(z.ipv6().safeParse(`2001:db8::${c}1`).success).toBe(false);
+    expect(z.ipv6().safeParse(`::1${c}`).success).toBe(false);
+    expect(z.cidrv6().safeParse(`2001:db8::${c}1/128`).success).toBe(false);
+    expect(z.cidrv6().safeParse(`::1${c}/128`).success).toBe(false);
+  }
+
+  // still valid without them
+  expect(z.url().parse("https://example.com")).toBe("https://example.com");
+  expect(z.httpUrl().parse("https://example.com")).toBe("https://example.com");
+  expect(z.ipv6().parse("2001:db8::1")).toBe("2001:db8::1");
+  expect(z.cidrv6().parse("2001:db8::1/128")).toBe("2001:db8::1/128");
+});
+
 test("url normalize flag", () => {
   const normalizeUrl = z.url({ normalize: true });
   const preserveUrl = z.url(); // normalize: false/undefined by default

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -404,6 +404,14 @@ test("url, ipv6 and cidrv6 reject ASCII tab and newline", () => {
   expect(z.httpUrl().parse("https://example.com")).toBe("https://example.com");
   expect(z.ipv6().parse("2001:db8::1")).toBe("2001:db8::1");
   expect(z.cidrv6().parse("2001:db8::1/128")).toBe("2001:db8::1/128");
+
+  // The rejection must surface as a real validation issue, so a future refactor
+  // that stops throwing can't silently re-pass these (success:false alone would).
+  const withTab = z.ipv6().safeParse("::1\t");
+  expect(withTab.success).toBe(false);
+  if (!withTab.success) {
+    expect(withTab.error.issues.length).toBeGreaterThan(0);
+  }
 });
 
 test("url normalize flag", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -473,6 +473,10 @@ export const $ZodEmail: core.$constructor<$ZodEmail> = /*@__PURE__*/ core.$const
 
 //////////////////////////////   ZodURL   //////////////////////////////
 
+// The WHATWG URL parser deletes ASCII tab and newline instead of failing, so `new URL()` reports
+// on a different string than the one it was given. Formats validated through it reject them.
+const asciiTabOrNewline = /[\t\n\r]/;
+
 export interface $ZodURLDef extends $ZodStringFormatDef<"url"> {
   hostname?: RegExp | undefined;
   protocol?: RegExp | undefined;
@@ -492,6 +496,8 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
     try {
       // Trim whitespace from input
       const trimmed = payload.value.trim();
+
+      if (asciiTabOrNewline.test(trimmed)) throw new Error();
 
       // When normalize is off, require :// for http/https URLs
       // This prevents strings like "http:example.com" or "https:/path" from being silently accepted
@@ -817,6 +823,7 @@ export const $ZodIPv6: core.$constructor<$ZodIPv6> = /*@__PURE__*/ core.$constru
 
   inst._zod.check = (payload) => {
     try {
+      if (asciiTabOrNewline.test(payload.value)) throw new Error();
       // @ts-ignore
       new URL(`http://[${payload.value}]`);
       // return;
@@ -895,8 +902,9 @@ export const $ZodCIDRv6: core.$constructor<$ZodCIDRv6> = /*@__PURE__*/ core.$con
     $ZodStringFormat.init(inst, def);
 
     inst._zod.check = (payload) => {
-      const parts = payload.value.split("/");
       try {
+        if (asciiTabOrNewline.test(payload.value)) throw new Error();
+        const parts = payload.value.split("/");
         if (parts.length !== 2) throw new Error();
         const [address, prefix] = parts;
         if (!prefix) throw new Error();


### PR DESCRIPTION
Fixes #6395.

Step 2 of the WHATWG basic URL parser **deletes** every ASCII tab, LF and CR from its input before parsing, rather than failing on them. `new URL()` therefore succeeds and reports on a string that isn't the one it was given, and every format validated through it inherited that. The consequential case is the host: `new URL("https://exa\nmple.com").host` is `example.com`, so on 4.4.3 `z.url()` and `z.httpUrl()` validated one host and returned a string naming a different one. `z.ipv6().parse("::1\n")` returned `"::1\n"` and `z.cidrv6().parse("::1\n/64")` returned `"::1\n/64"`.

Tab, LF and CR are the only characters with that property. I enumerated all 32 C0 controls at host, path, query, fragment, leading and trailing positions: every other one is percent-encoded (`https://example.com/pa%00th`) or rejected, and U+0009/U+000A/U+000D are the only three that can be injected into the **host** and still validate. Separately, scanning every code point 0x0000–0x10FFFF inserted into `::1` and `::1/64`, `z.ipv6()` disagrees with `net.isIPv6` on exactly those three and nothing else — after the change they agree everywhere except zone IDs (`fe80::1%eth0`), which Zod has never accepted and this doesn't touch.

`z.ipv6()`'s own `toJSONSchema()` pattern rejects these strings, so `parse()` and the schema Zod publishes for it disagreed on the same input. That's now consistent; `regexes.ts` is untouched, so no emitted pattern moved.

The fix is a scan for `[\t\n\r]` ahead of each `new URL()` call, the same shape as `isValidBase64` rejecting the whitespace `atob()` ignores. `z.url()` tests the *trimmed* string, so the deliberate leading/trailing whitespace allowance is untouched — `url.parse("\t\nhttps://example.com\t\n")` still returns `"https://example.com"`.

**Scope — what this does not fix.** `z.url()` accepts and returns the other C0 controls (U+0000–U+0008, U+000B, U+000C, U+000E–U+001F) in path, query and fragment, and at the string edges, both before and after this change. A URL string with a leading NUL (U+0000) parses successfully on both revisions and comes back with the NUL still in it. The parser percent-encodes or edge-strips those rather than deleting them, so they don't produce the validated-one-string-returned-another mismatch above, and rejecting them is a larger default-behaviour question I've deliberately left alone. So this narrows a specific inconsistency; it does not make `z.url()` output control-character-free, and shouldn't be read as closing a security boundary.

Two behaviour changes worth calling out explicitly:

- **`z.httpUrl()`** routes through `$ZodURL` and is equally affected — it accepted `"https://exa\nmple.com"` and now rejects it.
- **`z.url({ normalize: true })`** was *not* affected by the output half of the defect: it returns `url.href`, so on 4.4.3 it already produced sanitized output (`"http://exa\nmple.com"` → `"http://example.com/"`). This PR makes it reject instead, for consistency with the non-normalizing path, and the test asserts that. If you'd rather the normalize path keep silently sanitizing, that's a one-line change.

**Regression surface.** Differential over 41,032 rows — 24 hand-written url/ipv6/cidrv6 seeds crossed with `\t \n \r \v \f`, space, NBSP, `%09`, `%0a`, U+2028, U+2029, NUL, U+0001 and U+001F injected at head/middle/tail, plus 40k seeded-PRNG mutations of the same seeds — run against the built artifact on both revisions:

- 3,764 accept → reject (`url` 1237, `urlNorm` 1237, `httpUrl` 340, `ipv6` 684, `cidrv6` 266)
- 0 reject → accept
- 0 inputs accepted on both sides whose returned value changed
- 0 accept → reject flips on an input that does not contain a tab, LF or CR
- `zod/mini` and classic agree on every row, on both revisions

**Three axes.** Load average 5.9–6.8, so under AGENTS.md's ~8 bar but not lab-grade; the numbers below are two independent runs and I've given the spread rather than the prettier of the two.

| axis | result |
| --- | --- |
| runtime | `safeParse` on a valid input, 8 process alternations per side, min-of-25 inner rounds, 20k parses per round: `z.url()` 125 → 133 ns/op (+6 to +8%), `z.ipv6()` 223 → 232 ns/op (+4%), `z.cidrv6()` 255 → 260 ns/op (+2%). An untouched control (`z.string().min(3)`) read 31.0 → 31.1 and 31.1 → 31.1 ns/op across the two runs, which bounds the resolution at about ±1.5%. No other schema type is on this path. |
| memory | unchanged. Retained bytes per instance, median of 5 runs of 20,000 under `--expose-gc`: `z.url()` 1723 → 1723, `z.ipv6()` 1787 → 1787, `z.cidrv6()` 1790 → 1790, `z.httpUrl()` 1766 → 1765/1766. The regex is module-level; nothing per-instance and no descriptor moves. `%HasFastProperties` reports `fast` for every instance and its `_zod` on both revisions. |
| bundle | `esbuild --bundle --conditions=@zod/source --format=esm --minify`, then `gzip -9`. Classic `zod-string` fixture: 61662 → 61778 raw (+116), 17205 → 17227 gz (+22). `zod-mini-string`: 7808 → 7808, unchanged — the constructors tree-shake out entirely. A fixture that actually uses all three formats: classic 17594 → 17613 gz (+19), mini 13445 → 13560 raw (+115), 4503 → 4522 gz (+19). |

`[\t\n\r]` is a single character class with no quantifier, alternation or group, so it can't backtrack, and there's no `/g` so no `lastIndex` state. Long-input timings, min-of-9: at 1 MB, `z.url()` 0.347 → 0.372 ms, `z.ipv6()` 0.177 → 0.207 ms, `z.cidrv6()` 0.196 → 0.223 ms, scaling linearly from 1 KB through 1 MB on both revisions. The guard strictly reduces what reaches `new URL()`, since it rejects before construction.

Suite is green on all three CI TypeScript legs (5.5.4, 6.0.3, 7.0.2): 348 files / 3965 tests, no type errors, with no pre-existing failures on either revision. `format:check`, `lint:check`, `check:circular`, and the resolution and integration workspaces all pass.

**What I haven't verified:** whether any real caller depends on tab/newline being tolerated. This is a strictness change and I found no test, issue or doc asserting the old behaviour, but it changes a default and the call is yours. The `z.url({ normalize: true })` decision above is the part I'd most expect you to want different. I also left zone IDs alone (`fe80::1%eth0`), which `net.isIPv6` accepts and `z.ipv6()` rejects — that divergence is pre-existing and I haven't judged whether it's intended.
