### PR TITLE
fix(v4): fold an intersection of object schemas into one object

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1052,32 +1052,20 @@ describe("toJSONSchema", () => {
     expect(z.toJSONSchema(schema)).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "allOf": [
-          {
-            "additionalProperties": false,
-            "properties": {
-              "name": {
-                "type": "string",
-              },
-            },
-            "required": [
-              "name",
-            ],
-            "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "age": {
+            "type": "number",
           },
-          {
-            "additionalProperties": false,
-            "properties": {
-              "age": {
-                "type": "number",
-              },
-            },
-            "required": [
-              "age",
-            ],
-            "type": "object",
+          "name": {
+            "type": "string",
           },
+        },
+        "required": [
+          "name",
+          "age",
         ],
+        "type": "object",
       }
     `);
   });
@@ -2975,29 +2963,38 @@ test("basic registry", () => {
 });
 
 test("large registry converts in linear time", () => {
-  const registry = z.registry<{ id: string }>();
   const count = 2000;
-  for (let i = 0; i < count; i++) {
-    registry.add(
-      z.object({ id: z.string(), name: z.string(), count: z.number(), nested: z.object({ a: z.boolean() }) }),
-      { id: `Type${i}` }
-    );
-  }
+  const convert = (withIntersection: boolean) => {
+    const registry = z.registry<{ id: string }>();
+    for (let i = 0; i < count; i++) {
+      registry.add(
+        z.object({ id: z.string(), name: z.string(), count: z.number(), nested: z.object({ a: z.boolean() }) }),
+        { id: `Type${i}` }
+      );
+    }
+    if (withIntersection) registry.add(z.object({ a: z.string() }).and(z.object({ b: z.string() })), { id: "Inter" });
 
-  const start = performance.now();
-  const { schemas } = z.toJSONSchema(registry, { uri: (id) => `https://example.com/${id}.json` });
-  const elapsed = performance.now() - start;
+    const start = performance.now();
+    const { schemas } = z.toJSONSchema(registry, { uri: (id) => `https://example.com/${id}.json` });
+    return { schemas, elapsed: performance.now() - start };
+  };
 
-  expect(Object.keys(schemas)).toHaveLength(count);
-  expect(schemas.Type0).toMatchObject({
+  const plain = convert(false);
+  expect(Object.keys(plain.schemas)).toHaveLength(count);
+  expect(plain.schemas.Type0).toMatchObject({
     $id: "https://example.com/Type0.json",
     type: "object",
     properties: { nested: { type: "object" } },
   });
-  expect(schemas[`Type${count - 1}`]!.$id).toBe(`https://example.com/Type${count - 1}.json`);
+  expect(plain.schemas[`Type${count - 1}`]!.$id).toBe(`https://example.com/Type${count - 1}.json`);
 
   // The whole-map passes in extractDefs/finalize used to re-run once per registered schema, which made this quadratic: ~9s of CPU at this size before the passes were hoisted, ~50ms after.
-  expect(elapsed).toBeLessThan(5000);
+  expect(plain.elapsed).toBeLessThan(5000);
+
+  // The intersection fold walks the whole map as well, so it has to run inside the same guard. Hoisting it back out costs ~10x at this size. Comparing the two conversions rather than asserting a fixed budget keeps this independent of how fast the machine is.
+  const folded = convert(true);
+  expect(folded.schemas.Inter).toMatchObject({ type: "object", properties: { a: {}, b: {} } });
+  expect(folded.elapsed).toBeLessThan(plain.elapsed * 4 + 100);
 });
 
 test("registry extracts unregistered subschemas into __shared", () => {
@@ -3624,45 +3621,25 @@ test("flatten simple intersections", () => {
   expect(result).toMatchInlineSnapshot(`
     {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "allOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "testNum": {
-              "type": "number",
-            },
-          },
-          "required": [
-            "testNum",
-          ],
-          "type": "object",
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "testStr": {
-              "type": "string",
-            },
-          },
-          "required": [
-            "testStr",
-          ],
-          "type": "object",
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "testBool": {
-              "type": "boolean",
-            },
-          },
-          "required": [
-            "testBool",
-          ],
-          "type": "object",
-        },
-      ],
+      "additionalProperties": false,
       "description": "123",
+      "properties": {
+        "testBool": {
+          "type": "boolean",
+        },
+        "testNum": {
+          "type": "number",
+        },
+        "testStr": {
+          "type": "string",
+        },
+      },
+      "required": [
+        "testNum",
+        "testStr",
+        "testBool",
+      ],
+      "type": "object",
     }
   `);
 });
@@ -4077,5 +4054,327 @@ describe("unrepresentable callback", () => {
         "type": "string",
       }
     `);
+  });
+});
+
+describe("intersection folding", () => {
+  const TARGETS = ["draft-2020-12", "draft-07", "draft-04", "openapi-3.0"] as const;
+  const body = (schema: z.ZodType, params?: Parameters<typeof z.toJSONSchema>[1]) => {
+    const { $schema, ...rest } = z.toJSONSchema(schema, params) as Record<string, unknown>;
+    return rest;
+  };
+
+  test("two objects become one object", () => {
+    expect(body(z.object({ name: z.string() }).and(z.object({ age: z.number() })))).toMatchInlineSnapshot(`
+      {
+        "additionalProperties": false,
+        "properties": {
+          "age": {
+            "type": "number",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "name",
+          "age",
+        ],
+        "type": "object",
+      }
+    `);
+  });
+
+  test("the folded shape is identical on every target", () => {
+    const schema = z.object({ name: z.string() }).and(z.object({ age: z.number() }));
+    const bodies = TARGETS.map((target) => body(schema, { target }));
+    for (const emitted of bodies) expect(emitted).toEqual(bodies[0]);
+  });
+
+  test("closed only when every member is closed", () => {
+    expect(body(z.strictObject({ a: z.string() }).and(z.strictObject({ b: z.number() })))).toMatchObject({
+      additionalProperties: false,
+    });
+    // A loose member keeps the intersection open, which is what the parser does: it merges both results, so the loose side's extra keys survive.
+    expect(body(z.looseObject({ a: z.string() }).and(z.object({ b: z.number() })))).not.toHaveProperty(
+      "additionalProperties"
+    );
+  });
+
+  test("chained and nested intersections fold flat", () => {
+    const chained = z
+      .object({ a: z.string() })
+      .and(z.object({ b: z.string() }))
+      .and(z.object({ c: z.string() }));
+    expect(body(chained)).toMatchObject({ properties: { a: {}, b: {}, c: {} }, required: ["a", "b", "c"] });
+    const nested = z.object({ a: z.string() }).and(z.object({ b: z.string() }).and(z.object({ c: z.string() })));
+    expect(body(nested)).toEqual(body(chained));
+  });
+
+  test("required is the union, and an optional key stays optional", () => {
+    expect(body(z.object({ a: z.string().optional() }).and(z.object({ b: z.string() })))).toMatchObject({
+      properties: { a: { type: "string" }, b: { type: "string" } },
+      required: ["b"],
+    });
+  });
+
+  test("a key both members declare has to satisfy both", () => {
+    // identical declarations collapse
+    expect(body(z.object({ k: z.string() }).and(z.object({ k: z.string() })))).toMatchObject({
+      properties: { k: { type: "string" } },
+    });
+    // object declarations fold, matching the parser's deep merge
+    expect(
+      body(z.object({ k: z.object({ a: z.string() }) }).and(z.object({ k: z.object({ b: z.string() }) })))
+    ).toMatchObject({
+      properties: { k: { type: "object", properties: { a: {}, b: {} }, required: ["a", "b"] } },
+    });
+    // anything else stays an intersection one level down
+    expect(body(z.object({ k: z.string() }).and(z.object({ k: z.number() })))).toMatchObject({
+      properties: { k: { allOf: [{ type: "string" }, { type: "number" }] } },
+    });
+  });
+
+  test("an intersection distributes over a union", () => {
+    const schema = z
+      .object({ name: z.string() })
+      .and(
+        z.discriminatedUnion("type", [
+          z.object({ type: z.literal("a"), value: z.string() }),
+          z.object({ type: z.literal("b"), count: z.number() }),
+        ])
+      );
+    expect(body(schema)).toMatchObject({
+      oneOf: [
+        { type: "object", properties: { name: {}, type: {}, value: {} }, additionalProperties: false },
+        { type: "object", properties: { name: {}, type: {}, count: {} }, additionalProperties: false },
+      ],
+    });
+    const inclusive = z
+      .object({ name: z.string() })
+      .and(z.union([z.object({ v: z.string() }), z.object({ c: z.number() })]));
+    expect(body(inclusive)).toMatchObject({
+      anyOf: [{ properties: { name: {}, v: {} } }, { properties: { name: {}, c: {} } }],
+    });
+  });
+
+  test("input conversion has nothing to close", () => {
+    expect(body(z.object({ a: z.string() }).and(z.object({ b: z.string() })), { io: "input" })).toEqual({
+      type: "object",
+      properties: { a: { type: "string" }, b: { type: "string" } },
+      required: ["a", "b"],
+    });
+  });
+
+  test("folds through a property and through z.lazy", () => {
+    expect(body(z.object({ inner: z.object({ a: z.string() }).and(z.object({ b: z.string() })) }))).toMatchObject({
+      properties: { inner: { type: "object", properties: { a: {}, b: {} } } },
+    });
+    const self: z.ZodType = z.lazy(() => z.object({ a: z.string() }).and(z.object({ next: z.optional(self) })));
+    expect(body(self)).toMatchObject({ type: "object", properties: { a: {}, next: { $ref: "#" } } });
+  });
+
+  test("metadata on the intersection itself survives", () => {
+    expect(
+      body(
+        z
+          .object({ a: z.string() })
+          .and(z.object({ b: z.string() }))
+          .meta({ title: "T" })
+      )
+    ).toMatchObject({
+      title: "T",
+      type: "object",
+      properties: { a: {}, b: {} },
+    });
+  });
+
+  test("a catchall constrains the sibling's keys too", () => {
+    // The catchall member does not declare `b`, so its `additionalProperties` is what it demands of `b`. Folding `b` into `properties` has to carry that demand across, or the key would escape it.
+    const schema = z
+      .object({ a: z.string() })
+      .catchall(z.number())
+      .and(z.object({ b: z.string() }));
+    expect(body(schema)).toEqual({
+      type: "object",
+      properties: { a: { type: "string" }, b: { allOf: [{ type: "number" }, { type: "string" }] } },
+      required: ["a", "b"],
+      additionalProperties: { type: "number" },
+    });
+  });
+
+  test("two catchalls both constrain the keys neither declares", () => {
+    const schema = z
+      .object({})
+      .catchall(z.number())
+      .and(z.object({}).catchall(z.number().min(0)));
+    expect(body(schema)).toEqual({
+      type: "object",
+      properties: {},
+      additionalProperties: { allOf: [{ type: "number" }, { type: "number", minimum: 0 }] },
+    });
+    expect(schema.safeParse({ zz: 5 }).success).toBe(true);
+    expect(schema.safeParse({ zz: -1 }).success).toBe(false);
+  });
+
+  test("the emitted openness agrees with the parser for every pair of object modes", () => {
+    const modes = {
+      strip: (shape: z.ZodRawShape) => z.object(shape),
+      strict: (shape: z.ZodRawShape) => z.strictObject(shape),
+      loose: (shape: z.ZodRawShape) => z.looseObject(shape),
+      catchall: (shape: z.ZodRawShape) => z.object(shape).catchall(z.number()),
+    };
+    const grid: Record<string, unknown> = {};
+    for (const [leftName, left] of Object.entries(modes)) {
+      for (const [rightName, right] of Object.entries(modes)) {
+        const schema = left({ a: z.string() }).and(right({ b: z.number() }));
+        const emitted = body(schema) as { additionalProperties?: unknown };
+        grid[`${leftName} & ${rightName}`] = emitted.additionalProperties ?? "open";
+
+        // Whatever the emitted keyword says, it has to agree with what the parser does with a key neither member declares.
+        const parsed = schema.safeParse({ a: "s", b: 1, zz: 7 });
+        const keepsUnknown = parsed.success && Object.prototype.hasOwnProperty.call(parsed.data, "zz");
+        if (keepsUnknown) expect(emitted.additionalProperties).not.toBe(false);
+      }
+    }
+    expect(grid).toMatchInlineSnapshot(`
+      {
+        "catchall & catchall": {
+          "type": "number",
+        },
+        "catchall & loose": {
+          "type": "number",
+        },
+        "catchall & strict": {
+          "type": "number",
+        },
+        "catchall & strip": {
+          "type": "number",
+        },
+        "loose & catchall": {
+          "type": "number",
+        },
+        "loose & loose": "open",
+        "loose & strict": "open",
+        "loose & strip": "open",
+        "strict & catchall": {
+          "type": "number",
+        },
+        "strict & loose": "open",
+        "strict & strict": false,
+        "strict & strip": false,
+        "strip & catchall": {
+          "type": "number",
+        },
+        "strip & loose": "open",
+        "strip & strict": false,
+        "strip & strip": false,
+      }
+    `);
+  });
+
+  test("a __proto__ key stays an own property", () => {
+    const folded = body(z.object({ ["__proto__"]: z.string() }).and(z.object({ b: z.number() }))) as any;
+    expect(Object.prototype.hasOwnProperty.call(folded.properties, "__proto__")).toBe(true);
+    expect(folded.required).toEqual(["__proto__", "b"]);
+  });
+});
+
+describe("intersection folding declines", () => {
+  // Every case here keeps the `allOf` it produces today. The fold only understands the four object keywords, so a member carrying anything else is left alone rather than having a constraint dropped or an annotation re-scoped.
+  const allOf = (schema: z.ZodType, params?: Parameters<typeof z.toJSONSchema>[1]) =>
+    (z.toJSONSchema(schema, params) as any).allOf;
+
+  test("a member that is a reference keeps its reference", () => {
+    const named = z.object({ a: z.string() }).meta({ id: "Named" });
+    expect(allOf(named.and(z.object({ b: z.string() })))[0]).toEqual({ $ref: "#/$defs/Named" });
+
+    const shared = z.object({ c: z.string() });
+    const reused = z.toJSONSchema(z.object({ x: shared.and(z.object({ d: z.string() })), y: shared }), {
+      reused: "ref",
+    }) as any;
+    expect(reused.properties.x.allOf[0]).toEqual({ $ref: "#/$defs/__schema0" });
+
+    const cyclic: any = z.object({
+      get next() {
+        return z.optional(cyclic);
+      },
+      n: z.string(),
+    });
+    expect(allOf(cyclic.and(z.object({ m: z.string() })))[0].$ref).toBe("#/$defs/__schema0");
+  });
+
+  test("an annotated member keeps its place", () => {
+    expect(
+      allOf(
+        z
+          .object({ a: z.string() })
+          .describe("A")
+          .and(z.object({ b: z.string() }))
+      )[0]
+    ).toMatchObject({
+      description: "A",
+    });
+  });
+
+  test("members that are not plain objects are left alone", () => {
+    expect(allOf(z.intersection(z.string().min(2), z.string().max(5)))).toHaveLength(2);
+    expect(allOf(z.object({ a: z.string() }).and(z.nullable(z.object({ b: z.string() }))))).toHaveLength(2);
+    expect(
+      allOf(z.object({ label: z.string() }).and(z.looseRecord(z.string().regex(/^label:[a-z]{2}$/), z.string())))
+    ).toHaveLength(2);
+  });
+
+  test("a shared member is never rewritten for its other uses", () => {
+    const shared = z.object({ c: z.string() });
+    const result = z.toJSONSchema(z.object({ x: shared.and(z.object({ d: z.string() })), y: shared })) as any;
+    expect(result.properties.x).toMatchObject({ properties: { c: {}, d: {} }, additionalProperties: false });
+    // `y` is the same Zod schema, emitted separately, and keeps the closedness it had on its own.
+    expect(result.properties.y).toEqual({
+      type: "object",
+      properties: { c: { type: "string" } },
+      required: ["c"],
+      additionalProperties: false,
+    });
+  });
+
+  test("registry conversion keeps its cross-references", () => {
+    const registry = z.registry<{ id: string }>();
+    const left = z.object({ p: z.string() });
+    const right = z.object({ q: z.string() });
+    registry.add(left, { id: "P" });
+    registry.add(right, { id: "Q" });
+    registry.add(left.and(right), { id: "PQ" });
+    expect((z.toJSONSchema(registry) as any).schemas.PQ.allOf).toEqual([{ $ref: "P" }, { $ref: "Q" }]);
+  });
+
+  test("override still runs, and sees the intersection before it folds", () => {
+    const schema = z.object({ a: z.string() }).and(z.object({ b: z.string() }));
+    const result = z.toJSONSchema(schema, {
+      override(ctx) {
+        if ((ctx.jsonSchema as any).allOf) (ctx.jsonSchema as any).title = "intersection";
+      },
+    }) as any;
+    expect(result).toMatchObject({ title: "intersection", type: "object", properties: { a: {}, b: {} } });
+  });
+
+  test("an override that writes object keywords wins over the fold", () => {
+    // The override runs first, so anything it puts on the intersection is deliberate. Folding would overwrite it silently, so the fold stands down instead.
+    const result = z.toJSONSchema(z.object({ a: z.string() }).and(z.object({ b: z.string() })), {
+      override(ctx) {
+        if ((ctx.jsonSchema as any).allOf) (ctx.jsonSchema as any).additionalProperties = true;
+      },
+    }) as any;
+    expect(result.additionalProperties).toBe(true);
+    expect(result.allOf).toHaveLength(2);
+  });
+
+  test("more than one union member is left alone rather than multiplied out", () => {
+    // The second union lands among the members the first is distributed across, and a union is not an object, so every branch fails to fold and the whole intersection stands down.
+    const schema = z
+      .object({ a: z.string() })
+      .and(z.union([z.object({ v: z.string() }), z.object({ w: z.string() })]))
+      .and(z.union([z.object({ x: z.string() }), z.object({ y: z.string() })]));
+    expect(allOf(schema)).toHaveLength(3);
   });
 });

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -389,6 +389,8 @@ export const intersectionProcessor: Processor<schemas.$ZodIntersection> = (schem
     ...(isSimpleIntersection(b) ? (b.allOf as any[]) : [b]),
   ];
   json.allOf = allOf;
+  // Recorded innermost first, so a nested intersection has already folded by the time this one is considered. The array is the handle rather than the schema, because a wrapper that inherits this schema shares the same array; `finalize` folds every object holding it. See `foldIntersection`.
+  ctx.intersections.push(allOf);
 };
 
 export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json, params) => {

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -140,6 +140,8 @@ export interface ToJSONSchemaContext {
   sharedEmitDoneFor?: ToJSONSchemaContext["external"];
   cycles: "ref" | "throw";
   reused: "ref" | "inline";
+  /** The `allOf` array of each intersection encountered during traversal, innermost first. `finalize` folds every emitted object holding one; see `foldIntersection`. */
+  intersections: JSONSchema.BaseSchema[][];
   external?:
     | {
         registry: $ZodRegistry<{ id?: string | undefined }>;
@@ -177,6 +179,7 @@ export function initializeContext(params: JSONSchemaGeneratorParams): ToJSONSche
     sharedEmitDoneFor: undefined,
     cycles: params?.cycles ?? "ref",
     reused: params?.reused ?? "inline",
+    intersections: [],
     external: params?.external ?? undefined,
   };
 }
@@ -456,6 +459,107 @@ function compactTypeUnion(schema: JSONSchema.BaseSchema): void {
   schema.type = types.length === 1 ? types[0] : types;
 }
 
+/** Keywords `foldIntersection` knows how to combine. Anything else — `$ref`, `patternProperties`,
+ * an annotation like `description` — makes a member unfoldable, so a constraint this does not
+ * understand leaves the `allOf` alone instead of being silently dropped or misattributed. */
+const FOLDABLE_KEYS = new Set(["type", "properties", "required", "additionalProperties"]);
+const UNION_KEYS = ["oneOf", "anyOf"] as const;
+
+/** A member's constraint on a key it does not declare itself. A `catchall` states one; `false`, an absent `additionalProperties`, and the empty schema a loose object emits state nothing. */
+function undeclaredConstraint(member: JSONSchema.ObjectSchema): JSONSchema.BaseSchema | null {
+  const extra = member.additionalProperties;
+  if (extra === undefined || extra === false || typeof extra !== "object" || extra === null) return null;
+  return Object.keys(extra).length ? (extra as JSONSchema.BaseSchema) : null;
+}
+
+/** Combines object members into the single object they describe together, or returns `null` if any of them carries a keyword outside {@link FOLDABLE_KEYS}. */
+function foldObjects(members: JSONSchema._JSONSchema[]): JSONSchema.ObjectSchema | null {
+  const objects: JSONSchema.ObjectSchema[] = [];
+  for (const member of members) {
+    // A boolean subschema is legal JSON Schema and carries no keywords to fold.
+    if (typeof member !== "object" || member.type !== "object") return null;
+    for (const key in member) {
+      if (!FOLDABLE_KEYS.has(key)) return null;
+    }
+    objects.push(member as JSONSchema.ObjectSchema);
+  }
+
+  const properties: Record<string, JSONSchema._JSONSchema> = {};
+  const required = new Set<string>();
+  for (const object of objects) {
+    for (const key in object.properties) {
+      // `in` would report a `__proto__` key as already present via the prototype chain and skip it.
+      if (Object.prototype.hasOwnProperty.call(properties, key)) continue;
+      // Every member constrains this key: the ones that declare it say how, and a `catchall` member constrains it too even though it does not name it. The key has to satisfy all of them, which is the same intersection one level down.
+      const parts: JSONSchema._JSONSchema[] = [];
+      for (const other of objects) {
+        const part = other.properties?.[key] ?? undeclaredConstraint(other);
+        if (part === null || part === undefined) continue;
+        if (!parts.some((seen) => JSON.stringify(seen) === JSON.stringify(part))) parts.push(part);
+      }
+      const merged =
+        parts.length === 1
+          ? parts[0]!
+          : (foldObjects(parts) ?? ({ allOf: parts as JSONSchema.BaseSchema[] } as JSONSchema.BaseSchema));
+      assignProp(properties, key, merged);
+    }
+    for (const key of object.required ?? []) required.add(key);
+  }
+
+  const folded: JSONSchema.ObjectSchema = { type: "object", properties };
+  if (required.size) folded.required = [...required];
+  // A key no member declares is rejected only when every member rejects it, so the fold is closed only when every member is. Otherwise it carries whatever the `catchall` members demand of such a key.
+  if (objects.every((object) => object.additionalProperties === false)) {
+    folded.additionalProperties = false;
+  } else {
+    const constraints: JSONSchema.BaseSchema[] = [];
+    for (const object of objects) {
+      const constraint = undeclaredConstraint(object);
+      if (constraint && !constraints.some((seen) => JSON.stringify(seen) === JSON.stringify(constraint)))
+        constraints.push(constraint);
+    }
+    if (constraints.length === 1) folded.additionalProperties = constraints[0]!;
+    else if (constraints.length > 1) folded.additionalProperties = { allOf: constraints };
+  }
+  return folded;
+}
+
+/** `additionalProperties` in an `allOf` member sees only that member's own `properties`, so two
+ * closed object members reject each other's keys and the schema validates nothing. Zod's parser
+ * pools the key sets instead — `handleIntersectionResults` reports a key as unrecognized only when
+ * *every* side rejects it — so the emitted schema has to pool them too, and folding the members
+ * into one object is the encoding that says so on every target.
+ *
+ * This runs from `finalize`, after `extractDefs`, which is what keeps it clear of the `$ref`
+ * machinery: a member extracted into `$defs` is already a `$ref` by now and declines to fold, so it
+ * keeps its reference and its own closedness rather than being inlined as a stale copy. */
+function foldIntersection(json: JSONSchema.BaseSchema): void {
+  const allOf = json.allOf;
+  if (!Array.isArray(allOf) || allOf.length < 2) return;
+  // An `override` runs before this pass and may have written object keywords onto the intersection itself. Those are deliberate, so decline rather than overwrite them.
+  for (const key of FOLDABLE_KEYS) if (key in json) return;
+
+  // An intersection distributes over a union: `A & (X | Y)` is `(A & X) | (A & Y)`. Only the first union is distributed over; a second one stays among the members every branch folds against, where it fails the object check and declines the whole intersection rather than multiplying out.
+  const unions = allOf.filter((m) => UNION_KEYS.some((k) => Array.isArray(m[k])));
+
+  let folded: JSONSchema.BaseSchema | null = null;
+  if (!unions.length) {
+    folded = foldObjects(allOf);
+  } else {
+    const union = unions[0]!;
+    const keyword = UNION_KEYS.find((k) => Array.isArray(union[k]))!;
+    if (Object.keys(union).length !== 1) return;
+    const rest = allOf.filter((m) => m !== union);
+    const branches = (union[keyword] as JSONSchema._JSONSchema[]).map((branch) => foldObjects([...rest, branch]));
+    if (branches.some((b) => !b)) return;
+    folded = { [keyword]: branches } as JSONSchema.BaseSchema;
+  }
+  if (!folded) return;
+
+  delete json.allOf;
+  assignProps(json, folded);
+}
+
 export function finalize<T extends schemas.$ZodType>(
   ctx: ToJSONSchemaContext,
   schema: T
@@ -553,6 +657,23 @@ export function finalize<T extends schemas.$ZodType>(
     if (ctx.target !== "openapi-3.0") {
       for (const entry of ctx.seen.entries()) {
         compactTypeUnion(entry[1].def ?? entry[1].schema);
+      }
+    }
+
+    // After flattening, every member that was extracted is a `$ref`, so the fold sees the final shape. A schema that inherits an intersection — through `z.lazy`, or any `ref` chain — holds the same `allOf` array, so fold by array identity to catch every copy.
+    if (ctx.intersections.length) {
+      const carriers = new Map<JSONSchema.BaseSchema[], JSONSchema.BaseSchema[]>();
+      for (const seen of ctx.seen.values()) {
+        for (const json of [seen.schema, seen.def]) {
+          const allOf = json?.allOf as JSONSchema.BaseSchema[] | undefined;
+          if (!Array.isArray(allOf)) continue;
+          const existing = carriers.get(allOf);
+          if (existing) existing.push(json!);
+          else carriers.set(allOf, [json!]);
+        }
+      }
+      for (const allOf of ctx.intersections) {
+        for (const json of carriers.get(allOf) ?? []) foldIntersection(json);
       }
     }
   }


### PR DESCRIPTION
Converting an intersection produces `allOf: [A, B]`. In JSON Schema, `additionalProperties` only sees `properties` in its own schema object — never a sibling `allOf` entry — so two closed object members forbid each other's keys and no object validates, while the parser accepts the same value.

```ts
const schema = z.object({ name: z.string() }).and(z.object({ age: z.number() }));

schema.parse({ name: "a", age: 1 }); // ok
// the emitted schema rejects that, and every other object too
```

The parser already answers this. Its intersection handler pools the members' key sets: a key is reported as unrecognized only when *every* side rejects it. So an intersection is closed exactly when every member is closed, over the union of their keys — which is a single object, and is what the intersection means.

```json
{
  "type": "object",
  "properties": { "name": { "type": "string" }, "age": { "type": "number" } },
  "required": ["name", "age"],
  "additionalProperties": false
}
```

Folding runs during finalization, after defs are extracted, so a member already pulled into `$defs` is a `$ref` by then and keeps its reference instead of being inlined as a stale copy. The member test is a whitelist of the four object keywords, so a keyword it does not understand leaves the `allOf` exactly as it is today rather than dropping a constraint. An intersection also distributes over a union, so a base object combined with a discriminated union folds to a `oneOf` of merged objects.

The output is identical on every target. No `unevaluatedProperties`, no placeholder properties, no per-draft branching.

### How the four object modes combine

Whether the fold is closed is decided by the members, and a `catchall` also constrains keys it does not itself declare — including its sibling's, which have to carry that constraint across when they fold in. The emitted keyword for every pair:

| left \ right | `object` | `strictObject` | `looseObject` | `.catchall(T)` |
| --- | --- | --- | --- | --- |
| `object` | `false` | `false` | open | `T` |
| `strictObject` | `false` | `false` | open | `T` |
| `looseObject` | open | open | open | `T` |
| `.catchall(T)` | `T` | `T` | `T` | `T` |

### Where it declines

Each of these keeps the `allOf` it emits today: a member that is a reference (named with `.meta({ id })`, reused under `reused: "ref"`, or cyclic), a member carrying an annotation such as `.describe()`, and more than one union member. An annotation describes the member it is attached to, and folding would re-scope it to the whole.

A `z.record()` member also declines, so `z.object({ a: z.number() }).and(z.record(z.string(), z.number()))` still emits the `allOf` it does today. A record states a key schema through `propertyNames`, which constrains which keys may appear at all rather than what a named key holds, and the fold has no reading for it. That is the same divergence #5390 reports and it is worth its own change.

An `override` also wins. It runs before this pass, so anything it wrote onto the intersection is deliberate and the fold stands down rather than overwriting it.

### Measured

A generated sweep crosses the four object modes on both sides, thirteen key relationships (disjoint, shared key, shared object key, optional, defaulted, nullable, nested, array, empty, `__proto__`) and seven wrappings (bare, in an object, in a strict object, in an array, optional, as a record value, in a union) — 1456 fixtures, emitted on draft-2020-12, draft-07, draft-04, OpenAPI 3.0 and as an input schema. Every value the parser produces must be accepted by the emitted schema, checked with ajv 8.20.0.

| | groups where the schema disagrees with the parser |
| --- | --- |
| before | 3022 |
| after | 96 |

19,420 accept-assertions. **2926 fixed, 0 regressed.**

The linear-time registry test now carries an intersection and compares against an intersection-free control, so the fold pass cannot be lifted out of the guard that keeps it linear without the suite noticing — hoisting it costs ~10x at 2000 schemas, and the test fails when it is.

All 96 remaining are one shape, and the parser is right in every one of them: a `catchall` governs every key its own member does not declare, so a sibling's key holding the wrong type for it is an error — the same rule #6412 established for a record's key schema. A `.default()` supplied by the other member is added to the output only, so the output can carry a key the input-side catchall would have rejected. The emitted schema describes the parser's rule rather than that output.

```ts
const s = z.object({ a: z.string().default("d") }).and(z.object({ b: z.number() }).catchall(z.number()));

s.parse({ b: 2 });           // { a: "d", b: 2 }
s.parse({ a: "d", b: 2 });   // throws
```

| axis | result |
| --- | --- |
| bundle | +565–594 B gzipped across the classic fixtures, 0 B on `zod/mini` |
| runtime | unaffected — conversion only, nothing on the parse path |
| memory | unaffected — no new per-schema state |
| emitted size | −22% for a plain two-object intersection, −12% for a base plus a two-variant union, +28% for a base distributed across a twenty-variant union |

Two existing snapshots change, both shrinking: the intersection test and the flattening test, which are the two that pinned the unsatisfiable output.

Supersedes #5702, which fixes the same bug by rewriting the emitted `allOf` in place. That approach clones each member, and def extraction works by mutating members in place, so a named member loses its `$ref` and leaks its internal `id` — ajv then refuses to compile the document at all.

Closes #5390.

