### PR TITLE
fix(v4): measure string length in Unicode code points

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -219,6 +219,14 @@ z.string().check(z.lowercase());
 </Tab>
 </Tabs>
 
+Length is measured in Unicode code points, not UTF-16 code units. Emoji outside the Basic Multilingual Plane count as one, and combining marks and ZWJ sequences count as several.
+
+```ts
+z.string().length(1).parse("😀"); // one code point, two UTF-16 units
+z.string().length(2).parse("e\u0301"); // "é" — an e plus a combining acute
+z.string().length(3).parse("🧑‍🍼"); // person + ZWJ + baby bottle
+```
+
 To perform some simple string transforms:
 
 <Tabs groupId="lib" items={["Zod", "Zod Mini"]}>

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -39,7 +39,8 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  */
 const CEILINGS: Record<string, number> = {
   "zod-mini-boolean": 2813,
-  "zod-mini-string": 3130,
+  // Raised from 3130 in the commit that caused it: string length checks now measure code points, so any bundle using `.min`/`.max`/`.length` on a string carries the surrogate scan. Measured 3257; 28 bytes of headroom to match the others. `zod-mini-object` does not move — a bundle with no length check still carries none of it.
+  "zod-mini-string": 3285,
   // Raised from 4257 in the commit that caused it: the construction-time discriminator check writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` carries it. Measured 4260; 28 bytes of headroom to match the other two.
   "zod-mini-object": 4288,
 };

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -869,6 +869,47 @@ test("boundary cases with zero length", () => {
   expect(() => maxZero.parse("hello")).toThrow();
 });
 
+test("length checks count Unicode code points, not UTF-16 code units", () => {
+  // "\u{1F600}" is one code point but two UTF-16 code units
+  const five = "\u{1F600}\u{1F600}\u{1F600}\u{1F600}\u{1F600}";
+  expect(z.string().max(5).safeParse(five).success).toBe(true);
+  expect(
+    z
+      .string()
+      .max(5)
+      .safeParse(five + "\u{1F600}").success
+  ).toBe(false);
+  expect(z.string().min(5).safeParse(five).success).toBe(true);
+  expect(z.string().min(5).safeParse("\u{1F600}\u{1F600}\u{1F600}\u{1F600}").success).toBe(false);
+  expect(z.string().length(5).safeParse(five).success).toBe(true);
+  expect(z.string().length(1).safeParse("\u{1F600}").success).toBe(true);
+  expect(z.string().nonempty().safeParse("\u{1F600}").success).toBe(true);
+
+  // code points, not graphemes: a combining mark and a ZWJ sequence each stay several
+  expect(z.string().length(2).safeParse("e\u0301").success).toBe(true);
+  expect(z.string().length(3).safeParse("\u{1F9D1}\u200D\u{1F37C}").success).toBe(true);
+
+  // an unpaired surrogate is its own code point
+  expect(z.string().length(1).safeParse("\uD83D").success).toBe(true);
+  expect(z.string().length(2).safeParse("\uDE00\uD83D").success).toBe(true);
+
+  // the reported bound is still the declared one
+  expect(
+    z
+      .string()
+      .max(5)
+      .safeParse(five + "\u{1F600}").error!.issues[0]
+  ).toMatchObject({
+    code: "too_big",
+    maximum: 5,
+    origin: "string",
+  });
+
+  // other lengthables keep counting elements
+  expect(z.array(z.string()).max(2).safeParse(["a", "b", "c"]).success).toBe(false);
+  expect(z.array(z.string()).length(2).safeParse(["\u{1F600}", "\u{1F600}"]).success).toBe(true);
+});
+
 test("trim", () => {
   expect(z.string().trim().min(2).parse(" 12 ")).toEqual("12");
 

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -623,7 +623,9 @@ export const $ZodCheckMaxLength: core.$constructor<$ZodCheckMaxLength> = /*@__PU
 
     inst._zod.check = (payload) => {
       const input = payload.value;
-      const length = input.length;
+      const units = input.length;
+      // Strings are measured in Unicode code points, not UTF-16 units. A code point is at most two units, so a string that already fits in units fits in code points; only an overflow has to be counted.
+      const length = typeof input === "string" && units > def.maximum ? util.codePointLength(input) : units;
 
       if (length <= def.maximum) return;
       const origin = util.getLengthableOrigin(input);
@@ -671,7 +673,12 @@ export const $ZodCheckMinLength: core.$constructor<$ZodCheckMinLength> = /*@__PU
 
     inst._zod.check = (payload) => {
       const input = payload.value;
-      const length = input.length;
+      const units = input.length;
+      // A code point is one or two UTF-16 units, so fewer units than the floor can never reach it and twice the floor always clears it. Only in between is the exact count in doubt.
+      const length =
+        typeof input === "string" && units >= def.minimum && units < def.minimum * 2
+          ? util.codePointLength(input)
+          : units;
 
       if (length >= def.minimum) return;
       const origin = util.getLengthableOrigin(input);
@@ -722,7 +729,12 @@ export const $ZodCheckLengthEquals: core.$constructor<$ZodCheckLengthEquals> = /
 
     inst._zod.check = (payload) => {
       const input = payload.value;
-      const length = input.length;
+      const units = input.length;
+      // A code point is one or two UTF-16 units, so outside `[length, length * 2]` units the target is missed either way — and missed in the same direction in both measures.
+      const length =
+        typeof input === "string" && units >= def.length && units <= def.length * 2
+          ? util.codePointLength(input)
+          : units;
       if (length === def.length) return;
       const origin = util.getLengthableOrigin(input);
       const tooBig = length > def.length;

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -325,15 +325,34 @@ function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accesso
       case "number_format":
         generateNumberFormatCheck(doc, def, currentAccessor);
         break;
-      case "min_length":
-        doc.write(`if (${currentAccessor}.length < ${numericOperand(def.minimum, "min_length")}) return INVALID;`);
+      case "min_length": {
+        const min = numericOperand(def.minimum, "min_length");
+        const len = codePointLengthVar(
+          doc,
+          ctx,
+          currentAccessor,
+          `${currentAccessor}.length >= ${min} && ${currentAccessor}.length < ${def.minimum * 2}`
+        );
+        doc.write(`if (${len} < ${min}) return INVALID;`);
         break;
-      case "max_length":
-        doc.write(`if (${currentAccessor}.length > ${numericOperand(def.maximum, "max_length")}) return INVALID;`);
+      }
+      case "max_length": {
+        const max = numericOperand(def.maximum, "max_length");
+        const len = codePointLengthVar(doc, ctx, currentAccessor, `${currentAccessor}.length > ${max}`);
+        doc.write(`if (${len} > ${max}) return INVALID;`);
         break;
-      case "length_equals":
-        doc.write(`if (${currentAccessor}.length !== ${numericOperand(def.length, "length_equals")}) return INVALID;`);
+      }
+      case "length_equals": {
+        const exact = numericOperand(def.length, "length_equals");
+        const len = codePointLengthVar(
+          doc,
+          ctx,
+          currentAccessor,
+          `${currentAccessor}.length >= ${exact} && ${currentAccessor}.length <= ${def.length * 2}`
+        );
+        doc.write(`if (${len} !== ${exact}) return INVALID;`);
         break;
+      }
       case "min_size":
         doc.write(`if (${currentAccessor}.size < ${numericOperand(def.minimum, "min_size")}) return INVALID;`);
         break;
@@ -373,6 +392,14 @@ function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accesso
   }
 
   return currentAccessor;
+}
+
+// Emit the length operand for a length check, mirroring `$ZodCheckMinLength` and friends: strings measure in code points, everything else in `.length`. `inDoubt` is the caller's cheap UTF-16 bound test — outside it the unit count already settles the comparison, so the scan is skipped.
+function codePointLengthVar(doc: Doc, ctx: CompileContext, accessor: string, inDoubt: string): string {
+  const cpLen = addConstant(ctx, util.codePointLength);
+  const v = newVar(ctx);
+  doc.write(`const ${v} = typeof ${accessor} === "string" && ${inDoubt} ? ${cpLen}(${accessor}) : ${accessor}.length;`);
+  return v;
 }
 
 // Emit a source operand for a gt/lt bound. Numbers inline; Dates hoist as a constant (relational operators compare via valueOf). NaN and Invalid Date bounds can't compile to a comparison that matches runtime semantics.

--- a/packages/zod/src/v4/core/tests/compile-differential.test.ts
+++ b/packages/zod/src/v4/core/tests/compile-differential.test.ts
@@ -437,6 +437,21 @@ test("string length checks", () => {
   differential(z.string().min(3).max(5), ["abc", "abcde", "ab", "abcdef", "abcd"]);
 });
 
+test("string length checks measure code points", () => {
+  const inputs = [
+    "abc",
+    "\u{1F600}",
+    "\u{1F600}\u{1F600}",
+    "\u{1F600}\u{1F600}\u{1F600}",
+    "\u{1F600}\u{1F600}ab",
+    "\uD83D",
+    "",
+  ];
+  differential(z.string().min(3), inputs);
+  differential(z.string().max(3), inputs);
+  differential(z.string().length(3), inputs);
+});
+
 test("string regex", () => {
   differential(z.string().regex(/^[a-z]+$/), ["abc", "ABC", "abc123", ""]);
 });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -895,6 +895,22 @@ export function getSizableOrigin(input: any): "set" | "map" | "file" | "unknown"
   return "unknown";
 }
 
+const highSurrogate = /[\uD800-\uDBFF]/;
+
+// Number of Unicode code points in `str`. A surrogate pair counts once and a lone surrogate counts as itself, matching `for..of` and `String.prototype.codePointAt`. Hand-rolled instead of `[...str].length` because the string iterator allocates and runs ~250x slower, and this sits on the parse path. The regex probe is the fast exit for a string that has no astral characters at all, which is nearly all of them — it settles a 255-character string ~50x quicker than reaching the loop.
+export function codePointLength(str: string): number {
+  const units = str.length;
+  if (!highSurrogate.test(str)) return units;
+  let count = units;
+  for (let i = 0; i < units - 1; i++) {
+    if ((str.charCodeAt(i) & 0xfc00) === 0xd800 && (str.charCodeAt(i + 1) & 0xfc00) === 0xdc00) {
+      count--;
+      i++;
+    }
+  }
+  return count;
+}
+
 export function getLengthableOrigin(input: any): "array" | "string" | "unknown" {
   if (Array.isArray(input)) return "array";
   if (typeof input === "string") return "string";


### PR DESCRIPTION
`.min()`, `.max()` and `.length()` counted UTF-16 code units, so `z.string().max(5)` rejected five emoji and `z.string().min(5)` accepted three. Every non-JS consumer of a length bound counts code points — Postgres, MySQL, Go, Python, and the `maxLength` that `z.toJSONSchema()` already emits — and the docs said "characters".

```ts
z.string().max(5).parse("😀😀😀😀😀"); // was too_big, now passes
z.string().min(5).parse("😀😀"); // was fine, now too_small
z.string().length(2).parse("é"); // combining marks stay two
```

Graphemes are unchanged — a ZWJ sequence is still several code points, not one — and non-strings still count elements.

This is a behavior change. `.min()` and `.length()` tighten for astral input — a schema that accepted `"🔑🔑🔑🔑"` under `.min(8)` now rejects it. `.max()` only loosens, but it loosens by up to 2x in UTF-16 units, so a `.max(255)` standing in for a storage or payload bound now admits 510 units.

### Cost

A code point is one or two UTF-16 units, which bounds the count tightly enough that the common case never scans. `max(N)` counts only when the unit length already overflows; `min(N)` only between `N` and `2N` units; `length(N)` only between `N` and `2N`. Inside that window a regex probe exits early for a string with no astral characters at all.

| 2M `parse()` calls | main | this branch |
| --- | --- | --- |
| `max(255)`, 11 ASCII chars | 42.7 ms | 43.4 ms |
| `max(255)`, 100 ASCII chars | 69.1 ms | 69.7 ms |
| `max(255)`, 10 emoji | 93.1 ms | 90.9 ms |
| `min(1).max(100)`, 40 ASCII chars | 129.6 ms | 132.0 ms |
| `length(11)`, 11 ASCII chars | 90.3 ms | 102.1 ms |
| `min(8)`, 8 ASCII chars | 85.8 ms | 103.4 ms |

Min of 7 rounds, revisions interleaved. `.min()` and `.length()` pay the probe whenever the string sits in the doubt window; `.max()`, by far the most common, does not.

Per-schema memory is unchanged. Bundle grows 137 B gzipped on the classic string fixture (18999 → 19136), 131 B on the classic object fixture, and 136 B on `zod/mini`'s string fixture (3121 → 3257), which moves the `zod-mini-string` ceiling from 3130 to 3285 in this commit. A bundle with no length check carries none of it — `zod-mini-object` does not move.

`compile.ts` emits the same arithmetic, so the compiled fast path agrees with the interpreter; `compile-differential.test.ts` covers it, and a 40k-case randomized sweep over surrogate-heavy strings (lone surrogates, reversed pairs, combining marks) agrees with `[...str].length` on both paths.

Closes #3355. Supersedes #6369, which used `[...str].length` on every check: on the same fixtures that costs 16x on `max(255)` over a 100-character string, and it leaves `compile.ts` untouched, so the compiled path accepts `min(3)` strings the interpreter rejects.


