### PR TITLE
fix(v4): resolve ZodObject shape and config against `this`

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1571,12 +1571,12 @@ export interface ZodObject<
    */
   merge<U extends ZodObject>(other: U): ZodObject<util.Extend<this["shape"], U["shape"]>, U["_zod"]["config"]>;
 
-  // no `Record<Exclude<keyof M, keyof Shape>, never>` guard — no formulation rejects a mixed mask and still accepts a chained generic receiver; an unrecognized key throws when the shape is first read
-  pick<M extends util.Mask<keyof Shape>>(
+  // the mask is typed `util.Mask<PropertyKey>` rather than against `Shape` — every narrower form also rejects a valid mask once the receiver's shape is deferred, so an unrecognized key is caught when the shape is first read instead
+  pick<M extends util.Mask<PropertyKey>>(
     mask: M
   ): ZodObject<util.Flatten<Pick<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;
 
-  omit<M extends util.Mask<keyof Shape>>(
+  omit<M extends util.Mask<PropertyKey>>(
     mask: M
   ): ZodObject<util.Flatten<Omit<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;
 
@@ -1586,7 +1586,7 @@ export interface ZodObject<
     },
     this["_zod"]["config"]
   >;
-  partial<M extends util.Mask<keyof Shape>>(
+  partial<M extends util.Mask<PropertyKey>>(
     mask: M
   ): ZodObject<
     {
@@ -1607,7 +1607,7 @@ export interface ZodObject<
     },
     this["_zod"]["config"]
   >;
-  exactPartial<M extends util.Mask<keyof Shape>>(
+  exactPartial<M extends util.Mask<PropertyKey>>(
     mask: M
   ): ZodObject<
     {
@@ -1623,7 +1623,7 @@ export interface ZodObject<
     },
     this["_zod"]["config"]
   >;
-  required<M extends util.Mask<keyof Shape>>(
+  required<M extends util.Mask<PropertyKey>>(
     mask: M
   ): ZodObject<
     {

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1542,90 +1542,93 @@ export interface ZodObject<
   "~standard": ZodStandardSchemaWithJSON<this>;
   shape: Shape;
 
-  keyof(): ZodEnum<util.ToEnum<keyof Shape & string>>;
+  // Return types index `this` instead of naming `Shape`/`Config` directly. TypeScript resolves a member of `T extends ZodObject` through the constraint, so naming the parameter collapses the result to the `ZodObject` default whenever a method is called on a bare type parameter. Parameter types deliberately stay on `Shape`: deferring those leaves `safeExtend`'s conditional shape unresolvable and rejects calls that compile today.
+  keyof(): ZodEnum<util.ToEnum<keyof this["shape"] & string>>;
   /** Define a schema to validate all unrecognized keys. This overrides the existing strict/loose behavior. */
-  catchall<T extends core.SomeType>(schema: T): ZodObject<Shape, core.$catchall<T>>;
+  catchall<T extends core.SomeType>(schema: T): ZodObject<this["shape"], core.$catchall<T>>;
 
   /** @deprecated Use `z.looseObject()` or `.loose()` instead. */
-  passthrough(): ZodObject<Shape, core.$loose>;
+  passthrough(): ZodObject<this["shape"], core.$loose>;
   /** Consider `z.looseObject(A.shape)` instead */
-  loose(): ZodObject<Shape, core.$loose>;
+  loose(): ZodObject<this["shape"], core.$loose>;
 
   /** Consider `z.strictObject(A.shape)` instead */
-  strict(): ZodObject<Shape, core.$strict>;
+  strict(): ZodObject<this["shape"], core.$strict>;
 
   /** This is the default behavior. This method call is likely unnecessary. */
-  strip(): ZodObject<Shape, core.$strip>;
+  strip(): ZodObject<this["shape"], core.$strip>;
 
-  extend<U extends core.$ZodLooseShape>(shape: U): ZodObject<util.Extend<Shape, util.Writeable<U>>, Config>;
+  extend<U extends core.$ZodLooseShape>(
+    shape: U
+  ): ZodObject<util.Extend<this["shape"], util.Writeable<U>>, this["_zod"]["config"]>;
 
   safeExtend<U extends core.$ZodLooseShape>(
     shape: SafeExtendShape<Shape, U> & Partial<Record<keyof Shape, core.SomeType>>
-  ): ZodObject<util.Extend<Shape, util.Writeable<U>>, Config>;
+  ): ZodObject<util.Extend<this["shape"], util.Writeable<U>>, this["_zod"]["config"]>;
 
   /**
    * @deprecated Use [`A.extend(B.shape)`](https://zod.dev/api?id=extend) instead.
    */
-  merge<U extends ZodObject>(other: U): ZodObject<util.Extend<Shape, U["shape"]>, U["_zod"]["config"]>;
+  merge<U extends ZodObject>(other: U): ZodObject<util.Extend<this["shape"], U["shape"]>, U["_zod"]["config"]>;
 
   pick<M extends util.Mask<keyof Shape>>(
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
-  ): ZodObject<util.Flatten<Pick<Shape, Extract<keyof Shape, keyof M>>>, Config>;
+  ): ZodObject<util.Flatten<Pick<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;
 
   omit<M extends util.Mask<keyof Shape>>(
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
-  ): ZodObject<util.Flatten<Omit<Shape, Extract<keyof Shape, keyof M>>>, Config>;
+  ): ZodObject<util.Flatten<Omit<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;
 
   partial(): ZodObject<
     {
-      -readonly [k in keyof Shape]: ZodOptional<Shape[k]>;
+      -readonly [k in keyof this["shape"]]: ZodOptional<this["shape"][k]>;
     },
-    Config
+    this["_zod"]["config"]
   >;
   partial<M extends util.Mask<keyof Shape>>(
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
   ): ZodObject<
     {
-      -readonly [k in keyof Shape]: k extends keyof M
-        ? // Shape[k] extends OptionalInSchema
-          //   ? Shape[k]
+      -readonly [k in keyof this["shape"]]: k extends keyof M
+        ? // this["shape"][k] extends OptionalInSchema
+          //   ? this["shape"][k]
           //   :
-          ZodOptional<Shape[k]>
-        : Shape[k];
+          ZodOptional<this["shape"][k]>
+        : this["shape"][k];
     },
-    Config
+    this["_zod"]["config"]
   >;
 
   // exactPartial
   exactPartial(): ZodObject<
     {
-      -readonly [k in keyof Shape]: ZodExactOptional<Shape[k]>;
+      -readonly [k in keyof this["shape"]]: ZodExactOptional<this["shape"][k]>;
     },
-    Config
+    this["_zod"]["config"]
   >;
   exactPartial<M extends util.Mask<keyof Shape>>(
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
   ): ZodObject<
     {
-      -readonly [k in keyof Shape]: k extends keyof M ? ZodExactOptional<Shape[k]> : Shape[k];
+      -readonly [k in keyof this["shape"]]: k extends keyof M ? ZodExactOptional<this["shape"][k]> : this["shape"][k];
     },
-    Config
+    this["_zod"]["config"]
   >;
 
   // required
   required(): ZodObject<
     {
-      -readonly [k in keyof Shape]: ZodNonOptional<Shape[k]>;
+      -readonly [k in keyof this["shape"]]: ZodNonOptional<this["shape"][k]>;
     },
-    Config
+    this["_zod"]["config"]
   >;
   required<M extends util.Mask<keyof Shape>>(
     mask: M & Record<Exclude<keyof M, keyof Shape>, never>
   ): ZodObject<
     {
-      -readonly [k in keyof Shape]: k extends keyof M ? ZodNonOptional<Shape[k]> : Shape[k];
+      -readonly [k in keyof this["shape"]]: k extends keyof M ? ZodNonOptional<this["shape"][k]> : this["shape"][k];
     },
-    Config
+    this["_zod"]["config"]
   >;
 }
 

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1571,12 +1571,12 @@ export interface ZodObject<
    */
   merge<U extends ZodObject>(other: U): ZodObject<util.Extend<this["shape"], U["shape"]>, U["_zod"]["config"]>;
 
-  // the mask is typed `util.Mask<PropertyKey>` rather than against `Shape` — every narrower form also rejects a valid mask once the receiver's shape is deferred, so an unrecognized key is caught when the shape is first read instead
-  pick<M extends util.Mask<PropertyKey>>(
+  // the mask constraint is inline rather than `util.Mask<keyof Shape>` — a homomorphic mapped type defers while the receiver's shape is generic, then checks normally once it resolves
+  pick<M extends { [K in keyof this["shape"]]?: true }>(
     mask: M
   ): ZodObject<util.Flatten<Pick<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;
 
-  omit<M extends util.Mask<PropertyKey>>(
+  omit<M extends { [K in keyof this["shape"]]?: true }>(
     mask: M
   ): ZodObject<util.Flatten<Omit<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;
 
@@ -1586,7 +1586,7 @@ export interface ZodObject<
     },
     this["_zod"]["config"]
   >;
-  partial<M extends util.Mask<PropertyKey>>(
+  partial<M extends { [K in keyof this["shape"]]?: true }>(
     mask: M
   ): ZodObject<
     {
@@ -1607,7 +1607,7 @@ export interface ZodObject<
     },
     this["_zod"]["config"]
   >;
-  exactPartial<M extends util.Mask<PropertyKey>>(
+  exactPartial<M extends { [K in keyof this["shape"]]?: true }>(
     mask: M
   ): ZodObject<
     {
@@ -1623,7 +1623,7 @@ export interface ZodObject<
     },
     this["_zod"]["config"]
   >;
-  required<M extends util.Mask<PropertyKey>>(
+  required<M extends { [K in keyof this["shape"]]?: true }>(
     mask: M
   ): ZodObject<
     {

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1542,7 +1542,7 @@ export interface ZodObject<
   "~standard": ZodStandardSchemaWithJSON<this>;
   shape: Shape;
 
-  // Return types index `this` instead of naming `Shape`/`Config` directly. TypeScript resolves a member of `T extends ZodObject` through the constraint, so naming the parameter collapses the result to the `ZodObject` default whenever a method is called on a bare type parameter. Parameter types deliberately stay on `Shape`: deferring those leaves `safeExtend`'s conditional shape unresolvable and rejects calls that compile today.
+  // return types index `this`, not `Shape`/`Config` — naming the parameter resolves it through the constraint and collapses to the `ZodObject` default on a bare type parameter
   keyof(): ZodEnum<util.ToEnum<keyof this["shape"] & string>>;
   /** Define a schema to validate all unrecognized keys. This overrides the existing strict/loose behavior. */
   catchall<T extends core.SomeType>(schema: T): ZodObject<this["shape"], core.$catchall<T>>;
@@ -1571,12 +1571,13 @@ export interface ZodObject<
    */
   merge<U extends ZodObject>(other: U): ZodObject<util.Extend<this["shape"], U["shape"]>, U["_zod"]["config"]>;
 
+  // no `Record<Exclude<keyof M, keyof Shape>, never>` guard — it cannot resolve once `Shape` is deferred, so it rejected every chained call; `util.pick` still throws on an unrecognized key
   pick<M extends util.Mask<keyof Shape>>(
-    mask: M & Record<Exclude<keyof M, keyof Shape>, never>
+    mask: M
   ): ZodObject<util.Flatten<Pick<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;
 
   omit<M extends util.Mask<keyof Shape>>(
-    mask: M & Record<Exclude<keyof M, keyof Shape>, never>
+    mask: M
   ): ZodObject<util.Flatten<Omit<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;
 
   partial(): ZodObject<
@@ -1586,7 +1587,7 @@ export interface ZodObject<
     this["_zod"]["config"]
   >;
   partial<M extends util.Mask<keyof Shape>>(
-    mask: M & Record<Exclude<keyof M, keyof Shape>, never>
+    mask: M
   ): ZodObject<
     {
       -readonly [k in keyof this["shape"]]: k extends keyof M
@@ -1607,7 +1608,7 @@ export interface ZodObject<
     this["_zod"]["config"]
   >;
   exactPartial<M extends util.Mask<keyof Shape>>(
-    mask: M & Record<Exclude<keyof M, keyof Shape>, never>
+    mask: M
   ): ZodObject<
     {
       -readonly [k in keyof this["shape"]]: k extends keyof M ? ZodExactOptional<this["shape"][k]> : this["shape"][k];
@@ -1623,7 +1624,7 @@ export interface ZodObject<
     this["_zod"]["config"]
   >;
   required<M extends util.Mask<keyof Shape>>(
-    mask: M & Record<Exclude<keyof M, keyof Shape>, never>
+    mask: M
   ): ZodObject<
     {
       -readonly [k in keyof this["shape"]]: k extends keyof M ? ZodNonOptional<this["shape"][k]> : this["shape"][k];

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1571,7 +1571,7 @@ export interface ZodObject<
    */
   merge<U extends ZodObject>(other: U): ZodObject<util.Extend<this["shape"], U["shape"]>, U["_zod"]["config"]>;
 
-  // no `Record<Exclude<keyof M, keyof Shape>, never>` guard — it cannot resolve once `Shape` is deferred, so it rejected every chained call; `util.pick` still throws on an unrecognized key
+  // no `Record<Exclude<keyof M, keyof Shape>, never>` guard — no formulation rejects a mixed mask and still accepts a chained generic receiver; an unrecognized key throws when the shape is first read
   pick<M extends util.Mask<keyof Shape>>(
     mask: M
   ): ZodObject<util.Flatten<Pick<this["shape"], Extract<keyof this["shape"], keyof M>>>, this["_zod"]["config"]>;

--- a/packages/zod/src/v4/classic/tests/generics.test.ts
+++ b/packages/zod/src/v4/classic/tests/generics.test.ts
@@ -159,12 +159,16 @@ test("chained object methods keep the shape through a generic wrapper", () => {
   const looseRequired = <T extends z.ZodObject>(s: T) => s.loose().required({ b: true });
   const catchallPartial = <T extends z.ZodObject>(s: T) => s.catchall(z.string()).partial({ a: true });
   const stripExactPartial = <T extends z.ZodObject>(s: T) => s.strip().exactPartial({ a: true });
+  const extendPick = <T extends z.ZodObject>(s: T) => s.extend({ c: z.boolean() }).pick({ a: true });
+  const mergeOmit = <T extends z.ZodObject>(s: T) => s.merge(z.object({ c: z.boolean() })).omit({ a: true });
 
   expectTypeOf<Infer<typeof strictPick<Src>>>().toEqualTypeOf<{ a: string }>();
   expectTypeOf<Infer<typeof partialOmit<Src>>>().toEqualTypeOf<{ b?: number | undefined }>();
   expectTypeOf<Infer<typeof looseRequired<Src>>["b"]>().toEqualTypeOf<number>();
   expectTypeOf<Infer<typeof catchallPartial<Src>>["a"]>().toEqualTypeOf<string | undefined>();
   expectTypeOf<Infer<typeof stripExactPartial<Src>>>().toEqualTypeOf<{ a?: string; b?: number | undefined }>();
+  expectTypeOf<Infer<typeof extendPick<Src>>>().toEqualTypeOf<{ a: string }>();
+  expectTypeOf<Infer<typeof mergeOmit<Src>>>().toEqualTypeOf<{ c: boolean; b?: number | undefined }>();
 
   // known limitation: safeExtend keeps a compatibility guard that references `Shape`, and it cannot resolve against a chained receiver
   // @ts-expect-error

--- a/packages/zod/src/v4/classic/tests/generics.test.ts
+++ b/packages/zod/src/v4/classic/tests/generics.test.ts
@@ -147,3 +147,27 @@ test("a recursive schema survives a generic wrapper", () => {
     children: [{ id: "b", children: [] }],
   });
 });
+
+// chaining a mask-taking method onto another object method is the case the excess-key guard used to reject
+test("chained object methods keep the shape through a generic wrapper", () => {
+  const src = z.object({ a: z.string(), b: z.number().optional() });
+  type Src = typeof src;
+  type Infer<F extends (...args: never) => z.ZodType> = z.infer<ReturnType<F>>;
+
+  const strictPick = <T extends z.ZodObject>(s: T) => s.strict().pick({ a: true });
+  const partialOmit = <T extends z.ZodObject>(s: T) => s.partial().omit({ a: true });
+  const looseRequired = <T extends z.ZodObject>(s: T) => s.loose().required({ b: true });
+  const catchallPartial = <T extends z.ZodObject>(s: T) => s.catchall(z.string()).partial({ a: true });
+  const stripExactPartial = <T extends z.ZodObject>(s: T) => s.strip().exactPartial({ a: true });
+
+  expectTypeOf<Infer<typeof strictPick<Src>>>().toEqualTypeOf<{ a: string }>();
+  expectTypeOf<Infer<typeof partialOmit<Src>>>().toEqualTypeOf<{ b?: number | undefined }>();
+  expectTypeOf<Infer<typeof looseRequired<Src>>["b"]>().toEqualTypeOf<number>();
+  expectTypeOf<Infer<typeof catchallPartial<Src>>["a"]>().toEqualTypeOf<string | undefined>();
+  expectTypeOf<Infer<typeof stripExactPartial<Src>>>().toEqualTypeOf<{ a?: string; b?: number | undefined }>();
+
+  // known limitation: safeExtend keeps a compatibility guard that references `Shape`, and it cannot resolve against a chained receiver
+  // @ts-expect-error
+  const _chainedSafeExtend = <T extends z.ZodObject>(s: T) => s.strict().safeExtend({ x: z.bigint() });
+  void _chainedSafeExtend;
+});

--- a/packages/zod/src/v4/classic/tests/generics.test.ts
+++ b/packages/zod/src/v4/classic/tests/generics.test.ts
@@ -70,3 +70,80 @@ test("generic on output type", () => {
     }),
   })?._zod?.output?.name;
 });
+
+// Every ZodObject method that returns a ZodObject resolves its shape and config against `this`, so a schema passed into a generic wrapper keeps its concrete shape instead of collapsing to the `ZodObject` default.
+test("object methods keep the shape through a generic wrapper", () => {
+  const src = z.object({ a: z.string(), b: z.number().optional() });
+  type Src = typeof src;
+  type Infer<F extends (...args: never) => z.ZodType> = z.infer<ReturnType<F>>;
+  type Base = { a: string; b?: number | undefined };
+
+  const keyof_ = <T extends z.ZodObject>(s: T) => s.keyof();
+  const catchall = <T extends z.ZodObject>(s: T) => s.catchall(z.bigint());
+  const passthrough = <T extends z.ZodObject>(s: T) => s.passthrough();
+  const loose = <T extends z.ZodObject>(s: T) => s.loose();
+  const strict = <T extends z.ZodObject>(s: T) => s.strict();
+  const strip = <T extends z.ZodObject>(s: T) => s.strip();
+  const extend = <T extends z.ZodObject>(s: T) => s.extend({ c: z.boolean() });
+  const safeExtend = <T extends z.ZodObject>(s: T) => s.safeExtend({ c: z.boolean() });
+  const merge = <T extends z.ZodObject>(s: T) => s.merge(z.object({ c: z.boolean() }));
+  const pick = <T extends z.ZodObject>(s: T) => s.pick({ a: true });
+  const omit = <T extends z.ZodObject>(s: T) => s.omit({ a: true });
+  const partial = <T extends z.ZodObject>(s: T) => s.partial();
+  const partialMask = <T extends z.ZodObject>(s: T) => s.partial({ a: true });
+  const exactPartial = <T extends z.ZodObject>(s: T) => s.exactPartial();
+  const exactPartialMask = <T extends z.ZodObject>(s: T) => s.exactPartial({ a: true });
+  const required = <T extends z.ZodObject>(s: T) => s.required();
+  const requiredMask = <T extends z.ZodObject>(s: T) => s.required({ b: true });
+
+  expectTypeOf<Infer<typeof keyof_<Src>>>().toEqualTypeOf<"a" | "b">();
+  expectTypeOf<Infer<typeof strict<Src>>>().toEqualTypeOf<Base>();
+  expectTypeOf<Infer<typeof strip<Src>>>().toEqualTypeOf<Base>();
+  expectTypeOf<Infer<typeof extend<Src>>>().toEqualTypeOf<{ a: string; c: boolean; b?: number | undefined }>();
+  expectTypeOf<Infer<typeof safeExtend<Src>>>().toEqualTypeOf<{ a: string; c: boolean; b?: number | undefined }>();
+  expectTypeOf<Infer<typeof merge<Src>>>().toEqualTypeOf<{ a: string; c: boolean; b?: number | undefined }>();
+  expectTypeOf<Infer<typeof pick<Src>>>().toEqualTypeOf<{ a: string }>();
+  expectTypeOf<Infer<typeof omit<Src>>>().toEqualTypeOf<{ b?: number | undefined }>();
+  expectTypeOf<Infer<typeof partial<Src>>>().toEqualTypeOf<{ a?: string | undefined; b?: number | undefined }>();
+  expectTypeOf<Infer<typeof partialMask<Src>>>().toEqualTypeOf<{ a?: string | undefined; b?: number | undefined }>();
+  expectTypeOf<Infer<typeof exactPartial<Src>>>().toEqualTypeOf<{ a?: string; b?: number | undefined }>();
+  expectTypeOf<Infer<typeof exactPartialMask<Src>>>().toEqualTypeOf<{ a?: string; b?: number | undefined }>();
+  expectTypeOf<Infer<typeof required<Src>>>().toEqualTypeOf<{ a: string; b: number }>();
+  expectTypeOf<Infer<typeof requiredMask<Src>>>().toEqualTypeOf<{ a: string; b: number }>();
+
+  // The catchall variants carry an index signature alongside the concrete keys, so assert the keys directly.
+  expectTypeOf<Infer<typeof catchall<Src>>["a"]>().toEqualTypeOf<string>();
+  expectTypeOf<Infer<typeof catchall<Src>>[string]>().toEqualTypeOf<bigint>();
+  expectTypeOf<Infer<typeof passthrough<Src>>["a"]>().toEqualTypeOf<string>();
+  expectTypeOf<Infer<typeof loose<Src>>["a"]>().toEqualTypeOf<string>();
+  expectTypeOf<Infer<typeof loose<Src>>[string]>().toEqualTypeOf<unknown>();
+});
+
+test("object methods keep the catchall config through a generic wrapper", () => {
+  const strictSrc = z.strictObject({ a: z.string() });
+  const looseSrc = z.looseObject({ a: z.string() });
+  const partial = <T extends z.ZodObject>(s: T) => s.partial();
+  const pick = <T extends z.ZodObject>(s: T) => s.pick({ a: true });
+
+  expectTypeOf<ReturnType<typeof partial<typeof strictSrc>>["_zod"]["config"]>().toEqualTypeOf<z.core.$strict>();
+  expectTypeOf<ReturnType<typeof pick<typeof looseSrc>>["_zod"]["config"]>().toEqualTypeOf<z.core.$loose>();
+});
+
+test("a recursive schema survives a generic wrapper", () => {
+  const Node = z.object({
+    id: z.string(),
+    get children() {
+      return z.array(Node);
+    },
+  });
+  const strict = <T extends z.ZodObject>(s: T) => s.strict();
+  const StrictNode = strict(Node);
+
+  type StrictNode = z.infer<typeof StrictNode>;
+  expectTypeOf<StrictNode["id"]>().toEqualTypeOf<string>();
+  expectTypeOf<StrictNode["children"][number]["children"][number]["id"]>().toEqualTypeOf<string>();
+  expect(StrictNode.parse({ id: "a", children: [{ id: "b", children: [] }] })).toEqual({
+    id: "a",
+    children: [{ id: "b", children: [] }],
+  });
+});

--- a/packages/zod/src/v4/classic/tests/pickomit.test.ts
+++ b/packages/zod/src/v4/classic/tests/pickomit.test.ts
@@ -114,17 +114,13 @@ test("pick/omit/required/partial - do not allow unknown keys", () => {
     age: z.number(),
   });
 
-  // Mixed valid + invalid keys
-  // @ts-expect-error
+  // mixed valid + invalid keys are caught at runtime only — the mask type cannot reject them once the shape is deferred
   expect(() => schema.pick({ name: true, asdf: true }).safeParse({})).toThrow();
-  // @ts-expect-error
   expect(() => schema.omit({ name: true, asdf: true }).safeParse({})).toThrow();
-  // @ts-expect-error
   expect(() => schema.partial({ name: true, asdf: true }).safeParse({})).toThrow();
-  // @ts-expect-error
   expect(() => schema.required({ name: true, asdf: true }).safeParse({})).toThrow();
 
-  // Only invalid keys
+  // an all-invalid mask still fails to compile, since it has no key in common with the shape
   // @ts-expect-error
   expect(() => schema.pick({ $unknown: true }).safeParse({})).toThrow();
   // @ts-expect-error

--- a/packages/zod/src/v4/classic/tests/pickomit.test.ts
+++ b/packages/zod/src/v4/classic/tests/pickomit.test.ts
@@ -114,20 +114,16 @@ test("pick/omit/required/partial - do not allow unknown keys", () => {
     age: z.number(),
   });
 
-  // mixed valid + invalid keys are caught at runtime only — a mask guard that rejects them cannot also accept a chained generic receiver
+  // mask keys are validated at runtime only — every compile-time formulation that rejects them also rejects a valid mask on a generic receiver
   expect(() => schema.pick({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.omit({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.partial({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.required({ name: true, asdf: true }).safeParse({})).toThrow();
 
-  // an all-invalid mask still fails to compile, since it has no key in common with the shape
-  // @ts-expect-error
+  // an all-invalid mask is caught at runtime too — the mask type accepts any key so that a generic receiver still resolves
   expect(() => schema.pick({ $unknown: true }).safeParse({})).toThrow();
-  // @ts-expect-error
   expect(() => schema.omit({ $unknown: true }).safeParse({})).toThrow();
-  // @ts-expect-error
   expect(() => schema.required({ $unknown: true }).safeParse({})).toThrow();
-  // @ts-expect-error
   expect(() => schema.partial({ $unknown: true }).safeParse({})).toThrow();
 });
 

--- a/packages/zod/src/v4/classic/tests/pickomit.test.ts
+++ b/packages/zod/src/v4/classic/tests/pickomit.test.ts
@@ -114,7 +114,7 @@ test("pick/omit/required/partial - do not allow unknown keys", () => {
     age: z.number(),
   });
 
-  // mixed valid + invalid keys are caught at runtime only — the mask type cannot reject them once the shape is deferred
+  // mixed valid + invalid keys are caught at runtime only — a mask guard that rejects them cannot also accept a chained generic receiver
   expect(() => schema.pick({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.omit({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.partial({ name: true, asdf: true }).safeParse({})).toThrow();

--- a/packages/zod/src/v4/classic/tests/pickomit.test.ts
+++ b/packages/zod/src/v4/classic/tests/pickomit.test.ts
@@ -119,6 +119,7 @@ test("pick/omit/required/partial - do not allow unknown keys", () => {
   expect(() => schema.omit({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.partial({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.required({ name: true, asdf: true }).safeParse({})).toThrow();
+  expect(() => schema.exactPartial({ name: true, asdf: true }).safeParse({})).toThrow();
 
   // an all-invalid mask is still rejected at compile time — the mask constraint defers while the receiver's shape is generic, then checks normally once it resolves
   // @ts-expect-error
@@ -129,6 +130,8 @@ test("pick/omit/required/partial - do not allow unknown keys", () => {
   expect(() => schema.required({ $unknown: true }).safeParse({})).toThrow();
   // @ts-expect-error
   expect(() => schema.partial({ $unknown: true }).safeParse({})).toThrow();
+  // @ts-expect-error
+  expect(() => schema.exactPartial({ $unknown: true }).safeParse({})).toThrow();
 });
 
 test("pick - throws error on schema with refinements", () => {

--- a/packages/zod/src/v4/classic/tests/pickomit.test.ts
+++ b/packages/zod/src/v4/classic/tests/pickomit.test.ts
@@ -114,16 +114,20 @@ test("pick/omit/required/partial - do not allow unknown keys", () => {
     age: z.number(),
   });
 
-  // mask keys are validated at runtime only — every compile-time formulation that rejects them also rejects a valid mask on a generic receiver
+  // a mask mixing valid and invalid keys is caught at runtime only — no constraint rejects it without also rejecting a valid mask on a generic receiver
   expect(() => schema.pick({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.omit({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.partial({ name: true, asdf: true }).safeParse({})).toThrow();
   expect(() => schema.required({ name: true, asdf: true }).safeParse({})).toThrow();
 
-  // an all-invalid mask is caught at runtime too — the mask type accepts any key so that a generic receiver still resolves
+  // an all-invalid mask is still rejected at compile time — the mask constraint defers while the receiver's shape is generic, then checks normally once it resolves
+  // @ts-expect-error
   expect(() => schema.pick({ $unknown: true }).safeParse({})).toThrow();
+  // @ts-expect-error
   expect(() => schema.omit({ $unknown: true }).safeParse({})).toThrow();
+  // @ts-expect-error
   expect(() => schema.required({ $unknown: true }).safeParse({})).toThrow();
+  // @ts-expect-error
   expect(() => schema.partial({ $unknown: true }).safeParse({})).toThrow();
 });
 

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -964,6 +964,7 @@ export function merge<T extends ZodMiniObject, U extends ZodMiniObject>(
 }
 
 // @__NO_SIDE_EFFECTS__
+// the mask constraint is inline rather than `util.Mask<keyof T["shape"]>` — a homomorphic mapped type defers while the shape is generic, then checks normally once it resolves
 export function pick<T extends ZodMiniObject, M extends { [K in keyof T["shape"]]?: true }>(
   schema: T,
   mask: M

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -964,7 +964,7 @@ export function merge<T extends ZodMiniObject, U extends ZodMiniObject>(
 }
 
 // @__NO_SIDE_EFFECTS__
-export function pick<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
+export function pick<T extends ZodMiniObject, M extends { [K in keyof T["shape"]]?: true }>(
   schema: T,
   mask: M
 ): ZodMiniObject<util.Flatten<Pick<T["shape"], keyof T["shape"] & keyof M>>, T["_zod"]["config"]> {
@@ -974,7 +974,7 @@ export function pick<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
 // .omit
 
 // @__NO_SIDE_EFFECTS__
-export function omit<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
+export function omit<T extends ZodMiniObject, M extends { [K in keyof T["shape"]]?: true }>(
   schema: T,
   mask: M
 ): ZodMiniObject<util.Flatten<Omit<T["shape"], keyof M>>, T["_zod"]["config"]> {
@@ -991,7 +991,7 @@ export function partial<T extends ZodMiniObject>(
   T["_zod"]["config"]
 >;
 // @__NO_SIDE_EFFECTS__
-export function partial<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
+export function partial<T extends ZodMiniObject, M extends { [K in keyof T["shape"]]?: true }>(
   schema: T,
   mask: M
 ): ZodMiniObject<
@@ -1015,7 +1015,7 @@ export function exactPartial<T extends ZodMiniObject>(
   T["_zod"]["config"]
 >;
 // @__NO_SIDE_EFFECTS__
-export function exactPartial<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
+export function exactPartial<T extends ZodMiniObject, M extends { [K in keyof T["shape"]]?: true }>(
   schema: T,
   mask: M
 ): ZodMiniObject<
@@ -1050,7 +1050,7 @@ export function required<T extends ZodMiniObject>(
   T["_zod"]["config"]
 >;
 // @__NO_SIDE_EFFECTS__
-export function required<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
+export function required<T extends ZodMiniObject, M extends { [K in keyof T["shape"]]?: true }>(
   schema: T,
   mask: M
 ): ZodMiniObject<

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -963,8 +963,8 @@ export function merge<T extends ZodMiniObject, U extends ZodMiniObject>(
   return util.merge(a, b) as any;
 }
 
-// @__NO_SIDE_EFFECTS__
 // the mask constraint is inline rather than `util.Mask<keyof T["shape"]>` — a homomorphic mapped type defers while the shape is generic, then checks normally once it resolves
+// @__NO_SIDE_EFFECTS__
 export function pick<T extends ZodMiniObject, M extends { [K in keyof T["shape"]]?: true }>(
   schema: T,
   mask: M

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -966,7 +966,7 @@ export function merge<T extends ZodMiniObject, U extends ZodMiniObject>(
 // @__NO_SIDE_EFFECTS__
 export function pick<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
   schema: T,
-  mask: M & Record<Exclude<keyof M, keyof T["shape"]>, never>
+  mask: M
 ): ZodMiniObject<util.Flatten<Pick<T["shape"], keyof T["shape"] & keyof M>>, T["_zod"]["config"]> {
   return util.pick(schema, mask as any);
 }
@@ -976,7 +976,7 @@ export function pick<T extends ZodMiniObject, M extends util.Mask<keyof T["shape
 // @__NO_SIDE_EFFECTS__
 export function omit<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
   schema: T,
-  mask: M & Record<Exclude<keyof M, keyof T["shape"]>, never>
+  mask: M
 ): ZodMiniObject<util.Flatten<Omit<T["shape"], keyof M>>, T["_zod"]["config"]> {
   return util.omit(schema, mask);
 }
@@ -993,7 +993,7 @@ export function partial<T extends ZodMiniObject>(
 // @__NO_SIDE_EFFECTS__
 export function partial<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
   schema: T,
-  mask: M & Record<Exclude<keyof M, keyof T["shape"]>, never>
+  mask: M
 ): ZodMiniObject<
   {
     -readonly [k in keyof T["shape"]]: k extends keyof M ? ZodMiniOptional<T["shape"][k]> : T["shape"][k];
@@ -1017,7 +1017,7 @@ export function exactPartial<T extends ZodMiniObject>(
 // @__NO_SIDE_EFFECTS__
 export function exactPartial<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
   schema: T,
-  mask: M & Record<Exclude<keyof M, keyof T["shape"]>, never>
+  mask: M
 ): ZodMiniObject<
   {
     -readonly [k in keyof T["shape"]]: k extends keyof M ? ZodMiniExactOptional<T["shape"][k]> : T["shape"][k];
@@ -1052,7 +1052,7 @@ export function required<T extends ZodMiniObject>(
 // @__NO_SIDE_EFFECTS__
 export function required<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
   schema: T,
-  mask: M & Record<Exclude<keyof M, keyof T["shape"]>, never>
+  mask: M
 ): ZodMiniObject<
   util.Extend<
     T["shape"],

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -964,7 +964,7 @@ export function merge<T extends ZodMiniObject, U extends ZodMiniObject>(
 }
 
 // @__NO_SIDE_EFFECTS__
-export function pick<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
+export function pick<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
   schema: T,
   mask: M
 ): ZodMiniObject<util.Flatten<Pick<T["shape"], keyof T["shape"] & keyof M>>, T["_zod"]["config"]> {
@@ -974,7 +974,7 @@ export function pick<T extends ZodMiniObject, M extends util.Mask<keyof T["shape
 // .omit
 
 // @__NO_SIDE_EFFECTS__
-export function omit<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
+export function omit<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
   schema: T,
   mask: M
 ): ZodMiniObject<util.Flatten<Omit<T["shape"], keyof M>>, T["_zod"]["config"]> {
@@ -991,7 +991,7 @@ export function partial<T extends ZodMiniObject>(
   T["_zod"]["config"]
 >;
 // @__NO_SIDE_EFFECTS__
-export function partial<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
+export function partial<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
   schema: T,
   mask: M
 ): ZodMiniObject<
@@ -1015,7 +1015,7 @@ export function exactPartial<T extends ZodMiniObject>(
   T["_zod"]["config"]
 >;
 // @__NO_SIDE_EFFECTS__
-export function exactPartial<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
+export function exactPartial<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
   schema: T,
   mask: M
 ): ZodMiniObject<
@@ -1050,7 +1050,7 @@ export function required<T extends ZodMiniObject>(
   T["_zod"]["config"]
 >;
 // @__NO_SIDE_EFFECTS__
-export function required<T extends ZodMiniObject, M extends util.Mask<keyof T["shape"]>>(
+export function required<T extends ZodMiniObject, M extends util.Mask<PropertyKey>>(
   schema: T,
   mask: M
 ): ZodMiniObject<

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -239,14 +239,10 @@ test("z.pick/omit/partial/required - do not allow unknown keys", () => {
     age: z.number(),
   });
 
-  // Mixed valid + invalid keys - throws at parse time (lazy evaluation)
-  // @ts-expect-error
+  // mixed valid + invalid keys are caught at parse time only — a mask guard that rejects them cannot also accept a generic receiver
   expect(() => z.parse(z.pick(schema, { name: true, asdf: true }), {})).toThrow();
-  // @ts-expect-error
   expect(() => z.parse(z.omit(schema, { name: true, asdf: true }), {})).toThrow();
-  // @ts-expect-error
   expect(() => z.parse(z.partial(schema, { name: true, asdf: true }), {})).toThrow();
-  // @ts-expect-error
   expect(() => z.parse(z.required(schema, { name: true, asdf: true }), {})).toThrow();
 
   // Only invalid keys

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -255,6 +255,8 @@ test("z.pick/omit/partial/required - do not allow unknown keys", () => {
   expect(() => z.parse(z.partial(schema, { $unknown: true }), {})).toThrow();
   // @ts-expect-error
   expect(() => z.parse(z.required(schema, { $unknown: true }), {})).toThrow();
+  // @ts-expect-error
+  expect(() => z.parse(z.exactPartial(schema, { $unknown: true }), {})).toThrow();
 });
 
 test("z.catchall", () => {
@@ -293,7 +295,11 @@ test("mask helpers keep the shape through a generic wrapper", () => {
   const src = z.object({ a: z.string(), b: z.number() });
   const pick = <T extends z.ZodMiniObject>(s: T) => z.pick(s, { a: true });
   const chained = <T extends z.ZodMiniObject>(s: T) => z.pick(z.partial(s), { a: true });
+  const afterExtend = <T extends z.ZodMiniObject>(s: T) => z.pick(z.extend(s, { c: z.boolean() }), { a: true });
+  const omitAfterExtend = <T extends z.ZodMiniObject>(s: T) => z.omit(z.extend(s, { c: z.boolean() }), { a: true });
 
   expectTypeOf<z.infer<ReturnType<typeof pick<typeof src>>>>().toEqualTypeOf<{ a: string }>();
   expectTypeOf<z.infer<ReturnType<typeof chained<typeof src>>>>().toEqualTypeOf<{ a?: string | undefined }>();
+  expectTypeOf<z.infer<ReturnType<typeof afterExtend<typeof src>>>>().toEqualTypeOf<{ a: string }>();
+  expectTypeOf<z.infer<ReturnType<typeof omitAfterExtend<typeof src>>>>().toEqualTypeOf<{ b: number; c: boolean }>();
 });

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -239,21 +239,17 @@ test("z.pick/omit/partial/required - do not allow unknown keys", () => {
     age: z.number(),
   });
 
-  // mixed valid + invalid keys are caught at parse time only — a mask guard that rejects them cannot also accept a generic receiver
+  // mask keys are validated at parse time only — every compile-time formulation that rejects them also rejects a valid mask on a generic receiver
   expect(() => z.parse(z.pick(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.omit(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.partial(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.required(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.exactPartial(schema, { name: true, asdf: true }), {})).toThrow();
 
-  // Only invalid keys
-  // @ts-expect-error
+  // an all-invalid mask is caught at parse time too
   expect(() => z.parse(z.pick(schema, { $unknown: true }), {})).toThrow();
-  // @ts-expect-error
   expect(() => z.parse(z.omit(schema, { $unknown: true }), {})).toThrow();
-  // @ts-expect-error
   expect(() => z.parse(z.partial(schema, { $unknown: true }), {})).toThrow();
-  // @ts-expect-error
   expect(() => z.parse(z.required(schema, { $unknown: true }), {})).toThrow();
 });
 

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -239,17 +239,21 @@ test("z.pick/omit/partial/required - do not allow unknown keys", () => {
     age: z.number(),
   });
 
-  // mask keys are validated at parse time only — every compile-time formulation that rejects them also rejects a valid mask on a generic receiver
+  // a mask mixing valid and invalid keys is caught at parse time only — no constraint rejects it without also rejecting a valid mask on a generic receiver
   expect(() => z.parse(z.pick(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.omit(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.partial(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.required(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.exactPartial(schema, { name: true, asdf: true }), {})).toThrow();
 
-  // an all-invalid mask is caught at parse time too
+  // an all-invalid mask is still rejected at compile time
+  // @ts-expect-error
   expect(() => z.parse(z.pick(schema, { $unknown: true }), {})).toThrow();
+  // @ts-expect-error
   expect(() => z.parse(z.omit(schema, { $unknown: true }), {})).toThrow();
+  // @ts-expect-error
   expect(() => z.parse(z.partial(schema, { $unknown: true }), {})).toThrow();
+  // @ts-expect-error
   expect(() => z.parse(z.required(schema, { $unknown: true }), {})).toThrow();
 });
 

--- a/packages/zod/src/v4/mini/tests/object.test.ts
+++ b/packages/zod/src/v4/mini/tests/object.test.ts
@@ -244,6 +244,7 @@ test("z.pick/omit/partial/required - do not allow unknown keys", () => {
   expect(() => z.parse(z.omit(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.partial(schema, { name: true, asdf: true }), {})).toThrow();
   expect(() => z.parse(z.required(schema, { name: true, asdf: true }), {})).toThrow();
+  expect(() => z.parse(z.exactPartial(schema, { name: true, asdf: true }), {})).toThrow();
 
   // Only invalid keys
   // @ts-expect-error
@@ -285,4 +286,14 @@ test("z.catchall", () => {
   });
 
   expect(() => schema.parse({ name: "john", age: 30 })).toThrow();
+});
+
+// the mask helpers take the schema as an argument, so `T["shape"]` was already deferred and an excess-key guard rejected every generic receiver
+test("mask helpers keep the shape through a generic wrapper", () => {
+  const src = z.object({ a: z.string(), b: z.number() });
+  const pick = <T extends z.ZodMiniObject>(s: T) => z.pick(s, { a: true });
+  const chained = <T extends z.ZodMiniObject>(s: T) => z.pick(z.partial(s), { a: true });
+
+  expectTypeOf<z.infer<ReturnType<typeof pick<typeof src>>>>().toEqualTypeOf<{ a: string }>();
+  expectTypeOf<z.infer<ReturnType<typeof chained<typeof src>>>>().toEqualTypeOf<{ a?: string | undefined }>();
 });


### PR DESCRIPTION
Calling a ZodObject method through a generic wrapper dropped the object's shape:

```ts
const wrap = <T extends z.ZodObject>(schema: T) => schema.strict();
const s = wrap(z.object({ someKey: z.object({ anotherKey: z.string() }) }));

type Out = z.infer<typeof s>;
// before: Record<string, unknown>
// after:  { someKey: { anotherKey: string } }
```

TypeScript resolves a member of `T extends z.ZodObject` through the constraint, whose default shape is `$ZodLooseShape`, so every method that named `Shape` or `Config` in its return type collapsed. Indexing `this` defers resolution to the call site, where it binds to the caller's concrete type.

That covers all fourteen shape-returning methods: `keyof`, `catchall`, `passthrough`, `loose`, `strict`, `strip`, `extend`, `safeExtend`, `merge`, `pick`, `omit`, `partial`, `exactPartial` and `required`.

## The mask guard has to go with it

Deferring the shape and the excess-key mask guard cannot coexist. The guard on `pick`, `omit`, `partial`, `exactPartial` and `required` was `mask: M & Record<Exclude<keyof M, keyof Shape>, never>`, and it only ever worked because a generic receiver collapsed `Shape`: `keyof Shape` was `string`, the `Exclude` reduced to `never`, and the whole guard reduced to `{}`. Once anything defers, `Shape` is `T["shape"]`, the `Exclude` never reduces, and `Record<unresolved, never>` rejects every mask — valid keys included:

```ts
const wrap = <T extends z.ZodObject>(s: T) => s.strict().pick({ a: true }); // TS2345
```

Spelling the shape out in the constraint does not help either, so a cast was the only way out — the same cast [#6039](https://github.com/colinhacks/zod/issues/6039) asked to remove. Nine other formulations were tried; each either fails the same way or disables the check entirely.

The `M` constraint stays keyed on the shape, but written inline as `{ [K in keyof this["shape"]]?: true }` rather than through `util.Mask`. Instantiating the alias at a type parameter is not homomorphic; written inline it is, so TypeScript defers it while the receiver's shape is generic and applies normal excess-property checking once the shape resolves. An all-invalid mask, a numeric key and a symbol key are all still rejected at compile time in both builds.

**Two narrower cases are breaking changes.** A mask mixing valid and invalid keys — `schema.pick({ name: true, typo: true })` — and a mask whose key type is `string` rather than a literal both compile now. The first throws `Unrecognized key` when the shape is first read, which both suites still assert; the second silently widens the result type to the whole shape. Rejecting either needs the intersection that broke every chained call.

`zod/mini` carries the identical guard on its standalone `pick`/`omit`/`partial`/`exactPartial`/`required`, and because those take the schema as an argument rather than through `this`, `T["shape"]` was already deferred — a generic wrapper is a hard `TS2345` on `main` today, with no deferral involved. Dropping it there fixes that and keeps the two builds in step.

One residual: `safeExtend` keeps its compatibility guard, which is the point of the method, so a chained `safeExtend` inside a generic wrapper stays unresolvable. It is pinned in the tests.

The change is type-only, so there is no runtime, memory or bundle cost. Direct calls, recursive schemas, symbol keys and readonly shapes all infer exactly as before.

Supersedes #6239, which carries the same chained-call regression in its five-method subset. Fixes #6039.
