### PR TITLE
fix(json-schema): resolve tuple minItems past transform and catch in input mode

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1365,6 +1365,23 @@ describe("toJSONSchema", () => {
     expect(output.maxItems).toBe(2);
   });
 
+  test("closed tuple length resolves input optionality past transform and catch", () => {
+    const minItems = (schema: z.core.$ZodType, io: "input" | "output") =>
+      z.toJSONSchema(schema, { target: "draft-2020-12", io }).minItems;
+
+    // Both let the parser observe an absent slot, but declare a required input.
+    const pre = z.tuple([z.string(), z.preprocess((v) => v, z.string())]);
+    expect(minItems(pre, "input")).toBe(2);
+    expect(minItems(pre, "output")).toBe(2);
+
+    const caught = z.tuple([z.string(), z.string().catch("x")]);
+    expect(minItems(caught, "input")).toBe(2);
+    expect(minItems(caught, "output")).toBe(2);
+
+    // Resolution passes through the wrapper rather than stopping at it.
+    expect(minItems(z.tuple([z.string(), z.string().optional().catch("x")]), "input")).toBe(1);
+  });
+
   test("promise", () => {
     const schema = z.promise(z.string());
     expect(z.toJSONSchema(schema)).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -266,9 +266,8 @@ export const arrayProcessor: Processor<schemas.$ZodArray> = (schema, ctx, _json,
 // Transform and catch set `optin = "optional"` at runtime so the parser lets them observe an
 // absent key, but their declared input type stays required. An input JSON Schema describes the
 // declared type, so resolve past them to the schema that actually carries the optionality.
-// `tupleProcessor` reads `optin` in the same input branch but has not been given this treatment,
-// so its `minItems` still tracks the runtime flag; see wiki/optionality.md, "The JSON Schema
-// emitter reads the *static* value".
+// Used by both `objectProcessor` (for `required`) and `tupleProcessor` (for `minItems`); see
+// wiki/optionality.md, "The JSON Schema emitter reads the *static* value".
 function inputOptin(schema: schemas.$ZodType): "optional" | undefined {
   const def = schema._zod.def;
   if (def.type === "pipe" && (def as schemas.$ZodPipeDef).in._zod.traits.has("$ZodTransform")) {
@@ -391,9 +390,11 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
       })
     : null;
 
-  const optKey = ctx.io === "input" ? "optin" : "optout";
   let minItems = def.items.length;
-  while (minItems > 0 && (def.items[minItems - 1] as schemas.SomeType)._zod[optKey] === "optional") {
+  while (minItems > 0) {
+    const item = def.items[minItems - 1] as schemas.$ZodType;
+    const optional = ctx.io === "input" ? inputOptin(item) === "optional" : item._zod.optout === "optional";
+    if (!optional) break;
     minItems--;
   }
   const maxItems = def.items.length;

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -10,7 +10,7 @@ Three runtime signals:
 
 | Signal | Set by | Consumed by | Means |
 |---|---|---|---|
-| `_zod.optin === "optional"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional`; also the JSON Schema emitter, where `objectProcessor` reads the **static** value but `tupleProcessor` still reads the runtime one — see below | "I accept absent input" |
+| `_zod.optin === "optional"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional`; also the JSON Schema emitter, where `objectProcessor` and `tupleProcessor` both read the **static** value — see below | "I accept absent input" |
 | `_zod.optout === "optional"` | optional, exact-optional, default-on-output cases | `$ZodObject`, `$ZodTuple` | "My output may legitimately be `undefined`; treat that as absent for length-shortening / key-omission" |
 | `payload.fallback === true` | catch (when `catchValue` substitutes), transform | `$ZodOptional` (in `handleOptionalResult`) | "This value is provisional; an outer wrapper may override it on undefined input" |
 

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -115,7 +115,7 @@ So `optional` *invokes* its inner whenever inner says "I handle absence." It onl
 
 ### The JSON Schema emitter reads the *static* value
 
-The JSON Schema emitter consumes `optin` too, in two places. `io: "input"` describes the declared input type, so the three schemas above that diverge have to be resolved past to whatever actually carries the optionality. `objectProcessor` in `json-schema-processors.ts` does this:
+The JSON Schema emitter consumes `optin` too, in two places: `objectProcessor` for `required` and `tupleProcessor` for `minItems`. `io: "input"` describes the declared input type, so the three schemas above that diverge have to be resolved past to whatever actually carries the optionality. Both go through one helper in `json-schema-processors.ts`:
 
 ```ts
 function inputOptin(schema: $ZodType): "optional" | undefined {
@@ -126,17 +126,17 @@ function inputOptin(schema: $ZodType): "optional" | undefined {
 }
 ```
 
-Reading `_zod.optin` directly here builds a `required` list that matches runtime parse behavior instead of the declared type, dropping a preprocessed or caught key even though `z.input<>` shows it as required. #5003 settled the policy — the input JSON Schema describes what you *should* pass, not everything you *can* pass — and #6133 restored it after #5939 and #5941 set the runtime flags.
+Reading `_zod.optin` directly builds a `required` list — or a `minItems` — that matches runtime parse behavior instead of the declared type, dropping a preprocessed or caught slot even though `z.input<>` shows it as required. #5003 settled the policy — the input JSON Schema describes what you *should* pass, not everything you *can* pass — and #6133 restored it after #5939 and #5941 set the runtime flags.
 
-**`tupleProcessor` has not been brought in line.** Its `minItems` tail scan reads `_zod[optKey]` directly, so the same divergence is still live for tuples:
+The tuple side went the same way in #6418. Its `minItems` tail scan used to read the runtime flag, so a trailing preprocessed slot shortened `minItems` and the emitted schema matched neither the declared type nor the parser:
 
 ```ts
 z.toJSONSchema(z.tuple([z.string(), z.preprocess((v) => v, z.string())]), { io: "input" });
-// minItems: 1 — but z.input<> is [string, string], and .safeParse(["a"]) rejects
-// the object equivalent emits required: ["a", "b"]
+// before: minItems 1 — but z.input<> is [string, string], and .safeParse(["a"]) rejects
+// now:    minItems 2, matching the object equivalent's required: ["a", "b"]
 ```
 
-For `catch` that output at least tracks the parser (`.safeParse(["a"])` succeeds); for `preprocess` it matches neither the declared type nor the parser. Nothing pins either direction in the tuple `minItems` tests, so this is unsettled rather than deliberate.
+Output mode still reads `optout` directly in both processors — the divergence is input-side only.
 
 The same split applies to emitted *values*, not just requiredness: `isTransforming` now recurses through `catch` (#6409), so a catch no longer hides an inner transform from its ancestors and the output-typed `default` is stripped under `io: "input"`. A catch over a non-transforming inner keeps its `default`. Both halves answer the same question, and they have to answer it the same way.
 


### PR DESCRIPTION
Follow-up to #6417, which documented this gap rather than fixing it.

#6133 routed `objectProcessor`'s `required` list through `inputOptin`, so an input JSON Schema describes the declared input type rather than the runtime `optin` flag. `tupleProcessor`'s `minItems` tail scan kept reading the runtime flag, so the same divergence stayed live for tuples:

```ts
z.toJSONSchema(z.tuple([z.string(), z.preprocess((v) => v, z.string())]), { io: "input" });
// minItems: 1 — but z.input<> is [string, string], and .safeParse(["a"]) rejects
```

That matched neither the declared type nor the parser, while the object equivalent already emitted `required: ["a", "b"]`.

Routes the input-mode scan through the same helper. Output mode still reads `optout` directly — the divergence is input-side only. A trailing `.default()` or `.optional()` still shortens `minItems`, since those declare optional input statically, and resolution passes *through* the wrapper rather than stopping at it, so a catch over an optional inner shortens too.

No existing snapshot changes — the affected cases had no coverage, which is how this survived. Adds one covering preprocess, catch, and the optional-inner catch.
