### PR TITLE
fix(v4): align record keys and intersection strictness with TypeScript

### DIFF
--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -214,3 +214,39 @@ test("invalid deep merge of object and array combination", async () => {
     `[Error: Unmergable intersection. Error path: ["students",0,"name"]]`
   );
 });
+
+// An enumerable key schema declares which keys the record owns, so a key outside the
+// set is unrecognized and the other side of the intersection may claim it. A
+// non-enumerable key schema is a constraint every key must satisfy, so it still
+// applies to keys owned by the other side.
+test("record key schema in intersection: enumerable vs constraint", () => {
+  const Obj = z.object({ name: z.string() });
+
+  // Enumerable: the object's own key survives the record's key set.
+  const withEnum = z.intersection(Obj, z.partialRecord(z.enum(["p1", "p2"]), z.string()));
+  expect(withEnum.parse({ name: "a", p1: "x" })).toEqual({ name: "a", p1: "x" });
+  expect(z.intersection(Obj, z.record(z.enum(["p1"]), z.string())).parse({ name: "a", p1: "x" })).toEqual({
+    name: "a",
+    p1: "x",
+  });
+
+  // Non-enumerable: the regex applies to every key, including the object's own.
+  const withRegex = z.intersection(Obj, z.record(z.string().regex(/^S_/), z.string()));
+  expect(withRegex.safeParse({ name: "a", S_a: "s" }).success).toBe(false);
+
+  // A key neither side owns is still rejected, when a side actually flags it.
+  const strict = z.intersection(z.strictObject({ name: z.string() }), z.partialRecord(z.enum(["p1"]), z.string()));
+  expect(strict.parse({ name: "a", p1: "x" })).toEqual({ name: "a", p1: "x" });
+  expect(strict.safeParse({ name: "a", p1: "x", evil: "q" }).success).toBe(false);
+});
+
+test("partialRecord reports an out-of-set key as unrecognized, not invalid", () => {
+  const enumKeys = z.partialRecord(z.enum(["a", "b"]), z.string()).safeParse({ a: "x", zzz: "q" });
+  expect(enumKeys.success).toBe(false);
+  expect(enumKeys.error!.issues[0].code).toBe("unrecognized_keys");
+
+  // A regex key schema still reports the failure as an invalid key.
+  const regexKeys = z.record(z.string().regex(/^S_/), z.string()).safeParse({ S_a: "x", zzz: "q" });
+  expect(regexKeys.success).toBe(false);
+  expect(regexKeys.error!.issues[0].code).toBe("invalid_key");
+});

--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -215,29 +215,38 @@ test("invalid deep merge of object and array combination", async () => {
   );
 });
 
-// An enumerable key schema declares which keys the record owns, so a key outside the
-// set is unrecognized and the other side of the intersection may claim it. A
-// non-enumerable key schema is a constraint every key must satisfy, so it still
-// applies to keys owned by the other side.
-test("record key schema in intersection: enumerable vs constraint", () => {
+// A record's key schema says which keys that record GOVERNS; it is not a predicate
+// every key in the result must satisfy. TypeScript works the same way: in
+// `{name: string} & Record<`S_${string}`, string>` the index signature constrains
+// only the keys matching it, so `name` is fine. So a key one side does not govern
+// is reconciled against the other side, exactly as unrecognized_keys already is.
+test("a record's key schema governs only its own keys inside an intersection", () => {
   const Obj = z.object({ name: z.string() });
+  const value = { name: "a", S_a: "s" };
 
-  // Enumerable: the object's own key survives the record's key set.
-  const withEnum = z.intersection(Obj, z.partialRecord(z.enum(["p1", "p2"]), z.string()));
-  expect(withEnum.parse({ name: "a", p1: "x" })).toEqual({ name: "a", p1: "x" });
+  // Every key-schema flavor behaves the same: `name` belongs to the object side.
+  expect(z.intersection(Obj, z.record(z.string().regex(/^S_/), z.string())).parse(value)).toEqual(value);
+  expect(z.intersection(Obj, z.record(z.templateLiteral(["S_", z.string()]), z.string())).parse(value)).toEqual(value);
+  expect(z.intersection(Obj, z.partialRecord(z.enum(["p1", "p2"]), z.string())).parse({ name: "a", p1: "x" })).toEqual({
+    name: "a",
+    p1: "x",
+  });
   expect(z.intersection(Obj, z.record(z.enum(["p1"]), z.string())).parse({ name: "a", p1: "x" })).toEqual({
     name: "a",
     p1: "x",
   });
 
-  // Non-enumerable: the regex applies to every key, including the object's own.
-  const withRegex = z.intersection(Obj, z.record(z.string().regex(/^S_/), z.string()));
-  expect(withRegex.safeParse({ name: "a", S_a: "s" }).success).toBe(false);
+  // A key the record DOES govern still has its value validated across the intersection.
+  const governed = z.intersection(z.object({ S_x: z.number() }), z.record(z.string().regex(/^S_/), z.string()));
+  expect(governed.safeParse({ S_x: 1 }).success).toBe(false);
 
-  // A key neither side owns is still rejected, when a side actually flags it.
-  const strict = z.intersection(z.strictObject({ name: z.string() }), z.partialRecord(z.enum(["p1"]), z.string()));
-  expect(strict.parse({ name: "a", p1: "x" })).toEqual({ name: "a", p1: "x" });
-  expect(strict.safeParse({ name: "a", p1: "x", evil: "q" }).success).toBe(false);
+  // A key NEITHER side governs is still rejected.
+  const strict = z.intersection(z.strictObject({ name: z.string() }), z.record(z.string().regex(/^S_/), z.string()));
+  expect(strict.parse(value)).toEqual(value);
+  expect(strict.safeParse({ ...value, evil: "q" }).success).toBe(false);
+
+  // Standalone, a record still rejects a key it does not govern.
+  expect(z.record(z.string().regex(/^S_/), z.string()).safeParse({ S_a: "s", bad: "x" }).success).toBe(false);
 });
 
 test("partialRecord reports an out-of-set key as unrecognized, not invalid", () => {

--- a/packages/zod/src/v4/classic/tests/intersection.test.ts
+++ b/packages/zod/src/v4/classic/tests/intersection.test.ts
@@ -259,3 +259,76 @@ test("partialRecord reports an out-of-set key as unrecognized, not invalid", () 
   expect(regexKeys.success).toBe(false);
   expect(regexKeys.error!.issues[0].code).toBe("invalid_key");
 });
+
+test("intersection operands run their own checks, refinements and transforms", () => {
+  let checks = 0;
+  const failing = z.intersection(
+    z.strictObject({ x: z.string() }).check(() => {
+      checks++;
+    }),
+    z.strictObject({ a: z.string() }).superRefine((_data, ctx) => {
+      checks++;
+      ctx.addIssue({ code: "custom", message: "boom" });
+    })
+  );
+  expect(failing.safeParse({ x: "test", a: "hello" })).toMatchObject({
+    success: false,
+    error: { issues: [{ code: "custom", message: "boom" }] },
+  });
+  expect(checks).toBe(2);
+
+  const transformed = z.intersection(
+    z.strictObject({ x: z.string() }).transform((v) => ({ ...v, x: v.x.toUpperCase() })),
+    z.strictObject({ a: z.string() }).transform((v) => ({ ...v, seen: true }))
+  );
+  expect(transformed.parse({ x: "test", a: "hello" })).toEqual({ x: "TEST", a: "hello", seen: true });
+});
+
+test("intersection operands apply defaults, including through a nested intersection", () => {
+  const inner = z.intersection(
+    z.strictObject({ x: z.string().default("X default"), y: z.number() }),
+    z.strictObject({ z: z.boolean() })
+  );
+  const schema = z.intersection(inner, z.strictObject({ a: z.string() }));
+  expectTypeOf<z.output<typeof schema>>().toEqualTypeOf<{ x: string; y: number } & { z: boolean } & { a: string }>();
+
+  expect(schema.parse({ y: 34, z: true, a: "hello" })).toEqual({ x: "X default", y: 34, z: true, a: "hello" });
+});
+
+test("a record operand runs its own refinements inside an intersection", () => {
+  let calls = 0;
+  const schema = z
+    .record(z.enum(["p1", "p2"]), z.string())
+    .superRefine((_data, ctx) => {
+      calls++;
+      ctx.addIssue({ code: "custom", message: "record refined" });
+    })
+    .and(z.strictObject({ name: z.string() }));
+
+  expect(schema.safeParse({ p1: "a", p2: "b", name: "n" })).toMatchObject({
+    success: false,
+    error: { issues: [{ code: "custom", message: "record refined" }] },
+  });
+  expect(calls).toBe(1);
+});
+
+test("a strict object nested under an operand keeps its strictness", () => {
+  const schema = z.intersection(
+    z.object({ inner: z.strictObject({ a: z.string() }) }),
+    z.object({ other: z.string() })
+  );
+
+  expect(schema.parse({ inner: { a: "x" }, other: "y" })).toEqual({ inner: { a: "x" }, other: "y" });
+  expect(schema.safeParse({ inner: { a: "x", extra: 1 }, other: "y" })).toMatchObject({
+    success: false,
+    error: { issues: [{ code: "unrecognized_keys", keys: ["extra"], path: ["inner"] }] },
+  });
+});
+
+test("a strict object composes with a refined object", () => {
+  const A = z.object({ key1: z.boolean() }).strict();
+  const B = z.object({ key2: z.boolean() }).refine(({ key2 }) => key2, "key2 must be true");
+
+  expect(A.and(B).parse({ key1: true, key2: true })).toEqual({ key1: true, key2: true });
+  expect(A.and(B).safeParse({ key1: true, key2: false }).success).toBe(false);
+});

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -561,24 +561,12 @@ test("partialRecord with z.literal([key, ...])", () => {
     {
       "error": [ZodError: [
       {
-        "code": "invalid_key",
-        "origin": "record",
-        "issues": [
-          {
-            "code": "invalid_value",
-            "values": [
-              "id",
-              "name",
-              "email"
-            ],
-            "path": [],
-            "message": "Invalid option: expected one of \\"id\\"|\\"name\\"|\\"email\\""
-          }
-        ],
-        "path": [
+        "code": "unrecognized_keys",
+        "keys": [
           "foo"
         ],
-        "message": "Invalid key in record"
+        "path": [],
+        "message": "Unrecognized key: \\"foo\\""
       }
     ]],
       "success": false,

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2630,37 +2630,49 @@ function mergeValues(
 }
 
 function handleIntersectionResults(result: ParsePayload, left: ParsePayload, right: ParsePayload): ParsePayload {
-  // Track which side(s) report each key as unrecognized
+  // Track which side(s) reject each key. A key rejection is reported only when
+  // BOTH sides reject it, so a key owned by one branch survives the other's
+  // key schema. strictObject reports these as unrecognized_keys; a record with
+  // an open key schema reports one invalid_key per key.
   const unrecKeys = new Map<string, { l?: true; r?: true }>();
   let unrecIssue: errors.$ZodRawIssue | undefined;
+  const keyIssues = new Map<string, errors.$ZodRawIssue>();
 
-  for (const iss of left.issues) {
+  const collect = (iss: errors.$ZodRawIssue, side: "l" | "r"): boolean => {
+    let keys: string[];
     if (iss.code === "unrecognized_keys") {
       unrecIssue ??= iss;
-      for (const k of iss.keys) {
-        if (!unrecKeys.has(k)) unrecKeys.set(k, {});
-        unrecKeys.get(k)!.l = true;
-      }
+      keys = iss.keys as string[];
+    } else if (iss.code === "invalid_key" && iss.origin === "record" && iss.path?.length === 1) {
+      const k = String(iss.path[0]);
+      if (!keyIssues.has(k)) keyIssues.set(k, iss);
+      keys = [k];
     } else {
-      result.issues.push(iss);
+      return false;
     }
+    for (const k of keys) {
+      if (!unrecKeys.has(k)) unrecKeys.set(k, {});
+      unrecKeys.get(k)![side] = true;
+    }
+    return true;
+  };
+
+  for (const iss of left.issues) {
+    if (!collect(iss, "l")) result.issues.push(iss);
   }
 
   for (const iss of right.issues) {
-    if (iss.code === "unrecognized_keys") {
-      for (const k of iss.keys) {
-        if (!unrecKeys.has(k)) unrecKeys.set(k, {});
-        unrecKeys.get(k)!.r = true;
-      }
-    } else {
-      result.issues.push(iss);
-    }
+    if (!collect(iss, "r")) result.issues.push(iss);
   }
 
-  // Report only keys unrecognized by BOTH sides
+  // Report only keys rejected by BOTH sides
   const bothKeys = [...unrecKeys].filter(([, f]) => f.l && f.r).map(([k]) => k);
-  if (bothKeys.length && unrecIssue) {
-    result.issues.push({ ...unrecIssue, keys: bothKeys });
+  if (bothKeys.length) {
+    const aggregated = unrecIssue ? bothKeys.filter((k) => (unrecIssue!.keys as string[]).includes(k)) : [];
+    if (aggregated.length) result.issues.push({ ...unrecIssue!, keys: aggregated });
+    for (const k of bothKeys) {
+      if (!aggregated.includes(k) && keyIssues.has(k)) result.issues.push(keyIssues.get(k)!);
+    }
   }
 
   if (util.aborted(result)) return result;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1957,6 +1957,10 @@ function handleCatchall(
       keys: unrecognized,
       input,
       inst,
+      // Describes the shape of the input, not the validity of the parsed value, so it never
+      // aborts. The parse still fails; the schema's own checks just get to run first, and an
+      // enclosing intersection can reconcile the key against a sibling operand.
+      continue: true,
     });
   }
 
@@ -2640,7 +2644,7 @@ function handleIntersectionResults(result: ParsePayload, left: ParsePayload, rig
 
   const collect = (iss: errors.$ZodRawIssue, side: "l" | "r"): boolean => {
     let keys: string[];
-    if (iss.code === "unrecognized_keys") {
+    if (iss.code === "unrecognized_keys" && !iss.path?.length) {
       unrecIssue ??= iss;
       keys = iss.keys as string[];
     } else if (iss.code === "invalid_key" && iss.origin === "record" && iss.path?.length === 1) {
@@ -2675,11 +2679,10 @@ function handleIntersectionResults(result: ParsePayload, left: ParsePayload, rig
     }
   }
 
-  if (util.aborted(result)) return result;
-
   const merged = mergeValues(left.value, right.value);
 
   if (!merged.valid) {
+    if (util.aborted(result)) return result;
     throw new Error(`Unmergable intersection. Error path: ` + `${JSON.stringify(merged.mergeErrorPath)}`);
   }
 
@@ -3043,6 +3046,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
           input,
           inst,
           keys: unrecognized,
+          continue: true,
         });
       }
     } else {
@@ -3126,6 +3130,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
           input,
           inst,
           keys: unrecognized,
+          continue: true,
         });
       }
     }
@@ -4154,7 +4159,10 @@ export const $ZodPipe: core.$constructor<$ZodPipe> = /*@__PURE__*/ core.$constru
 });
 
 function handlePipeResult(left: ParsePayload, next: $ZodType, ctx: ParseContextInternal) {
-  if (left.issues.length) {
+  // Any issue stops the pipe, so a failing refinement never feeds its transform. An
+  // unrecognized key is the exception: it describes the input's extra properties, not the
+  // value being piped, and an enclosing intersection may yet reconcile it.
+  if (left.issues.some((iss) => iss.code !== "unrecognized_keys")) {
     // prevent further checks
     left.aborted = true;
     return left;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3035,6 +3035,11 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       }
     } else {
       payload.value = {};
+      // An enumerable key schema declares which keys the record owns, so a key outside
+      // the set is unrecognized. A non-enumerable one (regex, refine) is a constraint
+      // every key must satisfy, so a failing key is invalid. Only the former is
+      // reconcilable against the other side of an intersection.
+      let unrecognized!: string[];
       // Reflect.ownKeys for Symbol-key support; filter non-enumerable to match z.object()
       for (const key of Reflect.ownKeys(input)) {
         if (key === "__proto__") continue;
@@ -3061,6 +3066,9 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
           if (def.mode === "loose") {
             // Pass through unchanged
             payload.value[key] = input[key];
+          } else if (values) {
+            unrecognized = unrecognized ?? [];
+            unrecognized.push(key as string);
           } else {
             // Default "strict" behavior: error on invalid key
             payload.issues.push({
@@ -3097,6 +3105,16 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
           }
           payload.value[outKey] = result.value;
         }
+      }
+
+      if (unrecognized && unrecognized.length > 0) {
+        payload.issues.push({
+          code: "unrecognized_keys",
+
+          input,
+          inst,
+          keys: unrecognized,
+        });
       }
     }
 


### PR DESCRIPTION
Makes a record's key schema behave the way TypeScript treats an index signature, and stops an unrecognized key from suppressing the rest of a schema.

### A record's key schema governs its own keys, not every key

```ts
z.object({ name: z.string() }).and(z.record(z.string().regex(/^S_/), z.string()))
  .parse({ name: "a", S_a: "s" });
// before: throws invalid_key on "name"
// now:    { name: "a", S_a: "s" }
```

`name` is the object's key, not the record's. TypeScript agrees — in `{name: string} & Record<`S_${string}`, string>` the index signature constrains only the keys matching it, while a matching key with the wrong value type is still an error. `z.infer` already matched TypeScript here; the parser did not, so the runtime rejected values the inferred type accepted.

This holds for every key-schema flavor: `z.enum`, `z.literal([...])`, `z.string().regex()`, `z.templateLiteral()`. Two changes get there. `$ZodRecord` chose its issue code from `def.partial` rather than from the key schema, so `z.partialRecord(z.enum([...]))` reported `invalid_key` where `z.record(z.enum([...]))` reported `unrecognized_keys`; it now classifies on the key schema. And `handleIntersectionResults` reconciles a record's `invalid_key` the same way it already reconciles `unrecognized_keys`, so a key one operand does not govern is reported only when no operand governs it.

The reconciliation rule itself is unchanged: report a key only when every operand objects to it. A stripping schema never objects, so it never contributes. Standalone records are unchanged — a key outside the key schema is still an error, matching TypeScript's excess-property check on a fresh object literal.

### An unrecognized key no longer aborts the schema it came from

```ts
z.strictObject({ a: z.string() }).safeParse({ a: 1, extra: 2 });
// before: ["unrecognized_keys"]
// now:    ["invalid_type", "unrecognized_keys"]
```

`unrecognized_keys` describes the shape of the input, not the validity of the parsed value, so it is now continuable at every emission site. A strict operand inside an intersection runs its own checks, refinements and transforms; a `.default()` inside a nested intersection applies. The parse still fails.

A pipe keeps its rule that any issue stops it, so a failing refinement never feeds its transform and `z.string().refine(isJSON).transform(JSON.parse)` still fails cleanly rather than throwing. The single exception is `unrecognized_keys`, where the value handed downstream is identical whether or not the extra key was present.

Supersedes #5905, #6234 and #6248. Fixes #2200. Fixes #2573. Fixes #4017. Fixes #5663.
