### PR TITLE
fix(v4): let a schema's error map cover its own checks' issues

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -434,8 +434,8 @@ Below is a quick reference for determining error precedence: if multiple error c
 2. **Schema-level error** — Any error message "hard coded" into a schema definition. It covers issues raised by the schema's own checks, so it is the fallback when the check defines no error of its own.
 
   ```ts
-  z.string("Invalid name").parse(12);        // => "Invalid name"
-  z.string("Invalid name").min(5).parse("ab"); // => "Invalid name"
+  z.string("Invalid name").safeParse(12);          // => "Invalid name"
+  z.string("Invalid name").min(5).safeParse("ab"); // => "Invalid name"
   ```
 
 3. **Per-parse error** — A custom error map passed into the `.parse()` method.

--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -425,13 +425,19 @@ The following locales are available:
 
 Below is a quick reference for determining error precedence: if multiple error customizations have been defined, which one takes priority? From *highest to lowest* priority:
 
-1. **Schema-level error** — Any error message "hard coded" into a schema definition.
+1. **Check-level error** — An error defined on the individual check that failed.
+
+  ```ts
+  z.string().min(5, "Too short!");
+  ```
+
+2. **Schema-level error** — Any error message "hard coded" into a schema definition. It covers issues raised by the schema's own checks, so it is the fallback when the check defines no error of its own.
 
   ```ts
   z.string("Not a string!");
   ```
 
-2. **Per-parse error** — A custom error map passed into the `.parse()` method.
+3. **Per-parse error** — A custom error map passed into the `.parse()` method.
 
   ```ts
   z.string().parse(12, {
@@ -439,7 +445,7 @@ Below is a quick reference for determining error precedence: if multiple error c
   });
   ```
 
-3. **Global error map** — A custom error map passed into `z.config()`.
+4. **Global error map** — A custom error map passed into `z.config()`.
 
   ```ts
   z.config({
@@ -447,7 +453,7 @@ Below is a quick reference for determining error precedence: if multiple error c
   });
   ```
 
-4. **Locale error map** — A custom error map passed into `z.config()`.
+5. **Locale error map** — A custom error map passed into `z.config()`.
 
   ```ts
   z.config(z.locales.en());

--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -434,7 +434,8 @@ Below is a quick reference for determining error precedence: if multiple error c
 2. **Schema-level error** — Any error message "hard coded" into a schema definition. It covers issues raised by the schema's own checks, so it is the fallback when the check defines no error of its own.
 
   ```ts
-  z.string("Not a string!");
+  z.string("Invalid name").parse(12);        // => "Invalid name"
+  z.string("Invalid name").min(5).parse("ab"); // => "Invalid name"
   ```
 
 3. **Per-parse error** — A custom error map passed into the `.parse()` method.

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -523,7 +523,7 @@ test("z.config customError ", () => {
   // support overrideErrorMap
 
   z.config({ customError: () => ({ message: "override" }) });
-  const result = stringWithCustomError.min(10).safeParse("tooshort");
+  const result = z.string().min(10).safeParse("tooshort");
   expect(result.success).toBe(false);
   expect(result.error).toMatchInlineSnapshot(`
     [ZodError: [
@@ -538,6 +538,42 @@ test("z.config customError ", () => {
     ]]
   `);
   expect(result.error!.issues[0].message).toEqual("override");
+  z.config({ customError: undefined });
+});
+
+test("bound error map covers issues raised by its own checks", () => {
+  const result = stringWithCustomError.min(10).safeParse("tooshort");
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0].message).toEqual("bound");
+});
+
+test("a check's own error map beats the schema's", () => {
+  const result = stringWithCustomError.min(10, { error: () => "check" }).safeParse("tooshort");
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0].message).toEqual("check");
+});
+
+test("the schema's error map beats contextual and global for a check issue", () => {
+  z.config({ customError: () => "global" });
+  const result = stringWithCustomError.min(10).safeParse("tooshort", { error: () => "contextual" });
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0].message).toEqual("bound");
+  z.config({ customError: undefined });
+});
+
+test("a schema map returning undefined defers to the next rung, and runs once", () => {
+  let calls = 0;
+  const deferring = z.string({
+    error: () => {
+      calls++;
+      return undefined;
+    },
+  });
+  z.config({ customError: () => "global" });
+  const result = deferring.min(10).safeParse("tooshort");
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0].message).toEqual("global");
+  expect(calls).toEqual(1);
   z.config({ customError: undefined });
 });
 

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1,6 +1,11 @@
 import { inspect } from "node:util";
-import { expect, test } from "vitest";
+import { afterEach, expect, test } from "vitest";
 import * as z from "zod/v4";
+
+// Several tests install a global error map. Resetting on the last line of each leaks it into every later test in the file whenever an assertion above that line fails, which turns one real failure into a cascade.
+afterEach(() => {
+  z.config({ customError: undefined });
+});
 
 test("error creation", () => {
   const err1 = new z.ZodError([]);
@@ -538,7 +543,6 @@ test("z.config customError ", () => {
     ]]
   `);
   expect(result.error!.issues[0].message).toEqual("override");
-  z.config({ customError: undefined });
 });
 
 test("bound error map covers issues raised by its own checks", () => {
@@ -558,7 +562,6 @@ test("the schema's error map beats contextual and global for a check issue", () 
   const result = stringWithCustomError.min(10).safeParse("tooshort", { error: () => "contextual" });
   expect(result.success).toBe(false);
   expect(result.error!.issues[0].message).toEqual("bound");
-  z.config({ customError: undefined });
 });
 
 test("a schema map returning undefined defers to the next rung, and runs once", () => {
@@ -574,7 +577,6 @@ test("a schema map returning undefined defers to the next rung, and runs once", 
   expect(result.success).toBe(false);
   expect(result.error!.issues[0].message).toEqual("global");
   expect(calls).toEqual(1);
-  z.config({ customError: undefined });
 });
 
 // test("invalid and required", () => {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -867,9 +867,12 @@ export function finalizeIssue(
     else (iss as any).schema = iss.inst;
   }
 
+  // Decreasing specificity, short-circuiting on the first map that returns a message. `inst` is whatever raised the issue, so for a check-originated issue that rung is the check's own map; the owning schema's map sits one rung below it and above the parse call. Skipped when the schema raised the issue itself, since `inst` was already the schema.
+  const schemaError = iss.schema !== iss.inst ? iss.schema?._zod.def?.error : undefined;
   const message = iss.message
     ? iss.message
     : (unwrapMessage(iss.inst?._zod.def?.error?.(iss as never)) ??
+      unwrapMessage(schemaError?.(iss as never)) ??
       unwrapMessage(ctx?.error?.(iss as never)) ??
       unwrapMessage(config.customError?.(iss)) ??
       unwrapMessage(config.localeError?.(iss)) ??


### PR DESCRIPTION
Closes #6108.

`finalizeIssue` walks the error maps in decreasing specificity and short-circuits on the first one that returns a message. That design is fine — this is a missing rung in the ladder, not a problem with the ladder.

## `inst` vs `schema`

Two different questions, and the distinction is the whole fix:

- **`iss.inst`** — *who raised this?* Typed `$ZodType | $ZodCheck`. For `z.string().min(5)` failing on length, `inst` is the `$ZodCheckMinLength`. For the same schema failing on type, `inst` is the `ZodString`.
- **`iss.schema`** — *which schema does this belong to?* Always a `$ZodType`. Added in #6420. Equal to `inst` when a schema raised its own issue; the schema the check was attached to when a check did.

The chain only ever read `inst`. So for a check-originated issue it consulted the **check's** map and then jumped straight to the parse call — the owning schema's map had no rung at all:

```ts
z.string({ error: () => "bound" }).min(5).safeParse("ab");
// before: "Too small: expected string to have >=5 characters"   ← "bound" never consulted
// after:  "bound"
```

Before #6420 there was no way to reach the owning schema from here, which is probably why the rung was never there.

## The change

```ts
const schemaError = iss.schema !== iss.inst ? iss.schema?._zod.def?.error : undefined;
const message = iss.message
  ? iss.message
  : (unwrapMessage(iss.inst?._zod.def?.error?.(iss as never)) ??
+     unwrapMessage(schemaError?.(iss as never)) ??
      unwrapMessage(ctx?.error?.(iss as never)) ??
      unwrapMessage(config.customError?.(iss)) ??
      unwrapMessage(config.localeError?.(iss)) ??
      "Invalid input");
```

One rung, placed where specificity puts it: below the check that actually failed, above the parse call. The `schema !== inst` guard keeps a schema that raised its own issue from being asked twice — which matters because a map returning `undefined` is how you defer to the next rung, and a double call would run its side effects twice. There is a test for exactly that.

A check's own error still wins, so `z.string({ error: "a" }).min(5, { error: "b" })` gives `"b"`.

## The test I rewrote

`test("z.config customError ")` asserted that the global map beats a schema-bound map. That inverts the documented precedence *and* the sibling test immediately above it (`test("bound error map overrides contextual")`), and it only passed because the schema map was never called on its `.min(10)` fixture.

`git log -S` traces the assertion to v3's `overrideErrorMap` test, where the v3 map explicitly deferred via `ctx.defaultError` for non-`invalid_type` codes. The v4 port dropped the deferral and kept the assertion. It now runs on a plain `z.string()`, so it tests the global map — which is what its name says.

## Checking this is real rather than green-by-accident

The new tests fail against unpatched `core/util.ts` and pass with it — I reverted the one file and re-ran to confirm, rather than trusting a green suite.

The full run has four failures on my machine, all wall-clock timeouts under a load average of 556 (`attw`, `redos`, and two `treeshake` bundling tests). Each passes in isolation and none loads a locale or an error map. Leaving CI to be the real gate.

## Scope — bigger than I first wrote

My original note said this affects "anyone relying on a global `customError` to override a schema-bound map." That undersold it, and the correction matters more than anything else in this PR.

The real affected group is **anyone who passed a message to a schema constructor and then attached any check.** Verified by running both revisions:

| schema | input | before | after |
| --- | --- | --- | --- |
| `z.string("Not a string!").min(5)` | `"ab"` | `Too small: expected string to have >=5 characters` | `Not a string!` |
| `z.number({error:"num"}).int()` | `1.5` | `Invalid input: expected int, received number` | `num` |
| `z.string({error:"bound"}).email()` | `"nope"` | `Invalid email address` | `bound` |
| `z.array(z.string(),{error:"arr"}).min(3)` | `["a"]` | `Too small: expected array to have >=3 items` | `arr` |
| mini `z.string({error:"m"}).check(minLength(5))` | `"ab"` | `Too small: expected string to have >=5 characters` | `m` |
| nested child `z.object({a},{error:"obj"})` | `{a:1}` | `Invalid input: expected string, received number` | unchanged |

**The failure mode is a plausible-looking wrong message, not a crash.** The most common idiom is a type-error message — `z.string("Not a string!")` — and it now answers for length, format and integer failures too, where it reads wrong. `zod/mini` swings hardest: it ships no locale, so those check issues previously fell through to `Invalid input`.

This is the documented contract (`error-customization.mdx:66` promises the bound map covers "any validation issues that originate from this schema"), so the direction is defensible. But the direction and the blast radius are separate questions, and the second is a maintainer call:

- Does this ship as a minor with a release note? Anyone snapshot-testing error strings will churn.
- Should there be a documented escape hatch for "schema message for the type error only"? Today that means branching on `iss.code` and returning `undefined` otherwise. If that becomes the recommended pattern it belongs in the docs beside the new rung.
