### PR TITLE
docs: blog visual concepts (review only)

### DIFF
--- a/packages/docs/app/blog-concepts/[concept]/[slug]/page.tsx
+++ b/packages/docs/app/blog-concepts/[concept]/[slug]/page.tsx
@@ -1,0 +1,34 @@
+import { concepts } from "@/components/blog-concepts";
+import { minutesFor } from "@/components/blog-concepts/shared";
+import { blog } from "@/loaders/source";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { notFound } from "next/navigation";
+import type { ComponentType } from "react";
+
+export default async function ConceptPostPage(props: { params: Promise<{ concept: string; slug: string }> }) {
+  const { concept, slug } = await props.params;
+  const c = concepts[concept];
+  const page = blog.getPage([slug]) as any;
+  if (!c || !page) notFound();
+
+  const dateValue = page.data?.date as string | Date | undefined;
+  return (
+    <div className={`${c.className} flex grow flex-col`}>
+      <c.Post
+        title={page.data.title ?? slug}
+        description={page.data.description}
+        date={dateValue ? new Date(dateValue) : undefined}
+        author={page.data.author ?? "Colin McDonnell"}
+        minutes={minutesFor(page)}
+        toc={page.data.toc ?? []}
+        backHref={`/blog-concepts/${concept}`}
+        Mdx={page.data.body as ComponentType<any>}
+        components={defaultMdxComponents}
+      />
+    </div>
+  );
+}
+
+export function generateStaticParams(): { concept: string; slug: string }[] {
+  return Object.keys(concepts).flatMap((concept) => blog.getPages().map((page) => ({ concept, slug: page.slugs[0] })));
+}

--- a/packages/docs/app/blog-concepts/[concept]/page.tsx
+++ b/packages/docs/app/blog-concepts/[concept]/page.tsx
@@ -1,0 +1,34 @@
+import { concepts } from "@/components/blog-concepts";
+import { type PostItem, minutesFor, samplePosts } from "@/components/blog-concepts/shared";
+import { blog } from "@/loaders/source";
+import { notFound } from "next/navigation";
+
+export default async function ConceptIndexPage(props: { params: Promise<{ concept: string }> }) {
+  const { concept } = await props.params;
+  const c = concepts[concept];
+  if (!c) notFound();
+
+  const pages = blog.getPages() as any[];
+  const real: PostItem[] = pages.map((page) => ({
+    slug: page.slugs[0],
+    title: page.data.title ?? page.slugs.join("/"),
+    description: page.data.description ?? "",
+    date: new Date(page.data.date),
+    author: page.data.author ?? "Colin McDonnell",
+    url: `/blog-concepts/${concept}/${page.slugs[0]}`,
+    minutes: minutesFor(page),
+  }));
+  // placeholder rows link to the real post so every row opens something
+  const samples: PostItem[] = samplePosts.map((s) => ({ ...s, url: real[0]?.url ?? `/blog-concepts/${concept}` }));
+  const posts = [...real, ...samples].sort((a, b) => b.date.getTime() - a.date.getTime());
+
+  return (
+    <div className={`${c.className} flex grow flex-col`}>
+      <c.Index posts={posts} />
+    </div>
+  );
+}
+
+export function generateStaticParams(): { concept: string }[] {
+  return Object.keys(concepts).map((concept) => ({ concept }));
+}

--- a/packages/docs/app/blog-concepts/concepts.css
+++ b/packages/docs/app/blog-concepts/concepts.css
@@ -1,0 +1,69 @@
+/* global.css sets unlayered h1 / .prose h2 borders that utilities cannot override, so the resets live here */
+.blog-concept h1 {
+  border: 0;
+  padding: 0;
+}
+
+.blog-concept .prose h2 {
+  border: 0;
+  padding: 0;
+}
+
+.blog-concept {
+  --font-serif: var(--font-concept-serif), Georgia, "Times New Roman", serif;
+  --font-mono: var(--font-concept-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* editorial */
+.concept-editorial .prose h2 {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: 2.15em;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin-top: 2.4em;
+  margin-bottom: 0.6em;
+}
+
+.concept-editorial .prose h3 {
+  font-family: var(--font-serif);
+  font-weight: 400;
+  font-size: 1.6em;
+}
+
+.concept-editorial .prose a {
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+/* timeline */
+.concept-timeline .prose h2 {
+  margin-top: 2.6em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.concept-timeline .prose h2::before {
+  content: "";
+  display: inline-block;
+  width: 0.4em;
+  height: 0.4em;
+  margin-right: 0.55em;
+  transform: rotate(45deg) translateY(-0.12em);
+  border: 1.5px solid var(--ui-color);
+}
+
+/* glow */
+.concept-glow .prose h2 {
+  margin-top: 2.6em;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+/* margin */
+.concept-margin .prose h2 {
+  margin-top: 2.6em;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  scroll-margin-top: 6rem;
+}

--- a/packages/docs/app/blog-concepts/layout.tsx
+++ b/packages/docs/app/blog-concepts/layout.tsx
@@ -1,0 +1,13 @@
+import { baseOptions } from "@/app/layout.config";
+import { mono, serif } from "@/components/blog-concepts/fonts";
+import { HomeLayout } from "fumadocs-ui/layouts/home";
+import type { ReactNode } from "react";
+import "./concepts.css";
+
+export default function BlogConceptsLayout({ children }: { children: ReactNode }) {
+  return (
+    <HomeLayout {...baseOptions}>
+      <div className={`blog-concept flex grow flex-col ${serif.variable} ${mono.variable}`}>{children}</div>
+    </HomeLayout>
+  );
+}

--- a/packages/docs/app/blog-concepts/page.tsx
+++ b/packages/docs/app/blog-concepts/page.tsx
@@ -1,0 +1,33 @@
+import { concepts } from "@/components/blog-concepts";
+import { blog } from "@/loaders/source";
+import Link from "next/link";
+
+export default function ConceptChooserPage() {
+  const firstSlug = blog.getPages()[0]?.slugs[0];
+  return (
+    <main className="grow container px-4 py-16">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-semibold tracking-tight">Blog concepts</h1>
+        <p className="mt-2 text-fd-muted-foreground">Review-only. Each concept renders the real post plus placeholder index rows.</p>
+        <ul className="mt-8 grid gap-4 sm:grid-cols-2">
+          {Object.entries(concepts).map(([name, c]) => (
+            <li key={name} className="rounded-xl border border-fd-border p-5">
+              <h2 className="font-semibold">{c.label}</h2>
+              <p className="mt-1 text-sm text-fd-muted-foreground">{c.blurb}</p>
+              <p className="mt-4 flex gap-4 text-sm">
+                <Link href={`/blog-concepts/${name}`} className="underline underline-offset-4 hover:text-[var(--ui-color)]">
+                  Index
+                </Link>
+                {firstSlug ? (
+                  <Link href={`/blog-concepts/${name}/${firstSlug}`} className="underline underline-offset-4 hover:text-[var(--ui-color)]">
+                    Post
+                  </Link>
+                ) : null}
+              </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/packages/docs/components/blog-concepts/editorial.tsx
+++ b/packages/docs/components/blog-concepts/editorial.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import { AUTHOR_URL, type IndexProps, type PostProps, formatDate, groupByYear } from "./shared";
+
+function Gem() {
+  return (
+    <span aria-hidden className="inline-block size-2 rotate-45 bg-[var(--ui-color)]" style={{ verticalAlign: "0.1em" }} />
+  );
+}
+
+function Meta({ children }: { children: React.ReactNode }) {
+  return <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-fd-muted-foreground">{children}</p>;
+}
+
+export function Index({ posts }: IndexProps) {
+  return (
+    <main className="grow container px-4 py-16 md:py-24">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-16 md:mb-24">
+          <Meta>The Zod blog</Meta>
+          <h1 className="font-serif text-6xl md:text-[88px] leading-[0.95] tracking-[-0.01em] mt-4">
+            Notes from <em className="text-[var(--ui-color)]">the project</em>
+          </h1>
+          <p className="font-serif italic text-2xl md:text-[28px] leading-snug text-fd-muted-foreground mt-6 max-w-[28ch]">
+            Announcements, design decisions, and the occasional funding story.
+          </p>
+        </header>
+
+        <ol>
+          {groupByYear(posts).map(([year, group]) => (
+            <li key={year} className="grid md:grid-cols-[6rem_1fr] border-t border-fd-border">
+              <p className="font-serif text-3xl text-fd-muted-foreground pt-7 md:pt-8">{year}</p>
+              <ol>
+                {group.map((post, i) => (
+                  <li key={post.slug} className={i > 0 ? "border-t border-fd-border" : ""}>
+                    <Link href={post.url} className="group block py-7 md:py-8">
+                      <h2 className="font-serif text-3xl md:text-[40px] leading-[1.08] group-hover:text-[var(--ui-color)] transition-colors">
+                        {post.title}
+                      </h2>
+                      <p className="mt-3 text-fd-muted-foreground text-[17px] leading-relaxed max-w-[52ch]">{post.description}</p>
+                      <div className="mt-4">
+                        <Meta>
+                          {formatDate(post.date, "long")} <span className="mx-1.5 opacity-50">/</span> {post.minutes} min
+                        </Meta>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ol>
+            </li>
+          ))}
+        </ol>
+        <div className="border-t border-fd-border" />
+      </div>
+    </main>
+  );
+}
+
+export function Post({ title, description, date, author, minutes, backHref, Mdx, components }: PostProps) {
+  return (
+    <main className="grow container px-4">
+      <header className="mx-auto max-w-3xl pt-14 md:pt-20">
+        <Link href={backHref} className="inline-block hover:text-[var(--ui-color)]">
+          <Meta>
+            <Gem /> <span className="ml-2">Blog</span>
+          </Meta>
+        </Link>
+        <h1 className="font-serif text-5xl md:text-[68px] leading-[1.02] tracking-[-0.01em] mt-6">{title}</h1>
+        {description ? (
+          <p className="font-serif italic text-2xl md:text-[27px] leading-snug text-fd-muted-foreground mt-5 max-w-[34ch]">
+            {description}
+          </p>
+        ) : null}
+        <div className="mt-8 flex items-center gap-3">
+          <Meta>
+            <a href={AUTHOR_URL} className="text-fd-foreground hover:text-[var(--ui-color)]">
+              {author}
+            </a>
+            {date ? (
+              <>
+                <span className="mx-1.5 opacity-50">/</span>
+                <time dateTime={date.toISOString()}>{formatDate(date, "long")}</time>
+                <span className="mx-1.5 opacity-50">/</span>
+                {minutes} min
+              </>
+            ) : null}
+          </Meta>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-3xl my-12 md:my-16 flex items-center gap-4 text-fd-border">
+        <span className="h-px grow bg-current" />
+        <Gem />
+        <span className="h-px grow bg-current" />
+      </div>
+
+      <article className="mx-auto max-w-3xl pb-20">
+        <div className="prose prose-lg min-w-0">
+          <Mdx components={components} />
+        </div>
+        <footer className="mt-16 pt-8 border-t border-fd-border flex flex-wrap items-baseline justify-between gap-4">
+          <p className="font-serif italic text-xl text-fd-muted-foreground">
+            Written by{" "}
+            <a href={AUTHOR_URL} className="text-fd-foreground hover:text-[var(--ui-color)]">
+              {author}
+            </a>
+            {date ? <> on {formatDate(date, "long")}</> : null}
+          </p>
+          <Link href={backHref} className="hover:text-[var(--ui-color)]">
+            <Meta>All posts →</Meta>
+          </Link>
+        </footer>
+      </article>
+    </main>
+  );
+}

--- a/packages/docs/components/blog-concepts/fonts.ts
+++ b/packages/docs/components/blog-concepts/fonts.ts
@@ -1,0 +1,13 @@
+import { Instrument_Serif, JetBrains_Mono } from "next/font/google";
+
+export const serif = Instrument_Serif({
+  weight: "400",
+  style: ["normal", "italic"],
+  subsets: ["latin"],
+  variable: "--font-concept-serif",
+});
+
+export const mono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-concept-mono",
+});

--- a/packages/docs/components/blog-concepts/glow.tsx
+++ b/packages/docs/components/blog-concepts/glow.tsx
@@ -1,0 +1,142 @@
+import Image from "next/image";
+import Link from "next/link";
+import { AUTHOR_URL, AVATAR, type IndexProps, type PostProps, formatDate } from "./shared";
+
+// the site's hero glow, reused as a wash behind the header: blue from the logo, magenta from the accent
+const GLOW =
+  "radial-gradient(42% 55% at 30% 0%, color-mix(in oklab, #4f8ef7 22%, transparent), transparent 70%), radial-gradient(38% 50% at 72% 8%, color-mix(in oklab, var(--ui-color) 16%, transparent), transparent 70%)";
+
+// cards are links themselves, so the byline inside them must not nest another anchor
+function Byline({ author, date, link = true }: { author: string; date?: Date; link?: boolean }) {
+  return (
+    <div className="flex items-center gap-3 text-sm">
+      <Image src={AVATAR} alt="" width={28} height={28} className="rounded-full size-7" />
+      {link ? (
+        <a href={AUTHOR_URL} className="font-medium hover:text-[var(--ui-color)]">
+          {author}
+        </a>
+      ) : (
+        <span className="font-medium">{author}</span>
+      )}
+      {date ? (
+        <>
+          <span className="text-fd-muted-foreground/60">·</span>
+          <time dateTime={date.toISOString()} className="text-fd-muted-foreground">
+            {formatDate(date)}
+          </time>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+export function Index({ posts }: IndexProps) {
+  const [featured, ...rest] = posts;
+  return (
+    <main className="grow">
+      <section className="relative overflow-hidden">
+        <div aria-hidden className="absolute inset-0 -z-10" style={{ background: GLOW }} />
+        <div className="container px-4 pt-16 pb-12 md:pt-24 md:pb-16">
+          <div className="mx-auto max-w-4xl">
+            <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight">Blog</h1>
+            <p className="mt-4 text-lg text-fd-muted-foreground max-w-[44ch]">
+              Release announcements, design notes, and deep dives from the Zod project.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <div className="container px-4 pb-20">
+        <div className="mx-auto max-w-4xl">
+          {featured ? (
+            <Link
+              href={featured.url}
+              className="group relative block rounded-3xl border border-fd-border overflow-hidden p-8 md:p-12 transition-shadow hover:shadow-[0_0_0_4px_color-mix(in_oklab,var(--ui-color)_18%,transparent)]"
+            >
+              <div
+                aria-hidden
+                className="absolute inset-0 -z-10 opacity-80 group-hover:opacity-100 transition-opacity"
+                style={{
+                  background:
+                    "linear-gradient(135deg, color-mix(in oklab, #4f8ef7 12%, transparent), transparent 50%, color-mix(in oklab, var(--ui-color) 12%, transparent))",
+                }}
+              />
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--ui-color)]/30 bg-fd-background/60 px-2.5 py-0.5 text-xs font-medium text-[var(--ui-color)]">
+                Latest
+              </span>
+              <h2 className="mt-5 text-3xl md:text-[40px] font-bold tracking-tight leading-[1.1] max-w-[22ch]">{featured.title}</h2>
+              <p className="mt-4 text-fd-muted-foreground text-lg leading-relaxed max-w-[52ch]">{featured.description}</p>
+              <div className="mt-8">
+                <Byline author={featured.author} date={featured.date} link={false} />
+              </div>
+            </Link>
+          ) : null}
+
+          <ul className="mt-6 grid gap-6 md:grid-cols-2">
+            {rest.map((post) => (
+              <li key={post.slug}>
+                <Link
+                  href={post.url}
+                  className="group flex h-full flex-col rounded-2xl border border-fd-border bg-fd-card p-6 md:p-7 transition-all hover:border-[var(--ui-color)]/50 hover:shadow-[0_0_0_4px_color-mix(in_oklab,var(--ui-color)_12%,transparent)]"
+                >
+                  <time dateTime={post.date.toISOString()} className="text-xs font-medium text-fd-muted-foreground">
+                    {formatDate(post.date)}
+                  </time>
+                  <h3 className="mt-3 text-xl md:text-[22px] font-semibold tracking-tight leading-snug group-hover:text-[var(--ui-color)] transition-colors">
+                    {post.title}
+                  </h3>
+                  <p className="mt-2 text-fd-muted-foreground leading-relaxed grow">{post.description}</p>
+                  <p className="mt-5 text-sm font-medium text-fd-muted-foreground group-hover:text-[var(--ui-color)] transition-colors">
+                    Read post →
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export function Post({ title, description, date, author, backHref, Mdx, components }: PostProps) {
+  return (
+    <main className="grow">
+      <header className="relative overflow-hidden">
+        <div aria-hidden className="absolute inset-0 -z-10" style={{ background: GLOW }} />
+        <div className="container px-4 pt-14 pb-12 md:pt-20 md:pb-16">
+          <div className="mx-auto max-w-3xl">
+            <Link
+              href={backHref}
+              className="inline-flex items-center gap-1.5 rounded-full border border-fd-border bg-fd-background/70 backdrop-blur px-3 py-1 text-xs font-medium text-fd-muted-foreground hover:text-fd-foreground hover:border-[var(--ui-color)]/50"
+            >
+              ← Blog
+            </Link>
+            <h1 className="mt-6 text-4xl md:text-[56px] font-extrabold tracking-tight leading-[1.05]">{title}</h1>
+            {description ? <p className="mt-5 text-lg md:text-xl text-fd-muted-foreground leading-relaxed max-w-[56ch]">{description}</p> : null}
+            <div className="mt-8">
+              <Byline author={author} date={date} />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <article className="container px-4 py-10 md:py-14">
+        <div className="mx-auto max-w-3xl">
+          <div className="prose prose-lg min-w-0">
+            <Mdx components={components} />
+          </div>
+          <footer className="mt-16 rounded-2xl border border-fd-border p-6 md:p-8 flex flex-wrap items-center justify-between gap-6">
+            <Byline author={author} date={date} />
+            <Link
+              href={backHref}
+              className="rounded-full bg-[var(--ui-color)] px-4 py-2 text-sm font-medium text-white hover:opacity-90 dark:text-fd-background"
+            >
+              More posts
+            </Link>
+          </footer>
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/packages/docs/components/blog-concepts/index.ts
+++ b/packages/docs/components/blog-concepts/index.ts
@@ -1,0 +1,32 @@
+import * as editorial from "./editorial";
+import * as glow from "./glow";
+import * as margin from "./margin";
+import type { Concept } from "./shared";
+import * as timeline from "./timeline";
+
+export const concepts: Record<string, Concept> = {
+  editorial: {
+    label: "Editorial",
+    blurb: "Serif display type, italic deks, year labels in the gutter, a gem divider.",
+    className: "concept-editorial",
+    ...editorial,
+  },
+  timeline: {
+    label: "Timeline",
+    blurb: "Sticky intro column, dated rail with diamond markers, monospace metadata.",
+    className: "concept-timeline",
+    ...timeline,
+  },
+  glow: {
+    label: "Glow",
+    blurb: "Brand gradient wash behind the header, featured latest post, card grid.",
+    className: "concept-glow",
+    ...glow,
+  },
+  margin: {
+    label: "Margin",
+    blurb: "Big-type list with right-aligned dates; post page with a sticky margin column and TOC.",
+    className: "concept-margin",
+    ...margin,
+  },
+};

--- a/packages/docs/components/blog-concepts/margin.tsx
+++ b/packages/docs/components/blog-concepts/margin.tsx
@@ -1,0 +1,110 @@
+import Image from "next/image";
+import Link from "next/link";
+import { AUTHOR_URL, AVATAR, type IndexProps, type PostProps, formatDate } from "./shared";
+
+function Label({ children }: { children: React.ReactNode }) {
+  return <dt className="text-[11px] font-medium uppercase tracking-[0.16em] text-fd-muted-foreground">{children}</dt>;
+}
+
+export function Index({ posts }: IndexProps) {
+  return (
+    <main className="grow container px-4 py-16 md:py-24">
+      <div className="mx-auto max-w-4xl">
+        <div className="flex items-baseline justify-between">
+          <h1 className="text-[11px] font-medium uppercase tracking-[0.18em] text-fd-muted-foreground">Blog</h1>
+          <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-fd-muted-foreground tabular-nums">
+            {posts.length} posts
+          </p>
+        </div>
+        <ul className="mt-8 border-t border-fd-border">
+          {posts.map((post) => (
+            <li key={post.slug} className="border-b border-fd-border">
+              <Link href={post.url} className="group grid gap-x-10 gap-y-3 py-9 md:grid-cols-[minmax(0,1fr)_9rem] md:py-11 items-baseline">
+                <div>
+                  <h2 className="text-3xl md:text-[42px] font-semibold tracking-[-0.03em] leading-[1.05] group-hover:text-[var(--ui-color)] transition-colors">
+                    {post.title}
+                  </h2>
+                  <p className="mt-4 text-fd-muted-foreground text-[17px] leading-relaxed max-w-[54ch]">{post.description}</p>
+                </div>
+                <time
+                  dateTime={post.date.toISOString()}
+                  className="text-sm text-fd-muted-foreground tabular-nums md:text-right md:pt-2 order-first md:order-none"
+                >
+                  {formatDate(post.date)}
+                </time>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}
+
+export function Post({ title, description, date, author, minutes, toc, backHref, Mdx, components }: PostProps) {
+  const headings = toc.filter((h) => h.depth <= 2);
+  return (
+    <main className="grow container px-4 py-12 md:py-20">
+      <div className="mx-auto max-w-6xl lg:grid lg:grid-cols-[13rem_minmax(0,1fr)] lg:gap-20">
+        <aside className="lg:sticky lg:top-24 self-start text-sm mb-10 lg:mb-0">
+          <Link href={backHref} className="text-fd-muted-foreground hover:text-[var(--ui-color)]">
+            ← Blog
+          </Link>
+          <dl className="mt-8 grid grid-cols-2 gap-x-6 gap-y-5 lg:grid-cols-1">
+            {date ? (
+              <div>
+                <Label>Published</Label>
+                <dd className="mt-1">
+                  <time dateTime={date.toISOString()}>{formatDate(date, "long")}</time>
+                </dd>
+              </div>
+            ) : null}
+            <div>
+              <Label>Author</Label>
+              <dd className="mt-1.5 flex items-center gap-2">
+                <Image src={AVATAR} alt="" width={20} height={20} className="rounded-full size-5" />
+                <a href={AUTHOR_URL} className="hover:text-[var(--ui-color)]">
+                  {author}
+                </a>
+              </dd>
+            </div>
+            <div>
+              <Label>Reading time</Label>
+              <dd className="mt-1">{minutes} min</dd>
+            </div>
+          </dl>
+          {headings.length ? (
+            <nav className="mt-8 hidden lg:block">
+              <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-fd-muted-foreground">On this page</p>
+              <ol className="mt-2 border-l border-fd-border">
+                {headings.map((h) => (
+                  <li key={h.url}>
+                    <a
+                      href={h.url}
+                      className="block -ml-px border-l border-transparent pl-4 py-1 text-fd-muted-foreground hover:text-fd-foreground hover:border-[var(--ui-color)]"
+                    >
+                      {h.title}
+                    </a>
+                  </li>
+                ))}
+              </ol>
+            </nav>
+          ) : null}
+        </aside>
+
+        <article className="min-w-0">
+          <h1 className="text-4xl md:text-[60px] font-semibold tracking-[-0.035em] leading-[1.02] max-w-[18ch]">{title}</h1>
+          {description ? <p className="mt-6 text-xl text-fd-muted-foreground leading-relaxed max-w-[50ch]">{description}</p> : null}
+          <div className="prose prose-lg min-w-0 mt-10 max-w-[68ch]">
+            <Mdx components={components} />
+          </div>
+          <footer className="mt-16 pt-6 border-t border-fd-border text-sm text-fd-muted-foreground max-w-[68ch]">
+            <Link href={backHref} className="hover:text-[var(--ui-color)]">
+              ← All posts
+            </Link>
+          </footer>
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/packages/docs/components/blog-concepts/shared.ts
+++ b/packages/docs/components/blog-concepts/shared.ts
@@ -1,0 +1,105 @@
+import type { ComponentType, ReactNode } from "react";
+
+export interface PostItem {
+  slug: string;
+  title: string;
+  description: string;
+  date: Date;
+  author: string;
+  url: string;
+  minutes: number;
+  // review-only placeholder rows so the index has enough entries to judge
+  sample?: boolean;
+}
+
+export interface TocEntry {
+  title: ReactNode;
+  url: string;
+  depth: number;
+}
+
+export interface IndexProps {
+  posts: PostItem[];
+}
+
+export interface PostProps {
+  title: string;
+  description?: string;
+  date?: Date;
+  author: string;
+  minutes: number;
+  toc: TocEntry[];
+  backHref: string;
+  Mdx: ComponentType<any>;
+  components: Record<string, ComponentType<any>>;
+}
+
+export interface Concept {
+  label: string;
+  blurb: string;
+  className: string;
+  Index: ComponentType<IndexProps>;
+  Post: ComponentType<PostProps>;
+}
+
+export const AUTHOR_URL = "https://x.com/colinhacks";
+export const AVATAR = "/logo/profile_circle.png";
+
+export const samplePosts: Omit<PostItem, "url">[] = [
+  {
+    slug: "zod-4-stable",
+    title: "Zod 4 is stable",
+    description:
+      "A ground-up rewrite: faster parsing, far fewer type instantiations, a 2 kB core, and a Zod Mini variant for bundle-conscious apps.",
+    date: new Date("2025-05-19"),
+    author: "Colin McDonnell",
+    minutes: 9,
+    sample: true,
+  },
+  {
+    slug: "codecs",
+    title: "Codecs: bidirectional transforms",
+    description:
+      "Encode and decode with one schema. How codecs fit alongside pipes, and what changes for library authors.",
+    date: new Date("2025-08-14"),
+    author: "Colin McDonnell",
+    minutes: 5,
+    sample: true,
+  },
+  {
+    slug: "aot",
+    title: "Ahead-of-time compilation",
+    description:
+      "Compiling schemas to specialized parse functions at construction time, and where the speedup comes from.",
+    date: new Date("2026-03-02"),
+    author: "Colin McDonnell",
+    minutes: 7,
+    sample: true,
+  },
+];
+
+export function formatDate(date: Date, style: "short" | "long" | "iso" = "short"): string {
+  if (style === "iso") return date.toISOString().slice(0, 10);
+  return date.toLocaleDateString("en-US", {
+    month: style === "long" ? "long" : "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export function groupByYear(posts: PostItem[]): [number, PostItem[]][] {
+  const groups = new Map<number, PostItem[]>();
+  for (const post of posts) {
+    const year = post.date.getUTCFullYear();
+    if (!groups.has(year)) groups.set(year, []);
+    groups.get(year)!.push(post);
+  }
+  return [...groups.entries()].sort((a, b) => b[0] - a[0]);
+}
+
+export function minutesFor(page: any): number {
+  const contents: { content?: string }[] = page.data?.structuredData?.contents ?? [];
+  const words = contents.reduce((n, c) => n + (c.content?.split(/\s+/).length ?? 0), 0);
+  return Math.max(1, Math.round(words / 220));
+}

--- a/packages/docs/components/blog-concepts/timeline.tsx
+++ b/packages/docs/components/blog-concepts/timeline.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import { AUTHOR_URL, type IndexProps, type PostProps, formatDate } from "./shared";
+
+function Diamond({ className = "" }: { className?: string }) {
+  return (
+    <span
+      aria-hidden
+      className={`block size-2.5 rotate-45 border-[1.5px] border-[var(--ui-color)] bg-fd-background ${className}`}
+    />
+  );
+}
+
+export function Index({ posts }: IndexProps) {
+  const years = new Set(posts.map((p) => p.date.getUTCFullYear()));
+  const since = Math.min(...years);
+  let lastYear: number | undefined;
+
+  return (
+    <main className="grow container px-4 py-16 md:py-24">
+      <div className="mx-auto max-w-5xl grid gap-12 lg:grid-cols-[17rem_minmax(0,1fr)] lg:gap-20">
+        <aside className="lg:sticky lg:top-24 self-start">
+          <p className="font-mono text-xs text-[var(--ui-color)]">~/zod/blog</p>
+          <h1 className="text-4xl font-semibold tracking-tight mt-3">Blog</h1>
+          <p className="mt-4 text-fd-muted-foreground leading-relaxed">
+            Release write-ups, design notes, and announcements from the project.
+          </p>
+          <dl className="mt-8 font-mono text-xs text-fd-muted-foreground grid grid-cols-[auto_1fr] gap-x-6 gap-y-2">
+            <dt>posts</dt>
+            <dd className="text-fd-foreground tabular-nums">{posts.length}</dd>
+            <dt>since</dt>
+            <dd className="text-fd-foreground tabular-nums">{since}</dd>
+            <dt>author</dt>
+            <dd>
+              <a href={AUTHOR_URL} className="text-fd-foreground hover:text-[var(--ui-color)]">
+                @colinhacks
+              </a>
+            </dd>
+          </dl>
+        </aside>
+
+        <ol className="relative ml-1.5 border-l border-fd-border">
+          {posts.map((post) => {
+            const year = post.date.getUTCFullYear();
+            const showYear = year !== lastYear;
+            lastYear = year;
+            return (
+              <li key={post.slug} className="relative pl-8 md:pl-10 pb-12 last:pb-0">
+                {showYear ? (
+                  <p className="font-mono text-xs text-fd-muted-foreground mb-4 -mt-1">
+                    <span className="inline-block w-4 border-t border-fd-border align-middle -ml-8 md:-ml-10 mr-4" />
+                    {year}
+                  </p>
+                ) : null}
+                <div className="relative">
+                  <Diamond className="absolute -left-[calc(2rem+6px)] md:-left-[calc(2.5rem+6px)] top-[0.45rem]" />
+                  <p className="font-mono text-xs text-fd-muted-foreground tabular-nums">
+                    {formatDate(post.date, "iso")}
+                    <span className="mx-2 opacity-40">·</span>
+                    {post.minutes} min
+                  </p>
+                  <Link href={post.url} className="group block mt-2">
+                    <h2 className="text-2xl md:text-[26px] font-semibold tracking-tight leading-snug group-hover:text-[var(--ui-color)] transition-colors">
+                      {post.title}
+                    </h2>
+                    <p className="mt-2 text-fd-muted-foreground leading-relaxed max-w-[56ch]">{post.description}</p>
+                  </Link>
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </main>
+  );
+}
+
+export function Post({ title, description, date, author, minutes, backHref, Mdx, components }: PostProps) {
+  return (
+    <main className="grow container px-4">
+      <header className="mx-auto max-w-3xl pt-14 md:pt-20">
+        <p className="font-mono text-xs text-fd-muted-foreground">
+          <Link href={backHref} className="text-[var(--ui-color)] hover:underline underline-offset-4">
+            ~/zod/blog
+          </Link>
+          {date ? (
+            <>
+              <span className="mx-2 opacity-40">/</span>
+              <time dateTime={date.toISOString()}>{formatDate(date, "iso")}</time>
+            </>
+          ) : null}
+          <span className="mx-2 opacity-40">·</span>
+          {minutes} min
+        </p>
+        <h1 className="text-4xl md:text-[52px] font-semibold tracking-tight leading-[1.08] mt-5">{title}</h1>
+        {description ? <p className="mt-4 text-lg md:text-xl text-fd-muted-foreground leading-relaxed max-w-[56ch]">{description}</p> : null}
+        <div className="mt-8 flex items-center gap-3 text-sm">
+          <Diamond />
+          <a href={AUTHOR_URL} className="font-medium hover:text-[var(--ui-color)]">
+            {author}
+          </a>
+        </div>
+      </header>
+
+      <article className="mx-auto max-w-3xl py-12 md:py-16">
+        <div className="prose prose-lg min-w-0">
+          <Mdx components={components} />
+        </div>
+        <footer className="mt-16 pt-6 border-t border-fd-border font-mono text-xs text-fd-muted-foreground flex justify-between">
+          <Link href={backHref} className="hover:text-[var(--ui-color)]">
+            ← all posts
+          </Link>
+          {date ? <span className="tabular-nums">{formatDate(date, "iso")}</span> : null}
+        </footer>
+      </article>
+    </main>
+  );
+}


### PR DESCRIPTION
Four visual directions for the docs blog, mounted under `/blog-concepts` so they render with the real post and the site chrome. Review-only: nothing here touches `/blog`, and the index rows other than the Clerk post are placeholders so there is enough to judge a list layout.

- `/blog-concepts/editorial` — Instrument Serif display type, italic deks, year labels in the gutter, a gem divider.
- `/blog-concepts/timeline` — sticky intro column, dated rail with diamond markers, monospace metadata.
- `/blog-concepts/glow` — brand gradient wash behind the header, featured latest post, card grid.
- `/blog-concepts/margin` — big-type list with right-aligned dates; post page with a sticky margin column and TOC.

Once a direction is picked, the winner gets ported onto `/blog` and the other three plus the placeholder rows are removed before this merges.
