### PR TITLE
feat(v4): add an abortEarly parse option

### DIFF
--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -279,7 +279,12 @@ z.array(z.string()).safeParse([1, 2, 3], {
 // one issue, instead of one per element
 ```
 
-This only applies to schemas that validate synchronously. An async schema runs all of its children before any of them settles, so there is no issue to stop on yet.
+The flag does not apply everywhere:
+
+- Objects skip the compiled parser, so a valid object parses more slowly too.
+- Unions keep trying their options, since a later one may still match.
+- A tuple's fixed items all report; only its rest elements stop early.
+- An async schema runs all of its children before any of them settles, so there is nothing to stop on yet.
 
 ## Global error customization
 

--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -270,13 +270,22 @@ z.string().parse(12, {
 
 ### Stop at the first error
 
-By default, Zod reports every issue it finds. On a large invalid input that means one issue per invalid element. To stop as soon as one is found, use the `abortEarly` flag:
+By default, Zod reports every issue it finds, so a large invalid input produces one issue per invalid element. The `abortEarly` flag stops each container at its first aborting error, which bounds the issue count by the schema instead of the input:
 
 ```ts
 z.array(z.string()).safeParse([1, 2, 3], {
   abortEarly: true
 });
 // one issue, instead of one per element
+```
+
+Some issues are continuable: Zod keeps validating past them so a surrounding schema can still reconcile them away. Those never stop a parse, so elements that fail a range or format check still report one issue each.
+
+```ts
+z.array(z.number().max(1)).safeParse([5, 5, 5], {
+  abortEarly: true
+});
+// three issues, since too_big is continuable
 ```
 
 The flag does not apply everywhere:

--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -268,6 +268,19 @@ z.string().parse(12, {
 // ]
 ```
 
+### Stop at the first error
+
+By default, Zod reports every issue it finds. On a large invalid input that means one issue per invalid element. To stop as soon as one is found, use the `abortEarly` flag:
+
+```ts
+z.array(z.string()).safeParse([1, 2, 3], {
+  abortEarly: true
+});
+// one issue, instead of one per element
+```
+
+This only applies to schemas that validate synchronously. An async schema runs all of its children before any of them settles, so there is no issue to stop on yet.
+
 ## Global error customization
 
 To specify a global error map, use `z.config()` to set Zod's `customError` configuration setting:

--- a/packages/docs/content/error-customization.mdx
+++ b/packages/docs/content/error-customization.mdx
@@ -270,7 +270,7 @@ z.string().parse(12, {
 
 ### Stop at the first error
 
-By default, Zod reports every issue it finds, so a large invalid input produces one issue per invalid element. The `abortEarly` flag stops each container at its first aborting error, which bounds the issue count by the schema instead of the input:
+By default, Zod reports every issue it finds, so a large invalid input produces one issue per invalid element. The `abortEarly` flag stops each container at its first aborting error:
 
 ```ts
 z.array(z.string()).safeParse([1, 2, 3], {

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,14 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2903 / 3366 / 4437 by the commit that caused it: the `abortEarly` parse option costs +28 / +31 / +72, and every bundle carries the check-loop exit in `core.ts`; measured 2904 / 3368 / 4480 plus 28 headroom, and the per-fixture notes below record what each already carried
-  "zod-mini-boolean": 2932,
+  // raised from 2836 / 3299 / 4374 by the commit that caused it: suppressing v8's stack capture while building an error costs +68 / +68 / +63, and every bundle carries `core.ts`; measured 2875 / 3338 / 4409 plus 28 headroom, and the per-fixture notes below record what each already carried
+  "zod-mini-boolean": 2903,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3396,
+  "zod-mini-string": 3366,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4508,
+  // Also carries the `abortEarly` guards, which live only in the container loops: +56 over the 4409 above, measured 4464 plus 28 headroom.
+  "zod-mini-object": 4492,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2903 / 3366 / 4437 by the commit that caused it: the `abortEarly` parse option costs +19 / +26 / +47, and every bundle carries the check-loop exit in `core.ts`; measured 2895 / 3363 / 4455 plus 28 headroom, and the per-fixture notes below record what each already carried
-  "zod-mini-boolean": 2923,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: the `abortEarly` parse option costs +28 / +31 / +72, and every bundle carries the check-loop exit in `core.ts`; measured 2904 / 3368 / 4480 plus 28 headroom, and the per-fixture notes below record what each already carried
+  "zod-mini-boolean": 2932,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3391,
+  "zod-mini-string": 3396,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4483,
+  "zod-mini-object": 4508,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -44,8 +44,8 @@ const CEILINGS: Record<string, number> = {
   "zod-mini-string": 3366,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  // Also carries the `abortEarly` guards, which live only in the container loops: +56 over the 4409 above, measured 4464 plus 28 headroom.
-  "zod-mini-object": 4492,
+  // Also carries the `abortEarly` guards, which live only in the container loops: +63 over the 4409 above, measured 4471 plus 28 headroom.
+  "zod-mini-object": 4499,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2836 / 3299 / 4374 by the commit that caused it: suppressing v8's stack capture while building an error costs +68 / +68 / +63, and every bundle carries `core.ts`; measured 2875 / 3338 / 4409 plus 28 headroom, and the per-fixture notes below record what each already carried
-  "zod-mini-boolean": 2903,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: the `abortEarly` parse option costs +19 / +26 / +47, and every bundle carries the check-loop exit in `core.ts`; measured 2895 / 3363 / 4455 plus 28 headroom, and the per-fixture notes below record what each already carried
+  "zod-mini-boolean": 2923,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3366,
+  "zod-mini-string": 3391,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4437,
+  "zod-mini-object": 4483,
 };
 
 /**

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1064,6 +1064,42 @@ test("abortEarly applies to async parses", async () => {
   expect((await arr.safeParseAsync([1, 2, 3], { abortEarly: true })).error!.issues.length).toBe(1);
 });
 
+test("abortEarly is invisible to a parse that succeeds", () => {
+  // a pipe forwards a continuable unrecognized_keys into the next stage and the enclosing intersection reconciles it away, so these loops are entered with issues they did not produce
+  const left = z.strictObject({ a: z.string() }).overwrite((v) => ({ ...v, tag: "left" }));
+  const withCheck = z.intersection(left, z.object({ a: z.string(), b: z.number() }));
+  expect(withCheck.parse({ a: "x", b: 1 }, { abortEarly: true })).toEqual(withCheck.parse({ a: "x", b: 1 }));
+
+  const piped = z.strictObject({ a: z.string() }).pipe(z.object({ a: z.string() }));
+  const withPipe = z.intersection(piped, z.strictObject({ b: z.string() }));
+  expect(withPipe.parse({ a: "x", b: "y" }, { abortEarly: true })).toEqual(withPipe.parse({ a: "x", b: "y" }));
+});
+
+test("abortEarly never reports more issues than the default", () => {
+  const cases: Array<[z.ZodType, unknown]> = [
+    // an enum key type drives a post-loop pass that needs every declared key collected
+    [z.record(z.enum(["a", "b", "c"]), z.string()), { a: 1, b: "x", c: "y" }],
+    [z.record(z.string(), z.string()), { a: 1, b: 2 }],
+    [z.array(z.string()), [1, 2, 3]],
+    [z.object({ a: z.string(), b: z.string() }), {}],
+    [z.object({ a: z.string() }).catchall(z.string()), { a: 1, b: 2 }],
+    [z.strictObject({ a: z.string() }), { a: 1, b: 2 }],
+    [z.tuple([z.string()], z.string()), ["a", 1, 2]],
+    [z.set(z.string()), new Set([1, 2])],
+    [z.map(z.string(), z.string()), new Map([[1, 2]])],
+    [z.string().min(5).regex(/^x/), "a"],
+  ];
+  for (const [schema, input] of cases) {
+    const base = schema.safeParse(input);
+    const early = schema.safeParse(input, { abortEarly: true });
+    expect(early.success).toBe(base.success);
+    const baseCount = base.success ? 0 : base.error.issues.length;
+    const earlyCount = early.success ? 0 : early.error.issues.length;
+    expect(earlyCount).toBeLessThanOrEqual(baseCount);
+    expect(earlyCount).toBeGreaterThan(0);
+  }
+});
+
 test("abortEarly does not short-circuit a genuinely async element schema", async () => {
   // the loop dispatches every child before any promise settles, so there is no issue to see yet
   const arr = z.array(z.string().refine(async () => false));

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -977,3 +977,95 @@ test("error initializer never installs onto an intrinsic prototype", () => {
   expect({}.toString()).toEqual("[object Object]");
   expect(String(new Error("boom"))).toEqual("Error: boom");
 });
+
+test("abortEarly stops at the first issue", () => {
+  const arr = z.array(z.string());
+  expect(arr.safeParse([1, 2, 3]).error!.issues.length).toBe(3);
+  expect(arr.safeParse([1, 2, 3], { abortEarly: true }).error!.issues.length).toBe(1);
+
+  // objects take the compiled parser by default, which has no early exit, so abortEarly has to fall back to the interpreter
+  const obj = z.object({ a: z.string(), b: z.string(), c: z.string() });
+  expect(obj.safeParse({}).error!.issues.length).toBe(3);
+  expect(obj.safeParse({}, { abortEarly: true }).error!.issues.length).toBe(1);
+
+  const rec = z.record(z.string(), z.string());
+  expect(rec.safeParse({ a: 1, b: 2 }).error!.issues.length).toBe(2);
+  expect(rec.safeParse({ a: 1, b: 2 }, { abortEarly: true }).error!.issues.length).toBe(1);
+
+  const set = z.set(z.string());
+  expect(set.safeParse(new Set([1, 2])).error!.issues.length).toBe(2);
+  expect(set.safeParse(new Set([1, 2]), { abortEarly: true }).error!.issues.length).toBe(1);
+
+  // a map entry is one unit, so its key and value both report before the next entry is skipped
+  const map = z.map(z.string(), z.string());
+  expect(
+    map.safeParse(
+      new Map([
+        [1, 2],
+        [3, 4],
+      ])
+    ).error!.issues.length
+  ).toBe(4);
+  expect(
+    map.safeParse(
+      new Map([
+        [1, 2],
+        [3, 4],
+      ]),
+      { abortEarly: true }
+    ).error!.issues.length
+  ).toBe(2);
+
+  const catchall = z.object({ a: z.string() }).catchall(z.string());
+  expect(catchall.safeParse({ a: "x", b: 1, c: 2 }).error!.issues.length).toBe(2);
+  expect(catchall.safeParse({ a: "x", b: 1, c: 2 }, { abortEarly: true }).error!.issues.length).toBe(1);
+
+  const tup = z.tuple([z.string()], z.string());
+  expect(tup.safeParse(["a", 1, 2]).error!.issues.length).toBe(2);
+  expect(tup.safeParse(["a", 1, 2], { abortEarly: true }).error!.issues.length).toBe(1);
+});
+
+test("abortEarly stops running checks after one fails", () => {
+  const schema = z.string().min(5).regex(/^x/);
+  expect(schema.safeParse("a").error!.issues.length).toBe(2);
+  expect(schema.safeParse("a", { abortEarly: true }).error!.issues.length).toBe(1);
+
+  const spy = vi.fn();
+  z.string()
+    .min(5)
+    .refine((v) => {
+      spy(v);
+      return true;
+    })
+    .safeParse("a", { abortEarly: true });
+  expect(spy).not.toHaveBeenCalled();
+});
+
+test("abortEarly leaves valid parses untouched", () => {
+  expect(z.array(z.string()).parse(["a", "b"], { abortEarly: true })).toEqual(["a", "b"]);
+  expect(z.object({ a: z.string() }).parse({ a: "x" }, { abortEarly: true })).toEqual({ a: "x" });
+
+  // a union has to keep trying options after an earlier one fails
+  expect(z.union([z.string(), z.number()]).parse(42, { abortEarly: true })).toBe(42);
+  expect(z.string().optional().parse(undefined, { abortEarly: true })).toBe(undefined);
+  expect(z.string().catch("fallback").parse(1, { abortEarly: true })).toBe("fallback");
+});
+
+test("abortEarly bounds the issue count on a large invalid input", () => {
+  const schema = z.array(z.object({ a: z.string(), b: z.string() }));
+  const input = Array(1000).fill({});
+  expect(schema.safeParse(input).error!.issues.length).toBe(2000);
+  expect(schema.safeParse(input, { abortEarly: true }).error!.issues.length).toBe(1);
+});
+
+test("abortEarly applies to async parses", async () => {
+  const arr = z.array(z.string());
+  expect((await arr.safeParseAsync([1, 2, 3])).error!.issues.length).toBe(3);
+  expect((await arr.safeParseAsync([1, 2, 3], { abortEarly: true })).error!.issues.length).toBe(1);
+});
+
+test("abortEarly does not short-circuit a genuinely async element schema", async () => {
+  // the loop dispatches every child before any promise settles, so there is no issue to see yet
+  const arr = z.array(z.string().refine(async () => false));
+  expect((await arr.safeParseAsync(["a", "b", "c"], { abortEarly: true })).error!.issues.length).toBe(3);
+});

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1025,20 +1025,17 @@ test("abortEarly stops at the first issue", () => {
   expect(tup.safeParse(["a", 1, 2], { abortEarly: true }).error!.issues.length).toBe(1);
 });
 
-test("abortEarly stops running checks after one fails", () => {
-  const schema = z.string().min(5).regex(/^x/);
-  expect(schema.safeParse("a").error!.issues.length).toBe(2);
-  expect(schema.safeParse("a", { abortEarly: true }).error!.issues.length).toBe(1);
+test("abortEarly stops only on an issue that aborts validation", () => {
+  // too_small and invalid_format are continuable, so the rest of the chain still runs
+  const chain = z.string().min(5).regex(/^x/);
+  expect(chain.safeParse("a", { abortEarly: true }).error!.issues.length).toBe(2);
 
-  const spy = vi.fn();
-  z.string()
-    .min(5)
-    .refine((v) => {
-      spy(v);
-      return true;
-    })
-    .safeParse("a", { abortEarly: true });
-  expect(spy).not.toHaveBeenCalled();
+  // too_big is continuable too, so a range failure still reports once per element
+  const ranged = z.array(z.number().max(1));
+  expect(ranged.safeParse([5, 5, 5], { abortEarly: true }).error!.issues.length).toBe(3);
+
+  // a wrong element type aborts, so the array stops on the first one
+  expect(z.array(z.number()).safeParse(["a", "b", "c"], { abortEarly: true }).error!.issues.length).toBe(1);
 });
 
 test("abortEarly leaves valid parses untouched", () => {
@@ -1073,6 +1070,23 @@ test("abortEarly is invisible to a parse that succeeds", () => {
   const piped = z.strictObject({ a: z.string() }).pipe(z.object({ a: z.string() }));
   const withPipe = z.intersection(piped, z.strictObject({ b: z.string() }));
   expect(withPipe.parse({ a: "x", b: "y" }, { abortEarly: true })).toEqual(withPipe.parse({ a: "x", b: "y" }));
+});
+
+test("abortEarly does not stop on a continuable issue", () => {
+  // unrecognized_keys is continuable, so an enclosing intersection may still reconcile it away;
+  // stopping on one would leave a truncated value that mergeValues cannot merge
+  const schema = z.intersection(
+    z.array(z.strictObject({ a: z.string() })),
+    z.array(z.object({ a: z.string(), b: z.number() }))
+  );
+  const input = [
+    { a: "x", b: 1 },
+    { a: "y", b: 2 },
+  ];
+  const base = schema.safeParse(input);
+  const early = schema.safeParse(input, { abortEarly: true });
+  expect(early.success).toBe(base.success);
+  expect(early.error!.issues.length).toBe(base.error!.issues.length);
 });
 
 test("abortEarly never reports more issues than the default", () => {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1797,6 +1797,7 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
     payload.value = memo ? memo.alloc(inst, payload, Array(input.length), ctx) : Array(input.length);
     const proms: Promise<any>[] = [];
     const abortEarly = ctx?.abortEarly;
+    // advance past issues already examined; rescanning from the loop entry is quadratic when children emit continuable issues
     let seen = payload.issues.length;
     for (let i = 0; i < input.length; i++) {
       if (abortEarly) {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1797,9 +1797,12 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
     payload.value = memo ? memo.alloc(inst, payload, Array(input.length), ctx) : Array(input.length);
     const proms: Promise<any>[] = [];
     const abortEarly = ctx?.abortEarly;
-    const startLen = payload.issues.length;
+    let seen = payload.issues.length;
     for (let i = 0; i < input.length; i++) {
-      if (abortEarly && util.aborted(payload, startLen)) break;
+      if (abortEarly) {
+        if (util.aborted(payload, seen)) break;
+        seen = payload.issues.length;
+      }
       const item = input[i];
       const result = def.element._zod.run(
         {
@@ -2028,9 +2031,12 @@ function handleCatchall(
   const optin = _catchall.optin;
   const optout = _catchall.optout;
   const abortEarly = ctx?.abortEarly;
-  const startLen = payload.issues.length;
+  let seen = payload.issues.length;
   for (const key in input) {
-    if (abortEarly && util.aborted(payload, startLen)) break;
+    if (abortEarly) {
+      if (util.aborted(payload, seen)) break;
+      seen = payload.issues.length;
+    }
     // Must precede the __proto__ branch: a declared key is not unrecognized, even though the shape loop deliberately strips __proto__ from the parsed output.
     if (keySet.has(key)) continue;
     // Don't copy an undeclared __proto__ into the result; assignment to a plain {} would replace the result prototype. But in strict mode it is still an unknown key, so report it before skipping.
@@ -2135,10 +2141,13 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     const proms: Promise<any>[] = [];
     const shape = value.shape;
     const abortEarly = ctx?.abortEarly;
-    const startLen = payload.issues.length;
+    let seen = payload.issues.length;
 
     for (const key of value.allKeys) {
-      if (abortEarly && util.aborted(payload, startLen)) break;
+      if (abortEarly) {
+        if (util.aborted(payload, seen)) break;
+        seen = payload.issues.length;
+      }
       if (key === "__proto__") continue;
       const el = (shape as any)[key]!;
       const optin = el._zod.optin;
@@ -2976,9 +2985,12 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       let i = items.length - 1;
       const rest = input.slice(items.length);
       const abortEarly = ctx?.abortEarly;
-      const startLen = payload.issues.length;
+      let seen = payload.issues.length;
       for (const el of rest) {
-        if (abortEarly && util.aborted(payload, startLen)) break;
+        if (abortEarly) {
+          if (util.aborted(payload, seen)) break;
+          seen = payload.issues.length;
+        }
         i++;
         const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
         if (result instanceof Promise) {
@@ -3149,7 +3161,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
 
     const proms: Promise<any>[] = [];
     const abortEarly = ctx?.abortEarly;
-    const startLen = payload.issues.length;
+    let seen = payload.issues.length;
 
     const values = def.keyType._zod.values;
     if (values && !def.partial) {
@@ -3161,7 +3173,10 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
           // A declared __proto__ is stripped but is not an unrecognized key.
           if (key === "__proto__") continue;
           // skip the validation work but keep collecting keys, so the unrecognized pass below stays correct
-          if (abortEarly && util.aborted(payload, startLen)) continue;
+          if (abortEarly) {
+            if (util.aborted(payload, seen)) continue;
+            seen = payload.issues.length;
+          }
           const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
             throw new Error("Async schemas not supported in object keys currently");
@@ -3228,7 +3243,10 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       let unrecognized!: string[];
       // Reflect.ownKeys for Symbol-key support; filter non-enumerable to match z.object()
       for (const key of Reflect.ownKeys(input)) {
-        if (abortEarly && util.aborted(payload, startLen)) break;
+        if (abortEarly) {
+          if (util.aborted(payload, seen)) break;
+          seen = payload.issues.length;
+        }
         if (key === "__proto__") continue;
         if (!Object.prototype.propertyIsEnumerable.call(input, key)) continue;
         let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
@@ -3356,10 +3374,13 @@ export const $ZodMap: core.$constructor<$ZodMap> = /*@__PURE__*/ core.$construct
     const proms: Promise<any>[] = [];
     payload.value = memo ? memo.alloc(inst, payload, new Map(), ctx) : new Map();
     const abortEarly = ctx?.abortEarly;
-    const startLen = payload.issues.length;
+    let seen = payload.issues.length;
 
     for (const [key, value] of input) {
-      if (abortEarly && util.aborted(payload, startLen)) break;
+      if (abortEarly) {
+        if (util.aborted(payload, seen)) break;
+        seen = payload.issues.length;
+      }
       const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
       const valueResult = def.valueType._zod.run({ value: value, issues: [] }, ctx);
 
@@ -3463,9 +3484,12 @@ export const $ZodSet: core.$constructor<$ZodSet> = /*@__PURE__*/ core.$construct
     const proms: Promise<any>[] = [];
     payload.value = memo ? memo.alloc(inst, payload, new Set(), ctx) : new Set();
     const abortEarly = ctx?.abortEarly;
-    const startLen = payload.issues.length;
+    let seen = payload.issues.length;
     for (const item of input) {
-      if (abortEarly && util.aborted(payload, startLen)) break;
+      if (abortEarly) {
+        if (util.aborted(payload, seen)) break;
+        seen = payload.issues.length;
+      }
       const result = def.valueType._zod.run({ value: item, issues: [] }, ctx);
       if (result instanceof Promise) {
         proms.push(result.then((result) => handleSetResult(result, payload)));

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -237,12 +237,8 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
 
       let isAborted = util.aborted(payload);
 
-      const abortEarly = ctx?.abortEarly;
-      const startLen = payload.issues.length;
-
       let asyncResult!: Promise<unknown> | undefined;
       for (const ch of checks) {
-        if (abortEarly && payload.issues.length > startLen) break;
         if (ch._zod.def.when) {
           if (util.explicitlyAborted(payload)) continue;
           const shouldRun = ch._zod.def.when(payload);
@@ -1803,7 +1799,7 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
     const abortEarly = ctx?.abortEarly;
     const startLen = payload.issues.length;
     for (let i = 0; i < input.length; i++) {
-      if (abortEarly && payload.issues.length > startLen) break;
+      if (abortEarly && util.aborted(payload, startLen)) break;
       const item = input[i];
       const result = def.element._zod.run(
         {
@@ -2034,7 +2030,7 @@ function handleCatchall(
   const abortEarly = ctx?.abortEarly;
   const startLen = payload.issues.length;
   for (const key in input) {
-    if (abortEarly && payload.issues.length > startLen) break;
+    if (abortEarly && util.aborted(payload, startLen)) break;
     // Must precede the __proto__ branch: a declared key is not unrecognized, even though the shape loop deliberately strips __proto__ from the parsed output.
     if (keySet.has(key)) continue;
     // Don't copy an undeclared __proto__ into the result; assignment to a plain {} would replace the result prototype. But in strict mode it is still an unknown key, so report it before skipping.
@@ -2142,7 +2138,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     const startLen = payload.issues.length;
 
     for (const key of value.allKeys) {
-      if (abortEarly && payload.issues.length > startLen) break;
+      if (abortEarly && util.aborted(payload, startLen)) break;
       if (key === "__proto__") continue;
       const el = (shape as any)[key]!;
       const optin = el._zod.optin;
@@ -2982,7 +2978,7 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       const abortEarly = ctx?.abortEarly;
       const startLen = payload.issues.length;
       for (const el of rest) {
-        if (abortEarly && payload.issues.length > startLen) break;
+        if (abortEarly && util.aborted(payload, startLen)) break;
         i++;
         const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
         if (result instanceof Promise) {
@@ -3165,7 +3161,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
           // A declared __proto__ is stripped but is not an unrecognized key.
           if (key === "__proto__") continue;
           // skip the validation work but keep collecting keys, so the unrecognized pass below stays correct
-          if (abortEarly && payload.issues.length > startLen) continue;
+          if (abortEarly && util.aborted(payload, startLen)) continue;
           const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
             throw new Error("Async schemas not supported in object keys currently");
@@ -3232,7 +3228,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       let unrecognized!: string[];
       // Reflect.ownKeys for Symbol-key support; filter non-enumerable to match z.object()
       for (const key of Reflect.ownKeys(input)) {
-        if (abortEarly && payload.issues.length > startLen) break;
+        if (abortEarly && util.aborted(payload, startLen)) break;
         if (key === "__proto__") continue;
         if (!Object.prototype.propertyIsEnumerable.call(input, key)) continue;
         let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
@@ -3363,7 +3359,7 @@ export const $ZodMap: core.$constructor<$ZodMap> = /*@__PURE__*/ core.$construct
     const startLen = payload.issues.length;
 
     for (const [key, value] of input) {
-      if (abortEarly && payload.issues.length > startLen) break;
+      if (abortEarly && util.aborted(payload, startLen)) break;
       const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
       const valueResult = def.valueType._zod.run({ value: value, issues: [] }, ctx);
 
@@ -3469,7 +3465,7 @@ export const $ZodSet: core.$constructor<$ZodSet> = /*@__PURE__*/ core.$construct
     const abortEarly = ctx?.abortEarly;
     const startLen = payload.issues.length;
     for (const item of input) {
-      if (abortEarly && payload.issues.length > startLen) break;
+      if (abortEarly && util.aborted(payload, startLen)) break;
       const result = def.valueType._zod.run({ value: item, issues: [] }, ctx);
       if (result instanceof Promise) {
         proms.push(result.then((result) => handleSetResult(result, payload)));

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -22,7 +22,7 @@ export interface ParseContext<T extends errors.$ZodIssueBase = never> {
   /** Skip eval-based fast path. Default `false`. */
   readonly jitless?: boolean;
   /** Abort validation after the first error. Default `false`. */
-  // readonly abortEarly?: boolean;
+  readonly abortEarly?: boolean;
 }
 
 /** @internal */
@@ -237,8 +237,11 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
 
       let isAborted = util.aborted(payload);
 
+      const abortEarly = ctx?.abortEarly;
+
       let asyncResult!: Promise<unknown> | undefined;
       for (const ch of checks) {
+        if (abortEarly && payload.issues.length) break;
         if (ch._zod.def.when) {
           if (util.explicitlyAborted(payload)) continue;
           const shouldRun = ch._zod.def.when(payload);
@@ -1796,7 +1799,9 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
 
     payload.value = memo ? memo.alloc(inst, payload, Array(input.length), ctx) : Array(input.length);
     const proms: Promise<any>[] = [];
+    const abortEarly = ctx?.abortEarly;
     for (let i = 0; i < input.length; i++) {
+      if (abortEarly && payload.issues.length) break;
       const item = input[i];
       const result = def.element._zod.run(
         {
@@ -2024,7 +2029,9 @@ function handleCatchall(
   const t = _catchall.def.type;
   const optin = _catchall.optin;
   const optout = _catchall.optout;
+  const abortEarly = ctx?.abortEarly;
   for (const key in input) {
+    if (abortEarly && payload.issues.length) break;
     // Must precede the __proto__ branch: a declared key is not unrecognized, even though the shape loop deliberately strips __proto__ from the parsed output.
     if (keySet.has(key)) continue;
     // Don't copy an undeclared __proto__ into the result; assignment to a plain {} would replace the result prototype. But in strict mode it is still an unknown key, so report it before skipping.
@@ -2128,8 +2135,10 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
 
     const proms: Promise<any>[] = [];
     const shape = value.shape;
+    const abortEarly = ctx?.abortEarly;
 
     for (const key of value.allKeys) {
+      if (abortEarly && payload.issues.length) break;
       if (key === "__proto__") continue;
       const el = (shape as any)[key]!;
       const optin = el._zod.optin;
@@ -2281,7 +2290,8 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         return payload;
       }
 
-      if (jit && fastEnabled && ctx?.async === false && ctx.jitless !== true) {
+      // the compiled parser has no early exit, so abortEarly takes the interpreter
+      if (jit && fastEnabled && ctx?.async === false && ctx.jitless !== true && ctx.abortEarly !== true) {
         // always synchronous
         if (!fastpass) fastpass = generateFastpass(def.shape);
         payload = fastpass(payload, ctx);
@@ -2965,7 +2975,9 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
     if (def.rest) {
       let i = items.length - 1;
       const rest = input.slice(items.length);
+      const abortEarly = ctx?.abortEarly;
       for (const el of rest) {
+        if (abortEarly && payload.issues.length) break;
         i++;
         const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
         if (result instanceof Promise) {
@@ -3135,12 +3147,14 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
     }
 
     const proms: Promise<any>[] = [];
+    const abortEarly = ctx?.abortEarly;
 
     const values = def.keyType._zod.values;
     if (values && !def.partial) {
       payload.value = memo ? memo.alloc(inst, payload, {}, ctx) : {};
       const recordKeys = new Set<string | symbol>();
       for (const key of values) {
+        if (abortEarly && payload.issues.length) break;
         if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
           recordKeys.add(typeof key === "number" ? key.toString() : key);
           // A declared __proto__ is stripped but is not an unrecognized key.
@@ -3211,6 +3225,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       let unrecognized!: string[];
       // Reflect.ownKeys for Symbol-key support; filter non-enumerable to match z.object()
       for (const key of Reflect.ownKeys(input)) {
+        if (abortEarly && payload.issues.length) break;
         if (key === "__proto__") continue;
         if (!Object.prototype.propertyIsEnumerable.call(input, key)) continue;
         let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
@@ -3337,8 +3352,10 @@ export const $ZodMap: core.$constructor<$ZodMap> = /*@__PURE__*/ core.$construct
 
     const proms: Promise<any>[] = [];
     payload.value = memo ? memo.alloc(inst, payload, new Map(), ctx) : new Map();
+    const abortEarly = ctx?.abortEarly;
 
     for (const [key, value] of input) {
+      if (abortEarly && payload.issues.length) break;
       const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
       const valueResult = def.valueType._zod.run({ value: value, issues: [] }, ctx);
 
@@ -3441,7 +3458,9 @@ export const $ZodSet: core.$constructor<$ZodSet> = /*@__PURE__*/ core.$construct
 
     const proms: Promise<any>[] = [];
     payload.value = memo ? memo.alloc(inst, payload, new Set(), ctx) : new Set();
+    const abortEarly = ctx?.abortEarly;
     for (const item of input) {
+      if (abortEarly && payload.issues.length) break;
       const result = def.valueType._zod.run({ value: item, issues: [] }, ctx);
       if (result instanceof Promise) {
         proms.push(result.then((result) => handleSetResult(result, payload)));

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -238,10 +238,11 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
       let isAborted = util.aborted(payload);
 
       const abortEarly = ctx?.abortEarly;
+      const startLen = payload.issues.length;
 
       let asyncResult!: Promise<unknown> | undefined;
       for (const ch of checks) {
-        if (abortEarly && payload.issues.length) break;
+        if (abortEarly && payload.issues.length > startLen) break;
         if (ch._zod.def.when) {
           if (util.explicitlyAborted(payload)) continue;
           const shouldRun = ch._zod.def.when(payload);
@@ -1800,8 +1801,9 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
     payload.value = memo ? memo.alloc(inst, payload, Array(input.length), ctx) : Array(input.length);
     const proms: Promise<any>[] = [];
     const abortEarly = ctx?.abortEarly;
+    const startLen = payload.issues.length;
     for (let i = 0; i < input.length; i++) {
-      if (abortEarly && payload.issues.length) break;
+      if (abortEarly && payload.issues.length > startLen) break;
       const item = input[i];
       const result = def.element._zod.run(
         {
@@ -2030,8 +2032,9 @@ function handleCatchall(
   const optin = _catchall.optin;
   const optout = _catchall.optout;
   const abortEarly = ctx?.abortEarly;
+  const startLen = payload.issues.length;
   for (const key in input) {
-    if (abortEarly && payload.issues.length) break;
+    if (abortEarly && payload.issues.length > startLen) break;
     // Must precede the __proto__ branch: a declared key is not unrecognized, even though the shape loop deliberately strips __proto__ from the parsed output.
     if (keySet.has(key)) continue;
     // Don't copy an undeclared __proto__ into the result; assignment to a plain {} would replace the result prototype. But in strict mode it is still an unknown key, so report it before skipping.
@@ -2136,9 +2139,10 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     const proms: Promise<any>[] = [];
     const shape = value.shape;
     const abortEarly = ctx?.abortEarly;
+    const startLen = payload.issues.length;
 
     for (const key of value.allKeys) {
-      if (abortEarly && payload.issues.length) break;
+      if (abortEarly && payload.issues.length > startLen) break;
       if (key === "__proto__") continue;
       const el = (shape as any)[key]!;
       const optin = el._zod.optin;
@@ -2976,8 +2980,9 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
       let i = items.length - 1;
       const rest = input.slice(items.length);
       const abortEarly = ctx?.abortEarly;
+      const startLen = payload.issues.length;
       for (const el of rest) {
-        if (abortEarly && payload.issues.length) break;
+        if (abortEarly && payload.issues.length > startLen) break;
         i++;
         const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
         if (result instanceof Promise) {
@@ -3148,17 +3153,19 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
 
     const proms: Promise<any>[] = [];
     const abortEarly = ctx?.abortEarly;
+    const startLen = payload.issues.length;
 
     const values = def.keyType._zod.values;
     if (values && !def.partial) {
       payload.value = memo ? memo.alloc(inst, payload, {}, ctx) : {};
       const recordKeys = new Set<string | symbol>();
       for (const key of values) {
-        if (abortEarly && payload.issues.length) break;
         if (typeof key === "string" || typeof key === "number" || typeof key === "symbol") {
           recordKeys.add(typeof key === "number" ? key.toString() : key);
           // A declared __proto__ is stripped but is not an unrecognized key.
           if (key === "__proto__") continue;
+          // skip the validation work but keep collecting keys, so the unrecognized pass below stays correct
+          if (abortEarly && payload.issues.length > startLen) continue;
           const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
           if (keyResult instanceof Promise) {
             throw new Error("Async schemas not supported in object keys currently");
@@ -3225,7 +3232,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       let unrecognized!: string[];
       // Reflect.ownKeys for Symbol-key support; filter non-enumerable to match z.object()
       for (const key of Reflect.ownKeys(input)) {
-        if (abortEarly && payload.issues.length) break;
+        if (abortEarly && payload.issues.length > startLen) break;
         if (key === "__proto__") continue;
         if (!Object.prototype.propertyIsEnumerable.call(input, key)) continue;
         let keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
@@ -3353,9 +3360,10 @@ export const $ZodMap: core.$constructor<$ZodMap> = /*@__PURE__*/ core.$construct
     const proms: Promise<any>[] = [];
     payload.value = memo ? memo.alloc(inst, payload, new Map(), ctx) : new Map();
     const abortEarly = ctx?.abortEarly;
+    const startLen = payload.issues.length;
 
     for (const [key, value] of input) {
-      if (abortEarly && payload.issues.length) break;
+      if (abortEarly && payload.issues.length > startLen) break;
       const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
       const valueResult = def.valueType._zod.run({ value: value, issues: [] }, ctx);
 
@@ -3459,8 +3467,9 @@ export const $ZodSet: core.$constructor<$ZodSet> = /*@__PURE__*/ core.$construct
     const proms: Promise<any>[] = [];
     payload.value = memo ? memo.alloc(inst, payload, new Set(), ctx) : new Set();
     const abortEarly = ctx?.abortEarly;
+    const startLen = payload.issues.length;
     for (const item of input) {
-      if (abortEarly && payload.issues.length) break;
+      if (abortEarly && payload.issues.length > startLen) break;
       const result = def.valueType._zod.run({ value: item, issues: [] }, ctx);
       if (result instanceof Promise) {
         proms.push(result.then((result) => handleSetResult(result, payload)));


### PR DESCRIPTION
Zod reports every issue it finds, so the issue count on a failing parse is set by the input rather than the schema. A large invalid array produces one issue per element, and a wide element schema multiplies that again: 20k empty objects against a 100-field element schema build two million issue objects out of 58 KB of input, and roughly 900 MB of heap to hold them.

The `abortEarly` flag stops the parse at the first issue.

```ts
z.array(z.string()).safeParse([1, 2, 3], { abortEarly: true });
// one issue, instead of one per element
```

Every fan-out loop whose length the input controls gets the same exit: array, object shape, object catchall, record, map, set, and a tuple's rest elements.

Each guard is `util.aborted(payload, startLen)` — it stops only on an issue that the loop itself produced, and only on one that aborts validation. Both halves are load-bearing. A pipe forwards a continuable `unrecognized_keys` into its next stage and an enclosing intersection can reconcile it away, so a guard that counted from zero made the flag observable on a parse that still succeeds; and a guard that stopped on a continuable issue left holes in an array's pre-allocated value, which reached `mergeValues` and threw where the default returned a `ZodError`.

### What the flag does not cover

- Continuable issues never stop a parse. Elements failing a range or format check still report one issue each, since Zod keeps validating past those so a surrounding schema can reconcile them. Aborting issues — a wrong type, a missing key — are bounded as expected.
- Unions keep trying their options, since a later one may still match.
- A tuple's fixed items all report; their count comes from the schema and the results are post-processed whole.
- Objects skip the compiled parser, since it has no early exit.
- The exit is synchronous. A genuinely async child schema dispatches every sibling before any of them settles, so there is nothing to stop on yet; a sync schema parsed through `parseAsync` still short-circuits.

### On the three axes

| axis | result |
| --- | --- |
| runtime, flag off | No change separable from noise. Six interleaved main-vs-branch rounds in separate processes: the array parse moved +0.3% to +0.5%, while object construction — which this change cannot touch — moved ~1% in the same run. That is the noise floor. |
| runtime, flag on | Two costs. Skipping the compiled parser makes an object parse roughly 7x slower on valid input as well: 13.4 ms fastpass against 109.5 ms with the flag, on a 12-field object over 200k iterations. That is the existing interpreter penalty rather than a new one — `jitless: true` measures 107.2 ms on the same run — and it is called out in the docs. Separately, the container guards are linear in the element count: on `z.array(z.number().max(1))` over 40k elements the flag costs 22 ms against 14 ms without it. |
| memory | Schema footprint unchanged (±1 B in both directions, i.e. harness noise). No new own-properties or retained closures; the hoisted locals are per-call. Every instance still reports fast properties. |
| bundle | The guards live only in the container loops, so a bundle without one pays nothing: `zod-mini-boolean` and `zod-mini-string` are unchanged. `zod-mini-object` is +63 B gzipped (+1.43%) and the classic object fixture +74 B (+0.30%). Only the object ceiling moves. |

Refs #1872
