### PR TITLE
perf(core): memoize a non-undefined internal even when a cycle was broken

### DIFF
--- a/packages/zod/src/v4/classic/tests/lazy.test.ts
+++ b/packages/zod/src/v4/classic/tests/lazy.test.ts
@@ -252,3 +252,10 @@ test("an internal computed without a cycle break is memoized", () => {
   expect(union._zod.optin).toEqual(undefined);
   expect(Object.getOwnPropertyNames(union._zod)).toContain("optin");
 });
+
+test("a non-undefined internal is memoized even when a cycle was broken", () => {
+  // The cycle here closes through types that all forward `optin` lazily, so every read breaks it. The answer is stable, so it still has to cache or the getter re-runs per parse.
+  const union: any = z.union([z.string(), z.lazy(() => union).optional()]);
+  expect(union._zod.optin).toEqual("optional");
+  expect(Object.getOwnPropertyNames(union._zod)).toContain("optin");
+});

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1092,8 +1092,8 @@ export function defineLazyInternal<T extends { _zod: any }>(
       } finally {
         active.delete(this);
       }
-      // Only a result that resolved through a recursion break goes uncached, since it has to be recomputed once the schema graph is complete. Everything else memoizes, `undefined` included — it is the ordinary answer for most schemas, and these getters are read per parse on the tuple and interpreted-object paths.
-      if (cycleBreaks === before) {
+      // `defineLazy`'s rule: a result is provisional only when a recursion break produced `undefined`, and that alone is left uncached so it can be recomputed once the schema graph is complete. Everything else memoizes, since these getters are read per parse on the tuple and interpreted-object paths.
+      if (cycleBreaks === before || value !== undefined) {
         Object.defineProperty(this, key, { configurable: true, writable: true, value });
       }
       return value;


### PR DESCRIPTION
#6429 fixed the two parse regressions from #6415, but its memoization rule came out stricter than `defineLazy` ever was. `defineLazy` only ever skipped the memo for `undefined`; #6429 skips it for anything computed while a recursion break happened, `undefined` or not.

That costs a shape where the cycle closes through types that all forward the key lazily — union, lazy, optional — so every read breaks the cycle and nothing ever caches. `z.union([z.string(), z.lazy(() => A).optional()])`, 50k tuple parses:

| | |
| --- | --- |
| `ccc15144` (last release) | 10.2 ms |
| `9f0a3d81` (main) | **19.9 ms** |
| this PR | **7.4 ms** |

A break only makes a result provisional when it produced `undefined` — a value that came back defined is the answer, and it caches. That is exactly `defineLazy`'s rule, so this is a restoration rather than a new policy.

The shapes people actually write were never affected and are unchanged: recursive JSON (`lazy → union → array`) 14.9 → 14.8 ms and recursive-object-via-getter 10.3 → 11.0 ms, both flat across every revision measured. All four correctness cases from #6429 still match the pre-#6415 baseline, and the new test fails without the change.

| axis | vs `main` |
| --- | --- |
| runtime | 19.9 → 7.4 ms on the affected shape; controls flat |
| memory | unchanged |
| bundle | +6 B classic, +0 B mini gzipped |

4361 tests pass. `dict-mode.ts` reports `fast` for every instance and every `_zod`.
