### PR TITLE
ci: replace the archived create-release action on the publish path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,34 +139,34 @@ jobs:
       - name: Configure changelog
         if: ${{ steps.publish.outputs.type }}
         run: |
-          echo '{"categories": [], "template": "## Commits:\n\n${{ '${{UNCATEGORIZED}}' }}", "pr_template": ${{ '"- ${{MERGE_SHA}} ${{TITLE}}"' }} }' > changelog_config.json
+          echo '{"categories": [], "template": "## Commits:\n\n#{{UNCATEGORIZED}}", "pr_template": "- #{{MERGE_SHA}} #{{TITLE}}"}' > changelog_config.json
           cat changelog_config.json
           echo "last_tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-          echo "curr_commit=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Generate changelog
         if: ${{ steps.publish.outputs.type }}
         id: github_release
-        uses: mikepenz/release-changelog-builder-action@v2.9.0
+        uses: mikepenz/release-changelog-builder-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           fromTag: "${{ env.last_tag }}"
           toTag: ${{ github.ref }}
-          commitMode: true
+          mode: COMMIT
           configuration: changelog_config.json
 
+      # Replaces actions/create-release@v1, which was archived in 2021 and still declares the node12 runtime. The notes go through a file and the environment rather than an expression inside the script, so a commit subject can't break out of the command.
       - name: Create release
         if: ${{ steps.publish.outputs.type }}
-        id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.publish.outputs.version }}
-          release_name: v${{ steps.publish.outputs.version }}
-          commitish: ${{ github.ref }}
-          body: ${{steps.github_release.outputs.changelog}}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.publish.outputs.version }}
+          CHANGELOG: ${{ steps.github_release.outputs.changelog }}
+        run: |
+          printf '%s' "$CHANGELOG" > "$RUNNER_TEMP/release_notes.md"
+          gh release create "v$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "v$VERSION" \
+            --notes-file "$RUNNER_TEMP/release_notes.md"
 


### PR DESCRIPTION
Two actions on the publish path still declare the `node12` runtime and only survive on GitHub's force-migration. Both are gated on `if: steps.publish.outputs.type`, so they fire on a real version publish and never on a canary — a failure there surfaces mid-release.

The worse of the two, `actions/create-release@v1`, was archived in March 2021, so there is no newer version to move to. I read its source and reproduced each field with `gh release create`, which is preinstalled on the runners:

| action input | replacement |
| --- | --- |
| `tag_name` | positional tag argument |
| `release_name` | `--title` |
| `commitish` | `--target` |
| `body` | `--notes-file` |
| `draft: false` / `prerelease: false` | absent flags, which default to false |

The step declared an `id` but nothing consumed its outputs, so nothing else had to change.

Two differences are deliberate. The `--target` flag passes `GITHUB_SHA` instead of `github.ref`, so the tag records the commit that was actually published rather than whatever main's tip is by the time the API call lands. And the notes travel through the environment and a file instead of an expression pasted into the script, so a commit subject cannot break out of the command.

I verified the replacement on a branch by creating a draft release with the exact command. Reading it back returned `targetCommitish` equal to `GITHUB_SHA`, `name` and `tagName` equal to the version, `isPrerelease` false, and a body carrying shell metacharacters byte-intact.

The other bump takes `mikepenz/release-changelog-builder-action` from v2.9.0 to v6, and `commitMode: true` to the supported `mode: COMMIT` — `resolveMode` in v6 maps both to `COMMIT`. The template placeholders move to `#{{...}}` to match current docs, which also drops the escaping the old delimiter required. Running both configs side by side on a branch produced identical changelogs, so v6 still accepts the old spelling and that part is tidying rather than a fix.

Follow-up to #6444.
