### PR TITLE
fix(core): restore exactOptional's narrowed values/pattern

### DIFF
--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -206,6 +206,39 @@ test("exactOptional optionality", () => {
   expectTypeOf<typeof a._zod.optout>().toEqualTypeOf<"optional">();
 });
 
+// exactOptional narrows the value set rather than widening it: an absent key is not a value, and explicit undefined is rejected outright.
+test("exactOptional does not add undefined to values/pattern", () => {
+  expect(z.exactOptional(z.literal("a"))._zod.values).toEqual(new Set(["a"]));
+  expect(z.exactOptional(z.enum(["a", "b"]))._zod.pattern).toEqual(/^(a|b)$/);
+
+  // optional widens both, since undefined really is one of its accepted values
+  expect(z.optional(z.literal("a"))._zod.values).toEqual(new Set(["a", undefined]));
+  expect(z.optional(z.enum(["a", "b"]))._zod.pattern).toEqual(/^((a|b))?$/);
+});
+
+test("exactOptional keeps a template literal segment required", () => {
+  const schema = z.templateLiteral(["x", z.exactOptional(z.enum(["a", "b"]))]);
+  expect(schema.safeParse("xa").success).toEqual(true);
+  expect(schema.safeParse("x").success).toEqual(false);
+});
+
+test("exactOptional discriminator does not match an absent key", () => {
+  const schema = z.discriminatedUnion("k", [
+    z.object({ k: z.exactOptional(z.literal("a")), x: z.string() }),
+    z.object({ k: z.literal("b"), y: z.number() }),
+  ]);
+  expect(schema.safeParse({ k: "a", x: "s" }).success).toEqual(true);
+  expect(schema.safeParse({ x: "s" }).success).toEqual(false);
+
+  // disjoint exactOptional discriminators no longer collide on a shared undefined
+  expect(() =>
+    z.discriminatedUnion("k", [
+      z.object({ k: z.exactOptional(z.literal("a")) }),
+      z.object({ k: z.exactOptional(z.literal("c")) }),
+    ])
+  ).not.toThrow();
+});
+
 test("exactOptional in objects - absent keys", () => {
   const schema = z.object({
     a: z.string().exactOptional(),

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3666,12 +3666,12 @@ export interface $ZodExactOptional<T extends SomeType = $ZodType> extends $ZodTy
 export const $ZodExactOptional: core.$constructor<$ZodExactOptional> = /*@__PURE__*/ core.$constructor(
   "$ZodExactOptional",
   (inst, def) => {
-    // Call parent init - inherits optin/optout = "optional"
-    $ZodOptional.init(inst, def);
-
-    // Override values/pattern to NOT add undefined
+    // values/pattern do NOT gain undefined here: an absent key is not a value. They are claimed before the parent init because defineLazyInternal is first-wins on the shared prototype, so $ZodOptional's widening versions would otherwise take the slots and these would silently no-op.
     util.defineLazyInternal(inst, "values", (zod) => zod.def.innerType._zod.values);
     util.defineLazyInternal(inst, "pattern", (zod) => zod.def.innerType._zod.pattern);
+
+    // Call parent init - inherits optin/optout = "optional"
+    $ZodOptional.init(inst, def);
 
     // Override parse to just delegate (no undefined handling)
     inst._zod.parse = (payload, ctx) => {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1062,6 +1062,10 @@ export function installLazyProps<T extends object>(inst: T, sentinel: string, pr
  * Installs a lazily-derived internal on the `_zod` prototype of `inst`'s
  * constructor, computed from the internals object itself and cached there on
  * first read. One accessor per constructor rather than one per instance.
+ *
+ * First-wins: the first call for a key owns it, and later calls are no-ops. A
+ * subclass that derives a key differently from the parent it delegates to must
+ * therefore claim that key *before* calling the parent's `init`.
  */
 export function defineLazyInternal<T extends { _zod: any }>(
   inst: T,


### PR DESCRIPTION
`$ZodExactOptional`'s `values`/`pattern` overrides have been dead code since #6415. That PR moved derived internals onto a per-constructor prototype through `defineLazyInternal`, which opens with `if (key in proto) return;` — first-wins. `$ZodExactOptional.init` called `$ZodOptional.init` first, so the parent's widening versions claimed both slots on the shared prototype and the child's subsequent calls silently no-opped. The comment above them, `// Override values/pattern to NOT add undefined`, has been describing behavior that stopped happening.

The fix claims the two keys before delegating to the parent. I swept every constructor that delegates to a parent `init` by instrumenting `defineLazyInternal` to record the call site that wins each key and flag any later call site it silently skips, then constructing ~2900 schemas across classic and mini. `$ZodExactOptional` is the only collision that changes a value, in both entrypoints; `$ZodObjectJIT`, `$ZodXor`, `$ZodPreprocess` and `$ZodDiscriminatedUnion` are clean.

There is one other collision, and it is inert: `ZodCodec` and `ZodMiniCodec` both run `ZodPipe.init` before `core.$ZodCodec.init`, so `$ZodPipe` claims `values`/`optin`/`optout`/`propValues` and `$ZodCodec`'s installs no-op. Nothing observable changes, because the two sets of derivations are character-for-character identical. **It should stay that way** — the ordering there is load-bearing for a different reason. `$ZodPipe.init` and `$ZodCodec.init` both assign `inst._zod.parse`, and codec has to be the one that wins; flip the two calls and `z.codec(z.string(), z.number(), …).safeParse(\"42\")` fails with `expected number, received string`, because the codec degrades into a plain pipe that never runs `decode`. So the codec pair is not a latent instance of the bug this PR fixes, and the convention documented on `defineLazyInternal` does not ask it to change: that note is conditional on a subclass deriving a key *differently* from its parent, which codec does not.

Two consequences, both restored to their pre-#6415 values:

```ts
z.templateLiteral(["x", z.exactOptional(z.enum(["a", "b"]))]).safeParse("x");
// 4.4.3: true — a required segment could be missing. Now false.

z.discriminatedUnion("k", [
  z.object({ k: z.exactOptional(z.literal("a")) }),
  z.object({ k: z.exactOptional(z.literal("c")) }),
]);
// 4.4.3: throws `Duplicate discriminator value "undefined"` — two branches with
// disjoint discriminators couldn't be combined. Now constructs.
```

The discriminated-union direction is the debatable one, so to be explicit about it: an absent `exactOptional` discriminator no longer matches a branch, which means `z.discriminatedUnion` now rejects `{ x: "s" }` where the equivalent `z.union` still accepts it. I think that's correct, and not merely older. `values` is a set of accepted *values*, and `exactOptional` demonstrably does not accept `undefined` — `z.object({ k: z.exactOptional(z.literal("a")) }).safeParse({ k: undefined })` fails. Putting `undefined` in the set to make routing work was asserting something false about the schema, and it paid for that routing with a construction-time error on the two-branch case above. Absence is carried by `optin`, not by `values`; if we want the DU to route absent discriminators, that belongs in the discriminator lookup consulting presence, not in `values`. `z.optional` is unaffected and still routes on absence, because `undefined` genuinely is one of its values.

I also documented the first-wins contract on `defineLazyInternal` rather than making it last-wins. The `key in proto` guard is what #6415 bought — it is the reason installation happens once per constructor instead of once per instance — and an explicit override mode would either redefine the accessor on every construction or need a per-key marker, spending exactly what that PR saved for a single call site. Ordering plus a comment plus the regression tests is the proportionate version.

Three axes, measured against `main` (b1077f05):

- **Bundle** — no change. `zod-object` 79695 B raw / 22282 B gzipped on both; `zod-mini-object` 11581 B raw on both, gzip 4087 → 4086 B, which is entropy noise from the statement reorder.
- **Memory** — no change. For `z.exactOptional(...)` in classic and mini: identical own-property counts (4 on the instance, 10 on `_zod`, 13 after every derived internal is read), identical descriptors (`get/set`, `configurable: true`, `enumerable: false`), identical retained bytes per instance (1.5 KB / 2.4 KB classic, 1.1 KB mini), and `%HasFastProperties` true on the instance, the internals and the prototype on both revisions — no dictionary-mode demotion from the changed install order.
- **Runtime** — not measured. The machine was at a load average of 220–610 throughout, far above the ~8 ceiling where these numbers mean anything. The change moves two constructor statements and adds no work to any parse path.

