### PR TITLE
perf(json-schema): make toJSONSchema(registry) linear in registry size

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2620,6 +2620,33 @@ test("basic registry", () => {
   `);
 });
 
+test("large registry converts in linear time", () => {
+  const registry = z.registry<{ id: string }>();
+  const count = 2000;
+  for (let i = 0; i < count; i++) {
+    registry.add(
+      z.object({ id: z.string(), name: z.string(), count: z.number(), nested: z.object({ a: z.boolean() }) }),
+      { id: `Type${i}` }
+    );
+  }
+
+  const start = performance.now();
+  const { schemas } = z.toJSONSchema(registry, { uri: (id) => `https://example.com/${id}.json` });
+  const elapsed = performance.now() - start;
+
+  expect(Object.keys(schemas)).toHaveLength(count);
+  expect(schemas.Type0).toMatchObject({
+    $id: "https://example.com/Type0.json",
+    type: "object",
+    properties: { nested: { type: "object" } },
+  });
+  expect(schemas[`Type${count - 1}`]!.$id).toBe(`https://example.com/Type${count - 1}.json`);
+
+  // The whole-map passes in extractDefs/finalize used to re-run once per registered schema, which
+  // made this quadratic: ~9s of CPU at this size before the passes were hoisted, ~50ms after.
+  expect(elapsed).toBeLessThan(5000);
+});
+
 test("_ref", () => {
   // const a = z.promise(z.string().describe("a"));
   const a = z.toJSONSchema(z.promise(z.string().describe("a")));

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2647,6 +2647,73 @@ test("large registry converts in linear time", () => {
   expect(elapsed).toBeLessThan(5000);
 });
 
+test("registry extracts unregistered subschemas into __shared", () => {
+  const registry = z.registry<{ id: string }>();
+  const address = z.object({ street: z.string() }).meta({ id: "Address" });
+  registry.add(z.object({ home: address, work: address }), { id: "Person" });
+  registry.add(z.object({ hq: address }), { id: "Company" });
+
+  const { schemas } = z.toJSONSchema(registry, { uri: (id) => `https://example.com/${id}.json` });
+
+  expect(schemas.__shared).toMatchInlineSnapshot(`
+    {
+      "$defs": {
+        "Address": {
+          "additionalProperties": false,
+          "properties": {
+            "street": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "street",
+          ],
+          "type": "object",
+        },
+      },
+    }
+  `);
+  expect(schemas.Person).toMatchInlineSnapshot(`
+    {
+      "$id": "https://example.com/Person.json",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
+      "properties": {
+        "home": {
+          "$ref": "https://example.com/__shared.json#/$defs/Address",
+        },
+        "work": {
+          "$ref": "https://example.com/__shared.json#/$defs/Address",
+        },
+      },
+      "required": [
+        "home",
+        "work",
+      ],
+      "type": "object",
+    }
+  `);
+  // Company is emitted after Person, so it only resolves if the shared $defs built on the first
+  // finalize are still reachable — the pass that writes them no longer runs per schema.
+  expect(schemas.Company!.properties!.hq).toEqual({
+    $ref: "https://example.com/__shared.json#/$defs/Address",
+  });
+});
+
+test("registry extracts reused subschemas into __shared without an id", () => {
+  const registry = z.registry<{ id: string }>();
+  const shared = z.object({ q: z.string() });
+  registry.add(z.object({ a: shared, b: shared }), { id: "First" });
+  registry.add(z.object({ c: shared }), { id: "Second" });
+
+  const { schemas } = z.toJSONSchema(registry, { uri: (id) => `${id}.json`, reused: "ref" });
+
+  // The id is counter-generated, so this pins that ctx.counter is consumed exactly once.
+  expect(Object.keys(schemas.__shared!.$defs!)).toEqual(["schema0"]);
+  expect(schemas.First!.properties!.a).toEqual({ $ref: "__shared.json#/$defs/schema0" });
+  expect(schemas.Second!.properties!.c).toEqual({ $ref: "__shared.json#/$defs/schema0" });
+});
+
 test("_ref", () => {
   // const a = z.promise(z.string().describe("a"));
   const a = z.toJSONSchema(z.promise(z.string().describe("a")));

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2752,6 +2752,26 @@ test("JSONSchemaGenerator still throws on cycles when a later emit asks for it",
   expect(() => gen.emit(Node, { external, cycles: "throw" })).toThrow(/Cycle detected/);
 });
 
+test("JSONSchemaGenerator re-runs shared passes on a no-params emit", () => {
+  const shared = z.object({ s: z.string() });
+  const a = z.object({ x: shared });
+  const registry = z.registry<{ id: string }>();
+  registry.add(a, { id: "A" });
+
+  const gen = new z.core.JSONSchemaGenerator({ target: "draft-2020-12" });
+  gen.process(a);
+  const defs: Record<string, any> = {};
+  gen.emit(a, { external: { registry, uri: (id: string) => `${id}.json`, defs }, reused: "ref" });
+
+  // Re-processing an already-seen schema bumps `seen.count`, which `extractDefs` branches on
+  // under `reused: "ref"` — and it returns early, so it cannot clear the guards itself.
+  gen.process(shared);
+  const second: any = gen.emit(a);
+
+  expect(Object.keys(defs)).toEqual(["schema0"]);
+  expect(second.properties.x).toEqual({ $ref: "__shared.json#/$defs/schema0" });
+});
+
 test("_ref", () => {
   // const a = z.promise(z.string().describe("a"));
   const a = z.toJSONSchema(z.promise(z.string().describe("a")));

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2714,6 +2714,44 @@ test("registry extracts reused subschemas into __shared without an id", () => {
   expect(schemas.Second!.properties!.c).toEqual({ $ref: "__shared.json#/$defs/schema0" });
 });
 
+test("JSONSchemaGenerator re-runs shared passes when emit params change", () => {
+  const shared = z.object({ s: z.string() });
+  const a = z.object({ x: shared, y: shared });
+  const registry = z.registry<{ id: string }>();
+  registry.add(a, { id: "A" });
+
+  const gen = new z.core.JSONSchemaGenerator({ target: "draft-2020-12" });
+  gen.process(a);
+  const defs: Record<string, any> = {};
+  const external = { registry, uri: (id: string) => `${id}.json`, defs };
+
+  gen.emit(a, { external, reused: "inline" });
+  // Same `external`, different `reused` — the second emit must still extract `shared`.
+  const second: any = gen.emit(a, { external, reused: "ref" });
+
+  expect(Object.keys(defs)).toEqual(["schema0"]);
+  expect(second.properties.x).toEqual({ $ref: "__shared.json#/$defs/schema0" });
+  expect(second.properties.y).toEqual({ $ref: "__shared.json#/$defs/schema0" });
+});
+
+test("JSONSchemaGenerator still throws on cycles when a later emit asks for it", () => {
+  const Node: any = z.object({
+    v: z.string(),
+    get next() {
+      return Node;
+    },
+  });
+  const registry = z.registry<{ id: string }>();
+  registry.add(Node, { id: "Node" });
+
+  const gen = new z.core.JSONSchemaGenerator({ target: "draft-2020-12" });
+  gen.process(Node);
+  const external = { registry, uri: (id: string) => `${id}.json`, defs: {} };
+
+  gen.emit(Node, { external, cycles: "ref" });
+  expect(() => gen.emit(Node, { external, cycles: "throw" })).toThrow(/Cycle detected/);
+});
+
 test("_ref", () => {
   // const a = z.promise(z.string().describe("a"));
   const a = z.toJSONSchema(z.promise(z.string().describe("a")));

--- a/packages/zod/src/v4/core/json-schema-generator.ts
+++ b/packages/zod/src/v4/core/json-schema-generator.ts
@@ -115,6 +115,11 @@ export class JSONSchemaGenerator {
       if (_params.cycles) this.ctx.cycles = _params.cycles;
       if (_params.reused) this.ctx.reused = _params.reused;
       if (_params.external) this.ctx.external = _params.external;
+      // extractDefs/finalize skip their whole-map passes when they have already run for this
+      // `external`, but they also branch on `cycles` and `reused` — which this is free to change
+      // between emits. Drop the guards so the passes re-run against the new configuration.
+      this.ctx.sharedDefsExtractedFor = undefined;
+      this.ctx.sharedEmitDoneFor = undefined;
     }
 
     extractDefs(this.ctx, schema);

--- a/packages/zod/src/v4/core/json-schema-generator.ts
+++ b/packages/zod/src/v4/core/json-schema-generator.ts
@@ -115,12 +115,15 @@ export class JSONSchemaGenerator {
       if (_params.cycles) this.ctx.cycles = _params.cycles;
       if (_params.reused) this.ctx.reused = _params.reused;
       if (_params.external) this.ctx.external = _params.external;
-      // extractDefs/finalize skip their whole-map passes when they have already run for this
-      // `external`, but they also branch on `cycles` and `reused` — which this is free to change
-      // between emits. Drop the guards so the passes re-run against the new configuration.
-      this.ctx.sharedDefsExtractedFor = undefined;
-      this.ctx.sharedEmitDoneFor = undefined;
     }
+
+    // extractDefs/finalize skip their whole-map passes when they have already run for this
+    // `external`, but they also branch on `cycles`, `reused`, `seen.count` and the metadata
+    // registry — any of which can change between emits, including with no params at all. Drop
+    // the guards so the passes re-run. The registry conversion calls extractDefs/finalize
+    // directly and never routes through here, so it keeps skipping them.
+    this.ctx.sharedDefsExtractedFor = undefined;
+    this.ctx.sharedEmitDoneFor = undefined;
 
     extractDefs(this.ctx, schema);
     const result = finalize(this.ctx, schema);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -129,8 +129,13 @@ export interface ToJSONSchemaContext {
    *
    * The passes are valid only while nothing they read has changed, so both are cleared in
    * `process()` when the map grows, and in `JSONSchemaGenerator.emit()`, which can also change
-   * the `cycles` and `reused` they branch on. Anything else that mutates the context between
-   * emits must clear them too. */
+   * the `cycles` and `reused` they branch on.
+   *
+   * One case is deliberately not covered: an `override` callback that writes to
+   * `metadataRegistry` mid-conversion. It runs inside `finalize`, so a registry conversion has
+   * nowhere left to clear the guards, and later schemas keep the ids the first pass saw. That
+   * output was never coherent — before this, whether a shared subschema was inlined or extracted
+   * depended on which registry entry happened to be emitted when the callback fired. */
   sharedDefsExtractedFor?: ToJSONSchemaContext["external"];
   sharedEmitDoneFor?: ToJSONSchemaContext["external"];
   cycles: "ref" | "throw";

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -125,7 +125,12 @@ export interface ToJSONSchemaContext {
   /** Registry conversions share one `seen` map across every emitted schema. These hold the
    * `external` the whole-map passes below last ran for, so the passes are not repeated once per
    * schema — and still re-run if the map grows or `external` is swapped. `sharedEmitDoneFor`
-   * covers both passes in `finalize`: the ref flattening and the `$defs` build. */
+   * covers both passes in `finalize`: the ref flattening and the `$defs` build.
+   *
+   * The passes are valid only while nothing they read has changed, so both are cleared in
+   * `process()` when the map grows, and in `JSONSchemaGenerator.emit()`, which can also change
+   * the `cycles` and `reused` they branch on. Anything else that mutates the context between
+   * emits must clear them too. */
   sharedDefsExtractedFor?: ToJSONSchemaContext["external"];
   sharedEmitDoneFor?: ToJSONSchemaContext["external"];
   cycles: "ref" | "throw";

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -124,9 +124,10 @@ export interface ToJSONSchemaContext {
   seen: Map<schemas.$ZodType, Seen>;
   /** Registry conversions share one `seen` map across every emitted schema. These hold the
    * `external` the whole-map passes below last ran for, so the passes are not repeated once per
-   * schema — and still re-run if the map grows or `external` is swapped. */
-  sharedDefsExtractedFor?: unknown;
-  sharedRefsFlattenedFor?: unknown;
+   * schema — and still re-run if the map grows or `external` is swapped. `sharedEmitDoneFor`
+   * covers both passes in `finalize`: the ref flattening and the `$defs` build. */
+  sharedDefsExtractedFor?: ToJSONSchemaContext["external"];
+  sharedEmitDoneFor?: ToJSONSchemaContext["external"];
   cycles: "ref" | "throw";
   reused: "ref" | "inline";
   external?:
@@ -163,7 +164,7 @@ export function initializeContext(params: JSONSchemaGeneratorParams): ToJSONSche
     counter: 0,
     seen: new Map(),
     sharedDefsExtractedFor: undefined,
-    sharedRefsFlattenedFor: undefined,
+    sharedEmitDoneFor: undefined,
     cycles: params?.cycles ?? "ref",
     reused: params?.reused ?? "inline",
     external: params?.external ?? undefined,
@@ -218,7 +219,7 @@ export function process<T extends schemas.$ZodType>(
   const result: Seen = { schema: {}, count: 1, cycle: undefined, path: _params.path };
   ctx.seen.set(schema, result);
   ctx.sharedDefsExtractedFor = undefined;
-  ctx.sharedRefsFlattenedFor = undefined;
+  ctx.sharedEmitDoneFor = undefined;
 
   // custom method overrides default behavior
   const overrideSchema = schema._zod.toJSONSchema?.();
@@ -519,7 +520,7 @@ export function finalize<T extends schemas.$ZodType>(
 
   // Flattening walks the whole map and clears each `ref` as it goes, so a second call over the
   // same map is a no-op scan. Skip it outright once it has run for a registry conversion.
-  if (!ctx.external || ctx.sharedRefsFlattenedFor !== ctx.external) {
+  if (!ctx.external || ctx.sharedEmitDoneFor !== ctx.external) {
     for (const entry of [...ctx.seen.entries()].reverse()) {
       flattenRef(entry[0]);
     }
@@ -557,7 +558,7 @@ export function finalize<T extends schemas.$ZodType>(
   // With `external`, `defs` is the shared object every schema writes into, so the same entries
   // are reassigned on every call. Without it, `defs` is fresh per call and must be rebuilt.
   const defs: JSONSchema.BaseSchema["$defs"] = ctx.external?.defs ?? {};
-  if (!ctx.external || ctx.sharedRefsFlattenedFor !== ctx.external) {
+  if (!ctx.external || ctx.sharedEmitDoneFor !== ctx.external) {
     for (const entry of ctx.seen.entries()) {
       const seen = entry[1];
       if (seen.def && seen.defId) {
@@ -566,7 +567,7 @@ export function finalize<T extends schemas.$ZodType>(
       }
     }
   }
-  if (ctx.external) ctx.sharedRefsFlattenedFor = ctx.external;
+  if (ctx.external) ctx.sharedEmitDoneFor = ctx.external;
 
   // set definitions in result
   if (ctx.external) {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -122,6 +122,11 @@ export interface ToJSONSchemaContext {
   io: "input" | "output";
   counter: number;
   seen: Map<schemas.$ZodType, Seen>;
+  /** Registry conversions share one `seen` map across every emitted schema. These hold the
+   * `external` the whole-map passes below last ran for, so the passes are not repeated once per
+   * schema — and still re-run if the map grows or `external` is swapped. */
+  sharedDefsExtractedFor?: unknown;
+  sharedRefsFlattenedFor?: unknown;
   cycles: "ref" | "throw";
   reused: "ref" | "inline";
   external?:
@@ -157,6 +162,8 @@ export function initializeContext(params: JSONSchemaGeneratorParams): ToJSONSche
     io: params?.io ?? "output",
     counter: 0,
     seen: new Map(),
+    sharedDefsExtractedFor: undefined,
+    sharedRefsFlattenedFor: undefined,
     cycles: params?.cycles ?? "ref",
     reused: params?.reused ?? "inline",
     external: params?.external ?? undefined,
@@ -210,6 +217,8 @@ export function process<T extends schemas.$ZodType>(
   // initialize
   const result: Seen = { schema: {}, count: 1, cycle: undefined, path: _params.path };
   ctx.seen.set(schema, result);
+  ctx.sharedDefsExtractedFor = undefined;
+  ctx.sharedRefsFlattenedFor = undefined;
 
   // custom method overrides default behavior
   const overrideSchema = schema._zod.toJSONSchema?.();
@@ -278,6 +287,11 @@ export function extractDefs<T extends schemas.$ZodType>(
   const root = ctx.seen.get(schema);
 
   if (!root) throw new Error("Unprocessed schema. This is a bug in Zod.");
+
+  // With `external` set, every registered schema resolves through the external branch of
+  // `makeURI`, so the root branch below produces the same ref the external branch would —
+  // this pass is identical whichever schema it is called with, and only needs to run once.
+  if (ctx.external && ctx.sharedDefsExtractedFor === ctx.external) return;
 
   // Track ids to detect duplicates across different schemas
   const idToSchema = new Map<string, schemas.$ZodType>();
@@ -409,6 +423,8 @@ export function extractDefs<T extends schemas.$ZodType>(
       }
     }
   }
+
+  if (ctx.external) ctx.sharedDefsExtractedFor = ctx.external;
 }
 
 export function finalize<T extends schemas.$ZodType>(
@@ -501,8 +517,12 @@ export function finalize<T extends schemas.$ZodType>(
     });
   };
 
-  for (const entry of [...ctx.seen.entries()].reverse()) {
-    flattenRef(entry[0]);
+  // Flattening walks the whole map and clears each `ref` as it goes, so a second call over the
+  // same map is a no-op scan. Skip it outright once it has run for a registry conversion.
+  if (!ctx.external || ctx.sharedRefsFlattenedFor !== ctx.external) {
+    for (const entry of [...ctx.seen.entries()].reverse()) {
+      flattenRef(entry[0]);
+    }
   }
 
   const result: JSONSchema.BaseSchema = {};
@@ -534,14 +554,19 @@ export function finalize<T extends schemas.$ZodType>(
   if (rootMetaId !== undefined && result.id === rootMetaId) delete result.id;
 
   // build defs object
+  // With `external`, `defs` is the shared object every schema writes into, so the same entries
+  // are reassigned on every call. Without it, `defs` is fresh per call and must be rebuilt.
   const defs: JSONSchema.BaseSchema["$defs"] = ctx.external?.defs ?? {};
-  for (const entry of ctx.seen.entries()) {
-    const seen = entry[1];
-    if (seen.def && seen.defId) {
-      if (seen.def.id === seen.defId) delete seen.def.id;
-      assignProp(defs, seen.defId, seen.def);
+  if (!ctx.external || ctx.sharedRefsFlattenedFor !== ctx.external) {
+    for (const entry of ctx.seen.entries()) {
+      const seen = entry[1];
+      if (seen.def && seen.defId) {
+        if (seen.def.id === seen.defId) delete seen.def.id;
+        assignProp(defs, seen.defId, seen.def);
+      }
     }
   }
+  if (ctx.external) ctx.sharedRefsFlattenedFor = ctx.external;
 
   // set definitions in result
   if (ctx.external) {


### PR DESCRIPTION
Fixes #6161.

Converting a registry runs `extractDefs` and `finalize` once per registered schema, and both re-scan the whole shared `seen` map on every call — five full-map passes repeated N times, so the work grows as O(N²) in the number of registered schemas. The reporter saw ~30s for ~3000 types.

None of those passes actually depend on which schema they were called with. With `external` set, every registered schema resolves through the external branch of `makeURI`, so the root branch (`schema === entry[0]`) returns exactly the ref the external branch would, and `extractToDef` returns early once `$ref` is set — calls 2..N are no-op scans. The flatten sweep clears each `ref` as it goes, and the defs loop writes into the shared `external.defs`.

So they now run once per `seen` map. The guard keys on the identity of `external` rather than a boolean, because `JSONSchemaGenerator.emit()` can swap `external` between calls and a flag would skip the defs pass and leave the second `defs` empty. `process()` clears the guards when the map grows. Conversions without `external` are untouched — every guard evaluates false and each pass runs exactly as before.

Measured with user CPU time (wall clock swings several-fold on this machine), min of 5, against `main`:

| registered schemas | before | after |
| --- | --- | --- |
| 500 | 270ms | 9ms |
| 1000 | 1361ms | 18ms |
| 2000 | 8931ms | 51ms |

Growth per doubling drops from ~5x to ~2.1x, so it is linear and the gap widens with registry size.

Output is byte-identical to `main` — verified across all four targets, cycles, reuse, parent chains, tuples, `__shared` counter-generated ids, duplicate-id and cycle errors, and repeated `JSONSchemaGenerator.emit()` over one map. No snapshots changed. The added test fails on `main` (`expected 9469.127042 to be less than 5000`) and passes here.

This supersedes #6162, which targeted the same `finalize` sweep but left the other four passes quadratic. Its `$ZodRegistry.get` cache is orthogonal, but measured on top of this change it was no faster (22ms vs 18ms at N=1000), since the parent-chain walk it avoids is now called a linear number of times.
