### PR TITLE
fix(v4): empty enums and literals match nothing

### DIFF
--- a/packages/zod/src/v4/classic/tests/enum.test.ts
+++ b/packages/zod/src/v4/classic/tests/enum.test.ts
@@ -160,6 +160,15 @@ test("exclude", () => {
   expectTypeOf<z.infer<typeof EmptyFoodEnum>>().toEqualTypeOf<never>();
 });
 
+test("empty enum matches nothing", () => {
+  const Empty = z.enum([]);
+  expect(Empty._zod.pattern.test("")).toEqual(false);
+  expect(z.templateLiteral(["", Empty]).safeParse("").success).toEqual(false);
+  expect(z.templateLiteral(["", z.object({}).keyof()]).safeParse("").success).toEqual(false);
+
+  expect(z.templateLiteral(["", z.enum([""])]).safeParse("").success).toEqual(true);
+});
+
 test("error map inheritance", () => {
   const foods = ["Pasta", "Pizza", "Tacos", "Burgers", "Salad"] as const;
   const FoodEnum = z.enum(foods, { error: () => "This is not food!" });

--- a/packages/zod/src/v4/classic/tests/enum.test.ts
+++ b/packages/zod/src/v4/classic/tests/enum.test.ts
@@ -166,6 +166,8 @@ test("empty enum matches nothing", () => {
   expect(z.templateLiteral(["", Empty]).safeParse("").success).toEqual(false);
   expect(z.templateLiteral(["", z.object({}).keyof()]).safeParse("").success).toEqual(false);
 
+  expect(z.toJSONSchema(Empty)).toMatchObject({ not: {} });
+
   expect(z.templateLiteral(["", z.enum([""])]).safeParse("").success).toEqual(true);
 });
 

--- a/packages/zod/src/v4/classic/tests/literal.test.ts
+++ b/packages/zod/src/v4/classic/tests/literal.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, expectTypeOf, test } from "vitest";
 
 import * as z from "zod/v4";
 
@@ -114,4 +114,15 @@ test("literal pattern", () => {
       "success": false,
     }
   `);
+});
+
+test("empty literal matches nothing", () => {
+  const empty = z.literal([]);
+  expectTypeOf<z.infer<typeof empty>>().toEqualTypeOf<never>();
+  expect(empty.safeParse("").success).toEqual(false);
+  expect(empty.safeParse(undefined).success).toEqual(false);
+  expect(z.templateLiteral(["", empty]).safeParse("").success).toEqual(false);
+  expect(z.toJSONSchema(empty)).toMatchObject({ not: {} });
+
+  expect(z.literal("").safeParse("").success).toEqual(true);
 });

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1389,8 +1389,8 @@ function generateLiteralCheck(doc: Doc, ctx: CompileContext, schema: SomeType, a
   const def = schema._zod.def as unknown as { values: unknown[] };
   const values = def.values;
 
-  // Multi-value literals (z.literal(["a", "b", c])) use Set.has so every allowed value participates. Single-value stays inlined for speed.
-  if (values.length > 1) {
+  // Anything but a single value goes through Set.has: multi-value (z.literal(["a", "b", c])) so every allowed value participates, and empty (z.literal([])) so nothing matches — reading values[0] there would be undefined and compile to an `!== undefined` check that accepts it. Single-value stays inlined for speed.
+  if (values.length !== 1) {
     const literalSet = addConstant(ctx, new Set(values));
     doc.write(`if (!${literalSet}.has(${accessor})) return INVALID;`);
     return accessor;

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1389,7 +1389,7 @@ function generateLiteralCheck(doc: Doc, ctx: CompileContext, schema: SomeType, a
   const def = schema._zod.def as unknown as { values: unknown[] };
   const values = def.values;
 
-  // Anything but a single value goes through Set.has: multi-value (z.literal(["a", "b", c])) so every allowed value participates, and empty (z.literal([])) so nothing matches — reading values[0] there would be undefined and compile to an `!== undefined` check that accepts it. Single-value stays inlined for speed.
+  // Anything but a single value goes through Set.has: multi-value so every value participates, empty so nothing does — values[0] would be undefined and compile to an `!== undefined` check that accepts it. Single-value stays inlined for speed.
   if (values.length !== 1) {
     const literalSet = addConstant(ctx, new Set(values));
     doc.write(`if (!${literalSet}.has(${accessor})) return INVALID;`);

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -154,6 +154,13 @@ export const enumProcessor: Processor<schemas.$ZodEnum> = (schema, _ctx, json, _
 
 export const literalProcessor: Processor<schemas.$ZodLiteral> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodLiteralDef<any>;
+
+  // a literal with no values accepts nothing, same as z.never()
+  if (def.values.length === 0) {
+    json.not = {};
+    return;
+  }
+
   const vals: (string | number | boolean | null)[] = [];
   for (const val of def.values) {
     if (val === undefined) {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -146,6 +146,13 @@ export const dateProcessor: Processor<schemas.$ZodDate> = (schema, ctx, json, pa
 export const enumProcessor: Processor<schemas.$ZodEnum> = (schema, _ctx, json, _params) => {
   const def = schema._zod.def as schemas.$ZodEnumDef;
   const values = getEnumValues(def.entries);
+
+  // an empty enum accepts nothing, same as z.never()
+  if (values.length === 0) {
+    json.not = {};
+    return;
+  }
+
   // Number enums can have both string and number values
   if (values.every((v) => typeof v === "number")) json.type = "number";
   if (values.every((v) => typeof v === "string")) json.type = "string";

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3497,9 +3497,9 @@ export const $ZodEnum: core.$constructor<$ZodEnum> = /*@__PURE__*/ core.$constru
 
   const patternValues = values.filter((k) => util.propertyKeyTypes.has(typeof k));
 
-  // an empty alternation compiles to /^()$/, which matches the empty string; `(?!)` matches nothing
+  // unmatchable fallback, RE2-safe: an empty alternation would compile to /^()$/, which matches ""
   inst._zod.pattern = new RegExp(
-    patternValues.length ? `^(${patternValues.map((o) => util.escapeRegex(o.toString())).join("|")})$` : "^(?!)$"
+    patternValues.length ? `^(${patternValues.map((o) => util.escapeRegex(o.toString())).join("|")})$` : "^[^\\s\\S]$"
   );
 
   inst._zod.parse = (payload, _ctx) => {
@@ -3550,13 +3550,13 @@ export const $ZodLiteral: core.$constructor<$ZodLiteral> = /*@__PURE__*/ core.$c
     const values = new Set<util.Literal>(def.values);
     inst._zod.values = values;
 
-    // an empty alternation compiles to /^()$/, which matches the empty string; `(?!)` matches nothing
+    // unmatchable fallback, RE2-safe: an empty alternation would compile to /^()$/, which matches ""
     inst._zod.pattern = new RegExp(
       def.values.length
         ? `^(${def.values
             .map((o) => (typeof o === "string" ? util.escapeRegex(o) : o ? util.escapeRegex(o.toString()) : String(o)))
             .join("|")})$`
-        : "^(?!)$"
+        : "^[^\\s\\S]$"
     );
 
     inst._zod.parse = (payload, _ctx) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3546,17 +3546,17 @@ export const $ZodLiteral: core.$constructor<$ZodLiteral> = /*@__PURE__*/ core.$c
   "$ZodLiteral",
   (inst, def) => {
     $ZodType.init(inst, def);
-    if (def.values.length === 0) {
-      throw new Error("Cannot create literal schema with no valid values");
-    }
 
     const values = new Set<util.Literal>(def.values);
     inst._zod.values = values;
-    inst._zod.pattern = new RegExp(
-      `^(${def.values
 
-        .map((o) => (typeof o === "string" ? util.escapeRegex(o) : o ? util.escapeRegex(o.toString()) : String(o)))
-        .join("|")})$`
+    // an empty alternation compiles to /^()$/, which matches the empty string; `(?!)` matches nothing
+    inst._zod.pattern = new RegExp(
+      def.values.length
+        ? `^(${def.values
+            .map((o) => (typeof o === "string" ? util.escapeRegex(o) : o ? util.escapeRegex(o.toString()) : String(o)))
+            .join("|")})$`
+        : "^(?!)$"
     );
 
     inst._zod.parse = (payload, _ctx) => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3495,11 +3495,11 @@ export const $ZodEnum: core.$constructor<$ZodEnum> = /*@__PURE__*/ core.$constru
   const valuesSet = new Set<util.Primitive>(values);
   inst._zod.values = valuesSet;
 
+  const patternValues = values.filter((k) => util.propertyKeyTypes.has(typeof k));
+
+  // an empty alternation compiles to /^()$/, which matches the empty string; `(?!)` matches nothing
   inst._zod.pattern = new RegExp(
-    `^(${values
-      .filter((k) => util.propertyKeyTypes.has(typeof k))
-      .map((o) => util.escapeRegex(o.toString()))
-      .join("|")})$`
+    patternValues.length ? `^(${patternValues.map((o) => util.escapeRegex(o.toString())).join("|")})$` : "^(?!)$"
   );
 
   inst._zod.parse = (payload, _ctx) => {


### PR DESCRIPTION
Three empty-values fixes that came out of triaging #6042.

An enum's pattern is built by joining its values into an alternation, so an enum with nothing to join compiled to `/^()$/` — which matches the empty string. A template literal or union containing such an enum accepted `""`. Empty enums are reachable on contract: `z.object({}).keyof()`, excluding every member of an enum, and `.extract([])` all produce one.

The second commit drops the throw on `z.literal([])`. An empty literal is coherent — its value set is empty, so it rejects every input and infers `never`, exactly like an empty enum — and nothing inside the library builds a literal, so the guard only ever fired on a user's own dynamic array, at schema-construction time. Removing it turned up a defect it had been masking: the AOT compiler read `values[0]`, which is `undefined` when there are none, and emitted an `!== undefined` check, so a compiled empty literal accepted `undefined`.

The third covers the JSON Schema side. Both an empty enum and an empty literal now serialize to `not: {}`, the same output `z.never()` produces. An empty enum previously emitted `{"type":"string","enum":[]}`, which draft-04 rejects outright, and the type there came from `[].every()` being vacuously true rather than from any value. The unmatchable pattern is `[^\s\S]` rather than `(?!)` — identical across every composition I checked, but the source string reaches `toJSONSchema` output verbatim through a template literal, and RE2-backed validators cannot compile a lookahead.

Bundle, `gzip -9` over an esbuild `--minify` fixture: the enum path costs 26 B on mini and 34 B on classic, and the literal path returns 10 B on mini and costs 7 B on classic. Retained bytes per schema and construction cost are both within noise, and no line inside either `parse` closure is touched.

Refs #6042
