### PR TITLE
test(v4): pin issue.schema across every error map kind

### DIFF
--- a/packages/zod/src/v4/classic/tests/issue-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/issue-schema.test.ts
@@ -141,3 +141,43 @@ test("`inst` keeps its meaning and `schema` stays off the finalized issue", () =
   expect(Object.keys(tooSmall.error!.issues[0])).not.toContain("schema");
   expect(Object.keys(wrongType.error!.issues[0])).not.toContain("schema");
 });
+
+test("every error map kind receives the owning schema", () => {
+  const seen: Record<string, z.core.GlobalMeta | undefined> = {};
+  const capture = (key: string) => (issue: { schema?: z.core.$ZodType | undefined }) => {
+    seen[key] = issue.schema && z.globalRegistry.get(issue.schema);
+    return undefined;
+  };
+
+  z.string()
+    .min(5, { error: capture("check") })
+    .meta({ title: "Check" })
+    .safeParse("ab");
+
+  // A schema-bound map is only consulted for issues the schema itself raised, so this one needs a type error.
+  z.string({ error: capture("schema") })
+    .meta({ title: "Schema" })
+    .safeParse(123);
+
+  z.string()
+    .min(5)
+    .meta({ title: "Parse" })
+    .safeParse("ab", { error: capture("parse") });
+
+  z.config({ customError: capture("customError") });
+  z.string().min(5).meta({ title: "Custom" }).safeParse("ab");
+
+  // localeError carries the default English locale, so it is restored rather than cleared.
+  const localeError = z.config().localeError;
+  z.config({ customError: undefined, localeError: capture("localeError") });
+  z.string().min(5).meta({ title: "Locale" }).safeParse("ab");
+  z.config({ localeError });
+
+  expect(seen).toEqual({
+    check: { title: "Check" },
+    schema: { title: "Schema" },
+    parse: { title: "Parse" },
+    customError: { title: "Custom" },
+    localeError: { title: "Locale" },
+  });
+});


### PR DESCRIPTION
Follow-up to #6420, which exercised only `config.customError`. The other four error-map kinds already receive `issue.schema` — it is one field on the raw issue, resolved at the top of `finalizeIssue` before the precedence chain runs — but nothing held them there, so a later refactor of that chain could drop one silently.

Adds a single test that drives all five in one pass: check-bound (`.min(5, { error })`), schema-bound (`z.string({ error })`), per-parse (`safeParse(v, { error })`), `customError`, and `localeError`.

Two things worth noting from writing it:

The schema-bound case needs a type error rather than a check failure. `finalizeIssue` reads `iss.inst._zod.def.error`, and for a check-originated issue `inst` is the check — so a schema's own `error` option is never consulted for its checks' issues. `z.string({ error }).min(5).safeParse("ab")` does not call that map at all. That predates #6420 and is unchanged by it, but it is the reason the test uses `safeParse(123)` there.

`localeError` carries the default English locale, so the test restores the previous value instead of clearing it. Setting it to `undefined` would strip English messages for every test that ran afterwards in the same process.

Verified the assertion is load-bearing rather than vacuous: stubbing out the trait lookup in `finalizeIssue` fails this test along with the two existing schema-origination tests.
