### PR TITLE
fix(v4): stop emitting a multipleOf that JSON Schema rejects

### DIFF
--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -71,6 +71,7 @@ z.set(); // ❌
 z.transform(); // ❌
 z.nan(); // ❌
 z.custom(); // ❌
+z.number().multipleOf(0); // ❌ the divisor must be finite and greater than zero
 ```
 
 
@@ -238,6 +239,7 @@ z.set(); // ❌
 z.transform(); // ❌
 z.nan(); // ❌
 z.custom(); // ❌
+z.number().multipleOf(0); // ❌ the divisor must be finite and greater than zero
 ```
 
 By default, Zod will throw an error if any of these are encountered. 

--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -71,7 +71,7 @@ z.set(); // ❌
 z.transform(); // ❌
 z.nan(); // ❌
 z.custom(); // ❌
-z.number().multipleOf(0); // ❌ the divisor must be finite and greater than zero
+z.number().multipleOf(0); // ❌ the divisor must be finite and non-zero
 ```
 
 
@@ -239,7 +239,7 @@ z.set(); // ❌
 z.transform(); // ❌
 z.nan(); // ❌
 z.custom(); // ❌
-z.number().multipleOf(0); // ❌ the divisor must be finite and greater than zero
+z.number().multipleOf(0); // ❌ the divisor must be finite and non-zero
 ```
 
 By default, Zod will throw an error if any of these are encountered. 

--- a/packages/docs/content/json-schema.mdx
+++ b/packages/docs/content/json-schema.mdx
@@ -249,11 +249,14 @@ z.toJSONSchema(z.bigint());
 // => throws Error
 ```
 
-You can change this behavior by setting the `unrepresentable` option to `"any"`. This will convert any unrepresentable types to `{}` (the equivalent of `unknown` in JSON Schema).
+You can change this behavior by setting the `unrepresentable` option to `"any"`. This will convert any unrepresentable type to `{}` (the equivalent of `unknown` in JSON Schema), and drop an unrepresentable check from the schema that carries it.
 
 ```ts
 z.toJSONSchema(z.bigint(), { unrepresentable: "any" });
 // => {}
+
+z.toJSONSchema(z.number().multipleOf(0), { unrepresentable: "any" });
+// => { type: "number" }
 ```
 
 To decide case by case, pass a function instead. It's called for each unrepresentable schema encountered. Return a JSON Schema to use in its place, `"any"`, or `"throw"` (the default when you return nothing).

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -2402,6 +2402,23 @@ test("escapes JSON Pointer reserved characters in the root $ref", () => {
   expect(Object.keys(result.$defs!)).toEqual(["Shared/User~"]);
 });
 
+test("a multipleOf divisor JSON Schema cannot express goes through `unrepresentable`", () => {
+  // the keyword must be strictly greater than zero, and NaN/Infinity do not survive JSON at all
+  for (const divisor of [0, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+    expect(() => z.toJSONSchema(z.number().multipleOf(divisor))).toThrow(/cannot be represented in JSON Schema/);
+    expect(z.toJSONSchema(z.number().multipleOf(divisor), { unrepresentable: "any" })).toMatchObject({
+      type: "number",
+    });
+    expect(z.toJSONSchema(z.number().multipleOf(divisor), { unrepresentable: "any" })).not.toHaveProperty("multipleOf");
+  }
+
+  // a negative divisor accepts exactly what its absolute value accepts, so it still maps
+  expect(z.number().multipleOf(-5).safeParse(10).success).toEqual(true);
+  expect(z.number().multipleOf(-5).safeParse(13).success).toEqual(false);
+  expect(z.toJSONSchema(z.number().multipleOf(-5))).toMatchObject({ multipleOf: 5 });
+  expect(z.toJSONSchema(z.number().multipleOf(0.1))).toMatchObject({ multipleOf: 0.1 });
+});
+
 test("unrepresentable default values go through `unrepresentable`", () => {
   // a bigint default has no reliable JSON encoding, so it is dropped rather than approximated
   expect(z.toJSONSchema(z.bigint().default(0n), { unrepresentable: "any" })).toMatchInlineSnapshot(`

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -61,7 +61,7 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
   }
 };
 
-export const numberProcessor: Processor<schemas.$ZodNumber> = (schema, ctx, _json, _params) => {
+export const numberProcessor: Processor<schemas.$ZodNumber> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.NumberSchema | JSONSchema.IntegerSchema;
   const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum } = schema._zod.bag;
   if (typeof format === "string" && format.includes("int")) json.type = "integer";
@@ -94,7 +94,18 @@ export const numberProcessor: Processor<schemas.$ZodNumber> = (schema, ctx, _jso
     json.maximum = maximum;
   }
 
-  if (typeof multipleOf === "number") json.multipleOf = multipleOf;
+  if (typeof multipleOf === "number") {
+    // JSON Schema requires a divisor strictly greater than zero, and a non-finite one does not survive JSON at all. A negative divisor accepts exactly what its absolute value accepts, so it still maps; zero, NaN and Infinity have no keyword form.
+    if (Number.isFinite(multipleOf) && multipleOf !== 0) json.multipleOf = Math.abs(multipleOf);
+    else
+      handleUnrepresentable(
+        schema,
+        ctx,
+        json,
+        params,
+        `A multipleOf divisor of ${multipleOf} cannot be represented in JSON Schema`
+      );
+  }
 };
 
 export const booleanProcessor: Processor<schemas.$ZodBoolean> = (_schema, _ctx, json, _params) => {


### PR DESCRIPTION
JSON Schema requires `multipleOf` to be a number strictly greater than zero, but every degenerate divisor reached the output unchanged. A zero divisor emitted `0`, and NaN and Infinity emitted `null`, since neither survives JSON. A conformant consumer rejects all three.

A negative divisor is the one case that still maps — it accepts exactly what its absolute value accepts, so it now emits that absolute value. Zero, NaN and Infinity have no keyword form, so they go through `unrepresentable`: throwing by default, and dropping the keyword under `unrepresentable: "any"`.

Costs 38 bytes gzipped in a classic bundle and nothing in `zod/mini`, which shakes the processor out unless `toJSONSchema` is used. Parse and construction are untouched.

Found while fixing the bigint `multipleOf(0n)` crash in #6466.
