### PR TITLE
fix(v4): stop the object JIT fastpass keeping a swallowed issue's value

### DIFF
--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -331,3 +331,30 @@ test("tuple tail optionality through optout propagation", () => {
   const interiorOptional = z.tuple([z.string(), z.number().optional(), z.string()]);
   expectTypeOf<z.output<typeof interiorOptional>>().toEqualTypeOf<[string, number | undefined, string]>();
 });
+
+// An absent optional key whose check fails has its issue swallowed; the value the
+// check wrote must go with it, on the JIT fastpass as well as the interpreted path.
+test("swallowed issue on an absent optional key drops its value", async () => {
+  const schema = z.object({
+    a: z
+      .string()
+      .optional()
+      .superRefine((_v, ctx) => {
+        ctx.addIssue({ code: "custom", message: "bad" });
+        ctx.value = "leaked";
+      }),
+  });
+
+  for (const result of [
+    schema.safeParse({}),
+    schema.safeParse({}, { jitless: true }),
+    await schema.safeParseAsync({}),
+  ]) {
+    expect(result.success).toEqual(true);
+    expect("a" in result.data!).toEqual(false);
+  }
+
+  // A present key keeps both the issue and its value.
+  expect(schema.safeParse({ a: "x" }).success).toEqual(false);
+  expect(schema.safeParse({ a: "x" }, { jitless: true }).success).toEqual(false);
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2087,23 +2087,21 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         doc.write(`const ${id} = ${parseStr(key)};`);
 
         if (isOptionalIn && isOptionalOut) {
-          // For optional-in/out schemas, ignore errors on absent keys
+          // For optional-in/out schemas, ignore errors on absent keys — and,
+          // like the interpreted path, drop the value produced alongside them.
           doc.write(`
-        if (${id}.issues.length) {
-          if (${isPresent}) {
+        const ${id}_present = ${isPresent};
+        if (!${id}.issues.length || ${id}_present) {
+          if (${id}.issues.length) {
             payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
               ...iss,
               path: iss.path ? [${k}, ...iss.path] : [${k}]
             })));
           }
-        }
-        
-        if (${id}.value === undefined) {
-          if (${isPresent}) {
-            newResult[${k}] = undefined;
+
+          if (${id}.value !== undefined || ${id}_present) {
+            newResult[${k}] = ${id}.value;
           }
-        } else {
-          newResult[${k}] = ${id}.value;
         }
 
       `);
@@ -2126,11 +2124,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         }
 
         if (${id}_present) {
-          if (${id}.value === undefined) {
-            newResult[${k}] = undefined;
-          } else {
-            newResult[${k}] = ${id}.value;
-          }
+          newResult[${k}] = ${id}.value;
         }
 
       `);


### PR DESCRIPTION
The object JIT fastpass keeps a value written alongside an issue it swallowed, so a failing check can land its value in a successful result.

```ts
const schema = z.object({
  a: z.string().optional().superRefine((_v, ctx) => {
    ctx.addIssue({ code: "custom", message: "bad" });
    ctx.value = "leaked";
  }),
});

schema.safeParse({});                    // { success: true, data: { a: "leaked" } }
schema.safeParse({}, { jitless: true }); // { success: true, data: {} }
await schema.safeParseAsync({});         // { success: true, data: {} }
```

The `optin`/`optout`-optional codegen branch guards only the `payload.issues` concat with the presence check, not the assignment that follows. `handlePropertyResult` returns early in the same situation, and async goes through it, so the divergence is JIT-only. Any check that writes `ctx.value` reaches it — no transform required.

The generated branch now guards both on `!issues.length || present`. While here, the required-in branch's two identical assignment arms collapse to one, which shrinks the generated source by four lines per key.

Split out of #6400, which is closed. This carries none of that PR's key-emission change — which keys get emitted is untouched.
