### PR TITLE
fix(v4): make record input keys optional when the value can fill them

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2008,6 +2008,15 @@ intKeys.parse({
 });
 ```
 
+A value schema that can stand in for an absent key — `.default()`, `.prefault()`, `.optional()` — makes that key optional on the input side, the same as it does inside `z.object()`:
+
+```ts
+const Person = z.record(z.enum(["id", "name"]), z.string().default(""));
+
+type Input = z.input<typeof Person>; // { id?: string; name?: string }
+type Output = z.output<typeof Person>; // { id: string; name: string }
+```
+
 ### `z.partialRecord`
 
 

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -76,6 +76,37 @@ test("enum exhaustiveness", () => {
   `);
 });
 
+test("optional-in value type", () => {
+  const defaulted = z.record(z.enum(["Tuna", "Salmon"]), z.string().default("unknown"));
+  expectTypeOf<z.input<typeof defaulted>>().toEqualTypeOf<Partial<Record<"Tuna" | "Salmon", string | undefined>>>();
+  expectTypeOf<z.output<typeof defaulted>>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
+  expect(defaulted.parse({ Tuna: "asdf" })).toEqual({ Tuna: "asdf", Salmon: "unknown" });
+
+  const prefaulted = z.record(z.enum(["Tuna", "Salmon"]), z.string().prefault("unknown"));
+  expectTypeOf<z.input<typeof prefaulted>>().toEqualTypeOf<Partial<Record<"Tuna" | "Salmon", string | undefined>>>();
+  expect(prefaulted.parse({ Tuna: "asdf" })).toEqual({ Tuna: "asdf", Salmon: "unknown" });
+
+  const optional = z.record(z.enum(["Tuna", "Salmon"]), z.string().optional());
+  expectTypeOf<z.input<typeof optional>>().toEqualTypeOf<Partial<Record<"Tuna" | "Salmon", string | undefined>>>();
+  // toStrictEqual, not toEqual: an exhaustive record assigns every key, and toEqual cannot tell an absent key from one holding undefined.
+  expect(optional.parse({ Tuna: "asdf" })).toStrictEqual({ Tuna: "asdf", Salmon: undefined });
+
+  // A value that needs a slot keeps the key required, and a non-enumerable key stays an index signature either way.
+  const required = z.record(z.enum(["Tuna", "Salmon"]), z.string());
+  expectTypeOf<z.input<typeof required>>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
+  const indexed = z.record(z.string(), z.string().default("unknown"));
+  expectTypeOf<z.input<typeof indexed>>().toEqualTypeOf<Record<string, string | undefined>>();
+
+  // A catch and a preprocess pipe declare no static optin, so the key stays required even where the parser can fill it. The static predicate and the one the JSON Schema emitter uses resolve these differently, and the two have to keep agreeing.
+  const caught = z.record(z.enum(["Tuna", "Salmon"]), z.string().catch("unknown"));
+  expectTypeOf<z.input<typeof caught>>().toEqualTypeOf<Record<"Tuna" | "Salmon", string>>();
+  const preprocessed = z.record(
+    z.enum(["Tuna", "Salmon"]),
+    z.preprocess((v) => v, z.string())
+  );
+  expectTypeOf<z.input<typeof preprocessed>>().toEqualTypeOf<Record<"Tuna" | "Salmon", unknown>>();
+});
+
 test("typescript enum exhaustiveness", () => {
   enum BigFish {
     Tuna = 0,

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1137,6 +1137,22 @@ describe("toJSONSchema", () => {
     `);
   });
 
+  test("record with enum keys drops required for an optional-in value under io: input", () => {
+    const schema = z.record(z.enum(["key1", "key2"]), z.number().default(0));
+
+    expect(z.toJSONSchema(schema, { io: "input" }).required).toBeUndefined();
+    expect(z.toJSONSchema(schema).required).toEqual(["key1", "key2"]);
+    expect(z.toJSONSchema(z.record(z.enum(["key1", "key2"]), z.number()), { io: "input" }).required).toEqual([
+      "key1",
+      "key2",
+    ]);
+    // A caught value keeps required, matching the input type and z.object().
+    expect(z.toJSONSchema(z.record(z.enum(["key1", "key2"]), z.number().catch(0)), { io: "input" }).required).toEqual([
+      "key1",
+      "key2",
+    ]);
+  });
+
   test("record filters enum values to strings and numbers for required", () => {
     enum NumberEnum {
       Zero = 0,

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -484,7 +484,9 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
 
   // Add required for keys with discrete values (enum, literal, etc.)
   const keyValues = keyType._zod.values;
-  if (keyValues && !def.partial) {
+  // Every key shares one value schema, so an optional-in value makes the whole key set omittable on input. Output keeps them: the exhaustive branch assigns every key, even one whose value came back undefined.
+  const omittableOnInput = ctx.io === "input" && inputOptin(def.valueType as schemas.$ZodType) !== undefined;
+  if (keyValues && !def.partial && !omittableOnInput) {
     const validKeyValues = [...keyValues].filter(
       (v): v is string | number => typeof v === "string" || typeof v === "number"
     );

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3095,7 +3095,10 @@ export type $InferZodRecordInput<
   Value extends SomeType = $ZodType,
 > = Key extends $partial
   ? Partial<Record<core.input<Key> & PropertyKey, core.input<Value>>>
-  : Record<core.input<Key> & PropertyKey, core.input<Value>>;
+  : // A value schema that accepts an absent slot makes the key omittable on the way in, exactly as it does in an object shape. The output side keeps every key, since the parser fills each one.
+    [Value] extends [OptionalInSchema]
+    ? Partial<Record<core.input<Key> & PropertyKey, core.input<Value>>>
+    : Record<core.input<Key> & PropertyKey, core.input<Value>>;
 
 export interface $ZodRecordInternals<Key extends $ZodRecordKey = $ZodRecordKey, Value extends SomeType = $ZodType>
   extends $ZodTypeInternals<$InferZodRecordOutput<Key, Value>, $InferZodRecordInput<Key, Value>> {


### PR DESCRIPTION
An exhaustive record already fills a missing key when its value schema can stand in for one — `z.record(z.enum(["UP","DOWN"]), z.string().default("unknown")).parse({ UP: "a" })` returns both keys. The input type said otherwise and required both, so passing the partial object needed a `@ts-ignore`.

Key optionality on the input side now follows the value schema, the same way it already does inside `z.object()`. A default, a prefault or an optional makes the key omittable. A value that needs a slot keeps it required, so exhaustiveness is unchanged.

The input-mode JSON Schema had the same defect independently: it emitted the full `required` list for a record the parser accepts without either key. The record emitter now reads the same optionality helper the object and tuple emitters already use.

Output is unchanged on both surfaces. An exhaustive record assigns every declared key, so the output type and the output `required` list still carry all of them.

One consumer-visible note: this widens a published type. Passing a value in is unaffected, and per-key access was already `V | undefined`, but assigning a `z.input<typeof R>` value to a stricter annotation — or enumerating one and assuming every enum key is present — stops typechecking.

Closes #6163
