### PR TITLE
feat(v4): expose the owning schema on check-originated issues

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -157,9 +157,24 @@ z.string({
     iss.code; // the issue code
     iss.input; // the input data
     iss.inst; // the schema/check that originated this issue
+    iss.schema; // the schema that owns this issue
     iss.path; // the path of the error
   },
 });
+```
+
+Unlike `iss.inst`, `iss.schema` is always the schema, even when a check originated the issue. Use it to read the owning schema's [metadata](/metadata).
+
+```ts
+z.config({
+  customError: (iss) => {
+    const meta = iss.schema && z.globalRegistry.get(iss.schema);
+    return `${meta?.title ?? "Field"} is invalid.`;
+  },
+});
+
+z.string().min(5).meta({ title: "Password" }).safeParse("abc");
+// => "Password is invalid."
 ```
 
 Depending on the API you are using, there may be additional properties available. Use TypeScript's autocomplete to explore the available properties.

--- a/packages/zod/src/v4/classic/tests/issue-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/issue-schema.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, expect, test } from "vitest";
+import * as z from "zod/v4";
+
+afterEach(() => {
+  z.config({ customError: undefined });
+});
+
+/** Collects the owning schema's registered metadata for every issue an error map sees. */
+function captureMeta(): { seen: (z.core.GlobalMeta | undefined)[] } {
+  const seen: (z.core.GlobalMeta | undefined)[] = [];
+  z.config({
+    customError: (issue) => {
+      seen.push(issue.schema && z.globalRegistry.get(issue.schema));
+      return undefined;
+    },
+  });
+  return { seen };
+}
+
+test("check-originated issues expose the owning schema", () => {
+  const { seen } = captureMeta();
+
+  z.object({ name: z.string().min(5).meta({ title: "Name" }) }).safeParse({ name: "ab" });
+  z.string().max(2).meta({ title: "Max" }).safeParse("abc");
+  z.email().meta({ title: "Email" }).safeParse("nope");
+  z.number().multipleOf(3).meta({ title: "Multiple" }).safeParse(4);
+  z.array(z.string()).min(2).meta({ title: "Array" }).safeParse([]);
+
+  expect(seen).toEqual([
+    { title: "Name" },
+    { title: "Max" },
+    { title: "Email" },
+    { title: "Multiple" },
+    { title: "Array" },
+  ]);
+});
+
+test("schema-originated issues expose the owning schema", () => {
+  const { seen } = captureMeta();
+
+  z.object({ name: z.string().min(5).meta({ title: "Name" }) }).safeParse({ name: 123 });
+  z.email().meta({ title: "Email" }).safeParse(123);
+
+  expect(seen).toEqual([{ title: "Name" }, { title: "Email" }]);
+});
+
+test("refinements attribute to the refined schema, not the internal check schema", () => {
+  const { seen } = captureMeta();
+
+  z.string()
+    .refine(() => false)
+    .meta({ title: "Refine" })
+    .safeParse("abc");
+  z.string()
+    .superRefine((_, ctx) => ctx.addIssue({ code: "custom", message: "" }))
+    .meta({ title: "SuperRefine" })
+    .safeParse("abc");
+
+  expect(seen).toEqual([{ title: "Refine" }, { title: "SuperRefine" }]);
+});
+
+test("the innermost schema owns the issue", () => {
+  const { seen } = captureMeta();
+
+  z.array(z.string().min(5).meta({ title: "Element" }))
+    .meta({ title: "Array" })
+    .safeParse(["ab"]);
+  z.string()
+    .pipe(z.string().min(5).meta({ title: "Target" }))
+    .meta({ title: "Pipe" })
+    .safeParse("ab");
+  z.looseObject({})
+    .check(z.property("a", z.string().meta({ title: "Property" })))
+    .meta({ title: "Object" })
+    .safeParse({ a: 1 });
+
+  expect(seen).toEqual([{ title: "Element" }, { title: "Target" }, { title: "Property" }]);
+});
+
+test("issues carrying no usable `inst` still get the owning schema", () => {
+  const { seen } = captureMeta();
+
+  // A hand-pushed issue may carry no inst at all, and ctx.addIssue(string) puts the check's def — not a Zod object — on inst.
+  z.string()
+    .check((payload) => {
+      payload.issues.push({ code: "custom", input: payload.value });
+    })
+    .meta({ title: "Bare" })
+    .safeParse("abc");
+  const shorthand = z
+    .string()
+    .superRefine((_, ctx) => ctx.addIssue("bad stuff"))
+    .meta({ title: "Shorthand" })
+    .safeParse("abc");
+
+  expect(seen).toEqual([{ title: "Bare" }]);
+  expect(shorthand.error!.issues[0].message).toEqual("bad stuff");
+});
+
+test("async checks expose the owning schema", async () => {
+  const { seen } = captureMeta();
+
+  await z
+    .string()
+    .refine(async () => false)
+    .meta({ title: "Async" })
+    .safeParseAsync("abc");
+
+  expect(seen).toEqual([{ title: "Async" }]);
+});
+
+test("the owning schema is the clone `.meta()` registered, not the pre-metadata schema", () => {
+  const bare = z.string().min(5);
+  const labeled = bare.meta({ title: "Labeled" });
+  const seen: unknown[] = [];
+  z.config({
+    customError: (issue) => {
+      seen.push(issue.schema === labeled);
+      return undefined;
+    },
+  });
+
+  labeled.safeParse("ab");
+
+  expect(seen).toEqual([true]);
+});
+
+test("`inst` keeps its meaning and `schema` stays off the finalized issue", () => {
+  const insts: string[] = [];
+  z.config({
+    customError: (issue) => {
+      insts.push(issue.inst!.constructor.name);
+      return undefined;
+    },
+  });
+
+  const tooSmall = z.string().min(5).safeParse("ab");
+  const wrongType = z.string().safeParse(123);
+
+  expect(insts).toEqual(["$ZodCheckMinLength", "ZodString"]);
+  expect(Object.keys(tooSmall.error!.issues[0])).not.toContain("schema");
+  expect(Object.keys(wrongType.error!.issues[0])).not.toContain("schema");
+});

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -202,6 +202,8 @@ type RawIssue<T extends $ZodIssueBase> = T extends any
         readonly input: unknown;
         /** The schema or check that originated this issue. */
         readonly inst?: $ZodType | $ZodCheck;
+        /** The schema that owns the issue. Equal to `inst` when a schema originated the issue, and the schema the check was attached to when a check did. */
+        readonly schema?: $ZodType | undefined;
         /** If `true`, Zod will continue executing checks/refinements after this issue. */
         readonly continue?: boolean | undefined;
       } & Record<string, unknown>

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -257,11 +257,13 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
             await _;
             const nextLen = payload.issues.length;
             if (nextLen === currLen) return;
+            util.attachSchema(payload.issues, currLen, inst);
             if (!isAborted) isAborted = util.aborted(payload, currLen);
           });
         } else {
           const nextLen = payload.issues.length;
           if (nextLen === currLen) continue;
+          util.attachSchema(payload.issues, currLen, inst);
           if (!isAborted) isAborted = util.aborted(payload, currLen);
         }
       }

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -851,11 +851,25 @@ export function unwrapMessage(message: string | { message: string } | undefined 
   return typeof message === "string" ? message : message?.message;
 }
 
+/* A check holds no link back to the schema it is attached to — the same check instance is shared by every clone of that schema — so the owner is stamped onto the issues a check just raised, at the only point where both are in scope. Runs on the failure path only; `start` is the issue count from before the check ran. */
+export function attachSchema(issues: errors.$ZodRawIssue[], start: number, inst: schemas.$ZodType): void {
+  for (let i = start; i < issues.length; i++) {
+    (issues[i] as any).schema ??= inst;
+  }
+}
+
 export function finalizeIssue(
   iss: errors.$ZodRawIssue,
   ctx: schemas.ParseContextInternal | undefined,
   config: $ZodConfig
 ): errors.$ZodIssue {
+  // A schema that raised an issue itself owns it outright, and outranks any stamp an enclosing check left in `attachSchema`. String formats and z.custom() are schema and check at once, so when they act as a check they defer to that stamp instead.
+  const traits: Set<string> | undefined = (iss.inst as any)?._zod?.traits;
+  if (traits?.has("$ZodType")) {
+    if (traits.has("$ZodCheck")) (iss as any).schema ??= iss.inst;
+    else (iss as any).schema = iss.inst;
+  }
+
   const message = iss.message
     ? iss.message
     : (unwrapMessage(iss.inst?._zod.def?.error?.(iss as never)) ??
@@ -864,7 +878,7 @@ export function finalizeIssue(
       unwrapMessage(config.localeError?.(iss)) ??
       "Invalid input");
 
-  const { inst: _inst, continue: _continue, input: _input, ...rest } = iss as any;
+  const { inst: _inst, schema: _schema, continue: _continue, input: _input, ...rest } = iss as any;
   rest.path ??= [];
   rest.message = message;
   if (ctx?.reportInput) {


### PR DESCRIPTION
Closes #5240. Also covers #4681 and #5329, and the request in discussion #5259.

## The gap

An error map can reach a schema's metadata only when the schema itself raised the issue. For the check-originated codes — `too_small`, `too_big`, `invalid_format`, `not_multiple_of` — `issue.inst` is the `$ZodCheck`, which has no `meta()` and no link back to the schema it was attached to. So the most common case, labelling a `.min()` failure with the field's own `title`, was not reachable:

```ts
z.config({
  customError: (iss) => `${(iss.inst as any).meta?.().title} is invalid.`,
});

z.string().min(5).meta({ title: "Password" }).safeParse("abc");
// => "undefined is invalid."   (iss.inst is $ZodCheckMinLength)
z.string().meta({ title: "Password" }).safeParse(123);
// => "Password is invalid."    (iss.inst is the ZodString)
```

The literal request in #5240 was a second `schemaInstance` argument on `customError`. I didn't do that — the issue object is the right carrier, and for half the codes the schema is already on `iss.inst`.

## What this adds

An optional `schema` on the raw issue that always names the owning schema, whatever raised the issue:

```ts
z.config({
  customError: (iss) => {
    const meta = iss.schema && z.globalRegistry.get(iss.schema);
    return `${meta?.title ?? "Field"} is invalid.`;
  },
});

z.string().min(5).meta({ title: "Password" }).safeParse("abc");
// => "Password is invalid."
```

Two population points, because the schema is in scope in two different ways:

- **Checks.** `runChecks` in `core/schemas.ts` stamps the owning schema onto the issues a check just raised. That is the only place where the check and its schema are both in scope. It sits behind the existing `if (nextLen === currLen) continue;`, so a passing check adds nothing.
- **Schemas.** A schema that raised its own issue put itself on `inst`, so `finalizeIssue` resolves `schema` from there. It also outranks a stamp left by an enclosing check, which is what keeps `z.property()` attributing to the inner schema rather than the object the check hangs off.

The `$ZodType`/`$ZodCheck` trait pair is what distinguishes the two — no branching on concrete schema types. It has to be the pair rather than `$ZodType` alone: string formats and `z.custom()` are schema and check at once, so `z.email()` and `.refine()` both need the check reading.

The innermost schema always wins, so nesting behaves the way the field-label use case expects:

| schema | code | `issue.schema` |
| --- | --- | --- |
| `z.object({ name: z.string().min(5) })` | `too_small` | the `ZodString` |
| `z.object({ name: z.string().min(5) })` | `invalid_type` | the `ZodString` |
| `z.email()` | `invalid_format` / `invalid_type` | the `ZodEmail` |
| `z.array(z.string()).min(2)` | `too_small` | the `ZodArray` |
| `z.array(z.string().min(5))` | `too_small` | the element `ZodString` |
| `z.string().refine(fn)` | `custom` | the `ZodString`, not the internal `ZodCustom` |
| `z.string().pipe(z.string().min(5))` | `too_small` | the pipe target |
| `z.looseObject({}).check(z.property("a", z.string()))` | `invalid_type` | the property's `ZodString` |

The link has to be made at parse time rather than at attach time. `.meta()` clones the schema and clones share check instances, so a back-pointer stored on the check in `onattach` would name the pre-metadata schema — exactly wrong for `z.string().min(5).meta({ title })`, the case this is for.

`schema` is declared next to `inst` on the raw issue and stripped in `finalizeIssue` alongside it, so it never reaches `$ZodIssue`. That part is deliberate: `$ZodError.message` is `JSON.stringify` over the issues, and a live schema on a finalized issue would serialize the whole schema graph and go circular on a recursive one.

Nothing existing changes shape. `issue.inst` keeps its current meaning, including the check for check-originated codes.

## Relation to #6008

Same pattern — enrich the issue object, don't add a parameter — and the same stamping point in `finalizeIssue`, so the two compose without conflict. They differ on one axis only: `locale` is a string that is useful on the finalized issue and serializes fine, so #6008 declares it on `$ZodIssueBase`; `schema` is a live object that must not survive finalization, so it goes on the raw-issue type with `inst`. If #6008 lands first this rebases cleanly.

## The three axes

**Bundle.** esbuild `--minify --conditions=@zod/source` over the `packages/treeshake` fixtures, gzip -9. This is the axis that actually moves.

| fixture | before | after | delta |
| --- | --- | --- | --- |
| `zod-object` (classic) | 22,115 | 22,200 | +85 B (+0.38%) |
| `zod-string` (classic) | 18,321 | 18,406 | +85 B (+0.46%) |
| `zod-mini-object` | 3,973 | 4,044 | +71 B (+1.79%) |
| `zod-mini-string` | 2,951 | 3,027 | +76 B (+2.58%) |

Unminified-but-bundled, that is +227 B classic and +207 B mini. Mini pays ~2.6% on the smallest fixture, which is the real cost of this PR — `finalizeIssue` and `runChecks` both ship in every build, so there is nothing to tree-shake it out of. Roughly 45% of it is the ownership resolution in `finalizeIssue`; dropping the `z.property()`/nested-schema case would buy back about a third of the total.

**Memory.** `packages/bench/memory/schema-footprint.ts`, n=20,000, under `--expose-gc`: identical on all 29 cases within ±2 B, which is the sampler's granularity. No own property is added to any schema or check instance, and nothing is retained past finalization — `schema` only ever exists on a raw issue during a failing parse. `memory/dict-mode.ts` reports `fast` for every instance.

**Runtime.** The success path is untouched by construction: the new call in `runChecks` sits after the `nextLen === currLen` early-continue that every passing check takes. The failure path gains one `??=` per newly-pushed issue plus one `Set.has` per issue in `finalizeIssue`.

Ten rounds, base and head interleaved round-by-round, separate processes so the call sites stay monomorphic, fixed iteration count with `gc()` between samples:

| case | base (min / median) | head (min / median) | delta |
| --- | --- | --- | --- |
| `z.object()` 3 keys, all pass | 104.9 / 108.0 ns | 104.9 / 107.7 ns | +0.0% / −0.3% |
| `z.object()` 3 keys, 3 issues | 4805 / 5002 ns | 4929 / 5162 ns | +2.6% / +3.2% |
| `z.string().min(5)`, 1 issue | 3601 / 3758 ns | 3681 / 3841 ns | +2.2% / +2.2% |

So: nothing on the success path, and roughly +2–3% on a failing parse. The passing case is the control — it is the one where the answer has to be zero, and both estimators return zero, which is what makes the failure numbers worth quoting at all. Caveat them anyway: this machine never got below a load average of 26, and the per-side spread was 5–10%, so read +2–3% as an upper bound rather than a measurement. Most of it is likely the hidden-class transition from writing a new property onto an already-constructed issue literal, not the `??=` itself.
