### PR TITLE
refactor(v4): declare a trait's members on $constructor

### DIFF
--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +25 / +41 / +23, and every bundle carries `core.ts`; measured 2901 / 3378 / 4431 plus 28 headroom, and the per-fixture notes below record what each already carried. Classic pays nothing for it — its string fixture drops 71 gzipped bytes.
-  "zod-mini-boolean": 2929,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +32 / +48 / +30, and every bundle carries `core.ts`; measured 2908 / 3385 / 4438 plus 28 headroom, and the per-fixture notes below record what each already carried. Classic pays nothing for it — its string fixture drops 65 gzipped bytes.
+  "zod-mini-boolean": 2936,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3406,
+  "zod-mini-string": 3413,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4459,
+  "zod-mini-object": 4466,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +32 / +48 / +30, and every bundle carries `core.ts`; measured 2908 / 3385 / 4438 plus 28 headroom, and the per-fixture notes below record what each already carried. Classic pays nothing for it — its string fixture drops 65 gzipped bytes.
-  "zod-mini-boolean": 2936,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +54 / +70 / +65, and every bundle carries `core.ts`; measured 2930 / 3407 / 4473 plus 28 headroom, and the per-fixture notes below record what each already carried. Most of that is writing the members as `this`-methods rather than per-key factories: `nullable(){return e(this)}` minifies larger than `nullable:t=>()=>e(t)`, since `this` is not renameable and a block body cannot collapse to an arrow.
+  "zod-mini-boolean": 2958,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3413,
+  "zod-mini-string": 3435,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4466,
+  "zod-mini-object": 4501,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +54 / +70 / +65, and every bundle carries `core.ts`; measured 2930 / 3407 / 4473 plus 28 headroom, and the per-fixture notes below record what each already carried. Most of that is writing the members as `this`-methods rather than per-key factories: `nullable(){return e(this)}` minifies larger than `nullable:t=>()=>e(t)`, since `this` is not renameable and a block body cannot collapse to an arrow.
-  "zod-mini-boolean": 2958,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +98 / +113 / +108, and every bundle carries `core.ts`; measured 2974 / 3450 / 4516 plus 28 headroom, and the per-fixture notes below record what each already carried. Most of that is writing the members as `this`-methods rather than per-key factories: `nullable(){return e(this)}` minifies larger than `nullable:t=>()=>e(t)`, since `this` is not renameable and a block body cannot collapse to an arrow. About 43 of it is the guard that keeps the install off a user subclass's prototype.
+  "zod-mini-boolean": 3002,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3435,
+  "zod-mini-string": 3478,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4501,
+  "zod-mini-object": 4544,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2836 / 3299 / 4374 by the commit that caused it: suppressing v8's stack capture while building an error costs +68 / +68 / +63, and every bundle carries `core.ts`; measured 2875 / 3338 / 4409 plus 28 headroom, and the per-fixture notes below record what each already carried
-  "zod-mini-boolean": 2903,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +19 / +31 / +16, and every bundle carries `core.ts`; measured 2895 / 3368 / 4424 plus 28 headroom, and the per-fixture notes below record what each already carried. Classic pays nothing for it — its string fixture drops 76 gzipped bytes.
+  "zod-mini-boolean": 2923,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3366,
+  "zod-mini-string": 3396,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4437,
+  "zod-mini-object": 4452,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +19 / +31 / +16, and every bundle carries `core.ts`; measured 2895 / 3368 / 4424 plus 28 headroom, and the per-fixture notes below record what each already carried. Classic pays nothing for it — its string fixture drops 76 gzipped bytes.
-  "zod-mini-boolean": 2923,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +25 / +41 / +23, and every bundle carries `core.ts`; measured 2901 / 3378 / 4431 plus 28 headroom, and the per-fixture notes below record what each already carried. Classic pays nothing for it — its string fixture drops 71 gzipped bytes.
+  "zod-mini-boolean": 2929,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3396,
+  "zod-mini-string": 3406,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4452,
+  "zod-mini-object": 4459,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -38,13 +38,13 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  * The failure message prints the measured size, so updating is mechanical.
  */
 const CEILINGS: Record<string, number> = {
-  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +98 / +113 / +108, and every bundle carries `core.ts`; measured 2974 / 3450 / 4516 plus 28 headroom, and the per-fixture notes below record what each already carried. Most of that is writing the members as `this`-methods rather than per-key factories: `nullable(){return e(this)}` minifies larger than `nullable:t=>()=>e(t)`, since `this` is not renameable and a block body cannot collapse to an arrow. About 43 of it is the guard that keeps the install off a user subclass's prototype.
-  "zod-mini-boolean": 3002,
+  // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +70 / +83 / +95, and every bundle carries `core.ts`; measured 2946 / 3420 / 4503 plus 28 headroom, and the per-fixture notes below record what each already carried. About half of it is the guard that keeps the install off a user subclass's prototype; the rest is writing the members as `this`-methods, since `this` is not renameable and a block body cannot collapse to an arrow.
+  "zod-mini-boolean": 2974,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3478,
+  "zod-mini-string": 3448,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4544,
+  "zod-mini-object": 4531,
 };
 
 /**

--- a/packages/zod/src/v4/classic/errors.ts
+++ b/packages/zod/src/v4/classic/errors.ts
@@ -74,9 +74,14 @@ const initializer = (inst: ZodError, issues: core.$ZodIssue[]) => {
   });
 };
 export const ZodError: core.$constructor<ZodError> = /*@__PURE__*/ core.$constructor("ZodError", initializer);
-export const ZodRealError: core.$constructor<ZodError> = /*@__PURE__*/ core.$constructor("ZodError", initializer, {
-  Parent: Error,
-});
+export const ZodRealError: core.$constructor<ZodError> = /*@__PURE__*/ core.$constructor(
+  "ZodError",
+  initializer,
+  undefined,
+  {
+    Parent: Error,
+  }
+);
 
 /** @deprecated Use `z.core.$ZodFlattenedError` instead. */
 export type ZodFlattenedError<T, U = string> = core.$ZodFlattenedError<T, U>;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -175,7 +175,8 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   },
   {
     proto: {
-      check(...chks) {
+      // `this` is declared on the two members that call each other through it: without that TypeScript gives up on the whole literal's contextual types and every parameter below lands as `any`
+      check(this: ZodType, ...chks) {
         const def = this.def;
         return this.clone(
           util.mergeDefs(def, {
@@ -194,7 +195,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
         return this.check(...chks);
       },
 
-      clone(def, params) {
+      clone(this: ZodType, def, params) {
         return core.clone(this, def, params);
       },
 
@@ -303,16 +304,13 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
 
       // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
       get "~standard"(): ZodType["~standard"] {
-        const props = {
+        return util.hide(this, "~standard", {
           ...core.standardProps(this),
           jsonSchema: {
             input: createStandardJSONSchemaMethod(this, "input"),
             output: createStandardJSONSchemaMethod(this, "output"),
           },
-        } as ZodType["~standard"];
-        // cached, but not enumerable: it was never an own data property, so it must stay out of `Object.keys`
-        Object.defineProperty(this, "~standard", { configurable: true, writable: true, value: props });
-        return props;
+        } as ZodType["~standard"]);
       },
       set "~standard"(value: ZodType["~standard"]) {
         util.own(this, "~standard", value);
@@ -375,7 +373,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
       get _def(): core.$ZodTypeDef {
         return (this as unknown as ZodType)._zod.def;
       },
-    } satisfies core.util.ProtoOf<ZodType>,
+    },
   }
 );
 

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -188,98 +188,75 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
         { parent: true }
       );
     },
-
     with(...chks) {
       return this.check(...chks);
     },
-
     clone(def, params) {
       return core.clone(this, def, params);
     },
-
     brand() {
       return this;
     },
-
     register(reg, meta) {
       reg.add(this, meta);
       return this;
     },
-
     refine(check, params) {
       return this.check(refine(check, params));
     },
-
     superRefine(refinement, params) {
       return this.check(superRefine(refinement, params));
     },
-
     overwrite(fn) {
       return this.check(checks.overwrite(fn));
     },
-
     optional() {
       return optional(this);
     },
-
     exactOptional() {
       return exactOptional(this);
     },
-
     nullable() {
       return nullable(this);
     },
-
     nullish() {
       return optional(nullable(this));
     },
-
     nonoptional(params) {
       return nonoptional(this, params);
     },
-
     array() {
       return array(this);
     },
-
     or(arg) {
       return union([this, arg]);
     },
-
     and(arg) {
       return intersection(this, arg);
     },
-
     transform(tx) {
       return pipe(this, transform(tx));
     },
-
     default(d) {
       return _default(this, d);
     },
-
     prefault(d) {
       return prefault(this, d);
     },
-
     catch(params) {
       return _catch(this, params);
     },
-
     pipe(target) {
       return pipe(this, target);
     },
-
     readonly() {
       return readonly(this);
     },
-
     describe(description) {
       const cl = this.clone();
       core.globalRegistry.add(cl, { description });
       return cl;
     },
-
     meta(...args: any[]): any {
       // overloaded: meta() returns the registered metadata, meta(data) returns a clone with `data` registered. The mapped type picks up the second overload, so we accept variadic any-args and return `any` to satisfy both at runtime.
       if (args.length === 0) return core.globalRegistry.get(this);
@@ -287,19 +264,15 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
       core.globalRegistry.add(cl, args[0]);
       return cl;
     },
-
     isOptional() {
       return this.safeParse(undefined).success;
     },
-
     isNullable() {
       return this.safeParse(null).success;
     },
-
     apply(fn, ...args) {
       return args.length === 0 ? fn(this) : fn(this, ...args);
     },
-
     // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
     get "~standard"(): ZodType["~standard"] {
       return util.hide(this, "~standard", {
@@ -366,7 +339,6 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     get description(): string | undefined {
       return core.globalRegistry.get(this as unknown as ZodType)?.description;
     },
-
     // No setter: `schema._def = x` throws, as it did when `_def` was a non-writable own property.
     get _def(): core.$ZodTypeDef {
       return (this as unknown as ZodType)._zod.def;
@@ -419,59 +391,45 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
     regex(...args) {
       return this.check((checks.regex as any)(...args));
     },
-
     includes(...args) {
       return this.check((checks.includes as any)(...args));
     },
-
     startsWith(...args) {
       return this.check((checks.startsWith as any)(...args));
     },
-
     endsWith(...args) {
       return this.check((checks.endsWith as any)(...args));
     },
-
     min(...args) {
       return this.check((checks.minLength as any)(...args));
     },
-
     max(...args) {
       return this.check((checks.maxLength as any)(...args));
     },
-
     length(...args) {
       return this.check((checks.length as any)(...args));
     },
-
     nonempty(...args) {
       return this.check((checks.minLength as any)(1, ...args));
     },
-
     lowercase(params) {
       return this.check(checks.lowercase(params));
     },
-
     uppercase(params) {
       return this.check(checks.uppercase(params));
     },
-
     trim() {
       return this.check(checks.trim());
     },
-
     normalize(...args) {
       return this.check(checks.normalize(...args));
     },
-
     toLowerCase() {
       return this.check(checks.toLowerCase());
     },
-
     toUpperCase() {
       return this.check(checks.toUpperCase());
     },
-
     slugify() {
       return this.check(checks.slugify());
     },
@@ -565,102 +523,78 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
     email(params) {
       return this.check(core._email(ZodEmail, params));
     },
-
     url(params) {
       return this.check(core._url(ZodURL, params));
     },
-
     jwt(params) {
       return this.check(core._jwt(ZodJWT, params));
     },
-
     emoji(params) {
       return this.check(core._emoji(ZodEmoji, params));
     },
-
     guid(params) {
       return this.check(core._guid(ZodGUID, params));
     },
-
     uuid(params) {
       return this.check(core._uuid(ZodUUID, params));
     },
-
     uuidv4(params) {
       return this.check(core._uuidv4(ZodUUID, params));
     },
-
     uuidv6(params) {
       return this.check(core._uuidv6(ZodUUID, params));
     },
-
     uuidv7(params) {
       return this.check(core._uuidv7(ZodUUID, params));
     },
-
     nanoid(params) {
       return this.check(core._nanoid(ZodNanoID, params));
     },
-
     cuid(params) {
       return this.check(core._cuid(ZodCUID, params));
     },
-
     cuid2(params) {
       return this.check(core._cuid2(ZodCUID2, params));
     },
-
     ulid(params) {
       return this.check(core._ulid(ZodULID, params));
     },
-
     base64(params) {
       return this.check(core._base64(ZodBase64, params));
     },
-
     base64url(params) {
       return this.check(core._base64url(ZodBase64URL, params));
     },
-
     xid(params) {
       return this.check(core._xid(ZodXID, params));
     },
-
     ksuid(params) {
       return this.check(core._ksuid(ZodKSUID, params));
     },
-
     ipv4(params) {
       return this.check(core._ipv4(ZodIPv4, params));
     },
-
     ipv6(params) {
       return this.check(core._ipv6(ZodIPv6, params));
     },
-
     cidrv4(params) {
       return this.check(core._cidrv4(ZodCIDRv4, params));
     },
-
     cidrv6(params) {
       return this.check(core._cidrv6(ZodCIDRv6, params));
     },
-
     e164(params) {
       return this.check(core._e164(ZodE164, params));
     },
     datetime(params) {
       return this.check(core._isoDateTime(ZodISODateTime, params as any));
     },
-
     date(params) {
       return this.check(core._isoDate(ZodISODate, params as any));
     },
-
     time(params) {
       return this.check(core._isoTime(ZodISOTime, params as any));
     },
-
     duration(params) {
       return this.check(core._isoDuration(ZodISODuration, params as any));
     },
@@ -1201,59 +1135,45 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
     gt(value, params) {
       return this.check(checks.gt(value, params));
     },
-
     gte(value, params) {
       return this.check(checks.gte(value, params));
     },
-
     min(value, params) {
       return this.check(checks.gte(value, params));
     },
-
     lt(value, params) {
       return this.check(checks.lt(value, params));
     },
-
     lte(value, params) {
       return this.check(checks.lte(value, params));
     },
-
     max(value, params) {
       return this.check(checks.lte(value, params));
     },
-
     int(params) {
       return this.check(int(params));
     },
-
     safe(params) {
       return this.check(int(params));
     },
-
     positive(params) {
       return this.check(checks.gt(0, params));
     },
-
     nonnegative(params) {
       return this.check(checks.gte(0, params));
     },
-
     negative(params) {
       return this.check(checks.lt(0, params));
     },
-
     nonpositive(params) {
       return this.check(checks.lte(0, params));
     },
-
     multipleOf(value, params) {
       return this.check(checks.multipleOf(value, params));
     },
-
     step(value, params) {
       return this.check(checks.multipleOf(value, params));
     },
-
     finite() {
       return this;
     },
@@ -1357,43 +1277,33 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
     gte(value, params) {
       return this.check(checks.gte(value, params));
     },
-
     min(value, params) {
       return this.check(checks.gte(value, params));
     },
-
     gt(value, params) {
       return this.check(checks.gt(value, params));
     },
-
     lt(value, params) {
       return this.check(checks.lt(value, params));
     },
-
     lte(value, params) {
       return this.check(checks.lte(value, params));
     },
-
     max(value, params) {
       return this.check(checks.lte(value, params));
     },
-
     positive(params) {
       return this.check(checks.gt(BigInt(0), params));
     },
-
     negative(params) {
       return this.check(checks.lt(BigInt(0), params));
     },
-
     nonpositive(params) {
       return this.check(checks.lte(BigInt(0), params));
     },
-
     nonnegative(params) {
       return this.check(checks.gte(BigInt(0), params));
     },
-
     multipleOf(value, params) {
       return this.check(checks.multipleOf(value, params));
     },
@@ -1575,19 +1485,15 @@ export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constru
     min(n, params) {
       return this.check(checks.minLength(n, params));
     },
-
     nonempty(params) {
       return this.check(checks.minLength(1, params));
     },
-
     max(n, params) {
       return this.check(checks.maxLength(n, params));
     },
-
     length(n, params) {
       return this.check(checks.length(n, params));
     },
-
     unwrap() {
       return this.element;
     },
@@ -1728,55 +1634,42 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
     keyof() {
       return _enum(Object.keys(this._zod.def.shape));
     },
-
     catchall(catchall) {
       return this.clone({ ...this._zod.def, catchall: catchall as any });
     },
-
     passthrough() {
       return this.clone({ ...this._zod.def, catchall: unknown() });
     },
-
     loose() {
       return this.clone({ ...this._zod.def, catchall: unknown() });
     },
-
     strict() {
       return this.clone({ ...this._zod.def, catchall: never() });
     },
-
     strip() {
       return this.clone({ ...this._zod.def, catchall: undefined });
     },
-
     extend(incoming) {
       return util.extend(this, incoming);
     },
-
     safeExtend(incoming) {
       return util.safeExtend(this, incoming);
     },
-
     merge(other) {
       return util.merge(this, other);
     },
-
     pick(mask) {
       return util.pick(this, mask);
     },
-
     omit(mask) {
       return util.omit(this, mask);
     },
-
     partial(...args) {
       return util.partial(ZodOptional, this, args[0]);
     },
-
     exactPartial(...args) {
       return util.partial(ZodExactOptional, this, args[0], "exactPartial");
     },
-
     required(...args) {
       return util.required(ZodNonOptional, this, args[0]);
     },
@@ -1963,7 +1856,6 @@ export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constru
         rest: rest as any as core.$ZodType,
       }) as any;
     },
-
     partial() {
       const def = this._zod.def;
       // a refinement was authored against the full arity; partialing would run it on a shorter array

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -174,205 +174,203 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     return inst;
   },
   {
-    proto: {
-      // `this` is declared on the two members that call each other through it: without that TypeScript gives up on the whole literal's contextual types and every parameter below lands as `any`
-      check(this: ZodType, ...chks) {
-        const def = this.def;
-        return this.clone(
-          util.mergeDefs(def, {
-            checks: [
-              ...(def.checks ?? []),
-              ...chks.map((ch) =>
-                typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
-              ),
-            ],
-          }),
-          { parent: true }
-        );
-      },
+    // `this` is declared on the two members that call each other through it: without that TypeScript gives up on the whole literal's contextual types and every parameter below lands as `any`
+    check(this: ZodType, ...chks) {
+      const def = this.def;
+      return this.clone(
+        util.mergeDefs(def, {
+          checks: [
+            ...(def.checks ?? []),
+            ...chks.map((ch) =>
+              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+            ),
+          ],
+        }),
+        { parent: true }
+      );
+    },
 
-      with(...chks) {
-        return this.check(...chks);
-      },
+    with(...chks) {
+      return this.check(...chks);
+    },
 
-      clone(this: ZodType, def, params) {
-        return core.clone(this, def, params);
-      },
+    clone(this: ZodType, def, params) {
+      return core.clone(this, def, params);
+    },
 
-      brand() {
-        return this;
-      },
+    brand() {
+      return this;
+    },
 
-      register(reg, meta) {
-        reg.add(this, meta);
-        return this;
-      },
+    register(reg, meta) {
+      reg.add(this, meta);
+      return this;
+    },
 
-      refine(check, params) {
-        return this.check(refine(check, params));
-      },
+    refine(check, params) {
+      return this.check(refine(check, params));
+    },
 
-      superRefine(refinement, params) {
-        return this.check(superRefine(refinement, params));
-      },
+    superRefine(refinement, params) {
+      return this.check(superRefine(refinement, params));
+    },
 
-      overwrite(fn) {
-        return this.check(checks.overwrite(fn));
-      },
+    overwrite(fn) {
+      return this.check(checks.overwrite(fn));
+    },
 
-      optional() {
-        return optional(this);
-      },
+    optional() {
+      return optional(this);
+    },
 
-      exactOptional() {
-        return exactOptional(this);
-      },
+    exactOptional() {
+      return exactOptional(this);
+    },
 
-      nullable() {
-        return nullable(this);
-      },
+    nullable() {
+      return nullable(this);
+    },
 
-      nullish() {
-        return optional(nullable(this));
-      },
+    nullish() {
+      return optional(nullable(this));
+    },
 
-      nonoptional(params) {
-        return nonoptional(this, params);
-      },
+    nonoptional(params) {
+      return nonoptional(this, params);
+    },
 
-      array() {
-        return array(this);
-      },
+    array() {
+      return array(this);
+    },
 
-      or(arg) {
-        return union([this, arg]);
-      },
+    or(arg) {
+      return union([this, arg]);
+    },
 
-      and(arg) {
-        return intersection(this, arg);
-      },
+    and(arg) {
+      return intersection(this, arg);
+    },
 
-      transform(tx) {
-        return pipe(this, transform(tx));
-      },
+    transform(tx) {
+      return pipe(this, transform(tx));
+    },
 
-      default(d) {
-        return _default(this, d);
-      },
+    default(d) {
+      return _default(this, d);
+    },
 
-      prefault(d) {
-        return prefault(this, d);
-      },
+    prefault(d) {
+      return prefault(this, d);
+    },
 
-      catch(params) {
-        return _catch(this, params);
-      },
+    catch(params) {
+      return _catch(this, params);
+    },
 
-      pipe(target) {
-        return pipe(this, target);
-      },
+    pipe(target) {
+      return pipe(this, target);
+    },
 
-      readonly() {
-        return readonly(this);
-      },
+    readonly() {
+      return readonly(this);
+    },
 
-      describe(description) {
-        const cl = this.clone();
-        core.globalRegistry.add(cl, { description });
-        return cl;
-      },
+    describe(description) {
+      const cl = this.clone();
+      core.globalRegistry.add(cl, { description });
+      return cl;
+    },
 
-      meta(...args: any[]): any {
-        // overloaded: meta() returns the registered metadata, meta(data) returns a clone with `data` registered. The mapped type picks up the second overload, so we accept variadic any-args and return `any` to satisfy both at runtime.
-        if (args.length === 0) return core.globalRegistry.get(this);
-        const cl = this.clone();
-        core.globalRegistry.add(cl, args[0]);
-        return cl;
-      },
+    meta(...args: any[]): any {
+      // overloaded: meta() returns the registered metadata, meta(data) returns a clone with `data` registered. The mapped type picks up the second overload, so we accept variadic any-args and return `any` to satisfy both at runtime.
+      if (args.length === 0) return core.globalRegistry.get(this);
+      const cl = this.clone();
+      core.globalRegistry.add(cl, args[0]);
+      return cl;
+    },
 
-      isOptional() {
-        return this.safeParse(undefined).success;
-      },
+    isOptional() {
+      return this.safeParse(undefined).success;
+    },
 
-      isNullable() {
-        return this.safeParse(null).success;
-      },
+    isNullable() {
+      return this.safeParse(null).success;
+    },
 
-      apply(fn, ...args) {
-        return args.length === 0 ? fn(this) : fn(this, ...args);
-      },
+    apply(fn, ...args) {
+      return args.length === 0 ? fn(this) : fn(this, ...args);
+    },
 
-      // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
-      get "~standard"(): ZodType["~standard"] {
-        return util.hide(this, "~standard", {
-          ...core.standardProps(this),
-          jsonSchema: {
-            input: createStandardJSONSchemaMethod(this, "input"),
-            output: createStandardJSONSchemaMethod(this, "output"),
-          },
-        } as ZodType["~standard"]);
-      },
-      set "~standard"(value: ZodType["~standard"]) {
-        util.own(this, "~standard", value);
-      },
-      parse: function _parse(data, params) {
-        return parse.parse(this, data, params, { callee: _parse });
-      },
-      parseAsync: async function _parseAsync(data, params) {
-        return await parse.parseAsync(this, data, params, { callee: _parseAsync });
-      },
-      safeParse(data, params) {
-        return parse.safeParse(this, data, params);
-      },
-      async safeParseAsync(data, params) {
-        return parse.safeParseAsync(this, data, params);
-      },
-      // `spa` is an alias: same function object as `safeParseAsync`, as before.
-      get spa(): ZodType["safeParseAsync"] {
-        return this.safeParseAsync;
-      },
-      set spa(value: ZodType["safeParseAsync"]) {
-        util.own(this, "spa", value);
-      },
-      encode: function _encode(data, params) {
-        return parse.encode(this, data, params, { callee: _encode });
-      },
-      decode: function _decode(data, params) {
-        return parse.decode(this, data, params, { callee: _decode });
-      },
-      encodeAsync: async function _encodeAsync(data, params) {
-        return await parse.encodeAsync(this, data, params, { callee: _encodeAsync });
-      },
-      decodeAsync: async function _decodeAsync(data, params) {
-        return await parse.decodeAsync(this, data, params, { callee: _decodeAsync });
-      },
-      safeEncode(data, params) {
-        return parse.safeEncode(this, data, params);
-      },
-      safeDecode(data, params) {
-        return parse.safeDecode(this, data, params);
-      },
-      async safeEncodeAsync(data, params) {
-        return parse.safeEncodeAsync(this, data, params);
-      },
-      async safeDecodeAsync(data, params) {
-        return parse.safeDecodeAsync(this, data, params);
-      },
-      get toJSONSchema(): ZodType["toJSONSchema"] {
-        return util.own(this, "toJSONSchema", createToJSONSchemaMethod(this, {}));
-      },
-      set toJSONSchema(value: ZodType["toJSONSchema"]) {
-        util.own(this, "toJSONSchema", value);
-      },
-      // Reads through to the registry on every access, so it must not cache.
-      get description(): string | undefined {
-        return core.globalRegistry.get(this as unknown as ZodType)?.description;
-      },
+    // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
+    get "~standard"(): ZodType["~standard"] {
+      return util.hide(this, "~standard", {
+        ...core.standardProps(this),
+        jsonSchema: {
+          input: createStandardJSONSchemaMethod(this, "input"),
+          output: createStandardJSONSchemaMethod(this, "output"),
+        },
+      } as ZodType["~standard"]);
+    },
+    set "~standard"(value: ZodType["~standard"]) {
+      util.own(this, "~standard", value);
+    },
+    parse: function _parse(data, params) {
+      return parse.parse(this, data, params, { callee: _parse });
+    },
+    parseAsync: async function _parseAsync(data, params) {
+      return await parse.parseAsync(this, data, params, { callee: _parseAsync });
+    },
+    safeParse(data, params) {
+      return parse.safeParse(this, data, params);
+    },
+    async safeParseAsync(data, params) {
+      return parse.safeParseAsync(this, data, params);
+    },
+    // `spa` is an alias: same function object as `safeParseAsync`, as before.
+    get spa(): ZodType["safeParseAsync"] {
+      return this.safeParseAsync;
+    },
+    set spa(value: ZodType["safeParseAsync"]) {
+      util.own(this, "spa", value);
+    },
+    encode: function _encode(data, params) {
+      return parse.encode(this, data, params, { callee: _encode });
+    },
+    decode: function _decode(data, params) {
+      return parse.decode(this, data, params, { callee: _decode });
+    },
+    encodeAsync: async function _encodeAsync(data, params) {
+      return await parse.encodeAsync(this, data, params, { callee: _encodeAsync });
+    },
+    decodeAsync: async function _decodeAsync(data, params) {
+      return await parse.decodeAsync(this, data, params, { callee: _decodeAsync });
+    },
+    safeEncode(data, params) {
+      return parse.safeEncode(this, data, params);
+    },
+    safeDecode(data, params) {
+      return parse.safeDecode(this, data, params);
+    },
+    async safeEncodeAsync(data, params) {
+      return parse.safeEncodeAsync(this, data, params);
+    },
+    async safeDecodeAsync(data, params) {
+      return parse.safeDecodeAsync(this, data, params);
+    },
+    get toJSONSchema(): ZodType["toJSONSchema"] {
+      return util.own(this, "toJSONSchema", createToJSONSchemaMethod(this, {}));
+    },
+    set toJSONSchema(value: ZodType["toJSONSchema"]) {
+      util.own(this, "toJSONSchema", value);
+    },
+    // Reads through to the registry on every access, so it must not cache.
+    get description(): string | undefined {
+      return core.globalRegistry.get(this as unknown as ZodType)?.description;
+    },
 
-      // No setter: `schema._def = x` throws, as it did when `_def` was a non-writable own property.
-      get _def(): core.$ZodTypeDef {
-        return (this as unknown as ZodType)._zod.def;
-      },
+    // No setter: `schema._def = x` throws, as it did when `_def` was a non-writable own property.
+    get _def(): core.$ZodTypeDef {
+      return (this as unknown as ZodType)._zod.def;
     },
   }
 );
@@ -419,66 +417,64 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
     inst.maxLength = bag.maximum ?? null;
   },
   {
-    proto: {
-      regex(...args) {
-        return this.check((checks.regex as any)(...args));
-      },
+    regex(...args) {
+      return this.check((checks.regex as any)(...args));
+    },
 
-      includes(...args) {
-        return this.check((checks.includes as any)(...args));
-      },
+    includes(...args) {
+      return this.check((checks.includes as any)(...args));
+    },
 
-      startsWith(...args) {
-        return this.check((checks.startsWith as any)(...args));
-      },
+    startsWith(...args) {
+      return this.check((checks.startsWith as any)(...args));
+    },
 
-      endsWith(...args) {
-        return this.check((checks.endsWith as any)(...args));
-      },
+    endsWith(...args) {
+      return this.check((checks.endsWith as any)(...args));
+    },
 
-      min(...args) {
-        return this.check((checks.minLength as any)(...args));
-      },
+    min(...args) {
+      return this.check((checks.minLength as any)(...args));
+    },
 
-      max(...args) {
-        return this.check((checks.maxLength as any)(...args));
-      },
+    max(...args) {
+      return this.check((checks.maxLength as any)(...args));
+    },
 
-      length(...args) {
-        return this.check((checks.length as any)(...args));
-      },
+    length(...args) {
+      return this.check((checks.length as any)(...args));
+    },
 
-      nonempty(...args) {
-        return this.check((checks.minLength as any)(1, ...args));
-      },
+    nonempty(...args) {
+      return this.check((checks.minLength as any)(1, ...args));
+    },
 
-      lowercase(params) {
-        return this.check(checks.lowercase(params));
-      },
+    lowercase(params) {
+      return this.check(checks.lowercase(params));
+    },
 
-      uppercase(params) {
-        return this.check(checks.uppercase(params));
-      },
+    uppercase(params) {
+      return this.check(checks.uppercase(params));
+    },
 
-      trim() {
-        return this.check(checks.trim());
-      },
+    trim() {
+      return this.check(checks.trim());
+    },
 
-      normalize(...args) {
-        return this.check(checks.normalize(...args));
-      },
+    normalize(...args) {
+      return this.check(checks.normalize(...args));
+    },
 
-      toLowerCase() {
-        return this.check(checks.toLowerCase());
-      },
+    toLowerCase() {
+      return this.check(checks.toLowerCase());
+    },
 
-      toUpperCase() {
-        return this.check(checks.toUpperCase());
-      },
+    toUpperCase() {
+      return this.check(checks.toUpperCase());
+    },
 
-      slugify() {
-        return this.check(checks.slugify());
-      },
+    slugify() {
+      return this.check(checks.slugify());
     },
   }
 );
@@ -567,109 +563,107 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
     _ZodString.init(inst, def);
   },
   {
-    proto: {
-      email(params) {
-        return this.check(core._email(ZodEmail, params));
-      },
+    email(params) {
+      return this.check(core._email(ZodEmail, params));
+    },
 
-      url(params) {
-        return this.check(core._url(ZodURL, params));
-      },
+    url(params) {
+      return this.check(core._url(ZodURL, params));
+    },
 
-      jwt(params) {
-        return this.check(core._jwt(ZodJWT, params));
-      },
+    jwt(params) {
+      return this.check(core._jwt(ZodJWT, params));
+    },
 
-      emoji(params) {
-        return this.check(core._emoji(ZodEmoji, params));
-      },
+    emoji(params) {
+      return this.check(core._emoji(ZodEmoji, params));
+    },
 
-      guid(params) {
-        return this.check(core._guid(ZodGUID, params));
-      },
+    guid(params) {
+      return this.check(core._guid(ZodGUID, params));
+    },
 
-      uuid(params) {
-        return this.check(core._uuid(ZodUUID, params));
-      },
+    uuid(params) {
+      return this.check(core._uuid(ZodUUID, params));
+    },
 
-      uuidv4(params) {
-        return this.check(core._uuidv4(ZodUUID, params));
-      },
+    uuidv4(params) {
+      return this.check(core._uuidv4(ZodUUID, params));
+    },
 
-      uuidv6(params) {
-        return this.check(core._uuidv6(ZodUUID, params));
-      },
+    uuidv6(params) {
+      return this.check(core._uuidv6(ZodUUID, params));
+    },
 
-      uuidv7(params) {
-        return this.check(core._uuidv7(ZodUUID, params));
-      },
+    uuidv7(params) {
+      return this.check(core._uuidv7(ZodUUID, params));
+    },
 
-      nanoid(params) {
-        return this.check(core._nanoid(ZodNanoID, params));
-      },
+    nanoid(params) {
+      return this.check(core._nanoid(ZodNanoID, params));
+    },
 
-      cuid(params) {
-        return this.check(core._cuid(ZodCUID, params));
-      },
+    cuid(params) {
+      return this.check(core._cuid(ZodCUID, params));
+    },
 
-      cuid2(params) {
-        return this.check(core._cuid2(ZodCUID2, params));
-      },
+    cuid2(params) {
+      return this.check(core._cuid2(ZodCUID2, params));
+    },
 
-      ulid(params) {
-        return this.check(core._ulid(ZodULID, params));
-      },
+    ulid(params) {
+      return this.check(core._ulid(ZodULID, params));
+    },
 
-      base64(params) {
-        return this.check(core._base64(ZodBase64, params));
-      },
+    base64(params) {
+      return this.check(core._base64(ZodBase64, params));
+    },
 
-      base64url(params) {
-        return this.check(core._base64url(ZodBase64URL, params));
-      },
+    base64url(params) {
+      return this.check(core._base64url(ZodBase64URL, params));
+    },
 
-      xid(params) {
-        return this.check(core._xid(ZodXID, params));
-      },
+    xid(params) {
+      return this.check(core._xid(ZodXID, params));
+    },
 
-      ksuid(params) {
-        return this.check(core._ksuid(ZodKSUID, params));
-      },
+    ksuid(params) {
+      return this.check(core._ksuid(ZodKSUID, params));
+    },
 
-      ipv4(params) {
-        return this.check(core._ipv4(ZodIPv4, params));
-      },
+    ipv4(params) {
+      return this.check(core._ipv4(ZodIPv4, params));
+    },
 
-      ipv6(params) {
-        return this.check(core._ipv6(ZodIPv6, params));
-      },
+    ipv6(params) {
+      return this.check(core._ipv6(ZodIPv6, params));
+    },
 
-      cidrv4(params) {
-        return this.check(core._cidrv4(ZodCIDRv4, params));
-      },
+    cidrv4(params) {
+      return this.check(core._cidrv4(ZodCIDRv4, params));
+    },
 
-      cidrv6(params) {
-        return this.check(core._cidrv6(ZodCIDRv6, params));
-      },
+    cidrv6(params) {
+      return this.check(core._cidrv6(ZodCIDRv6, params));
+    },
 
-      e164(params) {
-        return this.check(core._e164(ZodE164, params));
-      },
-      datetime(params) {
-        return this.check(core._isoDateTime(ZodISODateTime, params as any));
-      },
+    e164(params) {
+      return this.check(core._e164(ZodE164, params));
+    },
+    datetime(params) {
+      return this.check(core._isoDateTime(ZodISODateTime, params as any));
+    },
 
-      date(params) {
-        return this.check(core._isoDate(ZodISODate, params as any));
-      },
+    date(params) {
+      return this.check(core._isoDate(ZodISODate, params as any));
+    },
 
-      time(params) {
-        return this.check(core._isoTime(ZodISOTime, params as any));
-      },
+    time(params) {
+      return this.check(core._isoTime(ZodISOTime, params as any));
+    },
 
-      duration(params) {
-        return this.check(core._isoDuration(ZodISODuration, params as any));
-      },
+    duration(params) {
+      return this.check(core._isoDuration(ZodISODuration, params as any));
     },
   }
 );
@@ -1205,66 +1199,64 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
     inst.format = bag.format ?? null;
   },
   {
-    proto: {
-      gt(value, params) {
-        return this.check(checks.gt(value, params));
-      },
+    gt(value, params) {
+      return this.check(checks.gt(value, params));
+    },
 
-      gte(value, params) {
-        return this.check(checks.gte(value, params));
-      },
+    gte(value, params) {
+      return this.check(checks.gte(value, params));
+    },
 
-      min(value, params) {
-        return this.check(checks.gte(value, params));
-      },
+    min(value, params) {
+      return this.check(checks.gte(value, params));
+    },
 
-      lt(value, params) {
-        return this.check(checks.lt(value, params));
-      },
+    lt(value, params) {
+      return this.check(checks.lt(value, params));
+    },
 
-      lte(value, params) {
-        return this.check(checks.lte(value, params));
-      },
+    lte(value, params) {
+      return this.check(checks.lte(value, params));
+    },
 
-      max(value, params) {
-        return this.check(checks.lte(value, params));
-      },
+    max(value, params) {
+      return this.check(checks.lte(value, params));
+    },
 
-      int(params) {
-        return this.check(int(params));
-      },
+    int(params) {
+      return this.check(int(params));
+    },
 
-      safe(params) {
-        return this.check(int(params));
-      },
+    safe(params) {
+      return this.check(int(params));
+    },
 
-      positive(params) {
-        return this.check(checks.gt(0, params));
-      },
+    positive(params) {
+      return this.check(checks.gt(0, params));
+    },
 
-      nonnegative(params) {
-        return this.check(checks.gte(0, params));
-      },
+    nonnegative(params) {
+      return this.check(checks.gte(0, params));
+    },
 
-      negative(params) {
-        return this.check(checks.lt(0, params));
-      },
+    negative(params) {
+      return this.check(checks.lt(0, params));
+    },
 
-      nonpositive(params) {
-        return this.check(checks.lte(0, params));
-      },
+    nonpositive(params) {
+      return this.check(checks.lte(0, params));
+    },
 
-      multipleOf(value, params) {
-        return this.check(checks.multipleOf(value, params));
-      },
+    multipleOf(value, params) {
+      return this.check(checks.multipleOf(value, params));
+    },
 
-      step(value, params) {
-        return this.check(checks.multipleOf(value, params));
-      },
+    step(value, params) {
+      return this.check(checks.multipleOf(value, params));
+    },
 
-      finite() {
-        return this;
-      },
+    finite() {
+      return this;
     },
   }
 );
@@ -1363,50 +1355,48 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
     inst.format = bag.format ?? null;
   },
   {
-    proto: {
-      gte(value, params) {
-        return this.check(checks.gte(value, params));
-      },
+    gte(value, params) {
+      return this.check(checks.gte(value, params));
+    },
 
-      min(value, params) {
-        return this.check(checks.gte(value, params));
-      },
+    min(value, params) {
+      return this.check(checks.gte(value, params));
+    },
 
-      gt(value, params) {
-        return this.check(checks.gt(value, params));
-      },
+    gt(value, params) {
+      return this.check(checks.gt(value, params));
+    },
 
-      lt(value, params) {
-        return this.check(checks.lt(value, params));
-      },
+    lt(value, params) {
+      return this.check(checks.lt(value, params));
+    },
 
-      lte(value, params) {
-        return this.check(checks.lte(value, params));
-      },
+    lte(value, params) {
+      return this.check(checks.lte(value, params));
+    },
 
-      max(value, params) {
-        return this.check(checks.lte(value, params));
-      },
+    max(value, params) {
+      return this.check(checks.lte(value, params));
+    },
 
-      positive(params) {
-        return this.check(checks.gt(BigInt(0), params));
-      },
+    positive(params) {
+      return this.check(checks.gt(BigInt(0), params));
+    },
 
-      negative(params) {
-        return this.check(checks.lt(BigInt(0), params));
-      },
+    negative(params) {
+      return this.check(checks.lt(BigInt(0), params));
+    },
 
-      nonpositive(params) {
-        return this.check(checks.lte(BigInt(0), params));
-      },
+    nonpositive(params) {
+      return this.check(checks.lte(BigInt(0), params));
+    },
 
-      nonnegative(params) {
-        return this.check(checks.gte(BigInt(0), params));
-      },
+    nonnegative(params) {
+      return this.check(checks.gte(BigInt(0), params));
+    },
 
-      multipleOf(value, params) {
-        return this.check(checks.multipleOf(value, params));
-      },
+    multipleOf(value, params) {
+      return this.check(checks.multipleOf(value, params));
     },
   }
 );
@@ -1583,26 +1573,24 @@ export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constru
     inst.element = def.element;
   },
   {
-    proto: {
-      min(n, params) {
-        return this.check(checks.minLength(n, params));
-      },
+    min(n, params) {
+      return this.check(checks.minLength(n, params));
+    },
 
-      nonempty(params) {
-        return this.check(checks.minLength(1, params));
-      },
+    nonempty(params) {
+      return this.check(checks.minLength(1, params));
+    },
 
-      max(n, params) {
-        return this.check(checks.maxLength(n, params));
-      },
+    max(n, params) {
+      return this.check(checks.maxLength(n, params));
+    },
 
-      length(n, params) {
-        return this.check(checks.length(n, params));
-      },
+    length(n, params) {
+      return this.check(checks.length(n, params));
+    },
 
-      unwrap() {
-        return this.element;
-      },
+    unwrap() {
+      return this.element;
     },
   }
 );
@@ -1738,62 +1726,60 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
     });
   },
   {
-    proto: {
-      keyof() {
-        return _enum(Object.keys(this._zod.def.shape));
-      },
+    keyof() {
+      return _enum(Object.keys(this._zod.def.shape));
+    },
 
-      catchall(catchall) {
-        return this.clone({ ...this._zod.def, catchall: catchall as any });
-      },
+    catchall(catchall) {
+      return this.clone({ ...this._zod.def, catchall: catchall as any });
+    },
 
-      passthrough() {
-        return this.clone({ ...this._zod.def, catchall: unknown() });
-      },
+    passthrough() {
+      return this.clone({ ...this._zod.def, catchall: unknown() });
+    },
 
-      loose() {
-        return this.clone({ ...this._zod.def, catchall: unknown() });
-      },
+    loose() {
+      return this.clone({ ...this._zod.def, catchall: unknown() });
+    },
 
-      strict() {
-        return this.clone({ ...this._zod.def, catchall: never() });
-      },
+    strict() {
+      return this.clone({ ...this._zod.def, catchall: never() });
+    },
 
-      strip() {
-        return this.clone({ ...this._zod.def, catchall: undefined });
-      },
+    strip() {
+      return this.clone({ ...this._zod.def, catchall: undefined });
+    },
 
-      extend(incoming) {
-        return util.extend(this, incoming);
-      },
+    extend(incoming) {
+      return util.extend(this, incoming);
+    },
 
-      safeExtend(incoming) {
-        return util.safeExtend(this, incoming);
-      },
+    safeExtend(incoming) {
+      return util.safeExtend(this, incoming);
+    },
 
-      merge(other) {
-        return util.merge(this, other);
-      },
+    merge(other) {
+      return util.merge(this, other);
+    },
 
-      pick(mask) {
-        return util.pick(this, mask);
-      },
+    pick(mask) {
+      return util.pick(this, mask);
+    },
 
-      omit(mask) {
-        return util.omit(this, mask);
-      },
+    omit(mask) {
+      return util.omit(this, mask);
+    },
 
-      partial(...args) {
-        return util.partial(ZodOptional, this, args[0]);
-      },
+    partial(...args) {
+      return util.partial(ZodOptional, this, args[0]);
+    },
 
-      exactPartial(...args) {
-        return util.partial(ZodExactOptional, this, args[0], "exactPartial");
-      },
+    exactPartial(...args) {
+      return util.partial(ZodExactOptional, this, args[0], "exactPartial");
+    },
 
-      required(...args) {
-        return util.required(ZodNonOptional, this, args[0]);
-      },
+    required(...args) {
+      return util.required(ZodNonOptional, this, args[0]);
     },
   }
 );
@@ -1972,23 +1958,21 @@ export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constru
     inst._zod.processJSONSchema = (ctx, json, params) => processors.tupleProcessor(inst, ctx, json, params);
   },
   {
-    proto: {
-      rest(rest) {
-        return this.clone({
-          ...this._zod.def,
-          rest: rest as any as core.$ZodType,
-        }) as any;
-      },
+    rest(rest) {
+      return this.clone({
+        ...this._zod.def,
+        rest: rest as any as core.$ZodType,
+      }) as any;
+    },
 
-      partial() {
-        const def = this._zod.def;
-        // a refinement was authored against the full arity; partialing would run it on a shorter array
-        if (def.checks?.length) throw new Error(".partial() cannot be used on tuple schemas containing refinements");
-        return this.clone({
-          ...def,
-          items: def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
-        }) as any;
-      },
+    partial() {
+      const def = this._zod.def;
+      // a refinement was authored against the full arity; partialing would run it on a shorter array
+      if (def.checks?.length) throw new Error(".partial() cannot be used on tuple schemas containing refinements");
+      return this.clone({
+        ...def,
+        items: def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
+      }) as any;
     },
   }
 );

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -15,10 +15,6 @@ function _ensureDefaultLocale(): void {
 }
 
 // Methods live on each concrete constructor's prototype and materialize per instance on first access, so a schema only pays for what it is asked for.
-const _installLazyMethods = util.installLazyMethods;
-const _installLazyProps = util.installLazyProps;
-type _LazyMethodsOf<T> = util.LazyMethodsOf<T>;
-type _LazyPropsOf<T> = util.LazyPropsOf<T>;
 
 ///////////////////////////////////////////
 ///////////////////////////////////////////
@@ -166,188 +162,210 @@ export interface ZodType<
 export interface _ZodType<out Internals extends core.$ZodTypeInternals = core.$ZodTypeInternals>
   extends ZodType<any, any, Internals> {}
 
-export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$constructor("ZodType", (inst, def) => {
-  _ensureDefaultLocale();
-  core.$ZodType.init(inst, def);
+export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$constructor<ZodType>(
+  "ZodType",
+  (inst, def) => {
+    _ensureDefaultLocale();
+    core.$ZodType.init(inst, def);
 
-  inst.def = def;
-  inst.type = def.type;
+    inst.def = def;
+    inst.type = def.type;
 
-  _installLazyMethods(inst, "check", _zodTypeMethods);
-  _installLazyProps(inst, "parse", _zodTypeParseProps);
-  // Reads through to the registry on every access, so it must not cache.
-  const proto = Object.getPrototypeOf(inst);
-  if (!("description" in proto)) {
-    Object.defineProperty(proto, "description", {
-      configurable: true,
-      get(this: ZodType) {
-        return core.globalRegistry.get(this)?.description;
-      },
-    });
-    // No setter: `schema._def = x` throws, as it did when `_def` was a non-writable own property.
-    Object.defineProperty(proto, "_def", {
-      configurable: true,
-      get(this: ZodType) {
-        return this._zod.def;
-      },
-    });
-  }
-  return inst;
-});
-
-function _zodTypeMethods(): _LazyMethodsOf<ZodType> {
-  return {
-    check(...chks) {
-      const def = this.def;
-      return this.clone(
-        util.mergeDefs(def, {
-          checks: [
-            ...(def.checks ?? []),
-            ...chks.map((ch) =>
-              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
-            ),
-          ],
-        }),
-        { parent: true }
-      );
-    },
-    with(...chks) {
-      return this.check(...chks);
-    },
-    clone(def, params) {
-      return core.clone(this, def, params);
-    },
-    brand() {
-      return this;
-    },
-    register(reg, meta) {
-      reg.add(this, meta);
-      return this;
-    },
-    refine(check, params) {
-      return this.check(refine(check, params));
-    },
-    superRefine(refinement, params) {
-      return this.check(superRefine(refinement, params));
-    },
-    overwrite(fn) {
-      return this.check(checks.overwrite(fn));
-    },
-    optional() {
-      return optional(this);
-    },
-    exactOptional() {
-      return exactOptional(this);
-    },
-    nullable() {
-      return nullable(this);
-    },
-    nullish() {
-      return optional(nullable(this));
-    },
-    nonoptional(params) {
-      return nonoptional(this, params);
-    },
-    array() {
-      return array(this);
-    },
-    or(arg) {
-      return union([this, arg]);
-    },
-    and(arg) {
-      return intersection(this, arg);
-    },
-    transform(tx) {
-      return pipe(this, transform(tx));
-    },
-    default(d) {
-      return _default(this, d);
-    },
-    prefault(d) {
-      return prefault(this, d);
-    },
-    catch(params) {
-      return _catch(this, params);
-    },
-    pipe(target) {
-      return pipe(this, target);
-    },
-    readonly() {
-      return readonly(this);
-    },
-    describe(description) {
-      const cl = this.clone();
-      core.globalRegistry.add(cl, { description });
-      return cl;
-    },
-    meta(...args: any[]): any {
-      // overloaded: meta() returns the registered metadata, meta(data) returns a clone with `data` registered. The mapped type picks up the second overload, so we accept variadic any-args and return `any` to satisfy both at runtime.
-      if (args.length === 0) return core.globalRegistry.get(this);
-      const cl = this.clone();
-      core.globalRegistry.add(cl, args[0]);
-      return cl;
-    },
-    isOptional() {
-      return this.safeParse(undefined).success;
-    },
-    isNullable() {
-      return this.safeParse(null).success;
-    },
-    apply(fn, ...args) {
-      return args.length === 0 ? fn(this) : fn(this, ...args);
-    },
-  };
-}
-
-function _zodTypeParseProps(): _LazyPropsOf<ZodType> {
-  return {
-    // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
-    "~standard": (self) =>
-      ({
-        ...core.standardProps(self),
-        jsonSchema: {
-          input: createStandardJSONSchemaMethod(self, "input"),
-          output: createStandardJSONSchemaMethod(self, "output"),
+    return inst;
+  },
+  {
+    proto: {
+      check:
+        (self) =>
+        (...chks) => {
+          const def = self.def;
+          return self.clone(
+            util.mergeDefs(def, {
+              checks: [
+                ...(def.checks ?? []),
+                ...chks.map((ch) =>
+                  typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+                ),
+              ],
+            }),
+            { parent: true }
+          );
         },
-      }) as ZodType["~standard"],
-    parse: (self) => {
-      const fn: ZodType["parse"] = (data, params) => parse.parse(self, data, params, { callee: fn });
-      return fn;
+
+      with:
+        (self) =>
+        (...chks) => {
+          return self.check(...chks);
+        },
+
+      clone: (self) => (def, params) => {
+        return core.clone(self, def, params);
+      },
+
+      brand: (self) => () => {
+        return self;
+      },
+
+      register: (self) => (reg, meta) => {
+        reg.add(self, meta);
+        return self;
+      },
+
+      refine: (self) => (check, params) => {
+        return self.check(refine(check, params));
+      },
+
+      superRefine: (self) => (refinement, params) => {
+        return self.check(superRefine(refinement, params));
+      },
+
+      overwrite: (self) => (fn) => {
+        return self.check(checks.overwrite(fn));
+      },
+
+      optional: (self) => () => {
+        return optional(self);
+      },
+
+      exactOptional: (self) => () => {
+        return exactOptional(self);
+      },
+
+      nullable: (self) => () => {
+        return nullable(self);
+      },
+
+      nullish: (self) => () => {
+        return optional(nullable(self));
+      },
+
+      nonoptional: (self) => (params) => {
+        return nonoptional(self, params);
+      },
+
+      array: (self) => () => {
+        return array(self);
+      },
+
+      or: (self) => (arg) => {
+        return union([self, arg]);
+      },
+
+      and: (self) => (arg) => {
+        return intersection(self, arg);
+      },
+
+      transform: (self) => (tx) => {
+        return pipe(self, transform(tx));
+      },
+
+      default: (self) => (d) => {
+        return _default(self, d);
+      },
+
+      prefault: (self) => (d) => {
+        return prefault(self, d);
+      },
+
+      catch: (self) => (params) => {
+        return _catch(self, params);
+      },
+
+      pipe: (self) => (target) => {
+        return pipe(self, target);
+      },
+
+      readonly: (self) => () => {
+        return readonly(self);
+      },
+
+      describe: (self) => (description) => {
+        const cl = self.clone();
+        core.globalRegistry.add(cl, { description });
+        return cl;
+      },
+
+      meta:
+        (self) =>
+        (...args: any[]): any => {
+          // overloaded: meta() returns the registered metadata, meta(data) returns a clone with `data` registered. The mapped type picks up the second overload, so we accept variadic any-args and return `any` to satisfy both at runtime.
+          if (args.length === 0) return core.globalRegistry.get(self);
+          const cl = self.clone();
+          core.globalRegistry.add(cl, args[0]);
+          return cl;
+        },
+
+      isOptional: (self) => () => {
+        return self.safeParse(undefined).success;
+      },
+
+      isNullable: (self) => () => {
+        return self.safeParse(null).success;
+      },
+
+      apply:
+        (self) =>
+        (fn, ...args) => {
+          return args.length === 0 ? fn(self) : fn(self, ...args);
+        },
+
+      // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
+      "~standard": (self) =>
+        ({
+          ...core.standardProps(self),
+          jsonSchema: {
+            input: createStandardJSONSchemaMethod(self, "input"),
+            output: createStandardJSONSchemaMethod(self, "output"),
+          },
+        }) as ZodType["~standard"],
+      parse: (self) => {
+        const fn: ZodType["parse"] = (data, params) => parse.parse(self, data, params, { callee: fn });
+        return fn;
+      },
+      parseAsync: (self) => {
+        const fn: ZodType["parseAsync"] = async (data, params) =>
+          await parse.parseAsync(self, data, params, { callee: fn });
+        return fn;
+      },
+      safeParse: (self) => (data, params) => parse.safeParse(self, data, params),
+      safeParseAsync: (self) => async (data, params) => parse.safeParseAsync(self, data, params),
+      // `spa` is an alias: same function object as `safeParseAsync`, as before.
+      spa: (self) => self.safeParseAsync,
+      encode: (self) => {
+        const fn: ZodType["encode"] = (data, params) => parse.encode(self, data, params, { callee: fn });
+        return fn;
+      },
+      decode: (self) => {
+        const fn: ZodType["decode"] = (data, params) => parse.decode(self, data, params, { callee: fn });
+        return fn;
+      },
+      encodeAsync: (self) => {
+        const fn: ZodType["encodeAsync"] = async (data, params) =>
+          await parse.encodeAsync(self, data, params, { callee: fn });
+        return fn;
+      },
+      decodeAsync: (self) => {
+        const fn: ZodType["decodeAsync"] = async (data, params) =>
+          await parse.decodeAsync(self, data, params, { callee: fn });
+        return fn;
+      },
+      safeEncode: (self) => (data, params) => parse.safeEncode(self, data, params),
+      safeDecode: (self) => (data, params) => parse.safeDecode(self, data, params),
+      safeEncodeAsync: (self) => async (data, params) => parse.safeEncodeAsync(self, data, params),
+      safeDecodeAsync: (self) => async (data, params) => parse.safeDecodeAsync(self, data, params),
+      toJSONSchema: (self) => createToJSONSchemaMethod(self, {}),
+      // Reads through to the registry on every access, so it must not cache.
+      get description(): string | undefined {
+        return core.globalRegistry.get(this as unknown as ZodType)?.description;
+      },
+
+      // No setter: `schema._def = x` throws, as it did when `_def` was a non-writable own property.
+      get _def(): core.$ZodTypeDef {
+        return (this as unknown as ZodType)._zod.def;
+      },
     },
-    parseAsync: (self) => {
-      const fn: ZodType["parseAsync"] = async (data, params) =>
-        await parse.parseAsync(self, data, params, { callee: fn });
-      return fn;
-    },
-    safeParse: (self) => (data, params) => parse.safeParse(self, data, params),
-    safeParseAsync: (self) => async (data, params) => parse.safeParseAsync(self, data, params),
-    // `spa` is an alias: same function object as `safeParseAsync`, as before.
-    spa: (self) => self.safeParseAsync,
-    encode: (self) => {
-      const fn: ZodType["encode"] = (data, params) => parse.encode(self, data, params, { callee: fn });
-      return fn;
-    },
-    decode: (self) => {
-      const fn: ZodType["decode"] = (data, params) => parse.decode(self, data, params, { callee: fn });
-      return fn;
-    },
-    encodeAsync: (self) => {
-      const fn: ZodType["encodeAsync"] = async (data, params) =>
-        await parse.encodeAsync(self, data, params, { callee: fn });
-      return fn;
-    },
-    decodeAsync: (self) => {
-      const fn: ZodType["decodeAsync"] = async (data, params) =>
-        await parse.decodeAsync(self, data, params, { callee: fn });
-      return fn;
-    },
-    safeEncode: (self) => (data, params) => parse.safeEncode(self, data, params),
-    safeDecode: (self) => (data, params) => parse.safeDecode(self, data, params),
-    safeEncodeAsync: (self) => async (data, params) => parse.safeEncodeAsync(self, data, params),
-    safeDecodeAsync: (self) => async (data, params) => parse.safeDecodeAsync(self, data, params),
-    toJSONSchema: (self) => createToJSONSchemaMethod(self, {}),
-  };
-}
+  }
+);
 
 // ZodString
 export interface _ZodString<T extends core.$ZodStringInternals<unknown> = core.$ZodStringInternals<unknown>>
@@ -377,69 +395,101 @@ export interface _ZodString<T extends core.$ZodStringInternals<unknown> = core.$
 }
 
 /** @internal */
-export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$constructor("_ZodString", (inst, def) => {
-  core.$ZodString.init(inst, def);
-  ZodType.init(inst, def);
+export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$constructor<_ZodString>(
+  "_ZodString",
+  (inst, def) => {
+    core.$ZodString.init(inst, def);
+    ZodType.init(inst, def);
 
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.stringProcessor(inst, ctx, json, params);
+    inst._zod.processJSONSchema = (ctx, json, params) => processors.stringProcessor(inst, ctx, json, params);
 
-  const bag = inst._zod.bag;
-  inst.format = bag.format ?? null;
-  inst.minLength = bag.minimum ?? null;
-  inst.maxLength = bag.maximum ?? null;
+    const bag = inst._zod.bag;
+    inst.format = bag.format ?? null;
+    inst.minLength = bag.minimum ?? null;
+    inst.maxLength = bag.maximum ?? null;
+  },
+  {
+    proto: {
+      regex:
+        (self) =>
+        (...args) => {
+          return self.check((checks.regex as any)(...args));
+        },
 
-  _installLazyMethods(inst, "regex", _zodStringBaseMethods);
-});
+      includes:
+        (self) =>
+        (...args) => {
+          return self.check((checks.includes as any)(...args));
+        },
 
-function _zodStringBaseMethods(): _LazyMethodsOf<_ZodString> {
-  return {
-    regex(...args) {
-      return this.check((checks.regex as any)(...args));
+      startsWith:
+        (self) =>
+        (...args) => {
+          return self.check((checks.startsWith as any)(...args));
+        },
+
+      endsWith:
+        (self) =>
+        (...args) => {
+          return self.check((checks.endsWith as any)(...args));
+        },
+
+      min:
+        (self) =>
+        (...args) => {
+          return self.check((checks.minLength as any)(...args));
+        },
+
+      max:
+        (self) =>
+        (...args) => {
+          return self.check((checks.maxLength as any)(...args));
+        },
+
+      length:
+        (self) =>
+        (...args) => {
+          return self.check((checks.length as any)(...args));
+        },
+
+      nonempty:
+        (self) =>
+        (...args) => {
+          return self.check((checks.minLength as any)(1, ...args));
+        },
+
+      lowercase: (self) => (params) => {
+        return self.check(checks.lowercase(params));
+      },
+
+      uppercase: (self) => (params) => {
+        return self.check(checks.uppercase(params));
+      },
+
+      trim: (self) => () => {
+        return self.check(checks.trim());
+      },
+
+      normalize:
+        (self) =>
+        (...args) => {
+          return self.check(checks.normalize(...args));
+        },
+
+      toLowerCase: (self) => () => {
+        return self.check(checks.toLowerCase());
+      },
+
+      toUpperCase: (self) => () => {
+        return self.check(checks.toUpperCase());
+      },
+
+      slugify: (self) => () => {
+        return self.check(checks.slugify());
+      },
     },
-    includes(...args) {
-      return this.check((checks.includes as any)(...args));
-    },
-    startsWith(...args) {
-      return this.check((checks.startsWith as any)(...args));
-    },
-    endsWith(...args) {
-      return this.check((checks.endsWith as any)(...args));
-    },
-    min(...args) {
-      return this.check((checks.minLength as any)(...args));
-    },
-    max(...args) {
-      return this.check((checks.maxLength as any)(...args));
-    },
-    length(...args) {
-      return this.check((checks.length as any)(...args));
-    },
-    nonempty(...args) {
-      return this.check((checks.minLength as any)(1, ...args));
-    },
-    lowercase(params) {
-      return this.check(checks.lowercase(params));
-    },
-    uppercase(params) {
-      return this.check(checks.uppercase(params));
-    },
-    trim() {
-      return this.check(checks.trim());
-    },
-    normalize(...args) {
-      return this.check(checks.normalize(...args));
-    },
-    toLowerCase() {
-      return this.check(checks.toLowerCase());
-    },
-    toUpperCase() {
-      return this.check(checks.toUpperCase());
-    },
-    slugify() {
-      return this.check(checks.slugify());
-    },
-  };
-}
+  }
+);
 
 export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> {
   // string format checks
@@ -518,97 +568,119 @@ export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> 
   duration(params?: string | core.$ZodCheckISODurationParams): this;
 }
 
-export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$constructor("ZodString", (inst, def) => {
-  core.$ZodString.init(inst, def);
-  _ZodString.init(inst, def);
+export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$constructor<ZodString>(
+  "ZodString",
+  (inst, def) => {
+    core.$ZodString.init(inst, def);
+    _ZodString.init(inst, def);
+  },
+  {
+    proto: {
+      email: (self) => (params) => {
+        return self.check(core._email(ZodEmail, params));
+      },
 
-  _installLazyMethods(inst, "email", _zodStringMethods);
-});
+      url: (self) => (params) => {
+        return self.check(core._url(ZodURL, params));
+      },
 
-function _zodStringMethods(): _LazyMethodsOf<ZodString> {
-  return {
-    email(params) {
-      return this.check(core._email(ZodEmail, params));
-    },
-    url(params) {
-      return this.check(core._url(ZodURL, params));
-    },
-    jwt(params) {
-      return this.check(core._jwt(ZodJWT, params));
-    },
-    emoji(params) {
-      return this.check(core._emoji(ZodEmoji, params));
-    },
-    guid(params) {
-      return this.check(core._guid(ZodGUID, params));
-    },
-    uuid(params) {
-      return this.check(core._uuid(ZodUUID, params));
-    },
-    uuidv4(params) {
-      return this.check(core._uuidv4(ZodUUID, params));
-    },
-    uuidv6(params) {
-      return this.check(core._uuidv6(ZodUUID, params));
-    },
-    uuidv7(params) {
-      return this.check(core._uuidv7(ZodUUID, params));
-    },
-    nanoid(params) {
-      return this.check(core._nanoid(ZodNanoID, params));
-    },
-    cuid(params) {
-      return this.check(core._cuid(ZodCUID, params));
-    },
-    cuid2(params) {
-      return this.check(core._cuid2(ZodCUID2, params));
-    },
-    ulid(params) {
-      return this.check(core._ulid(ZodULID, params));
-    },
-    base64(params) {
-      return this.check(core._base64(ZodBase64, params));
-    },
-    base64url(params) {
-      return this.check(core._base64url(ZodBase64URL, params));
-    },
-    xid(params) {
-      return this.check(core._xid(ZodXID, params));
-    },
-    ksuid(params) {
-      return this.check(core._ksuid(ZodKSUID, params));
-    },
-    ipv4(params) {
-      return this.check(core._ipv4(ZodIPv4, params));
-    },
-    ipv6(params) {
-      return this.check(core._ipv6(ZodIPv6, params));
-    },
-    cidrv4(params) {
-      return this.check(core._cidrv4(ZodCIDRv4, params));
-    },
-    cidrv6(params) {
-      return this.check(core._cidrv6(ZodCIDRv6, params));
-    },
-    e164(params) {
-      return this.check(core._e164(ZodE164, params));
-    },
+      jwt: (self) => (params) => {
+        return self.check(core._jwt(ZodJWT, params));
+      },
 
-    // iso
-    datetime(params) {
-      return this.check(core._isoDateTime(ZodISODateTime, params as any));
+      emoji: (self) => (params) => {
+        return self.check(core._emoji(ZodEmoji, params));
+      },
+
+      guid: (self) => (params) => {
+        return self.check(core._guid(ZodGUID, params));
+      },
+
+      uuid: (self) => (params) => {
+        return self.check(core._uuid(ZodUUID, params));
+      },
+
+      uuidv4: (self) => (params) => {
+        return self.check(core._uuidv4(ZodUUID, params));
+      },
+
+      uuidv6: (self) => (params) => {
+        return self.check(core._uuidv6(ZodUUID, params));
+      },
+
+      uuidv7: (self) => (params) => {
+        return self.check(core._uuidv7(ZodUUID, params));
+      },
+
+      nanoid: (self) => (params) => {
+        return self.check(core._nanoid(ZodNanoID, params));
+      },
+
+      cuid: (self) => (params) => {
+        return self.check(core._cuid(ZodCUID, params));
+      },
+
+      cuid2: (self) => (params) => {
+        return self.check(core._cuid2(ZodCUID2, params));
+      },
+
+      ulid: (self) => (params) => {
+        return self.check(core._ulid(ZodULID, params));
+      },
+
+      base64: (self) => (params) => {
+        return self.check(core._base64(ZodBase64, params));
+      },
+
+      base64url: (self) => (params) => {
+        return self.check(core._base64url(ZodBase64URL, params));
+      },
+
+      xid: (self) => (params) => {
+        return self.check(core._xid(ZodXID, params));
+      },
+
+      ksuid: (self) => (params) => {
+        return self.check(core._ksuid(ZodKSUID, params));
+      },
+
+      ipv4: (self) => (params) => {
+        return self.check(core._ipv4(ZodIPv4, params));
+      },
+
+      ipv6: (self) => (params) => {
+        return self.check(core._ipv6(ZodIPv6, params));
+      },
+
+      cidrv4: (self) => (params) => {
+        return self.check(core._cidrv4(ZodCIDRv4, params));
+      },
+
+      cidrv6: (self) => (params) => {
+        return self.check(core._cidrv6(ZodCIDRv6, params));
+      },
+
+      e164: (self) => (params) => {
+        return self.check(core._e164(ZodE164, params));
+      },
+      datetime: (self) => (params) => {
+        return self.check(core._isoDateTime(ZodISODateTime, params as any));
+      },
+
+      date: (self) => (params) => {
+        return self.check(core._isoDate(ZodISODate, params as any));
+      },
+
+      time: (self) => (params) => {
+        return self.check(core._isoTime(ZodISOTime, params as any));
+      },
+
+      duration: (self) => (params) => {
+        return self.check(core._isoDuration(ZodISODuration, params as any));
+      },
     },
-    date(params) {
-      return this.check(core._isoDate(ZodISODate, params as any));
-    },
-    time(params) {
-      return this.check(core._isoTime(ZodISOTime, params as any));
-    },
-    duration(params) {
-      return this.check(core._isoDuration(ZodISODuration, params as any));
-    },
-  };
-}
+  }
+);
 
 export function string(params?: string | core.$ZodStringParams): ZodString;
 export function string<T extends string>(params?: string | core.$ZodStringParams): core.$ZodType<T, T>;
@@ -1122,74 +1194,88 @@ export interface _ZodNumber<Internals extends core.$ZodNumberInternals = core.$Z
 
 export interface ZodNumber extends _ZodNumber<core.$ZodNumberInternals<number>> {}
 
-export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$constructor("ZodNumber", (inst, def) => {
-  core.$ZodNumber.init(inst, def);
+export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$constructor<ZodNumber>(
+  "ZodNumber",
+  (inst, def) => {
+    core.$ZodNumber.init(inst, def);
 
-  ZodType.init(inst, def);
+    ZodType.init(inst, def);
 
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.numberProcessor(inst, ctx, json, params);
+    inst._zod.processJSONSchema = (ctx, json, params) => processors.numberProcessor(inst, ctx, json, params);
 
-  _installLazyMethods(inst, "gt", _zodNumberMethods);
+    const bag = inst._zod.bag;
+    inst.minValue =
+      Math.max(bag.minimum ?? Number.NEGATIVE_INFINITY, bag.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null;
+    inst.maxValue =
+      Math.min(bag.maximum ?? Number.POSITIVE_INFINITY, bag.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null;
+    inst.isInt = (bag.format ?? "").includes("int") || Number.isSafeInteger(bag.multipleOf ?? 0.5);
+    inst.isFinite = true;
+    inst.format = bag.format ?? null;
+  },
+  {
+    proto: {
+      gt: (self) => (value, params) => {
+        return self.check(checks.gt(value, params));
+      },
 
-  const bag = inst._zod.bag;
-  inst.minValue =
-    Math.max(bag.minimum ?? Number.NEGATIVE_INFINITY, bag.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null;
-  inst.maxValue =
-    Math.min(bag.maximum ?? Number.POSITIVE_INFINITY, bag.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null;
-  inst.isInt = (bag.format ?? "").includes("int") || Number.isSafeInteger(bag.multipleOf ?? 0.5);
-  inst.isFinite = true;
-  inst.format = bag.format ?? null;
-});
+      gte: (self) => (value, params) => {
+        return self.check(checks.gte(value, params));
+      },
 
-function _zodNumberMethods(): _LazyMethodsOf<ZodNumber> {
-  return {
-    gt(value, params) {
-      return this.check(checks.gt(value, params));
+      min: (self) => (value, params) => {
+        return self.check(checks.gte(value, params));
+      },
+
+      lt: (self) => (value, params) => {
+        return self.check(checks.lt(value, params));
+      },
+
+      lte: (self) => (value, params) => {
+        return self.check(checks.lte(value, params));
+      },
+
+      max: (self) => (value, params) => {
+        return self.check(checks.lte(value, params));
+      },
+
+      int: (self) => (params) => {
+        return self.check(int(params));
+      },
+
+      safe: (self) => (params) => {
+        return self.check(int(params));
+      },
+
+      positive: (self) => (params) => {
+        return self.check(checks.gt(0, params));
+      },
+
+      nonnegative: (self) => (params) => {
+        return self.check(checks.gte(0, params));
+      },
+
+      negative: (self) => (params) => {
+        return self.check(checks.lt(0, params));
+      },
+
+      nonpositive: (self) => (params) => {
+        return self.check(checks.lte(0, params));
+      },
+
+      multipleOf: (self) => (value, params) => {
+        return self.check(checks.multipleOf(value, params));
+      },
+
+      step: (self) => (value, params) => {
+        return self.check(checks.multipleOf(value, params));
+      },
+
+      finite: (self) => () => {
+        return self;
+      },
     },
-    gte(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    min(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    lt(value, params) {
-      return this.check(checks.lt(value, params));
-    },
-    lte(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    max(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    int(params) {
-      return this.check(int(params));
-    },
-    safe(params) {
-      return this.check(int(params));
-    },
-    positive(params) {
-      return this.check(checks.gt(0, params));
-    },
-    nonnegative(params) {
-      return this.check(checks.gte(0, params));
-    },
-    negative(params) {
-      return this.check(checks.lt(0, params));
-    },
-    nonpositive(params) {
-      return this.check(checks.lte(0, params));
-    },
-    multipleOf(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-    step(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-    finite() {
-      return this;
-    },
-  };
-}
+  }
+);
 
 export function number(params?: string | core.$ZodNumberParams): ZodNumber {
   return core._number(ZodNumber, params);
@@ -1272,56 +1358,66 @@ export interface _ZodBigInt<T extends core.$ZodBigIntInternals = core.$ZodBigInt
 }
 
 export interface ZodBigInt extends _ZodBigInt<core.$ZodBigIntInternals<bigint>> {}
-export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$constructor("ZodBigInt", (inst, def) => {
-  core.$ZodBigInt.init(inst, def);
-  ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.bigintProcessor(inst, ctx, json, params);
+export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$constructor<ZodBigInt>(
+  "ZodBigInt",
+  (inst, def) => {
+    core.$ZodBigInt.init(inst, def);
+    ZodType.init(inst, def);
+    inst._zod.processJSONSchema = (ctx, json, params) => processors.bigintProcessor(inst, ctx, json, params);
 
-  _installLazyMethods(inst, "gte", _zodBigIntMethods);
+    const bag = inst._zod.bag;
+    inst.minValue = bag.minimum ?? null;
+    inst.maxValue = bag.maximum ?? null;
+    inst.format = bag.format ?? null;
+  },
+  {
+    proto: {
+      gte: (self) => (value, params) => {
+        return self.check(checks.gte(value, params));
+      },
 
-  const bag = inst._zod.bag;
-  inst.minValue = bag.minimum ?? null;
-  inst.maxValue = bag.maximum ?? null;
-  inst.format = bag.format ?? null;
-});
+      min: (self) => (value, params) => {
+        return self.check(checks.gte(value, params));
+      },
 
-function _zodBigIntMethods(): _LazyMethodsOf<ZodBigInt> {
-  return {
-    gte(value, params) {
-      return this.check(checks.gte(value, params));
+      gt: (self) => (value, params) => {
+        return self.check(checks.gt(value, params));
+      },
+
+      lt: (self) => (value, params) => {
+        return self.check(checks.lt(value, params));
+      },
+
+      lte: (self) => (value, params) => {
+        return self.check(checks.lte(value, params));
+      },
+
+      max: (self) => (value, params) => {
+        return self.check(checks.lte(value, params));
+      },
+
+      positive: (self) => (params) => {
+        return self.check(checks.gt(BigInt(0), params));
+      },
+
+      negative: (self) => (params) => {
+        return self.check(checks.lt(BigInt(0), params));
+      },
+
+      nonpositive: (self) => (params) => {
+        return self.check(checks.lte(BigInt(0), params));
+      },
+
+      nonnegative: (self) => (params) => {
+        return self.check(checks.gte(BigInt(0), params));
+      },
+
+      multipleOf: (self) => (value, params) => {
+        return self.check(checks.multipleOf(value, params));
+      },
     },
-    min(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    gt(value, params) {
-      return this.check(checks.gt(value, params));
-    },
-    lt(value, params) {
-      return this.check(checks.lt(value, params));
-    },
-    lte(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    max(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    positive(params) {
-      return this.check(checks.gt(BigInt(0), params));
-    },
-    negative(params) {
-      return this.check(checks.lt(BigInt(0), params));
-    },
-    nonpositive(params) {
-      return this.check(checks.lte(BigInt(0), params));
-    },
-    nonnegative(params) {
-      return this.check(checks.gte(BigInt(0), params));
-    },
-    multipleOf(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-  };
-}
+  }
+);
 
 export function bigint(params?: string | core.$ZodBigIntParams): ZodBigInt {
   return core._bigint(ZodBigInt, params);
@@ -1484,35 +1580,40 @@ export interface ZodArray<T extends core.SomeType = core.$ZodType>
   unwrap(): T;
   "~standard": ZodStandardSchemaWithJSON<this>;
 }
-export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constructor("ZodArray", (inst, def) => {
-  core.attachMemoizer(inst);
-  core.$ZodArray.init(inst, def);
-  ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.arrayProcessor(inst, ctx, json, params);
+export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constructor<ZodArray>(
+  "ZodArray",
+  (inst, def) => {
+    core.attachMemoizer(inst);
+    core.$ZodArray.init(inst, def);
+    ZodType.init(inst, def);
+    inst._zod.processJSONSchema = (ctx, json, params) => processors.arrayProcessor(inst, ctx, json, params);
 
-  inst.element = def.element;
-  _installLazyMethods(inst, "min", _zodArrayMethods);
-});
+    inst.element = def.element;
+  },
+  {
+    proto: {
+      min: (self) => (n, params) => {
+        return self.check(checks.minLength(n, params));
+      },
 
-function _zodArrayMethods(): _LazyMethodsOf<ZodArray> {
-  return {
-    min(n, params) {
-      return this.check(checks.minLength(n, params));
+      nonempty: (self) => (params) => {
+        return self.check(checks.minLength(1, params));
+      },
+
+      max: (self) => (n, params) => {
+        return self.check(checks.maxLength(n, params));
+      },
+
+      length: (self) => (n, params) => {
+        return self.check(checks.length(n, params));
+      },
+
+      unwrap: (self) => () => {
+        return self.element;
+      },
     },
-    nonempty(params) {
-      return this.check(checks.minLength(1, params));
-    },
-    max(n, params) {
-      return this.check(checks.maxLength(n, params));
-    },
-    length(n, params) {
-      return this.check(checks.length(n, params));
-    },
-    unwrap() {
-      return this.element;
-    },
-  };
-}
+  }
+);
 
 export function array<T extends core.SomeType>(element: T, params?: string | core.$ZodArrayParams): ZodArray<T> {
   return core._array(ZodArray, element as any, params) as any;
@@ -1632,65 +1733,84 @@ export interface ZodObject<
   >;
 }
 
-export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$constructor("ZodObject", (inst, def) => {
-  core.attachMemoizer(inst);
-  core.$ZodObjectJIT.init(inst, def);
-  ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.objectProcessor(inst, ctx, json, params);
+export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$constructor<ZodObject>(
+  "ZodObject",
+  (inst, def) => {
+    core.attachMemoizer(inst);
+    core.$ZodObjectJIT.init(inst, def);
+    ZodType.init(inst, def);
+    inst._zod.processJSONSchema = (ctx, json, params) => processors.objectProcessor(inst, ctx, json, params);
 
-  util.defineLazy(inst, "shape", () => {
-    return def.shape;
-  });
+    util.defineLazy(inst, "shape", () => {
+      return def.shape;
+    });
+  },
+  {
+    proto: {
+      keyof: (self) => () => {
+        return _enum(Object.keys(self._zod.def.shape));
+      },
 
-  _installLazyMethods(inst, "keyof", _zodObjectMethods);
-});
+      catchall: (self) => (catchall) => {
+        return self.clone({ ...self._zod.def, catchall: catchall as any });
+      },
 
-function _zodObjectMethods(): _LazyMethodsOf<ZodObject> {
-  return {
-    keyof() {
-      return _enum(Object.keys(this._zod.def.shape));
+      passthrough: (self) => () => {
+        return self.clone({ ...self._zod.def, catchall: unknown() });
+      },
+
+      loose: (self) => () => {
+        return self.clone({ ...self._zod.def, catchall: unknown() });
+      },
+
+      strict: (self) => () => {
+        return self.clone({ ...self._zod.def, catchall: never() });
+      },
+
+      strip: (self) => () => {
+        return self.clone({ ...self._zod.def, catchall: undefined });
+      },
+
+      extend: (self) => (incoming) => {
+        return util.extend(self, incoming);
+      },
+
+      safeExtend: (self) => (incoming) => {
+        return util.safeExtend(self, incoming);
+      },
+
+      merge: (self) => (other) => {
+        return util.merge(self, other);
+      },
+
+      pick: (self) => (mask) => {
+        return util.pick(self, mask);
+      },
+
+      omit: (self) => (mask) => {
+        return util.omit(self, mask);
+      },
+
+      partial:
+        (self) =>
+        (...args) => {
+          return util.partial(ZodOptional, self, args[0]);
+        },
+
+      exactPartial:
+        (self) =>
+        (...args) => {
+          return util.partial(ZodExactOptional, self, args[0], "exactPartial");
+        },
+
+      required:
+        (self) =>
+        (...args) => {
+          return util.required(ZodNonOptional, self, args[0]);
+        },
     },
-    catchall(catchall) {
-      return this.clone({ ...this._zod.def, catchall: catchall as any });
-    },
-    passthrough() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
-    },
-    loose() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
-    },
-    strict() {
-      return this.clone({ ...this._zod.def, catchall: never() });
-    },
-    strip() {
-      return this.clone({ ...this._zod.def, catchall: undefined });
-    },
-    extend(incoming) {
-      return util.extend(this, incoming);
-    },
-    safeExtend(incoming) {
-      return util.safeExtend(this, incoming);
-    },
-    merge(other) {
-      return util.merge(this, other);
-    },
-    pick(mask) {
-      return util.pick(this, mask);
-    },
-    omit(mask) {
-      return util.omit(this, mask);
-    },
-    partial(...args) {
-      return util.partial(ZodOptional, this, args[0]);
-    },
-    exactPartial(...args) {
-      return util.partial(ZodExactOptional, this, args[0], "exactPartial");
-    },
-    required(...args) {
-      return util.required(ZodNonOptional, this, args[0]);
-    },
-  };
-}
+  }
+);
 
 export function object<T extends core.$ZodLooseShape = Partial<Record<never, core.SomeType>>>(
   shape?: T,
@@ -1857,33 +1977,35 @@ export interface ZodTuple<
   rest<Rest extends core.SomeType = core.$ZodType>(rest: Rest): ZodTuple<T, Rest>;
   partial(): ZodTuple<{ -readonly [k in keyof T]: ZodOptional<T[k]> }, Rest>;
 }
-export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constructor("ZodTuple", (inst, def) => {
-  core.attachMemoizer(inst);
-  core.$ZodTuple.init(inst, def);
-  ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.tupleProcessor(inst, ctx, json, params);
-  _installLazyMethods(inst, "rest", _zodTupleMethods);
-});
+export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constructor<ZodTuple>(
+  "ZodTuple",
+  (inst, def) => {
+    core.attachMemoizer(inst);
+    core.$ZodTuple.init(inst, def);
+    ZodType.init(inst, def);
+    inst._zod.processJSONSchema = (ctx, json, params) => processors.tupleProcessor(inst, ctx, json, params);
+  },
+  {
+    proto: {
+      rest: (self) => (rest) => {
+        return self.clone({
+          ...self._zod.def,
+          rest: rest as any as core.$ZodType,
+        }) as any;
+      },
 
-function _zodTupleMethods(): _LazyMethodsOf<ZodTuple> {
-  return {
-    rest(rest) {
-      return this.clone({
-        ...this._zod.def,
-        rest: rest as any as core.$ZodType,
-      }) as any;
+      partial: (self) => () => {
+        const def = self._zod.def;
+        // a refinement was authored against the full arity; partialing would run it on a shorter array
+        if (def.checks?.length) throw new Error(".partial() cannot be used on tuple schemas containing refinements");
+        return self.clone({
+          ...def,
+          items: def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
+        }) as any;
+      },
     },
-    partial() {
-      const def = this._zod.def;
-      // a refinement was authored against the full arity; partialing would run it on a shorter array
-      if (def.checks?.length) throw new Error(".partial() cannot be used on tuple schemas containing refinements");
-      return this.clone({
-        ...def,
-        items: def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
-      }) as any;
-    },
-  };
-}
+  }
+);
 
 export function tuple<T extends readonly [core.SomeType, ...core.SomeType[]]>(
   items: T,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -176,10 +176,10 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   {
     proto: {
       check:
-        (self) =>
+        (inst) =>
         (...chks) => {
-          const def = self.def;
-          return self.clone(
+          const def = inst.def;
+          return inst.clone(
             util.mergeDefs(def, {
               checks: [
                 ...(def.checks ?? []),
@@ -193,167 +193,167 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
         },
 
       with:
-        (self) =>
+        (inst) =>
         (...chks) => {
-          return self.check(...chks);
+          return inst.check(...chks);
         },
 
-      clone: (self) => (def, params) => {
-        return core.clone(self, def, params);
+      clone: (inst) => (def, params) => {
+        return core.clone(inst, def, params);
       },
 
-      brand: (self) => () => {
-        return self;
+      brand: (inst) => () => {
+        return inst;
       },
 
-      register: (self) => (reg, meta) => {
-        reg.add(self, meta);
-        return self;
+      register: (inst) => (reg, meta) => {
+        reg.add(inst, meta);
+        return inst;
       },
 
-      refine: (self) => (check, params) => {
-        return self.check(refine(check, params));
+      refine: (inst) => (check, params) => {
+        return inst.check(refine(check, params));
       },
 
-      superRefine: (self) => (refinement, params) => {
-        return self.check(superRefine(refinement, params));
+      superRefine: (inst) => (refinement, params) => {
+        return inst.check(superRefine(refinement, params));
       },
 
-      overwrite: (self) => (fn) => {
-        return self.check(checks.overwrite(fn));
+      overwrite: (inst) => (fn) => {
+        return inst.check(checks.overwrite(fn));
       },
 
-      optional: (self) => () => {
-        return optional(self);
+      optional: (inst) => () => {
+        return optional(inst);
       },
 
-      exactOptional: (self) => () => {
-        return exactOptional(self);
+      exactOptional: (inst) => () => {
+        return exactOptional(inst);
       },
 
-      nullable: (self) => () => {
-        return nullable(self);
+      nullable: (inst) => () => {
+        return nullable(inst);
       },
 
-      nullish: (self) => () => {
-        return optional(nullable(self));
+      nullish: (inst) => () => {
+        return optional(nullable(inst));
       },
 
-      nonoptional: (self) => (params) => {
-        return nonoptional(self, params);
+      nonoptional: (inst) => (params) => {
+        return nonoptional(inst, params);
       },
 
-      array: (self) => () => {
-        return array(self);
+      array: (inst) => () => {
+        return array(inst);
       },
 
-      or: (self) => (arg) => {
-        return union([self, arg]);
+      or: (inst) => (arg) => {
+        return union([inst, arg]);
       },
 
-      and: (self) => (arg) => {
-        return intersection(self, arg);
+      and: (inst) => (arg) => {
+        return intersection(inst, arg);
       },
 
-      transform: (self) => (tx) => {
-        return pipe(self, transform(tx));
+      transform: (inst) => (tx) => {
+        return pipe(inst, transform(tx));
       },
 
-      default: (self) => (d) => {
-        return _default(self, d);
+      default: (inst) => (d) => {
+        return _default(inst, d);
       },
 
-      prefault: (self) => (d) => {
-        return prefault(self, d);
+      prefault: (inst) => (d) => {
+        return prefault(inst, d);
       },
 
-      catch: (self) => (params) => {
-        return _catch(self, params);
+      catch: (inst) => (params) => {
+        return _catch(inst, params);
       },
 
-      pipe: (self) => (target) => {
-        return pipe(self, target);
+      pipe: (inst) => (target) => {
+        return pipe(inst, target);
       },
 
-      readonly: (self) => () => {
-        return readonly(self);
+      readonly: (inst) => () => {
+        return readonly(inst);
       },
 
-      describe: (self) => (description) => {
-        const cl = self.clone();
+      describe: (inst) => (description) => {
+        const cl = inst.clone();
         core.globalRegistry.add(cl, { description });
         return cl;
       },
 
       meta:
-        (self) =>
+        (inst) =>
         (...args: any[]): any => {
           // overloaded: meta() returns the registered metadata, meta(data) returns a clone with `data` registered. The mapped type picks up the second overload, so we accept variadic any-args and return `any` to satisfy both at runtime.
-          if (args.length === 0) return core.globalRegistry.get(self);
-          const cl = self.clone();
+          if (args.length === 0) return core.globalRegistry.get(inst);
+          const cl = inst.clone();
           core.globalRegistry.add(cl, args[0]);
           return cl;
         },
 
-      isOptional: (self) => () => {
-        return self.safeParse(undefined).success;
+      isOptional: (inst) => () => {
+        return inst.safeParse(undefined).success;
       },
 
-      isNullable: (self) => () => {
-        return self.safeParse(null).success;
+      isNullable: (inst) => () => {
+        return inst.safeParse(null).success;
       },
 
       apply:
-        (self) =>
+        (inst) =>
         (fn, ...args) => {
-          return args.length === 0 ? fn(self) : fn(self, ...args);
+          return args.length === 0 ? fn(inst) : fn(inst, ...args);
         },
 
       // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
-      "~standard": (self) =>
+      "~standard": (inst) =>
         ({
-          ...core.standardProps(self),
+          ...core.standardProps(inst),
           jsonSchema: {
-            input: createStandardJSONSchemaMethod(self, "input"),
-            output: createStandardJSONSchemaMethod(self, "output"),
+            input: createStandardJSONSchemaMethod(inst, "input"),
+            output: createStandardJSONSchemaMethod(inst, "output"),
           },
         }) as ZodType["~standard"],
-      parse: (self) => {
-        const fn: ZodType["parse"] = (data, params) => parse.parse(self, data, params, { callee: fn });
+      parse: (inst) => {
+        const fn: ZodType["parse"] = (data, params) => parse.parse(inst, data, params, { callee: fn });
         return fn;
       },
-      parseAsync: (self) => {
+      parseAsync: (inst) => {
         const fn: ZodType["parseAsync"] = async (data, params) =>
-          await parse.parseAsync(self, data, params, { callee: fn });
+          await parse.parseAsync(inst, data, params, { callee: fn });
         return fn;
       },
-      safeParse: (self) => (data, params) => parse.safeParse(self, data, params),
-      safeParseAsync: (self) => async (data, params) => parse.safeParseAsync(self, data, params),
+      safeParse: (inst) => (data, params) => parse.safeParse(inst, data, params),
+      safeParseAsync: (inst) => async (data, params) => parse.safeParseAsync(inst, data, params),
       // `spa` is an alias: same function object as `safeParseAsync`, as before.
-      spa: (self) => self.safeParseAsync,
-      encode: (self) => {
-        const fn: ZodType["encode"] = (data, params) => parse.encode(self, data, params, { callee: fn });
+      spa: (inst) => inst.safeParseAsync,
+      encode: (inst) => {
+        const fn: ZodType["encode"] = (data, params) => parse.encode(inst, data, params, { callee: fn });
         return fn;
       },
-      decode: (self) => {
-        const fn: ZodType["decode"] = (data, params) => parse.decode(self, data, params, { callee: fn });
+      decode: (inst) => {
+        const fn: ZodType["decode"] = (data, params) => parse.decode(inst, data, params, { callee: fn });
         return fn;
       },
-      encodeAsync: (self) => {
+      encodeAsync: (inst) => {
         const fn: ZodType["encodeAsync"] = async (data, params) =>
-          await parse.encodeAsync(self, data, params, { callee: fn });
+          await parse.encodeAsync(inst, data, params, { callee: fn });
         return fn;
       },
-      decodeAsync: (self) => {
+      decodeAsync: (inst) => {
         const fn: ZodType["decodeAsync"] = async (data, params) =>
-          await parse.decodeAsync(self, data, params, { callee: fn });
+          await parse.decodeAsync(inst, data, params, { callee: fn });
         return fn;
       },
-      safeEncode: (self) => (data, params) => parse.safeEncode(self, data, params),
-      safeDecode: (self) => (data, params) => parse.safeDecode(self, data, params),
-      safeEncodeAsync: (self) => async (data, params) => parse.safeEncodeAsync(self, data, params),
-      safeDecodeAsync: (self) => async (data, params) => parse.safeDecodeAsync(self, data, params),
-      toJSONSchema: (self) => createToJSONSchemaMethod(self, {}),
+      safeEncode: (inst) => (data, params) => parse.safeEncode(inst, data, params),
+      safeDecode: (inst) => (data, params) => parse.safeDecode(inst, data, params),
+      safeEncodeAsync: (inst) => async (data, params) => parse.safeEncodeAsync(inst, data, params),
+      safeDecodeAsync: (inst) => async (data, params) => parse.safeDecodeAsync(inst, data, params),
+      toJSONSchema: (inst) => createToJSONSchemaMethod(inst, {}),
       // Reads through to the registry on every access, so it must not cache.
       get description(): string | undefined {
         return core.globalRegistry.get(this as unknown as ZodType)?.description;
@@ -411,81 +411,81 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
   {
     proto: {
       regex:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check((checks.regex as any)(...args));
+          return inst.check((checks.regex as any)(...args));
         },
 
       includes:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check((checks.includes as any)(...args));
+          return inst.check((checks.includes as any)(...args));
         },
 
       startsWith:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check((checks.startsWith as any)(...args));
+          return inst.check((checks.startsWith as any)(...args));
         },
 
       endsWith:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check((checks.endsWith as any)(...args));
+          return inst.check((checks.endsWith as any)(...args));
         },
 
       min:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check((checks.minLength as any)(...args));
+          return inst.check((checks.minLength as any)(...args));
         },
 
       max:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check((checks.maxLength as any)(...args));
+          return inst.check((checks.maxLength as any)(...args));
         },
 
       length:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check((checks.length as any)(...args));
+          return inst.check((checks.length as any)(...args));
         },
 
       nonempty:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check((checks.minLength as any)(1, ...args));
+          return inst.check((checks.minLength as any)(1, ...args));
         },
 
-      lowercase: (self) => (params) => {
-        return self.check(checks.lowercase(params));
+      lowercase: (inst) => (params) => {
+        return inst.check(checks.lowercase(params));
       },
 
-      uppercase: (self) => (params) => {
-        return self.check(checks.uppercase(params));
+      uppercase: (inst) => (params) => {
+        return inst.check(checks.uppercase(params));
       },
 
-      trim: (self) => () => {
-        return self.check(checks.trim());
+      trim: (inst) => () => {
+        return inst.check(checks.trim());
       },
 
       normalize:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return self.check(checks.normalize(...args));
+          return inst.check(checks.normalize(...args));
         },
 
-      toLowerCase: (self) => () => {
-        return self.check(checks.toLowerCase());
+      toLowerCase: (inst) => () => {
+        return inst.check(checks.toLowerCase());
       },
 
-      toUpperCase: (self) => () => {
-        return self.check(checks.toUpperCase());
+      toUpperCase: (inst) => () => {
+        return inst.check(checks.toUpperCase());
       },
 
-      slugify: (self) => () => {
-        return self.check(checks.slugify());
+      slugify: (inst) => () => {
+        return inst.check(checks.slugify());
       },
     },
   }
@@ -576,107 +576,107 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   },
   {
     proto: {
-      email: (self) => (params) => {
-        return self.check(core._email(ZodEmail, params));
+      email: (inst) => (params) => {
+        return inst.check(core._email(ZodEmail, params));
       },
 
-      url: (self) => (params) => {
-        return self.check(core._url(ZodURL, params));
+      url: (inst) => (params) => {
+        return inst.check(core._url(ZodURL, params));
       },
 
-      jwt: (self) => (params) => {
-        return self.check(core._jwt(ZodJWT, params));
+      jwt: (inst) => (params) => {
+        return inst.check(core._jwt(ZodJWT, params));
       },
 
-      emoji: (self) => (params) => {
-        return self.check(core._emoji(ZodEmoji, params));
+      emoji: (inst) => (params) => {
+        return inst.check(core._emoji(ZodEmoji, params));
       },
 
-      guid: (self) => (params) => {
-        return self.check(core._guid(ZodGUID, params));
+      guid: (inst) => (params) => {
+        return inst.check(core._guid(ZodGUID, params));
       },
 
-      uuid: (self) => (params) => {
-        return self.check(core._uuid(ZodUUID, params));
+      uuid: (inst) => (params) => {
+        return inst.check(core._uuid(ZodUUID, params));
       },
 
-      uuidv4: (self) => (params) => {
-        return self.check(core._uuidv4(ZodUUID, params));
+      uuidv4: (inst) => (params) => {
+        return inst.check(core._uuidv4(ZodUUID, params));
       },
 
-      uuidv6: (self) => (params) => {
-        return self.check(core._uuidv6(ZodUUID, params));
+      uuidv6: (inst) => (params) => {
+        return inst.check(core._uuidv6(ZodUUID, params));
       },
 
-      uuidv7: (self) => (params) => {
-        return self.check(core._uuidv7(ZodUUID, params));
+      uuidv7: (inst) => (params) => {
+        return inst.check(core._uuidv7(ZodUUID, params));
       },
 
-      nanoid: (self) => (params) => {
-        return self.check(core._nanoid(ZodNanoID, params));
+      nanoid: (inst) => (params) => {
+        return inst.check(core._nanoid(ZodNanoID, params));
       },
 
-      cuid: (self) => (params) => {
-        return self.check(core._cuid(ZodCUID, params));
+      cuid: (inst) => (params) => {
+        return inst.check(core._cuid(ZodCUID, params));
       },
 
-      cuid2: (self) => (params) => {
-        return self.check(core._cuid2(ZodCUID2, params));
+      cuid2: (inst) => (params) => {
+        return inst.check(core._cuid2(ZodCUID2, params));
       },
 
-      ulid: (self) => (params) => {
-        return self.check(core._ulid(ZodULID, params));
+      ulid: (inst) => (params) => {
+        return inst.check(core._ulid(ZodULID, params));
       },
 
-      base64: (self) => (params) => {
-        return self.check(core._base64(ZodBase64, params));
+      base64: (inst) => (params) => {
+        return inst.check(core._base64(ZodBase64, params));
       },
 
-      base64url: (self) => (params) => {
-        return self.check(core._base64url(ZodBase64URL, params));
+      base64url: (inst) => (params) => {
+        return inst.check(core._base64url(ZodBase64URL, params));
       },
 
-      xid: (self) => (params) => {
-        return self.check(core._xid(ZodXID, params));
+      xid: (inst) => (params) => {
+        return inst.check(core._xid(ZodXID, params));
       },
 
-      ksuid: (self) => (params) => {
-        return self.check(core._ksuid(ZodKSUID, params));
+      ksuid: (inst) => (params) => {
+        return inst.check(core._ksuid(ZodKSUID, params));
       },
 
-      ipv4: (self) => (params) => {
-        return self.check(core._ipv4(ZodIPv4, params));
+      ipv4: (inst) => (params) => {
+        return inst.check(core._ipv4(ZodIPv4, params));
       },
 
-      ipv6: (self) => (params) => {
-        return self.check(core._ipv6(ZodIPv6, params));
+      ipv6: (inst) => (params) => {
+        return inst.check(core._ipv6(ZodIPv6, params));
       },
 
-      cidrv4: (self) => (params) => {
-        return self.check(core._cidrv4(ZodCIDRv4, params));
+      cidrv4: (inst) => (params) => {
+        return inst.check(core._cidrv4(ZodCIDRv4, params));
       },
 
-      cidrv6: (self) => (params) => {
-        return self.check(core._cidrv6(ZodCIDRv6, params));
+      cidrv6: (inst) => (params) => {
+        return inst.check(core._cidrv6(ZodCIDRv6, params));
       },
 
-      e164: (self) => (params) => {
-        return self.check(core._e164(ZodE164, params));
+      e164: (inst) => (params) => {
+        return inst.check(core._e164(ZodE164, params));
       },
-      datetime: (self) => (params) => {
-        return self.check(core._isoDateTime(ZodISODateTime, params as any));
-      },
-
-      date: (self) => (params) => {
-        return self.check(core._isoDate(ZodISODate, params as any));
+      datetime: (inst) => (params) => {
+        return inst.check(core._isoDateTime(ZodISODateTime, params as any));
       },
 
-      time: (self) => (params) => {
-        return self.check(core._isoTime(ZodISOTime, params as any));
+      date: (inst) => (params) => {
+        return inst.check(core._isoDate(ZodISODate, params as any));
       },
 
-      duration: (self) => (params) => {
-        return self.check(core._isoDuration(ZodISODuration, params as any));
+      time: (inst) => (params) => {
+        return inst.check(core._isoTime(ZodISOTime, params as any));
+      },
+
+      duration: (inst) => (params) => {
+        return inst.check(core._isoDuration(ZodISODuration, params as any));
       },
     },
   }
@@ -1214,64 +1214,64 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
   },
   {
     proto: {
-      gt: (self) => (value, params) => {
-        return self.check(checks.gt(value, params));
+      gt: (inst) => (value, params) => {
+        return inst.check(checks.gt(value, params));
       },
 
-      gte: (self) => (value, params) => {
-        return self.check(checks.gte(value, params));
+      gte: (inst) => (value, params) => {
+        return inst.check(checks.gte(value, params));
       },
 
-      min: (self) => (value, params) => {
-        return self.check(checks.gte(value, params));
+      min: (inst) => (value, params) => {
+        return inst.check(checks.gte(value, params));
       },
 
-      lt: (self) => (value, params) => {
-        return self.check(checks.lt(value, params));
+      lt: (inst) => (value, params) => {
+        return inst.check(checks.lt(value, params));
       },
 
-      lte: (self) => (value, params) => {
-        return self.check(checks.lte(value, params));
+      lte: (inst) => (value, params) => {
+        return inst.check(checks.lte(value, params));
       },
 
-      max: (self) => (value, params) => {
-        return self.check(checks.lte(value, params));
+      max: (inst) => (value, params) => {
+        return inst.check(checks.lte(value, params));
       },
 
-      int: (self) => (params) => {
-        return self.check(int(params));
+      int: (inst) => (params) => {
+        return inst.check(int(params));
       },
 
-      safe: (self) => (params) => {
-        return self.check(int(params));
+      safe: (inst) => (params) => {
+        return inst.check(int(params));
       },
 
-      positive: (self) => (params) => {
-        return self.check(checks.gt(0, params));
+      positive: (inst) => (params) => {
+        return inst.check(checks.gt(0, params));
       },
 
-      nonnegative: (self) => (params) => {
-        return self.check(checks.gte(0, params));
+      nonnegative: (inst) => (params) => {
+        return inst.check(checks.gte(0, params));
       },
 
-      negative: (self) => (params) => {
-        return self.check(checks.lt(0, params));
+      negative: (inst) => (params) => {
+        return inst.check(checks.lt(0, params));
       },
 
-      nonpositive: (self) => (params) => {
-        return self.check(checks.lte(0, params));
+      nonpositive: (inst) => (params) => {
+        return inst.check(checks.lte(0, params));
       },
 
-      multipleOf: (self) => (value, params) => {
-        return self.check(checks.multipleOf(value, params));
+      multipleOf: (inst) => (value, params) => {
+        return inst.check(checks.multipleOf(value, params));
       },
 
-      step: (self) => (value, params) => {
-        return self.check(checks.multipleOf(value, params));
+      step: (inst) => (value, params) => {
+        return inst.check(checks.multipleOf(value, params));
       },
 
-      finite: (self) => () => {
-        return self;
+      finite: (inst) => () => {
+        return inst;
       },
     },
   }
@@ -1372,48 +1372,48 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
   },
   {
     proto: {
-      gte: (self) => (value, params) => {
-        return self.check(checks.gte(value, params));
+      gte: (inst) => (value, params) => {
+        return inst.check(checks.gte(value, params));
       },
 
-      min: (self) => (value, params) => {
-        return self.check(checks.gte(value, params));
+      min: (inst) => (value, params) => {
+        return inst.check(checks.gte(value, params));
       },
 
-      gt: (self) => (value, params) => {
-        return self.check(checks.gt(value, params));
+      gt: (inst) => (value, params) => {
+        return inst.check(checks.gt(value, params));
       },
 
-      lt: (self) => (value, params) => {
-        return self.check(checks.lt(value, params));
+      lt: (inst) => (value, params) => {
+        return inst.check(checks.lt(value, params));
       },
 
-      lte: (self) => (value, params) => {
-        return self.check(checks.lte(value, params));
+      lte: (inst) => (value, params) => {
+        return inst.check(checks.lte(value, params));
       },
 
-      max: (self) => (value, params) => {
-        return self.check(checks.lte(value, params));
+      max: (inst) => (value, params) => {
+        return inst.check(checks.lte(value, params));
       },
 
-      positive: (self) => (params) => {
-        return self.check(checks.gt(BigInt(0), params));
+      positive: (inst) => (params) => {
+        return inst.check(checks.gt(BigInt(0), params));
       },
 
-      negative: (self) => (params) => {
-        return self.check(checks.lt(BigInt(0), params));
+      negative: (inst) => (params) => {
+        return inst.check(checks.lt(BigInt(0), params));
       },
 
-      nonpositive: (self) => (params) => {
-        return self.check(checks.lte(BigInt(0), params));
+      nonpositive: (inst) => (params) => {
+        return inst.check(checks.lte(BigInt(0), params));
       },
 
-      nonnegative: (self) => (params) => {
-        return self.check(checks.gte(BigInt(0), params));
+      nonnegative: (inst) => (params) => {
+        return inst.check(checks.gte(BigInt(0), params));
       },
 
-      multipleOf: (self) => (value, params) => {
-        return self.check(checks.multipleOf(value, params));
+      multipleOf: (inst) => (value, params) => {
+        return inst.check(checks.multipleOf(value, params));
       },
     },
   }
@@ -1592,24 +1592,24 @@ export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constru
   },
   {
     proto: {
-      min: (self) => (n, params) => {
-        return self.check(checks.minLength(n, params));
+      min: (inst) => (n, params) => {
+        return inst.check(checks.minLength(n, params));
       },
 
-      nonempty: (self) => (params) => {
-        return self.check(checks.minLength(1, params));
+      nonempty: (inst) => (params) => {
+        return inst.check(checks.minLength(1, params));
       },
 
-      max: (self) => (n, params) => {
-        return self.check(checks.maxLength(n, params));
+      max: (inst) => (n, params) => {
+        return inst.check(checks.maxLength(n, params));
       },
 
-      length: (self) => (n, params) => {
-        return self.check(checks.length(n, params));
+      length: (inst) => (n, params) => {
+        return inst.check(checks.length(n, params));
       },
 
-      unwrap: (self) => () => {
-        return self.element;
+      unwrap: (inst) => () => {
+        return inst.element;
       },
     },
   }
@@ -1747,66 +1747,66 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
   },
   {
     proto: {
-      keyof: (self) => () => {
-        return _enum(Object.keys(self._zod.def.shape));
+      keyof: (inst) => () => {
+        return _enum(Object.keys(inst._zod.def.shape));
       },
 
-      catchall: (self) => (catchall) => {
-        return self.clone({ ...self._zod.def, catchall: catchall as any });
+      catchall: (inst) => (catchall) => {
+        return inst.clone({ ...inst._zod.def, catchall: catchall as any });
       },
 
-      passthrough: (self) => () => {
-        return self.clone({ ...self._zod.def, catchall: unknown() });
+      passthrough: (inst) => () => {
+        return inst.clone({ ...inst._zod.def, catchall: unknown() });
       },
 
-      loose: (self) => () => {
-        return self.clone({ ...self._zod.def, catchall: unknown() });
+      loose: (inst) => () => {
+        return inst.clone({ ...inst._zod.def, catchall: unknown() });
       },
 
-      strict: (self) => () => {
-        return self.clone({ ...self._zod.def, catchall: never() });
+      strict: (inst) => () => {
+        return inst.clone({ ...inst._zod.def, catchall: never() });
       },
 
-      strip: (self) => () => {
-        return self.clone({ ...self._zod.def, catchall: undefined });
+      strip: (inst) => () => {
+        return inst.clone({ ...inst._zod.def, catchall: undefined });
       },
 
-      extend: (self) => (incoming) => {
-        return util.extend(self, incoming);
+      extend: (inst) => (incoming) => {
+        return util.extend(inst, incoming);
       },
 
-      safeExtend: (self) => (incoming) => {
-        return util.safeExtend(self, incoming);
+      safeExtend: (inst) => (incoming) => {
+        return util.safeExtend(inst, incoming);
       },
 
-      merge: (self) => (other) => {
-        return util.merge(self, other);
+      merge: (inst) => (other) => {
+        return util.merge(inst, other);
       },
 
-      pick: (self) => (mask) => {
-        return util.pick(self, mask);
+      pick: (inst) => (mask) => {
+        return util.pick(inst, mask);
       },
 
-      omit: (self) => (mask) => {
-        return util.omit(self, mask);
+      omit: (inst) => (mask) => {
+        return util.omit(inst, mask);
       },
 
       partial:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return util.partial(ZodOptional, self, args[0]);
+          return util.partial(ZodOptional, inst, args[0]);
         },
 
       exactPartial:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return util.partial(ZodExactOptional, self, args[0], "exactPartial");
+          return util.partial(ZodExactOptional, inst, args[0], "exactPartial");
         },
 
       required:
-        (self) =>
+        (inst) =>
         (...args) => {
-          return util.required(ZodNonOptional, self, args[0]);
+          return util.required(ZodNonOptional, inst, args[0]);
         },
     },
   }
@@ -1987,18 +1987,18 @@ export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constru
   },
   {
     proto: {
-      rest: (self) => (rest) => {
-        return self.clone({
-          ...self._zod.def,
+      rest: (inst) => (rest) => {
+        return inst.clone({
+          ...inst._zod.def,
           rest: rest as any as core.$ZodType,
         }) as any;
       },
 
-      partial: (self) => () => {
-        const def = self._zod.def;
+      partial: (inst) => () => {
+        const def = inst._zod.def;
         // a refinement was authored against the full arity; partialing would run it on a shorter array
         if (def.checks?.length) throw new Error(".partial() cannot be used on tuple schemas containing refinements");
-        return self.clone({
+        return inst.clone({
           ...def,
           items: def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
         }) as any;

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -174,8 +174,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     return inst;
   },
   {
-    // `this` is declared on the two members that call each other through it: without that TypeScript gives up on the whole literal's contextual types and every parameter below lands as `any`
-    check(this: ZodType, ...chks) {
+    check(...chks) {
       const def = this.def;
       return this.clone(
         util.mergeDefs(def, {
@@ -194,7 +193,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
       return this.check(...chks);
     },
 
-    clone(this: ZodType, def, params) {
+    clone(def, params) {
       return core.clone(this, def, params);
     },
 

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -175,185 +175,197 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
   },
   {
     proto: {
-      check:
-        (inst) =>
-        (...chks) => {
-          const def = inst.def;
-          return inst.clone(
-            util.mergeDefs(def, {
-              checks: [
-                ...(def.checks ?? []),
-                ...chks.map((ch) =>
-                  typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
-                ),
-              ],
-            }),
-            { parent: true }
-          );
-        },
-
-      with:
-        (inst) =>
-        (...chks) => {
-          return inst.check(...chks);
-        },
-
-      clone: (inst) => (def, params) => {
-        return core.clone(inst, def, params);
+      check(...chks) {
+        const def = this.def;
+        return this.clone(
+          util.mergeDefs(def, {
+            checks: [
+              ...(def.checks ?? []),
+              ...chks.map((ch) =>
+                typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+              ),
+            ],
+          }),
+          { parent: true }
+        );
       },
 
-      brand: (inst) => () => {
-        return inst;
+      with(...chks) {
+        return this.check(...chks);
       },
 
-      register: (inst) => (reg, meta) => {
-        reg.add(inst, meta);
-        return inst;
+      clone(def, params) {
+        return core.clone(this, def, params);
       },
 
-      refine: (inst) => (check, params) => {
-        return inst.check(refine(check, params));
+      brand() {
+        return this;
       },
 
-      superRefine: (inst) => (refinement, params) => {
-        return inst.check(superRefine(refinement, params));
+      register(reg, meta) {
+        reg.add(this, meta);
+        return this;
       },
 
-      overwrite: (inst) => (fn) => {
-        return inst.check(checks.overwrite(fn));
+      refine(check, params) {
+        return this.check(refine(check, params));
       },
 
-      optional: (inst) => () => {
-        return optional(inst);
+      superRefine(refinement, params) {
+        return this.check(superRefine(refinement, params));
       },
 
-      exactOptional: (inst) => () => {
-        return exactOptional(inst);
+      overwrite(fn) {
+        return this.check(checks.overwrite(fn));
       },
 
-      nullable: (inst) => () => {
-        return nullable(inst);
+      optional() {
+        return optional(this);
       },
 
-      nullish: (inst) => () => {
-        return optional(nullable(inst));
+      exactOptional() {
+        return exactOptional(this);
       },
 
-      nonoptional: (inst) => (params) => {
-        return nonoptional(inst, params);
+      nullable() {
+        return nullable(this);
       },
 
-      array: (inst) => () => {
-        return array(inst);
+      nullish() {
+        return optional(nullable(this));
       },
 
-      or: (inst) => (arg) => {
-        return union([inst, arg]);
+      nonoptional(params) {
+        return nonoptional(this, params);
       },
 
-      and: (inst) => (arg) => {
-        return intersection(inst, arg);
+      array() {
+        return array(this);
       },
 
-      transform: (inst) => (tx) => {
-        return pipe(inst, transform(tx));
+      or(arg) {
+        return union([this, arg]);
       },
 
-      default: (inst) => (d) => {
-        return _default(inst, d);
+      and(arg) {
+        return intersection(this, arg);
       },
 
-      prefault: (inst) => (d) => {
-        return prefault(inst, d);
+      transform(tx) {
+        return pipe(this, transform(tx));
       },
 
-      catch: (inst) => (params) => {
-        return _catch(inst, params);
+      default(d) {
+        return _default(this, d);
       },
 
-      pipe: (inst) => (target) => {
-        return pipe(inst, target);
+      prefault(d) {
+        return prefault(this, d);
       },
 
-      readonly: (inst) => () => {
-        return readonly(inst);
+      catch(params) {
+        return _catch(this, params);
       },
 
-      describe: (inst) => (description) => {
-        const cl = inst.clone();
+      pipe(target) {
+        return pipe(this, target);
+      },
+
+      readonly() {
+        return readonly(this);
+      },
+
+      describe(description) {
+        const cl = this.clone();
         core.globalRegistry.add(cl, { description });
         return cl;
       },
 
-      meta:
-        (inst) =>
-        (...args: any[]): any => {
-          // overloaded: meta() returns the registered metadata, meta(data) returns a clone with `data` registered. The mapped type picks up the second overload, so we accept variadic any-args and return `any` to satisfy both at runtime.
-          if (args.length === 0) return core.globalRegistry.get(inst);
-          const cl = inst.clone();
-          core.globalRegistry.add(cl, args[0]);
-          return cl;
-        },
-
-      isOptional: (inst) => () => {
-        return inst.safeParse(undefined).success;
+      meta(...args: any[]): any {
+        // overloaded: meta() returns the registered metadata, meta(data) returns a clone with `data` registered. The mapped type picks up the second overload, so we accept variadic any-args and return `any` to satisfy both at runtime.
+        if (args.length === 0) return core.globalRegistry.get(this);
+        const cl = this.clone();
+        core.globalRegistry.add(cl, args[0]);
+        return cl;
       },
 
-      isNullable: (inst) => () => {
-        return inst.safeParse(null).success;
+      isOptional() {
+        return this.safeParse(undefined).success;
       },
 
-      apply:
-        (inst) =>
-        (fn, ...args) => {
-          return args.length === 0 ? fn(inst) : fn(inst, ...args);
-        },
+      isNullable() {
+        return this.safeParse(null).success;
+      },
+
+      apply(fn, ...args) {
+        return args.length === 0 ? fn(this) : fn(this, ...args);
+      },
 
       // Overrides core's `~standard` to add `jsonSchema`. Must stay a prototype entry: redefining it per instance demotes instances to dictionary mode.
-      "~standard": (inst) =>
-        ({
-          ...core.standardProps(inst),
+      get "~standard"(): ZodType["~standard"] {
+        const props = {
+          ...core.standardProps(this),
           jsonSchema: {
-            input: createStandardJSONSchemaMethod(inst, "input"),
-            output: createStandardJSONSchemaMethod(inst, "output"),
+            input: createStandardJSONSchemaMethod(this, "input"),
+            output: createStandardJSONSchemaMethod(this, "output"),
           },
-        }) as ZodType["~standard"],
-      parse: (inst) => {
-        const fn: ZodType["parse"] = (data, params) => parse.parse(inst, data, params, { callee: fn });
-        return fn;
+        } as ZodType["~standard"];
+        // cached, but not enumerable: it was never an own data property, so it must stay out of `Object.keys`
+        Object.defineProperty(this, "~standard", { configurable: true, writable: true, value: props });
+        return props;
       },
-      parseAsync: (inst) => {
-        const fn: ZodType["parseAsync"] = async (data, params) =>
-          await parse.parseAsync(inst, data, params, { callee: fn });
-        return fn;
+      set "~standard"(value: ZodType["~standard"]) {
+        util.own(this, "~standard", value);
       },
-      safeParse: (inst) => (data, params) => parse.safeParse(inst, data, params),
-      safeParseAsync: (inst) => async (data, params) => parse.safeParseAsync(inst, data, params),
+      parse: function _parse(data, params) {
+        return parse.parse(this, data, params, { callee: _parse });
+      },
+      parseAsync: async function _parseAsync(data, params) {
+        return await parse.parseAsync(this, data, params, { callee: _parseAsync });
+      },
+      safeParse(data, params) {
+        return parse.safeParse(this, data, params);
+      },
+      async safeParseAsync(data, params) {
+        return parse.safeParseAsync(this, data, params);
+      },
       // `spa` is an alias: same function object as `safeParseAsync`, as before.
-      spa: (inst) => inst.safeParseAsync,
-      encode: (inst) => {
-        const fn: ZodType["encode"] = (data, params) => parse.encode(inst, data, params, { callee: fn });
-        return fn;
+      get spa(): ZodType["safeParseAsync"] {
+        return this.safeParseAsync;
       },
-      decode: (inst) => {
-        const fn: ZodType["decode"] = (data, params) => parse.decode(inst, data, params, { callee: fn });
-        return fn;
+      set spa(value: ZodType["safeParseAsync"]) {
+        util.own(this, "spa", value);
       },
-      encodeAsync: (inst) => {
-        const fn: ZodType["encodeAsync"] = async (data, params) =>
-          await parse.encodeAsync(inst, data, params, { callee: fn });
-        return fn;
+      encode: function _encode(data, params) {
+        return parse.encode(this, data, params, { callee: _encode });
       },
-      decodeAsync: (inst) => {
-        const fn: ZodType["decodeAsync"] = async (data, params) =>
-          await parse.decodeAsync(inst, data, params, { callee: fn });
-        return fn;
+      decode: function _decode(data, params) {
+        return parse.decode(this, data, params, { callee: _decode });
       },
-      safeEncode: (inst) => (data, params) => parse.safeEncode(inst, data, params),
-      safeDecode: (inst) => (data, params) => parse.safeDecode(inst, data, params),
-      safeEncodeAsync: (inst) => async (data, params) => parse.safeEncodeAsync(inst, data, params),
-      safeDecodeAsync: (inst) => async (data, params) => parse.safeDecodeAsync(inst, data, params),
-      toJSONSchema: (inst) => createToJSONSchemaMethod(inst, {}),
+      encodeAsync: async function _encodeAsync(data, params) {
+        return await parse.encodeAsync(this, data, params, { callee: _encodeAsync });
+      },
+      decodeAsync: async function _decodeAsync(data, params) {
+        return await parse.decodeAsync(this, data, params, { callee: _decodeAsync });
+      },
+      safeEncode(data, params) {
+        return parse.safeEncode(this, data, params);
+      },
+      safeDecode(data, params) {
+        return parse.safeDecode(this, data, params);
+      },
+      async safeEncodeAsync(data, params) {
+        return parse.safeEncodeAsync(this, data, params);
+      },
+      async safeDecodeAsync(data, params) {
+        return parse.safeDecodeAsync(this, data, params);
+      },
+      get toJSONSchema(): ZodType["toJSONSchema"] {
+        return util.own(this, "toJSONSchema", createToJSONSchemaMethod(this, {}));
+      },
+      set toJSONSchema(value: ZodType["toJSONSchema"]) {
+        util.own(this, "toJSONSchema", value);
+      },
       // Reads through to the registry on every access, so it must not cache.
       get description(): string | undefined {
         return core.globalRegistry.get(this as unknown as ZodType)?.description;
@@ -363,7 +375,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
       get _def(): core.$ZodTypeDef {
         return (this as unknown as ZodType)._zod.def;
       },
-    },
+    } satisfies core.util.ProtoOf<ZodType>,
   }
 );
 
@@ -410,82 +422,64 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
   },
   {
     proto: {
-      regex:
-        (inst) =>
-        (...args) => {
-          return inst.check((checks.regex as any)(...args));
-        },
-
-      includes:
-        (inst) =>
-        (...args) => {
-          return inst.check((checks.includes as any)(...args));
-        },
-
-      startsWith:
-        (inst) =>
-        (...args) => {
-          return inst.check((checks.startsWith as any)(...args));
-        },
-
-      endsWith:
-        (inst) =>
-        (...args) => {
-          return inst.check((checks.endsWith as any)(...args));
-        },
-
-      min:
-        (inst) =>
-        (...args) => {
-          return inst.check((checks.minLength as any)(...args));
-        },
-
-      max:
-        (inst) =>
-        (...args) => {
-          return inst.check((checks.maxLength as any)(...args));
-        },
-
-      length:
-        (inst) =>
-        (...args) => {
-          return inst.check((checks.length as any)(...args));
-        },
-
-      nonempty:
-        (inst) =>
-        (...args) => {
-          return inst.check((checks.minLength as any)(1, ...args));
-        },
-
-      lowercase: (inst) => (params) => {
-        return inst.check(checks.lowercase(params));
+      regex(...args) {
+        return this.check((checks.regex as any)(...args));
       },
 
-      uppercase: (inst) => (params) => {
-        return inst.check(checks.uppercase(params));
+      includes(...args) {
+        return this.check((checks.includes as any)(...args));
       },
 
-      trim: (inst) => () => {
-        return inst.check(checks.trim());
+      startsWith(...args) {
+        return this.check((checks.startsWith as any)(...args));
       },
 
-      normalize:
-        (inst) =>
-        (...args) => {
-          return inst.check(checks.normalize(...args));
-        },
-
-      toLowerCase: (inst) => () => {
-        return inst.check(checks.toLowerCase());
+      endsWith(...args) {
+        return this.check((checks.endsWith as any)(...args));
       },
 
-      toUpperCase: (inst) => () => {
-        return inst.check(checks.toUpperCase());
+      min(...args) {
+        return this.check((checks.minLength as any)(...args));
       },
 
-      slugify: (inst) => () => {
-        return inst.check(checks.slugify());
+      max(...args) {
+        return this.check((checks.maxLength as any)(...args));
+      },
+
+      length(...args) {
+        return this.check((checks.length as any)(...args));
+      },
+
+      nonempty(...args) {
+        return this.check((checks.minLength as any)(1, ...args));
+      },
+
+      lowercase(params) {
+        return this.check(checks.lowercase(params));
+      },
+
+      uppercase(params) {
+        return this.check(checks.uppercase(params));
+      },
+
+      trim() {
+        return this.check(checks.trim());
+      },
+
+      normalize(...args) {
+        return this.check(checks.normalize(...args));
+      },
+
+      toLowerCase() {
+        return this.check(checks.toLowerCase());
+      },
+
+      toUpperCase() {
+        return this.check(checks.toUpperCase());
+      },
+
+      slugify() {
+        return this.check(checks.slugify());
       },
     },
   }
@@ -576,107 +570,107 @@ export const ZodString: core.$constructor<ZodString> = /*@__PURE__*/ core.$const
   },
   {
     proto: {
-      email: (inst) => (params) => {
-        return inst.check(core._email(ZodEmail, params));
+      email(params) {
+        return this.check(core._email(ZodEmail, params));
       },
 
-      url: (inst) => (params) => {
-        return inst.check(core._url(ZodURL, params));
+      url(params) {
+        return this.check(core._url(ZodURL, params));
       },
 
-      jwt: (inst) => (params) => {
-        return inst.check(core._jwt(ZodJWT, params));
+      jwt(params) {
+        return this.check(core._jwt(ZodJWT, params));
       },
 
-      emoji: (inst) => (params) => {
-        return inst.check(core._emoji(ZodEmoji, params));
+      emoji(params) {
+        return this.check(core._emoji(ZodEmoji, params));
       },
 
-      guid: (inst) => (params) => {
-        return inst.check(core._guid(ZodGUID, params));
+      guid(params) {
+        return this.check(core._guid(ZodGUID, params));
       },
 
-      uuid: (inst) => (params) => {
-        return inst.check(core._uuid(ZodUUID, params));
+      uuid(params) {
+        return this.check(core._uuid(ZodUUID, params));
       },
 
-      uuidv4: (inst) => (params) => {
-        return inst.check(core._uuidv4(ZodUUID, params));
+      uuidv4(params) {
+        return this.check(core._uuidv4(ZodUUID, params));
       },
 
-      uuidv6: (inst) => (params) => {
-        return inst.check(core._uuidv6(ZodUUID, params));
+      uuidv6(params) {
+        return this.check(core._uuidv6(ZodUUID, params));
       },
 
-      uuidv7: (inst) => (params) => {
-        return inst.check(core._uuidv7(ZodUUID, params));
+      uuidv7(params) {
+        return this.check(core._uuidv7(ZodUUID, params));
       },
 
-      nanoid: (inst) => (params) => {
-        return inst.check(core._nanoid(ZodNanoID, params));
+      nanoid(params) {
+        return this.check(core._nanoid(ZodNanoID, params));
       },
 
-      cuid: (inst) => (params) => {
-        return inst.check(core._cuid(ZodCUID, params));
+      cuid(params) {
+        return this.check(core._cuid(ZodCUID, params));
       },
 
-      cuid2: (inst) => (params) => {
-        return inst.check(core._cuid2(ZodCUID2, params));
+      cuid2(params) {
+        return this.check(core._cuid2(ZodCUID2, params));
       },
 
-      ulid: (inst) => (params) => {
-        return inst.check(core._ulid(ZodULID, params));
+      ulid(params) {
+        return this.check(core._ulid(ZodULID, params));
       },
 
-      base64: (inst) => (params) => {
-        return inst.check(core._base64(ZodBase64, params));
+      base64(params) {
+        return this.check(core._base64(ZodBase64, params));
       },
 
-      base64url: (inst) => (params) => {
-        return inst.check(core._base64url(ZodBase64URL, params));
+      base64url(params) {
+        return this.check(core._base64url(ZodBase64URL, params));
       },
 
-      xid: (inst) => (params) => {
-        return inst.check(core._xid(ZodXID, params));
+      xid(params) {
+        return this.check(core._xid(ZodXID, params));
       },
 
-      ksuid: (inst) => (params) => {
-        return inst.check(core._ksuid(ZodKSUID, params));
+      ksuid(params) {
+        return this.check(core._ksuid(ZodKSUID, params));
       },
 
-      ipv4: (inst) => (params) => {
-        return inst.check(core._ipv4(ZodIPv4, params));
+      ipv4(params) {
+        return this.check(core._ipv4(ZodIPv4, params));
       },
 
-      ipv6: (inst) => (params) => {
-        return inst.check(core._ipv6(ZodIPv6, params));
+      ipv6(params) {
+        return this.check(core._ipv6(ZodIPv6, params));
       },
 
-      cidrv4: (inst) => (params) => {
-        return inst.check(core._cidrv4(ZodCIDRv4, params));
+      cidrv4(params) {
+        return this.check(core._cidrv4(ZodCIDRv4, params));
       },
 
-      cidrv6: (inst) => (params) => {
-        return inst.check(core._cidrv6(ZodCIDRv6, params));
+      cidrv6(params) {
+        return this.check(core._cidrv6(ZodCIDRv6, params));
       },
 
-      e164: (inst) => (params) => {
-        return inst.check(core._e164(ZodE164, params));
+      e164(params) {
+        return this.check(core._e164(ZodE164, params));
       },
-      datetime: (inst) => (params) => {
-        return inst.check(core._isoDateTime(ZodISODateTime, params as any));
-      },
-
-      date: (inst) => (params) => {
-        return inst.check(core._isoDate(ZodISODate, params as any));
+      datetime(params) {
+        return this.check(core._isoDateTime(ZodISODateTime, params as any));
       },
 
-      time: (inst) => (params) => {
-        return inst.check(core._isoTime(ZodISOTime, params as any));
+      date(params) {
+        return this.check(core._isoDate(ZodISODate, params as any));
       },
 
-      duration: (inst) => (params) => {
-        return inst.check(core._isoDuration(ZodISODuration, params as any));
+      time(params) {
+        return this.check(core._isoTime(ZodISOTime, params as any));
+      },
+
+      duration(params) {
+        return this.check(core._isoDuration(ZodISODuration, params as any));
       },
     },
   }
@@ -1214,64 +1208,64 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
   },
   {
     proto: {
-      gt: (inst) => (value, params) => {
-        return inst.check(checks.gt(value, params));
+      gt(value, params) {
+        return this.check(checks.gt(value, params));
       },
 
-      gte: (inst) => (value, params) => {
-        return inst.check(checks.gte(value, params));
+      gte(value, params) {
+        return this.check(checks.gte(value, params));
       },
 
-      min: (inst) => (value, params) => {
-        return inst.check(checks.gte(value, params));
+      min(value, params) {
+        return this.check(checks.gte(value, params));
       },
 
-      lt: (inst) => (value, params) => {
-        return inst.check(checks.lt(value, params));
+      lt(value, params) {
+        return this.check(checks.lt(value, params));
       },
 
-      lte: (inst) => (value, params) => {
-        return inst.check(checks.lte(value, params));
+      lte(value, params) {
+        return this.check(checks.lte(value, params));
       },
 
-      max: (inst) => (value, params) => {
-        return inst.check(checks.lte(value, params));
+      max(value, params) {
+        return this.check(checks.lte(value, params));
       },
 
-      int: (inst) => (params) => {
-        return inst.check(int(params));
+      int(params) {
+        return this.check(int(params));
       },
 
-      safe: (inst) => (params) => {
-        return inst.check(int(params));
+      safe(params) {
+        return this.check(int(params));
       },
 
-      positive: (inst) => (params) => {
-        return inst.check(checks.gt(0, params));
+      positive(params) {
+        return this.check(checks.gt(0, params));
       },
 
-      nonnegative: (inst) => (params) => {
-        return inst.check(checks.gte(0, params));
+      nonnegative(params) {
+        return this.check(checks.gte(0, params));
       },
 
-      negative: (inst) => (params) => {
-        return inst.check(checks.lt(0, params));
+      negative(params) {
+        return this.check(checks.lt(0, params));
       },
 
-      nonpositive: (inst) => (params) => {
-        return inst.check(checks.lte(0, params));
+      nonpositive(params) {
+        return this.check(checks.lte(0, params));
       },
 
-      multipleOf: (inst) => (value, params) => {
-        return inst.check(checks.multipleOf(value, params));
+      multipleOf(value, params) {
+        return this.check(checks.multipleOf(value, params));
       },
 
-      step: (inst) => (value, params) => {
-        return inst.check(checks.multipleOf(value, params));
+      step(value, params) {
+        return this.check(checks.multipleOf(value, params));
       },
 
-      finite: (inst) => () => {
-        return inst;
+      finite() {
+        return this;
       },
     },
   }
@@ -1372,48 +1366,48 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
   },
   {
     proto: {
-      gte: (inst) => (value, params) => {
-        return inst.check(checks.gte(value, params));
+      gte(value, params) {
+        return this.check(checks.gte(value, params));
       },
 
-      min: (inst) => (value, params) => {
-        return inst.check(checks.gte(value, params));
+      min(value, params) {
+        return this.check(checks.gte(value, params));
       },
 
-      gt: (inst) => (value, params) => {
-        return inst.check(checks.gt(value, params));
+      gt(value, params) {
+        return this.check(checks.gt(value, params));
       },
 
-      lt: (inst) => (value, params) => {
-        return inst.check(checks.lt(value, params));
+      lt(value, params) {
+        return this.check(checks.lt(value, params));
       },
 
-      lte: (inst) => (value, params) => {
-        return inst.check(checks.lte(value, params));
+      lte(value, params) {
+        return this.check(checks.lte(value, params));
       },
 
-      max: (inst) => (value, params) => {
-        return inst.check(checks.lte(value, params));
+      max(value, params) {
+        return this.check(checks.lte(value, params));
       },
 
-      positive: (inst) => (params) => {
-        return inst.check(checks.gt(BigInt(0), params));
+      positive(params) {
+        return this.check(checks.gt(BigInt(0), params));
       },
 
-      negative: (inst) => (params) => {
-        return inst.check(checks.lt(BigInt(0), params));
+      negative(params) {
+        return this.check(checks.lt(BigInt(0), params));
       },
 
-      nonpositive: (inst) => (params) => {
-        return inst.check(checks.lte(BigInt(0), params));
+      nonpositive(params) {
+        return this.check(checks.lte(BigInt(0), params));
       },
 
-      nonnegative: (inst) => (params) => {
-        return inst.check(checks.gte(BigInt(0), params));
+      nonnegative(params) {
+        return this.check(checks.gte(BigInt(0), params));
       },
 
-      multipleOf: (inst) => (value, params) => {
-        return inst.check(checks.multipleOf(value, params));
+      multipleOf(value, params) {
+        return this.check(checks.multipleOf(value, params));
       },
     },
   }
@@ -1592,24 +1586,24 @@ export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constru
   },
   {
     proto: {
-      min: (inst) => (n, params) => {
-        return inst.check(checks.minLength(n, params));
+      min(n, params) {
+        return this.check(checks.minLength(n, params));
       },
 
-      nonempty: (inst) => (params) => {
-        return inst.check(checks.minLength(1, params));
+      nonempty(params) {
+        return this.check(checks.minLength(1, params));
       },
 
-      max: (inst) => (n, params) => {
-        return inst.check(checks.maxLength(n, params));
+      max(n, params) {
+        return this.check(checks.maxLength(n, params));
       },
 
-      length: (inst) => (n, params) => {
-        return inst.check(checks.length(n, params));
+      length(n, params) {
+        return this.check(checks.length(n, params));
       },
 
-      unwrap: (inst) => () => {
-        return inst.element;
+      unwrap() {
+        return this.element;
       },
     },
   }
@@ -1747,67 +1741,61 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
   },
   {
     proto: {
-      keyof: (inst) => () => {
-        return _enum(Object.keys(inst._zod.def.shape));
+      keyof() {
+        return _enum(Object.keys(this._zod.def.shape));
       },
 
-      catchall: (inst) => (catchall) => {
-        return inst.clone({ ...inst._zod.def, catchall: catchall as any });
+      catchall(catchall) {
+        return this.clone({ ...this._zod.def, catchall: catchall as any });
       },
 
-      passthrough: (inst) => () => {
-        return inst.clone({ ...inst._zod.def, catchall: unknown() });
+      passthrough() {
+        return this.clone({ ...this._zod.def, catchall: unknown() });
       },
 
-      loose: (inst) => () => {
-        return inst.clone({ ...inst._zod.def, catchall: unknown() });
+      loose() {
+        return this.clone({ ...this._zod.def, catchall: unknown() });
       },
 
-      strict: (inst) => () => {
-        return inst.clone({ ...inst._zod.def, catchall: never() });
+      strict() {
+        return this.clone({ ...this._zod.def, catchall: never() });
       },
 
-      strip: (inst) => () => {
-        return inst.clone({ ...inst._zod.def, catchall: undefined });
+      strip() {
+        return this.clone({ ...this._zod.def, catchall: undefined });
       },
 
-      extend: (inst) => (incoming) => {
-        return util.extend(inst, incoming);
+      extend(incoming) {
+        return util.extend(this, incoming);
       },
 
-      safeExtend: (inst) => (incoming) => {
-        return util.safeExtend(inst, incoming);
+      safeExtend(incoming) {
+        return util.safeExtend(this, incoming);
       },
 
-      merge: (inst) => (other) => {
-        return util.merge(inst, other);
+      merge(other) {
+        return util.merge(this, other);
       },
 
-      pick: (inst) => (mask) => {
-        return util.pick(inst, mask);
+      pick(mask) {
+        return util.pick(this, mask);
       },
 
-      omit: (inst) => (mask) => {
-        return util.omit(inst, mask);
+      omit(mask) {
+        return util.omit(this, mask);
       },
 
-      partial:
-        (inst) =>
-        (...args) => {
-          return util.partial(ZodOptional, inst, args[0]);
-        },
+      partial(...args) {
+        return util.partial(ZodOptional, this, args[0]);
+      },
 
-      exactPartial:
-        (inst) =>
-        (...args) => {
-          return util.partial(ZodExactOptional, inst, args[0], "exactPartial");
-        },
+      exactPartial(...args) {
+        return util.partial(ZodExactOptional, this, args[0], "exactPartial");
+      },
 
-      required:
-        (inst) =>
-        (...args) => {
-          return util.required(ZodNonOptional, inst, args[0]);
-        },
+      required(...args) {
+        return util.required(ZodNonOptional, this, args[0]);
+      },
     },
   }
 );
@@ -1987,18 +1975,18 @@ export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constru
   },
   {
     proto: {
-      rest: (inst) => (rest) => {
-        return inst.clone({
-          ...inst._zod.def,
+      rest(rest) {
+        return this.clone({
+          ...this._zod.def,
           rest: rest as any as core.$ZodType,
         }) as any;
       },
 
-      partial: (inst) => () => {
-        const def = inst._zod.def;
+      partial() {
+        const def = this._zod.def;
         // a refinement was authored against the full arity; partialing would run it on a shorter array
         if (def.checks?.length) throw new Error(".partial() cannot be used on tuple schemas containing refinements");
-        return inst.clone({
+        return this.clone({
           ...def,
           items: def.items.map((item) => new ZodOptional({ type: "optional", innerType: item })),
         }) as any;

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -183,7 +183,8 @@ test("a subclass's own members survive the install", () => {
   const sym = Symbol();
   expect(z.symbol().parse(sym)).toBe(sym);
 
-  // and the other way round, with the base prototype already built
+  // and the other way round, with the base prototype already built by the `z.number()` above. Asserted for the same reason: drop that one and this block quietly becomes a second copy of the cold case.
+  expect(Object.prototype.hasOwnProperty.call((z.ZodNumber as any).prototype, "parse")).toBe(true);
   const Second = class extends (z.ZodNumber as any) {
     parse() {
       return "SECOND";

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -143,3 +143,14 @@ test("a live member is not cached per instance", () => {
   expect(schema.description).toBe("later");
   expect(Object.prototype.hasOwnProperty.call(schema, "description")).toBe(false);
 });
+
+test("constructing through a subclass does not strip the base prototype", () => {
+  // `super(def)` gives `this` a prototype of `new.target.prototype`, so a constructor can complete a construction without having built its own prototype.
+  const MyString: new (def: { type: "string" }) => z.ZodString = class extends (z.ZodString as any) {} as any;
+  new MyString({ type: "string" });
+
+  const plain = z.string();
+  expect(plain.parse("x")).toBe("x");
+  expect(typeof plain.email).toBe("function");
+  expect(typeof new MyString({ type: "string" }).email).toBe("function");
+});

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -167,8 +167,9 @@ test("constructing through a subclass does not strip the base prototype", () => 
 });
 
 test("a subclass's own members survive the install", () => {
-  // The members go on the nearest prototype a `$constructor` built, so a subclass's prototype keeps whatever it declared. `z.number()` is untouched here to construct the subclass before its base.
-  const First = class extends (z.ZodNumber as any) {
+  // The members go on the prototype of the constructor that built the instance, so a subclass's own prototype keeps what it declared. `z.symbol()` is constructed nowhere else here, which puts the subclass before its base — the ordering the install has to get right. Asserted rather than assumed, so warming it elsewhere fails the test instead of hollowing it out.
+  expect(Object.prototype.hasOwnProperty.call((z.ZodSymbol as any).prototype, "parse")).toBe(false);
+  const First = class extends (z.ZodSymbol as any) {
     parse() {
       return "PARSE";
     }
@@ -176,10 +177,11 @@ test("a subclass's own members survive the install", () => {
       return "OPTIONAL";
     }
   } as any;
-  const first = new First({ type: "number" });
-  expect(first.parse(1)).toBe("PARSE");
+  const first = new First({ type: "symbol" });
+  expect(first.parse(Symbol())).toBe("PARSE");
   expect(first.optional()).toBe("OPTIONAL");
-  expect(z.number().parse(1)).toBe(1);
+  const sym = Symbol();
+  expect(z.symbol().parse(sym)).toBe(sym);
 
   // and the other way round, with the base prototype already built
   const Second = class extends (z.ZodNumber as any) {
@@ -189,7 +191,7 @@ test("a subclass's own members survive the install", () => {
   } as any;
   expect(new Second({ type: "number" }).parse(1)).toBe("SECOND");
 
-  // two levels deep: neither prototype gets its own copy, so the inherited member is one function
+  // two levels deep: neither prototype takes a copy, so the inherited member is one function
   const Third = class extends (Second as any) {} as any;
   new Third({ type: "number" });
   expect(Second.prototype.parse).toBe(Third.prototype.parse);

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -106,7 +106,7 @@ test("deferred initializers are released after construction", () => {
 });
 
 test("a trait initializer called directly still installs its members", () => {
-  // `$constructor` skips the prototype initializers while constructing from a constructor that has already run them. A direct `init` is not that, so it has to see the guard off.
+  // a direct `init` installs onto the receiver's own prototype, since it is not below the constructor's
   z.string();
 
   const proto = {};
@@ -118,16 +118,27 @@ test("a trait initializer called directly still installs its members", () => {
   expect(Object.prototype.hasOwnProperty.call(proto, "email")).toBe(true);
 });
 
-test("an initializer that throws leaves the install guard off", () => {
-  // A successful one first, so the guard is armed for this constructor when the next throws.
-  z.uuid();
-  expect(() => z.uuid({ version: "v9" as never })).toThrow();
+test("a nested init during a repeat construction still installs its members", () => {
+  // the install used to read a module-level flag the outer construction set, so a nested `init` on an unrelated receiver inherited an answer that was not about it
+  const seen: string[] = [];
 
-  const proto = {};
-  const inst = Object.create(proto) as z.ZodString;
-  z.ZodString.init(inst, { type: "string" });
+  // an assertion signature needs the call target explicitly annotated
+  const Nested: core.$constructor<any> = core.$constructor<any>("Nested", () => {}, {
+    tag() {
+      return "nested";
+    },
+  });
+  const Outer = core.$constructor<any>("Outer", (_inst, def) => {
+    if (!def.nest) return;
+    const plain: any = {};
+    Nested.init(plain, {});
+    seen.push(typeof plain.tag);
+  });
 
-  expect(Object.prototype.hasOwnProperty.call(proto, "email")).toBe(true);
+  new Outer({ nest: false });
+  new Outer({ nest: true });
+
+  expect(seen).toEqual(["function"]);
 });
 
 test("a derived trait's members win over the ones it composes", () => {

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -183,7 +183,7 @@ test("a subclass's own members survive the install", () => {
   const sym = Symbol();
   expect(z.symbol().parse(sym)).toBe(sym);
 
-  // and the other way round, with the base prototype already built by the `z.number()` above. Asserted for the same reason: drop that one and this block quietly becomes a second copy of the cold case.
+  // and the other way round, with the base prototype already built by one of the `z.number()` calls above. Asserted for the same reason: warm it nowhere and this block quietly becomes a second copy of the cold case.
   expect(Object.prototype.hasOwnProperty.call((z.ZodNumber as any).prototype, "parse")).toBe(true);
   const Second = class extends (z.ZodNumber as any) {
     parse() {

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -130,7 +130,8 @@ test("a nested init during a repeat construction still installs its members", ()
   });
   const Outer = core.$constructor<any>("Outer", (_inst, def) => {
     if (!def.nest) return;
-    const plain: any = {};
+    // not a plain `{}`: the install target would resolve to `Object.prototype` and leak `tag` into every object the worker touches
+    const plain: any = Object.create({});
     Nested.init(plain, {});
     seen.push(typeof plain.tag);
   });

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -135,6 +135,17 @@ test("a derived trait's members win over the ones it composes", () => {
   expect(typeof (z.string()["~standard"] as any).jsonSchema.input).toBe("function");
 });
 
+test("a live member keeps the descriptor a prototype member had", () => {
+  // An object literal's getter is enumerable; the `defineProperty` it replaced was not. `for..in` over a schema is public surface, and the construction path walks the prototype with it.
+  const proto = Object.getPrototypeOf(z.string());
+  expect(Object.getOwnPropertyDescriptor(proto, "description")?.enumerable).toBe(false);
+  expect(Object.getOwnPropertyDescriptor(proto, "_def")?.enumerable).toBe(false);
+
+  const keys: string[] = [];
+  for (const k in z.string()) keys.push(k);
+  expect(keys).toEqual(["def", "type", "format", "minLength", "maxLength"]);
+});
+
 test("a live member is not cached per instance", () => {
   const schema = z.string();
 

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 
 import * as zm from "zod/mini";
 import * as z from "zod/v4";
+import * as core from "zod/v4/core";
 
 // V8 sizes an instance's property backing store in steps, and schema instances get no in-object slots (their constructor assigns nothing itself): 12 own properties cost 128 bytes, 13 cost 848, 21 cost 1616. Methods therefore live on the prototype and materialize per instance on first read. These bounds are what keeps a schema graph small; crossing one silently multiplies its memory by 6x.
 const MAX_OWN_PROPS = 12;
@@ -102,4 +103,43 @@ test("_def stays read-only", () => {
 test("deferred initializers are released after construction", () => {
   expect(z.string()._zod.deferred).toEqual(undefined);
   expect(z.object({ a: z.string() })._zod.deferred).toEqual(undefined);
+});
+
+test("a trait initializer called directly still installs its members", () => {
+  // `$constructor` skips the prototype initializers while constructing from a constructor that has already run them. A direct `init` is not that, so it has to see the guard off.
+  z.string();
+
+  const proto = {};
+  const inst = Object.create(proto) as z.ZodString;
+  z.ZodString.init(inst, { type: "string" });
+
+  expect(typeof inst.email).toBe("function");
+  expect(typeof inst.optional).toBe("function");
+  expect(Object.prototype.hasOwnProperty.call(proto, "email")).toBe(true);
+});
+
+test("an initializer that throws leaves the install guard off", () => {
+  // A successful one first, so the guard is armed for this constructor when the next throws.
+  z.uuid();
+  expect(() => z.uuid({ version: "v9" as never })).toThrow();
+
+  const proto = {};
+  const inst = Object.create(proto) as z.ZodString;
+  z.ZodString.init(inst, { type: "string" });
+
+  expect(Object.prototype.hasOwnProperty.call(proto, "email")).toBe(true);
+});
+
+test("a derived trait's members win over the ones it composes", () => {
+  // Classic installs a richer `~standard` over core's. Trait dedupe is what orders them: core's initializer runs once, at the first `init` that reaches it, so classic's always lands second.
+  expect(typeof (z.string()["~standard"] as any).jsonSchema.input).toBe("function");
+});
+
+test("a live member is not cached per instance", () => {
+  const schema = z.string();
+
+  expect(schema.description).toBe(undefined);
+  core.globalRegistry.add(schema, { description: "later" });
+  expect(schema.description).toBe("later");
+  expect(Object.prototype.hasOwnProperty.call(schema, "description")).toBe(false);
 });

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -165,3 +165,45 @@ test("constructing through a subclass does not strip the base prototype", () => 
   expect(typeof plain.email).toBe("function");
   expect(typeof new MyString({ type: "string" }).email).toBe("function");
 });
+
+test("a subclass's own members survive the install", () => {
+  // The members go on the nearest prototype a `$constructor` built, so a subclass's prototype keeps whatever it declared. `z.number()` is untouched here to construct the subclass before its base.
+  const First = class extends (z.ZodNumber as any) {
+    parse() {
+      return "PARSE";
+    }
+    optional() {
+      return "OPTIONAL";
+    }
+  } as any;
+  const first = new First({ type: "number" });
+  expect(first.parse(1)).toBe("PARSE");
+  expect(first.optional()).toBe("OPTIONAL");
+  expect(z.number().parse(1)).toBe(1);
+
+  // and the other way round, with the base prototype already built
+  const Second = class extends (z.ZodNumber as any) {
+    parse() {
+      return "SECOND";
+    }
+  } as any;
+  expect(new Second({ type: "number" }).parse(1)).toBe("SECOND");
+
+  // two levels deep: neither prototype gets its own copy, so the inherited member is one function
+  const Third = class extends (Second as any) {} as any;
+  new Third({ type: "number" });
+  expect(Second.prototype.parse).toBe(Third.prototype.parse);
+});
+
+test("a hand-written getter member accepts assignment", () => {
+  // Every member was an accessor with a setter before they moved onto `proto`, so a getter written by hand needs one too.
+  const schema: any = z.string();
+  schema.spa = () => "SPA";
+  schema.toJSONSchema = () => "JSON";
+  expect(schema.spa()).toBe("SPA");
+  expect(schema.toJSONSchema()).toBe("JSON");
+
+  const mini: any = zm.string();
+  mini.with = () => "WITH";
+  expect(mini.with()).toBe("WITH");
+});

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -93,7 +93,7 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
     initializer(inst, def);
 
     if (initialized && !protoReady) {
-      // `super(def)` from a user subclass gives `this` a prototype the subclass owns, and installing there would overwrite whatever the subclass declared. `constr` built the instance, so its prototype is the one below the subclass's that should carry the members. A plain object handed straight to `init` is not below it and takes them itself, as before.
+      // `super(def)` from a user subclass gives `this` a prototype the subclass owns, and installing there would overwrite whatever the subclass declared. `constr` built the instance, so its prototype is the one below the subclass's that should carry the members. A receiver whose chain never reaches that prototype installs on its own, which for a plain object handed straight to `init` means `Object.prototype` — unchanged from before.
       const own = Object.getPrototypeOf(inst);
       const ctorProto = inst._zod.constr.prototype;
       let up: object | null = own;

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -10,10 +10,8 @@ export interface $constructor<T extends ZodTrait, D = T["_zod"]["def"]> {
   init(inst: T, def: D): asserts inst is T;
 }
 
-export interface $constructorParams<T> {
+export interface $constructorParams {
   Parent?: typeof Class;
-  /** This trait's members, installed once on every prototype that composes it. They cannot be declared in the initializer above: that runs per instance, and the prototype is shared. */
-  proto?: ProtoOf<T>;
 }
 
 /** A special constant with type `never` */
@@ -24,9 +22,6 @@ export const NEVER: never = /*@__PURE__*/ Object.freeze({
 /* Shared descriptor for installing `_zod`; defineProperty reads it
  * synchronously, so reusing one object avoids a per-instance allocation. */
 const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
-
-// Set while constructing an instance whose constructor has already run its prototype initializers. They are idempotent, so on every construction after the first they have nothing to do; this is how they find that out without looking.
-let protoReady = false;
 
 // null where suppressing the capture would be unrecoverable: `parse()` puts the frames back with `captureStackTrace`, so without it the throw would lose its stack. also latched to null once `stackTraceLimit` proves unassignable, which a realm can do at any point by hardening Error
 let _E: (ErrorConstructor & { stackTraceLimit?: number }) | null = "captureStackTrace" in Error ? Error : null;
@@ -56,7 +51,9 @@ function newError(Definition: new () => any): any {
 export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T["_zod"]["def"]>(
   name: string,
   initializer: (inst: T, def: D) => void,
-  params?: $constructorParams<T>
+  /** This trait's members, installed once on every prototype that composes it. They cannot be declared in the initializer above: that runs per instance, and the prototype is shared. */
+  proto?: ProtoOf<T>,
+  params?: $constructorParams
 ): $constructor<T, D> {
   // Prototype for this constructor's `_zod` internals. Lazily-derived fields (`values`, `pattern`, `optin`, …) install here once rather than as an accessor on every instance.
   const zodProto: any = {};
@@ -69,7 +66,7 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
   }
   Internals.prototype = zodProto;
 
-  const protoMembers = params?.proto;
+  const protoMembers = proto;
   // One trait's members land on every prototype whose chain composes it, so the answer is per prototype rather than per trait.
   const initialized = protoMembers && new WeakSet<object>();
 
@@ -92,7 +89,7 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
 
     initializer(inst, def);
 
-    if (initialized && !protoReady) {
+    if (initialized) {
       // `super(def)` from a user subclass gives `this` a prototype the subclass owns, and installing there would overwrite whatever the subclass declared. `constr` built the instance, so its prototype is the one below the subclass's that should carry the members. A receiver whose chain never reaches that prototype installs on its own, which for a plain object handed straight to `init` means `Object.prototype` — unchanged from before.
       const own = Object.getPrototypeOf(inst);
       const ctorProto = inst._zod.constr.prototype;
@@ -120,20 +117,9 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
   class Definition extends Parent {}
   Object.defineProperty(Definition, "name", { value: name });
 
-  // The prototype the last complete construction built. Not a boolean: `super(def)` from a subclass gives `this` a prototype of `new.target.prototype`, so a constructor can complete without having built its own.
-  let builtProto: object | undefined;
-
   function _(this: any, def: D) {
     const inst = params?.Parent ? newError(Definition) : this;
-    const proto = Object.getPrototypeOf(inst);
-    protoReady = proto === builtProto;
-    try {
-      init(inst, def);
-    } finally {
-      // Cleared even on throw, so a direct `SomeTrait.init(obj, def)` outside a construction never inherits another constructor's answer.
-      protoReady = false;
-    }
-    builtProto = proto;
+    init(inst, def);
     const deferred = inst._zod.deferred;
     if (deferred) {
       for (const fn of deferred) {

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -1,6 +1,6 @@
 import type * as errors from "./errors.js";
 import type * as schemas from "./schemas.js";
-import type { Class, LazyPropsOf } from "./util.js";
+import type { Class, ProtoOf } from "./util.js";
 import { members as installMembers } from "./util.js";
 //////////////////////////////   CONSTRUCTORS   ///////////////////////////////////////
 
@@ -13,7 +13,7 @@ export interface $constructor<T extends ZodTrait, D = T["_zod"]["def"]> {
 export interface $constructorParams<T> {
   Parent?: typeof Class;
   /** This trait's members, installed once on every prototype that composes it. They cannot be declared in the initializer above: that runs per instance, and the prototype is shared. */
-  proto?: LazyPropsOf<T>;
+  proto?: ProtoOf<T>;
 }
 
 /** A special constant with type `never` */

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -1,12 +1,19 @@
 import type * as errors from "./errors.js";
 import type * as schemas from "./schemas.js";
-import type { Class } from "./util.js";
+import type { Class, LazyPropsOf } from "./util.js";
+import { members as installMembers } from "./util.js";
 //////////////////////////////   CONSTRUCTORS   ///////////////////////////////////////
 
 type ZodTrait = { _zod: { def: any; [k: string]: any } };
 export interface $constructor<T extends ZodTrait, D = T["_zod"]["def"]> {
   new (def: D): T;
   init(inst: T, def: D): asserts inst is T;
+}
+
+export interface $constructorParams<T> {
+  Parent?: typeof Class;
+  /** This trait's members, installed once on every prototype that composes it. They cannot be declared in the initializer above: that runs per instance, and the prototype is shared. */
+  proto?: LazyPropsOf<T>;
 }
 
 /** A special constant with type `never` */
@@ -17,6 +24,9 @@ export const NEVER: never = /*@__PURE__*/ Object.freeze({
 /* Shared descriptor for installing `_zod`; defineProperty reads it
  * synchronously, so reusing one object avoids a per-instance allocation. */
 const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
+
+// Set while constructing an instance whose constructor has already run its prototype initializers. They are idempotent, so on every construction after the first they have nothing to do; this is how they find that out without looking.
+let protoReady = false;
 
 // null where suppressing the capture would be unrecoverable: `parse()` puts the frames back with `captureStackTrace`, so without it the throw would lose its stack. also latched to null once `stackTraceLimit` proves unassignable, which a realm can do at any point by hardening Error
 let _E: (ErrorConstructor & { stackTraceLimit?: number }) | null = "captureStackTrace" in Error ? Error : null;
@@ -46,7 +56,7 @@ function newError(Definition: new () => any): any {
 export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T["_zod"]["def"]>(
   name: string,
   initializer: (inst: T, def: D) => void,
-  params?: { Parent?: typeof Class }
+  params?: $constructorParams<T>
 ): $constructor<T, D> {
   // Prototype for this constructor's `_zod` internals. Lazily-derived fields (`values`, `pattern`, `optin`, …) install here once rather than as an accessor on every instance.
   const zodProto: any = {};
@@ -58,6 +68,10 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
     this.traits = new Set();
   }
   Internals.prototype = zodProto;
+
+  const protoMembers = params?.proto;
+  // One trait's members land on every prototype whose chain composes it, so the answer is per prototype rather than per trait.
+  const initialized = protoMembers && new WeakSet<object>();
 
   function init(inst: T, def: D) {
     if (!inst._zod) {
@@ -78,6 +92,14 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
 
     initializer(inst, def);
 
+    if (initialized && !protoReady) {
+      const proto = Object.getPrototypeOf(inst);
+      if (!initialized.has(proto)) {
+        initialized.add(proto);
+        installMembers(proto, protoMembers!);
+      }
+    }
+
     // support prototype modifications; for-in avoids the array allocation of Object.keys on the (usually empty) prototype
     const proto = _.prototype;
     for (const k in proto) {
@@ -93,9 +115,19 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
   class Definition extends Parent {}
   Object.defineProperty(Definition, "name", { value: name });
 
+  // Flipped by the first complete construction, which is what runs this constructor's prototype initializers.
+  let ready = false;
+
   function _(this: any, def: D) {
     const inst = params?.Parent ? newError(Definition) : this;
-    init(inst, def);
+    protoReady = ready;
+    try {
+      init(inst, def);
+    } finally {
+      // Cleared even on throw, so a direct `SomeTrait.init(obj, def)` outside a construction never inherits another constructor's answer.
+      protoReady = false;
+    }
+    ready = true;
     const deferred = inst._zod.deferred;
     if (deferred) {
       for (const fn of deferred) {

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -93,10 +93,15 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
     initializer(inst, def);
 
     if (initialized && !protoReady) {
-      const proto = Object.getPrototypeOf(inst);
-      if (!initialized.has(proto)) {
-        initialized.add(proto);
-        installMembers(proto, protoMembers!);
+      // `super(def)` from a user subclass gives `this` a prototype the subclass owns, and installing there would overwrite whatever the subclass declared. `constr` built the instance, so its prototype is the one below the subclass's that should carry the members. A plain object handed straight to `init` is not below it and takes them itself, as before.
+      const own = Object.getPrototypeOf(inst);
+      const ctorProto = inst._zod.constr.prototype;
+      let up: object | null = own;
+      while (up && up !== ctorProto) up = Object.getPrototypeOf(up);
+      const target = up ?? own;
+      if (!initialized.has(target)) {
+        initialized.add(target);
+        installMembers(target, protoMembers!);
       }
     }
 

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -115,19 +115,20 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
   class Definition extends Parent {}
   Object.defineProperty(Definition, "name", { value: name });
 
-  // Flipped by the first complete construction, which is what runs this constructor's prototype initializers.
-  let ready = false;
+  // The prototype the last complete construction built. Not a boolean: `super(def)` from a subclass gives `this` a prototype of `new.target.prototype`, so a constructor can complete without having built its own.
+  let builtProto: object | undefined;
 
   function _(this: any, def: D) {
     const inst = params?.Parent ? newError(Definition) : this;
-    protoReady = ready;
+    const proto = Object.getPrototypeOf(inst);
+    protoReady = proto === builtProto;
     try {
       init(inst, def);
     } finally {
       // Cleared even on throw, so a direct `SomeTrait.init(obj, def)` outside a construction never inherits another constructor's answer.
       protoReady = false;
     }
-    ready = true;
+    builtProto = proto;
     const deferred = inst._zod.deferred;
     if (deferred) {
       for (const fn of deferred) {

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -293,7 +293,9 @@ const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
 
 export const $ZodError: $constructor<$ZodError> = $constructor("$ZodError", initializer);
 interface $ZodRealError<T = any> extends $ZodError<T> {}
-export const $ZodRealError: $constructor<$ZodRealError> = $constructor("$ZodError", initializer, { Parent: Error });
+export const $ZodRealError: $constructor<$ZodRealError> = $constructor("$ZodError", initializer, undefined, {
+  Parent: Error,
+});
 
 ///////////////////    ERROR UTILITIES   ////////////////////////
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -324,13 +324,11 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   },
   {
     // Wrappers extend this by installing a richer factory over it; reading it eagerly would defeat the laziness.
-    proto: {
-      get "~standard"(): StandardSchemaV1.Props<any, any> {
-        return util.hide(this, "~standard", standardProps(this));
-      },
-      set "~standard"(value: StandardSchemaV1.Props<any, any>) {
-        util.own(this, "~standard", value);
-      },
+    get "~standard"(): StandardSchemaV1.Props<any, any> {
+      return util.hide(this, "~standard", standardProps(this));
+    },
+    set "~standard"(value: StandardSchemaV1.Props<any, any>) {
+      util.own(this, "~standard", value);
     },
   }
 );

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -326,10 +326,7 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
     // Wrappers extend this by installing a richer factory over it; reading it eagerly would defeat the laziness.
     proto: {
       get "~standard"(): StandardSchemaV1.Props<any, any> {
-        const props = standardProps(this);
-        // cached, but not enumerable: it was never an own data property, so it must stay out of `Object.keys`
-        Object.defineProperty(this, "~standard", { configurable: true, writable: true, value: props });
-        return props;
+        return util.hide(this, "~standard", standardProps(this));
       },
       set "~standard"(value: StandardSchemaV1.Props<any, any>) {
         util.own(this, "~standard", value);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -200,129 +200,133 @@ export interface $ZodType<
 export interface _$ZodType<T extends $ZodTypeInternals = $ZodTypeInternals>
   extends $ZodType<T["output"], T["input"], T> {}
 
-export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constructor("$ZodType", (inst, def) => {
-  inst ??= {} as any;
+export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constructor<$ZodType>(
+  "$ZodType",
+  (inst, def) => {
+    inst ??= {} as any;
 
-  inst._zod.def = def; // set _def property
-  inst._zod.bag = inst._zod.bag || {}; // initialize _bag object
-  inst._zod.version = version;
+    inst._zod.def = def; // set _def property
+    inst._zod.bag = inst._zod.bag || {}; // initialize _bag object
+    inst._zod.version = version;
 
-  const defChecks = inst._zod.def.checks;
-  // if inst is itself a checks.$ZodCheck, run it as a check
-  const checks: checks.$ZodCheck<never>[] = inst._zod.traits.has("$ZodCheck")
-    ? [inst as any, ...(defChecks ?? [])]
-    : defChecks?.length
-      ? [...defChecks]
-      : [];
+    const defChecks = inst._zod.def.checks;
+    // if inst is itself a checks.$ZodCheck, run it as a check
+    const checks: checks.$ZodCheck<never>[] = inst._zod.traits.has("$ZodCheck")
+      ? [inst as any, ...(defChecks ?? [])]
+      : defChecks?.length
+        ? [...defChecks]
+        : [];
 
-  for (const ch of checks) {
-    for (const fn of ch._zod.onattach) {
-      fn(inst);
+    for (const ch of checks) {
+      for (const fn of ch._zod.onattach) {
+        fn(inst);
+      }
     }
-  }
 
-  if (checks.length === 0) {
-    // deferred initializer inst._zod.parse is not yet defined
-    inst._zod.deferred ??= [];
-    inst._zod.deferred?.push(() => {
-      inst._zod.run = inst._zod.parse;
-    });
-  } else {
-    const runChecks = (
-      payload: ParsePayload,
-      checks: checks.$ZodCheck<never>[],
-      ctx?: ParseContextInternal | undefined
-    ): util.MaybeAsync<ParsePayload> => {
-      if (payload.memo) return payload;
+    if (checks.length === 0) {
+      // deferred initializer inst._zod.parse is not yet defined
+      inst._zod.deferred ??= [];
+      inst._zod.deferred?.push(() => {
+        inst._zod.run = inst._zod.parse;
+      });
+    } else {
+      const runChecks = (
+        payload: ParsePayload,
+        checks: checks.$ZodCheck<never>[],
+        ctx?: ParseContextInternal | undefined
+      ): util.MaybeAsync<ParsePayload> => {
+        if (payload.memo) return payload;
 
-      let isAborted = util.aborted(payload);
+        let isAborted = util.aborted(payload);
 
-      let asyncResult!: Promise<unknown> | undefined;
-      for (const ch of checks) {
-        if (ch._zod.def.when) {
-          if (util.explicitlyAborted(payload)) continue;
-          const shouldRun = ch._zod.def.when(payload);
-          if (!shouldRun) continue;
-        } else if (isAborted) {
-          continue;
-        }
-        const currLen = payload.issues.length;
-        const _ = ch._zod.check(payload as any) as any as ParsePayload;
+        let asyncResult!: Promise<unknown> | undefined;
+        for (const ch of checks) {
+          if (ch._zod.def.when) {
+            if (util.explicitlyAborted(payload)) continue;
+            const shouldRun = ch._zod.def.when(payload);
+            if (!shouldRun) continue;
+          } else if (isAborted) {
+            continue;
+          }
+          const currLen = payload.issues.length;
+          const _ = ch._zod.check(payload as any) as any as ParsePayload;
 
-        if (_ instanceof Promise && ctx?.async === false) {
-          throw new core.$ZodAsyncError();
-        }
-        if (asyncResult || _ instanceof Promise) {
-          asyncResult = (asyncResult ?? Promise.resolve()).then(async () => {
-            await _;
+          if (_ instanceof Promise && ctx?.async === false) {
+            throw new core.$ZodAsyncError();
+          }
+          if (asyncResult || _ instanceof Promise) {
+            asyncResult = (asyncResult ?? Promise.resolve()).then(async () => {
+              await _;
+              const nextLen = payload.issues.length;
+              if (nextLen === currLen) return;
+              util.attachSchema(payload.issues, currLen, inst);
+              if (!isAborted) isAborted = util.aborted(payload, currLen);
+            });
+          } else {
             const nextLen = payload.issues.length;
-            if (nextLen === currLen) return;
+            if (nextLen === currLen) continue;
             util.attachSchema(payload.issues, currLen, inst);
             if (!isAborted) isAborted = util.aborted(payload, currLen);
-          });
-        } else {
-          const nextLen = payload.issues.length;
-          if (nextLen === currLen) continue;
-          util.attachSchema(payload.issues, currLen, inst);
-          if (!isAborted) isAborted = util.aborted(payload, currLen);
-        }
-      }
-
-      if (asyncResult) {
-        return asyncResult.then(() => {
-          return payload;
-        });
-      }
-      return payload;
-    };
-
-    const handleCanaryResult = (canary: ParsePayload, payload: ParsePayload, ctx: ParseContextInternal) => {
-      // abort if the canary is aborted
-      if (util.aborted(canary)) {
-        canary.aborted = true;
-        return canary;
-      }
-
-      // run checks first, then
-      const checkResult = runChecks(payload, checks, ctx);
-      if (checkResult instanceof Promise) {
-        if (ctx.async === false) throw new core.$ZodAsyncError();
-        return checkResult.then((checkResult) => inst._zod.parse(checkResult, ctx));
-      }
-      return inst._zod.parse(checkResult, ctx);
-    };
-
-    inst._zod.run = (payload, ctx) => {
-      if (ctx.skipChecks) {
-        return inst._zod.parse(payload, ctx);
-      }
-      if (ctx.direction === "backward") {
-        // run canary initial pass (no checks)
-        const canary = inst._zod.parse({ value: payload.value, issues: [] }, { ...ctx, skipChecks: true });
-
-        if (canary instanceof Promise) {
-          return canary.then((canary) => {
-            return handleCanaryResult(canary, payload, ctx);
-          });
+          }
         }
 
-        return handleCanaryResult(canary, payload, ctx);
-      }
+        if (asyncResult) {
+          return asyncResult.then(() => {
+            return payload;
+          });
+        }
+        return payload;
+      };
 
-      // forward
-      const result = inst._zod.parse(payload, ctx);
-      if (result instanceof Promise) {
-        if (ctx.async === false) throw new core.$ZodAsyncError();
-        return result.then((result) => runChecks(result, checks, ctx));
-      }
+      const handleCanaryResult = (canary: ParsePayload, payload: ParsePayload, ctx: ParseContextInternal) => {
+        // abort if the canary is aborted
+        if (util.aborted(canary)) {
+          canary.aborted = true;
+          return canary;
+        }
 
-      return runChecks(result, checks, ctx);
-    };
+        // run checks first, then
+        const checkResult = runChecks(payload, checks, ctx);
+        if (checkResult instanceof Promise) {
+          if (ctx.async === false) throw new core.$ZodAsyncError();
+          return checkResult.then((checkResult) => inst._zod.parse(checkResult, ctx));
+        }
+        return inst._zod.parse(checkResult, ctx);
+      };
+
+      inst._zod.run = (payload, ctx) => {
+        if (ctx.skipChecks) {
+          return inst._zod.parse(payload, ctx);
+        }
+        if (ctx.direction === "backward") {
+          // run canary initial pass (no checks)
+          const canary = inst._zod.parse({ value: payload.value, issues: [] }, { ...ctx, skipChecks: true });
+
+          if (canary instanceof Promise) {
+            return canary.then((canary) => {
+              return handleCanaryResult(canary, payload, ctx);
+            });
+          }
+
+          return handleCanaryResult(canary, payload, ctx);
+        }
+
+        // forward
+        const result = inst._zod.parse(payload, ctx);
+        if (result instanceof Promise) {
+          if (ctx.async === false) throw new core.$ZodAsyncError();
+          return result.then((result) => runChecks(result, checks, ctx));
+        }
+
+        return runChecks(result, checks, ctx);
+      };
+    }
+  },
+  {
+    // Wrappers extend this by installing a richer factory over it; reading it eagerly would defeat the laziness.
+    proto: { "~standard": standardProps },
   }
-
-  // Wrappers extend this by installing a richer factory over it; reading it eagerly would defeat the laziness.
-  util.installLazyProp(inst, "~standard", standardProps);
-});
+);
 
 /** The Standard Schema surface for `inst`. Shared so wrappers can extend it without forcing it. */
 const toStandardResult = (r: util.SafeParseResult<unknown>) =>

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -324,7 +324,17 @@ export const $ZodType: core.$constructor<$ZodType> = /*@__PURE__*/ core.$constru
   },
   {
     // Wrappers extend this by installing a richer factory over it; reading it eagerly would defeat the laziness.
-    proto: { "~standard": standardProps },
+    proto: {
+      get "~standard"(): StandardSchemaV1.Props<any, any> {
+        const props = standardProps(this);
+        // cached, but not enumerable: it was never an own data property, so it must stay out of `Object.keys`
+        Object.defineProperty(this, "~standard", { configurable: true, writable: true, value: props });
+        return props;
+      },
+      set "~standard"(value: StandardSchemaV1.Props<any, any>) {
+        util.own(this, "~standard", value);
+      },
+    },
   }
 );
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1071,8 +1071,8 @@ export abstract class Class {
 export function members(proto: object, table: object): void {
   for (const key in table) {
     const desc = Object.getOwnPropertyDescriptor(table, key)!;
-    // A getter installs as written, so it stays live — `description` reads through to the registry on every access.
-    if (desc.get) Object.defineProperty(proto, key, desc);
+    // A getter installs as written, so it stays live — `description` reads through to the registry on every access. Not enumerable: an object literal's is, and a prototype member never was.
+    if (desc.get) Object.defineProperty(proto, key, { ...desc, enumerable: false });
     else defineCached(proto, key, desc.value);
   }
 }

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1071,10 +1071,31 @@ export abstract class Class {
 export function members(proto: object, table: object): void {
   for (const key in table) {
     const desc = Object.getOwnPropertyDescriptor(table, key)!;
-    // A getter installs as written, so it stays live — `description` reads through to the registry on every access. Not enumerable: an object literal's is, and a prototype member never was.
+    // a getter installs as written, so it stays live: `description` reads through to the registry on every access. not enumerable: an object literal's is, and a prototype member never was
     if (desc.get) Object.defineProperty(proto, key, { ...desc, enumerable: false });
-    else defineCached(proto, key, desc.value);
+    // a method materializes bound on first read, which is what keeps a detached member working: `const opt = schema.optional; opt()`
+    else defineBound(proto, key, desc.value);
   }
+}
+
+/** Shadows a prototype member with an own value, so a getter that builds from the instance runs once. */
+export function own<T>(inst: object, key: string, value: T): T {
+  Object.defineProperty(inst, key, { configurable: true, writable: true, enumerable: true, value });
+  return value;
+}
+
+function defineBound(proto: object, key: string, fn: AnyFunc): void {
+  Object.defineProperty(proto, key, {
+    configurable: true,
+    get(this: any) {
+      const value = fn.bind(this);
+      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
+      return value;
+    },
+    set(this: any, value: unknown) {
+      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
+    },
+  });
 }
 
 /** Returns the prototype to install on, or `undefined` if this group is already installed on it. */
@@ -1116,10 +1137,15 @@ export type LazyPropsOf<T> = {
     | undefined;
 } & ThisType<T>;
 
+/** A trait's prototype members: a partial view of its own interface, with `this` typed as the instance. */
+export type ProtoOf<T> = {
+  // `infer R` resolves a polymorphic `this` return type to `T`, which a method written here can actually produce
+  [K in keyof T]?: (T[K] extends (...args: infer A) => infer R ? (...args: A) => R : T[K]) | undefined;
+} & ThisType<T>;
+
 /**
- * Installs methods that bind to the instance on first access. Not for hot-path
- * functions — a bound function pays a call-time trampoline; use
- * `installLazyProps` there.
+ * Installs methods that bind to the instance on first access. Superseded by
+ * `$constructor`'s `proto` parameter; kept for anyone who called it directly.
  */
 export function installLazyMethods<T extends object>(inst: T, sentinel: string, methods: () => LazyMethodsOf<T>): void {
   const proto = claim(inst, sentinel);
@@ -1131,7 +1157,7 @@ export function installLazyMethods<T extends object>(inst: T, sentinel: string, 
   }
 }
 
-/** Like `installLazyMethods`, but the factory builds the value instead of binding a shared function. */
+/** Like `installLazyMethods`, but the factory builds the value instead of binding a shared function. Superseded by `$constructor`'s `proto` parameter. */
 export function installLazyProps<T extends object>(inst: T, sentinel: string, props: () => LazyPropsOf<T>): void {
   const proto = claim(inst, sentinel);
   if (!proto) return;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1063,6 +1063,20 @@ export abstract class Class {
 //
 // Members live on the prototype and materialize per instance on first read, which keeps own-property count under the step where V8 stops using inline slots. Changing anything here means re-measuring runtime, memory and bundle size together — see "The three axes" in AGENTS.md.
 
+/**
+ * Installs a trait's members on its prototype. Each value builds that member for one instance on first read; the built value shadows the accessor as an own property, so a detached `const { parse } = schema` keeps working.
+ *
+ * Call this from a `proto` initializer, which runs once per prototype — never per instance.
+ */
+export function members(proto: object, table: object): void {
+  for (const key in table) {
+    const desc = Object.getOwnPropertyDescriptor(table, key)!;
+    // A getter installs as written, so it stays live — `description` reads through to the registry on every access.
+    if (desc.get) Object.defineProperty(proto, key, desc);
+    else defineCached(proto, key, desc.value);
+  }
+}
+
 /** Returns the prototype to install on, or `undefined` if this group is already installed on it. */
 function claim(inst: object, sentinel: string): object | undefined {
   const proto = Object.getPrototypeOf(inst);
@@ -1091,8 +1105,16 @@ export type LazyMethodsOf<T> = Partial<{
   [K in keyof T]: T[K] extends (...args: infer A) => infer R ? (this: T, ...args: A) => R : never;
 }>;
 
-/** Factories for properties whose value is built per instance on first read. */
-export type LazyPropsOf<T> = Partial<{ [K in keyof T]: (self: T) => T[K] }>;
+/**
+ * A trait's members, as `$constructor` takes them. Each entry is a factory that builds the member for one instance on first read, except a getter, which installs as written and stays live.
+ *
+ * A method's signature is erased to its call form, so an overloaded or generic one is written once against its constraint.
+ */
+export type LazyPropsOf<T> = {
+  [K in keyof T]?:
+    | (T[K] extends (...args: infer A) => infer R ? (self: T) => (...args: A) => R : ((self: T) => T[K]) | T[K])
+    | undefined;
+} & ThisType<T>;
 
 /**
  * Installs methods that bind to the instance on first access. Not for hot-path

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1105,7 +1105,7 @@ function claim(inst: object, sentinel: string): object | undefined {
   return sentinel in proto ? undefined : proto;
 }
 
-function defineCached(proto: object, key: string, compute: (inst: any) => unknown): void {
+function defineCached(proto: object, key: string, compute: (self: any) => unknown): void {
   // `~standard` was never an own data property, so caching it must not add it to `Object.keys`. Everything else here was enumerable and stays so.
   const enumerable = key !== "~standard";
   Object.defineProperty(proto, key, {
@@ -1153,7 +1153,7 @@ export function installLazyMethods<T extends object>(inst: T, sentinel: string, 
   const built = methods();
   for (const key in built) {
     const fn = built[key]!;
-    defineCached(proto, key, (inst) => (fn as AnyFunc).bind(inst));
+    defineCached(proto, key, (self) => (fn as AnyFunc).bind(self));
   }
 }
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1064,7 +1064,7 @@ export abstract class Class {
 // Members live on the prototype and materialize per instance on first read, which keeps own-property count under the step where V8 stops using inline slots. Changing anything here means re-measuring runtime, memory and bundle size together — see "The three axes" in AGENTS.md.
 
 /**
- * Installs a trait's members on its prototype. Each value builds that member for one instance on first read; the built value shadows the accessor as an own property, so a detached `const { parse } = schema` keeps working.
+ * Installs a trait's members on its prototype. Each value builds that member for the instance on first read; the built value shadows the accessor as an own property, so a detached `const { parse } = schema` keeps working.
  *
  * Call this from a `proto` initializer, which runs once per prototype — never per instance.
  */
@@ -1084,7 +1084,7 @@ function claim(inst: object, sentinel: string): object | undefined {
   return sentinel in proto ? undefined : proto;
 }
 
-function defineCached(proto: object, key: string, compute: (self: any) => unknown): void {
+function defineCached(proto: object, key: string, compute: (inst: any) => unknown): void {
   // `~standard` was never an own data property, so caching it must not add it to `Object.keys`. Everything else here was enumerable and stays so.
   const enumerable = key !== "~standard";
   Object.defineProperty(proto, key, {
@@ -1112,7 +1112,7 @@ export type LazyMethodsOf<T> = Partial<{
  */
 export type LazyPropsOf<T> = {
   [K in keyof T]?:
-    | (T[K] extends (...args: infer A) => infer R ? (self: T) => (...args: A) => R : ((self: T) => T[K]) | T[K])
+    | (T[K] extends (...args: infer A) => infer R ? (inst: T) => (...args: A) => R : ((inst: T) => T[K]) | T[K])
     | undefined;
 } & ThisType<T>;
 
@@ -1127,7 +1127,7 @@ export function installLazyMethods<T extends object>(inst: T, sentinel: string, 
   const built = methods();
   for (const key in built) {
     const fn = built[key]!;
-    defineCached(proto, key, (self) => (fn as AnyFunc).bind(self));
+    defineCached(proto, key, (inst) => (fn as AnyFunc).bind(inst));
   }
 }
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1080,7 +1080,16 @@ export function members(proto: object, table: object): void {
 
 /** Shadows a prototype member with an own value, so a getter that builds from the instance runs once. */
 export function own<T>(inst: object, key: string, value: T): T {
-  Object.defineProperty(inst, key, { configurable: true, writable: true, enumerable: true, value });
+  return shadow(inst, key, value, true);
+}
+
+/** Like {@link own}, for a member that was never an own data property and has to stay out of `Object.keys`. */
+export function hide<T>(inst: object, key: string, value: T): T {
+  return shadow(inst, key, value, false);
+}
+
+function shadow<T>(inst: object, key: string, value: T, enumerable: boolean): T {
+  Object.defineProperty(inst, key, { configurable: true, writable: true, enumerable, value });
   return value;
 }
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1079,30 +1079,24 @@ export function members(proto: object, table: object): void {
 }
 
 /** Shadows a prototype member with an own value, so a getter that builds from the instance runs once. */
-export function own<T>(inst: object, key: string, value: T): T {
-  return shadow(inst, key, value, true);
+export function own<T>(inst: object, key: string, value: T, enumerable = true): T {
+  Object.defineProperty(inst, key, { configurable: true, writable: true, enumerable, value });
+  return value;
 }
 
 /** Like {@link own}, for a member that was never an own data property and has to stay out of `Object.keys`. */
 export function hide<T>(inst: object, key: string, value: T): T {
-  return shadow(inst, key, value, false);
-}
-
-function shadow<T>(inst: object, key: string, value: T, enumerable: boolean): T {
-  Object.defineProperty(inst, key, { configurable: true, writable: true, enumerable, value });
-  return value;
+  return own(inst, key, value, false);
 }
 
 function defineBound(proto: object, key: string, fn: AnyFunc): void {
   Object.defineProperty(proto, key, {
     configurable: true,
     get(this: any) {
-      const value = fn.bind(this);
-      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
-      return value;
+      return own(this, key, fn.bind(this));
     },
     set(this: any, value: unknown) {
-      Object.defineProperty(this, key, { configurable: true, writable: true, enumerable: true, value });
+      own(this, key, value);
     },
   });
 }

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -59,23 +59,18 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
     set with(value: ZodMiniType["check"]) {
       util.own(this, "with", value);
     },
-
     parse(data, params) {
       return parse.parse(this, data, params, { callee: this.parse });
     },
-
     parseAsync(data, params) {
       return parse.parseAsync(this, data, params, { callee: this.parseAsync });
     },
-
     safeParse(data, params) {
       return parse.safeParse(this, data, params);
     },
-
     safeParseAsync(data, params) {
       return parse.safeParseAsync(this, data, params);
     },
-
     check(...checks) {
       const def = this.def;
       return this.clone(
@@ -91,20 +86,16 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
         { parent: true }
       );
     },
-
     clone(_def, params) {
       return core.clone(this, _def, params);
     },
-
     brand() {
       return this as any;
     },
-
     register(reg: any, meta: any): any {
       reg.add(this, meta);
       return this;
     },
-
     apply(fn: any, ...args: any[]) {
       return args.length === 0 ? fn(this) : fn(this, ...args);
     },

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -52,64 +52,62 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
     inst.type = def.type;
   },
   {
-    proto: {
-      // `with` is an alias for `check`: the same function object, not a wrapper.
-      get with(): ZodMiniType["check"] {
-        return this.check;
-      },
-      set with(value: ZodMiniType["check"]) {
-        util.own(this, "with", value);
-      },
+    // `with` is an alias for `check`: the same function object, not a wrapper.
+    get with(): ZodMiniType["check"] {
+      return this.check;
+    },
+    set with(value: ZodMiniType["check"]) {
+      util.own(this, "with", value);
+    },
 
-      parse(data, params) {
-        return parse.parse(this, data, params, { callee: this.parse });
-      },
+    parse(data, params) {
+      return parse.parse(this, data, params, { callee: this.parse });
+    },
 
-      parseAsync(data, params) {
-        return parse.parseAsync(this, data, params, { callee: this.parseAsync });
-      },
+    parseAsync(data, params) {
+      return parse.parseAsync(this, data, params, { callee: this.parseAsync });
+    },
 
-      safeParse(data, params) {
-        return parse.safeParse(this, data, params);
-      },
+    safeParse(data, params) {
+      return parse.safeParse(this, data, params);
+    },
 
-      safeParseAsync(data, params) {
-        return parse.safeParseAsync(this, data, params);
-      },
+    safeParseAsync(data, params) {
+      return parse.safeParseAsync(this, data, params);
+    },
 
-      // `this` is declared on the two members that call each other through it: without that TypeScript gives up on the whole literal's contextual types and every parameter below lands as `any`
-      check(this: ZodMiniType, ...checks) {
-        const def = this.def;
-        return this.clone(
-          {
-            ...def,
-            checks: [
-              ...(def.checks ?? []),
-              ...checks.map((ch) =>
-                typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
-              ),
-            ],
-          },
-          { parent: true }
-        );
-      },
+    // `this` is declared on the two members that call each other through it: without that TypeScript gives up on the whole literal's contextual types and every parameter below lands as `any`
+    check(this: ZodMiniType, ...checks) {
+      const def = this.def;
+      return this.clone(
+        {
+          ...def,
+          checks: [
+            ...(def.checks ?? []),
+            ...checks.map((ch) =>
+              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+            ),
+          ],
+        },
+        { parent: true }
+      );
+    },
 
-      clone(this: ZodMiniType, _def, params) {
-        return core.clone(this, _def, params);
-      },
+    clone(this: ZodMiniType, _def, params) {
+      return core.clone(this, _def, params);
+    },
 
-      brand() {
-        return this as any;
-      },
+    brand() {
+      return this as any;
+    },
 
-      register(reg: any, meta: any): any {
-        reg.add(this, meta);
-        return this;
-      },
+    register(reg: any, meta: any): any {
+      reg.add(this, meta);
+      return this;
+    },
 
-      apply(fn: any, ...args: any[]) {
-        return args.length === 0 ? fn(this) : fn(this, ...args);
-      },
+    apply(fn: any, ...args: any[]) {
+      return args.length === 0 ? fn(this) : fn(this, ...args);
     },
   }
 );

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -54,8 +54,11 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
   {
     proto: {
       // `with` is an alias for `check`: the same function object, not a wrapper.
-      get with() {
+      get with(): ZodMiniType["check"] {
         return this.check;
+      },
+      set with(value: ZodMiniType["check"]) {
+        util.own(this, "with", value);
       },
 
       parse(data, params) {

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -54,29 +54,29 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
   {
     proto: {
       // `with` is an alias for `check`: the same function object, not a wrapper.
-      with: (self) => self.check,
+      with: (inst) => inst.check,
 
-      parse: (self) => (data, params) => {
-        return parse.parse(self, data, params, { callee: self.parse });
+      parse: (inst) => (data, params) => {
+        return parse.parse(inst, data, params, { callee: inst.parse });
       },
 
-      parseAsync: (self) => (data, params) => {
-        return parse.parseAsync(self, data, params, { callee: self.parseAsync });
+      parseAsync: (inst) => (data, params) => {
+        return parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
       },
 
-      safeParse: (self) => (data, params) => {
-        return parse.safeParse(self, data, params);
+      safeParse: (inst) => (data, params) => {
+        return parse.safeParse(inst, data, params);
       },
 
-      safeParseAsync: (self) => (data, params) => {
-        return parse.safeParseAsync(self, data, params);
+      safeParseAsync: (inst) => (data, params) => {
+        return parse.safeParseAsync(inst, data, params);
       },
 
       check:
-        (self) =>
+        (inst) =>
         (...checks) => {
-          const def = self.def;
-          return self.clone(
+          const def = inst.def;
+          return inst.clone(
             {
               ...def,
               checks: [
@@ -90,23 +90,23 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
           );
         },
 
-      clone: (self) => (_def, params) => {
-        return core.clone(self, _def, params);
+      clone: (inst) => (_def, params) => {
+        return core.clone(inst, _def, params);
       },
 
-      brand: (self) => () => {
-        return self as any;
+      brand: (inst) => () => {
+        return inst as any;
       },
 
-      register: ((self: ZodMiniType) => (reg: any, meta: any) => {
-        reg.add(self, meta);
-        return self;
+      register: ((inst: ZodMiniType) => (reg: any, meta: any) => {
+        reg.add(inst, meta);
+        return inst;
       }) as any,
 
       apply:
-        (self) =>
+        (inst) =>
         (fn: any, ...args: any[]) => {
-          return args.length === 0 ? fn(self) : fn(self, ...args);
+          return args.length === 0 ? fn(inst) : fn(inst, ...args);
         },
     },
   }

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -76,8 +76,7 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
       return parse.safeParseAsync(this, data, params);
     },
 
-    // `this` is declared on the two members that call each other through it: without that TypeScript gives up on the whole literal's contextual types and every parameter below lands as `any`
-    check(this: ZodMiniType, ...checks) {
+    check(...checks) {
       const def = this.def;
       return this.clone(
         {
@@ -93,7 +92,7 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
       );
     },
 
-    clone(this: ZodMiniType, _def, params) {
+    clone(_def, params) {
       return core.clone(this, _def, params);
     },
 

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -54,61 +54,59 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
   {
     proto: {
       // `with` is an alias for `check`: the same function object, not a wrapper.
-      with: (inst) => inst.check,
-
-      parse: (inst) => (data, params) => {
-        return parse.parse(inst, data, params, { callee: inst.parse });
+      get with() {
+        return this.check;
       },
 
-      parseAsync: (inst) => (data, params) => {
-        return parse.parseAsync(inst, data, params, { callee: inst.parseAsync });
+      parse(data, params) {
+        return parse.parse(this, data, params, { callee: this.parse });
       },
 
-      safeParse: (inst) => (data, params) => {
-        return parse.safeParse(inst, data, params);
+      parseAsync(data, params) {
+        return parse.parseAsync(this, data, params, { callee: this.parseAsync });
       },
 
-      safeParseAsync: (inst) => (data, params) => {
-        return parse.safeParseAsync(inst, data, params);
+      safeParse(data, params) {
+        return parse.safeParse(this, data, params);
       },
 
-      check:
-        (inst) =>
-        (...checks) => {
-          const def = inst.def;
-          return inst.clone(
-            {
-              ...def,
-              checks: [
-                ...(def.checks ?? []),
-                ...checks.map((ch) =>
-                  typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
-                ),
-              ],
-            },
-            { parent: true }
-          );
-        },
-
-      clone: (inst) => (_def, params) => {
-        return core.clone(inst, _def, params);
+      safeParseAsync(data, params) {
+        return parse.safeParseAsync(this, data, params);
       },
 
-      brand: (inst) => () => {
-        return inst as any;
+      check(...checks) {
+        const def = this.def;
+        return this.clone(
+          {
+            ...def,
+            checks: [
+              ...(def.checks ?? []),
+              ...checks.map((ch) =>
+                typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+              ),
+            ],
+          },
+          { parent: true }
+        );
       },
 
-      register: ((inst: ZodMiniType) => (reg: any, meta: any) => {
-        reg.add(inst, meta);
-        return inst;
-      }) as any,
+      clone(_def, params) {
+        return core.clone(this, _def, params);
+      },
 
-      apply:
-        (inst) =>
-        (fn: any, ...args: any[]) => {
-          return args.length === 0 ? fn(inst) : fn(inst, ...args);
-        },
-    },
+      brand() {
+        return this as any;
+      },
+
+      register(reg: any, meta: any): any {
+        reg.add(this, meta);
+        return this;
+      },
+
+      apply(fn: any, ...args: any[]) {
+        return args.length === 0 ? fn(this) : fn(this, ...args);
+      },
+    } satisfies core.util.ProtoOf<ZodMiniType>,
   }
 );
 

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -41,7 +41,7 @@ export interface ZodMiniType<
 interface _ZodMiniType<out Internals extends core.$ZodTypeInternals = core.$ZodTypeInternals>
   extends ZodMiniType<any, any, Internals> {}
 
-export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$constructor(
+export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$constructor<ZodMiniType>(
   "ZodMiniType",
   (inst, def) => {
     if (!inst._zod) throw new Error("Uninitialized schema in ZodMiniType.");
@@ -50,57 +50,67 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
 
     inst.def = def;
     inst.type = def.type;
+  },
+  {
+    proto: {
+      // `with` is an alias for `check`: the same function object, not a wrapper.
+      with: (self) => self.check,
 
-    util.installLazyMethods<ZodMiniType>(inst, "parse", _zodMiniTypeMethods);
-    // `with` is an alias for `check`: the same function object, not a wrapper.
-    util.installLazyProp(inst, "with", (self: ZodMiniType) => self.check);
+      parse: (self) => (data, params) => {
+        return parse.parse(self, data, params, { callee: self.parse });
+      },
+
+      parseAsync: (self) => (data, params) => {
+        return parse.parseAsync(self, data, params, { callee: self.parseAsync });
+      },
+
+      safeParse: (self) => (data, params) => {
+        return parse.safeParse(self, data, params);
+      },
+
+      safeParseAsync: (self) => (data, params) => {
+        return parse.safeParseAsync(self, data, params);
+      },
+
+      check:
+        (self) =>
+        (...checks) => {
+          const def = self.def;
+          return self.clone(
+            {
+              ...def,
+              checks: [
+                ...(def.checks ?? []),
+                ...checks.map((ch) =>
+                  typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
+                ),
+              ],
+            },
+            { parent: true }
+          );
+        },
+
+      clone: (self) => (_def, params) => {
+        return core.clone(self, _def, params);
+      },
+
+      brand: (self) => () => {
+        return self as any;
+      },
+
+      register: ((self: ZodMiniType) => (reg: any, meta: any) => {
+        reg.add(self, meta);
+        return self;
+      }) as any,
+
+      apply:
+        (self) =>
+        (fn: any, ...args: any[]) => {
+          return args.length === 0 ? fn(self) : fn(self, ...args);
+        },
+    },
   }
 );
-
-function _zodMiniTypeMethods(): util.LazyMethodsOf<ZodMiniType> {
-  return {
-    parse(data, params) {
-      return parse.parse(this, data, params, { callee: this.parse });
-    },
-    parseAsync(data, params) {
-      return parse.parseAsync(this, data, params, { callee: this.parseAsync });
-    },
-    safeParse(data, params) {
-      return parse.safeParse(this, data, params);
-    },
-    safeParseAsync(data, params) {
-      return parse.safeParseAsync(this, data, params);
-    },
-    check(...checks) {
-      const def = this.def;
-      return this.clone(
-        {
-          ...def,
-          checks: [
-            ...(def.checks ?? []),
-            ...checks.map((ch) =>
-              typeof ch === "function" ? { _zod: { check: ch, def: { check: "custom" }, onattach: [] } } : ch
-            ),
-          ],
-        },
-        { parent: true }
-      );
-    },
-    clone(_def, params) {
-      return core.clone(this, _def, params);
-    },
-    brand() {
-      return this as any;
-    },
-    register(reg: any, meta: any) {
-      reg.add(this, meta);
-      return this;
-    },
-    apply(fn, ...args) {
-      return args.length === 0 ? fn(this) : fn(this, ...args);
-    },
-  };
-}
 
 export interface _ZodMiniString<T extends core.$ZodStringInternals<unknown> = core.$ZodStringInternals<unknown>>
   extends _ZodMiniType<T>,

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -77,7 +77,8 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
         return parse.safeParseAsync(this, data, params);
       },
 
-      check(...checks) {
+      // `this` is declared on the two members that call each other through it: without that TypeScript gives up on the whole literal's contextual types and every parameter below lands as `any`
+      check(this: ZodMiniType, ...checks) {
         const def = this.def;
         return this.clone(
           {
@@ -93,7 +94,7 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
         );
       },
 
-      clone(_def, params) {
+      clone(this: ZodMiniType, _def, params) {
         return core.clone(this, _def, params);
       },
 
@@ -109,7 +110,7 @@ export const ZodMiniType: core.$constructor<ZodMiniType> = /*@__PURE__*/ core.$c
       apply(fn: any, ...args: any[]) {
         return args.length === 0 ? fn(this) : fn(this, ...args);
       },
-    } satisfies core.util.ProtoOf<ZodMiniType>,
+    },
   }
 );
 

--- a/play.ts
+++ b/play.ts
@@ -1,10 +1,26 @@
 import { z } from "zod";
-
-const formDate = z.iso
-  .datetime({ offset: true })
-  .or(z.literal(""))
-  .transform((v) => (v === "" ? null : v));
-
-console.log("empty:", formDate.safeParse(""));
-console.log("valid:", formDate.safeParse("2024-01-15T10:30:00.000Z"));
-console.log("invalid:", formDate.safeParse("not-a-date"));
+import * as m from "zod/mini";
+declare const gc: () => void;
+const TAG = process.env.TAG ?? "?";
+let sink = 0;
+function bench(label: string, body: () => void, iters: number) {
+  for (let i = 0; i < 4; i++) body();
+  const s: number[] = [];
+  for (let k = 0; k < 15; k++) { if (typeof gc === "function") gc(); const t0 = process.hrtime.bigint(); body(); s.push(Number(process.hrtime.bigint() - t0) / iters); }
+  s.sort((a, b) => a - b);
+  console.log(`RESULT ${TAG} ${label} ${s[0].toFixed(2)}`);
+}
+const A = 150_000, B = 30_000, C = 6_000;
+const User = z.object({ id: z.string(), age: z.number(), tags: z.array(z.string()), email: z.email() });
+const data = { id: "x", age: 3, tags: ["a"], email: "a@b.co" };
+bench("string-ctor", () => { for (let j = 0; j < A; j++) sink += z.string() ? 0 : 1; }, A);
+bench("number-ctor", () => { for (let j = 0; j < A; j++) sink += z.number() ? 0 : 1; }, A);
+bench("object2-ctor", () => { for (let j = 0; j < B; j++) sink += z.object({ a: z.string(), b: z.number() }) ? 0 : 1; }, B);
+bench("array-ctor", () => { for (let j = 0; j < B; j++) sink += z.array(z.string()) ? 0 : 1; }, B);
+bench("moltar-ctor", () => { for (let j = 0; j < C; j++) sink += z.object({ id: z.string(), age: z.number(), tags: z.array(z.string()), email: z.email(), nested: z.object({ a: z.string(), b: z.number(), c: z.boolean() }) }) ? 0 : 1; }, C);
+bench("clone-ctor", () => { for (let j = 0; j < B; j++) sink += z.string().min(1).max(9) ? 0 : 1; }, B);
+bench("mini-string-ctor", () => { for (let j = 0; j < A; j++) sink += m.string() ? 0 : 1; }, A);
+bench("mini-object-ctor", () => { for (let j = 0; j < B; j++) sink += m.object({ a: m.string(), b: m.number() }) ? 0 : 1; }, B);
+bench("object-parse", () => { for (let j = 0; j < B; j++) sink += User.parse(data) ? 0 : 1; }, B);
+bench("string-parse", () => { const s2 = z.string(); for (let j = 0; j < A; j++) sink += s2.parse("hello") ? 0 : 1; }, A);
+if (sink === -1) console.log(sink);

--- a/play.ts
+++ b/play.ts
@@ -1,26 +1,10 @@
 import { z } from "zod";
-import * as m from "zod/mini";
-declare const gc: () => void;
-const TAG = process.env.TAG ?? "?";
-let sink = 0;
-function bench(label: string, body: () => void, iters: number) {
-  for (let i = 0; i < 4; i++) body();
-  const s: number[] = [];
-  for (let k = 0; k < 15; k++) { if (typeof gc === "function") gc(); const t0 = process.hrtime.bigint(); body(); s.push(Number(process.hrtime.bigint() - t0) / iters); }
-  s.sort((a, b) => a - b);
-  console.log(`RESULT ${TAG} ${label} ${s[0].toFixed(2)}`);
-}
-const A = 150_000, B = 30_000, C = 6_000;
-const User = z.object({ id: z.string(), age: z.number(), tags: z.array(z.string()), email: z.email() });
-const data = { id: "x", age: 3, tags: ["a"], email: "a@b.co" };
-bench("string-ctor", () => { for (let j = 0; j < A; j++) sink += z.string() ? 0 : 1; }, A);
-bench("number-ctor", () => { for (let j = 0; j < A; j++) sink += z.number() ? 0 : 1; }, A);
-bench("object2-ctor", () => { for (let j = 0; j < B; j++) sink += z.object({ a: z.string(), b: z.number() }) ? 0 : 1; }, B);
-bench("array-ctor", () => { for (let j = 0; j < B; j++) sink += z.array(z.string()) ? 0 : 1; }, B);
-bench("moltar-ctor", () => { for (let j = 0; j < C; j++) sink += z.object({ id: z.string(), age: z.number(), tags: z.array(z.string()), email: z.email(), nested: z.object({ a: z.string(), b: z.number(), c: z.boolean() }) }) ? 0 : 1; }, C);
-bench("clone-ctor", () => { for (let j = 0; j < B; j++) sink += z.string().min(1).max(9) ? 0 : 1; }, B);
-bench("mini-string-ctor", () => { for (let j = 0; j < A; j++) sink += m.string() ? 0 : 1; }, A);
-bench("mini-object-ctor", () => { for (let j = 0; j < B; j++) sink += m.object({ a: m.string(), b: m.number() }) ? 0 : 1; }, B);
-bench("object-parse", () => { for (let j = 0; j < B; j++) sink += User.parse(data) ? 0 : 1; }, B);
-bench("string-parse", () => { const s2 = z.string(); for (let j = 0; j < A; j++) sink += s2.parse("hello") ? 0 : 1; }, A);
-if (sink === -1) console.log(sink);
+
+const formDate = z.iso
+  .datetime({ offset: true })
+  .or(z.literal(""))
+  .transform((v) => (v === "" ? null : v));
+
+console.log("empty:", formDate.safeParse(""));
+console.log("valid:", formDate.safeParse("2024-01-15T10:30:00.000Z"));
+console.log("invalid:", formDate.safeParse("not-a-date"));


### PR DESCRIPTION
A trait's members were installed from inside its per-instance initializer, by one of two installers, each handed a sentinel key naming a member of the group it was about to install:

```ts
_installLazyMethods(inst, "check", _zodTypeMethods);
_installLazyProps(inst, "parse", _zodTypeParseProps);
```

The work is per prototype, but the initializer runs per instance, so every construction re-asked a question whose answer could not change. The tables floated at module scope, reachable only through those two calls. And the split between the two was not a real distinction.

`$constructor` takes the members instead, written the way they read on the instance:

```ts
export const ZodString: core.$constructor<ZodString> = core.$constructor<ZodString>(
  "ZodString",
  (inst, def) => {
    core.$ZodString.init(inst, def);
    _ZodString.init(inst, def);
  },
  {
    email(params) {
      return this.check(core._email(ZodEmail, params));
    },
    // ...
  }
);
```

It installs them once on every prototype that composes the trait. Composition still flattens through `init`, so a trait's members reach every prototype below it without being re-listed anywhere — there is no parent list to keep in sync. The sentinels are gone; idempotence is a set of the prototypes already done.

Two forms remain and both are ordinary JavaScript, meaning what they already mean. A **method** materializes bound to the instance on first read and caches as an own property — binding is what keeps `const opt = schema.optional; opt()` working, which `detached-methods.test.ts` pins across about thirty members. A **getter** installs as written and stays live, which `description` needs to read through to the registry on every access.

`ProtoOf<T>` is a partial view of the trait's own interface with `this` typed as the instance. Passing it directly is what lets every table stay plain, with no `satisfies` and no `this` parameter: the literal gets its contextual type, `ThisType<T>` included, before any member is checked. Nested under an options object it does not — re-nesting it on this head puts every parameter in the two base tables back to `any`.

The parse family stays a named function expression rather than method shorthand. `captureStackTrace(err, callee)` matches the function on the stack, and V8 pushes no frame for a bound function, so `callee: this.parse` strips nothing and the error's first frame becomes `core/parse.ts` instead of the caller's.

## Measurements

Construction, measured at this head against `main`: six interleaved rounds, minimum of fifteen samples with `gc()` between, one revision per process. The control column is `main`'s own code run a third time each round.

| case | `main` | this branch | control |
| --- | --- | --- | --- |
| `z.array(z.string())` | 1729.0 ns | -5.2% | +6.5% |
| `z.string()` | 611.1 ns | **-4.9%** | +0.6% |
| `z.string().min(1).max(9)` | 7694.1 ns | -3.3% | +1.2% |
| `z.object({a,b})` | 4448.1 ns | -3.2% | +0.6% |
| `z.object()` 5 keys + nested | 16441.8 ns | +0.4% | +2.3% |
| `z.number()` | 471.6 ns | -0.1% | +0.5% |
| mini `z.object({a,b})` | 3610.9 ns | +1.4% | +0.9% |
| mini `z.string()` | 639.1 ns | +3.2% | -0.2% |

A modest classic win and a small mini regression, and the `z.array` row is unusable — its control moved 6.5%.

An earlier revision of this branch was much faster to construct: `z.string()` at -18.8%, `z.number()` at -11.5%. That came from a latch remembering that the last construction had built this same prototype, so a repeat could skip the `WeakSet` lookup proving the install had happened. It bought construction speed only, gave mini nothing — mini construction was flat with it and is flat without — and did not manage correctness either. `protoReady` was module-level while `builtProto` was per-constructor, so a repeat construction of the same prototype held the flag set for the whole dynamic extent of its `init`; a nested `SomeTrait.init(plainObject, def)` reached from an initializer then read an answer about the outer construction and skipped its own install, leaving that object without members. Nothing in the built-in graph has that shape, so it was latent rather than live. It is gone, which is worth 34 gzipped bytes on every mini bundle, a shorter `$constructor`, and one fewer way to end up with a memberless object — `instance-footprint.test.ts` pins that last one, and restoring the latch on this head fails it.

Parse is flat against `main`, in the same conditions: a string leaf +0.1%, `number` 0.0%, `safeParse` -0.2%, a three-key object -0.8%, all inside a control that moves up to 0.4%. Two runs, because one is not enough here — the first put the object case at -9.0% and the second did not reproduce it. `z.object().parse()` allocates, so a single sample of it measures the collector as much as the code.

Worth stating plainly, because it contradicts a micro-benchmark: measured in isolation a bound call looked 16% to 37% slower than an equivalent closure, and in situ that does not appear. The bind is genuinely on the path — `z.string().parse.name` is `"bound _parse"`.

Memory is unchanged from `main`, which is the result to want here: #6318's saving is preserved rather than traded for anything. `realworld.ts` holds 60,447,152 bytes against `main`'s 60,450,832 at 500 resource schemas, and `schema-footprint` is byte-identical per schema — `z.string().min(1)` 3451 against 3453, `z.string().brand()` 872 against 872, mini `z.string()` 577 against 577. `dict-mode` reports `fast` for every instance and every internals object on both.

That is worth stating precisely, because an earlier revision of this branch did not manage it. Building each member as a per-key factory cost about 2.1% of retained heap; writing them as methods gives it back, because a bound function is cheaper to retain than a closure that captures the instance. The micro-benchmark that said the opposite is the same one that mispredicted the call cost.

Bundle is the axis that pays, gzipped, as the ceiling test measures it:

| fixture | `main` | this branch |
| --- | --- | --- |
| classic string | 20272 | +139 |
| mini boolean | 2876 | +70 |
| mini string | 3337 | +83 |
| mini object | 4408 | +95 |

About half of mini's is the subclass guard below, at 37 bytes. The rest is the member form: `this` is not renameable and a block body cannot collapse to an arrow, so `nullable(){return Un(this)}` minifies larger than `nullable:e=>()=>Mn(e)`. It is a real cost on the axis `zod/mini` is sold on, taken for a member you can read and for a subclass that keeps its own methods. The three mini ceilings move, re-measured plus the file's headroom.

## Subclassing

Installing onto `Object.getPrototypeOf(inst)` is wrong for `class MyString extends z.ZodString {}`: `super(def)` gives `this` a prototype the subclass owns, so the members landed there and overwrote whatever it declared. The members now go on the prototype of the constructor that built the instance, which `constr` already records, and the subclass's own methods win by being nearer in the chain. A plain object handed straight to `init` is not below that prototype and still takes the members itself.

`main` only avoided most of this by accident. Its sentinel was itself a member of the group being installed, so a subclass overriding `parse` or `check` happened to skip that group, while one overriding `optional` or `toLowerCase` did not — those are clobbered on `main` today. This branch keeps all of them.

## Compatibility

`$constructor` takes the members third and its options fourth — `$constructor(name, initializer, proto, params)`. The members are the reason a third argument exists, so they get the slot. Two call sites pass `Parent` and both are `$ZodError`; a third-party call that passed it third has to move it, which is the whole migration. A two-argument call is unaffected. `installLazyMethods`, `installLazyProps` and `installLazyProp` stay exported, and a custom type that composes a trait with `SomeTrait.init(inst, def)` is untouched. Bundlers still drop the unused installers.

The observable member surface matches `main` on enumerability, writability and configurability of every member. One difference, in the cheaper direction: `spa` and mini's `with` are pure aliases and now resolve through a getter, so reading one no longer leaves an own property behind where `main` did. Binding also restores the names the previous approach dropped: `z.string().check.name` is `"bound check"` rather than `""`.

`core.ts` now imports the installer from `util.ts`, which already imported from `core.ts`. The circular check excludes `v4/core`, where that cycle already existed, and the import is a hoisted function declaration called only at construction time, so there is no evaluation-order hazard. `pnpm check:circular` is clean.

Supersedes #6476, which latched the same per-construction guard without removing what it was guarding. Refs #6318, #6415.




