### PR TITLE
perf(core): drop the seal and the per-key WeakSet from the lazy internals

### DIFF
--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,9 +38,9 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  "zod-mini-boolean": 2858,
-  "zod-mini-string": 3186,
-  "zod-mini-object": 4286,
+  "zod-mini-boolean": 2802,
+  "zod-mini-string": 3132,
+  "zod-mini-object": 4236,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,9 +38,9 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  "zod-mini-boolean": 2802,
-  "zod-mini-string": 3132,
-  "zod-mini-object": 4236,
+  "zod-mini-boolean": 2813,
+  "zod-mini-string": 3130,
+  "zod-mini-object": 4257,
 };
 
 /**

--- a/packages/zod/src/v4/classic/tests/lazy.test.ts
+++ b/packages/zod/src/v4/classic/tests/lazy.test.ts
@@ -252,3 +252,11 @@ test("an internal computed without a cycle break is memoized", () => {
   expect(union._zod.optin).toEqual(undefined);
   expect(Object.getOwnPropertyNames(union._zod)).toContain("optin");
 });
+
+// A compute that throws must memoize nothing, or the second read answers undefined for a schema whose internals were never derived.
+test("a throwing lazy internal throws on every read", () => {
+  const schema = z.discriminatedUnion("type", [z.string() as any]) as any;
+  for (let i = 0; i < 3; i++) {
+    expect(() => schema._zod.propValues).toThrow();
+  }
+});

--- a/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
+++ b/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
@@ -179,3 +179,10 @@ test("exactOptional overrides the values and pattern optional installs", () => {
   expect(z.exactOptional(z.string().regex(/^abc$/))._zod.pattern).toEqual(/^abc$/);
   expect(z.templateLiteral(["a", z.exactOptional(z.literal("b"))]).safeParse("a").success).toEqual(false);
 });
+
+// The override is installed once, on a prototype every instance of the type shares, so it has to hold for instances built after the first.
+test("exactOptional's override holds for later instances", () => {
+  z.exactOptional(z.enum(["a", "b"]));
+  expect(z.exactOptional(z.enum(["c", "d"]))._zod.values).toEqual(new Set(["c", "d"]));
+  expect(z.exactOptional(z.string().regex(/^xyz$/))._zod.pattern).toEqual(/^xyz$/);
+});

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -18,9 +18,6 @@ export const NEVER: never = /*@__PURE__*/ Object.freeze({
  * synchronously, so reusing one object avoids a per-instance allocation. */
 const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 
-// Marks a `_zod` prototype whose constructor has completed an instance: its lazily-derived internals are installed, so later constructions skip them.
-export const built: unique symbol = Symbol("zod_built");
-
 export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T["_zod"]["def"]>(
   name: string,
   initializer: (inst: T, def: D) => void,
@@ -28,9 +25,6 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
 ): $constructor<T, D> {
   // Prototype for this constructor's `_zod` internals. Lazily-derived fields (`values`, `pattern`, `optin`, …) install here once rather than as an accessor on every instance.
   const zodProto: any = {};
-
-  // Flipped once this constructor has produced an instance; after that the prototype's lazily-derived internals are installed and there is nothing left to seal.
-  let sealed = false;
 
   // Assigning the fields in the constructor body is what gives instances in-object slots; building the object literally and reparenting it costs a second allocation and a generic property copy.
   function Internals(this: any, def: D) {
@@ -86,13 +80,7 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
       inst._zod.deferred = undefined;
     }
 
-    if (!sealed) {
-      sealed = true;
-      const zodProtoUsed = Object.getPrototypeOf(inst._zod);
-      if (!zodProtoUsed[built]) Object.defineProperty(zodProtoUsed, built, { value: true });
-    }
-
-    // Global post-processor hook. Internal: installed by `import "zod/compile"` to enable AOT compilation for every constructed schema. Runs last, once the instance is fully built and sealed, because it hands the instance to compile(). The post-processor is expected to be reentrancy-guarded by its own implementation.
+    // Global post-processor hook. Internal: installed by `import "zod/compile"` to enable AOT compilation for every constructed schema. Runs last, once the instance is fully built, because it hands the instance to compile(). The post-processor is expected to be reentrancy-guarded by its own implementation.
     const pp = (globalThis as GlobalThisWithConfig).__zod_globalConfig?.postProcessor;
     if (pp) pp(inst);
     return inst;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1061,7 +1061,7 @@ export function installLazyProps<T extends object>(inst: T, sentinel: string, pr
   }
 }
 
-// The internals whose init chain is currently installing. A second call for the same one is a derived constructor replacing what its base installed; anything else is a repeat construction with nothing left to install.
+// The internals whose init chain is currently installing. A second call for the same one is a derived constructor replacing what its base installed; anything else is a repeat construction with nothing left to install. This makes the override order-dependent where a per-prototype seal would not be: a derived constructor must not construct another schema between its base's install and its own override, or the override is silently dropped.
 let installing: object | undefined;
 
 // Set while a getter is running, so a value that resolved through a recursion break is not memoized. One shared descriptor shadows the key for the duration, which costs no per-key allocation.
@@ -1086,7 +1086,7 @@ export function defineLazyInternal<T extends { _zod: any }>(
 ): void {
   const proto = Object.getPrototypeOf(inst._zod);
   if (key in proto && installing !== inst._zod) {
-    // A repeat construction: everything is installed already. Dropped rather than kept so the reference does not outlive the construction.
+    // A repeat construction: everything is installed already. Cleared here so the reference is not held past the first construction of every type.
     installing = undefined;
     return;
   }
@@ -1099,16 +1099,19 @@ export function defineLazyInternal<T extends { _zod: any }>(
       Object.defineProperty(this, key, breaker);
       const outer = broke;
       broke = false;
-      let value: unknown;
       try {
-        value = compute(this);
-      } finally {
+        const value = compute(this);
         // Only a result that resolved through a recursion break goes uncached, since it has to be recomputed once the schema graph is complete. Everything else memoizes, undefined included — it is the ordinary answer for most schemas, and these getters are read per parse on the tuple and interpreted-object paths.
         if (broke) delete this[key];
         else Object.defineProperty(this, key, { configurable: true, writable: true, value });
         broke = broke || outer;
+        return value;
+      } catch (err) {
+        // A compute that threw memoizes nothing, so a later read runs it again and fails the same way. The shadow goes with it, since leaving it installed would answer undefined for every later read.
+        delete this[key];
+        broke = broke || outer;
+        throw err;
       }
-      return value;
     },
     set(this: any, value: unknown) {
       Object.defineProperty(this, key, { configurable: true, writable: true, value });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1,5 +1,5 @@
 import type * as checks from "./checks.js";
-import { built, globalConfig } from "./core.js";
+import { globalConfig } from "./core.js";
 import type { $ZodConfig } from "./core.js";
 import type * as errors from "./errors.js";
 import type * as schemas from "./schemas.js";
@@ -1061,8 +1061,18 @@ export function installLazyProps<T extends object>(inst: T, sentinel: string, pr
   }
 }
 
-// Bumped whenever a recursive read resolves to `undefined` instead of recursing. Shared across every accessor, so a break anywhere inside a `compute` keeps that result from being memoized.
-let cycleBreaks = 0;
+// The internals whose init chain is currently installing. A second call for the same one is a derived constructor replacing what its base installed; anything else is a repeat construction with nothing left to install.
+let installing: object | undefined;
+
+// Set while a getter is running, so a value that resolved through a recursion break is not memoized. One shared descriptor shadows the key for the duration, which costs no per-key allocation.
+let broke = false;
+const breaker: PropertyDescriptor = {
+  configurable: true,
+  get() {
+    broke = true;
+    return undefined;
+  },
+};
 
 /**
  * Installs a lazily-derived internal on the `_zod` prototype of `inst`'s
@@ -1075,29 +1085,28 @@ export function defineLazyInternal<T extends { _zod: any }>(
   compute: (zod: T["_zod"]) => unknown
 ): void {
   const proto = Object.getPrototypeOf(inst._zod);
-  // Installs share one prototype across a whole init chain, so a derived constructor has to be able to replace what its base installed. Only a prototype a construction has already finished with is closed to further installs.
-  if (proto[built] && key in proto) return;
+  if (key in proto && installing !== inst._zod) {
+    // A repeat construction: everything is installed already. Dropped rather than kept so the reference does not outlive the construction.
+    installing = undefined;
+    return;
+  }
+  installing = inst._zod;
 
-  // Holds the internals whose getter is currently running, so a re-entrant read from a recursive schema resolves to `undefined` rather than recursing.
-  const active = new WeakSet<object>();
   Object.defineProperty(proto, key, {
     configurable: true,
     get(this: any) {
-      if (active.has(this)) {
-        cycleBreaks++;
-        return undefined;
-      }
-      active.add(this);
-      const before = cycleBreaks;
+      // Shadowed before computing so a re-entrant read from a recursive schema resolves to undefined instead of running the getter again.
+      Object.defineProperty(this, key, breaker);
+      const outer = broke;
+      broke = false;
       let value: unknown;
       try {
         value = compute(this);
       } finally {
-        active.delete(this);
-      }
-      // Only a result that resolved through a recursion break goes uncached, since it has to be recomputed once the schema graph is complete. Everything else memoizes, `undefined` included — it is the ordinary answer for most schemas, and these getters are read per parse on the tuple and interpreted-object paths.
-      if (cycleBreaks === before) {
-        Object.defineProperty(this, key, { configurable: true, writable: true, value });
+        // Only a result that resolved through a recursion break goes uncached, since it has to be recomputed once the schema graph is complete. Everything else memoizes, undefined included — it is the ordinary answer for most schemas, and these getters are read per parse on the tuple and interpreted-object paths.
+        if (broke) delete this[key];
+        else Object.defineProperty(this, key, { configurable: true, writable: true, value });
+        broke = broke || outer;
       }
       return value;
     },


### PR DESCRIPTION
#6429 restored two behaviours with two mechanisms, and only one of them has to cost anything.

The **seal** — the `built` symbol, the `sealed` closure flag, and the block in `$constructor` — exists so a derived constructor can replace what its base installed on the shared `_zod` prototype. But that only has to be legal *inside a single init chain*, and a chain is visible from the internals being installed: a later call for the same `_zod` is a subclass overriding its base, anything else is a repeat construction with nothing left to install. One module-level reference, cleared on the repeat-construction path so it is not held past the first construction of every type. No symbol, no per-constructor flag, and no hook in `$constructor`.

The **per-key `WeakSet`** becomes one shared accessor descriptor that shadows the key while its getter runs, so a re-entrant read from a recursive schema resolves to `undefined` without any key allocating anything. The memoization rule is unchanged: the decision still reads only the getter's own subtree, and the caller's state is restored afterward so a break still propagates to an ancestor.

`schemas.ts` is untouched — no call site learns an ordering rule, so the generality #6429 bought is intact. I did check the alternative: keeping first-wins and reordering `$ZodExactOptional` is 15 B smaller still, which did not seem worth putting the footgun back.

```
                  main    here     Δ
zod-mini-boolean  2830    2785   -45
zod-mini-string   3158    3102   -56
zod-mini-object   4258    4229   -29
zod-object       22767   22729   -38
```

Measured the way `bundle-size.test.ts` measures — bundling the built output and gzipping through `node:zlib` — so the numbers line up with the ceilings rather than with the `--conditions=@zod/source` figures the contributing guide describes.

The ceilings in `bundle-size.test.ts` come down to each fixture's new size plus the 28 bytes of headroom the docblock calibrates for, so the guard keeps its sensitivity instead of gaining slack.

Two tests. Next to #6429's: the override is installed once on a prototype every instance shares, so it has to hold for instances built after the first — the case chain-scoping could plausibly get wrong. And next to the recursion tests: a `compute` that throws memoizes nothing, so every read fails the same way.

Full suite green, both vitest projects (567 files / 7333 tests), including #6429's own recursion tests in `lazy.test.ts` and its `exactOptional` test in `optin-ladder.test.ts`. Memory unchanged: `%HasFastProperties` true on every instance, its internals and its prototype, no dictionary-mode demotion, retained bytes per instance identical to main — and one fewer `WeakSet` per key per constructor. Runtime not measured; the machine sat at a load average of 90–600 throughout, far past where those numbers mean anything.
