### PR TITLE
fix(v4): don't throw from safeParse on bigint multipleOf(0n)

### DIFF
--- a/packages/zod/src/v4/classic/tests/bigint.test.ts
+++ b/packages/zod/src/v4/classic/tests/bigint.test.ts
@@ -63,3 +63,13 @@ test("bigint formats are distinct at the type level", () => {
   // @ts-expect-error a uint64 schema is not a ZodInt64
   z.uint64() satisfies z.ZodInt64;
 });
+
+test("multipleOf(0n) does not throw from safeParse", () => {
+  // `value % 0n` throws RangeError; safeParse must never throw. Mirror the
+  // number branch, where z.number().multipleOf(0) reports a failure instead.
+  const schema = z.bigint().multipleOf(BigInt(0));
+  const result = schema.safeParse(BigInt(10));
+  expect(result.success).toBe(false);
+  // consistent with the number equivalent
+  expect(z.number().multipleOf(0).safeParse(10).success).toBe(false);
+});

--- a/packages/zod/src/v4/classic/tests/bigint.test.ts
+++ b/packages/zod/src/v4/classic/tests/bigint.test.ts
@@ -65,11 +65,19 @@ test("bigint formats are distinct at the type level", () => {
 });
 
 test("multipleOf(0n) does not throw from safeParse", () => {
-  // `value % 0n` throws RangeError; safeParse must never throw. Mirror the
-  // number branch, where z.number().multipleOf(0) reports a failure instead.
+  // `value % 0n` throws RangeError, so the compiled path declines and the runtime reports the failure
   const schema = z.bigint().multipleOf(BigInt(0));
   const result = schema.safeParse(BigInt(10));
   expect(result.success).toBe(false);
-  // consistent with the number equivalent
+  expect(result.error!.issues[0].code).toEqual("not_multiple_of");
+  expect(schema.safeParse(BigInt(0)).success).toBe(false);
+
+  // matches the number equivalent
   expect(z.number().multipleOf(0).safeParse(10).success).toBe(false);
+  expect(z.number().multipleOf(0).safeParse(0).success).toBe(false);
+
+  // a zero divisor nested in an object must not break the surrounding parse
+  const obj = z.object({ a: z.bigint().multipleOf(BigInt(0)), b: z.bigint() });
+  expect(obj.safeParse({ a: BigInt(1), b: BigInt(2) }).success).toBe(false);
+  expect(obj.safeParse({ a: BigInt(1), b: 2 }).success).toBe(false);
 });

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -190,7 +190,10 @@ export const $ZodCheckMultipleOf: core.$constructor<$ZodCheckMultipleOf<number |
         throw new Error("Cannot mix number and bigint in multiple_of check.");
       const isMultiple =
         typeof payload.value === "bigint"
-          ? payload.value % (def.value as bigint) === BigInt(0)
+          ? // Guard against a 0n divisor: `value % 0n` throws RangeError, which
+            // would escape safeParse. Treat it as "not a multiple", matching the
+            // number branch where floatSafeRemainder(value, 0) is NaN !== 0.
+            (def.value as bigint) !== BigInt(0) && payload.value % (def.value as bigint) === BigInt(0)
           : util.floatSafeRemainder(payload.value, def.value as number) === 0;
 
       if (isMultiple) return;

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -190,9 +190,7 @@ export const $ZodCheckMultipleOf: core.$constructor<$ZodCheckMultipleOf<number |
         throw new Error("Cannot mix number and bigint in multiple_of check.");
       const isMultiple =
         typeof payload.value === "bigint"
-          ? // Guard against a 0n divisor: `value % 0n` throws RangeError, which
-            // would escape safeParse. Treat it as "not a multiple", matching the
-            // number branch where floatSafeRemainder(value, 0) is NaN !== 0.
+          ? // `value % 0n` throws, and nothing is a multiple of zero — the number branch already fails this way via NaN
             (def.value as bigint) !== BigInt(0) && payload.value % (def.value as bigint) === BigInt(0)
           : util.floatSafeRemainder(payload.value, def.value as number) === 0;
 

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -460,6 +460,8 @@ function generateMultipleOfCheck(
   accessor: string
 ): void {
   if (typeof def.value === "bigint") {
+    // a zero divisor has no compiled form: `x % 0n` throws
+    if (def.value === BigInt(0)) throw new ZodCompileUnsupportedError("multiple_of check with a zero divisor");
     doc.write(`if (${accessor} % ${def.value}n !== 0n) return INVALID;`);
   } else {
     // Float `%` has well-known precision issues for sub-integer steps

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1482,6 +1482,8 @@ test("unsupported features throw ZodCompileUnsupportedError, not raw errors", ()
   );
   // NaN comparison bounds can't compile to a faithful comparison.
   expect(() => compile(z.number().gt(Number.NaN))).toThrow(ZodCompileUnsupportedError);
+  // A zero bigint divisor has no compiled form: `x % 0n` throws.
+  expect(() => compile(z.bigint().multipleOf(BigInt(0)))).toThrow(ZodCompileUnsupportedError);
   // Unsupported children still island inside containers.
   const aot = compile(z.object({ a: z.string(), x: z.xor([z.literal("p"), z.literal("q")]) }));
   expect(valid(aot, { a: "x", x: "p" })).toEqual({ a: "x", x: "p" });


### PR DESCRIPTION
Carries #6140 forward. The fork has maintainer edits turned off, so that branch couldn't be updated in place — MerlijnW70's commit is preserved here with authorship intact.

A bigint schema with `multipleOf(0n)` threw `RangeError: Division by zero` out of `safeParse`. The number equivalent already reports a failure instead of throwing, and the runtime check now guards the divisor the same way.

The original fix was incomplete. The compiler emits `x % 0n !== 0n`, so a compiled schema still threw and the new test failed under compile mode. A zero divisor is now declined at compile time, which turns the node into a runtime island — the same way the compiler already declines a NaN comparison bound.

#6126 fixes the same bug but treats `0n` as a valid multiple of `0n`, which the number branch rejects.

Costs 6 B gzipped on a classic bundle and nothing on mini; the compiler change tree-shakes out of both.
