### PR TITLE
Add shorn to Zod Utilities

### DIFF
--- a/packages/docs/components/ecosystem.tsx
+++ b/packages/docs/components/ecosystem.tsx
@@ -390,6 +390,12 @@ const zodUtilities: ZodResource[] = [
     description: "Oxlint plugin to enforce namespace imports for Zod.",
     slug: "samchungy/oxlint-plugin-import-zod",
   },
+  {
+    name: "shorn",
+    url: "https://shorn.dev",
+    description: "Compact binary serialization that uses your Zod schema as the wire format. No IDL or codegen.",
+    slug: "ChiChuRita/shorn",
+  },
 ];
 
 export {


### PR DESCRIPTION
Adds shorn to the Zod Utilities list.

shorn uses a Zod schema as a binary wire format. `z.object({ name: z.string(), age: z.int().nonnegative() })` holding `{ name: "Grace", age: 45 }` is 35 bytes of minified JSON and 8 bytes through shorn. Field names and type tags stay off the wire because the schema already carries them, so there is no IDL and nothing to generate.

It reads Zod 4.2+ through Standard Schema for validation and Standard JSON Schema for structure, so there is no Zod-specific code path in it. Validation runs on encode and again on decode.

Docs: https://shorn.dev
Repo: https://github.com/ChiChuRita/shorn
npm: `@chichurita/shorn`

One thing worth flagging: shorn is at 0.1.0 and describes itself as experimental. The wire format is not frozen until 1.0. If this list is meant for stable libraries only, I am happy to close and open it again later.