### PR TITLE
perf(v4): skip the eager stack capture when building a ZodError

### DIFF
--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,12 +38,12 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // Raised from 2813 / 3285 / 4288 by the commit that caused it: threading a `callee` to `Error.captureStackTrace` from every throwing parse entry point costs +13 / +17 / +16, since a bundle that parses at all carries it. Measured 2808 / 3271 / 4301 here; 28 bytes of headroom each. The per-fixture notes below record what each ceiling already carried before this.
-  "zod-mini-boolean": 2836,
+  // raised from 2836 / 3299 / 4329 — suppressing v8's stack capture costs +64 / +65 / +62 and every bundle carries `core.ts`; measured 2872 / 3336 / 4362 plus 28 headroom, and the per-fixture notes below record what each one already carried
+  "zod-mini-boolean": 2900,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3299,
+  "zod-mini-string": 3364,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
-  "zod-mini-object": 4329,
+  "zod-mini-object": 4390,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // Raised from 2813 / 3285 / 4288 by the commit that caused it: threading a `callee` to `Error.captureStackTrace` from every throwing parse entry point costs +13 / +17 / +16, since a bundle that parses at all carries it. Measured 2808 / 3271 / 4301 here; 28 bytes of headroom each. The per-fixture notes below record what each ceiling already carried before this.
-  "zod-mini-boolean": 2836,
+  // raised from 2836 / 3299 / 4374 by the commit that caused it: suppressing v8's stack capture while building an error costs +68 / +68 / +63, and every bundle carries `core.ts`; measured 2875 / 3338 / 4409 plus 28 headroom, and the per-fixture notes below record what each already carried
+  "zod-mini-boolean": 2903,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3299,
+  "zod-mini-string": 3366,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
-  // Raised from 4329 by the commit that caused it: declared symbol keys mean `normalizeDef` collects the shape's own symbols and the parse loop walks them, which every bundle containing `z.object` carries. Measured 4346 against a 4300 baseline; 28 bytes of headroom to match the others. Almost none of it is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4374,
+  // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
+  "zod-mini-object": 4437,
 };
 
 /**

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1,5 +1,5 @@
-import { inspect } from "node:util";
-import { afterEach, expect, test } from "vitest";
+import { inspect, types } from "node:util";
+import { afterEach, expect, test, vi } from "vitest";
 import * as z from "zod/v4";
 
 // Several tests install a global error map. Resetting on the last line of each leaks it into every later test in the file whenever an assertion above that line fails, which turns one real failure into a cascade.
@@ -739,7 +739,7 @@ test("error inheritance", () => {
   expect(e1).toBeInstanceOf(z.core.$ZodError);
   expect(e1).toBeInstanceOf(z.ZodError);
   expect(e1).toBeInstanceOf(z.ZodRealError);
-  // expect(e1).not.toBeInstanceOf(Error);
+  expect(e1).toBeInstanceOf(Error);
 
   try {
     z.string().parse(123);
@@ -747,7 +747,7 @@ test("error inheritance", () => {
     expect(e1).toBeInstanceOf(z.core.$ZodError);
     expect(e2).toBeInstanceOf(z.ZodError);
     expect(e2).toBeInstanceOf(z.ZodRealError);
-    // expect(e2).toBeInstanceOf(Error);
+    expect(e2).toBeInstanceOf(Error);
   }
 });
 
@@ -872,15 +872,72 @@ test("error helpers survive detaching", () => {
   expect(empty.message).toContain("added");
 });
 
-test("stack trace carries the message and the parse call site", () => {
-  function callSite() {
-    return z.string().safeParse(123).error!;
-  }
-  const stack = callSite().stack!;
+test("an error is a real Error, minus the captured frames", () => {
+  const err = z.string().safeParse(123).error!;
 
-  expect(stack.startsWith("ZodError: [")).toBe(true);
-  expect(stack).toContain("invalid_type");
-  expect(stack).toContain("callSite");
+  // suppressing the capture, not skipping the constructor, keeps every brand check working
+  expect(err).toBeInstanceOf(Error);
+  expect(types.isNativeError(err)).toBe(true);
+  expect(Object.prototype.toString.call(err)).toBe("[object Error]");
+  expect(structuredClone(err)).toBeInstanceOf(Error);
+
+  // only a returned error loses its frames; the throwing paths restore them
+  expect(err.stack!.startsWith("ZodError: [")).toBe(true);
+  expect(err.stack!).toContain("invalid_type");
+  expect(err.stack!.split("\n").some((line) => line.trim().startsWith("at "))).toBe(false);
+
+  // the borrowed global is given back unchanged, including a caller's own value
+  const ambient = Error.stackTraceLimit;
+  z.string().safeParse(123);
+  expect(Error.stackTraceLimit).toBe(ambient);
+  Error.stackTraceLimit = ambient + 3;
+  try {
+    z.string().safeParse(123);
+    expect(Error.stackTraceLimit).toBe(ambient + 3);
+  } finally {
+    Error.stackTraceLimit = ambient;
+  }
+});
+
+test("a realm that hardens Error after import degrades instead of throwing", async () => {
+  // lockdown() runs after zod's module graph evaluates, so the latch fires in a throwaway instance rather than the one this file uses
+  vi.resetModules();
+  const fresh = await import("zod/v4");
+  const desc = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit")!;
+  Object.defineProperty(Error, "stackTraceLimit", { value: 10, writable: false, configurable: true });
+
+  try {
+    for (const err of [fresh.string().safeParse(1).error!, fresh.string().safeParse(2).error!]) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.issues).toHaveLength(1);
+    }
+    expect(Error.stackTraceLimit).toBe(10);
+  } finally {
+    Object.defineProperty(Error, "stackTraceLimit", desc);
+  }
+});
+
+test("an engine with no stackTraceLimit is never written to", () => {
+  // off v8 the property is absent and SES deletes it before hardening; an accessor makes the write observable where a data property would not
+  const desc = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit")!;
+  let writes = 0;
+  Object.defineProperty(Error, "stackTraceLimit", {
+    get: () => undefined,
+    set: () => {
+      writes++;
+    },
+    configurable: true,
+  });
+
+  try {
+    const err = z.string().safeParse(123).error!;
+    expect(err).toBeInstanceOf(z.ZodError);
+    expect(types.isNativeError(err)).toBe(true);
+    expect(err.issues).toHaveLength(1);
+    expect(writes).toBe(0);
+  } finally {
+    Object.defineProperty(Error, "stackTraceLimit", desc);
+  }
 });
 
 test("error initializer never installs onto an intrinsic prototype", () => {

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1,5 +1,5 @@
-import { inspect } from "node:util";
-import { afterEach, expect, test } from "vitest";
+import { inspect, types } from "node:util";
+import { afterEach, expect, test, vi } from "vitest";
 import * as z from "zod/v4";
 
 // Several tests install a global error map. Resetting on the last line of each leaks it into every later test in the file whenever an assertion above that line fails, which turns one real failure into a cascade.
@@ -739,7 +739,7 @@ test("error inheritance", () => {
   expect(e1).toBeInstanceOf(z.core.$ZodError);
   expect(e1).toBeInstanceOf(z.ZodError);
   expect(e1).toBeInstanceOf(z.ZodRealError);
-  // expect(e1).not.toBeInstanceOf(Error);
+  expect(e1).toBeInstanceOf(Error);
 
   try {
     z.string().parse(123);
@@ -747,7 +747,7 @@ test("error inheritance", () => {
     expect(e1).toBeInstanceOf(z.core.$ZodError);
     expect(e2).toBeInstanceOf(z.ZodError);
     expect(e2).toBeInstanceOf(z.ZodRealError);
-    // expect(e2).toBeInstanceOf(Error);
+    expect(e2).toBeInstanceOf(Error);
   }
 });
 
@@ -872,15 +872,97 @@ test("error helpers survive detaching", () => {
   expect(empty.message).toContain("added");
 });
 
-test("stack trace carries the message and the parse call site", () => {
-  function callSite() {
-    return z.string().safeParse(123).error!;
-  }
-  const stack = callSite().stack!;
+test("an error is a real Error, minus the captured frames", () => {
+  const err = z.string().safeParse(123).error!;
 
-  expect(stack.startsWith("ZodError: [")).toBe(true);
-  expect(stack).toContain("invalid_type");
-  expect(stack).toContain("callSite");
+  // suppressing the capture, not skipping the constructor, keeps every brand check working
+  expect(err).toBeInstanceOf(Error);
+  expect(types.isNativeError(err)).toBe(true);
+  expect(Object.prototype.toString.call(err)).toBe("[object Error]");
+  expect(structuredClone(err)).toBeInstanceOf(Error);
+
+  // only a returned error loses its frames; the throwing paths restore them
+  expect(err.stack!.startsWith("ZodError: [")).toBe(true);
+  expect(err.stack!).toContain("invalid_type");
+  expect(err.stack!.split("\n").some((line) => line.trim().startsWith("at "))).toBe(false);
+
+  // the borrowed global is given back unchanged, including a caller's own value
+  const ambient = Error.stackTraceLimit;
+  z.string().safeParse(123);
+  expect(Error.stackTraceLimit).toBe(ambient);
+  Error.stackTraceLimit = ambient + 3;
+  try {
+    z.string().safeParse(123);
+    expect(Error.stackTraceLimit).toBe(ambient + 3);
+  } finally {
+    Error.stackTraceLimit = ambient;
+  }
+});
+
+test("an engine without captureStackTrace keeps the frames on a thrown error", async () => {
+  // suppressing the capture is only safe where `parse()` can put the frames back; Safari 11.1 through 17.1 has `stackTraceLimit` but not `captureStackTrace`, and suppressing there would strip the throw's stack
+  const desc = Object.getOwnPropertyDescriptor(Error, "captureStackTrace")!;
+  vi.resetModules();
+  delete (Error as { captureStackTrace?: unknown }).captureStackTrace;
+
+  let thrown: unknown;
+  try {
+    const fresh = await import("zod/v4");
+    function callSite() {
+      fresh.string().parse(1);
+    }
+    try {
+      callSite();
+    } catch (err) {
+      thrown = err;
+    }
+  } finally {
+    Object.defineProperty(Error, "captureStackTrace", desc);
+  }
+
+  expect(thrown).toBeInstanceOf(Error);
+  expect((thrown as Error).stack).toContain("callSite");
+});
+
+test("a realm that hardens Error after import degrades instead of throwing", async () => {
+  // lockdown() runs after zod's module graph evaluates, so the latch fires in a throwaway instance rather than the one this file uses
+  vi.resetModules();
+  const fresh = await import("zod/v4");
+  const desc = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit")!;
+  Object.defineProperty(Error, "stackTraceLimit", { value: 10, writable: false, configurable: true });
+
+  try {
+    for (const err of [fresh.string().safeParse(1).error!, fresh.string().safeParse(2).error!]) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err.issues).toHaveLength(1);
+    }
+    expect(Error.stackTraceLimit).toBe(10);
+  } finally {
+    Object.defineProperty(Error, "stackTraceLimit", desc);
+  }
+});
+
+test("an engine with no stackTraceLimit is never written to", () => {
+  // off v8 the property is absent and SES deletes it before hardening; an accessor makes the write observable where a data property would not
+  const desc = Object.getOwnPropertyDescriptor(Error, "stackTraceLimit")!;
+  let writes = 0;
+  Object.defineProperty(Error, "stackTraceLimit", {
+    get: () => undefined,
+    set: () => {
+      writes++;
+    },
+    configurable: true,
+  });
+
+  try {
+    const err = z.string().safeParse(123).error!;
+    expect(err).toBeInstanceOf(z.ZodError);
+    expect(types.isNativeError(err)).toBe(true);
+    expect(err.issues).toHaveLength(1);
+    expect(writes).toBe(0);
+  } finally {
+    Object.defineProperty(Error, "stackTraceLimit", desc);
+  }
 });
 
 test("error initializer never installs onto an intrinsic prototype", () => {

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -18,8 +18,8 @@ export const NEVER: never = /*@__PURE__*/ Object.freeze({
  * synchronously, so reusing one object avoids a per-instance allocation. */
 const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 
-// latched to null once `stackTraceLimit` proves unassignable, which a realm can do at any point by hardening Error
-let _E: (ErrorConstructor & { stackTraceLimit?: number }) | null = Error;
+// null where suppressing the capture would be unrecoverable: `parse()` puts the frames back with `captureStackTrace`, so without it the throw would lose its stack. also latched to null once `stackTraceLimit` proves unassignable, which a realm can do at any point by hardening Error
+let _E: (ErrorConstructor & { stackTraceLimit?: number }) | null = "captureStackTrace" in Error ? Error : null;
 
 // v8 captures a stack trace inside the Error constructor, which dominates a failed parse; costs only the frames, and parse() restores those
 function newError(Definition: new () => any): any {

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -18,6 +18,31 @@ export const NEVER: never = /*@__PURE__*/ Object.freeze({
  * synchronously, so reusing one object avoids a per-instance allocation. */
 const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 
+// latched to null once `stackTraceLimit` proves unassignable, which a realm can do at any point by hardening Error
+let _E: (ErrorConstructor & { stackTraceLimit?: number }) | null = Error;
+
+// v8 captures a stack trace inside the Error constructor, which dominates a failed parse; costs only the frames, and parse() restores those
+function newError(Definition: new () => any): any {
+  const E = _E;
+  if (E) {
+    const saved = E.stackTraceLimit;
+    if (typeof saved === "number") {
+      try {
+        E.stackTraceLimit = 0;
+      } catch {
+        _E = null;
+        return new Definition();
+      }
+      try {
+        return new Definition();
+      } finally {
+        E.stackTraceLimit = saved;
+      }
+    }
+  }
+  return new Definition();
+}
+
 export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T["_zod"]["def"]>(
   name: string,
   initializer: (inst: T, def: D) => void,
@@ -69,7 +94,7 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
   Object.defineProperty(Definition, "name", { value: name });
 
   function _(this: any, def: D) {
-    const inst = params?.Parent ? new Definition() : this;
+    const inst = params?.Parent ? newError(Definition) : this;
     init(inst, def);
     const deferred = inst._zod.deferred;
     if (deferred) {

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1532,3 +1532,27 @@ test("date min/max bounds compile with runtime parity", () => {
   expect(valid(aot, inputs[0])).toEqual(inputs[0]);
   invalid(aot, inputs[2]);
 });
+
+test("the compiled fallback builds the same Error-shaped error as the runtime", () => {
+  const schema = z.object({ a: z.string(), b: z.number() });
+  const aot = compile(schema);
+
+  // both fast closures fall back to the runtime on rejection, so the error is the runtime's
+  const err = aot.safeParse({ a: 1, b: "x" }).error!;
+  expect(err).toBeInstanceOf(Error);
+  expect(err).toBeInstanceOf(z.core.$ZodError);
+  expect(err.issues).toEqual(schema.safeParse({ a: 1, b: "x" }).error!.issues);
+
+  function callSite() {
+    aot.parse({ a: 1, b: "x" });
+  }
+
+  let thrown: unknown;
+  try {
+    callSite();
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  expect((thrown as Error).stack).toContain("callSite");
+});

--- a/packages/zod/src/v4/mini/tests/error.test.ts
+++ b/packages/zod/src/v4/mini/tests/error.test.ts
@@ -11,12 +11,31 @@ test("no locale by default", () => {
 test("error inheritance", () => {
   const e1 = z.string().safeParse(123).error!;
   expect(e1).toBeInstanceOf(z.core.$ZodError);
-  // expect(e1).not.toBeInstanceOf(Error);
+  expect(e1).toBeInstanceOf(Error);
 
+  let e2: unknown;
   try {
     z.string().parse(123);
-  } catch (e2) {
-    expect(e2).toBeInstanceOf(z.core.$ZodRealError);
-    expect(e2).toBeInstanceOf(Error);
+  } catch (err) {
+    e2 = err;
   }
+  expect(e2).toBeInstanceOf(z.core.$ZodRealError);
+  expect(e2).toBeInstanceOf(Error);
+});
+
+test("a thrown error carries a stack rooted at the parse call site", () => {
+  function callSite() {
+    z.parse(z.string(), 123);
+  }
+
+  let thrown: unknown;
+  try {
+    callSite();
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  const stack = (thrown as Error).stack!;
+  expect(stack.startsWith("$ZodError: [")).toBe(true);
+  expect(stack).toContain("callSite");
 });


### PR DESCRIPTION
Constructing a ZodError runs the `Error` constructor, and V8 captures a structured stack trace there. That capture is the dominant cost of a failed parse and roughly half the error's retained bytes, and it grows with the depth of the call stack. Zeroing `Error.stackTraceLimit` around the construction skips it.

The error stays a genuine `Error`. Checks with `instanceof`, `Error.isError`, `util.types.isNativeError`, `Object.prototype.toString` and `structuredClone` all behave exactly as they do today. What it gives up is the frames on an error *returned* by `safeParse` — the message header is still there.

The throwing path keeps its full stack, and gets faster too. Today it captures twice: once in the `Error` constructor and again in `captureStackTrace`, which trims to the caller. Skipping the first leaves one capture and the same frames.

| | main | this branch | |
| --- | --- | --- | --- |
| failing `safeParse` | 250k | 569k | 2.28x |
| failing `parse` | 145k | 204k | 1.40x |

Across a wider set of failing `safeParse` shapes — `z.string()`, a 5-key object with one and with all keys bad, a 3-deep nested object, an array of 20, a discriminated union with no match — the range is 2.9x to 3.7x, against a control on valid input of 1.05x–1.09x. Retained bytes per returned error drop from 1073 B to 714 B, and from 1442 B to 708 B at call depth 40, so the cost no longer grows with stack depth. Gzipped bundle cost is +63 to +68 B, since every bundle carries `core.ts`.

Three alternatives do not work. Setting `stackTraceLimit` on the subclass is ignored, because V8 reads it only off `Error` — MDN is explicit that it is a static property with no per-subclass form. Assigning `Error.prepareStackTrace` suppresses the frames but leaves construction just as slow, so the eager cost is collecting them rather than formatting them. Dropping `extends Error` altogether measures the same as skipping only the constructor, so it would forfeit `instanceof Error` for nothing. Save, zero, construct, restore is what MDN documents and what Node core does internally (nodejs/node#24747).

Two engine cases fall back to a plain construction rather than the trick. Where `Error.captureStackTrace` is missing there is no way to put the frames back, so suppressing would strip the stack from a thrown error — Safari 11.1 through 17.1 has `stackTraceLimit` but not `captureStackTrace`. Where `stackTraceLimit` is absent or frozen, assigning would throw; SES `lockdown()` deletes it before hardening `Error`, and an app that hardens `Error` after import latches the trick off on the first failure. Each fallback fails a test when removed.

The cost worth naming explicitly is that a returned error carries no frames at all, so re-throwing one — `if (!r.success) throw r.error` — produces a thrown error with an empty trace where `parse()` would give five. Nothing downstream can recover them, since `throw` does not re-capture, and Node prints such an error as `[ZodError: …]`.

Refs #6316, #5910
