### PR TITLE
fix(v4): keep a memoized node's cached issues private to the cache

### DIFF
--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -617,3 +617,30 @@ test("resolves a recursive reference once, however it is written", () => {
   expect(getterCalls).toBe(1);
   expect(lazyCalls).toBe(1);
 });
+
+// The second visitor of a shared node must not prefix onto the first visitor's path.
+test.each([false, true])("prefixes a shared node's issues once per reference (jitless: %s)", (jitless) => {
+  z.config({ jitless });
+  try {
+    const Node: any = z.object({
+      name: z.string(),
+      get left() {
+        return z.optional(Node);
+      },
+      get right() {
+        return z.optional(Node);
+      },
+    });
+
+    const shared: any = { name: 123 };
+    const result = Node.safeParse({ name: "root", left: shared, right: shared });
+
+    expect(result.success).toBe(false);
+    expect(result.error.issues.map((iss: any) => iss.path)).toEqual([
+      ["left", "name"],
+      ["right", "name"],
+    ]);
+  } finally {
+    z.config({ jitless: false });
+  }
+});

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -27,6 +27,11 @@ type WithState = { [STATE]?: State };
 
 const NO_ISSUES: errors.$ZodRawIssue[] = [];
 
+// Receivers prefix paths in place, so the cache and every hand-out need their own copies.
+function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
+  return issues.map((iss) => (iss.path ? { ...iss, path: iss.path.slice() } : { ...iss }));
+}
+
 interface Memoizer extends $ZodMemoizer {
   recursive: boolean | undefined;
   /** Set immediately before delegating to core and cleared immediately after, so
@@ -156,7 +161,7 @@ export function attachMemoizer(inst: $ZodType): void {
       if (hit) {
         payload.value = hit.value;
         if (hit.issues) {
-          payload.issues.push(...hit.issues);
+          if (hit.issues.length) payload.issues.push(...cloneIssues(hit.issues));
         } else {
           // Still being parsed: its own checks cover it, so skip them here.
           payload.memo = true;
@@ -176,11 +181,11 @@ export function attachMemoizer(inst: $ZodType): void {
       // Both paths written out so the sync one allocates no closure. It runs once per node, and capturing here cost more than everything else combined.
       if (result instanceof Promise) {
         return result.then((r) => {
-          if (entry) entry.issues = r.issues.length ? r.issues.slice() : NO_ISSUES;
+          if (entry) entry.issues = r.issues.length ? cloneIssues(r.issues) : NO_ISSUES;
           return r;
         });
       }
-      if (entry) entry.issues = result.issues.length ? result.issues.slice() : NO_ISSUES;
+      if (entry) entry.issues = result.issues.length ? cloneIssues(result.issues) : NO_ISSUES;
       return result;
     };
 


### PR DESCRIPTION
An issue object belongs to the payload it was raised into, and every receiver prefixes a path onto it in place. The memoizer broke that: it cached the live issue objects and handed the same ones to every visitor of a shared node, so the second visitor prefixed onto the first one's path.

```ts
const Node: any = z.object({
  name: z.string(),
  get left() { return z.optional(Node); },
  get right() { return z.optional(Node); },
});

const shared: any = { name: 123 };
Node.safeParse({ name: "root", left: shared, right: shared });

// before: [["right","left","name"], ["right","left","name"]]
// after:  [["left","name"], ["right","name"]]
```

Both issues are also the same object before the fix, so mutating one mutates the other.

Only the jitless object path is reachable today: the object JIT copies each issue before prefixing it, and `util.prefixIssues` does not. The fix is in the memoizer rather than in either consumer, since that is the one place an issue legitimately enters two payloads — `cloneIssues` runs on store and on hand-out, so the cache owns pristine issues and every visitor gets its own. It only runs for a node that both failed and is shared.

Bundle cost is 0 bytes on `zod/mini` and +33 gzipped on classic.

Refs #6319, where the same aliasing surfaced in the object JIT.
