### PR TITLE
docs: point the Web URLs callout at z.httpUrl()

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -370,10 +370,13 @@ schema.parse("http://example.com"); // ❌
 ```
 
 <Callout>
-  **Web URLs** — In many cases, you'll want to validate Web URLs specifically. Here's the recommended schema for doing so:
+  **Web URLs** — In many cases, you'll want to validate Web URLs specifically. Use `z.httpUrl()`:
 
   ```ts
-  const httpUrl = z.url({
+  z.httpUrl();
+
+  // equivalent to
+  z.url({
     protocol: /^https?$/,
     hostname: z.regexes.domain
   });


### PR DESCRIPTION
The **Web URLs** callout in the URL docs was written in May 2025 and still tells readers to hand-roll the schema that `z.httpUrl()` shipped as in 4.1:

```ts
z.url({ protocol: /^https?$/, hostname: z.regexes.domain });
```

That is exactly what `z.httpUrl()` constructs — it passes `regexes.httpProtocol` (`/^https?$/`) and `regexes.domain`, the same two regexes. The callout even names its variable `httpUrl`. Points it at the builtin and keeps the hand-rolled form as the equivalence.

Came out of #6031, where the answer to the reporter is "use `z.httpUrl()`" but the docs section they'd land on never names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
