### PR TITLE
fix(mini): make merge() take an object schema, matching classic

### DIFF
--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -701,6 +701,9 @@ export function safeExtend(schema: schemas.$ZodObject, shape: schemas.$ZodShape)
 }
 
 export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
+  if (!b?._zod?.def) {
+    throw new Error("Invalid input to merge: expected an object schema. To merge a plain shape, use `.extend()`.");
+  }
   if (a._zod.def.checks?.length) {
     throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
   }

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -952,14 +952,15 @@ export function safeExtend<T extends ZodMiniObject, U extends core.$ZodLooseShap
   return util.safeExtend(schema, shape as any);
 }
 
-/** @deprecated Identical to `z.extend(A, B)` */
+/**
+ * @deprecated Use [`z.extend(A, B.shape)`](https://zod.dev/api?id=extend) instead.
+ */
+// @__NO_SIDE_EFFECTS__
 export function merge<T extends ZodMiniObject, U extends ZodMiniObject>(
   a: T,
   b: U
-): ZodMiniObject<util.Extend<T["shape"], U["shape"]>, T["_zod"]["config"]>;
-// @__NO_SIDE_EFFECTS__
-export function merge(schema: ZodMiniObject, shape: any): ZodMiniObject {
-  return util.extend(schema, shape);
+): ZodMiniObject<util.Extend<T["shape"], U["shape"]>, U["_zod"]["config"]> {
+  return util.merge(a, b) as any;
 }
 
 // @__NO_SIDE_EFFECTS__

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -116,6 +116,27 @@ test("z.extend", () => {
   expect(z.safeParse(extendedSchema, { name: "John", age: 30, isAdmin: true }).success).toBe(true);
 });
 
+test("z.merge", () => {
+  const mergedSchema = z.merge(userSchema, z.object({ isAdmin: z.boolean() }));
+  type MergedUser = z.infer<typeof mergedSchema>;
+  expectTypeOf<MergedUser>().toEqualTypeOf<{
+    name: string;
+    age: number;
+    email?: string | undefined;
+    isAdmin: boolean;
+  }>();
+  expect(z.safeParse(mergedSchema, { name: "John", age: 30, isAdmin: true }).success).toBe(true);
+
+  // the second schema's catchall wins, matching classic
+  const strict = z.merge(userSchema, z.strictObject({ isAdmin: z.boolean() }));
+  expect(z.safeParse(strict, { name: "John", age: 30, isAdmin: true, extra: 1 }).success).toBe(false);
+
+  expect(() =>
+    // @ts-expect-error second argument is a schema, not a shape
+    z.merge(userSchema, { isAdmin: z.boolean() })
+  ).toThrow("Invalid input to merge");
+});
+
 test("z.safeExtend", () => {
   const extended = z.safeExtend(userSchema, { name: z.string() });
   expect(z.safeParse(extended, { name: "John", age: 30 }).success).toBe(true);


### PR DESCRIPTION
`zod/mini`'s `merge()` has declared a schema-to-schema overload since the Zod 4 commit 85928549, but its body forwards to `util.extend()`, which wants a plain shape. The call that typechecks throws, and the call that runs is a type error. Reported in #6302.

The signature was right; the body was never pointed at `util.merge()`. This fixes that side, and returns `U`'s config rather than `T`'s so mini matches classic's declaration. The deprecation note now points at `z.extend(A, B.shape)`, the same escape hatch classic's does — the old note claimed `merge` was identical to `z.extend(A, B)`, which is a call that also throws.

`util.merge()` also gains a guard for a non-schema second argument. Anyone passing a plain shape now gets a message naming `.extend()` instead of `TypeError: Cannot read properties of undefined (reading 'def')`. That covers classic's `A.merge(shape)` too, which has always died the same way.

This is breaking for callers passing a plain shape to mini's `merge()`. That form has never typechecked, so reaching it took an `as any` or plain JS. The form the types have always advertised goes from throwing to working.

Supersedes #6303 and #6326.
