### PR TITLE
fix(core): an omittable discriminator claims undefined

### DIFF
--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -711,3 +711,27 @@ test.each(["__proto__", "constructor", "toString", "hasOwnProperty", "valueOf"])
     expect(parsed.value).toBe("ok");
   }
 );
+
+// An omittable discriminator reads back as undefined at the lookup, exactly as TypeScript sees it: `{ k?: "a" } | { k?: "c" }` does not narrow on `k === undefined`.
+test("an omittable discriminator claims undefined", () => {
+  const omittable = [z.exactOptional(z.literal("a")), z.optional(z.literal("a")), z.literal("a").default("a")];
+  for (const k of omittable) {
+    expect(z.object({ k })._zod.propValues.k).toEqual(new Set(["a", undefined]));
+  }
+
+  // one option omits the key: it claims undefined, so an absent key routes there and the union agrees
+  const options = [
+    z.object({ k: z.exactOptional(z.literal("a")), x: z.string() }),
+    z.object({ k: z.literal("b"), y: z.number() }),
+  ] as const;
+  expect(z.discriminatedUnion("k", options).safeParse({ x: "s" }).success).toEqual(true);
+  expect(z.union(options).safeParse({ x: "s" }).success).toEqual(true);
+  expect(z.discriminatedUnion("k", options).safeParse({ k: "b", y: 1 }).success).toEqual(true);
+
+  // two options omit the key: both claim undefined, so they are not discriminable on it
+  for (const k of omittable) {
+    expect(() =>
+      z.discriminatedUnion("k", [z.object({ k }), z.object({ k: z.exactOptional(z.literal("c")) })]).parse({})
+    ).toThrow(/Duplicate discriminator value "undefined"/);
+  }
+});

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1615,10 +1615,19 @@ function generateDiscriminatedUnionCheck(
   doc.write(`let ${outputVar};`);
 
   let firstBranch = true;
+  const claimed = new Set<util.Primitive>();
   for (const option of def.options) {
     const values = option._zod.propValues?.[def.discriminator];
     if (!values || values.size === 0) {
       throw new ZodCompileUnsupportedError("discriminated union option without static discriminator values");
+    }
+
+    // Two options claiming one value are not discriminable, and the branch chain below would silently give it to the first. Declining to compile hands that back to the interpreter, whose own map build reports it.
+    for (const value of values) {
+      if (claimed.has(value)) {
+        throw new ZodCompileUnsupportedError(`duplicate discriminator value ${String(value)}`);
+      }
+      claimed.add(value);
     }
 
     const conditions = Array.from(values, (value) => literalEquality(ctx, discVar, value));

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3743,8 +3743,13 @@ export const $ZodExactOptional: core.$constructor<$ZodExactOptional> = /*@__PURE
     util.defineLazyInternal(inst, "values", (zod) => zod.def.innerType._zod.values);
     util.defineLazyInternal(inst, "pattern", (zod) => zod.def.innerType._zod.pattern);
 
-    // Override parse to just delegate (no undefined handling)
+    // OPTION B PROTOTYPE: fix in $ZodExactOptional.parse, expressed through the inner's optin rung.
     inst._zod.parse = (payload, ctx) => {
+      const _inner = def.innerType._zod;
+      if (payload.value === undefined && _inner.optin !== "defaulted" && _inner.optout !== "optional") {
+        payload.issues.push({ code: "invalid_type", expected: "nonoptional", input: undefined, inst });
+        return payload;
+      }
       return def.innerType._zod.run(payload, ctx);
     };
   }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2077,6 +2077,8 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
           util.assignProp(propValues, key, new Set());
         }
         for (const v of field.values) propValues[key].add(v);
+        // An omittable slot reads back as undefined at a discriminator lookup, so it has to claim undefined: two options that can both omit the key are not discriminable on it.
+        if (field.optin !== undefined) propValues[key].add(undefined);
       }
     }
     return propValues;


### PR DESCRIPTION
A discriminator whose schema accepts an absent key reads back as `undefined` at the lookup, but `propValues` only ever claimed the schema's `values`. So two options that can both omit the key looked discriminable when they are not, and one option that can omit it failed to match an absent key at all.

`$ZodObject`'s `propValues` now claims `undefined` for any slot with `optin !== undefined` — the predicate the ladder comment at `core/schemas.ts:131` already prescribes for "may the slot be absent?". Two consequences:

```ts
z.discriminatedUnion("k", [
  z.object({ k: z.exactOptional(z.literal("a")) }),
  z.object({ k: z.exactOptional(z.literal("c")) }),
]).parse({});
// before: parsed nothing and reported no matching discriminator
// now:    throws `Duplicate discriminator value "undefined"`

const options = [
  z.object({ k: z.exactOptional(z.literal("a")), x: z.string() }),
  z.object({ k: z.literal("b"), y: z.number() }),
];
z.discriminatedUnion("k", options).safeParse({ x: "s" });
// before: false — while z.union(options) accepted the same input
// now:    true, matching the union
```

The first is the point: if both options can omit `k`, they are not discriminable on it, and TypeScript agrees — `{ k?: "a" } | { k?: "c" }` does not narrow on `k === undefined`, and neither `if (u.k === undefined)` nor `case undefined:` produces a single member. Rejecting the union outright is better than building a routing table that silently drops one branch.

This is uniform across the rungs, so `optional` and `default` discriminators behave the same as `exactOptional` rather than each having their own answer. `optional` already threw, since `undefined` was in its `values`; `default` did not, and now does.

No change to `values` or `pattern` themselves, so nothing moves for template literals or the `exactOptional` narrowing restored in #6429.

Bundle +35 B raw / +11 B gzipped on `zod-mini-object`, +35 B / +9 B on `zod-object`. Memory unchanged — `propValues` is lazy and this adds one `Set.add` to a set that is already being built. Runtime not measured; the box was at a load average above 200, far past where the numbers mean anything.


---

Second commit: the compiled dispatch in `core/compile.ts` is a first-match-wins condition chain built from the same `propValues`, with no duplicate detection, so two options claiming one value silently routed to the first while the interpreter reported it. It now declines to compile that schema, which hands it back to the interpreter and restores the parity `z.compile` promises. That gap predates this PR — `z.optional` discriminators already collided on `undefined` and already diverged between the two paths — but this change makes more schemas reach it, so it is fixed here.
