### PR TITLE
fix(core): restore defineLazy semantics lost in the internals move

### DIFF
--- a/packages/zod/src/v4/classic/tests/lazy.test.ts
+++ b/packages/zod/src/v4/classic/tests/lazy.test.ts
@@ -245,3 +245,10 @@ test("a cycle-broken internal is not memoized", () => {
   expect(lazyRef._zod.optin).toEqual("optional");
   expect(z.object({ x: Rec, y: lazyRef }).safeParse({ x: "a" }).success).toEqual(true);
 });
+
+test("an internal computed without a cycle break is memoized", () => {
+  // `undefined` is the legitimate answer here and still has to cache: these getters are read per parse, so recomputing them is a parse-path cost.
+  const union = z.union([z.string(), z.number()]);
+  expect(union._zod.optin).toEqual(undefined);
+  expect(Object.getOwnPropertyNames(union._zod)).toContain("optin");
+});

--- a/packages/zod/src/v4/classic/tests/lazy.test.ts
+++ b/packages/zod/src/v4/classic/tests/lazy.test.ts
@@ -235,3 +235,13 @@ test("derived internals resolve on self-referential lazy", () => {
   expect(pipe._zod.optin).toEqual(undefined);
   expect(pipe._zod.optout).toEqual(undefined);
 });
+
+test("a cycle-broken internal is not memoized", () => {
+  const lazyRef: any = z.lazy(() => Rec);
+  const Rec: any = z.union([z.string().optional(), lazyRef]);
+
+  // Reading the outer node first resolves `lazyRef`'s own `optin` through the cycle.
+  expect(Rec._zod.optin).toEqual("optional");
+  expect(lazyRef._zod.optin).toEqual("optional");
+  expect(z.object({ x: Rec, y: lazyRef }).safeParse({ x: "a" }).success).toEqual(true);
+});

--- a/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
+++ b/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
@@ -173,3 +173,9 @@ test("ladder: the rung values themselves", () => {
   expect(z.union([z.string().default("D"), z.number()])._zod.optin).toBe("defaulted");
   expect(z.union([z.string().optional(), z.number()])._zod.optin).toBe("optional");
 });
+
+test("exactOptional overrides the values and pattern optional installs", () => {
+  expect(z.exactOptional(z.enum(["a", "b"]))._zod.values).toEqual(new Set(["a", "b"]));
+  expect(z.exactOptional(z.string().regex(/^abc$/))._zod.pattern).toEqual(/^abc$/);
+  expect(z.templateLiteral(["a", z.exactOptional(z.literal("b"))]).safeParse("a").success).toEqual(false);
+});

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -18,6 +18,9 @@ export const NEVER: never = /*@__PURE__*/ Object.freeze({
  * synchronously, so reusing one object avoids a per-instance allocation. */
 const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 
+// Marks a `_zod` prototype whose constructor has completed an instance: its lazily-derived internals are installed, so later constructions skip them.
+export const built: unique symbol = Symbol("zod_built");
+
 export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T["_zod"]["def"]>(
   name: string,
   initializer: (inst: T, def: D) => void,
@@ -25,6 +28,9 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
 ): $constructor<T, D> {
   // Prototype for this constructor's `_zod` internals. Lazily-derived fields (`values`, `pattern`, `optin`, …) install here once rather than as an accessor on every instance.
   const zodProto: any = {};
+
+  // Flipped once this constructor has produced an instance; after that the prototype's lazily-derived internals are installed and there is nothing left to seal.
+  let sealed = false;
 
   // Assigning the fields in the constructor body is what gives instances in-object slots; building the object literally and reparenting it costs a second allocation and a generic property copy.
   function Internals(this: any, def: D) {
@@ -79,6 +85,13 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
       // Released: initializers run once, and the list would otherwise be retained for the schema's lifetime.
       inst._zod.deferred = undefined;
     }
+
+    if (!sealed) {
+      sealed = true;
+      const zodProtoUsed = Object.getPrototypeOf(inst._zod);
+      if (!zodProtoUsed[built]) Object.defineProperty(zodProtoUsed, built, { value: true });
+    }
+
     return inst;
   }
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1058,14 +1058,14 @@ export function installLazyProps<T extends object>(inst: T, sentinel: string, pr
   }
 }
 
+// Bumped whenever a recursive read resolves to `undefined` instead of recursing. Shared across every accessor, so a break anywhere inside a `compute` keeps that result from being memoized.
+let cycleBreaks = 0;
+
 /**
  * Installs a lazily-derived internal on the `_zod` prototype of `inst`'s
  * constructor, computed from the internals object itself and cached there on
  * first read. One accessor per constructor rather than one per instance.
  */
-// Bumped whenever a recursive read resolves to `undefined` instead of recursing. Shared across every accessor, so a break anywhere inside a `compute` keeps that result from being memoized.
-let cycleBreaks = 0;
-
 export function defineLazyInternal<T extends { _zod: any }>(
   inst: T,
   key: string,

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1,5 +1,5 @@
 import type * as checks from "./checks.js";
-import { globalConfig } from "./core.js";
+import { built, globalConfig } from "./core.js";
 import type { $ZodConfig } from "./core.js";
 import type * as errors from "./errors.js";
 import type * as schemas from "./schemas.js";
@@ -1069,14 +1069,26 @@ export function defineLazyInternal<T extends { _zod: any }>(
   compute: (zod: T["_zod"]) => unknown
 ): void {
   const proto = Object.getPrototypeOf(inst._zod);
-  if (key in proto) return;
+  // Installs share one prototype across a whole init chain, so a derived constructor has to be able to replace what its base installed. Only a prototype a construction has already finished with is closed to further installs.
+  if (proto[built] && key in proto) return;
+
+  // Holds the internals whose getter is currently running, so a re-entrant read from a recursive schema resolves to `undefined` rather than recursing.
+  const active = new WeakSet<object>();
   Object.defineProperty(proto, key, {
     configurable: true,
     get(this: any) {
-      // Installed before computing so a re-entrant read resolves against this own property instead of running the getter again; a recursive schema reaches its own derived internals while they are still being built.
-      Object.defineProperty(this, key, { configurable: true, writable: true, value: undefined });
-      const value = compute(this);
-      this[key] = value;
+      if (active.has(this)) return undefined;
+      active.add(this);
+      let value: unknown;
+      try {
+        value = compute(this);
+      } finally {
+        active.delete(this);
+      }
+      // `undefined` is never memoized, matching `defineLazy`: a cycle-broken read produces it, and that has to be recomputed once the schema graph is complete.
+      if (value !== undefined) {
+        Object.defineProperty(this, key, { configurable: true, writable: true, value });
+      }
       return value;
     },
     set(this: any, value: unknown) {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1063,6 +1063,9 @@ export function installLazyProps<T extends object>(inst: T, sentinel: string, pr
  * constructor, computed from the internals object itself and cached there on
  * first read. One accessor per constructor rather than one per instance.
  */
+// Bumped whenever a recursive read resolves to `undefined` instead of recursing. Shared across every accessor, so a break anywhere inside a `compute` keeps that result from being memoized.
+let cycleBreaks = 0;
+
 export function defineLazyInternal<T extends { _zod: any }>(
   inst: T,
   key: string,
@@ -1077,16 +1080,20 @@ export function defineLazyInternal<T extends { _zod: any }>(
   Object.defineProperty(proto, key, {
     configurable: true,
     get(this: any) {
-      if (active.has(this)) return undefined;
+      if (active.has(this)) {
+        cycleBreaks++;
+        return undefined;
+      }
       active.add(this);
+      const before = cycleBreaks;
       let value: unknown;
       try {
         value = compute(this);
       } finally {
         active.delete(this);
       }
-      // `undefined` is never memoized, matching `defineLazy`: a cycle-broken read produces it, and that has to be recomputed once the schema graph is complete.
-      if (value !== undefined) {
+      // Only a result that resolved through a recursion break goes uncached, since it has to be recomputed once the schema graph is complete. Everything else memoizes, `undefined` included — it is the ordinary answer for most schemas, and these getters are read per parse on the tuple and interpreted-object paths.
+      if (cycleBreaks === before) {
         Object.defineProperty(this, key, { configurable: true, writable: true, value });
       }
       return value;


### PR DESCRIPTION
Two regressions from #6415, both reachable from ordinary schemas and both caught by pullfrog's review on that PR after it had already merged.

**A derived constructor could no longer override what its base installed.** The whole init chain shares one `_zod` prototype — `init()` creates `_zod` once, from the outermost constructor — so when `$ZodExactOptional` calls `$ZodOptional.init` first, its own `values`/`pattern` hit `defineLazyInternal`'s already-installed guard and were silently dropped:

```ts
z.exactOptional(z.enum(["a", "b"]))._zod.values
// main: Set { 'a', 'b', undefined }   expected: Set { 'a', 'b' }

z.templateLiteral(["a", z.exactOptional(z.literal("b"))]).safeParse("a").success
// main: true   expected: false
```

A prototype is now closed to further installs only once a construction has finished with it, so a later install in the same chain wins the way `defineLazy` did. The guard still costs one boolean per construction after the first instance.

**Cycle-broken reads were memoized.** A value resolved through a recursion break froze whichever node happened to be visited first at its mid-construction value, making the result depend on traversal order:

```ts
const lazyRef = z.lazy(() => Rec);
const Rec = z.union([z.string().optional(), lazyRef]);

z.object({ x: Rec, y: lazyRef }).safeParse({ x: "a" }).success
// main: false   expected: true — `y` was treated as required
```

Re-entry is now tracked per accessor rather than by installing a placeholder, and a shared counter records how many reads resolved through a break. A result goes uncached only when one actually happened — `undefined` is otherwise memoized like any other value, since it is the ordinary answer for most schemas and these getters are read per parse by `getTupleOptStart` and the interpreted object path.

Both fixes are pinned by tests that fail on `main` and pass here.

| axis | vs `main` |
| --- | --- |
| runtime | parse level — `z.tuple([union, union])` 200k parses 20.9 ms both, nested-union `optin` reads 0.01–0.02 ms both; construction within noise |
| memory | unchanged — `z.string()` 784 B, `.optional()` 1533 B, 10-key object 11.5 KB, `_zod` still under the 12-property step |
| bundle | +123 B classic, +58 B mini gzipped |

`dict-mode.ts` reports `fast` for every instance and every `_zod`; the one `DICT` is `def` on `z.object`, unchanged from `ccc15144`. 4354 tests pass.
