### PR TITLE
perf(v4): latch the prototype installers per constructor

### DIFF
--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2836 / 3299 / 4374 by the commit that caused it: suppressing v8's stack capture while building an error costs +68 / +68 / +63, and every bundle carries `core.ts`; measured 2875 / 3338 / 4409 plus 28 headroom, and the per-fixture notes below record what each already carried
-  "zod-mini-boolean": 2903,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: latching the prototype installers per constructor costs +21 / +34 / +38, and every bundle carries `core.ts`; measured 2897 / 3371 / 4446 plus 28 headroom, and the per-fixture notes below record what each already carried
+  "zod-mini-boolean": 2925,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3366,
+  "zod-mini-string": 3399,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4437,
+  "zod-mini-object": 4474,
 };
 
 /**

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -176,8 +176,8 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   _installLazyMethods(inst, "check", _zodTypeMethods);
   _installLazyProps(inst, "parse", _zodTypeParseProps);
   // Reads through to the registry on every access, so it must not cache.
-  const proto = Object.getPrototypeOf(inst);
-  if (!("description" in proto)) {
+  const proto = util.claim(inst, "description");
+  if (proto) {
     Object.defineProperty(proto, "description", {
       configurable: true,
       get(this: ZodType) {

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -103,3 +103,28 @@ test("deferred initializers are released after construction", () => {
   expect(z.string()._zod.deferred).toEqual(undefined);
   expect(z.object({ a: z.string() })._zod.deferred).toEqual(undefined);
 });
+
+test("a trait initializer called directly still installs its members", () => {
+  // The installers skip their per-group lookup while a constructor that has already built its prototype is constructing. A direct `init` is not that, so it has to see the guard off.
+  z.string();
+
+  const proto = {};
+  const inst = Object.create(proto) as z.ZodString;
+  z.ZodString.init(inst, { type: "string" });
+
+  expect(typeof inst.email).toBe("function");
+  expect(typeof inst.optional).toBe("function");
+  expect(Object.prototype.hasOwnProperty.call(proto, "email")).toBe(true);
+});
+
+test("an initializer that throws leaves the install guard off", () => {
+  // A successful one first, so the guard is armed for this constructor when the next throws.
+  z.uuid();
+  expect(() => z.uuid({ version: "v9" as never })).toThrow();
+
+  const proto = {};
+  const inst = Object.create(proto) as z.ZodString;
+  z.ZodString.init(inst, { type: "string" });
+
+  expect(Object.prototype.hasOwnProperty.call(proto, "email")).toBe(true);
+});

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -18,6 +18,12 @@ export const NEVER: never = /*@__PURE__*/ Object.freeze({
  * synchronously, so reusing one object avoids a per-instance allocation. */
 const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 
+/**
+ * True for the length of a construction whose constructor has already built its prototype. The prototype installers in `util` are per-constructor and idempotent, so after the first construction their own lookups can only miss; this lets them skip the lookup instead. Read through the live binding in `util`.
+ * @internal
+ */
+export let protoBuilt = false;
+
 // null where suppressing the capture would be unrecoverable: `parse()` puts the frames back with `captureStackTrace`, so without it the throw would lose its stack. also latched to null once `stackTraceLimit` proves unassignable, which a realm can do at any point by hardening Error
 let _E: (ErrorConstructor & { stackTraceLimit?: number }) | null = "captureStackTrace" in Error ? Error : null;
 
@@ -93,9 +99,19 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
   class Definition extends Parent {}
   Object.defineProperty(Definition, "name", { value: name });
 
+  // Flipped by the first complete construction, which is what installs this constructor's prototype.
+  let installed = false;
+
   function _(this: any, def: D) {
     const inst = params?.Parent ? newError(Definition) : this;
-    init(inst, def);
+    protoBuilt = installed;
+    try {
+      init(inst, def);
+    } finally {
+      // Cleared even on throw, so a direct `SomeTrait.init(obj, def)` outside a construction never inherits another constructor's answer.
+      protoBuilt = false;
+    }
+    installed = true;
     const deferred = inst._zod.deferred;
     if (deferred) {
       for (const fn of deferred) {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1,5 +1,5 @@
 import type * as checks from "./checks.js";
-import { globalConfig } from "./core.js";
+import { globalConfig, protoBuilt } from "./core.js";
 import type { $ZodConfig } from "./core.js";
 import type * as errors from "./errors.js";
 import type * as schemas from "./schemas.js";
@@ -1064,7 +1064,9 @@ export abstract class Class {
 // Members live on the prototype and materialize per instance on first read, which keeps own-property count under the step where V8 stops using inline slots. Changing anything here means re-measuring runtime, memory and bundle size together — see "The three axes" in AGENTS.md.
 
 /** Returns the prototype to install on, or `undefined` if this group is already installed on it. */
-function claim(inst: object, sentinel: string): object | undefined {
+export function claim(inst: object, sentinel: string): object | undefined {
+  // A constructor that has completed one construction has its whole prototype, so the lookup below can only miss.
+  if (protoBuilt) return undefined;
   const proto = Object.getPrototypeOf(inst);
   // Runs on every construction, so `in` rather than the costlier `hasOwnProperty.call`. Sentinels are keys the group itself defines.
   return sentinel in proto ? undefined : proto;
@@ -1142,6 +1144,11 @@ export function defineLazyInternal<T extends { _zod: any }>(
   key: string,
   compute: (zod: T["_zod"]) => unknown
 ): void {
+  if (protoBuilt) {
+    // Released here too: the first construction leaves it pointing at that instance's internals.
+    installing = undefined;
+    return;
+  }
   const proto = Object.getPrototypeOf(inst._zod);
   if (key in proto && installing !== inst._zod) {
     // A repeat construction: everything is installed already. Cleared here so the reference is not held past the first construction of every type.


### PR DESCRIPTION
The member installers are per-constructor and idempotent: one asks whether a group's sentinel is already on the prototype, the other asks the same of a derived internal. Both run on every construction, and after the first one their answer cannot change — initializers compose unconditionally, so a constructor that has completed a construction has its whole prototype.

`$constructor` is the only place that knows that. One flag, set for the length of a construction whose constructor has already built its prototype, lets both installers skip the lookup instead of repeating it.

Construction, ns/op, four interleaved rounds against `main`, minimum of 15 samples with `gc()` between. The control column is `main`'s own code run a third time each round, so it is the noise floor:

| case | `main` | this branch | control |
| --- | --- | --- | --- |
| `z.number()` | 444.1 | **-20.4%** | +0.7% |
| `z.array(z.string())` | 1621.8 | **-16.7%** | -0.0% |
| `z.object()` 5 keys + nested | 15871.4 | **-15.8%** | -2.4% |
| `z.string()` | 644.0 | **-15.3%** | -1.6% |
| `z.object({a,b})` | 4572.2 | **-11.6%** | -1.5% |
| `z.string().min(1).max(9)` | 7797.5 | -5.7% | +0.3% |
| mini `z.object({a,b})` | 3735.1 | -5.8% | -0.0% |
| mini `z.string()` | 654.6 | -4.7% | -0.6% |

Parse is flat. Measured in its own process — running it after half a million constructions in one process reports a 14% regression that is entirely heap and IC pollution, and the control moves with it:

| case | `main` | this branch | control |
| --- | --- | --- | --- |
| string | 2.37 | +0.5% | +0.0% |
| number | 2.38 | -0.3% | +0.0% |
| safeParse | 2.38 | +0.2% | +0.2% |
| string with a check | 20.08 | +0.9% | +0.7% |
| object, 3 keys | 34.09 | +0.2% | +0.5% |

Memory is unchanged: every case in `schema-footprint` is byte-identical or within 1 B, the 500-resource `realworld` catalogue moves 60450832 → 60451328 B, and `dict-mode` reports `fast` for every instance and every internals object, with the same own-property counts.

Bundle is the cost. Gzipped, as the ceiling test measures it:

| fixture | `main` | this branch |
| --- | --- | --- |
| classic string | 20236 | +50 |
| classic object | 24260 | +41 |
| mini boolean | 2876 | +21 |
| mini string | 3337 | +34 |
| mini object | 4408 | +38 |

The three mini ceilings move with it, re-measured plus the file's 28 B headroom.

The flag clears in a `finally`, so a direct `SomeTrait.init(obj, def)` outside a construction — which no constructor's answer covers — still installs. Two tests pin that, one of them after an initializer throws; both fail if the reset is weakened.

This came out of looking at whether `$constructor` should instead take a declarative member list at definition time. It should not, and the measurements are the reason: prototypes are flat, one per constructor carrying the whole flattened surface, so building them eagerly costs ~1.7 MB of retained heap for an application that uses five schema types, and 4.5x this bundle cost on mini — for the same construction win this gets in 25 lines with no API surface.

Refs #6318, #6415.
