### PR TITLE
chore: record why the attw stderr filter needs a \s match

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
   auto-close:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v11               # Close stale issues & PRs :contentReference[oaicite:0]{index=0}
+      - uses: actions/stale@v11 # Close stale issues & PRs
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-label: 'needs-info'     # label you’ll add to trigger closing

--- a/packages/resolution/attw.test.ts
+++ b/packages/resolution/attw.test.ts
@@ -36,6 +36,7 @@ describe("Are The Types Wrong (attw) tests", () => {
     // Combine stdout and stderr for comprehensive output, minus pnpm's own warnings: under CI, setup-node writes an .npmrc containing an unresolved ${NODE_AUTH_TOKEN} and pnpm warns about it on every invocation, which is not part of attw's report.
     const stderr = result.stderr
       .split("\n")
+      // pnpm pads WARN with U+2009 thin spaces rather than ASCII spaces, so this has to stay a \s match; startsWith(" WARN") misses it entirely.
       .filter((line) => !/^\s*WARN\b/.test(line))
       .join("\n")
       .trim();


### PR DESCRIPTION
Two follow-ups from the reviews on #6444 and #6446, neither of which changes behavior.

The stderr filter added in #6446 matches through `\s` for a reason that is invisible in the diff: pnpm pads `WARN` with U+2009 thin spaces, not ASCII spaces. Verified with hexdump — the bytes are `e2 80 89 WARN e2 80 89`. A later tidy-up to `startsWith(" WARN")` or `/^ *WARN/` would silently stop matching and re-break the release pipeline in exactly the spot that PR fixed, so this records it at the line.

The second change drops the leftover citation markup from the `stale.yml` comment. It was never a link and rendered as nothing.

Refs #6444, #6446.
