### PR TITLE
fix(json-schema): require a form-defining keyword to suppress the unrepresentable error

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3279,6 +3279,39 @@ describe("override runs before the unrepresentable error", () => {
     );
   });
 
+  test("only a form-defining keyword counts as handling the type", () => {
+    // a broad override that sets a modifier must not silently disable the error
+    expect(() =>
+      z.toJSONSchema(z.object({ when: z.date() }), {
+        target: "openapi-3.0",
+        override: (ctx) => {
+          ctx.jsonSchema.nullable = true;
+        },
+      })
+    ).toThrow("Date cannot be represented in JSON Schema");
+    // nor does a constraint that presupposes a type it never sets
+    expect(() =>
+      z.toJSONSchema(z.date(), {
+        override: (ctx) => {
+          ctx.jsonSchema.format = "date-time";
+        },
+      })
+    ).toThrow("Date cannot be represented in JSON Schema");
+    // a `$ref` is a form, so it does count
+    expect(
+      z.toJSONSchema(z.date(), {
+        override: (ctx) => {
+          ctx.jsonSchema.$ref = "#/components/schemas/DateTime";
+        },
+      })
+    ).toMatchInlineSnapshot(`
+      {
+        "$ref": "#/components/schemas/DateTime",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+      }
+    `);
+  });
+
   test("value-level cases still throw even though their node has a form", () => {
     // the node is a `string`; only the dynamic catch value is unrepresentable
     expect(() =>

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -381,26 +381,16 @@ export function extractDefs<T extends schemas.$ZodType>(
   }
 }
 
-const ANNOTATION_KEYS = /*@__PURE__*/ new Set([
-  "title",
-  "description",
-  "default",
-  "examples",
-  "deprecated",
-  "readOnly",
-  "writeOnly",
-  "$comment",
-  "id",
-  "$id",
-  "_prefault",
-]);
+/** Keywords that actually assert what a value looks like. A schema carrying none of these describes
+ *  nothing, however many annotations or modifiers it has. */
+const FORM_KEYS = /*@__PURE__*/ new Set(["type", "$ref", "enum", "const", "allOf", "anyOf", "oneOf", "not"]);
 
-function structuralSnapshot(schema: JSONSchema.BaseSchema): string {
-  const structural: Record<string, unknown> = {};
+function formSnapshot(schema: JSONSchema.BaseSchema): string {
+  const form: Record<string, unknown> = {};
   for (const key in schema) {
-    if (!ANNOTATION_KEYS.has(key)) structural[key] = schema[key];
+    if (FORM_KEYS.has(key)) form[key] = schema[key];
   }
-  return JSON.stringify(structural);
+  return JSON.stringify(form);
 }
 
 export function finalize<T extends schemas.$ZodType>(
@@ -486,9 +476,9 @@ export function finalize<T extends schemas.$ZodType>(
     }
 
     // execute overrides
-    // Snapshot the structural (non-annotation) half so we can tell whether `override` actually
-    // gave this node a JSON Schema form.
-    const before = seen.unrepresentable !== undefined ? structuralSnapshot(schema) : "";
+    // Snapshot the form-defining keywords so we can tell whether `override` actually gave this node
+    // a JSON Schema shape.
+    const before = seen.unrepresentable !== undefined ? formSnapshot(schema) : "";
 
     ctx.override({
       zodSchema: zodSchema as schemas.$ZodTypes,
@@ -496,11 +486,12 @@ export function finalize<T extends schemas.$ZodType>(
       path: seen.path ?? [],
     });
 
-    // An unrepresentable node survives only if `override` changed something structural about it.
-    // Annotations don't count, so a blanket `description` override can't silently disable every
-    // unrepresentable error; and requiring a *change* keeps value-level cases (an `undefined`
-    // literal member, a dynamic `.catch()`) throwing even though their node already has a form.
-    if (seen.unrepresentable !== undefined && structuralSnapshot(schema) === before) {
+    // An unrepresentable node survives only if `override` changed a form-defining keyword. Testing
+    // the *form* keeps a broad override that only sets a modifier or an annotation (`nullable`,
+    // `description`) from silently disabling every unrepresentable error, and testing for a *change*
+    // keeps value-level cases throwing (a dynamic `.catch()` node is already a `string`, and
+    // `z.literal([undefined, "a"])` already carries `"a"`), which shape alone cannot detect.
+    if (seen.unrepresentable !== undefined && formSnapshot(schema) === before) {
       throw new Error(seen.unrepresentable);
     }
   };


### PR DESCRIPTION
Follow-up to #6391, which decided an `override` had handled an unrepresentable type if it changed any non-annotation key. `nullable` is a non-annotation key, so a broad override of the kind people actually write for OpenAPI silently swallowed the error and emitted a schema that describes nothing:

```ts
z.toJSONSchema(z.object({ when: z.date() }), {
  target: "openapi-3.0",
  override: (ctx) => { ctx.jsonSchema.nullable = true; },
});
// => { when: { nullable: true } }   ← no error, and no type either
```

This tests the form instead of the absence of annotation. The error is suppressed only when `override` changes `type`, `$ref`, `enum`, `const`, or a combinator — the keywords that actually assert what a value looks like. A modifier like `nullable`, or a constraint that presupposes a type it never sets like a bare `format`, no longer counts.

Testing for a *change* rather than mere presence still matters and is kept: a dynamic `.catch()` node is already a `string`, and `z.literal([undefined, "a"])` already carries `"a"`, so shape alone can't tell those apart from a genuinely handled node.
