### PR TITLE
fix(v4): don't let a coercion materialize an absent exactOptional key

### DIFF
--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -230,6 +230,89 @@ test("exactOptional in objects - explicit undefined rejected", () => {
   expect(schema.safeParse({ a: undefined }, { jitless: true }).success).toEqual(false);
 });
 
+test("exactOptional in objects - coercion doesn't materialize an absent key", () => {
+  for (const inner of [z.coerce.number(), z.coerce.string(), z.coerce.boolean(), z.coerce.bigint()]) {
+    const schema = z.object({ a: inner.exactOptional() });
+    expect(Object.keys(schema.parse({}))).toEqual([]);
+    expect(Object.keys(schema.parse({}, { jitless: true }))).toEqual([]);
+  }
+
+  // A present key still runs the coercion.
+  const num = z.object({ a: z.coerce.number().exactOptional() });
+  expect(num.parse({ a: "42" })).toEqual({ a: 42 });
+  expect(num.parse({ a: "42" }, { jitless: true })).toEqual({ a: 42 });
+});
+
+test("exactOptional in objects - explicit undefined is rejected even when the inner type coerces", () => {
+  // Without this the coercion swallows the undefined — String(undefined) is a valid
+  // string — and a field typed `string` ends up holding "undefined".
+  for (const inner of [z.coerce.string(), z.coerce.boolean(), z.coerce.number()]) {
+    const schema = z.object({ a: inner.exactOptional() });
+    expect(schema.safeParse({ a: undefined }).success).toEqual(false);
+    expect(schema.safeParse({ a: undefined }, { jitless: true }).success).toEqual(false);
+  }
+
+  // A non-coercive inner type still reports its own expected type.
+  expect(z.object({ a: z.string().exactOptional() }).safeParse({ a: undefined }).error!.issues[0]).toMatchObject({
+    expected: "string",
+  });
+});
+
+test("exactOptional in objects - an inner default still applies to an absent key", () => {
+  // `optin: "optional"` means the inner type consumes undefined on purpose, so it
+  // runs even when the key is missing — unlike a coercion.
+  for (const inner of [
+    z.string().default("x"),
+    z.string().default("x").nullable(),
+    z.string().default("x").pipe(z.string()),
+  ]) {
+    const schema = z.object({ a: inner.exactOptional() });
+    expect(schema.parse({})).toEqual({ a: "x" });
+    expect(schema.parse({}, { jitless: true })).toEqual({ a: "x" });
+  }
+});
+
+test("exactOptional in objects - a wrapper outside it sees the same result in both engines", () => {
+  const outer: [string, z.ZodType][] = [
+    ["prefault", z.coerce.number().exactOptional().prefault("42")],
+    ["nonoptional", z.coerce.number().exactOptional().nonoptional()],
+    [
+      "transform",
+      z
+        .string()
+        .exactOptional()
+        .transform((v) => v),
+    ],
+    ["catch", z.string().exactOptional().catch("x")],
+    ["default", z.coerce.number().exactOptional().default(7)],
+  ];
+
+  for (const [label, inner] of outer) {
+    const schema = z.object({ a: inner as any });
+    const jit = schema.safeParse({});
+    const jitless = schema.safeParse({}, { jitless: true });
+    expect({ [label]: jit.success ? jit.data : jit.error.issues }).toEqual({
+      [label]: jitless.success ? jitless.data : jitless.error.issues,
+    });
+  }
+});
+
+test("optional in objects - stays both key-optional and value-optional", () => {
+  // `toEqual` treats an undefined property as absent, so the surrounding tests
+  // can't tell {} from { a: undefined }. Check the key set directly.
+  const schema = z.object({ a: z.string().optional() });
+
+  for (const jitless of [false, true]) {
+    // Key optional: an absent key is omitted, not written as undefined.
+    expect(Object.keys(schema.parse({}, { jitless }))).toEqual([]);
+
+    // Value optional: an explicit undefined is accepted and keeps the key.
+    const undef = schema.parse({ a: undefined }, { jitless });
+    expect(Object.keys(undef)).toEqual(["a"]);
+    expect(undef.a).toEqual(undefined);
+  }
+});
+
 test("exactOptional type inference in objects", () => {
   const schema = z.object({
     a: z.string().exactOptional(),

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3692,9 +3692,21 @@ export const $ZodExactOptional: core.$constructor<$ZodExactOptional> = /*@__PURE
     util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
     util.defineLazy(inst._zod, "pattern", () => def.innerType._zod.pattern);
 
-    // Override parse to just delegate (no undefined handling)
+    // Never keep a value the inner type produced out of `undefined` it doesn't accept.
+    const reject = (result: ParsePayload) => {
+      result.value = undefined;
+      if (!result.issues.length) {
+        result.issues.push({ code: "invalid_type", expected: "nonoptional", input: undefined, inst });
+      }
+      return result;
+    };
+
     inst._zod.parse = (payload, ctx) => {
-      return def.innerType._zod.run(payload, ctx);
+      if (payload.value !== undefined || def.innerType._zod.optin === "optional") {
+        return def.innerType._zod.run(payload, ctx);
+      }
+      const result = def.innerType._zod.run(payload, ctx);
+      return result instanceof Promise ? result.then(reject) : reject(result);
     };
   }
 );


### PR DESCRIPTION
Fixes #6236.

```ts
z.object({ omg: z.coerce.string().exactOptional() }).parse({});  // { omg: "undefined" }
z.object({ omg: z.coerce.boolean().exactOptional() }).parse({}); // { omg: false }
```

`$ZodExactOptional.parse` delegated straight to its inner type, so the coercion ran on the missing key and turned `undefined` into a real value that the object then emitted.

#6407 already covers the half of this where the manufactured value *fails* validation — `z.coerce.number()` produces `NaN`, the number check rejects it, and the fastpass now drops a swallowed issue's value. What's left is the family where the coercion produces a *valid* value from `undefined`: no issue is raised, so there's nothing for that guard to catch.

`$ZodOptional` short-circuits on an `undefined` value, but `exactOptional` can't do the same — a *present* `undefined` is exactly what it has to reject, and the wrapper can't tell that from an absent key. So instead of learning about presence, it runs the inner type for its errors and simply refuses to keep a value the inner type never accepted `undefined` for:

```ts
if (payload.value !== undefined || def.innerType._zod.optin === "optional") {
  return def.innerType._zod.run(payload, ctx);
}
const result = def.innerType._zod.run(payload, ctx);
result.value = undefined;
if (!result.issues.length) {
  result.issues.push({ code: "invalid_type", expected: "nonoptional", input: undefined, inst });
}
return result;
```

The object parser's existing absent-key rule — ignore issues on a key that isn't there, and don't write an `undefined` value for it — then drops the whole thing, so no new presence signal is needed and neither object parser changes. `optin` already means "this schema consumes `undefined` on purpose", so `default` and `prefault` still apply to a missing key, including behind a `pipe` or `transform`.

One deliberate change beyond the reported bug: `exactOptional` now rejects an explicit `undefined` uniformly. Before, that only happened when the coerced value happened to fail validation, so `z.coerce.string().exactOptional()` accepted `{ a: undefined }` and put `"undefined"` into a field whose inferred type is `string`. A non-coercive inner type still reports its own `expected` — `z.string().exactOptional()` says `expected: "string"` exactly as before.

`.optional()` is untouched in both halves of its contract: an absent key is still omitted and an explicit `undefined` is still accepted, in both engines. There's a test pinning that now, because the existing one compared with `toEqual`, which can't tell `{}` from `{ a: undefined }`.
