### PR TITLE
fix(v4): an absent key on the middle rung supplies nothing

### DIFF
--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -33,7 +33,7 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
 const CEILINGS: Record<string, number> = {
   "zod-mini-boolean": 2830,
   "zod-mini-string": 3155,
-  "zod-mini-object": 4260,
+  "zod-mini-object": 4269,
 };
 
 /**

--- a/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
+++ b/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
@@ -74,6 +74,50 @@ test("ladder: exactOptional keeps its distinct meaning", () => {
   expect(z.object({ a: z.string().exactOptional() }).safeParse({ a: undefined }).success).toBe(false);
 });
 
+// An absent key never materializes a value from a schema that only claims the middle rung, however that schema answers `undefined`. The top rung still substitutes, and an explicitly present `undefined` still runs the inner.
+test.each([true, false])("ladder: an absent key stays absent on the middle rung (jitless=%s)", (jitless) => {
+  const opts = { jitless };
+  expect(z.object({ a: z.coerce.string().exactOptional() }).parse({}, opts)).toEqual({});
+  expect(z.object({ a: z.string().catch("C").exactOptional() }).parse({}, opts)).toEqual({});
+  expect(z.object({ a: z.preprocess((v) => v ?? "X", z.string()).exactOptional() }).parse({}, opts)).toEqual({});
+  expect(z.object({ a: z.union([z.coerce.string(), z.string().optional()]) }).parse({}, opts)).toEqual({});
+
+  expect(z.object({ a: z.string().default("D").exactOptional() }).parse({}, opts)).toEqual({ a: "D" });
+  expect(z.object({ a: z.string().prefault("P").exactOptional() }).parse({}, opts)).toEqual({ a: "P" });
+  expect(z.object({ a: z.coerce.string().exactOptional() }).parse({ a: undefined }, opts)).toEqual({ a: "undefined" });
+  expect(z.object({ a: z.coerce.string() }).parse({ a: undefined }, opts)).toEqual({ a: "undefined" });
+});
+
+test("ladder: an absent tuple slot on the middle rung truncates the tail", () => {
+  expect(z.tuple([z.string(), z.coerce.string().exactOptional()]).parse(["x"])).toEqual(["x"]);
+  expect(z.tuple([z.string(), z.string().catch("C").exactOptional()]).parse(["x"])).toEqual(["x"]);
+  expect(z.tuple([z.string(), z.string().default("D").exactOptional()]).parse(["x"])).toEqual(["x", "D"]);
+});
+
+// z.compile() assembles its own output, so the gate has to be mirrored there or compile mode silently keeps the invented value.
+test("ladder: compile mode agrees with the interpreted and JIT paths on absent middle-rung slots", () => {
+  const objects = [
+    [z.object({ a: z.coerce.string().exactOptional() }), {}],
+    [z.object({ a: z.string().catch("C").exactOptional() }), {}],
+    [z.object({ a: z.string().default("D").exactOptional() }), { a: "D" }],
+    [z.object({ a: z.string().catch("C") }), { a: "C" }],
+  ] as const;
+  for (const [schema, expected] of objects) {
+    expect(z.compile(schema).parse({})).toEqual(expected);
+    expect(schema.parse({}, { jitless: true })).toEqual(expected);
+    expect(schema.parse({})).toEqual(expected);
+  }
+
+  const tuples = [
+    [z.tuple([z.string(), z.coerce.string().exactOptional()]), ["x"]],
+    [z.tuple([z.string(), z.string().default("D").exactOptional()]), ["x", "D"]],
+  ] as const;
+  for (const [schema, expected] of tuples) {
+    expect(z.compile(schema).parse(["x"])).toEqual(expected);
+    expect(schema.parse(["x"], { jitless: true })).toEqual(expected);
+  }
+});
+
 test("ladder: tuple minimum length respects every rung", () => {
   expect(z.tuple([z.string().default("D")]).parse([])).toEqual(["D"]);
   expect(z.tuple([z.string().prefault("P")]).parse([])).toEqual(["P"]);

--- a/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
+++ b/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
@@ -77,21 +77,23 @@ test("ladder: exactOptional keeps its distinct meaning", () => {
 // An absent key never materializes a value from a schema that only claims the middle rung, however that schema answers `undefined`. The top rung still substitutes, and an explicitly present `undefined` still runs the inner.
 test.each([true, false])("ladder: an absent key stays absent on the middle rung (jitless=%s)", (jitless) => {
   const opts = { jitless };
-  expect(z.object({ a: z.coerce.string().exactOptional() }).parse({}, opts)).toEqual({});
-  expect(z.object({ a: z.string().catch("C").exactOptional() }).parse({}, opts)).toEqual({});
-  expect(z.object({ a: z.preprocess((v) => v ?? "X", z.string()).exactOptional() }).parse({}, opts)).toEqual({});
-  expect(z.object({ a: z.union([z.coerce.string(), z.string().optional()]) }).parse({}, opts)).toEqual({});
+  expect(z.object({ a: z.coerce.string().exactOptional() }).parse({}, opts)).toStrictEqual({});
+  expect(z.object({ a: z.string().catch("C").exactOptional() }).parse({}, opts)).toStrictEqual({});
+  expect(z.object({ a: z.preprocess((v) => v ?? "X", z.string()).exactOptional() }).parse({}, opts)).toStrictEqual({});
+  expect(z.object({ a: z.union([z.coerce.string(), z.string().optional()]) }).parse({}, opts)).toStrictEqual({});
 
-  expect(z.object({ a: z.string().default("D").exactOptional() }).parse({}, opts)).toEqual({ a: "D" });
-  expect(z.object({ a: z.string().prefault("P").exactOptional() }).parse({}, opts)).toEqual({ a: "P" });
-  expect(z.object({ a: z.coerce.string().exactOptional() }).parse({ a: undefined }, opts)).toEqual({ a: "undefined" });
-  expect(z.object({ a: z.coerce.string() }).parse({ a: undefined }, opts)).toEqual({ a: "undefined" });
+  expect(z.object({ a: z.string().default("D").exactOptional() }).parse({}, opts)).toStrictEqual({ a: "D" });
+  expect(z.object({ a: z.string().prefault("P").exactOptional() }).parse({}, opts)).toStrictEqual({ a: "P" });
+  expect(z.object({ a: z.coerce.string().exactOptional() }).parse({ a: undefined }, opts)).toStrictEqual({
+    a: "undefined",
+  });
+  expect(z.object({ a: z.coerce.string() }).parse({ a: undefined }, opts)).toStrictEqual({ a: "undefined" });
 });
 
 test("ladder: an absent tuple slot on the middle rung truncates the tail", () => {
-  expect(z.tuple([z.string(), z.coerce.string().exactOptional()]).parse(["x"])).toEqual(["x"]);
-  expect(z.tuple([z.string(), z.string().catch("C").exactOptional()]).parse(["x"])).toEqual(["x"]);
-  expect(z.tuple([z.string(), z.string().default("D").exactOptional()]).parse(["x"])).toEqual(["x", "D"]);
+  expect(z.tuple([z.string(), z.coerce.string().exactOptional()]).parse(["x"])).toStrictEqual(["x"]);
+  expect(z.tuple([z.string(), z.string().catch("C").exactOptional()]).parse(["x"])).toStrictEqual(["x"]);
+  expect(z.tuple([z.string(), z.string().default("D").exactOptional()]).parse(["x"])).toStrictEqual(["x", "D"]);
 });
 
 // z.compile() assembles its own output, so the gate has to be mirrored there or compile mode silently keeps the invented value.
@@ -103,9 +105,9 @@ test("ladder: compile mode agrees with the interpreted and JIT paths on absent m
     [z.object({ a: z.string().catch("C") }), { a: "C" }],
   ] as const;
   for (const [schema, expected] of objects) {
-    expect(z.compile(schema).parse({})).toEqual(expected);
-    expect(schema.parse({}, { jitless: true })).toEqual(expected);
-    expect(schema.parse({})).toEqual(expected);
+    expect(z.compile(schema).parse({})).toStrictEqual(expected);
+    expect(schema.parse({}, { jitless: true })).toStrictEqual(expected);
+    expect(schema.parse({})).toStrictEqual(expected);
   }
 
   const tuples = [
@@ -113,8 +115,8 @@ test("ladder: compile mode agrees with the interpreted and JIT paths on absent m
     [z.tuple([z.string(), z.string().default("D").exactOptional()]), ["x", "D"]],
   ] as const;
   for (const [schema, expected] of tuples) {
-    expect(z.compile(schema).parse(["x"])).toEqual(expected);
-    expect(schema.parse(["x"], { jitless: true })).toEqual(expected);
+    expect(z.compile(schema).parse(["x"])).toStrictEqual(expected);
+    expect(schema.parse(["x"], { jitless: true })).toStrictEqual(expected);
   }
 });
 

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1070,9 +1070,9 @@ function generateObjectCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
   }
   // else: strip mode (no catchall) - unknown keys ignored, only include known keys
 
-  // Build the output: shape keys first in declared order (the runtime assigns them before its catchall loop), then unknown keys in for...in order. Runtime inclusion rule (handlePropertyResult): a key is included iff its output value !== undefined OR the key is present on the input. Props that can never output undefined keep the fast object-literal form.
+  // Build the output: shape keys first in declared order (the runtime assigns them before its catchall loop), then unknown keys in for...in order. Runtime inclusion rule (handlePropertyResult): a key on the middle rung is included iff the key is present on the input; otherwise iff its output value !== undefined OR the key is present. Props that can never output undefined keep the fast object-literal form.
   const outputVar = newVar(ctx);
-  const hasConditionalKeys = keys.some((k) => mayOutputUndefined(shape[k]!));
+  const hasConditionalKeys = keys.some((k) => mayOutputUndefined(shape[k]!) || dropsWhenAbsent(shape[k]!));
 
   if (!hasConditionalKeys) {
     const propLiterals = keys.map((k) => `${util.esc(k)}: ${propOutputs[k]}`).join(", ");
@@ -1080,7 +1080,9 @@ function generateObjectCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
   } else {
     doc.write(`const ${outputVar} = {};`);
     for (const k of keys) {
-      if (mayOutputUndefined(shape[k]!)) {
+      if (dropsWhenAbsent(shape[k]!)) {
+        doc.write(`if (${util.esc(k)} in ${accessor}) ${outputVar}[${util.esc(k)}] = ${propOutputs[k]};`);
+      } else if (mayOutputUndefined(shape[k]!)) {
         doc.write(
           `if (${propOutputs[k]} !== undefined || ${util.esc(k)} in ${accessor}) ${outputVar}[${util.esc(k)}] = ${propOutputs[k]};`
         );
@@ -1237,6 +1239,11 @@ function fastPathAcceptsAbsence(schema: SomeType): boolean {
 // Whether a schema's success-path output can be `undefined`. Object output
 // assembly gives such props the runtime's value-or-presence inclusion rule;
 // everything else keeps the unconditional object-literal slot.
+/** The middle rung permits absence without supplying anything in its place, so an absent key contributes nothing — mirrors the leading gate in `handlePropertyResult`. */
+function dropsWhenAbsent(schema: SomeType): boolean {
+  return schema._zod.optin === "optional" && schema._zod.optout === "optional";
+}
+
 function mayOutputUndefined(schema: SomeType): boolean {
   const def = schema._zod.def as {
     type: string;
@@ -1478,6 +1485,11 @@ function generateTupleCheck(doc: Doc, ctx: CompileContext, schema: SomeType, acc
         });
         d.write(`} else {`);
         d.indented((d2) => {
+          // Middle rung: absence supplies nothing in its place, so truncate rather than running the item on `undefined` and keeping what it invents. Mirrors the leading gate in `handleTupleResults`.
+          if (dropsWhenAbsent(itemSchema)) {
+            d2.write(`${outputVar}.length = ${i};`);
+            return;
+          }
           const elemVar = newVar(ctx);
           const branchVar = newVar(ctx);
           d2.write(`const ${elemVar} = undefined;`);

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1236,14 +1236,14 @@ function fastPathAcceptsAbsence(schema: SomeType): boolean {
   }
 }
 
-// Whether a schema's success-path output can be `undefined`. Object output
-// assembly gives such props the runtime's value-or-presence inclusion rule;
-// everything else keeps the unconditional object-literal slot.
 /** The middle rung permits absence without supplying anything in its place, so an absent key contributes nothing — mirrors the leading gate in `handlePropertyResult`. */
 function dropsWhenAbsent(schema: SomeType): boolean {
   return schema._zod.optin === "optional" && schema._zod.optout === "optional";
 }
 
+// Whether a schema's success-path output can be `undefined`. Object output
+// assembly gives such props the runtime's value-or-presence inclusion rule;
+// everything else keeps the unconditional object-literal slot.
 function mayOutputUndefined(schema: SomeType): boolean {
   const def = schema._zod.def as {
     type: string;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1893,19 +1893,23 @@ function handlePropertyResult(
   final: ParsePayload,
   key: PropertyKey,
   input: any,
-  isOptionalIn: boolean,
+  optin: "optional" | "defaulted" | undefined,
   isOptionalOut: boolean
 ) {
   const isPresent = key in input;
+  // The middle rung means "absence permitted, nothing supplied in its place", so an absent key contributes nothing — whatever the schema made of `undefined` is invented, not substituted. Only `optional` reaches this with a value: `defaulted` substitutes, and a schema that isn't optional-out has to keep the key.
+  if (!isPresent && isOptionalOut && optin === "optional") {
+    return;
+  }
   if (result.issues.length) {
     // For optional-in/out schemas, ignore errors on absent keys.
-    if (isOptionalIn && isOptionalOut && !isPresent) {
+    if (optin !== undefined && isOptionalOut && !isPresent) {
       return;
     }
     final.issues.push(...util.prefixIssues(key, result.issues));
   }
 
-  if (!isPresent && !isOptionalIn) {
+  if (!isPresent && optin === undefined) {
     if (!result.issues.length) {
       final.issues.push({
         code: "invalid_type",
@@ -2006,7 +2010,7 @@ function handleCatchall(
   const keySet = def.keySet;
   const _catchall = def.catchall!._zod;
   const t = _catchall.def.type;
-  const isOptionalIn = _catchall.optin !== undefined;
+  const optin = _catchall.optin;
   const isOptionalOut = _catchall.optout === "optional";
   for (const key in input) {
     // Must precede the __proto__ branch: a declared key is not unrecognized, even though the shape loop deliberately strips __proto__ from the parsed output.
@@ -2023,9 +2027,9 @@ function handleCatchall(
     const r = _catchall.run({ value: input[key], issues: [] }, ctx);
 
     if (r instanceof Promise) {
-      proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut)));
+      proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, optin, isOptionalOut)));
     } else {
-      handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
+      handlePropertyResult(r, payload, key, input, optin, isOptionalOut);
     }
   }
 
@@ -2109,14 +2113,14 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     for (const key of value.keys) {
       if (key === "__proto__") continue;
       const el = shape[key]!;
-      const isOptionalIn = el._zod.optin !== undefined;
+      const optin = el._zod.optin;
       const isOptionalOut = el._zod.optout === "optional";
 
       const r = el._zod.run({ value: input[key], issues: [] }, ctx);
       if (r instanceof Promise) {
-        proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut)));
+        proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, optin, isOptionalOut)));
       } else {
-        handlePropertyResult(r, payload, key, input, isOptionalIn, isOptionalOut);
+        handlePropertyResult(r, payload, key, input, optin, isOptionalOut);
       }
     }
 
@@ -2164,13 +2168,15 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         const k = util.esc(key);
         const isPresent = `${k} in input`;
         const schema = shape[key];
-        const isOptionalIn = schema?._zod?.optin !== undefined;
+        const optin = schema?._zod?.optin;
+        const isOptionalIn = optin !== undefined;
         const isOptionalOut = schema?._zod?.optout === "optional";
 
         doc.write(`const ${id} = ${parseStr(key)};`);
 
         if (isOptionalIn && isOptionalOut) {
-          // For optional-in/out schemas, ignore errors on absent keys — and, like the interpreted path, drop the value produced alongside them.
+          // For optional-in/out schemas, ignore errors on absent keys — and, like the interpreted path, drop the value produced alongside them. The middle rung goes further: it permits absence without supplying anything in its place, so an absent key contributes nothing at all.
+          const assign = optin === "optional" ? `${id}_present` : `${id}.value !== undefined || ${id}_present`;
           doc.write(`
         const ${id}_present = ${isPresent};
         if (!${id}.issues.length || ${id}_present) {
@@ -2181,7 +2187,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
             })));
           }
 
-          if (${id}.value !== undefined || ${id}_present) {
+          if (${assign}) {
             newResult[${k}] = ${id}.value;
           }
         }
@@ -2940,6 +2946,11 @@ function handleTupleResults(
   for (let i = 0; i < items.length; i++) {
     const r = itemResults[i];
     const isPresent = i < input.length;
+    // The array analog of `handlePropertyResult`'s absent-key early return: the middle rung permits absence without supplying anything in its place, so the tail truncates here instead of materializing whatever the item made of `undefined`.
+    if (!isPresent && i >= optoutStart && items[i]._zod.optin === "optional") {
+      final.value.length = i;
+      break;
+    }
     if (r.issues.length) {
       if (!isPresent && i >= optoutStart) {
         final.value.length = i;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1894,9 +1894,10 @@ function handlePropertyResult(
   key: PropertyKey,
   input: any,
   optin: "optional" | "defaulted" | undefined,
-  isOptionalOut: boolean
+  optout: "optional" | undefined
 ) {
   const isPresent = key in input;
+  const isOptionalOut = optout === "optional";
   // The middle rung means "absence permitted, nothing supplied in its place", so an absent key contributes nothing — whatever the schema made of `undefined` is invented, not substituted. Only `optional` reaches this with a value: `defaulted` substitutes, and a schema that isn't optional-out has to keep the key.
   if (!isPresent && isOptionalOut && optin === "optional") {
     return;
@@ -2011,7 +2012,7 @@ function handleCatchall(
   const _catchall = def.catchall!._zod;
   const t = _catchall.def.type;
   const optin = _catchall.optin;
-  const isOptionalOut = _catchall.optout === "optional";
+  const optout = _catchall.optout;
   for (const key in input) {
     // Must precede the __proto__ branch: a declared key is not unrecognized, even though the shape loop deliberately strips __proto__ from the parsed output.
     if (keySet.has(key)) continue;
@@ -2027,9 +2028,9 @@ function handleCatchall(
     const r = _catchall.run({ value: input[key], issues: [] }, ctx);
 
     if (r instanceof Promise) {
-      proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, optin, isOptionalOut)));
+      proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, optin, optout)));
     } else {
-      handlePropertyResult(r, payload, key, input, optin, isOptionalOut);
+      handlePropertyResult(r, payload, key, input, optin, optout);
     }
   }
 
@@ -2116,13 +2117,13 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
       if (key === "__proto__") continue;
       const el = shape[key]!;
       const optin = el._zod.optin;
-      const isOptionalOut = el._zod.optout === "optional";
+      const optout = el._zod.optout;
 
       const r = el._zod.run({ value: input[key], issues: [] }, ctx);
       if (r instanceof Promise) {
-        proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, optin, isOptionalOut)));
+        proms.push(r.then((r) => handlePropertyResult(r, payload, key, input, optin, optout)));
       } else {
-        handlePropertyResult(r, payload, key, input, optin, isOptionalOut);
+        handlePropertyResult(r, payload, key, input, optin, optout);
       }
     }
 

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -81,7 +81,7 @@ The user-visible consequence: `z.input<typeof z.object({ a: z.preprocess(fn, T) 
 
 ```ts
 const isPresent = key in input;
-const optin = propSchema._zod.optin;
+const isOptionalOut = optout === "optional";   // optin and optout both arrive raw
 
 if (!isPresent && isOptionalOut && optin === "optional") {
   return; // absent slot, middle rung: contribute nothing at all — no issue, no key

--- a/wiki/optionality.md
+++ b/wiki/optionality.md
@@ -81,16 +81,20 @@ The user-visible consequence: `z.input<typeof z.object({ a: z.preprocess(fn, T) 
 
 ```ts
 const isPresent = key in input;
-const isOptionalIn = propSchema._zod.optin === "optional";
+const optin = propSchema._zod.optin;
+
+if (!isPresent && isOptionalOut && optin === "optional") {
+  return; // absent slot, middle rung: contribute nothing at all — no issue, no key
+}
 
 if (result.issues.length) {
-  if (isOptionalIn && isOptionalOut && !isPresent) {
+  if (optin !== undefined && isOptionalOut && !isPresent) {
     return; // swallow the issue — schema can't possibly succeed on absent input but is allowed to fail
   }
   final.issues.push(...prefixed);
 }
 
-if (!isPresent && !isOptionalIn) {
+if (!isPresent && optin === undefined) {
   if (!result.issues.length) {
     final.issues.push({ code: "invalid_type", expected: "nonoptional", input: undefined, path: [key] });
   }
@@ -104,7 +108,13 @@ if (result.value === undefined) {
 }
 ```
 
-`$ZodTuple` does the analogous thing for trailing tuple slots.
+The leading gate is what keeps an absent key absent. The ladder says the middle rung permits absence *without supplying anything in its place*, so whatever the property schema made of `undefined` is invented rather than substituted, and assigning it would contradict the schema's own declaration. `optout` is the other half of the gate: a schema that isn't optional-out has to keep the key, which is why `z.string().catch("c")` — optional-in only — still fills an absent key with `"c"`. Only the top rung reaches the assignment with a value.
+
+The wrapper alone cannot make this call. `$ZodOptional` never hits the gate with a value because it short-circuits on `undefined` unless the inner is `"defaulted"`; `$ZodExactOptional` deliberately does *not* short-circuit, because delegating to the inner is the only thing that makes it reject an explicitly present `undefined`. Since `el._zod.run({ value: input[key], issues: [] }, ctx)` carries no presence information, `$ZodObject` is the only place that knows the difference, and the gate belongs there.
+
+`$ZodTuple` does the analogous thing for trailing tuple slots, where "omit the key" becomes "truncate the tail".
+
+There are three parse paths, and the gate has to appear in all three or compile mode diverges. The interpreted path is `handlePropertyResult` above; `$ZodObjectJIT` emits `if (<key>_present)` instead of `if (value !== undefined || <key>_present)` for a middle-rung key; and `z.compile()` assembles its own output object, so `compileObject` applies `dropsWhenAbsent` — `optin === "optional" && optout === "optional"` — to pick the same condition, with the tuple compiler truncating instead of running an absent middle-rung item.
 
 `$ZodOptional` (the standalone wrapper) reads the *inner's* `optin` to decide whether to short-circuit on `undefined` input:
 
@@ -358,6 +368,23 @@ z.object({ a: z.unknown() }).parse({})
 
 z.object({ a: z.any() }).parse({})
 // → THROW  (same)
+
+// === exactOptional (delegates instead of short-circuiting) ===
+
+z.object({ a: z.coerce.string().exactOptional() }).parse({})
+// → {}  (absent + middle rung: the object drops what coerce made of undefined)
+
+z.object({ a: z.coerce.string().exactOptional() }).parse({ a: undefined })
+// → { a: "undefined" }  (present: the inner runs and its answer stands)
+
+z.object({ a: z.string().exactOptional() }).parse({ a: undefined })
+// → THROW  (present: string rejects undefined, and the object surfaces it)
+
+z.object({ a: z.string().default("x").exactOptional() }).parse({})
+// → { a: "x" }  (top rung substitutes, so the gate doesn't fire)
+
+z.tuple([z.string(), z.coerce.string().exactOptional()]).parse(["x"])
+// → ["x"]  (the tuple analog: truncate rather than materialize)
 
 // === Static type vs runtime divergence ===
 


### PR DESCRIPTION
The ladder defines the middle rung as "the container may omit it; nothing is supplied in its place." An absent key on that rung was still assigned whatever its schema made of `undefined`:

```ts
z.object({ a: z.coerce.string().exactOptional() }).parse({});          // { a: "undefined" }
z.object({ a: z.string().catch("C").exactOptional() }).parse({});      // { a: "C" }
z.tuple([z.string(), z.coerce.string().exactOptional()]).parse(["x"]); // ["x", "undefined"]
```

Plain `.optional()` never showed this, because it short-circuits on `undefined` unless the inner is `defaulted`. An exact optional deliberately does not short-circuit — delegating to the inner is the only thing that makes it reject an explicitly present `undefined` — so whatever the inner invents reached the output.

The gate reads the ladder back at the one place that knows presence:

```ts
// handlePropertyResult
if (!isPresent && isOptionalOut && optin === "optional") return;
```

Both axes are load-bearing, and that is what keeps the change narrow:

| schema | `optin` | `optout` | absent key |
| --- | --- | --- | --- |
| `z.string().catch("c")` | `optional` | — | still filled with `"c"` |
| `z.preprocess(fn, T)` | `optional` | — | still runs `fn` |
| `z.string().default("x")` | `defaulted` | — | still substitutes |
| `z.string().exactOptional()` | `optional` | `optional` | dropped |

Only a schema optional on both axes reaches the gate, and no schema type is named anywhere in the diff — a new wrapper gets the right answer because it already has to declare its rung.

Acceptance is untouched. Every present-key result is byte-identical, including `{ a: undefined }` on a coercing inner and the `expected: "string"` error message. Only absent keys move.

All three parse paths carry the gate:

- **Interpreted** — the early return above.
- **JIT fastpass** — emits `if (<key>_present)` in place of `if (value !== undefined || <key>_present)`.
- **Compiled** — `compileObject` and the tuple compiler apply the same test.

Without the compiled half, `z.compile()` silently kept the invented value while the other two dropped it. A test now pins the three against each other.

One consequence is not about exact optionals: a union optional on both axes whose options can produce a value from `undefined`, such as `z.union([z.coerce.string(), z.string().optional()])`, now drops the absent key too.

| bundle, gzipped | main `3c9ca1d9` | this PR |
| --- | --- | --- |
| `zod-object` | 22519 | 22567 (+48) |
| `zod-mini-object` | 4230 | 4238 (+8) |
| `zod-mini-string` | 3109 | 3108 (−1) |

Both sit under the ceilings `e125fd8d` set, so no ceiling moves here. Memory is unchanged: `packages/bench/memory/dict-mode.ts` reports identically to main, with every instance and every `_zod` still `fast`.

Runtime has no timing number. This machine has sat between load average 14 and 640 for two days, and CLAUDE.md rates anything above ~8 worthless, so a measured figure here would be noise wearing a decimal point. What can be measured deterministically is the generated code, and it moves the right way — for an object of five middle-rung keys the JIT fastpass emits **2538 bytes on main against 2393 on this branch**, the whole difference being five conditions that each lose a property read and a comparison:

```diff
-      if (key_0.value !== undefined || key_0_present) {
+      if (key_0_present) {
```

The interpreted path adds one compound test per property, short-circuiting on `!isPresent`. A timing number on a quiet machine is still owed.

Refs #6419, which built the ladder this reads. Refs #6236, which reported the coercion case. Merged after #6429 and confirmed the two compose: `values` on an exact-optional literal is still `["a"]`, and the template-literal case still rejects.

