### PR TITLE
perf(v4): prefix issue paths in place in the object JIT failure path

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2136,6 +2136,14 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         return `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
       };
 
+      // Prefixes in place, like util.prefixIssues does for every interpreted path.
+      const prefixStr = (id: string, k: string) => `
+          for (let i = 0; i < ${id}.issues.length; i++) {
+            const iss = ${id}.issues[i];
+            iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
+            payload.issues.push(iss);
+          }`;
+
       doc.write(`const input = payload.value;`);
 
       const ids: any = Object.create(null);
@@ -2164,12 +2172,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
           doc.write(`
         const ${id}_present = ${isPresent};
         if (!${id}.issues.length || ${id}_present) {
-          if (${id}.issues.length) {
-            for (let i = 0; i < ${id}.issues.length; i++) {
-              const iss = ${id}.issues[i];
-              iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
-              payload.issues.push(iss);
-            }
+          if (${id}.issues.length) {${prefixStr(id, k)}
           }
 
           if (${assign}) {
@@ -2181,12 +2184,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         } else if (!isOptionalIn) {
           doc.write(`
         const ${id}_present = ${isPresent};
-        if (${id}.issues.length) {
-          for (let i = 0; i < ${id}.issues.length; i++) {
-            const iss = ${id}.issues[i];
-            iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
-            payload.issues.push(iss);
-          }
+        if (${id}.issues.length) {${prefixStr(id, k)}
         }
         if (!${id}_present && !${id}.issues.length) {
           payload.issues.push({
@@ -2204,12 +2202,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
       `);
         } else {
           doc.write(`
-        if (${id}.issues.length) {
-          for (let i = 0; i < ${id}.issues.length; i++) {
-            const iss = ${id}.issues[i];
-            iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
-            payload.issues.push(iss);
-          }
+        if (${id}.issues.length) {${prefixStr(id, k)}
         }
         
         if (${id}.value === undefined) {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2165,10 +2165,11 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         const ${id}_present = ${isPresent};
         if (!${id}.issues.length || ${id}_present) {
           if (${id}.issues.length) {
-            payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-              ...iss,
-              path: iss.path ? [${k}, ...iss.path] : [${k}]
-            })));
+            for (let i = 0; i < ${id}.issues.length; i++) {
+              const iss = ${id}.issues[i];
+              iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
+              payload.issues.push(iss);
+            }
           }
 
           if (${assign}) {
@@ -2181,10 +2182,11 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
           doc.write(`
         const ${id}_present = ${isPresent};
         if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
+          for (let i = 0; i < ${id}.issues.length; i++) {
+            const iss = ${id}.issues[i];
+            iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
+            payload.issues.push(iss);
+          }
         }
         if (!${id}_present && !${id}.issues.length) {
           payload.issues.push({
@@ -2203,10 +2205,11 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         } else {
           doc.write(`
         if (${id}.issues.length) {
-          payload.issues = payload.issues.concat(${id}.issues.map(iss => ({
-            ...iss,
-            path: iss.path ? [${k}, ...iss.path] : [${k}]
-          })));
+          for (let i = 0; i < ${id}.issues.length; i++) {
+            const iss = ${id}.issues[i];
+            iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
+            payload.issues.push(iss);
+          }
         }
         
         if (${id}.value === undefined) {


### PR DESCRIPTION
Salvaged from #6319, which is closed — this is the half of it that costs `zod/mini` nothing.

The object JIT copied every issue to prefix a path onto it:

```js
payload.issues = payload.issues.concat(id.issues.map(iss => ({
  ...iss, path: iss.path ? [k, ...iss.path] : [k]
})));
```

The interpreted paths — arrays, records, and the jitless object path — have always prefixed in place through `util.prefixIssues`. The JIT path was the odd one out, so it now emits a loop that writes `iss.path` and pushes. The three call sites emit identical code, so the template is built once, which takes 262 minified bytes off a classic object bundle.

Measured against #6443 with a paired A/B harness, two runs, on a noise floor of ±0.3% for this case:

| case | run 1 | run 2 |
|---|---|---|
| union-parse | −12.3% | −12.8% |
| suite total | −1.5% | −0.9% |

Unions are where it shows up: every option before the matching one fails and hands its issues up.

Bundle: 0 bytes on all three `zod/mini` fixtures, which never bundle the object JIT, and +8 gzipped on classic `zod-object`. Memory is unchanged.

Prefixing in place is only safe on top of #6443, now merged as `b63db248`: the memoizer used to hand the same issue objects to every visitor of a shared node, so without that fix a DAG-shaped input reaching one invalid node twice comes out with both paths prefixed onto a single object.

Refs #6319.
