### PR TITLE
feat(v4): make a tuple's items optional with .partial()

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1774,6 +1774,29 @@ const variadicTuple = z.tuple([z.string()], z.number());
 // => [string, ...number[]];
 ```
 
+To make every element optional:
+
+<Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
+<Tab value="Zod">
+```ts zod
+const PartialTuple = z.tuple([z.string(), z.number()]).partial();
+// => [(string | undefined)?, (number | undefined)?]
+
+z.tuple([z.string()], z.number()).partial();
+// => [(string | undefined)?, ...number[]]
+```
+</Tab>
+<Tab value="Zod Mini">
+```ts
+const PartialTuple = z.partial(z.tuple([z.string(), z.number()]));
+// => [(string | undefined)?, (number | undefined)?]
+
+z.partial(z.tuple([z.string()], z.number()));
+// => [(string | undefined)?, ...number[]]
+```
+</Tab>
+</Tabs>
+
 ## Unions
 
 Union types (`A | B`) represent a logical "OR". Zod union schemas will check the input against each option in order. The first value that validates successfully is returned.

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1874,9 +1874,12 @@ function _zodTupleMethods(): _LazyMethodsOf<ZodTuple> {
       }) as any;
     },
     partial() {
+      const def = this._zod.def;
+      // a refinement was authored against the full arity; partialing would run it on a shorter array
+      if (def.checks?.length) throw new Error(".partial() cannot be used on tuple schemas containing refinements");
       return this.clone({
-        ...this._zod.def,
-        items: this._zod.def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
+        ...def,
+        items: def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
       }) as any;
     },
   };

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1855,18 +1855,32 @@ export interface ZodTuple<
     core.$ZodTuple<T, Rest> {
   "~standard": ZodStandardSchemaWithJSON<this>;
   rest<Rest extends core.SomeType = core.$ZodType>(rest: Rest): ZodTuple<T, Rest>;
+  partial(): ZodTuple<{ -readonly [k in keyof T]: ZodOptional<T[k]> }, Rest>;
 }
 export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constructor("ZodTuple", (inst, def) => {
   core.attachMemoizer(inst);
   core.$ZodTuple.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.tupleProcessor(inst, ctx, json, params);
-  inst.rest = (rest) =>
-    inst.clone({
-      ...inst._zod.def,
-      rest: rest as any as core.$ZodType,
-    }) as any;
+  _installLazyMethods(inst, "rest", _zodTupleMethods);
 });
+
+function _zodTupleMethods(): _LazyMethodsOf<ZodTuple> {
+  return {
+    rest(rest) {
+      return this.clone({
+        ...this._zod.def,
+        rest: rest as any as core.$ZodType,
+      }) as any;
+    },
+    partial() {
+      return this.clone({
+        ...this._zod.def,
+        items: this._zod.def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
+      }) as any;
+    },
+  };
+}
 
 export function tuple<T extends readonly [core.SomeType, ...core.SomeType[]]>(
   items: T,

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -488,6 +488,11 @@ test("partial", () => {
   expect(schema.parse(["a", 1, true])).toEqual(["a", 1, true]);
   expect(schema.safeParse(["a", "b"]).success).toEqual(false);
   expect(schema.safeParse(["a", 1, true, 4]).success).toEqual(false);
+
+  // the arity relaxation has to survive the JSON Schema round trip: `minItems` disappears
+  expect(z.toJSONSchema(schema)).toEqual(
+    z.toJSONSchema(z.tuple([z.string().optional(), z.number().optional(), z.boolean().optional()]))
+  );
 });
 
 test("partial leaves rest alone", () => {
@@ -496,5 +501,11 @@ test("partial leaves rest alone", () => {
 
   expect(schema.parse([])).toEqual([]);
   expect(schema.parse(["a", 1, 2])).toEqual(["a", 1, 2]);
-  expect(schema.safeParse([undefined, "b"]).success).toEqual(false);
+  // discriminating input: `true` only if rest had been wrapped too
+  expect(schema.safeParse(["a", undefined]).success).toEqual(false);
+});
+
+test("partial rejects a tuple carrying refinements", () => {
+  const schema = z.tuple([z.string(), z.number()]).refine(([a]) => a.length > 0);
+  expect(() => schema.partial()).toThrow("cannot be used on tuple schemas containing refinements");
 });

--- a/packages/zod/src/v4/classic/tests/tuple.test.ts
+++ b/packages/zod/src/v4/classic/tests/tuple.test.ts
@@ -476,3 +476,25 @@ test("too_big tuple still surfaces element-wise type errors for present indices"
     ]
   `);
 });
+
+test("partial", () => {
+  const schema = z.tuple([z.string(), z.number(), z.boolean()]).partial();
+  expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<
+    [(string | undefined)?, (number | undefined)?, (boolean | undefined)?]
+  >();
+
+  expect(schema.parse([])).toEqual([]);
+  expect(schema.parse(["a"])).toEqual(["a"]);
+  expect(schema.parse(["a", 1, true])).toEqual(["a", 1, true]);
+  expect(schema.safeParse(["a", "b"]).success).toEqual(false);
+  expect(schema.safeParse(["a", 1, true, 4]).success).toEqual(false);
+});
+
+test("partial leaves rest alone", () => {
+  const schema = z.tuple([z.string()], z.number()).partial();
+  expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<[(string | undefined)?, ...number[]]>();
+
+  expect(schema.parse([])).toEqual([]);
+  expect(schema.parse(["a", 1, 2])).toEqual(["a", 1, 2]);
+  expect(schema.safeParse([undefined, "b"]).success).toEqual(false);
+});

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1012,8 +1012,18 @@ export function partial<T extends ZodMiniObject, M extends util.Mask<keyof T["sh
   T["_zod"]["config"]
 >;
 // @__NO_SIDE_EFFECTS__
-export function partial(schema: ZodMiniObject, mask?: object) {
-  return util.partial(ZodMiniOptional, schema, mask);
+export function partial<T extends util.TupleItems, Rest extends SomeType | null>(
+  schema: ZodMiniTuple<T, Rest>
+): ZodMiniTuple<{ -readonly [k in keyof T]: ZodMiniOptional<T[k]> }, Rest>;
+// @__NO_SIDE_EFFECTS__
+export function partial(schema: ZodMiniObject | ZodMiniTuple, mask?: object) {
+  const def = schema._zod.def;
+  return def.type === "tuple"
+    ? util.clone(schema, {
+        ...def,
+        items: def.items.map((item) => new ZodMiniOptional({ type: "optional", innerType: item as core.$ZodType })),
+      })
+    : util.partial(ZodMiniOptional, schema as ZodMiniObject, mask);
 }
 
 // @__NO_SIDE_EFFECTS__

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1018,12 +1018,13 @@ export function partial<T extends util.TupleItems, Rest extends SomeType | null>
 // @__NO_SIDE_EFFECTS__
 export function partial(schema: ZodMiniObject | ZodMiniTuple, mask?: object) {
   const def = schema._zod.def;
-  return def.type === "tuple"
-    ? util.clone(schema, {
-        ...def,
-        items: def.items.map((item) => new ZodMiniOptional({ type: "optional", innerType: item as core.$ZodType })),
-      })
-    : util.partial(ZodMiniOptional, schema as ZodMiniObject, mask);
+  if (def.type !== "tuple") return util.partial(ZodMiniOptional, schema as ZodMiniObject, mask);
+  // a refinement was authored against the full arity; partialing would run it on a shorter array
+  if (def.checks?.length) throw new Error(".partial() cannot be used on tuple schemas containing refinements");
+  return util.clone(schema, {
+    ...def,
+    items: def.items.map((item) => new ZodMiniOptional({ type: "optional", innerType: item as core.$ZodType })),
+  });
 }
 
 // @__NO_SIDE_EFFECTS__

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -1045,3 +1045,13 @@ test("getDiscriminatedOption", () => {
   expect(z.getDiscriminatedOption(schema, "b")).toBe(b);
   expectTypeOf(z.getDiscriminatedOption(schema, "a")).toEqualTypeOf<typeof a>();
 });
+
+test("z.partial on a tuple", () => {
+  const schema = z.partial(z.tuple([z.string(), z.number()]));
+  expectTypeOf<z.infer<typeof schema>>().toEqualTypeOf<[(string | undefined)?, (number | undefined)?]>();
+
+  expect(z.safeParse(schema, []).success).toEqual(true);
+  expect(z.safeParse(schema, ["a"]).success).toEqual(true);
+  expect(z.safeParse(schema, ["a", 1]).success).toEqual(true);
+  expect(z.safeParse(schema, ["a", "b"]).success).toEqual(false);
+});

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -1054,4 +1054,7 @@ test("z.partial on a tuple", () => {
   expect(z.safeParse(schema, ["a"]).success).toEqual(true);
   expect(z.safeParse(schema, ["a", 1]).success).toEqual(true);
   expect(z.safeParse(schema, ["a", "b"]).success).toEqual(false);
+
+  const refined = z.tuple([z.string(), z.number()]).check(z.refine(([a]) => a.length > 0));
+  expect(() => z.partial(refined)).toThrow("cannot be used on tuple schemas containing refinements");
 });


### PR DESCRIPTION
Calling `.partial()` on a tuple wraps every item in `.optional()`, and `z.partial()` accepts a tuple in Mini.

The parse path already handled optional items — a tuple derives its minimum arity from each item's `optin`/`optout` and truncates the tail for absent optional slots — so this is only the mapping. A partialed tuple parses and emits the same JSON Schema as one written with `.optional()` by hand.

Rest is left alone. Its elements are already arity-optional, so wrapping it would only admit an explicit `undefined` in the variadic tail.

```ts
z.tuple([z.string(), z.number()]).partial();
// => [(string | undefined)?, (number | undefined)?]

z.tuple([z.string()], z.number()).partial();
// => [(string | undefined)?, ...number[]]
```

Refinements are rejected, matching `.partial()` on objects, `.extend()` and `.merge()`. Carrying them across would run a refinement authored against the full arity on a shorter array — `.refine(([a]) => a.length > 0)` threw a `TypeError` out of `safeParse` before the guard went in.

The tuple's methods also move onto the lazy-prototype install the other classic types use, so `rest` stops costing an own property.

| axis | result |
| --- | --- |
| memory | −64 B per tuple (2108 → 2044 B for `z.tuple([str])`); `z.object({a})` unchanged |
| bundle | classic object-only 0, Mini tuple that never calls `partial` 0, Mini `partial` of an object +67 B gz, classic tuple +88 B gz, classic full +87 B gz, Mini full +90 B gz |
| runtime | `core/schemas.ts` has a zero-line diff, so the parse path is unchanged; construction allocates one fewer closure |

A classic bundle containing any tuple pays that +88 B whether or not it calls `.partial()`, since the method factory carries both bodies. That is inherent to adding a classic method.

Two things deliberately left out: an index mask, because `z.tuple([a, b.optional()])` already says it in fewer characters, and `.exactPartial()` for tuples, which is not planned.

The Mini side branches on the tuple type inside `partial()`, which the contributor guide forbids in shared code. It buys the overload rather than a second exported name, and it is a builder rather than a parse path, but it is the tradeoff worth naming.

Refs #6142
