### PR TITLE
fix(v4): run a wrapper's inner schema on its own payload

### DIFF
--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -326,6 +326,42 @@ test("catch does not break intersection reconciliation", () => {
   expect(schema.parse({ a: "x", b: "y" })).toEqual({ a: "x", b: "y" });
 });
 
+test("catch propagates a back-edge to whatever wraps it", () => {
+  // The memoizer marks a payload whose value is a node still being parsed. That mark has to survive the catch: an enclosing readonly must not freeze a half-built object, and the node's checks belong to the node itself rather than to the back-edge.
+  const Node: any = z.object({
+    get self() {
+      return z
+        .lazy(() => Node)
+        .catch(null)
+        .readonly()
+        .optional();
+    },
+  });
+  const cyclic: any = {};
+  cyclic.self = cyclic;
+  const frozen = Node.safeParse(cyclic);
+  expect(frozen.success).toBe(true);
+  expect(Object.keys(frozen.data)).toEqual(["self"]);
+
+  let checks = 0;
+  const Checked: any = z.object({
+    get self() {
+      return z
+        .lazy(() => Checked)
+        .catch(null)
+        .refine(() => {
+          checks++;
+          return true;
+        })
+        .optional();
+    },
+  });
+  const cyclic2: any = {};
+  cyclic2.self = cyclic2;
+  Checked.safeParse(cyclic2);
+  expect(checks).toBe(0);
+});
+
 test("direction-aware catch", () => {
   const schema = z.string().catch("fallback");
 

--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -308,6 +308,14 @@ test("catch ctx carries the rest of the payload through", () => {
   expect(seen.aborted).toBe(true);
 });
 
+test("catch does not swallow an issue it did not cause", () => {
+  // A pipe hands its `out` schema the caller's issues array so an unrecognized key can survive to an enclosing intersection. The catch must not read that as its own inner failing.
+  const result = z.strictObject({ a: z.string() }).pipe(z.any().catch("CAUGHT")).safeParse({ a: "x", extra: 1 });
+
+  expect(result.success).toBe(false);
+  expect(result.error!.issues.map((i) => i.code)).toEqual(["unrecognized_keys"]);
+});
+
 test("direction-aware catch", () => {
   const schema = z.string().catch("fallback");
 

--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -362,6 +362,27 @@ test("catch propagates a back-edge to whatever wraps it", () => {
   expect(checks).toBe(0);
 });
 
+test("a catch that fires does not rescue an issue from outside it", () => {
+  // The callback still runs and still computes its fallback — the inner schema really did fail. What it cannot do is answer for the unrecognized key the pipe forwarded past it, so the parse fails anyway.
+  let fired = 0;
+  const result = z
+    .strictObject({ a: z.string() })
+    .pipe(
+      z
+        .object({ a: z.string() })
+        .refine(() => false)
+        .catch(() => {
+          fired++;
+          return { a: "FALLBACK" };
+        })
+    )
+    .safeParse({ a: "x", extra: 1 });
+
+  expect(fired).toBe(1);
+  expect(result.success).toBe(false);
+  expect(result.error!.issues.map((i) => i.code)).toEqual(["unrecognized_keys"]);
+});
+
 test("direction-aware catch", () => {
   const schema = z.string().catch("fallback");
 

--- a/packages/zod/src/v4/classic/tests/catch.test.ts
+++ b/packages/zod/src/v4/classic/tests/catch.test.ts
@@ -316,6 +316,16 @@ test("catch does not swallow an issue it did not cause", () => {
   expect(result.error!.issues.map((i) => i.code)).toEqual(["unrecognized_keys"]);
 });
 
+test("catch does not break intersection reconciliation", () => {
+  // Forwarding the unrecognized key is what lets the intersection reconcile it. A catch that fired on it substituted its fallback into one side, and the merge threw out of safeParse.
+  const schema = z.intersection(
+    z.strictObject({ a: z.string() }).pipe(z.any().catch("CAUGHT")),
+    z.strictObject({ b: z.string() })
+  );
+
+  expect(schema.parse({ a: "x", b: "y" })).toEqual({ a: "x", b: "y" });
+});
+
 test("direction-aware catch", () => {
   const schema = z.string().catch("fallback");
 

--- a/packages/zod/src/v4/classic/tests/optional.test.ts
+++ b/packages/zod/src/v4/classic/tests/optional.test.ts
@@ -352,3 +352,15 @@ test("swallowed issue on an absent optional key drops its value", async () => {
   expect(schema.safeParse({ a: "x" }).success).toEqual(false);
   expect(schema.safeParse({ a: "x" }, { jitless: true }).success).toEqual(false);
 });
+
+test("optional does not swallow an issue it did not cause", () => {
+  // A pipe hands its `out` schema the caller's issues array so an unrecognized key can survive to an enclosing intersection. A defaulted inner substituting for absence must not read that as its own failing and drop it.
+  const result = z
+    .strictObject({ a: z.string() })
+    .transform((): number | undefined => undefined)
+    .pipe(z.number().default(5).optional())
+    .safeParse({ a: "x", extra: 1 });
+
+  expect(result.success).toBe(false);
+  expect(result.error!.issues.map((i) => i.code)).toEqual(["unrecognized_keys"]);
+});

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3757,14 +3757,10 @@ export interface $ZodOptional<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodOptionalInternals<T>;
 }
 
-function handleOptionalResult(result: ParsePayload) {
-  // A substituting schema that still failed has no usable answer; yield undefined. Truncate rather than rebind, and clear the abort flag with it: a pipe shares its issues array with the next schema, so an outer holder reads the same one.
-  if (result.issues.length) {
-    result.issues.length = 0;
-    result.value = undefined;
-    result.aborted = false;
-  }
-  return result;
+function handleOptionalResult(payload: ParsePayload, result: ParsePayload) {
+  // A substituting schema that still failed has no usable answer; yield undefined. Its issues are simply dropped: it ran on a payload of its own, so there is no shared array to truncate and nothing of the caller's to lose with it.
+  payload.value = result.issues.length ? undefined : result.value;
+  return payload;
 }
 
 export const $ZodOptional: core.$constructor<$ZodOptional> = /*@__PURE__*/ core.$constructor(
@@ -3790,9 +3786,10 @@ export const $ZodOptional: core.$constructor<$ZodOptional> = /*@__PURE__*/ core.
       if (payload.value === undefined) {
         // Only the top rung substitutes a value for absence; everything else leaves it intact, which is what .optional() means.
         if (def.innerType._zod.optin !== "defaulted") return payload;
-        const result = def.innerType._zod.run(payload, ctx);
-        if (result instanceof Promise) return result.then(handleOptionalResult);
-        return handleOptionalResult(result);
+        // Its own payload, for the same reason $ZodCatch gets one: a pipe forwards an unrecognized key through the caller's issues array, and this must not read that as the substituting schema failing and drop it.
+        const result = def.innerType._zod.run({ value: payload.value, issues: [] }, ctx);
+        if (result instanceof Promise) return result.then((result) => handleOptionalResult(payload, result));
+        return handleOptionalResult(payload, result);
       }
       return def.innerType._zod.run(payload, ctx);
     };

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4180,32 +4180,21 @@ export interface $ZodCatch<T extends SomeType = $ZodType> extends $ZodType {
   _zod: $ZodCatchInternals<T>;
 }
 
-function handleCatchResult(
-  payload: ParsePayload,
-  result: ParsePayload,
-  input: unknown,
-  def: $ZodCatchDef,
-  ctx: ParseContextInternal
-) {
+function handleCatchResult(payload: ParsePayload, result: ParsePayload, def: $ZodCatchDef, ctx: ParseContextInternal) {
   if (!result.issues.length) {
     payload.value = result.value;
     return payload;
   }
 
-  // `value` and `issues` are pinned rather than left to the spread, because the payload keeps moving around this call: the inner run has already replaced `value` with whatever it coerced or transformed, and the truncation below empties the issues array in place. Everything else on the payload carries through untouched.
+  // Spread the inner's own payload, not ours: `value` has to stay the input the catch was handed, and the inner ran on a payload of its own so its issues are already private to this call.
   payload.value = def.catchValue({
-    ...payload,
-    value: input,
-    issues: [...result.issues],
+    ...result,
+    value: payload.value,
     error: {
       issues: result.issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())),
     },
-    input,
+    input: payload.value,
   });
-
-  // Truncate rather than rebind: as a pipe's `out` this shares the caller's array. See handleOptionalResult.
-  payload.issues.length = 0;
-  payload.aborted = false;
   return payload;
 }
 
@@ -4223,13 +4212,12 @@ export const $ZodCatch: core.$constructor<$ZodCatch> = /*@__PURE__*/ core.$const
     }
 
     // Forward direction (decode): apply catch logic
-    const input = payload.value;
-    const result = def.innerType._zod.run(payload, ctx);
+    const result = def.innerType._zod.run({ value: payload.value, issues: [] }, ctx);
     if (result instanceof Promise) {
-      return result.then((result) => handleCatchResult(payload, result, input, def, ctx));
+      return result.then((result) => handleCatchResult(payload, result, def, ctx));
     }
 
-    return handleCatchResult(payload, result, input, def, ctx);
+    return handleCatchResult(payload, result, def, ctx);
   };
 });
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4183,6 +4183,8 @@ export interface $ZodCatch<T extends SomeType = $ZodType> extends $ZodType {
 function handleCatchResult(payload: ParsePayload, result: ParsePayload, def: $ZodCatchDef, ctx: ParseContextInternal) {
   if (!result.issues.length) {
     payload.value = result.value;
+    // The value carries up, so the flag describing it has to carry with it: a back-edge into a node still being parsed must not be frozen by an enclosing readonly, and its checks belong to the node itself. Guarded so the ordinary case adds no own property.
+    if (result.memo) payload.memo = true;
     return payload;
   }
 


### PR DESCRIPTION
A pipe hands its `out` schema the caller's issues array, so an unrecognized key can survive to an enclosing intersection that may yet reconcile it. Two wrappers on the far side of that pipe read someone else's issue as their own inner failing, substitute for it, and clear the array.

For catch, that loses the strict violation:

```ts
z.strictObject({ a: z.string() })
  .pipe(z.any().catch("CAUGHT"))
  .safeParse({ a: "x", extra: 1 });
// before: { success: true, data: "CAUGHT" }
// after:  fails with unrecognized_keys
```

and, where an intersection was the reason the key was forwarded at all, it substitutes the fallback into one side of the merge and throws out of `safeParse`:

```ts
z.intersection(
  z.strictObject({ a: z.string() }).pipe(z.any().catch("CAUGHT")),
  z.strictObject({ b: z.string() })
).parse({ a: "x", b: "y" });
// before: Error: Unmergable intersection. Error path: []
// after:  { a: "x", b: "y" }
```

`.optional()` over a defaulted inner has the same hole:

```ts
z.strictObject({ a: z.string() })
  .transform((): number | undefined => undefined)
  .pipe(z.number().default(5).optional())
  .safeParse({ a: "x", extra: 1 });
// before: { success: true }
// after:  fails with unrecognized_keys, like the same shape without .optional()
```

`z.any()` cannot fail and a default cannot fail, so neither wrapper had any business substituting.

Both fire because they share a payload with their inner schema and so cannot tell whose issues they are looking at. Giving the inner a payload of its own removes the ambiguity — whatever lands in that array is the inner's, and the caller's is untouched. This is what v3 did, and what the compiled `runtimeCatch` already did.

Everything that existed to undo the inner's damage to the shared payload goes with it: the pre-run value capture, the defensive copy of the issues array, and the truncation and abort resets in both wrappers. Spreading the inner's result rather than the caller's payload keeps `ctx.aborted` reporting what it always reported, since the old spread read that payload only after the inner had finished mutating it.

One flag does have to be carried across by hand. The memoizer marks a payload whose value is a node still being parsed, and that mark describes the value, which still propagates. Without it an enclosing `readonly` froze a half-built object — silently dropping a key under the JIT, and throwing `TypeError` out of `parse` for records, tuples, arrays and jitless objects — and a check on the back-edge ran against the in-progress node.

Bundle is 2 B smaller raw and 5 B smaller gzipped on a classic fixture, unchanged on `zod/mini`. Retained bytes per schema are identical. Allocation on the failure path drops about 24 B per parse, with no measurable change on the success path.

Refs #6192
