### PR TITLE
ci: bump the GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,11 @@ jobs:
         typescript: ["5.5", "6"]
     name: Test with TypeScript ${{ matrix.typescript }} on Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - run: pnpm install
       # Build with the repo-pinned TypeScript, which is what actually ships. zshy
       # uses the classic compiler API, which TypeScript 7 no longer provides.
@@ -45,11 +45,11 @@ jobs:
         node: ["latest"]
     name: Lint on Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - run: pnpm install
       - run: pnpm format:check
       - run: pnpm lint:check
@@ -58,11 +58,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Check for circular dependencies
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "latest"
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - run: pnpm install
       - run: pnpm check:circular
 
@@ -74,12 +74,12 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "latest"
           registry-url: https://registry.npmjs.org/
@@ -88,7 +88,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
   auto-close:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9               # Close stale issues & PRs :contentReference[oaicite:0]{index=0}
+      - uses: actions/stale@v11               # Close stale issues & PRs :contentReference[oaicite:0]{index=0}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-label: 'needs-info'     # label you’ll add to trigger closing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,11 @@ jobs:
         typescript: ["5.5", "6", "latest"]
     name: Test with TypeScript ${{ matrix.typescript }} on Node ${{ matrix.node }} (${{ matrix.os }})
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - run: pnpm install
       # Build with the repo-pinned TypeScript: zshy uses the classic compiler API,
       # which TypeScript 7 no longer ships. The matrix version applies to the tests.
@@ -46,11 +46,11 @@ jobs:
         node: ["latest"]
     name: Lint on Node ${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - run: pnpm install
       - run: pnpm format:check
       - run: pnpm lint:check
@@ -60,10 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Check for circular dependencies
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "latest"
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - run: pnpm install
       - run: pnpm check:circular


### PR DESCRIPTION
Every CI run has been warning that `actions/checkout@v4`, `actions/setup-node@v4` and `pnpm/action-setup@v4` target Node 20, which GitHub deprecated in September 2025 and currently force-migrates to Node 24. This bumps all three to the current majors, plus `actions/stale@v9` → `v11`, which carried the same warning on the nightly cron.

Two behavior changes in these majors were checked and don't apply here. Automatic package-manager caching arrived in `setup-node@v5` and would have broken these jobs, since `setup-node` runs before pnpm is on PATH — but v6 narrowed it to npm only and v7 keeps it that way. The v7 release of `checkout` blocks fork checkouts on `pull_request_target` and `workflow_run`, and no workflow here uses either trigger.

The pullfrog workflow is vendor-managed and already on `checkout@v6`, so it's untouched. Every input in `stale.yml` is unchanged and still supported in v11.

Follow-up to #6307.
