### PR TITLE
fix(v4): correct the date/time format keywords in both JSON Schema directions

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -416,6 +416,8 @@ z.guid(); // => { type: "string", format: "uuid" }
 z.url(); // => { type: "string", format: "uri" }
 ```
 
+The `local: true` and `precision: -1` variants of `z.iso.datetime()` fall back to `pattern`, since RFC 3339 `date-time` requires both an offset and seconds.
+
 These schemas are supported via `contentEncoding`:
 
 ```ts

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -193,7 +193,7 @@ function getTupleRest(restSchema: JSONSchema._JSONSchema | undefined, ctx: Conve
   return convertSchema(restSchema, ctx);
 }
 
-// RFC 3339 full-time, which `z.iso.time()` is not; kept local because the only version that would share logic derives it from `timeSource`, which pins that builder into every bundle (+139 B gzipped on a mini `z.boolean()`).
+// the RFC 3339 full-time keyword, narrower than `z.iso.time()`; local because sharing it via `timeSource` pins that builder into every bundle (+139 B gzipped on a mini `z.boolean()`)
 const fullTime = /^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
 function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext): ZodType {

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -193,6 +193,9 @@ function getTupleRest(restSchema: JSONSchema._JSONSchema | undefined, ctx: Conve
   return convertSchema(restSchema, ctx);
 }
 
+// JSON Schema `time` is RFC 3339 `full-time`, which mandates seconds and a `Z` or numeric offset. `z.iso.time()` is `partial-time`, so it rejects every string this format is defined to accept and accepts every string it forbids — hence a pattern here rather than a borrowed format validator.
+const fullTime = /^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
+
 function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext): ZodType {
   // Handle unsupported features
   if (schema.not !== undefined) {
@@ -325,7 +328,7 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         } else if (format === "date") {
           stringSchema = stringSchema.check(z.iso.date());
         } else if (format === "time") {
-          stringSchema = stringSchema.check(z.iso.time());
+          stringSchema = stringSchema.check(z.regex(fullTime));
         } else if (format === "duration") {
           stringSchema = stringSchema.check(z.iso.duration());
         } else if (format === "hostname") {

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -193,7 +193,7 @@ function getTupleRest(restSchema: JSONSchema._JSONSchema | undefined, ctx: Conve
   return convertSchema(restSchema, ctx);
 }
 
-// RFC 3339 full-time, which `z.iso.time()` is not; kept local because exporting it from core/regexes.ts pins it into every bundle (+228 B on a mini `z.boolean()`).
+// RFC 3339 full-time, which `z.iso.time()` is not; kept local because the only version that would share logic derives it from `timeSource`, which pins that builder into every bundle (+139 B gzipped on a mini `z.boolean()`).
 const fullTime = /^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
 function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext): ZodType {

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -193,7 +193,7 @@ function getTupleRest(restSchema: JSONSchema._JSONSchema | undefined, ctx: Conve
   return convertSchema(restSchema, ctx);
 }
 
-// JSON Schema `time` is RFC 3339 `full-time`, which mandates seconds and a `Z` or numeric offset. `z.iso.time()` is `partial-time`, so it rejects every string this format is defined to accept and accepts every string it forbids — hence a pattern here rather than a borrowed format validator.
+// RFC 3339 full-time, which `z.iso.time()` is not; kept local because exporting it from core/regexes.ts pins it into every bundle (+228 B on a mini `z.boolean()`).
 const fullTime = /^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
 function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext): ZodType {

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -830,7 +830,7 @@ test("string format - time", () => {
     type: "string",
     format: "time",
   });
-  // JSON Schema `time` is RFC 3339 full-time, so seconds and an offset are both required.
+  // full-time, so seconds and an offset are both required
   expect(schema.safeParse("14:30:00Z").success).toBe(true);
   expect(schema.safeParse("16:30:00+02:00").success).toBe(true);
   expect(schema.safeParse("16:30:00.123-05:30").success).toBe(true);

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -825,6 +825,21 @@ test("string format - date-time", () => {
   expect(roundTripped.safeParse("2026-07-29T16:30:00+02:00").success).toBe(true);
 });
 
+test("string format - time", () => {
+  const schema = fromJSONSchema({
+    type: "string",
+    format: "time",
+  });
+  // JSON Schema `time` is RFC 3339 full-time, so seconds and an offset are both required.
+  expect(schema.safeParse("14:30:00Z").success).toBe(true);
+  expect(schema.safeParse("16:30:00+02:00").success).toBe(true);
+  expect(schema.safeParse("16:30:00.123-05:30").success).toBe(true);
+  expect(schema.safeParse("14:30:00").success).toBe(false);
+  expect(schema.safeParse("14:30Z").success).toBe(false);
+  expect(schema.safeParse("16:30:00+0200").success).toBe(false);
+  expect(schema.safeParse("16:30:00+24:00").success).toBe(false);
+});
+
 test("string format - hostname", () => {
   const schema = fromJSONSchema({
     type: "string",

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -99,7 +99,7 @@ describe("toJSONSchema", () => {
         "type": "string",
       }
     `);
-    // `format: "date-time"` is RFC 3339, which requires both an offset and seconds. `local` drops the first and `precision: -1` the second, so those two must not advertise it — including when composed onto a string rather than constructed directly.
+    // only shapes keeping both an offset and seconds may advertise `date-time`, composed onto a string as well as constructed
     expect(z.toJSONSchema(z.iso.datetime()).format).toEqual("date-time");
     expect(z.toJSONSchema(z.iso.datetime({ offset: true })).format).toEqual("date-time");
     expect(z.toJSONSchema(z.iso.datetime({ precision: 0 })).format).toEqual("date-time");
@@ -107,7 +107,7 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(z.iso.datetime({ precision: -1 })).format).toEqual(undefined);
     expect(z.toJSONSchema(z.string().check(z.iso.datetime({ local: true }))).format).toEqual(undefined);
     expect(z.toJSONSchema(z.string().check(z.iso.datetime())).format).toEqual("date-time");
-    // The pattern still describes what the schema accepts either way.
+    // the pattern still describes what the schema accepts
     expect(z.toJSONSchema(z.iso.datetime({ local: true })).pattern).toBeDefined();
 
     expect(z.toJSONSchema(z.iso.time())).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -99,6 +99,17 @@ describe("toJSONSchema", () => {
         "type": "string",
       }
     `);
+    // `format: "date-time"` is RFC 3339, which requires both an offset and seconds. `local` drops the first and `precision: -1` the second, so those two must not advertise it — including when composed onto a string rather than constructed directly.
+    expect(z.toJSONSchema(z.iso.datetime()).format).toEqual("date-time");
+    expect(z.toJSONSchema(z.iso.datetime({ offset: true })).format).toEqual("date-time");
+    expect(z.toJSONSchema(z.iso.datetime({ precision: 0 })).format).toEqual("date-time");
+    expect(z.toJSONSchema(z.iso.datetime({ local: true })).format).toEqual(undefined);
+    expect(z.toJSONSchema(z.iso.datetime({ precision: -1 })).format).toEqual(undefined);
+    expect(z.toJSONSchema(z.string().check(z.iso.datetime({ local: true }))).format).toEqual(undefined);
+    expect(z.toJSONSchema(z.string().check(z.iso.datetime())).format).toEqual("date-time");
+    // The pattern still describes what the schema accepts either way.
+    expect(z.toJSONSchema(z.iso.datetime({ local: true })).pattern).toBeDefined();
+
     expect(z.toJSONSchema(z.iso.time())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -39,7 +39,7 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
     json.format = formatMap[format as checks.$ZodStringFormats] ?? format;
     if (json.format === "") delete json.format; // empty format is not valid
 
-    // JSON Schema format: "time" requires a full time with offset or Z. z.iso.time() does not include timezone information, so format: "time" should never be used
+    // `time` is RFC 3339 full-time, which `z.iso.time()` never is; `laxFormat` carries the datetime shapes that likewise accept what their keyword forbids.
     if (format === "time" || laxFormat) {
       delete json.format;
     }

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -30,7 +30,7 @@ const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> =
 export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _json, _params) => {
   const json = _json as JSONSchema.StringSchema;
   json.type = "string";
-  const { minimum, maximum, format, patterns, contentEncoding } = schema._zod
+  const { minimum, maximum, format, patterns, contentEncoding, laxFormat } = schema._zod
     .bag as schemas.$ZodStringInternals<unknown>["bag"];
   if (typeof minimum === "number") json.minLength = minimum;
   if (typeof maximum === "number") json.maxLength = maximum;
@@ -40,7 +40,7 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
     if (json.format === "") delete json.format; // empty format is not valid
 
     // JSON Schema format: "time" requires a full time with offset or Z. z.iso.time() does not include timezone information, so format: "time" should never be used
-    if (format === "time") {
+    if (format === "time" || laxFormat) {
       delete json.format;
     }
   }

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -39,7 +39,7 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
     json.format = formatMap[format as checks.$ZodStringFormats] ?? format;
     if (json.format === "") delete json.format; // empty format is not valid
 
-    // `time` is RFC 3339 full-time, which `z.iso.time()` never is; `laxFormat` carries the datetime shapes that likewise accept what their keyword forbids.
+    // `z.iso.time()` is never full-time, and `laxFormat` carries the datetime shapes that also accept what their keyword forbids
     if (format === "time" || laxFormat) {
       delete json.format;
     }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -368,6 +368,8 @@ export interface $ZodStringInternals<Input> extends $ZodTypeInternals<string, In
     patterns: Set<RegExp>;
     format: string;
     contentEncoding: string;
+    /** The pattern admits strings the JSON Schema keyword named by `format` forbids, so `toJSONSchema` must not emit that keyword. */
+    laxFormat: boolean;
   }>;
 }
 
@@ -760,6 +762,14 @@ export const $ZodISODateTime: core.$constructor<$ZodISODateTime> = /*@__PURE__*/
   (inst, def): void => {
     def.pattern ??= regexes.datetime(def);
     $ZodStringFormat.init(inst, def);
+
+    // `local` drops the offset and `precision: -1` drops the seconds, and RFC 3339 `date-time` requires both — so these two opt out of the keyword they would otherwise advertise. Only they pay: the flag rides the bag rather than the def because the string a format check attaches to is a different schema under `z.string().check(...)`, and `init` has already run the attach list.
+    if (def.local || def.precision === -1) {
+      inst._zod.bag.laxFormat = true;
+      inst._zod.onattach.push((s) => {
+        (s._zod.bag as $ZodStringInternals<unknown>["bag"]).laxFormat = true;
+      });
+    }
   }
 );
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -763,7 +763,7 @@ export const $ZodISODateTime: core.$constructor<$ZodISODateTime> = /*@__PURE__*/
     def.pattern ??= regexes.datetime(def);
     $ZodStringFormat.init(inst, def);
 
-    // `local` drops the offset and `precision: -1` drops the seconds, and RFC 3339 `date-time` requires both — so these two opt out of the keyword they would otherwise advertise. Only they pay: the flag rides the bag rather than the def because the string a format check attaches to is a different schema under `z.string().check(...)`, and `init` has already run the attach list.
+    // These two drop the offset or the seconds RFC 3339 `date-time` requires, so they must not advertise the keyword — on the bag, not the def, since `z.string().check(...)` lands the format on a different schema.
     if (def.local || def.precision === -1) {
       inst._zod.bag.laxFormat = true;
       inst._zod.onattach.push((s) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -368,7 +368,7 @@ export interface $ZodStringInternals<Input> extends $ZodTypeInternals<string, In
     patterns: Set<RegExp>;
     format: string;
     contentEncoding: string;
-    /** The pattern admits strings the JSON Schema keyword named by `format` forbids, so `toJSONSchema` must not emit that keyword. */
+    /** the pattern admits strings its `format` keyword forbids, so `toJSONSchema` must not emit it */
     laxFormat: boolean;
   }>;
 }
@@ -763,7 +763,7 @@ export const $ZodISODateTime: core.$constructor<$ZodISODateTime> = /*@__PURE__*/
     def.pattern ??= regexes.datetime(def);
     $ZodStringFormat.init(inst, def);
 
-    // These two drop the offset or the seconds RFC 3339 `date-time` requires, so they must not advertise the keyword — on the bag, not the def, since `z.string().check(...)` lands the format on a different schema.
+    // these two drop the offset or seconds `date-time` requires — on the bag not the def, since `z.string().check(...)` lands the format on a different schema
     if (def.local || def.precision === -1) {
       inst._zod.bag.laxFormat = true;
       inst._zod.onattach.push((s) => {


### PR DESCRIPTION
Two JSON Schema date/time keywords were wrong in opposite directions.

**`fromJSONSchema` rejected everything `format: "time"` means.** The keyword is RFC 3339 `full-time` — seconds mandatory, `Z` or a numeric offset mandatory — and it was mapped onto `z.iso.time()`, which is `partial-time`:

```ts
const s = z.fromJSONSchema({ type: "string", format: "time" });

s.safeParse("10:15:30Z");      // false — the only shape full-time allows
s.safeParse("10:15:30+02:00"); // false
s.safeParse("10:15:30");       // true  — full-time forbids this
s.safeParse("10:15");          // true
```

Every OpenAPI `format: time` field round-tripped into a schema that rejects its own valid payloads. It was the only one of the four date/time formats affected; `date-time`, `date` and `duration` were already correct.

**`toJSONSchema` advertised `format: "date-time"` for schemas that are not one.** RFC 3339 `date-time` requires both an offset and seconds; `local: true` drops the first and `precision: -1` drops the second, yet both still emitted the keyword, so a validator asserting it rejected payloads Zod accepts. Those two now ship their pattern alone. The bare call, `{ offset: true }` and any `precision >= 0` are unchanged.

The parse side is deliberately untouched. `z.iso.datetime()` also accepts `2020-01-01T06:15Z`, which is not RFC 3339 either, but that is documented behaviour — "by default, seconds are optional", with the no-seconds example marked ✅ — so the defect there is the advertisement, not the parse. Gating on it too would have stripped `format: "date-time"` from the bare call and from `{ offset: true }`, which is very nearly every real schema.

No new public API. A bare time carrying an offset is not worth one: Temporal has no offset-time type, `Temporal.PlainTime.from("10:15:30Z")` throws, and Postgres documents its own `time with time zone` as of questionable usefulness for the same reason — an offset cannot be resolved without a date. Anyone who needs that shape has `z.string().regex(...)` with a `format` in `.meta()`, which already produces both the parse and the JSON Schema output.

Bundle, esbuild `--minify` under `--conditions=@zod/source`, gzip -9: +49 B for a classic `z.iso.datetime()` bundle, +44 B for a classic `z.string().min(5)` one (`ZodString.prototype.datetime` keeps the constructor reachable), +31 B for mini `z.iso.datetime()`, and 0 B for mini `z.boolean()`. Instances stay in fast properties and own-property counts are unchanged.

Closes #6204. Supersedes #6365.
