### PR TITLE
fix(v4): drop empty alternation branch from datetime pattern

### DIFF
--- a/packages/zod/src/v4/classic/tests/datetime.test.ts
+++ b/packages/zod/src/v4/classic/tests/datetime.test.ts
@@ -285,3 +285,11 @@ test("duration", () => {
     expect(result.error.issues[0].message).toEqual("Invalid ISO duration");
   }
 });
+
+test("datetime pattern has no empty alternation branch", () => {
+  for (const args of [{}, { local: true }, { offset: true }, { local: true, offset: true }]) {
+    const { pattern } = z.toJSONSchema(z.iso.datetime(args));
+    expect(pattern, JSON.stringify(args)).toBeDefined();
+    expect(pattern, JSON.stringify(args)).not.toMatch(/\|\||\(\?:\||\|\)/);
+  }
+});

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -133,10 +133,9 @@ export function datetime(args: {
 }): RegExp {
   const time = timeSource({ precision: args.precision });
   const opts = ["Z"];
-  if (args.local) opts.push("");
   // if (args.offset) opts.push(`([+-]\\d{2}:\\d{2})`);
   if (args.offset) opts.push(`([+-](?:[01]\\d|2[0-3]):[0-5]\\d)`);
-  const timeRegex = `${time}(?:${opts.join("|")})`;
+  const timeRegex = `${time}(?:${opts.join("|")})${args.local ? "?" : ""}`;
 
   return new RegExp(`^${dateSource}T(?:${timeRegex})$`);
 }


### PR DESCRIPTION
`z.iso.datetime({ local: true })` built its timezone suffix by pushing an empty string into the alternation list, so the emitted pattern carried a gratuitous empty branch — `(?:Z|)` on its own, `(?:Z||OFF)` alongside `offset`. Some strict JSON Schema compilers reject an empty alternation, and the branch encodes nothing, so the group is now made optional instead. v3 already built it this way.

Accepted language is unchanged for every flag combination. `local` semantics in particular are untouched: `z.iso.datetime({ offset: true })` still requires a suffix and rejects a bare `2020-01-01T00:00:00`.

| flags | before | after |
| --- | --- | --- |
| `{ local: true, offset: true }` | `(?:Z\|\|OFF)` | `(?:Z\|OFF)?` |
| `{ local: true }` | `(?:Z\|)` | `(?:Z)?` |
| `{ offset: true }` | `(?:Z\|OFF)` | unchanged |
| `{}` | `(?:Z)` | unchanged |

Fixes #6436
