### PR TITLE
revert(core): drop the exactOptional parse prototype from #6432

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3743,13 +3743,8 @@ export const $ZodExactOptional: core.$constructor<$ZodExactOptional> = /*@__PURE
     util.defineLazyInternal(inst, "values", (zod) => zod.def.innerType._zod.values);
     util.defineLazyInternal(inst, "pattern", (zod) => zod.def.innerType._zod.pattern);
 
-    // OPTION B PROTOTYPE: fix in $ZodExactOptional.parse, expressed through the inner's optin rung.
+    // Override parse to just delegate (no undefined handling)
     inst._zod.parse = (payload, ctx) => {
-      const _inner = def.innerType._zod;
-      if (payload.value === undefined && _inner.optin !== "defaulted" && _inner.optout !== "optional") {
-        payload.issues.push({ code: "invalid_type", expected: "nonoptional", input: undefined, inst });
-        return payload;
-      }
       return def.innerType._zod.run(payload, ctx);
     };
   }


### PR DESCRIPTION
The parse override in `$ZodExactOptional` on main carries a hunk labelled `// OPTION B PROTOTYPE`, merged in #6432. It changes what an exact optional accepts, which #6432 is otherwise not about, and the full suite passes without it.

```ts
z.object({ a: z.exactOptional(z.undefined()) }).safeParse({ a: undefined }); // rejected on main
```

That inner accepts only `undefined`, so the schema can never match when the key is present.

| inner | `{ a: undefined }` on main | after this revert |
| --- | --- | --- |
| `z.string()` | rejected, `expected: "nonoptional"` | rejected, `expected: "string"` |
| `z.coerce.string()` | rejected | accepted |
| `z.any()`, `z.unknown()` | rejected | accepted |
| `z.undefined()`, `z.literal(undefined)` | rejected | accepted |
| `z.string().catch("c")` | rejected | accepted |

Each of those inners accepts `undefined` on its own, so an exact optional wrapping one has no basis to reject it. The rejections also replaced the specific type in the error with `nonoptional`.

Only that hunk is reverted. The `propValues` change from #6432 stays — an omittable slot still claims `undefined` at a discriminator lookup — along with its tests and the compile-side duplicate-value guard.

The absent-key half that the prototype also affected is handled in #6434, in the object layer, without touching what is accepted.

Refs #6432.
