### PR TITLE
feat(v4): add z.isValid and z.isValidAsync

### DIFF
--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -128,6 +128,15 @@ await schema.safeParseAsync("hello");
 ```
 </Callout>
 
+When you only need to know whether an input is acceptable, use the top-level `z.isValid()` function. It returns a boolean, never builds an error, and acts as a type guard on the schema's input type.
+
+```ts
+z.isValid(Player, { username: "billie", xp: 100 }); // true
+z.isValid(Player, { username: 42, xp: "100" });     // false
+```
+
+Use `z.isValidAsync()` for schemas with async refinements or transforms. On a [compiled schema](/compile), `z.isValid()` answers directly from the compiled fast path.
+
 ## Inferring types
 
 Zod infers a static type from your schema definitions. You can extract this type with the `z.infer<>` utility and use it however you like.

--- a/packages/zod/src/compile.ts
+++ b/packages/zod/src/compile.ts
@@ -36,6 +36,8 @@ core.globalConfig.postProcessor = (inst: any) => {
       const compiled = compile(inst);
       // Only the run wrapper. Copying the compiled parse/safeParse closures would make their fallback re-enter this instance and run user callbacks a third time.
       inst._zod.run = compiled._zod.run;
+      inst._zod.bag.fastpass = compiled._zod.bag.fastpass;
+      inst._zod.bag.fallbackRun = compiled._zod.bag.fallbackRun;
     } catch {
       // Permanent fallback for unsupported schemas.
       inst._zod.run = originalRun;

--- a/packages/zod/src/v4/classic/parse.ts
+++ b/packages/zod/src/v4/classic/parse.ts
@@ -32,6 +32,8 @@ export const safeParseAsync: <T extends core.$ZodType>(
   _ctx?: core.ParseContext<core.$ZodIssue>
 ) => Promise<ZodSafeParseResult<core.output<T>>> = /* @__PURE__ */ core._safeParseAsync(ZodRealError) as any;
 
+export { isValid, isValidAsync } from "../core/index.js";
+
 // Codec functions
 export const encode: <T extends core.$ZodType>(
   schema: T,

--- a/packages/zod/src/v4/classic/tests/is-valid.test.ts
+++ b/packages/zod/src/v4/classic/tests/is-valid.test.ts
@@ -1,0 +1,72 @@
+import { expect, expectTypeOf, test } from "vitest";
+
+import * as zm from "zod/mini";
+import * as z from "zod/v4";
+
+test("isValid answers like safeParse.success", () => {
+  expect(z.isValid(z.string(), "asdf")).toBe(true);
+  expect(z.isValid(z.string(), 12)).toBe(false);
+  expect(z.isValid(z.number().int().min(0), 5)).toBe(true);
+  expect(z.isValid(z.number().int().min(0), -5)).toBe(false);
+  const schema = z.object({ a: z.string(), b: z.array(z.number()) });
+  expect(z.isValid(schema, { a: "x", b: [1, 2] })).toBe(true);
+  expect(z.isValid(schema, { a: "x", b: [1, "2"] })).toBe(false);
+  expect(z.isValid(schema, null)).toBe(false);
+});
+
+test("isValid runs transforms and refinements for the verdict only", () => {
+  const schema = z
+    .string()
+    .transform((s) => s.length)
+    .pipe(z.number().max(3));
+  expect(z.isValid(schema, "ab")).toBe(true);
+  expect(z.isValid(schema, "abcd")).toBe(false);
+  expect(z.isValid(z.coerce.number(), "5")).toBe(true);
+});
+
+test("isValid narrows to the input type", () => {
+  const value: unknown = "hi";
+  if (z.isValid(z.string(), value)) {
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+  const transforming = z.string().transform((s) => s.length);
+  if (z.isValid(transforming, value)) {
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+});
+
+test("isValid throws on async schemas; isValidAsync handles them", async () => {
+  const schema = z.string().refine(async (s) => s.length > 2);
+  expect(() => z.isValid(schema, "asdf")).toThrow();
+  await expect(z.isValidAsync(schema, "asdf")).resolves.toBe(true);
+  await expect(z.isValidAsync(schema, "a")).resolves.toBe(false);
+  await expect(z.isValidAsync(z.string(), "a")).resolves.toBe(true);
+});
+
+test("isValid agrees with the compiled fast path and keeps the callback bound", () => {
+  let calls = 0;
+  const schema = z.object({
+    name: z.string().refine((s) => {
+      calls++;
+      return s.length > 1;
+    }),
+  });
+  const compiled = z.compile(schema);
+
+  calls = 0;
+  expect(z.isValid(compiled, { name: "ok" })).toBe(true);
+  expect(calls).toBe(1);
+
+  calls = 0;
+  expect(z.isValid(compiled, { name: "x" })).toBe(false);
+  expect(calls).toBeLessThanOrEqual(2);
+
+  expect(z.isValid(compiled, { name: 42 })).toBe(false);
+  expect(z.isValid(schema, { name: "ok" })).toBe(true);
+});
+
+test("isValid is exported from zod/mini", () => {
+  expect(zm.isValid(zm.string(), "a")).toBe(true);
+  expect(zm.isValid(zm.string(), 1)).toBe(false);
+  expect(zm.isValid(zm.object({ a: zm.number() }), { a: 1 })).toBe(true);
+});

--- a/packages/zod/src/v4/classic/tests/is-valid.test.ts
+++ b/packages/zod/src/v4/classic/tests/is-valid.test.ts
@@ -41,6 +41,10 @@ test("isValid throws on async schemas; isValidAsync handles them", async () => {
   await expect(z.isValidAsync(schema, "asdf")).resolves.toBe(true);
   await expect(z.isValidAsync(schema, "a")).resolves.toBe(false);
   await expect(z.isValidAsync(z.string(), "a")).resolves.toBe(true);
+  // a promise-returning callback that is not declared async compiles, so the compiled schema must stay off the fast path
+  const compiled = z.compile(z.string().refine((s) => Promise.resolve(s.length > 1)));
+  await expect(z.isValidAsync(compiled, "abc")).resolves.toBe(true);
+  await expect(z.isValidAsync(compiled, "a")).resolves.toBe(false);
 });
 
 test("isValid agrees with the compiled fast path and keeps the callback bound", () => {

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -135,7 +135,7 @@ export function compile<T extends SomeType>(schema: T): T {
     if (ctx) (ctx as Record<symbol, unknown>)[FALLBACK_FLAG] = true;
     return originalRun(payload, ctx);
   };
-  // Let later compiles of (or through) this run unwrap to the true runtime — both the global shim and repeated z.compile calls rely on this. __fastpass lets the standalone isValid skip the payload and wrapper on the happy path.
+  // Let later compiles of (or through) this run unwrap to the true runtime — both the global shim and repeated z.compile calls rely on this. The bag's fastpass lets the standalone isValid skip the payload and wrapper on the happy path.
   (wrapped as { __originalRun?: typeof originalRun }).__originalRun = originalRun;
   clone._zod.bag.fastpass = fast;
   clone._zod.bag.fallbackRun = originalRun;

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -135,8 +135,10 @@ export function compile<T extends SomeType>(schema: T): T {
     if (ctx) (ctx as Record<symbol, unknown>)[FALLBACK_FLAG] = true;
     return originalRun(payload, ctx);
   };
-  // Let later compiles of (or through) this run unwrap to the true runtime — both the global shim and repeated z.compile calls rely on this.
+  // Let later compiles of (or through) this run unwrap to the true runtime — both the global shim and repeated z.compile calls rely on this. __fastpass lets the standalone isValid skip the payload and wrapper on the happy path.
   (wrapped as { __originalRun?: typeof originalRun }).__originalRun = originalRun;
+  clone._zod.bag.fastpass = fast;
+  clone._zod.bag.fallbackRun = originalRun;
   clone._zod.run = wrapped;
 
   // The fast parse/safeParse closures fall back through the source schema's methods. If the source is shim- or wrapper-managed, those methods route into a compiled run and would execute user callbacks a third time on invalid input — the plain method → wrapper path is exactly 2x, so skip.

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -149,18 +149,10 @@ export type $IsValidAsync = <T extends schemas.$ZodType>(
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
 ) => Promise<boolean>;
 
+// no fast path here: the compiler keeps async parses on the runtime, since a callback that returns a promise without being declared async compiles to a throw
 export const isValidAsync: $IsValidAsync = async (schema, value, _ctx) => {
-  const bag = schema._zod.bag as CompiledBag;
-  let result: unknown;
-  if (bag.fastpass && bag.fallbackRun) {
-    if (bag.fastpass(value) !== COMPILE_INVALID) return true;
-    const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
-    (ctx as Record<symbol, unknown>)[COMPILE_FALLBACK] = true;
-    result = bag.fallbackRun({ value, issues: [] }, ctx);
-  } else {
-    const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
-    result = schema._zod.run({ value, issues: [] }, ctx);
-  }
+  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
+  let result: unknown = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) result = await result;
   return (result as schemas.ParsePayload).issues.length === 0;
 };

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -149,7 +149,7 @@ export type $IsValidAsync = <T extends schemas.$ZodType>(
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
 ) => Promise<boolean>;
 
-// no fast path here: the compiler keeps async parses on the runtime, since a callback that returns a promise without being declared async compiles to a throw
+// no fast path: the compiler keeps async parses on the runtime, because a promise-returning callback that is not declared async compiles to a throw
 export const isValidAsync: $IsValidAsync = async (schema, value, _ctx) => {
   const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
   let result: unknown = schema._zod.run({ value, issues: [] }, ctx);

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -105,6 +105,66 @@ export const _safeParseAsync: (_Err: $ZodErrorClass) => $SafeParseAsync = (_Err)
 
 export const safeParseAsync: $SafeParseAsync = /* @__PURE__*/ _safeParseAsync(errors.$ZodRealError);
 
+// registry mirrors of the compiler's sentinels, so this module never imports the compiler
+const COMPILE_INVALID = /* @__PURE__ */ Symbol.for("zod.compile.invalid");
+const COMPILE_FALLBACK = /* @__PURE__ */ Symbol.for("zod.compile.fallback");
+
+interface CompiledBag {
+  fastpass?: (input: unknown) => unknown;
+  fallbackRun?: (payload: schemas.ParsePayload, ctx: schemas.ParseContextInternal) => unknown;
+}
+
+export type $IsValid = <T extends schemas.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>
+) => value is core.input<T>;
+
+export const isValid: $IsValid = ((
+  schema: schemas.$ZodType,
+  value: unknown,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>
+): boolean => {
+  const bag = schema._zod.bag as CompiledBag;
+  let result: unknown;
+  if (bag.fastpass && bag.fallbackRun) {
+    if (bag.fastpass(value) !== COMPILE_INVALID) return true;
+    const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
+    // skip nested fast paths on the fallback, so user callbacks keep the at-most-twice bound
+    (ctx as Record<symbol, unknown>)[COMPILE_FALLBACK] = true;
+    result = bag.fallbackRun({ value, issues: [] }, ctx);
+  } else {
+    const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
+    result = schema._zod.run({ value, issues: [] }, ctx);
+  }
+  if (result instanceof Promise) {
+    throw new core.$ZodAsyncError();
+  }
+  return (result as schemas.ParsePayload).issues.length === 0;
+}) as $IsValid;
+
+export type $IsValidAsync = <T extends schemas.$ZodType>(
+  schema: T,
+  value: unknown,
+  _ctx?: schemas.ParseContext<errors.$ZodIssue>
+) => Promise<boolean>;
+
+export const isValidAsync: $IsValidAsync = async (schema, value, _ctx) => {
+  const bag = schema._zod.bag as CompiledBag;
+  let result: unknown;
+  if (bag.fastpass && bag.fallbackRun) {
+    if (bag.fastpass(value) !== COMPILE_INVALID) return true;
+    const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
+    (ctx as Record<symbol, unknown>)[COMPILE_FALLBACK] = true;
+    result = bag.fallbackRun({ value, issues: [] }, ctx);
+  } else {
+    const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
+    result = schema._zod.run({ value, issues: [] }, ctx);
+  }
+  if (result instanceof Promise) result = await result;
+  return (result as schemas.ParsePayload).issues.length === 0;
+};
+
 // Codec functions
 export type $Encode = <T extends schemas.$ZodType>(
   schema: T,

--- a/packages/zod/src/v4/mini/parse.ts
+++ b/packages/zod/src/v4/mini/parse.ts
@@ -1,4 +1,6 @@
 export {
+  isValid,
+  isValidAsync,
   parse,
   safeParse,
   parseAsync,


### PR DESCRIPTION
Adds `z.isValid(schema, value)` and `z.isValidAsync(schema, value)`: standalone boolean validation, exported from Zod, Zod Mini, and Zod Core. The return type is a guard on the schema's input type, which stays sound under transforms.

```ts
z.isValid(z.string(), "hi"); // true, and narrows to string
z.isValid(Player, { username: 42 }); // false — no ZodError is ever built
```

On a [compiled schema](https://zod.dev/compile), `isValid` answers directly from the compiled fast path: `compile()` stashes the fast-path function and the runtime fallback on `_zod.bag` (the same caching spot `getDiscriminatedOption` uses), and the fallback call carries the compiler's fallback flag, so user callbacks keep the existing at-most-twice bound on invalid input. The parse module mirrors the compiler's registry sentinels via `Symbol.for` rather than importing it, so nothing new is retained in bundles that don't use it.

The motivation is boolean-only validation on hot paths — accepting or rejecting input without needing the parsed value — which is also the contract of the assert categories in cross-library benchmarks.

Three axes, measured on the moltar fixture with an interleaved min-of-rounds harness (ratios are the meaningful part; the machine was loaded):

| | ops/sec |
| --- | --- |
| `z.isValid`, compiled schema | 45.3M |
| `compiled.safeParse().success` | 52.1M |
| `z.isValid`, uncompiled | 12.5M |
| uncompiled `safeParse().success` | ~9.8M |

An earlier draft stored the fast-path references as properties on the wrapped `run` function; custom properties push function objects into slow storage and it measured 28M. Moving them to the bag recovered fast-mode reads.

Bundle: 0 bytes on every treeshake fixture — the two `Symbol.for` mirrors needed `@__PURE__` annotations, without which the mini fixtures grew 2 gzipped bytes; `bundle-size.test.ts` ceilings are unchanged. Memory: two bag entries on compiled schemas only; `instance-footprint.test.ts` is unchanged.

Docs get a short section under parsing in `basics.mdx`.
