### PR TITLE
fix(v4): refine optin into a three-rung ladder, retire the fallback payload flag

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2210,12 +2210,10 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
       if (output instanceof Promise) {
         return output.then((output) => {
           payload.value = output;
-          payload.fallback = true;
           return payload;
         });
       }
       payload.value = output;
-      payload.fallback = true;
       return payload;
     };
   }

--- a/packages/zod/src/v4/classic/tests/lazy.test.ts
+++ b/packages/zod/src/v4/classic/tests/lazy.test.ts
@@ -42,7 +42,7 @@ test("opt passthrough", () => {
   expect(z.lazy(() => z.string().optional())._zod.optin).toEqual("optional");
   expect(z.lazy(() => z.string().optional())._zod.optout).toEqual("optional");
 
-  expect(z.lazy(() => z.string().default("asdf"))._zod.optin).toEqual("optional");
+  expect(z.lazy(() => z.string().default("asdf"))._zod.optin).toEqual("defaulted");
   expect(z.lazy(() => z.string().default("asdf"))._zod.optout).toEqual(undefined);
 });
 

--- a/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
+++ b/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
@@ -1,0 +1,175 @@
+import { expect, expectTypeOf, test } from "vitest";
+import { z } from "zod/v4";
+
+/* ------------------------------------------------------------------ *
+ * TYPE-LEVEL — the dangerous half. Defaults must stay OPTIONAL in
+ * z.input and REQUIRED in z.output, exactly as before the ladder.
+ * ------------------------------------------------------------------ */
+test("ladder: z.input / z.output unchanged by the extra rung", () => {
+  const objDefault = z.object({ a: z.string().default("D"), b: z.number() });
+  expectTypeOf<z.input<typeof objDefault>>().toEqualTypeOf<{ a?: string | undefined; b: number }>();
+  expectTypeOf<z.output<typeof objDefault>>().toEqualTypeOf<{ a: string; b: number }>();
+
+  const objPrefault = z.object({ a: z.string().prefault("P"), b: z.number() });
+  expectTypeOf<z.input<typeof objPrefault>>().toEqualTypeOf<{ a?: string | undefined; b: number }>();
+  expectTypeOf<z.output<typeof objPrefault>>().toEqualTypeOf<{ a: string; b: number }>();
+
+  const objOptional = z.object({ a: z.string().optional() });
+  expectTypeOf<z.input<typeof objOptional>>().toEqualTypeOf<{ a?: string | undefined }>();
+
+  const objTransform = z.object({
+    a: z
+      .string()
+      .default("")
+      .transform((v) => v.length),
+  });
+  expectTypeOf<z.input<typeof objTransform>>().toEqualTypeOf<{ a?: string | undefined }>();
+  expectTypeOf<z.output<typeof objTransform>>().toEqualTypeOf<{ a: number }>();
+
+  const standalone = z.string().default("D");
+  expectTypeOf<z.input<typeof standalone>>().toEqualTypeOf<string | undefined>();
+  expectTypeOf<z.output<typeof standalone>>().toEqualTypeOf<string>();
+
+  // a trailing defaulted tuple slot stays optional in the input tuple
+  const tup = z.tuple([z.string(), z.number().default(1)]);
+  expectTypeOf<z.input<typeof tup>>().toEqualTypeOf<[string, (number | undefined)?]>();
+
+  const partialed = objDefault.partial();
+  expectTypeOf<z.input<typeof partialed>>().toEqualTypeOf<{ a?: string | undefined; b?: number | undefined }>();
+});
+
+/* ------------------------------------------------------------------ *
+ * RUNTIME
+ * ------------------------------------------------------------------ */
+test("ladder: the #6321 regression is fixed", () => {
+  const arr = z
+    .string()
+    .default("")
+    .transform((v) => (v ? v.split(",") : []));
+  expect(z.object({ a: arr }).partial().parse({})).toEqual({ a: [] });
+  expect(z.object({ a: arr }).partial().parse({ a: undefined })).toEqual({ a: [] });
+  expect(z.object({ a: arr }).partial().parse({ a: "x,y" })).toEqual({ a: ["x", "y"] });
+  expect(arr.optional().parse(undefined)).toEqual([]);
+  expect(
+    z
+      .string()
+      .prefault("hi")
+      .transform((v) => v.length)
+      .optional()
+      .parse(undefined)
+  ).toBe(2);
+});
+
+test("ladder: key-level admissibility across every rung", () => {
+  expect(z.object({ a: z.string().default("D") }).parse({})).toEqual({ a: "D" });
+  expect(z.object({ a: z.string().prefault("P") }).parse({})).toEqual({ a: "P" });
+  expect(z.object({ a: z.string().optional() }).parse({})).toEqual({});
+  expect(z.object({ a: z.transform(() => "T") }).parse({})).toEqual({ a: "T" });
+  expect(z.object({ a: z.string().catch("C") }).parse({})).toEqual({ a: "C" });
+  expect(z.object({ a: z.string() }).safeParse({}).success).toBe(false);
+});
+
+test("ladder: exactOptional keeps its distinct meaning", () => {
+  expect(z.object({ a: z.string().exactOptional() }).parse({})).toEqual({});
+  expect(z.object({ a: z.string().exactOptional() }).safeParse({ a: undefined }).success).toBe(false);
+});
+
+test("ladder: tuple minimum length respects every rung", () => {
+  expect(z.tuple([z.string().default("D")]).parse([])).toEqual(["D"]);
+  expect(z.tuple([z.string().prefault("P")]).parse([])).toEqual(["P"]);
+  expect(z.tuple([z.string().optional()]).parse([])).toEqual([]);
+  expect(z.tuple([z.string()]).safeParse([]).success).toBe(false);
+  expect(z.tuple([z.string(), z.number().default(1)]).parse(["x"])).toEqual(["x", 1]);
+});
+
+test("ladder: the #5941 / #5939 clobber invariants still hold", () => {
+  expect(
+    z
+      .preprocess((v) => v ?? "X", z.string())
+      .optional()
+      .parse(undefined)
+  ).toBeUndefined();
+  expect(z.string().catch("X").optional().parse(undefined)).toBeUndefined();
+  expect(
+    z
+      .string()
+      .catch("X")
+      .transform((s) => `${s}!`)
+      .optional()
+      .parse(undefined)
+  ).toBeUndefined();
+  expect(
+    z
+      .transform(() => "T")
+      .optional()
+      .parse(undefined)
+  ).toBeUndefined();
+  expect(
+    z
+      .union([z.preprocess((v) => v ?? "X", z.string()), z.number()])
+      .optional()
+      .parse(undefined)
+  ).toBeUndefined();
+  expect(z.object({ a: z.preprocess((v) => v ?? "X", z.string()) }).parse({})).toEqual({ a: "X" });
+});
+
+test("ladder: the top rung survives every wrapper order", () => {
+  expect(z.string().default("D").optional().parse(undefined)).toBe("D");
+  expect(z.string().default("D").optional().optional().parse(undefined)).toBe("D");
+  expect(z.string().default("D").nullable().optional().parse(undefined)).toBe("D");
+  expect(z.string().default("D").readonly().optional().parse(undefined)).toBe("D");
+  expect(z.string().default("D").catch("C").optional().parse(undefined)).toBe("D");
+  expect(z.string().default("D").pipe(z.string()).optional().parse(undefined)).toBe("D");
+  expect(
+    z
+      .union([z.string().default("D"), z.number()])
+      .optional()
+      .parse(undefined)
+  ).toBe("D");
+  expect(
+    z
+      .lazy(() => z.string().default("D"))
+      .optional()
+      .parse(undefined)
+  ).toBe("D");
+});
+
+test("ladder: record and catchall paths that read optin", () => {
+  expect(z.record(z.string(), z.string().default("D")).parse({ k: undefined })).toEqual({ k: "D" });
+  expect(z.object({}).catchall(z.string().default("D")).parse({ x: undefined })).toEqual({ x: "D" });
+});
+
+test("ladder: async parity", async () => {
+  const a = z
+    .string()
+    .default("")
+    .transform(async (v) => (v ? v.split(",") : []));
+  expect((await a.optional().safeParseAsync(undefined)).data).toEqual([]);
+  expect((await z.object({ a }).partial().safeParseAsync({})).data).toEqual({ a: [] });
+  expect(
+    (
+      await z
+        .preprocess(async (v) => v ?? "X", z.string())
+        .optional()
+        .safeParseAsync(undefined)
+    ).data
+  ).toBeUndefined();
+});
+
+test("ladder: the rung values themselves", () => {
+  expect(z.string()._zod.optin).toBeUndefined();
+  expect(z.string().optional()._zod.optin).toBe("optional");
+  expect(z.transform(() => 1)._zod.optin).toBe("optional");
+  expect(z.string().catch("C")._zod.optin).toBe("optional");
+  expect(z.string().default("D")._zod.optin).toBe("defaulted");
+  expect(z.string().prefault("P")._zod.optin).toBe("defaulted");
+  expect(
+    z
+      .string()
+      .default("D")
+      .transform((v) => v)._zod.optin
+  ).toBe("defaulted");
+  expect(z.string().default("D").optional()._zod.optin).toBe("defaulted");
+  expect(z.union([z.string().default("D"), z.number()])._zod.optin).toBe("defaulted");
+  expect(z.union([z.string().optional(), z.number()])._zod.optin).toBe("optional");
+});

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -27,7 +27,7 @@ test("optionality", () => {
   expect(b._zod.optout).toEqual("optional");
 
   const c = z.string().default("asdf");
-  expect(c._zod.optin).toEqual("optional");
+  expect(c._zod.optin).toEqual("defaulted");
   expect(c._zod.optout).toEqual(undefined);
 
   const d = z.string().optional().nullable();
@@ -35,27 +35,27 @@ test("optionality", () => {
   expect(d._zod.optout).toEqual("optional");
 
   const e = z.string().default("asdf").nullable();
-  expect(e._zod.optin).toEqual("optional");
+  expect(e._zod.optin).toEqual("defaulted");
   expect(e._zod.optout).toEqual(undefined);
 
   // z.undefined should NOT be optional
   const f = z.undefined();
   expect(f._zod.optin).toEqual(undefined);
   expect(f._zod.optout).toEqual(undefined);
-  expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | undefined>();
+  expectTypeOf<typeof f._zod.optin>().toEqualTypeOf<"optional" | "defaulted" | undefined>();
   expectTypeOf<typeof f._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
   // z.union should be optional if any of the types are optional
   const g = z.union([z.string(), z.undefined()]);
   expect(g._zod.optin).toEqual(undefined);
   expect(g._zod.optout).toEqual(undefined);
-  expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | undefined>();
+  expectTypeOf<typeof g._zod.optin>().toEqualTypeOf<"optional" | "defaulted" | undefined>();
   expectTypeOf<typeof g._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
   const h = z.union([z.string(), z.optional(z.string())]);
   expect(h._zod.optin).toEqual("optional");
   expect(h._zod.optout).toEqual("optional");
-  expectTypeOf<typeof h._zod.optin>().toEqualTypeOf<"optional">();
+  expectTypeOf<typeof h._zod.optin>().toEqualTypeOf<"optional" | "defaulted">();
   expectTypeOf<typeof h._zod.optout>().toEqualTypeOf<"optional">();
 });
 
@@ -64,7 +64,7 @@ test("pipe optionality", () => {
   const a = z.string().optional().pipe(z.string());
   expect(a._zod.optin).toEqual("optional");
   expect(a._zod.optout).toEqual(undefined);
-  expectTypeOf<typeof a._zod.optin>().toEqualTypeOf<"optional">();
+  expectTypeOf<typeof a._zod.optin>().toEqualTypeOf<"optional" | "defaulted">();
   expectTypeOf<typeof a._zod.optout>().toEqualTypeOf<"optional" | undefined>();
 
   const b = z
@@ -73,11 +73,11 @@ test("pipe optionality", () => {
     .pipe(z.string().optional());
   expect(b._zod.optin).toEqual(undefined);
   expect(b._zod.optout).toEqual("optional");
-  expectTypeOf<typeof b._zod.optin>().toEqualTypeOf<"optional" | undefined>();
+  expectTypeOf<typeof b._zod.optin>().toEqualTypeOf<"optional" | "defaulted" | undefined>();
   expectTypeOf<typeof b._zod.optout>().toEqualTypeOf<"optional">();
 
   const c = z.string().default("asdf").pipe(z.string());
-  expect(c._zod.optin).toEqual("optional");
+  expect(c._zod.optin).toEqual("defaulted");
   expect(c._zod.optout).toEqual(undefined);
 
   const d = z
@@ -202,7 +202,7 @@ test("exactOptional optionality", () => {
   const a = z.string().exactOptional();
   expect(a._zod.optin).toEqual("optional");
   expect(a._zod.optout).toEqual("optional");
-  expectTypeOf<typeof a._zod.optin>().toEqualTypeOf<"optional">();
+  expectTypeOf<typeof a._zod.optin>().toEqualTypeOf<"optional" | "defaulted">();
   expectTypeOf<typeof a._zod.optout>().toEqualTypeOf<"optional">();
 });
 

--- a/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/preprocess-types.test.ts
@@ -11,11 +11,11 @@ test("ZodPreprocess<B> assignable to ZodPipe<$ZodTransform, B>", () => {
 
 test("ZodPreprocess optin/optout defer to B", () => {
   const optionalInside = z.preprocess((v) => v, z.string().optional());
-  expectTypeOf<(typeof optionalInside)["_zod"]["optin"]>().toEqualTypeOf<"optional">();
+  expectTypeOf<(typeof optionalInside)["_zod"]["optin"]>().toEqualTypeOf<"optional" | "defaulted">();
   expectTypeOf<(typeof optionalInside)["_zod"]["optout"]>().toEqualTypeOf<"optional">();
 
   const required = z.preprocess((v) => v, z.string());
-  expectTypeOf<(typeof required)["_zod"]["optin"]>().toEqualTypeOf<"optional" | undefined>();
+  expectTypeOf<(typeof required)["_zod"]["optin"]>().toEqualTypeOf<"optional" | "defaulted" | undefined>();
   expectTypeOf<(typeof required)["_zod"]["optout"]>().toEqualTypeOf<"optional" | undefined>();
 });
 
@@ -40,5 +40,5 @@ test("narrowed ZodPreprocess still assignable to the bare type", () => {
   const pre = z.preprocess((v: string) => v.length, z.number());
   const _bare: z.ZodPreprocess<z.ZodNumber> = pre;
   const _bareCore: z.core.$ZodPreprocess = pre;
-  expectTypeOf<(typeof pre)["_zod"]["optin"]>().toEqualTypeOf<"optional" | undefined>();
+  expectTypeOf<(typeof pre)["_zod"]["optin"]>().toEqualTypeOf<"optional" | "defaulted" | undefined>();
 });

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -269,7 +269,7 @@ export const arrayProcessor: Processor<schemas.$ZodArray> = (schema, ctx, _json,
 // declared type, so resolve past them to the schema that actually carries the optionality.
 // Used by both `objectProcessor` (for `required`) and `tupleProcessor` (for `minItems`); see
 // wiki/optionality.md, "The JSON Schema emitter reads the *static* value".
-function inputOptin(schema: schemas.$ZodType): "optional" | undefined {
+function inputOptin(schema: schemas.$ZodType): "optional" | "defaulted" | undefined {
   const def = schema._zod.def;
   if (def.type === "pipe" && (def as schemas.$ZodPipeDef).in._zod.traits.has("$ZodTransform")) {
     return inputOptin((def as schemas.$ZodPipeDef).out);
@@ -392,7 +392,7 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
   let minItems = def.items.length;
   while (minItems > 0) {
     const item = def.items[minItems - 1] as schemas.$ZodType;
-    const optional = ctx.io === "input" ? inputOptin(item) === "optional" : item._zod.optout === "optional";
+    const optional = ctx.io === "input" ? inputOptin(item) !== undefined : item._zod.optout === "optional";
     if (!optional) break;
     minItems--;
   }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -42,11 +42,6 @@ export interface ParsePayload<T = unknown> {
   issues: errors.$ZodRawIssue[];
   /** A way to mark a whole payload as aborted. Used in codecs/pipes. */
   aborted?: boolean;
-  /** @internal Marks a value as a fallback that an outer wrapper (e.g.
-   * $ZodOptional) may override with its own interpretation when input was
-   * undefined. Set by $ZodCatch when catchValue substitutes and by every
-   * $ZodTransform invocation. */
-  fallback?: boolean | undefined;
   /** @internal Set when the value came from a repeat visit to a node still being
    * parsed. Its checks run on the node itself, against the finished value. */
   memo?: boolean | undefined;
@@ -129,8 +124,13 @@ export interface _$ZodTypeInternals {
    * @default Required
    */
 
-  /** @internal */
-  optin?: "optional" | undefined;
+  /** @internal Three rungs, each strictly stronger than the last:
+   *   undefined    — required; the container may not omit this slot
+   *   "optional"   — the container may omit it; nothing is supplied in its place
+   *   "defaulted"  — the container may omit it AND this schema substitutes a value
+   * Consumers asking "may the slot be absent?" test `!== undefined`.
+   * $ZodOptional asks the stronger question and tests `=== "defaulted"`. */
+  optin?: "optional" | "defaulted" | undefined;
   /** @internal */
   optout?: "optional" | undefined;
 
@@ -1760,7 +1760,7 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
 //////////////////////////////////////////
 
 type OptionalOutSchema = { _zod: { optout: "optional" } };
-type OptionalInSchema = { _zod: { optin: "optional" } };
+type OptionalInSchema = { _zod: { optin: "optional" | "defaulted" } };
 
 export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<string, unknown>> = string extends keyof T
   ? util.IsAny<T[keyof T]> extends true
@@ -1938,7 +1938,7 @@ function handleCatchall(
   const keySet = def.keySet;
   const _catchall = def.catchall!._zod;
   const t = _catchall.def.type;
-  const isOptionalIn = _catchall.optin === "optional";
+  const isOptionalIn = _catchall.optin !== undefined;
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
     // Must precede the __proto__ branch: a declared key is not unrecognized, even though the shape loop deliberately strips __proto__ from the parsed output.
@@ -2041,7 +2041,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     for (const key of value.keys) {
       if (key === "__proto__") continue;
       const el = shape[key]!;
-      const isOptionalIn = el._zod.optin === "optional";
+      const isOptionalIn = el._zod.optin !== undefined;
       const isOptionalOut = el._zod.optout === "optional";
 
       const r = el._zod.run({ value: input[key], issues: [] }, ctx);
@@ -2096,7 +2096,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         const k = util.esc(key);
         const isPresent = `${k} in input`;
         const schema = shape[key];
-        const isOptionalIn = schema?._zod?.optin === "optional";
+        const isOptionalIn = schema?._zod?.optin !== undefined;
         const isOptionalOut = schema?._zod?.optout === "optional";
 
         doc.write(`const ${id} = ${parseStr(key)};`);
@@ -2235,7 +2235,7 @@ export interface $ZodUnionInternals<T extends readonly SomeType[] = readonly $Zo
   output: $InferUnionOutput<T[number]>;
   input: $InferUnionInput<T[number]>;
   // if any element in the union is optional, then the union is optional
-  optin: IsOptionalIn<T[number]> extends false ? "optional" | undefined : "optional";
+  optin: IsOptionalIn<T[number]> extends false ? "optional" | "defaulted" | undefined : "optional" | "defaulted";
   optout: IsOptionalOut<T[number]> extends false ? "optional" | undefined : "optional";
 }
 
@@ -2273,7 +2273,11 @@ export const $ZodUnion: core.$constructor<$ZodUnion> = /*@__PURE__*/ core.$const
   $ZodType.init(inst, def);
 
   util.defineLazy(inst._zod, "optin", () =>
-    def.options.some((o) => o._zod.optin === "optional") ? "optional" : undefined
+    def.options.some((o) => o._zod.optin === "defaulted")
+      ? "defaulted"
+      : def.options.some((o) => o._zod.optin !== undefined)
+        ? "optional"
+        : undefined
   );
 
   util.defineLazy(inst._zod, "optout", () =>
@@ -2719,7 +2723,7 @@ type TupleInputTypeWithOptionals<T extends util.TupleItems> = T extends readonly
   ...infer Prefix extends SomeType[],
   infer Tail extends SomeType,
 ]
-  ? Tail["_zod"]["optin"] extends "optional"
+  ? Tail["_zod"]["optin"] extends "optional" | "defaulted"
     ? [...TupleInputTypeWithOptionals<Prefix>, core.input<Tail>?]
     : TupleInputTypeNoOptionals<T>
   : [];
@@ -2843,7 +2847,9 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
 
 function getTupleOptStart(items: readonly $ZodType[], key: "optin" | "optout") {
   for (let i = items.length - 1; i >= 0; i--) {
-    if (items[i]._zod[key] !== "optional") return i + 1;
+    // optin is a three-rung ladder so any rung above `undefined` permits an absent slot; optout stays two-valued.
+    const omittable = key === "optin" ? items[i]._zod.optin !== undefined : items[i]._zod.optout === "optional";
+    if (!omittable) return i + 1;
   }
   return 0;
 }
@@ -3557,7 +3563,6 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
         const output = _out instanceof Promise ? _out : Promise.resolve(_out);
         return output.then((output) => {
           payload.value = output;
-          payload.fallback = true;
           return payload;
         });
       }
@@ -3567,7 +3572,6 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
       }
 
       payload.value = _out;
-      payload.fallback = true;
       return payload;
     };
   }
@@ -3588,7 +3592,7 @@ export interface $ZodOptionalDef<T extends SomeType = $ZodType> extends $ZodType
 export interface $ZodOptionalInternals<T extends SomeType = $ZodType>
   extends $ZodTypeInternals<core.output<T> | undefined, core.input<T> | undefined> {
   def: $ZodOptionalDef<T>;
-  optin: "optional";
+  optin: "optional" | "defaulted";
   optout: "optional";
   isst: never;
   values: T["_zod"]["values"];
@@ -3599,10 +3603,9 @@ export interface $ZodOptional<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodOptionalInternals<T>;
 }
 
-function handleOptionalResult(result: ParsePayload, input: unknown) {
-  if (input === undefined && (result.issues.length || result.fallback)) {
-    return { issues: [], value: undefined };
-  }
+function handleOptionalResult(result: ParsePayload) {
+  // A substituting schema that still failed has no usable answer; yield undefined.
+  if (result.issues.length) return { issues: [], value: undefined };
   return result;
 }
 
@@ -3610,7 +3613,8 @@ export const $ZodOptional: core.$constructor<$ZodOptional> = /*@__PURE__*/ core.
   "$ZodOptional",
   (inst, def) => {
     $ZodType.init(inst, def);
-    inst._zod.optin = "optional";
+    // .optional() propagates absence rather than substituting for it, so a defaulted inner keeps its rung.
+    util.defineLazy(inst._zod, "optin", () => (def.innerType._zod.optin === "defaulted" ? "defaulted" : "optional"));
     inst._zod.optout = "optional";
 
     util.defineLazy(inst._zod, "values", () => {
@@ -3622,14 +3626,12 @@ export const $ZodOptional: core.$constructor<$ZodOptional> = /*@__PURE__*/ core.
     });
 
     inst._zod.parse = (payload, ctx) => {
-      if (def.innerType._zod.optin === "optional") {
-        const input = payload.value;
-        const result = def.innerType._zod.run(payload, ctx);
-        if (result instanceof Promise) return result.then((r) => handleOptionalResult(r, input));
-        return handleOptionalResult(result, input);
-      }
       if (payload.value === undefined) {
-        return payload;
+        // Only the top rung substitutes a value for absence; everything else leaves it intact, which is what .optional() means.
+        if (def.innerType._zod.optin !== "defaulted") return payload;
+        const result = def.innerType._zod.run(payload, ctx);
+        if (result instanceof Promise) return result.then(handleOptionalResult);
+        return handleOptionalResult(result);
       }
       return def.innerType._zod.run(payload, ctx);
     };
@@ -3743,7 +3745,7 @@ export interface $ZodDefaultDef<T extends SomeType = $ZodType> extends $ZodTypeD
 export interface $ZodDefaultInternals<T extends SomeType = $ZodType>
   extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, core.input<T> | undefined> {
   def: $ZodDefaultDef<T>;
-  optin: "optional";
+  optin: "defaulted";
   optout?: "optional" | undefined; // required
   isst: never;
   values: T["_zod"]["values"];
@@ -3759,7 +3761,7 @@ export const $ZodDefault: core.$constructor<$ZodDefault> = /*@__PURE__*/ core.$c
     $ZodType.init(inst, def);
 
     // inst._zod.qin = "true";
-    inst._zod.optin = "optional";
+    inst._zod.optin = "defaulted";
     util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
 
     inst._zod.parse = (payload, ctx) => {
@@ -3810,7 +3812,7 @@ export interface $ZodPrefaultDef<T extends SomeType = $ZodType> extends $ZodType
 export interface $ZodPrefaultInternals<T extends SomeType = $ZodType>
   extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, core.input<T> | undefined> {
   def: $ZodPrefaultDef<T>;
-  optin: "optional";
+  optin: "defaulted";
   optout?: "optional" | undefined;
   isst: never;
   values: T["_zod"]["values"];
@@ -3825,7 +3827,7 @@ export const $ZodPrefault: core.$constructor<$ZodPrefault> = /*@__PURE__*/ core.
   (inst, def) => {
     $ZodType.init(inst, def);
 
-    inst._zod.optin = "optional";
+    inst._zod.optin = "defaulted";
     util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
 
     inst._zod.parse = (payload, ctx) => {
@@ -4019,7 +4021,7 @@ export interface $ZodCatch<T extends SomeType = $ZodType> extends $ZodType {
 
 export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$constructor("$ZodCatch", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.optin = "optional";
+  util.defineLazy(inst._zod, "optin", () => (def.innerType._zod.optin === "defaulted" ? "defaulted" : "optional"));
   util.defineLazy(inst._zod, "optout", () => def.innerType._zod.optout);
   util.defineLazy(inst._zod, "values", () => def.innerType._zod.values);
 
@@ -4042,7 +4044,6 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
             input: payload.value,
           });
           payload.issues = [];
-          payload.fallback = true;
         }
 
         return payload;
@@ -4060,7 +4061,6 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
       });
 
       payload.issues = [];
-      payload.fallback = true;
     }
 
     return payload;
@@ -4166,7 +4166,7 @@ function handlePipeResult(left: ParsePayload, next: $ZodType, ctx: ParseContextI
     left.aborted = true;
     return left;
   }
-  return next._zod.run({ value: left.value, issues: left.issues, fallback: left.fallback }, ctx);
+  return next._zod.run({ value: left.value, issues: left.issues }, ctx);
 }
 
 ////////////////////////////////////////////

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -572,7 +572,7 @@ export function stringifyPrimitive(value: any): string {
 
 export function optionalKeys(shape: schemas.$ZodShape): string[] {
   return Object.keys(shape).filter((k) => {
-    return shape[k]!._zod.optin === "optional" && shape[k]!._zod.optout === "optional";
+    return shape[k]!._zod.optin !== undefined && shape[k]!._zod.optout === "optional";
   });
 }
 

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -6,14 +6,12 @@ The system has accumulated a few orthogonal mechanisms. This doc names them, say
 
 ## TL;DR
 
-Three runtime signals:
+Two runtime signals:
 
 | Signal | Set by | Consumed by | Means |
 |---|---|---|---|
-| `_zod.optin === "optional"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional`; also the JSON Schema emitter, where `objectProcessor` and `tupleProcessor` both read the **static** value — see below | "I accept absent input" |
+| `_zod.optin` — `undefined` / `"optional"` / `"defaulted"` | catch, default, prefault, optional, transform | `$ZodObject`, `$ZodTuple`, `$ZodOptional`; also the JSON Schema emitter, where `objectProcessor` and `tupleProcessor` both read the **static** value — see below | A three-rung ladder: required / absence permitted / absence permitted *and substituted for* |
 | `_zod.optout === "optional"` | optional, exact-optional, default-on-output cases | `$ZodObject`, `$ZodTuple` | "My output may legitimately be `undefined`; treat that as absent for length-shortening / key-omission" |
-| `payload.fallback === true` | catch (when `catchValue` substitutes), transform | `$ZodOptional` (in `handleOptionalResult`) | "This value is provisional; an outer wrapper may override it on undefined input" |
-
 Plus one bookkeeping flag:
 
 | Signal | Set by | Consumed by | Means |
@@ -33,25 +31,36 @@ Pre-4.4, Zod conflated these: for object property `a`, parsing `{}` and parsing 
 
 ## `optin`
 
-> "Can the parent container omit this slot?"
+> "Can the parent container omit this slot, and does anything fill it?"
 
-A static-and-runtime declaration on the schema's `_zod`. Possible values: `"optional"` or `undefined`.
+A static-and-runtime declaration on the schema's `_zod`. Three rungs, each strictly stronger than the last:
+
+| Value | Means |
+|---|---|
+| `undefined` | Required. The container may not omit this slot. |
+| `"optional"` | The container may omit it. Nothing is supplied in its place. |
+| `"defaulted"` | The container may omit it **and** this schema substitutes a value. |
+
+Consumers asking "may the slot be absent?" test `!== undefined`. `$ZodOptional` asks the stronger question and tests `=== "defaulted"`.
+
+This ladder is a restoration: `_zod.optionality?: "optional" | "defaulted"` existed pre-4.0 and was collapsed to two values as collateral of [#4405](https://github.com/colinhacks/zod/pull/4405), which split the single axis into `optin`/`optout`. The lost distinction was partially recovered at runtime by the `payload.fallback` flag ([#5939](https://github.com/colinhacks/zod/pull/5939) / [#5941](https://github.com/colinhacks/zod/pull/5941)) before being restored to the schema here.
 
 ### Who sets it
 
 | Schema | `optin` (static) | `optin` (runtime) | Notes |
 |---|---|---|---|
-| `$ZodOptional` | `"optional"` | `"optional"` | Hardcoded — that's its purpose |
+| `$ZodOptional` | `"optional" \| "defaulted"` | top rung of inner, else `"optional"` | Propagates absence rather than substituting, so a defaulted inner keeps its rung |
 | `$ZodExactOptional` | `"optional"` | `"optional"` | Same as optional, no value-side undefined widening |
 | `$ZodNonOptional` | `"optional" \| undefined` | inherits inner | Only narrows the *type* of the value |
-| `$ZodDefault` | `"optional"` | `"optional"` | Hardcoded |
-| `$ZodPrefault` | `"optional"` | `"optional"` | Hardcoded |
-| `$ZodCatch` | `T["_zod"]["optin"]` (defers to inner) | `"optional"` | **Static/runtime divergence** — see below |
+| `$ZodDefault` | `"defaulted"` | `"defaulted"` | Hardcoded — it substitutes |
+| `$ZodPrefault` | `"defaulted"` | `"defaulted"` | Hardcoded — it substitutes |
+| `$ZodCatch` | `T["_zod"]["optin"]` (defers to inner) | top rung of inner, else `"optional"` | **Static/runtime divergence** — see below |
 | `$ZodTransform` | inherited (`undefined` by default) | `"optional"` | **Static/runtime divergence** — branch only, prototype |
 | `$ZodPipe` | `def.in._zod.optin` (lazy defer to in side) | same | The leading position of the pipe drives optin |
 | `$ZodPreprocess` | `B["_zod"]["optin"]` (defers to inner) | inherits via pipe (in = transform → `"optional"`) | After the prototype, no constructor body |
 | `$ZodNullable` | `T["_zod"]["optin"]` | same | Transparent |
 | `$ZodReadonly` | `T["_zod"]["optin"]` | same | Transparent |
+| `$ZodUnion` | highest rung any option declares | same | `defaulted` if any option is, else `optional` if any is |
 | Everything else (string, number, etc.) | `undefined` | `undefined` | Required by default |
 
 ### Static/runtime divergence
@@ -156,111 +165,97 @@ A separate axis from `optin`. Set by:
 
 The relevant observation for users: a schema can be **input-required, output-optional** (`z.string().nullable()` with some shapes), or **input-optional, output-required** (`z.string().default("d")` — accepts absence, never produces undefined). The `optin` × `optout` matrix has all four combinations and they all matter for object/tuple parsing.
 
-## `fallback`
+## How `$ZodOptional` decides
 
-> "An outer wrapper may override this value with its own interpretation when input was undefined."
+> "Absent input arrived. Do I trust the inner, or yield `undefined`?"
 
-A *runtime-only* payload flag. Lives on `ParsePayload`:
-
-```ts
-interface ParsePayload<T> {
-  value: T;
-  issues: $ZodRawIssue[];
-  aborted?: boolean;
-  fallback?: boolean | undefined;
-}
-```
-
-### Who sets it
-
-| Schema | When | Why |
-|---|---|---|
-| `$ZodCatch` | When `catchValue` substitutes (i.e., the inner schema produced issues) | The substituted value is a recovery, not a deliberate output; an outer optional should be allowed to clobber it |
-| `$ZodTransform` | On every fn invocation (sync and async paths, both core and classic constructors) | The transform's output is provisional — for `undefined` input specifically, an outer optional should treat the transform's output as "what we got when input was missing" and replace with `undefined` |
-
-### Who reads it
-
-Only `$ZodOptional`, in `handleOptionalResult`:
+`$ZodOptional` reads the ladder and nothing else:
 
 ```ts
-function handleOptionalResult(result: ParsePayload, input: unknown) {
-  if (input === undefined && (result.issues.length || result.fallback)) {
-    return { issues: [], value: undefined };
+inst._zod.parse = (payload, ctx) => {
+  if (payload.value === undefined) {
+    // Only the top rung substitutes a value for absence; everything else leaves it intact, which is what .optional() means.
+    if (def.innerType._zod.optin !== "defaulted") return payload;
+    const result = def.innerType._zod.run(payload, ctx);
+    if (result instanceof Promise) return result.then(handleOptionalResult);
+    return handleOptionalResult(result);
   }
-  return result;
-}
+  return def.innerType._zod.run(payload, ctx);
+};
 ```
 
-Translation: "If the *original* input to optional was `undefined`, and the inner either failed or produced a fallback value, override with `undefined`."
+Two consequences worth naming:
 
-The `input === undefined` gate is critical: when input was a defined value, the inner's output is the *real* output (e.g., a successful transform run), not a fallback, even if the flag happens to be set. This is what makes "always set on transform" safe — defined-input transforms have the flag set but it's never read.
+- An inner that does *not* substitute is **not run at all** on absent input. Previously it ran and its output was discarded, so a side-effecting `preprocess` fn fired once per absent parse; now it fires zero times. Same result, fewer side effects.
+- `handleOptionalResult` only has to swallow issues. A substituting schema that still fails (a `prefault` value its inner rejects) has no usable answer, so it yields `undefined`.
 
-### Pipe propagation
+### There is no payload flag
 
-`handlePipeResult` builds a fresh payload for the right-hand side of a pipe:
+There used to be one. `payload.fallback` was set by `$ZodCatch` on substitution and by `$ZodTransform` on every invocation, propagated by hand through `handlePipeResult`, and read by `handleOptionalResult`. It existed to undo a wrong conclusion: `$ZodTransform` and `$ZodCatch` declared `optin = "optional"` so object parsers would run them on absent keys, which made `$ZodOptional` believe they had answered the absence.
 
-```ts
-return next._zod.run({ value: left.value, issues: left.issues, fallback: left.fallback }, ctx);
-```
+The ladder removes the wrong conclusion instead of undoing it, so the flag is gone. Two things it got wrong along the way, for the record:
 
-The `fallback` propagation is what #5941 fixed. Before that fix, any chain shaped like `catch().transform()...optional()` would lose the flag at the implicit pipe boundary that `.transform()` introduces, and `optional` couldn't tell that the inner had recovered.
+- It leaked. `$ZodPipe` had to copy it explicitly ([#5941](https://github.com/colinhacks/zod/pull/5941)'s first commit was that fix), and `$ZodUnion` never copied it into its options at all.
+- Marking every transform invocation was unsound when a `.default()` sat between the transform and the optional: the gate tested the *optional's* input while the transform had received the *substituted* value. That was [#6321](https://github.com/colinhacks/zod/issues/6321).
+
 
 ## What's `respect` vs `clobber`?
 
-When `optional` wraps a schema that produced *some* value for `undefined` input, the question is: does the wrapper return the inner value (respect), or override with `undefined` (clobber)?
+When `optional` receives `undefined`, the question is: does it return whatever the inner produces (respect), or yield `undefined` (clobber)?
 
-The rule, expressed in `handleOptionalResult`:
+The rule is the ladder:
 
 ```
-input was undefined AND (issues OR fallback)  →  clobber
-otherwise                                     →  respect
+inner optin === "defaulted"  →  respect (run it, use its value)
+otherwise                    →  clobber (yield undefined, don't run it)
 ```
 
 So:
 
-| Inner schema produced... | issues? | fallback? | result |
-|---|---|---|---|
-| valid value via normal path (default fired, prefault filled) | no | no | **respect** — return inner value |
-| recovery substitution (catch fired) | no (cleared) | yes | **clobber** — return undefined |
-| transform's output (preprocess, standalone transform, anything with a transform fn at the input side) | no | yes | **clobber** — return undefined |
-| failed validation but no recovery | yes | no | **clobber** (issues swallowed) — return undefined |
+| Inner schema | `optin` | result |
+|---|---|---|
+| `default` fired, `prefault` filled | `"defaulted"` | **respect** — return inner value |
+| recovery substitution (`catch` over a non-substituting inner) | `"optional"` | **clobber** — return undefined |
+| transform's output (preprocess, standalone transform) | `"optional"` | **clobber** — return undefined |
+| plain required schema | `undefined` | **clobber** — return undefined |
+| substituting schema that then failed | `"defaulted"` | **clobber** (issues swallowed) — return undefined |
 
 ### Why default and prefault aren't clobbered
 
-Default and prefault both set `optin = "optional"` at runtime, so `optional` invokes them. But they don't set `fallback`. `default` short-circuits on undefined input *before* running inner — it's an explicit absence handler that returns `def.defaultValue` directly. `prefault` substitutes the prefault value into the input *before* running inner. Both produce a "deliberate value" rather than a "recovery value" — which is why `optional` respects them.
+They are the only schemas that *answer* the absence. `default` short-circuits on undefined input before running inner and returns `def.defaultValue`; `prefault` substitutes its value into the input and then runs inner. Both produce a deliberate value rather than an incidental one, which is what the top rung records.
 
 ### Why catch is clobbered
 
-Catch runs inner, and only fires when inner produces *issues*. The substitution is reactive — "I'm recovering from a failure." On `undefined` input, inner failed because inner doesn't accept `undefined`, not because the user really wanted "the substitution value." Optional says: "the user wrote `.optional()`, so on undefined input they want `undefined`, not your recovery."
+Catch fires only when its inner produces *issues*. On `undefined` input, inner failed because it doesn't accept `undefined`, not because the user wanted the substitution value. So catch doesn't claim the top rung on its own — it carries through whatever its inner declares, which means `z.string().default("D").catch("C")` *is* `"defaulted"` and is respected.
 
 ### Why transform is clobbered
 
-For preprocess, the user's fn runs on `undefined` because the *outer* schema invoked it (object accepting an absent key, or optional with `optin === "optional"` invoking the inner). The user's intent was "transform whatever input shows up," but they also wrapped in `.optional()` to say "absent input → absent output." `fallback` lets `.optional()` honor that.
+For preprocess, the user's fn runs on `undefined` only because the outer schema invoked it. Their intent was "transform whatever shows up", but they also wrote `.optional()` to say "absent input → absent output". The transform never claims the top rung, so `.optional()` wins — and under the ladder it wins *without* running the fn.
 
-Standalone transform (rare) gets the same treatment by virtue of also being marked.
+Note the composition: a transform downstream of a default inherits `"defaulted"` through the pipe's `def.in`, so `z.string().default("").transform(fn)` is respected while `z.preprocess(fn, T)` is not. That is [#6321](https://github.com/colinhacks/zod/issues/6321), fixed structurally rather than by inspecting the transform's input.
+
 
 ## Walking through cases
 
-Concrete shapes and what they evaluate to. Asterisks mark behaviors that depend on the in-flight branch.
+Concrete shapes and what they evaluate to.
 
 ```ts
 // === Catch ===
 
 z.string().catch("c").parse(undefined)
-// → "c"  (catch fires on string(undefined) failure, fallback set, no outer reads it)
+// → "c"  (catch fires on string(undefined) failure; nothing outer to override it)
 
 z.string().catch("c").parse(123)
 // → "c"  (catch fires on string(123) failure)
 
 z.string().catch("c").optional().parse(undefined)
-// → undefined  (catch fires, fallback=true; handleOptionalResult clobbers on undef input)
+// → undefined  (catch.optin = "optional", not "defaulted", so optional yields undefined without running it)
 
 z.string().catch("c").optional().parse("hi")
-// → "hi"  (catch doesn't fire, no fallback)
+// → "hi"  (input defined, so optional just runs the inner)
 
 z.string().catch("c").transform((s) => s + "!").optional().parse(undefined)
-// → undefined  (catch fires, fallback propagates through pipe, optional clobbers)
-//   pre-#5941: was "c!" because fallback was dropped at the pipe boundary
+// → undefined  (pipe.optin = catch.optin = "optional"; optional yields undefined)
 
 z.object({ a: z.string().catch("c") }).parse({})
 // → { a: "c" }  (catch.optin = "optional" runtime; obj invokes catch with undefined; catch fires)
@@ -269,7 +264,7 @@ z.object({ a: z.string().catch("c") }).parse({ a: undefined })
 // → { a: "c" }  (key present with undefined; catch fires on string(undefined))
 
 z.object({ a: z.string().catch("c").optional() }).parse({})
-// → {}  (key absent; optional clobbered the recovery value via fallback flag)
+// → {}  (key absent; optional sees optin = "optional", not "defaulted", so yields undefined; obj omits)
 
 // === Default ===
 
@@ -277,10 +272,10 @@ z.string().default("d").parse(undefined)
 // → "d"  (default short-circuits on undef input, returns d directly)
 
 z.string().default("d").optional().parse(undefined)
-// → "d"  (optional invokes default; default returns d; no fallback set; optional respects)
+// → "d"  (default.optin = "defaulted"; optional runs it and respects the result)
 
 z.object({ a: z.string().default("d") }).parse({})
-// → { a: "d" }  (default.optin = "optional"; obj invokes default; short-circuits to d)
+// → { a: "d" }  (obj asks optin !== undefined; invokes default; short-circuits to d)
 
 // === Prefault ===
 
@@ -288,25 +283,33 @@ z.string().prefault("p").parse(undefined)
 // → "p"  (prefault substitutes, runs inner string("p") which succeeds)
 
 z.string().prefault("p").optional().parse(undefined)
-// → "p"  (prefault doesn't set fallback — it's an absence handler, not recovery)
+// → "p"  (prefault.optin = "defaulted" — it answers the absence, so optional respects it)
 
-// === Preprocess ===*
+// === Preprocess ===
 
 z.preprocess((v) => v ?? "X", z.string()).parse(undefined)
 // → "X"  (preprocess fn produces "X", inner string accepts)
 
 z.preprocess((v) => v ?? "X", z.string()).optional().parse(undefined)
-// → undefined  (transform sets fallback; optional clobbers on undef input)
+// → undefined  (pipe.optin = transform.optin = "optional"; optional yields undefined, fn never runs)
 
 z.object({ a: z.preprocess((v) => v ?? "X", z.string()) }).parse({})
 // → { a: "X" }  (preprocess.optin = "optional" via transform; obj invokes; fn runs)
-//   pre-branch: FAIL (4.4 regression after #5661 made obj parser strict)
 
 z.object({ a: z.preprocess((v) => v ?? "X", z.string()).optional() }).parse({})
-// → {}  (optional invokes preprocess; fn runs; fallback=true; optional clobbers; obj omits)
+// → {}  (optional sees "optional", not "defaulted"; yields undefined without running the fn; obj omits)
 
 z.object({ a: z.preprocess((v) => v, z.string().optional()) }).parse({})
 // → {}  (inner-optional preprocess; #5917/#5929 path)
+
+// === Default feeding a transform (the #6321 shape) ===
+
+z.string().default("").transform((v) => (v ? v.split(",") : [])).optional().parse(undefined)
+// → []  (pipe.optin = def.in.optin = default.optin = "defaulted"; optional runs it and respects)
+//   4.4.3-4.4.x: was undefined, because transform flagged every invocation as a fallback
+
+z.object({ a: z.string().default("").transform((v) => v.length) }).partial().parse({})
+// → { a: 0 }  (.partial() wraps in optional; the top rung carries through the pipe)
 
 // === Transform ===
 
@@ -320,7 +323,7 @@ z.transform((v) => v ?? "X").parse(undefined)
 // → "X"  (transform fn runs on undef, returns "X")
 
 z.transform((v) => v ?? "X").optional().parse(undefined)
-// → undefined  (optional invokes transform; fn runs; fallback=true; clobbers)
+// → undefined  (transform.optin = "optional"; optional yields undefined, fn never runs)
 
 z.object({ a: z.transform((v) => v ?? "X") }).parse({})
 // → { a: "X" }  (transform.optin = "optional" runtime; obj invokes transform with undef)
@@ -402,7 +405,9 @@ z.object({ a: z.preprocess(fn, z.string().optional()) }).parse({})
 | [#5661](https://github.com/colinhacks/zod/pull/5661) | Made `$ZodObject` / `$ZodTuple` strict about absent slots — consult `optin`. Source of the 4.4 regressions. |
 | [#5917](https://github.com/colinhacks/zod/pull/5917) / [#5929](https://github.com/colinhacks/zod/pull/5929) | Made preprocess defer optionality to inner schema (so `preprocess(fn, X.optional())` worked again). Pure metadata-override subtype design. |
 | [#5937](https://github.com/colinhacks/zod/issues/5937) / [#5939](https://github.com/colinhacks/zod/pull/5939) | Restored `$ZodCatch.optin = "optional"` runtime + introduced the `caught` flag so an outer `$ZodOptional` could clobber catch's recovery. |
-| [#5941](https://github.com/colinhacks/zod/pull/5941) | Renamed `caught → fallback`; propagated through `$ZodPipe` boundaries; also makes `$ZodPreprocess.optin = "optional"` and `$ZodTransform` set `fallback` on every invocation. Restores the bare-`preprocess` regression. **Plus** prototype commit promoting `optin = "optional"` from preprocess to transform (under consideration). |
+| [#4405](https://github.com/colinhacks/zod/pull/4405) | Split `_zod.optionality` into `optin` / `optout`. Collapsed the old `"optional" \| "defaulted"` ladder to two values as collateral — the distinction restored below. Pre-4.0, so nothing depended on it. |
+| [#5941](https://github.com/colinhacks/zod/pull/5941) | Renamed `caught → fallback`; propagated through `$ZodPipe` boundaries; also makes `$ZodPreprocess.optin = "optional"` and `$ZodTransform` set `fallback` on every invocation. Restores the bare-`preprocess` regression. |
+| [#6321](https://github.com/colinhacks/zod/issues/6321) / [#6419](https://github.com/colinhacks/zod/pull/6419) | "Set on every transform invocation" was unsound when a `.default()` sat between the transform and the outer `optional`. Restored the third rung (`optin = "defaulted"`) and retired `payload.fallback` entirely. |
 
 ## Design principle: flexible inputs, strict outputs (at runtime)
 
@@ -416,12 +421,12 @@ This is technically unsound — the runtime accepts inputs the type rejects — 
 
 The schemas where the input stays strict at runtime — `coerce`, `unknown`, `any`, plain `string`/`number`/etc. — don't have a user-written escape hatch. There's no reason for them to claim to handle absence; they should reject and let the user opt in explicitly. So the rule is: **schemas with a user-written escape hatch (catch's recovery, transform's fn) accept `undefined` at runtime; schemas without one don't.**
 
-`fallback` is the runtime mechanism that makes this safe to combine with `optional`: when an outer wrapper *also* expresses an opinion about absent input ("missing → undefined"), the inner schema's escape-hatch output gets overridden. The user's explicit `.optional()` wins over the inner's "I happened to produce this value when called with undefined." Catch and transform both flag their output as fallback for this reason; default and prefault don't because their values are the deliberate output, not an escape-hatch output.
+The `optin` ladder is what makes this safe to combine with `optional`: an escape hatch earns `"optional"` (absence permitted) but not `"defaulted"` (absence answered), so when an outer wrapper *also* has an opinion about absent input, the user's explicit `.optional()` wins. Default and prefault claim the top rung because their values *are* the deliberate output, not an escape-hatch output.
 
 ## Mental model (one paragraph)
 
-A schema's `optin` declares whether it accepts absent input. Object and tuple parsers consult it before running. Optional consults it to decide whether to short-circuit or invoke the inner. Default, prefault, optional, and exact-optional all hardcode `optin = "optional"`. Catch and transform set it at runtime only — their static type doesn't claim to accept absence even though they do (flexible inputs, strict outputs). Preprocess inherits transform's runtime optin via pipe.
+A schema's `optin` is a three-rung ladder: `undefined` (required), `"optional"` (absence permitted), `"defaulted"` (absence permitted *and* substituted for). Object and tuple parsers ask the weak question — `!== undefined` — before running a slot. Default and prefault claim the top rung; optional, catch, transform and preprocess claim only `"optional"`; transparent wrappers and the input side of a pipe carry through whatever they wrap, which is how `z.string().default("D").transform(fn)` stays `"defaulted"`.
 
-When `optional` wraps something with `optin === "optional"` and the input is `undefined`, it has to decide: *trust the inner's output*, or *override with `undefined`*. The `fallback` payload flag is how the inner tells the outer "this value is a recovery / a transform's interpretation, not a deliberate handling of absence — feel free to override." Catch sets it on substitution; transform sets it on every invocation. Default and prefault don't, because their values *are* the deliberate handling.
+When `optional` receives `undefined` it asks the strong question — `=== "defaulted"` — and runs the inner only if something down there actually answers the absence. Otherwise it yields `undefined` without running anything. There is no payload flag: the answer is a property of the schema's shape, so it needs no propagation and cannot be dropped at a combinator boundary.
 
 For everything else — `coerce`, `string`, `unknown`, `any`, `transform.pipe` shapes where transform is on the OUT side — `optin` stays `undefined`. Object and tuple parsers reject absent input. Users opt in explicitly via `.optional()` or `.default(...)` when they want absence accepted.


### PR DESCRIPTION
Closes #6321. Supersedes #6329 — the root-cause analysis and the mechanism are @deepshekhardas's; this lands the same fix structurally rather than as a runtime check.

## The bug

```ts
const arrayFromString = z.string().default("").transform((v) => (v ? v.split(",") : []));
z.object({ array: arrayFromString }).partial().parse({});
// 4.4.2: { array: [] }    4.4.3: {}
```

A regression in 4.4.3, from `c2be4f81` (#5941). `$ZodTransform` marked `payload.fallback` on *every* invocation, and `handleOptionalResult` gated on the **optional's** input rather than the **transform's** — so a `.default()` in between opened the gate on a value that was never a fallback.

## The fix

`optin` was overloaded across two readers asking different questions. `$ZodObject`/`$ZodTuple` asked "may this slot be absent?"; `$ZodOptional` asked "should I invoke you on `undefined` and trust the result?". `$ZodTransform` and `$ZodCatch` set `optin = "optional"` to satisfy the first — they genuinely can run on an absent key — which made the second draw the wrong conclusion. `payload.fallback` existed only to undo that at runtime.

Refine the value rather than adding a sibling:

```ts
optin?: "optional" | "defaulted" | undefined;
//  undefined    required
//  "optional"   the container may omit it; nothing is supplied
//  "defaulted"  the container may omit it AND this schema substitutes
```

`$ZodDefault`/`$ZodPrefault` declare `"defaulted"`. `$ZodOptional`/`$ZodCatch` carry the top rung through; pipe, codec, nullable, readonly and lazy already defer so they get it free. `$ZodUnion` takes the highest rung any option declares.

"May the slot be absent?" becomes `!== undefined`. `$ZodOptional` asks the stronger question:

```ts
if (payload.value === undefined) {
  if (def.innerType._zod.optin !== "defaulted") return payload;
  const result = def.innerType._zod.run(payload, ctx);
  return handleOptionalResult(result);
}
return def.innerType._zod.run(payload, ctx);
```

`payload.fallback` is removed entirely — `$ZodTransform` and `$ZodCatch` stop setting it, `handlePipeResult` stops copying it, and the field is gone from `ParsePayload`. #6321 falls out as a consequence, without the word "transform" appearing in the fix.

This is a restoration, not an invention. `_zod.optionality?: "optional" | "defaulted"` existed until #4405, which split the single axis into `optin`/`optout` and collapsed the ladder to two values as collateral. That was pre-4.0.0, so nothing depended on it. `fallback` was introduced a year later to recover part of the same distinction on the payload.

## Breaking: `optin`'s value changes for defaults

`z.string().default("x")._zod.optin` was `"optional"` and is now `"defaulted"`. **Introspection tooling that tests `optin === "optional"` to decide "this key is optional" will now miss every `.default()`.** The safe test is `optin !== undefined`.

`z.input` / `z.output` inference is unaffected — `OptionalInSchema` widens to `{ optin: "optional" | "defaulted" }`, so defaults stay optional in input types and required in output types.

## Two sites that silently produced wrong answers

Neither was a compile error:

1. **`getTupleOptStart(items, key)`** — one helper shared by `optin` and `optout`, testing `!== "optional"`. `optin` is now three-valued while `optout` stays two-valued, so the shared predicate stopped recognising defaults and `z.tuple([z.string().default("D")]).parse([])` began failing `too_small`.
2. **`json-schema-processors.ts`** — `inputOptin(item) === "optional"` for closed-tuple `minItems`, reporting 2 instead of 1.

## Also changed

`$ZodOptional` no longer *runs* an inner that doesn't substitute; it previously ran it and discarded the result. `z.preprocess(fn, z.string()).optional().parse(undefined)` invoked `fn` once before and zero times now. Same result, fewer side effects.

`wiki/optionality.md` is updated: the `fallback` section is replaced by how `$ZodOptional` reads the ladder, the respect/clobber table is re-keyed on `optin`, and the walkthroughs carry the #6321 shape.

## Verification

- 4336/4336 tests across 365 files, `Type Errors: no errors`, build clean, all three lint steps green.
- Behaviourally identical to #6329 across a 456-row combinator matrix — 0 differences.
- New `optin-ladder.test.ts` pins the rung values, `z.input`/`z.output` inference for defaults/prefaults/tuples/`.partial()`, tuple minimum lengths across every rung, the top rung surviving every wrapper order, and the #5941/#5939 clobber invariants.
- In-repo readers of `optin` are confined to `core/schemas.ts`, `core/util.ts` and `core/json-schema-processors.ts`; no other package reads it.
