### PR TITLE
fix(v4): strip output-typed catch values from the input JSON Schema

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2889,6 +2889,20 @@ test("catch on a transforming schema", () => {
       "type": "string",
     }
   `);
+
+  // the catch no longer hides the inner transform from ancestors, so their
+  // output-typed metadata is stripped too — matching a bare nested transform
+  expect(z.toJSONSchema(z.object({ a }).meta({ examples: [{ a: 1 }] }), { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "a": {
+          "type": "string",
+        },
+      },
+      "type": "object",
+    }
+  `);
 });
 
 test("falsy prefaults (false, 0, empty string)", () => {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2868,6 +2868,29 @@ test("defaults/prefaults", () => {
   `);
 });
 
+test("catch on a transforming schema", () => {
+  const a = z
+    .string()
+    .transform((val) => val.length)
+    .pipe(z.number())
+    .catch(0);
+
+  expect(z.toJSONSchema(a)).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "default": 0,
+      "type": "number",
+    }
+  `);
+  // catch values are output-typed, so they are not valid input
+  expect(z.toJSONSchema(a, { io: "input" })).toMatchInlineSnapshot(`
+    {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "string",
+    }
+  `);
+});
+
 test("falsy prefaults (false, 0, empty string)", () => {
   // boolean prefault false
   const a = z.boolean().prefault(false);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -640,7 +640,8 @@ function isTransforming(
     def.type === "nullable" ||
     def.type === "readonly" ||
     def.type === "default" ||
-    def.type === "prefault"
+    def.type === "prefault" ||
+    def.type === "catch"
   ) {
     return isTransforming(def.innerType, ctx);
   }


### PR DESCRIPTION
`catch` was missing from `isTransforming`, so the input-mode guard that strips output-typed values never fired for a `ZodCatch`. A `.catch()` on a transforming schema kept its fallback as `default` under `io: "input"`:

```ts
z.toJSONSchema(z.string().transform(v => v.length).pipe(z.number()).catch(0), { io: "input" });
// { type: "string", default: 0 }
```

Catch values are output-typed, same as `.default()` values, so this is the bug #4557 removed for defaults — it just never covered `catch`. Output mode is unchanged.

There is a second effect worth stating, since it isn't predictable from the title: because `isTransforming` runs at every node, a `ZodCatch` no longer hides an inner transform from its **ancestors** either. Output-typed `.meta({ examples })` / `.meta({ default })` sitting above a catch-over-transform is now stripped under `io: "input"` as well. That matches what a bare nested transform and a `.default()` already do — `catch` was the only wrapper that shadowed the transform. Both effects are pinned by tests.

Scope, since `ZodCatch` in `toJSONSchema` has history (#4134, #4768, #5003): this does not touch optionality. Requiredness is derived from `optin`/`optout`, not from the emitted `default`, and the `required` arrays are identical before and after in both io modes. Type information is preserved too — only the mistyped `default` is dropped, never the `type`.

Found while triaging #6049.
