### PR TITLE
fix(json-schema): unescape JSON Pointer tokens when resolving $ref

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -124,6 +124,12 @@ function applyMinItems(items: ZodType[], minItems: number): ZodType[] {
   return items.map((item, index) => (index < minItems ? item : item.optional()));
 }
 
+// Inverse of the encoding applied to $ref pointer segments in to-json-schema.ts.
+// Per RFC 6901 the `~1` replacement must run before `~0`.
+function decodeJSONPointerSegment(segment: string): string {
+  return segment.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
 function resolveRef(ref: string, ctx: ConversionContext): JSONSchema.JSONSchema {
   if (!ref.startsWith("#")) {
     throw new Error("External $ref is not supported, only local refs (#/...) are allowed");
@@ -139,7 +145,7 @@ function resolveRef(ref: string, ctx: ConversionContext): JSONSchema.JSONSchema 
   const defsKey = ctx.version === "draft-2020-12" ? "$defs" : "definitions";
 
   if (path[0] === defsKey) {
-    const key = path[1];
+    const key = path[1] === undefined ? undefined : decodeJSONPointerSegment(path[1]);
     if (!key || !ctx.defs[key]) {
       throw new Error(`Reference not found: ${ref}`);
     }

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -348,6 +348,15 @@ test("local $ref resolution", () => {
   expect(() => schema.parse({})).toThrow();
 });
 
+test("local $ref resolution unescapes JSON Pointer tokens", () => {
+  // `~1` must be decoded before `~0`, so the id "a~1b" survives as itself and not as "a/b".
+  for (const id of ["Shared/User", "My~Model", "a~b/c", "a~1b"]) {
+    const inner = z.object({ name: z.string() }).meta({ id });
+    const schema = fromJSONSchema(z.toJSONSchema(z.object({ inner })));
+    expect(schema.parse({ inner: { name: "John" } })).toEqual({ inner: { name: "John" } });
+  }
+});
+
 test("circular $ref with lazy", () => {
   const schema = fromJSONSchema({
     $defs: {


### PR DESCRIPTION
Follow-up to #6144, which fixed `toJSONSchema` to emit RFC 6901 escapes in the `$ref` pointer but left the other half of the round-trip alone. `resolveRef` in `from-json-schema.ts` splits the pointer and then looks the def up under the raw token, so it never sees the escapes.

That made #6144 a small regression for one case: an id containing `~` but no `/` round-tripped through `fromJSONSchema` before and throws `Reference not found` after. Ids containing `/` were already broken and stay broken without this.

```ts
const inner = z.object({ name: z.string() }).meta({ id: "My~Model" });
z.fromJSONSchema(z.toJSONSchema(z.object({ inner })));
// before #6144: ok
// after #6144:  Reference not found: #/$defs/My~0Model
```

Decoding the segment before the lookup fixes both. The `~1` replacement has to run before `~0` — the reverse turns an id like `a~1b` into `a/b` — so the test pins that ordering along with `/`, `~`, and both together.

Closes the round-trip half of #6027.
