### PR TITLE
fix(locales): add the credit_card key to the seven locales missing it

### DIFF
--- a/packages/zod/src/v4/locales/bn.ts
+++ b/packages/zod/src/v4/locales/bn.ts
@@ -45,6 +45,7 @@ const error: () => errors.$ZodErrorMap = () => {
     base64url: "base64url-এনকোডেড স্ট্রিং",
     json_string: "JSON স্ট্রিং",
     e164: "E.164 নম্বর",
+    credit_card: "ক্রেডিট কার্ড নম্বর",
     jwt: "JWT",
     template_literal: "ইনপুট",
   };

--- a/packages/zod/src/v4/locales/ckb.ts
+++ b/packages/zod/src/v4/locales/ckb.ts
@@ -45,6 +45,7 @@ const error: () => errors.$ZodErrorMap = () => {
     base64url: "دەقی base64url",
     json_string: "دەقی JSON",
     e164: "ژمارەی E.164",
+    credit_card: "ژمارەی کارتی کرێدیت",
     jwt: "JWT",
     template_literal: "تێکردە",
   };

--- a/packages/zod/src/v4/locales/hi.ts
+++ b/packages/zod/src/v4/locales/hi.ts
@@ -45,6 +45,7 @@ const error: () => errors.$ZodErrorMap = () => {
     base64url: "Base64URL-एन्कोडेड स्ट्रिंग",
     json_string: "JSON स्ट्रिंग",
     e164: "E.164 संख्या",
+    credit_card: "क्रेडिट कार्ड संख्या",
     jwt: "JWT",
     template_literal: "इनपुट",
   };

--- a/packages/zod/src/v4/locales/kn.ts
+++ b/packages/zod/src/v4/locales/kn.ts
@@ -45,6 +45,7 @@ const error: () => errors.$ZodErrorMap = () => {
     base64url: "base64url-encodedಸ್ಟ್ರಿಂಗ್",
     json_string: "JSONಸ್ಟ್ರಿಂಗ್",
     e164: "E.164 ಸಂಖ್ಯೆ",
+    credit_card: "ಕ್ರೆಡಿಟ್ ಕಾರ್ಡ್ ಸಂಖ್ಯೆ",
     jwt: "JWT",
     template_literal: "ಇನ್ಪುಟ್",
   };

--- a/packages/zod/src/v4/locales/nn.ts
+++ b/packages/zod/src/v4/locales/nn.ts
@@ -43,6 +43,7 @@ const error: () => errors.$ZodErrorMap = () => {
     base64url: "base64url-enkoda streng",
     json_string: "JSON-streng",
     e164: "E.164-nummer",
+    credit_card: "kredittkortnummer",
     jwt: "JWT",
     template_literal: "input",
   };

--- a/packages/zod/src/v4/locales/sk.ts
+++ b/packages/zod/src/v4/locales/sk.ts
@@ -45,6 +45,7 @@ const error: () => errors.$ZodErrorMap = () => {
     base64url: "reťazec zakódovaný vo formáte base64url",
     json_string: "reťazec vo formáte JSON",
     e164: "číslo E.164",
+    credit_card: "číslo kreditnej karty",
     jwt: "JWT",
     template_literal: "vstup",
   };

--- a/packages/zod/src/v4/locales/tk.ts
+++ b/packages/zod/src/v4/locales/tk.ts
@@ -44,6 +44,7 @@ const error: () => errors.$ZodErrorMap = () => {
     base64url: "base64url bilen şifrlenen setir",
     json_string: "JSON setiri",
     e164: "E.164 nomeri",
+    credit_card: "kredit kartynyň nomeri",
     jwt: "JWT",
     template_literal: "şablon",
   };


### PR DESCRIPTION
`credit_card` was missing from seven locales: `bn`, `ckb`, `hi`, `kn`, `nn`, `sk`, `tk`.

The pattern is not random. #5931 backfilled the key across every locale that existed when it landed, so the only gaps are locales added *after* it — five of the seven merged in the last day.

It also matters more than the other dictionary gaps. The fall-through renders `FormatDictionary[format] ?? format`, so a missing key prints the raw name: `Neplatný formát credit_card`. That underscore is the tell — `emoji` and `url` fall through to real words and read fine, which is why those gaps went unnoticed. `credit_card` is the only one that reads as broken rather than untranslated.

Each string reuses the word the same file already uses for `e164`, so it matches that locale's own vocabulary instead of importing a sibling's:

| | `e164` | added |
|---|---|---|
| `bn` | `E.164 নম্বর` | `ক্রেডিট কার্ড নম্বর` |
| `ckb` | `ژمارەی E.164` | `ژمارەی کارتی کرێدیت` |
| `hi` | `E.164 संख्या` | `क्रेडिट कार्ड संख्या` |
| `kn` | `E.164 ಸಂಖ್ಯೆ` | `ಕ್ರೆಡಿಟ್ ಕಾರ್ಡ್ ಸಂಖ್ಯೆ` |
| `nn` | `E.164-nummer` | `kredittkortnummer` (matches `no.ts`) |
| `sk` | `číslo E.164` | `číslo kreditnej karty` (matches `cs.ts`) |
| `tk` | `E.164 nomeri` | `kredit kartynyň nomeri` |

Verified by driving every locale's error map at runtime: `credit_card` now resolves in all 60, down from 7 missing.

Two things I left alone. `sk` renders `Neplatný formát číslo kreditnej karty`, which wants a genitive after `formát` — but that is pre-existing and systemic in `sk.ts` (`Neplatný formát číslo E.164`, `Neplatný formát IPv4 adresa`), so fixing it means reworking the template or every entry, and wants a native speaker. And the same audit shows `mac` missing in 49 locales and `emoji` in 35 — both benign fall-throughs, but worth knowing.
