### PR TITLE
docs: list el and hr in the supported locales

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -371,6 +371,7 @@ The following locales are available:
 - `cs` — Czech
 - `da` — Danish
 - `de` — German
+- `el` — Greek
 - `en` — English
 - `eo` — Esperanto
 - `es` — Spanish
@@ -380,6 +381,7 @@ The following locales are available:
 - `frCA` — Canadian French
 - `he` — Hebrew
 - `hi` — Hindi
+- `hr` — Croatian
 - `hu` — Hungarian
 - `hy` — Armenian
 - `id` — Indonesian


### PR DESCRIPTION
`el` and `hr` both ship as full locales but were never listed under the supported locales in the error customization docs, so they were undiscoverable.

`kh` and `ua` are still absent on purpose — they are deprecated aliases for `km` and `uk`, and listing them would advertise the deprecated spelling.

Found while merging the locale PRs that landed today; with these two added, every non-alias locale file now appears in the list (`fr-CA`, `pt-BR`, `zh-CN` and `zh-TW` are there under their export names).
