### PR TITLE
fix(resolution): keep pnpm's own warnings out of the attw snapshot

### DIFF
--- a/packages/resolution/attw.test.ts
+++ b/packages/resolution/attw.test.ts
@@ -33,8 +33,13 @@ describe("Are The Types Wrong (attw) tests", () => {
       reject: false, // Don't throw on non-zero exit codes
     });
 
-    // Combine stdout and stderr for comprehensive output
-    const output = result.stdout + (result.stderr ? "\n" + result.stderr : "");
+    // Combine stdout and stderr for comprehensive output, minus pnpm's own warnings: under CI, setup-node writes an .npmrc containing an unresolved ${NODE_AUTH_TOKEN} and pnpm warns about it on every invocation, which is not part of attw's report.
+    const stderr = result.stderr
+      .split("\n")
+      .filter((line) => !/^\s*WARN\b/.test(line))
+      .join("\n")
+      .trim();
+    const output = result.stdout + (stderr ? "\n" + stderr : "");
     // remove first line
     const outputWithoutFirstLine = output.split("\n").slice(2).join("\n").trim();
     expect(outputWithoutFirstLine).toMatchInlineSnapshot(`


### PR DESCRIPTION
The release pipeline is broken on `main` at 2a417097. The `build_and_publish` job fails at `pnpm test`, before it publishes anything.

Bumping to `actions/setup-node@v7` in #6444 is what exposed it. That release stopped exporting a dummy `NODE_AUTH_TOKEN` — [deliberately](https://github.com/actions/setup-node/pull/1558), because the dummy corrupted the `.npmrc` during an OIDC publish, which is how this repo publishes. The publish job passes `registry-url`, so setup-node writes an `.npmrc` holding `${NODE_AUTH_TOKEN}` and points `NPM_CONFIG_USERCONFIG` at it for the whole job. With nothing to resolve, pnpm now warns on every invocation:

```
 WARN  Issue while reading "/home/runner/work/_temp/.npmrc". Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

The attw test snapshots stdout and stderr combined, so that warning lands inside the assertion and the snapshot mismatches. Only `build_and_publish` sets `registry-url`, which is why the PR checks on #6444 were green.

This filters pnpm's `WARN` lines out of the captured stderr. The snapshot's subject is attw's report, not the package manager wrapping it. Re-adding a dummy token would undo the fix upstream just shipped for OIDC, so that isn't the answer.

Reproduced locally by pointing `NPM_CONFIG_USERCONFIG` at an `.npmrc` with an unresolvable token: the test fails before this change, passes after, and is unaffected when the variable is absent.

Refs #6444.
