### PR TITLE
fix(v4): validate the address, and return the string that was validated

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -384,6 +384,44 @@ test("url trims whitespace", () => {
   expect(url.parse("https://example.com/path")).toBe("https://example.com/path");
 });
 
+test("url returns the string the parser validated", () => {
+  // The URL parser deletes ASCII tab, LF and CR instead of failing, so `new URL()` reports on a string that is not the one it was given. The host is the consequential case: this validated example.com and used to hand back a URL naming a different host.
+  expect(z.url().parse("https://exa\nmple.com")).toBe("https://example.com");
+  expect(z.url().parse("https://exa\tmple.com")).toBe("https://example.com");
+  expect(z.url().parse("https://exa\rmple.com")).toBe("https://example.com");
+  expect(z.httpUrl().parse("https://exa\nmple.com")).toBe("https://example.com");
+  expect(z.url({ hostname: /^a\.com$/ }).parse("https://a\n.com")).toBe("https://a.com");
+  expect(z.url().parse("https://example.com/a\nb?c=\td#e")).toBe("https://example.com/ab?c=d#e");
+
+  // Nothing that parsed before stops parsing, and normalize still wins where it applies.
+  expect(z.url().parse("https://example.com/path")).toBe("https://example.com/path");
+  expect(z.url({ normalize: true }).parse("https://exa\nmple.com")).toBe("https://example.com/");
+});
+
+test("ipv6 and cidrv6 reject anything outside the address alphabet", () => {
+  // `new URL("http://[...]")` parses an authority rather than an address, so a delimiter re-splits it and the parser validates something else entirely.
+  expect(z.ipv6().safeParse("::@1\\").success).toBe(false); // used to validate against the host 0.0.0.1
+  expect(z.ipv6().safeParse("::]/1").success).toBe(false);
+  expect(z.ipv6().safeParse("@[::1").success).toBe(false);
+  expect(z.cidrv6().safeParse("::@1\\/64").success).toBe(false);
+
+  for (const c of ["\t", "\n", "\r"]) {
+    expect(z.ipv6().safeParse(`2001:db8::${c}1`).success).toBe(false);
+    expect(z.ipv6().safeParse(`::1${c}`).success).toBe(false);
+    expect(z.cidrv6().safeParse(`::1${c}/64`).success).toBe(false);
+  }
+
+  // A rejection has to surface as an issue, not just success: false.
+  const result = z.ipv6().safeParse("::1\n");
+  expect(result.success).toBe(false);
+  expect(result.error!.issues[0]).toMatchObject({ code: "invalid_format", format: "ipv6" });
+
+  expect(z.ipv6().parse("2001:db8::1")).toBe("2001:db8::1");
+  expect(z.ipv6().parse("::ffff:192.0.2.1")).toBe("::ffff:192.0.2.1");
+  expect(z.ipv6().parse("2001:DB8::1")).toBe("2001:DB8::1");
+  expect(z.cidrv6().parse("::ffff:192.0.2.1/96")).toBe("::ffff:192.0.2.1/96");
+});
+
 test("url normalize flag", () => {
   const normalizeUrl = z.url({ normalize: true });
   const preserveUrl = z.url(); // normalize: false/undefined by default

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -13,6 +13,7 @@ import {
   isValidJWT,
   mergeValues,
   parseURLObject,
+  stripTabAndNewline,
   urlHostnameOk,
   urlProtocolOk,
 } from "./schemas.js";
@@ -725,7 +726,8 @@ function generateStringFormatCheck(doc: Doc, ctx: CompileContext, def: StringFor
       doc.write(`if (!${protocolConst}(${urlVar}, ${defConst}.protocol)) return INVALID;`);
     }
     const outputVar = newVar(ctx);
-    doc.write(`const ${outputVar} = ${formatDef.normalize ? `${urlVar}.href` : trimVar};`);
+    const stripConst = addConstant(ctx, stripTabAndNewline);
+    doc.write(`const ${outputVar} = ${formatDef.normalize ? `${urlVar}.href` : `${stripConst}(${trimVar})`};`);
     return outputVar;
   }
 

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -726,8 +726,8 @@ function generateStringFormatCheck(doc: Doc, ctx: CompileContext, def: StringFor
       doc.write(`if (!${protocolConst}(${urlVar}, ${defConst}.protocol)) return INVALID;`);
     }
     const outputVar = newVar(ctx);
-    const stripConst = addConstant(ctx, stripTabAndNewline);
-    doc.write(`const ${outputVar} = ${formatDef.normalize ? `${urlVar}.href` : `${stripConst}(${trimVar})`};`);
+    const outputExpr = formatDef.normalize ? `${urlVar}.href` : `${addConstant(ctx, stripTabAndNewline)}(${trimVar})`;
+    doc.write(`const ${outputVar} = ${outputExpr};`);
     return outputVar;
   }
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -521,6 +521,13 @@ export function parseURLObject(
   }
 }
 
+const asciiTabOrNewline = /[\t\n\r]/g;
+
+/** The URL parser deletes every ASCII tab, LF and CR from its input before it parses, so `new URL("https://exa\nmple.com")` reports on `example.com`. Applying the same deletion to the returned value is what keeps the string Zod hands back the string Zod validated. */
+export function stripTabAndNewline(value: string): string {
+  return value.replace(asciiTabOrNewline, "");
+}
+
 export function urlHostnameOk(url: URL, hostname: RegExp): boolean {
   hostname.lastIndex = 0;
   return hostname.test(url.hostname);
@@ -587,7 +594,7 @@ export const $ZodURL: core.$constructor<$ZodURL> = /*@__PURE__*/ core.$construct
       }
 
       // Set the output value based on normalize flag
-      payload.value = def.normalize ? url.href : trimmed;
+      payload.value = def.normalize ? url.href : stripTabAndNewline(trimmed);
 
       return;
     } catch (_) {
@@ -847,7 +854,11 @@ export interface $ZodIPv6 extends $ZodType {
   _zod: $ZodIPv6Internals;
 }
 
+/** An IPv6 address is written with hex digits, colons and dots, and nothing else. The guard is what makes the check below an IPv6 check: `new URL("http://[...]")` parses an authority, not an address, so `@` and `\` re-delimit it and `"::@1\\"` validates against the host `0.0.0.1`. The URL parser also deletes ASCII tab, LF and CR rather than failing, which is how `"::1\n"` validated as `::1`. */
+const ipv6Alphabet = /^[0-9a-fA-F:.]+$/;
+
 export function isValidIPv6(value: string): boolean {
+  if (!ipv6Alphabet.test(value)) return false;
   try {
     // @ts-ignore
     new URL(`http://[${value}]`);
@@ -940,13 +951,7 @@ export function isValidCIDRv6(value: string): boolean {
   const prefixNum = Number(prefix);
   if (`${prefixNum}` !== prefix) return false;
   if (prefixNum < 0 || prefixNum > 128) return false;
-  try {
-    // @ts-ignore
-    new URL(`http://[${address}]`);
-    return true;
-  } catch {
-    return false;
-  }
+  return isValidIPv6(address);
 }
 
 export const $ZodCIDRv6: core.$constructor<$ZodCIDRv6> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -523,7 +523,7 @@ export function parseURLObject(
 
 const asciiTabOrNewline = /[\t\n\r]/g;
 
-/** The URL parser deletes every ASCII tab, LF and CR from its input before it parses, so `new URL("https://exa\nmple.com")` reports on `example.com`. Applying the same deletion to the returned value is what keeps the string Zod hands back the string Zod validated. */
+/** The URL parser deletes every ASCII tab, LF and CR from its input before it parses, so `new URL("https://exa\nmple.com")` reports on `example.com`. Applying the same deletion to the returned value closes the half of that divergence which can move the host; the parser's other rewrite, stripping C0 controls at the edges, cannot. */
 export function stripTabAndNewline(value: string): string {
   return value.replace(asciiTabOrNewline, "");
 }

--- a/packages/zod/src/v4/core/tests/compile-differential.test.ts
+++ b/packages/zod/src/v4/core/tests/compile-differential.test.ts
@@ -629,6 +629,10 @@ test("url options match the runtime across the whole option matrix", () => {
     "",
     "//example.com",
     "mailto:a@b.com",
+    // The WHATWG parser deletes these rather than failing, so the two paths only agree if both apply that deletion to the value they return.
+    "https://exa\nmple.com",
+    "https://exa\tmple.com",
+    "https://example.com/a\rb?c=d#e",
   ];
   const schemas: z.ZodType[] = [
     z.url(),


### PR DESCRIPTION
`new URL("http://[" + value + "]")` parses an authority, not an address. The brackets are just characters in that authority, so `@` and `\` re-delimit it and the parser validates something else entirely and reports success:

```ts
z.ipv6().parse("::@1\\"); // passed — new URL() resolved the host to 0.0.0.1
z.ipv6().parse("::]/1");  // passed — host resolved to [::]
z.ipv6().parse("::1\n");  // passed — the parser deletes the newline before parsing
net.isIPv6("::@1\\");     // false
```

Guard on the address alphabet instead — hex digits, colons and dots, and nothing else. That is exhaustive by construction rather than a list of characters that happen to be special to a borrowed parser, and it lets `isValidCIDRv6` delegate to `isValidIPv6` instead of carrying its own copy of the call. Scored over 56,638 two-character mutations of five IPv6 seeds against `net.isIPv6`: 4855 false accepts before, 0 after. The 153 false rejects are zone IDs (`fe80::1%eth0`), pre-existing and unchanged.

Separately, the URL parser deletes every ASCII tab, LF and CR from its input rather than failing, so `z.url()` validated one string and handed back another — `"https://exa\nmple.com"` came back verbatim after its host had been checked as `example.com`, and `z.url({ hostname })` and `z.url({ protocol })` were defeated the same way. The output now carries the same deletion. Every accept/reject verdict on `z.url()` is unchanged; only the returned value moves, and only for input the parser rewrote. `normalize: true` already avoided this by returning `url.href`, but it costs punycoding, percent-encoding and a trailing slash to get there.

Bundle +29 B gzipped on a classic string fixture, unchanged on `zod-mini-string` where the constructors tree-shake out, +39 B on a mini fixture that uses all four formats. Memory is unchanged — both regexes are module-level and no descriptor moves. No runtime number: the machine sat above load average 19 throughout, so anything measured there would be noise.

Closes #6395. Supersedes #6396, which fixed the tab/newline half by rejecting it and left the `@` and `\` cases open.
