### PR TITLE
test(treeshake): raise the zod-mini-string ceiling to its current size

### DIFF
--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -32,7 +32,7 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  */
 const CEILINGS: Record<string, number> = {
   "zod-mini-boolean": 2830,
-  "zod-mini-string": 3155,
+  "zod-mini-string": 3158,
   "zod-mini-object": 4260,
 };
 


### PR DESCRIPTION
main is failing this check right now. `zod-mini-string` measures 3158 gzipped bytes against a 3155 ceiling.

The ceiling landed with #6085, measured on a branch that predated the memory work in #6415 and #6429. Those two moved derived internals onto a per-constructor prototype and reported the mini cost at the time; by the time #6085 merged, main had already grown past the number it was carrying. Nothing regressed after #6085 — the ceiling was three bytes stale on arrival.

Raising it to the measured size rather than adding headroom, so the guard stays as tight as it was intended to be.