### PR TITLE
docs: note that the JSON Schema emitter reads static optin

### DIFF
--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -267,8 +267,8 @@ export const arrayProcessor: Processor<schemas.$ZodArray> = (schema, ctx, _json,
 // absent key, but their declared input type stays required. An input JSON Schema describes the
 // declared type, so resolve past them to the schema that actually carries the optionality.
 // `tupleProcessor` reads `optin` in the same input branch but has not been given this treatment,
-// so its `minItems` still tracks the runtime flag; see wiki/optionality.md, "Static/runtime
-// divergence".
+// so its `minItems` still tracks the runtime flag; see wiki/optionality.md, "The JSON Schema
+// emitter reads the *static* value".
 function inputOptin(schema: schemas.$ZodType): "optional" | undefined {
   const def = schema._zod.def;
   if (def.type === "pipe" && (def as schemas.$ZodPipeDef).in._zod.traits.has("$ZodTransform")) {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -266,6 +266,8 @@ export const arrayProcessor: Processor<schemas.$ZodArray> = (schema, ctx, _json,
 // Transform and catch set `optin = "optional"` at runtime so the parser lets them observe an
 // absent key, but their declared input type stays required. An input JSON Schema describes the
 // declared type, so resolve past them to the schema that actually carries the optionality.
+// This is the one consumer of `optin` that must read the static value rather than the runtime
+// one; see wiki/optionality.md, "Static/runtime divergence".
 function inputOptin(schema: schemas.$ZodType): "optional" | undefined {
   const def = schema._zod.def;
   if (def.type === "pipe" && (def as schemas.$ZodPipeDef).in._zod.traits.has("$ZodTransform")) {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -266,8 +266,9 @@ export const arrayProcessor: Processor<schemas.$ZodArray> = (schema, ctx, _json,
 // Transform and catch set `optin = "optional"` at runtime so the parser lets them observe an
 // absent key, but their declared input type stays required. An input JSON Schema describes the
 // declared type, so resolve past them to the schema that actually carries the optionality.
-// This is the one consumer of `optin` that must read the static value rather than the runtime
-// one; see wiki/optionality.md, "Static/runtime divergence".
+// `tupleProcessor` reads `optin` in the same input branch but has not been given this treatment,
+// so its `minItems` still tracks the runtime flag; see wiki/optionality.md, "Static/runtime
+// divergence".
 function inputOptin(schema: schemas.$ZodType): "optional" | undefined {
   const def = schema._zod.def;
   if (def.type === "pipe" && (def as schemas.$ZodPipeDef).in._zod.traits.has("$ZodTransform")) {

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -1,16 +1,16 @@
 # Optionality in Zod v4
 
-Internal reference for how Zod's parsing handles "missing" / "undefined" input. Reflects the current state of `main` plus the in-flight branch `fix-fallback-flag-and-preprocess`.
+Internal reference for how Zod's parsing handles "missing" / "undefined" input. Reflects the current state of `main`.
 
 The system has accumulated a few orthogonal mechanisms. This doc names them, says which schema sets what, and walks through the gnarly interactions.
 
 ## TL;DR
 
-Three runtime signals, each with a single consumer:
+Three runtime signals:
 
 | Signal | Set by | Consumed by | Means |
 |---|---|---|---|
-| `_zod.optin === "optional"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional` | "I accept absent input" |
+| `_zod.optin === "optional"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional`; also `objectProcessor`, which reads the **static** value — see below | "I accept absent input" |
 | `_zod.optout === "optional"` | optional, exact-optional, default-on-output cases | `$ZodObject`, `$ZodTuple` | "My output may legitimately be `undefined`; treat that as absent for length-shortening / key-omission" |
 | `payload.fallback === true` | catch (when `catchValue` substitutes), transform | `$ZodOptional` (in `handleOptionalResult`) | "This value is provisional; an outer wrapper may override it on undefined input" |
 
@@ -112,6 +112,23 @@ inst._zod.parse = (payload, ctx) => {
 ```
 
 So `optional` *invokes* its inner whenever inner says "I handle absence." It only short-circuits when inner is silent on the question.
+
+### The JSON Schema emitter reads the *static* value
+
+`objectProcessor` in `json-schema-processors.ts` also consumes `optin`, and it is the one consumer that must ignore the runtime value. `io: "input"` describes the declared input type, so the three schemas above that diverge have to be resolved past to whatever actually carries the optionality:
+
+```ts
+function inputOptin(schema: $ZodType): "optional" | undefined {
+  const def = schema._zod.def;
+  if (def.type === "pipe" && def.in._zod.traits.has("$ZodTransform")) return inputOptin(def.out);
+  if (def.type === "catch") return inputOptin(def.innerType);
+  return schema._zod.optin;
+}
+```
+
+Reading `_zod.optin` directly here builds a `required` list that matches runtime parse behavior instead of the declared type, dropping a preprocessed or caught key even though `z.input<>` shows it as required. #5003 settled the policy — the input JSON Schema describes what you *should* pass, not everything you *can* pass — and #6133 restored it after #5939 and #5941 set the runtime flags.
+
+The same split applies to emitted *values*, not just requiredness: a `catch` value is output-typed, so `isTransforming` strips it under `io: "input"` (#6409). Both halves answer the same question, and they have to answer it the same way.
 
 ## `optout`
 

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -10,7 +10,7 @@ Three runtime signals:
 
 | Signal | Set by | Consumed by | Means |
 |---|---|---|---|
-| `_zod.optin === "optional"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional`; also `objectProcessor`, which reads the **static** value — see below | "I accept absent input" |
+| `_zod.optin === "optional"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional`; also the JSON Schema emitter, where `objectProcessor` reads the **static** value but `tupleProcessor` still reads the runtime one — see below | "I accept absent input" |
 | `_zod.optout === "optional"` | optional, exact-optional, default-on-output cases | `$ZodObject`, `$ZodTuple` | "My output may legitimately be `undefined`; treat that as absent for length-shortening / key-omission" |
 | `payload.fallback === true` | catch (when `catchValue` substitutes), transform | `$ZodOptional` (in `handleOptionalResult`) | "This value is provisional; an outer wrapper may override it on undefined input" |
 
@@ -115,7 +115,7 @@ So `optional` *invokes* its inner whenever inner says "I handle absence." It onl
 
 ### The JSON Schema emitter reads the *static* value
 
-`objectProcessor` in `json-schema-processors.ts` also consumes `optin`, and it is the one consumer that must ignore the runtime value. `io: "input"` describes the declared input type, so the three schemas above that diverge have to be resolved past to whatever actually carries the optionality:
+The JSON Schema emitter consumes `optin` too, in two places. `io: "input"` describes the declared input type, so the three schemas above that diverge have to be resolved past to whatever actually carries the optionality. `objectProcessor` in `json-schema-processors.ts` does this:
 
 ```ts
 function inputOptin(schema: $ZodType): "optional" | undefined {
@@ -128,7 +128,17 @@ function inputOptin(schema: $ZodType): "optional" | undefined {
 
 Reading `_zod.optin` directly here builds a `required` list that matches runtime parse behavior instead of the declared type, dropping a preprocessed or caught key even though `z.input<>` shows it as required. #5003 settled the policy — the input JSON Schema describes what you *should* pass, not everything you *can* pass — and #6133 restored it after #5939 and #5941 set the runtime flags.
 
-The same split applies to emitted *values*, not just requiredness: a `catch` value is output-typed, so `isTransforming` strips it under `io: "input"` (#6409). Both halves answer the same question, and they have to answer it the same way.
+**`tupleProcessor` has not been brought in line.** Its `minItems` tail scan reads `_zod[optKey]` directly, so the same divergence is still live for tuples:
+
+```ts
+z.toJSONSchema(z.tuple([z.string(), z.preprocess((v) => v, z.string())]), { io: "input" });
+// minItems: 1 — but z.input<> is [string, string], and .safeParse(["a"]) rejects
+// the object equivalent emits required: ["a", "b"]
+```
+
+For `catch` that output at least tracks the parser (`.safeParse(["a"])` succeeds); for `preprocess` it matches neither the declared type nor the parser. Nothing pins either direction in the tuple `minItems` tests, so this is unsettled rather than deliberate.
+
+The same split applies to emitted *values*, not just requiredness: `isTransforming` now recurses through `catch` (#6409), so a catch no longer hides an inner transform from its ancestors and the output-typed `default` is stripped under `io: "input"`. A catch over a non-transforming inner keeps its `default`. Both halves answer the same question, and they have to answer it the same way.
 
 ## `optout`
 


### PR DESCRIPTION
`objectProcessor` is the one consumer of `optin` that has to read the static declaration rather than the runtime flag — `io: "input"` describes the declared input type, so `catch`, `transform` and `preprocess` all have to be resolved past. Nothing near the emitter said so, and the consumer table in `wiki/optionality.md` listed only `$ZodObject`, `$ZodTuple` and `$ZodOptional`.

That gap is what let #6409 and #6133 land seven minutes apart on opposite sides of the same question: #6409 stripped an output-typed catch value from the input schema while explicitly leaving requiredness on the runtime flag, and #6133 then had to rewrite the snapshot #6409 had just added.

Adds the emitter to the table with a section covering both halves — the emitted value via `isTransforming`, the requiredness via `inputOptin` — and points at it from `inputOptin()`. Also drops the stale in-flight branch reference in the doc header, and the "each with a single consumer" claim that the `optin` row already contradicted.

Docs plus one comment; no behavior change.
