### PR TITLE
perf(v4): close the fastpass bindings into the compiled parser

### DIFF
--- a/packages/zod/src/v4/core/doc.ts
+++ b/packages/zod/src/v4/core/doc.ts
@@ -1,12 +1,15 @@
 type ModeWriter = (doc: Doc, modes: { execution: "sync" | "async" }) => void;
 
 export class Doc {
-  args!: string[];
+  args: string[];
+  /** Bindings the compiled function closes over, by name. */
+  closed: Record<string, unknown>;
   content: string[] = [];
   indent = 0;
 
-  constructor(args: string[] = []) {
-    if (this) this.args = args;
+  constructor(args: string[] = [], closed: Record<string, unknown> = {}) {
+    this.args = args;
+    this.closed = closed;
   }
 
   indented(fn: (doc: Doc) => void) {
@@ -35,10 +38,11 @@ export class Doc {
 
   compile(): any {
     const F = Function;
-    const args = this?.args;
     const content = this?.content ?? [``];
-    const lines = [...content.map((x) => `  ${x}`)];
-    // console.log(lines.join("\n"));
-    return new F(...args, lines.join("\n")) as any;
+    const factory = new F(
+      ...Object.keys(this.closed),
+      `return function (${this.args.join(", ")}) {\n${content.join("\n")}\n};`
+    );
+    return factory(...Object.values(this.closed)) as any;
   }
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2158,18 +2158,9 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
 
     const generateFastpass = (shape: any) => {
       const normalized = _normalized.value;
-      // closure below retains this scope per schema, so add no bindings here — a key-expression helper cost 328 bytes each
       const syms = normalized.symbolKeys;
-      // a symbol has no source literal, so it is passed in and read as `syms[i]`; string-only shapes get no such parameter
-      const doc = new Doc(
-        syms.length
-          ? memo
-            ? ["shape", "payload", "ctx", "inst", "memo", "syms"]
-            : ["shape", "payload", "ctx", "syms"]
-          : memo
-            ? ["shape", "payload", "ctx", "inst", "memo"]
-            : ["shape", "payload", "ctx"]
-      );
+      // a symbol has no source literal, so it is read as `syms[i]` off the closed-over scope
+      const doc = new Doc(["payload", "ctx"], { shape, inst, memo, syms });
 
       const parseStr = (k: string) => `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
 
@@ -2256,13 +2247,8 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
 
       doc.write(`payload.value = newResult;`);
       doc.write(`return payload;`);
-      const fn = doc.compile();
-      if (syms.length) {
-        if (memo) return (payload: any, ctx: any) => fn(shape, payload, ctx, inst, memo, syms);
-        return (payload: any, ctx: any) => fn(shape, payload, ctx, syms);
-      }
-      if (memo) return (payload: any, ctx: any) => fn(shape, payload, ctx, inst, memo);
-      return (payload: any, ctx: any) => fn(shape, payload, ctx);
+      // closing `shape` in is what pays: turbofan specializes the parser against that one shape object, so every `shape[k]._zod.run` folds to a known callee. as a parameter it stays a generic load and measures 13% slower even with the forwarding frame gone
+      return doc.compile() as (payload: any, ctx: any) => any;
     };
 
     let fastpass!: ReturnType<typeof generateFastpass>;


### PR DESCRIPTION
The compiled object parser took the shape, the schema, the memoizer and the symbol-key array as parameters, and a forwarding closure pushed all four on every parse. A doc now carries the bindings its compiled function closes over, declared where the doc is created, so the parser takes only the payload and the context:

```ts
const doc = new Doc(["payload", "ctx"], { shape, inst, memo, syms });
// ...
return doc.compile();
```

The builder's own signature is unchanged — the constructor gains an optional second argument, and `compile()` still takes none.

**The shape binding is what pays, not the frame.** Same generated body every time, varying only how the bindings arrive, one schema, Node 26:

| | ns/parse | vs main |
| --- | --- | --- |
| shape/schema/memoizer as parameters, forwarding closure (main) | 21.351 | — |
| all four closed over (this PR) | 16.693 | −21.8% |
| only the shape closed over, the other three as parameters | 17.781 | −16.7% |
| the shape as a parameter, the other three closed over | 24.230 | +13.5% |

Closing over the shape recovers nearly the whole gain; keeping it a parameter loses even with the forwarding frame gone. The parser reads that binding once per key, so as a closure constant TurboFan specializes against the one shape object and each key's lookup folds to a known callee, where a parameter leaves a generic load.

Two things that are *not* the cause, both checked: the forwarding frame is free — V8's inlining trace shows it inlined into the caller, and adding it back to the closed-over version costs nothing — and it is not inline-cache pollution, since the gap is widest with a single schema. Profiling the steady-state loop puts the whole difference inside the compiled parser (1422 samples against 618 for identical work) rather than at the call boundary, and it nearly vanishes with TurboFan disabled.

Measured against the merge base with a fresh process per side, round-robin interleaved, fixed iteration count, `gc()` between samples, min of 12 samples, 24 rounds:

| workload | paired median | rounds won |
| --- | --- | --- |
| 8-key object, nested + array | −10.5% | 16/16 |
| 3-key object | −13.5% | 16/16 |

Retained heap per parsed schema, over 500 schemas with unique key names so no two generated sources are shared, is neutral to better on both supported runtimes:

| keys | Node 24.19 | Node 26.7 |
| --- | --- | --- |
| 3 | 0 | −60 |
| 8 | −154 | −56 |
| 24 | −713 | −56 |
| 100 | −437 (±1000, noisy) | −64 |

The two runtimes differ because Node 24 retains the generated parser source and Node 26 does not. That is why the generated body no longer carries its two-space indent: on Node 24 that whitespace is live memory, worth 1018 bytes per 24-key schema, and it costs nothing to drop since nothing reads the body and the ahead-of-time debug output is assembled separately.

Bundled with esbuild `--minify --conditions=@zod/source`, gzip -9: a classic object bundle drops 130 bytes raw / 22 gzipped, and a mini object bundle is byte-identical, since mini parses objects through the interpreted path.

Construction on its own is unchanged; construction plus the first parse is 2.9% faster.

The ahead-of-time path still assembles its own function rather than going through the doc builder. That predates this change, and unifying it would alter its generated wrapper, so it is left alone.

Refs #6109.
