### PR TITLE
docs: state that metadata wins over generated JSON Schema keywords

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -202,6 +202,18 @@ z.toJSONSchema(schema);
 // => { type: "string", whatever: 1234 }
 ```
 
+Metadata takes precedence over the keywords Zod generates.
+
+```ts
+z.toJSONSchema(z.string().meta({ type: "number" }));
+// => { type: "number" }
+
+z.toJSONSchema(z.date().meta({ type: "string", format: "date-time" }), { unrepresentable: "any" });
+// => { type: "string", format: "date-time" }
+```
+
+To drop metadata entirely, pass an empty registry: `z.toJSONSchema(schema, { metadata: z.registry() })`. To modify a generated schema, use [`override`](#override).
+
 ### `unrepresentable`
 
 The following APIs are not representable in JSON Schema. By default, Zod will throw an error if they are encountered. It is unsound to attempt a conversion to JSON Schema; you should modify your schemas  as they have no equivalent in JSON. An error will be thrown if any of these are encountered.


### PR DESCRIPTION
The metadata section says every field gets copied into the output but never says what happens when a field collides with a keyword Zod derived. That gap produced #5990 and two PRs trying to invert the precedence (#6134, #6270), both closed.

Metadata winning is the behavior worth keeping — it's the only per-schema way to give a schema a form Zod can't derive, which is what makes the `z.date()` workaround work. Documents that, plus the two escape hatches for the other direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
