### PR TITLE
fix(v4): stop catch resurrecting issues an optional already resolved

### DIFF
--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -448,3 +448,33 @@ test("catch clears the abort flag on the async branch too", () => {
     error: { issues: [{ message: "REFINE RAN" }] },
   });
 });
+
+test("catch resolves the issues array itself, so an outer catch does not resurrect them", () => {
+  // The same rebinding-vs-truncating distinction as `handleOptionalResult`. `handlePipeResult` runs a pipe's `out` on a payload sharing the caller's issues array, so a catch used as an `out` that rebinds its own reference leaves the caller's copy dirty — and appending an outer `.catch()`, which can only turn failure into success, turned success into failure.
+  const inner = z.string().pipe(z.string().min(10).catch("FB"));
+
+  expect(inner.safeParse("abc")).toMatchObject({ success: true, data: "FB" });
+  expect(inner.catch("FB2").safeParse("abc")).toMatchObject({ success: true, data: "FB" });
+
+  // Controls: catch still catches, still passes a success through, and the callback still sees the issues it caught.
+  expect(z.string().catch("FB").parse(123)).toBe("FB");
+  expect(z.string().catch("FB").parse("ok")).toBe("ok");
+  expect(
+    z
+      .string()
+      .catch((ctx) => `n=${ctx.error.issues.length}`)
+      .parse(123)
+  ).toBe("n=1");
+});
+
+test("catch resolves the issues array on the async branch too", () => {
+  // Reaching the async branch needs the catch's own inner to be async, as above.
+  const inner = z.string().pipe(
+    z
+      .string()
+      .refine(async () => false, "INNER")
+      .catch("FB")
+  );
+
+  return expect(inner.catch("FB2").safeParseAsync("abc")).resolves.toMatchObject({ success: true, data: "FB" });
+});

--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -385,3 +385,18 @@ test("catch does not resurrect issues an inner optional already resolved", () =>
   expect(z.string().catch("FB").parse(123)).toBe("FB");
   expect(z.string().optional().safeParse(123).success).toBe(false);
 });
+
+test("resolving an optional's failure clears the abort flag with it", () => {
+  // `handlePipeResult` marks the payload aborted when the pipe's `in` fails, and `util.aborted` short-circuits on that flag alone. Clearing the issues without the flag turns the failure into a success whose downstream checks are all skipped, so the refinement below never runs and the parse wrongly passes.
+  const schema = z
+    .string()
+    .min(10)
+    .prefault("abc")
+    .pipe(z.string())
+    .optional()
+    .refine(() => false, "REFINE RAN");
+
+  const result = schema.safeParse(undefined);
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0]?.message).toBe("REFINE RAN");
+});

--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -326,30 +326,60 @@ test("optional clobbers catch through pipe boundaries", () => {
 });
 
 test("catch does not resurrect issues an inner optional already resolved", () => {
-  // `.optional()` yields undefined when a substituting inner still failed, and it used to signal that by handing back a fresh payload. `.catch()` keeps the payload it passed down and reads issues off that one, so it saw the failure the optional had already resolved — and adding `.catch()`, which can only ever turn failure into success, turned success into failure.
-  const base = z
-    .undefined()
-    .prefault(null as any)
-    .optional();
-  const caught = z
-    .undefined()
-    .prefault(null as any)
-    .optional()
-    .catch(null as any);
+  // `.optional()` yields undefined when a substituting inner still failed. It used to signal that with a replacement payload, and `.catch()` keeps the payload it passed down and reads issues off that one — so it saw a failure the optional had already resolved, and appending `.catch()`, which can only ever turn failure into success, turned success into failure.
+  //
+  // Asserted as the invariant rather than as one input, because the first fix rebound a fresh array and closed only the cases where `result` IS the payload. A pipe forwards the same array to a different payload object, so the pipe rows below still failed until the issues were cleared on the array itself.
+  const chains: [string, () => z.ZodType][] = [
+    [
+      "prefault.optional",
+      () =>
+        z
+          .undefined()
+          .prefault(null as any)
+          .optional(),
+    ],
+    [
+      "default.optional",
+      () =>
+        z
+          .undefined()
+          .default(null as any)
+          .optional(),
+    ],
+    ["prefault.pipe.optional", () => z.string().prefault("abc").pipe(z.string().min(10)).optional()],
+    ["default.pipe.optional", () => z.string().default("abc").pipe(z.string().min(10)).optional()],
+    [
+      "prefault.optional.optional",
+      () =>
+        z
+          .undefined()
+          .prefault(null as any)
+          .optional()
+          .optional(),
+    ],
+    [
+      "prefault.pipe.optional.optional",
+      () => z.string().prefault("abc").pipe(z.string().min(10)).optional().optional(),
+    ],
+  ];
 
-  expect(base.safeParse(undefined).success).toBe(true);
-  expect(caught.safeParse(undefined).success).toBe(true);
+  for (const [name, make] of chains) {
+    expect(make().safeParse(undefined).success, `${name} without catch`).toBe(true);
+    expect((make() as any).catch(null).safeParse(undefined).success, `${name} + catch(value)`).toBe(true);
+    expect((make() as any).catch(() => null).safeParse(undefined).success, `${name} + catch(callback)`).toBe(true);
+  }
 
-  // Same defect through the other substituting rung, and through a container.
   expect(
     z
-      .undefined()
-      .default(null as any)
-      .optional()
-      .catch(null as any)
-      .safeParse(undefined).success
+      .object({
+        a: z
+          .undefined()
+          .prefault(null as any)
+          .optional()
+          .catch(null as any),
+      })
+      .safeParse({ a: undefined }).success
   ).toBe(true);
-  expect(z.object({ a: caught }).safeParse({ a: undefined }).success).toBe(true);
 
   // Controls: catch still catches, and optional still rejects a genuine type error.
   expect(z.string().catch("FB").parse(123)).toBe("FB");

--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -326,9 +326,7 @@ test("optional clobbers catch through pipe boundaries", () => {
 });
 
 test("catch does not resurrect issues an inner optional already resolved", () => {
-  // `.optional()` yields undefined when a substituting inner still failed. It used to signal that with a replacement payload, and `.catch()` keeps the payload it passed down and reads issues off that one — so it saw a failure the optional had already resolved, and appending `.catch()`, which can only ever turn failure into success, turned success into failure.
-  //
-  // Asserted as the invariant rather than as one input, because the first fix rebound a fresh array and closed only the cases where `result` IS the payload. A pipe forwards the same array to a different payload object, so the pipe rows below still failed until the issues were cleared on the array itself.
+  // `.catch()` reads issues off the payload it passed down, so an optional that resolved a failure without clearing that array let the failure resurface. The pipe rows matter: a pipe shares the array with a different payload object.
   const chains: [string, () => z.ZodType][] = [
     [
       "prefault.optional",
@@ -381,13 +379,12 @@ test("catch does not resurrect issues an inner optional already resolved", () =>
       .safeParse({ a: undefined }).success
   ).toBe(true);
 
-  // Controls: catch still catches, and optional still rejects a genuine type error.
   expect(z.string().catch("FB").parse(123)).toBe("FB");
   expect(z.string().optional().safeParse(123).success).toBe(false);
 });
 
 test("resolving an optional's failure clears the abort flag with it", () => {
-  // `handlePipeResult` marks the payload aborted when the pipe's `in` fails, and `util.aborted` short-circuits on that flag alone. Clearing the issues without the flag turns the failure into a success whose downstream checks are all skipped, so the refinement below never runs and the parse wrongly passes.
+  // A pipe marks the payload aborted when its `in` fails, and `util.aborted` tests that flag alone, so leaving it set skips every check after the optional.
   const schema = z
     .string()
     .min(10)
@@ -402,7 +399,7 @@ test("resolving an optional's failure clears the abort flag with it", () => {
 });
 
 test("catch clears the abort flag along with the issues", () => {
-  // Same defect as the optional case one wrapper over. A pipe marks the payload aborted when its `in` fails, and `util.aborted` short-circuits on that flag alone — so a catch that cleared only the issues reported success and then skipped every check after it, including this refinement.
+  // Same as the optional case one wrapper over: a catch that clears only the issues leaves the flag set, skipping every check after it.
   const schema = z
     .string()
     .min(10)
@@ -414,7 +411,6 @@ test("catch clears the abort flag along with the issues", () => {
   expect(result.success).toBe(false);
   expect(result.error!.issues[0]?.message).toBe("REFINE RAN");
 
-  // A catch that never fires must not have its flag touched, and one with no pipe never had it set.
   expect(
     z
       .string()
@@ -435,7 +431,7 @@ test("catch clears the abort flag along with the issues", () => {
 });
 
 test("catch clears the abort flag on the async branch too", () => {
-  // The clear is written twice, once per branch of the promise check, so the async branch needs its own guard. Reaching it requires the catch's INNER to be async — an async refinement *outside* the catch leaves the inner sync and exercises the other branch.
+  // Reaching the async branch needs the catch's own inner to be async; an async refinement outside it leaves the inner sync.
   const schema = z
     .string()
     .refine(async () => false, "INNER")
@@ -450,13 +446,12 @@ test("catch clears the abort flag on the async branch too", () => {
 });
 
 test("catch resolves the issues array itself, so an outer catch does not resurrect them", () => {
-  // The same rebinding-vs-truncating distinction as `handleOptionalResult`. `handlePipeResult` runs a pipe's `out` on a payload sharing the caller's issues array, so a catch used as an `out` that rebinds its own reference leaves the caller's copy dirty — and appending an outer `.catch()`, which can only turn failure into success, turned success into failure.
+  // A pipe runs its `out` on a payload sharing the caller's issues array, so a catch that rebinds its own reference leaves the caller's copy dirty.
   const inner = z.string().pipe(z.string().min(10).catch("FB"));
 
   expect(inner.safeParse("abc")).toMatchObject({ success: true, data: "FB" });
   expect(inner.catch("FB2").safeParse("abc")).toMatchObject({ success: true, data: "FB" });
 
-  // Controls: catch still catches, still passes a success through, and the callback still sees the issues it caught.
   expect(z.string().catch("FB").parse(123)).toBe("FB");
   expect(z.string().catch("FB").parse("ok")).toBe("ok");
   expect(
@@ -468,7 +463,6 @@ test("catch resolves the issues array itself, so an outer catch does not resurre
 });
 
 test("catch resolves the issues array on the async branch too", () => {
-  // Reaching the async branch needs the catch's own inner to be async, as above.
   const inner = z.string().pipe(
     z
       .string()

--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -324,3 +324,34 @@ test("optional clobbers catch through pipe boundaries", () => {
       .parse(123)
   ).toBe("X!");
 });
+
+test("catch does not resurrect issues an inner optional already resolved", () => {
+  // `.optional()` yields undefined when a substituting inner still failed, and it used to signal that by handing back a fresh payload. `.catch()` keeps the payload it passed down and reads issues off that one, so it saw the failure the optional had already resolved — and adding `.catch()`, which can only ever turn failure into success, turned success into failure.
+  const base = z
+    .undefined()
+    .prefault(null as any)
+    .optional();
+  const caught = z
+    .undefined()
+    .prefault(null as any)
+    .optional()
+    .catch(null as any);
+
+  expect(base.safeParse(undefined).success).toBe(true);
+  expect(caught.safeParse(undefined).success).toBe(true);
+
+  // Same defect through the other substituting rung, and through a container.
+  expect(
+    z
+      .undefined()
+      .default(null as any)
+      .optional()
+      .catch(null as any)
+      .safeParse(undefined).success
+  ).toBe(true);
+  expect(z.object({ a: caught }).safeParse({ a: undefined }).success).toBe(true);
+
+  // Controls: catch still catches, and optional still rejects a genuine type error.
+  expect(z.string().catch("FB").parse(123)).toBe("FB");
+  expect(z.string().optional().safeParse(123).success).toBe(false);
+});

--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -400,3 +400,51 @@ test("resolving an optional's failure clears the abort flag with it", () => {
   expect(result.success).toBe(false);
   expect(result.error!.issues[0]?.message).toBe("REFINE RAN");
 });
+
+test("catch clears the abort flag along with the issues", () => {
+  // Same defect as the optional case one wrapper over. A pipe marks the payload aborted when its `in` fails, and `util.aborted` short-circuits on that flag alone — so a catch that cleared only the issues reported success and then skipped every check after it, including this refinement.
+  const schema = z
+    .string()
+    .min(10)
+    .pipe(z.string())
+    .catch("FB")
+    .refine(() => false, "REFINE RAN");
+
+  const result = schema.safeParse("abc");
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0]?.message).toBe("REFINE RAN");
+
+  // A catch that never fires must not have its flag touched, and one with no pipe never had it set.
+  expect(
+    z
+      .string()
+      .min(2)
+      .pipe(z.string())
+      .catch("FB")
+      .refine(() => false, "REFINE RAN")
+      .safeParse("abcdef").success
+  ).toBe(false);
+  expect(
+    z
+      .string()
+      .min(10)
+      .catch("FB")
+      .refine(() => false, "REFINE RAN")
+      .safeParse("abc").success
+  ).toBe(false);
+});
+
+test("catch clears the abort flag on the async branch too", () => {
+  // The clear is written twice, once per branch of the promise check, so the async branch needs its own guard. Reaching it requires the catch's INNER to be async — an async refinement *outside* the catch leaves the inner sync and exercises the other branch.
+  const schema = z
+    .string()
+    .refine(async () => false, "INNER")
+    .pipe(z.string())
+    .catch("FB")
+    .refine(() => false, "REFINE RAN");
+
+  return expect(schema.safeParseAsync("abc")).resolves.toMatchObject({
+    success: false,
+    error: { issues: [{ message: "REFINE RAN" }] },
+  });
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3705,6 +3705,8 @@ function handleOptionalResult(result: ParsePayload) {
   if (result.issues.length) {
     result.issues.length = 0;
     result.value = undefined;
+    // `aborted` goes with them. A pipe marks the payload aborted when its `in` fails, and `util.aborted` short-circuits on that flag alone, so leaving it set resolves the failure into a success whose every downstream check is then skipped — a refinement after the optional silently stops running. The replacement payload this used to return carried no flag, which is the behaviour to keep. `false` rather than `delete`, which would drop the object into dictionary mode on a parse path; both readers test `=== true`.
+    result.aborted = false;
   }
   return result;
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3701,9 +3701,9 @@ export interface $ZodOptional<T extends SomeType = $ZodType> extends $ZodType {
 }
 
 function handleOptionalResult(result: ParsePayload) {
-  // A substituting schema that still failed has no usable answer; yield undefined. Resolve it on the payload rather than in a replacement: an outer schema that kept the payload it passed down still reads issues off that one, so handing back a clean copy leaves the original dirty and the failure resurfaces above. `.catch()` does exactly that. A fresh `issues` array rather than truncating in place, because a pipe hands its array to the next schema and truncating would clear it there too.
+  // A substituting schema that still failed has no usable answer; yield undefined. Resolve it on the ARRAY, not on the payload: an outer schema that kept the payload it passed down still reads issues off that one, so handing back a clean copy — or rebinding a fresh array here — leaves the original dirty and the failure resurfaces above. `.catch()` does exactly that. Rebinding is not enough either, because `handlePipeResult` forwards the SAME array to the next schema, so a pipe in the substituting inner makes `result` a different payload sharing the outer array; only truncating reaches both. Clearing it everywhere is the point: these issues no longer exist for anyone.
   if (result.issues.length) {
-    result.issues = [];
+    result.issues.length = 0;
     result.value = undefined;
   }
   return result;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3701,11 +3701,10 @@ export interface $ZodOptional<T extends SomeType = $ZodType> extends $ZodType {
 }
 
 function handleOptionalResult(result: ParsePayload) {
-  // A substituting schema that still failed has no usable answer; yield undefined. Resolve it on the ARRAY, not on the payload: an outer schema that kept the payload it passed down still reads issues off that one, so handing back a clean copy — or rebinding a fresh array here — leaves the original dirty and the failure resurfaces above. `.catch()` does exactly that. Rebinding is not enough either, because `handlePipeResult` forwards the SAME array to the next schema, so a pipe in the substituting inner makes `result` a different payload sharing the outer array; only truncating reaches both. Clearing it everywhere is the point: these issues no longer exist for anyone.
+  // A substituting schema that still failed has no usable answer; yield undefined. Truncate rather than rebind, and clear the abort flag with it: a pipe shares its issues array with the next schema, so an outer holder reads the same one.
   if (result.issues.length) {
     result.issues.length = 0;
     result.value = undefined;
-    // `aborted` goes with them. A pipe marks the payload aborted when its `in` fails, and `util.aborted` short-circuits on that flag alone, so leaving it set resolves the failure into a success whose every downstream check is then skipped — a refinement after the optional silently stops running. The replacement payload this used to return carried no flag, which is the behaviour to keep. `false` rather than `delete`, which would drop the object into dictionary mode on a parse path; both readers test `=== true`.
     result.aborted = false;
   }
   return result;
@@ -4168,7 +4167,7 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
         input: payload.value,
       });
 
-      // Resolve the issues on the ARRAY and take the abort flag with them. Truncating rather than rebinding because `handlePipeResult` runs a pipe's `out` on a payload sharing the caller's array, so a catch used as an `out` would otherwise leave the caller's copy dirty and the failure would resurface above it. The flag matters for the same reason: a pipe or codec marks the payload aborted when its `in` fails, and `util.aborted` short-circuits on that alone, so clearing only the issues reports success and then skips every check after the catch.
+      // Truncate rather than rebind: as a pipe's `out` this shares the caller's array. See handleOptionalResult.
       payload.issues.length = 0;
       payload.aborted = false;
     }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4151,6 +4151,7 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
             input: payload.value,
           });
           payload.issues = [];
+          payload.aborted = false;
         }
 
         return payload;
@@ -4167,7 +4168,9 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
         input: payload.value,
       });
 
+      // The abort flag goes with the issues. A pipe or codec marks the payload aborted when its `in` fails, and `util.aborted` short-circuits on that flag alone, so a catch that clears only the issues reports success and then every check after it is skipped.
       payload.issues = [];
+      payload.aborted = false;
     }
 
     return payload;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4150,7 +4150,7 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
             },
             input: payload.value,
           });
-          payload.issues = [];
+          payload.issues.length = 0;
           payload.aborted = false;
         }
 
@@ -4168,8 +4168,8 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
         input: payload.value,
       });
 
-      // The abort flag goes with the issues. A pipe or codec marks the payload aborted when its `in` fails, and `util.aborted` short-circuits on that flag alone, so a catch that clears only the issues reports success and then every check after it is skipped.
-      payload.issues = [];
+      // Resolve the issues on the ARRAY and take the abort flag with them. Truncating rather than rebinding because `handlePipeResult` runs a pipe's `out` on a payload sharing the caller's array, so a catch used as an `out` would otherwise leave the caller's copy dirty and the failure would resurface above it. The flag matters for the same reason: a pipe or codec marks the payload aborted when its `in` fails, and `util.aborted` short-circuits on that alone, so clearing only the issues reports success and then skips every check after the catch.
+      payload.issues.length = 0;
       payload.aborted = false;
     }
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3701,8 +3701,11 @@ export interface $ZodOptional<T extends SomeType = $ZodType> extends $ZodType {
 }
 
 function handleOptionalResult(result: ParsePayload) {
-  // A substituting schema that still failed has no usable answer; yield undefined.
-  if (result.issues.length) return { issues: [], value: undefined };
+  // A substituting schema that still failed has no usable answer; yield undefined. Resolve it on the payload rather than in a replacement: an outer schema that kept the payload it passed down still reads issues off that one, so handing back a clean copy leaves the original dirty and the failure resurfaces above. `.catch()` does exactly that. A fresh `issues` array rather than truncating in place, because a pipe hands its array to the next schema and truncating would clear it there too.
+  if (result.issues.length) {
+    result.issues = [];
+    result.value = undefined;
+  }
   return result;
 }
 


### PR DESCRIPTION
Adding `.catch()` to a chain that parses could make it stop parsing:

```ts
const s = z.undefined().prefault(null).optional();

s.safeParse(undefined);             // { success: true }
s.catch(null).safeParse(undefined); // { success: false }  ← was
```

`.catch()` can only ever turn failure into success, so this is backwards.

`handleOptionalResult` signalled "the inner substituted and still failed, yield undefined" by returning a *replacement* payload with an empty issues array. Every other schema resolves the payload it was handed. `$ZodCatch` keeps the payload it passed down and returns that one, reading only `result.issues` to decide whether to catch — so it saw nothing to catch and handed back the original, still carrying the failure the optional had already resolved.

Now it resolves in place. A fresh `issues` array rather than truncating, because a pipe passes its array to the next schema and truncating would clear it there too. Both callers are in `$ZodOptional` and return the value straight up, so nothing relied on getting a distinct object.

Same defect reached `.default()`, a doubled `.optional()`, `.catch()` with a callback, and the chain nested in an object or array — all covered by the fix, sync and async.

Found while reviewing #6085; unrelated to compilation and present well before it.
