### PR TITLE
feat(v4): expose the memoizer through z.config() so zod/mini can opt in

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1580,7 +1580,7 @@ const result = Category.parse(input);
 result.subcategories[0] === result; // true
 ```
 
-Zod Mini requires an opt-in for this; see [Zod Mini](/packages/mini#no-cycle-support-by-default).
+Zod Mini requires an opt-in for this; see [Reference cycles](/packages/mini#reference-cycles).
 
 You can also represent *mutually recursive types*:
 

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1570,8 +1570,10 @@ type Category = z.infer<typeof Category>;
 // { name: string; subcategories: Category[] }
 ```
 
-Input that contains reference cycles parses too. A reference back to an input that is still being parsed resolves to the output object being built for it, so the output graph mirrors the input graph.
+Cyclical inputs work out of the box with Zod. For bundle size reasons, Zod Mini requires you to register a memoizer explicitly (see code example).
 
+<Tabs groupId="lib" items={["Zod", "Zod Mini"]}>
+<Tab value="Zod">
 ```ts
 const input: any = { name: "root", subcategories: [] };
 input.subcategories.push(input);
@@ -1579,15 +1581,17 @@ input.subcategories.push(input);
 const result = Category.parse(input);
 result.subcategories[0] === result; // true
 ```
-
-In Zod Mini this requires an opt-in, configured before any schema is defined:
-
+</Tab>
+<Tab value="Zod Mini">
 ```ts
-import * as z from "zod/mini";
-
-// cyclical inputs require an explicit memoizer in Zod Mini
+// register a memoizer before defining any schemas
 z.config({ memoizer: z.memoizer() });
+
+const result = Category.parse(input);
+result.subcategories[0] === result; // true
 ```
+</Tab>
+</Tabs>
 
 You can also represent *mutually recursive types*:
 

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1580,12 +1580,18 @@ input.subcategories.push(input);
 
 const result = Category.parse(input);
 result.subcategories[0] === result; // true
+
+// the output graph mirrors the input graph
+result.subcategories[0].subcategories[0] === result; // true
 ```
 </Tab>
 <Tab value="Zod Mini">
 ```ts
-// register a memoizer before defining any schemas
+// Zod Mini requires a memoizer, registered before schemas are defined
 z.config({ memoizer: z.memoizer() });
+
+const input: any = { name: "root", subcategories: [] };
+input.subcategories.push(input);
 
 const result = Category.parse(input);
 result.subcategories[0] === result; // true

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1580,7 +1580,14 @@ const result = Category.parse(input);
 result.subcategories[0] === result; // true
 ```
 
-Zod Mini requires an opt-in for this; see [Reference cycles](/packages/mini#reference-cycles).
+In Zod Mini this requires an opt-in, configured before any schema is defined:
+
+```ts
+import * as z from "zod/mini";
+
+// cyclical inputs require an explicit memoizer in Zod Mini
+z.config({ memoizer: z.memoizer() });
+```
 
 You can also represent *mutually recursive types*:
 

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -1570,9 +1570,17 @@ type Category = z.infer<typeof Category>;
 // { name: string; subcategories: Category[] }
 ```
 
-<Callout type="warn"> 
-  Though recursive schemas are supported, passing cyclical data into Zod will cause an infinite loop.
-</Callout>
+Input that contains reference cycles parses too. A reference back to an input that is still being parsed resolves to the output object being built for it, so the output graph mirrors the input graph.
+
+```ts
+const input: any = { name: "root", subcategories: [] };
+input.subcategories.push(input);
+
+const result = Category.parse(input);
+result.subcategories[0] === result; // true
+```
+
+Zod Mini requires an opt-in for this; see [Zod Mini](/packages/mini#no-cycle-support-by-default).
 
 You can also represent *mutually recursive types*:
 

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -241,13 +241,3 @@ z.config(z.locales.en());
 ```
 
 Refer to the [Locales](/error-customization#internationalization) docs for more on localization.
-
-## Reference cycles
-
-To parse input that contains [reference cycles](/api#recursive-objects), configure the memoizer before defining any schemas. Regular Zod does this automatically; Zod Mini leaves it to an opt-in, which keeps the memoizer out of bundles that never parse cyclical data.
-
-```ts
-import * as z from "zod/mini"
-
-z.config({ memoizer: z.memoizer() });
-```

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -241,3 +241,13 @@ z.config(z.locales.en());
 ```
 
 Refer to the [Locales](/error-customization#internationalization) docs for more on localization.
+
+## No cycle support by default
+
+Regular Zod parses input that contains [reference cycles](/api#recursive-objects) by default. Zod Mini does not, which keeps that code out of the bundle. To enable it, configure the memoizer before defining any schemas:
+
+```ts
+import * as z from "zod/mini"
+
+z.config({ memoizer: z.memoizer() });
+```

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -242,9 +242,9 @@ z.config(z.locales.en());
 
 Refer to the [Locales](/error-customization#internationalization) docs for more on localization.
 
-## No cycle support by default
+## Reference cycles
 
-Regular Zod parses input that contains [reference cycles](/api#recursive-objects) by default. Zod Mini does not, which keeps that code out of the bundle. To enable it, configure the memoizer before defining any schemas:
+To parse input that contains [reference cycles](/api#recursive-objects), configure the memoizer before defining any schemas. Regular Zod does this automatically; Zod Mini leaves it to an opt-in, which keeps the memoizer out of bundles that never parse cyclical data.
 
 ```ts
 import * as z from "zod/mini"

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -44,7 +44,8 @@ const CEILINGS: Record<string, number> = {
   "zod-mini-string": 3448,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
-  "zod-mini-object": 4531,
+  // Also carries the memoizer seam from #6482: each container init reads `globalConfig.memoizer` and calls `attach`, which is what lets `zod/mini` opt into cycle support. Measured 4512 locally but 4533 on CI — the gzip stream differs across zlib builds — so the headroom rides on the CI number.
+  "zod-mini-object": 4561,
 };
 
 /**

--- a/packages/zod/src/v4/classic/external.ts
+++ b/packages/zod/src/v4/classic/external.ts
@@ -13,6 +13,7 @@ export {
   type GlobalMeta,
   registry,
   config,
+  memoizer,
   $output,
   $input,
   $brand,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2201,6 +2201,7 @@ export interface ZodTransform<O = unknown, I = unknown>
 export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.$constructor(
   "ZodTransform",
   (inst, def) => {
+    _ensureDefaultMemoizer();
     core.$ZodTransform.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => processors.transformProcessor(inst, ctx, json, params);

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2210,9 +2210,6 @@ export const ZodTransform: core.$constructor<ZodTransform> = /*@__PURE__*/ core.
         throw new core.$ZodEncodeError(inst.constructor.name);
       }
 
-      // The value is a placeholder a back-edge is still waiting on, so the cycle closes through this transform. Its output can't exist in time to bind.
-      if (core.isBackEdge(_ctx, payload.value)) throw new core.$ZodCyclicError();
-
       (payload as core.$RefinementCtx).addIssue = (issue) => {
         if (typeof issue === "string") {
           payload.issues.push(util.issue(issue, payload.value, def));

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -14,6 +14,11 @@ function _ensureDefaultLocale(): void {
   if (!core.globalConfig.localeError) core.config(en());
 }
 
+// the default memoizer is read by the core container init, which runs before `ZodType.init`, so each container calls this first
+function _ensureDefaultMemoizer(): void {
+  if (!core.globalConfig.memoizer) core.config({ memoizer: core.memoizer() });
+}
+
 // Methods live on each concrete constructor's prototype and materialize per instance on first access, so a schema only pays for what it is asked for.
 
 ///////////////////////////////////////////
@@ -1474,7 +1479,7 @@ export interface ZodArray<T extends core.SomeType = core.$ZodType>
 export const ZodArray: core.$constructor<ZodArray> = /*@__PURE__*/ core.$constructor<ZodArray>(
   "ZodArray",
   (inst, def) => {
-    core.attachMemoizer(inst);
+    _ensureDefaultMemoizer();
     core.$ZodArray.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => processors.arrayProcessor(inst, ctx, json, params);
@@ -1621,7 +1626,7 @@ export interface ZodObject<
 export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$constructor<ZodObject>(
   "ZodObject",
   (inst, def) => {
-    core.attachMemoizer(inst);
+    _ensureDefaultMemoizer();
     core.$ZodObjectJIT.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => processors.objectProcessor(inst, ctx, json, params);
@@ -1844,7 +1849,7 @@ export interface ZodTuple<
 export const ZodTuple: core.$constructor<ZodTuple> = /*@__PURE__*/ core.$constructor<ZodTuple>(
   "ZodTuple",
   (inst, def) => {
-    core.attachMemoizer(inst);
+    _ensureDefaultMemoizer();
     core.$ZodTuple.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => processors.tupleProcessor(inst, ctx, json, params);
@@ -1905,7 +1910,7 @@ export interface ZodRecord<
   valueType: Value;
 }
 export const ZodRecord: core.$constructor<ZodRecord> = /*@__PURE__*/ core.$constructor("ZodRecord", (inst, def) => {
-  core.attachMemoizer(inst);
+  _ensureDefaultMemoizer();
   core.$ZodRecord.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.recordProcessor(inst, ctx, json, params);
@@ -1977,7 +1982,7 @@ export interface ZodMap<Key extends core.SomeType = core.$ZodType, Value extends
   size(size: number, params?: string | core.$ZodCheckSizeEqualsParams): this;
 }
 export const ZodMap: core.$constructor<ZodMap> = /*@__PURE__*/ core.$constructor("ZodMap", (inst, def) => {
-  core.attachMemoizer(inst);
+  _ensureDefaultMemoizer();
   core.$ZodMap.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.mapProcessor(inst, ctx, json, params);
@@ -2013,7 +2018,7 @@ export interface ZodSet<T extends core.SomeType = core.$ZodType>
   size(size: number, params?: string | core.$ZodCheckSizeEqualsParams): this;
 }
 export const ZodSet: core.$constructor<ZodSet> = /*@__PURE__*/ core.$constructor("ZodSet", (inst, def) => {
-  core.attachMemoizer(inst);
+  _ensureDefaultMemoizer();
   core.$ZodSet.init(inst, def);
   ZodType.init(inst, def);
   inst._zod.processJSONSchema = (ctx, json, params) => processors.setProcessor(inst, ctx, json, params);

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -646,7 +646,7 @@ test.each([false, true])("prefixes a shared node's issues once per reference (ji
 });
 
 test("the default memoizer is installed before the first container reads it", () => {
-  // nothing built yet in a fresh process; a container with only getter keys constructs no leaf first
+  // the delete manufactures the fresh-process state; a container with only getter keys then constructs no leaf before the config read
   delete z.config().memoizer;
   const Node: any = z.object({
     get self() {

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -658,3 +658,21 @@ test("the default memoizer is installed before the first container reads it", ()
   const out = Node.parse(input);
   expect(out.self).toBe(out);
 });
+
+test("guards a transform built before any container", () => {
+  // the guard attaches at construction, so a transform predating the first container must still get the default
+  delete z.config().memoizer;
+  const wrap = z.transform((value: any) => ({ wrapped: value }));
+  const Inner: any = z.object({
+    name: z.string(),
+    get self() {
+      return Wrapped;
+    },
+  });
+  const Wrapped: any = z.pipe(Inner, wrap);
+
+  const input: any = { name: "x" };
+  input.self = input;
+
+  expect(() => Wrapped.parse(input)).toThrow(/reference cycle/);
+});

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -644,3 +644,17 @@ test.each([false, true])("prefixes a shared node's issues once per reference (ji
     z.config({ jitless: false });
   }
 });
+
+test("the default memoizer is installed before the first container reads it", () => {
+  // nothing built yet in a fresh process; a container with only getter keys constructs no leaf first
+  delete z.config().memoizer;
+  const Node: any = z.object({
+    get self() {
+      return Node;
+    },
+  });
+  const input: any = {};
+  input.self = input;
+  const out = Node.parse(input);
+  expect(out.self).toBe(out);
+});

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -198,6 +198,8 @@ export interface $ZodConfig {
   localeError?: errors.$ZodErrorMap | undefined;
   /** Disable JIT schema compilation. Useful in environments that disallow `eval`. */
   jitless?: boolean | undefined;
+  /** Enables parsing input that contains reference cycles. Read when a schema is constructed. */
+  memoizer?: schemas.$ZodMemoizer | undefined;
   /**
    * Internal: post-processor invoked on every freshly-constructed schema
    * instance, after init and deferred fns run. Set by `import "zod/compile"`

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -32,20 +32,6 @@ function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
   return issues.map((iss) => (iss.path ? { ...iss, path: iss.path.slice() } : { ...iss }));
 }
 
-interface Memoizer extends $ZodMemoizer {
-  recursive: boolean | undefined;
-  /** Set immediately before delegating to core and cleared immediately after, so
-   * `alloc` registers only for a visit this module is driving. */
-  handoff: Map<object, Entry> | undefined;
-  /** `bucket` memoized for one parse; a recursive schema is re-entered many
-   * times and its bucket never changes. */
-  ctx: object | undefined;
-  bucket: Map<object, Entry> | undefined;
-  /** Allocated but unfinished entries. `alloc` and the matching pop both happen
-   * in the synchronous part of a parse, so they nest even when children are async. */
-  open: Entry[];
-}
-
 const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
 
 /** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */
@@ -101,97 +87,104 @@ function bucketFor(state: State, inst: $ZodType): Map<object, Entry> {
   return bucket;
 }
 
-/**
- * Gives a container cycle support. Call before the container's `init`, which
- * reads the memoizer once and closes over it.
- */
-export function attachMemoizer(inst: $ZodType): void {
-  const m: Memoizer = {
-    recursive: undefined,
-    handoff: undefined,
-    ctx: undefined,
-    bucket: undefined,
-    open: [],
-    alloc(_inst, payload, empty) {
-      const bucket = m.handoff;
-      if (!bucket) return empty;
-      m.handoff = undefined;
-      const entry: Entry = { value: empty, issues: null };
-      bucket.set(payload.value as object, entry);
-      m.open.push(entry);
-      return empty;
-    },
-  };
-  inst._zod.memoizer = m;
+// Set immediately before delegating to core and cleared immediately after, so `alloc` registers only for a visit this module is driving.
+let handoff: Map<object, Entry> | undefined;
 
-  // Wraps `parse`, not `run`. `run` is assigned by a deferred of core's own that would replace anything installed here first; wrapping `parse` reaches both ways core builds `run` — it copies `parse` when there are no checks, and reads it dynamically when there are.
-  inst._zod.deferred ??= [];
-  inst._zod.deferred.push(() => {
-    const base = inst._zod.parse;
+// Allocated but unfinished entries. `alloc` and the matching pop both happen in the synchronous part of a parse, so they nest even when children are async, and one stack serves every schema.
+const open: Entry[] = [];
 
-    const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload> => {
-      if (m.recursive === undefined) {
-        m.recursive = isRecursive(inst, new Set());
-        if (!m.recursive) {
-          // Nothing here can ever fire, so take it back out. `run` has to be checked too: with no checks on the schema, core copies `parse` into it rather than reading it each time.
-          inst._zod.parse = base;
-          if (inst._zod.run === wrapped) inst._zod.run = base;
-          return base(payload, ctx);
+const memo: $ZodMemoizer = {
+  alloc(_inst, payload, empty) {
+    const bucket = handoff;
+    if (!bucket) return empty;
+    handoff = undefined;
+    const entry: Entry = { value: empty, issues: null };
+    bucket.set(payload.value as object, entry);
+    open.push(entry);
+    return empty;
+  },
+
+  attach(inst) {
+    let isRecursiveInst: boolean | undefined;
+    // `bucket` memoized for one parse; a recursive schema is re-entered many times and its bucket never changes
+    let lastCtx: object | undefined;
+    let lastBucket: Map<object, Entry> | undefined;
+
+    // Wraps `parse` in a deferred so it sees the container's final parse. Core's own deferred copies `parse` into `run` when there are no checks, and it ran first, so `run` is patched to match; with checks, `run` reads `parse` dynamically.
+    inst._zod.deferred ??= [];
+    inst._zod.deferred.push(() => {
+      const base = inst._zod.parse;
+
+      const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload> => {
+        if (isRecursiveInst === undefined) {
+          isRecursiveInst = isRecursive(inst, new Set());
+          if (!isRecursiveInst) {
+            // Nothing here can ever fire, so take it back out.
+            inst._zod.parse = base;
+            if (inst._zod.run === wrapped) inst._zod.run = base;
+            return base(payload, ctx);
+          }
         }
-      }
 
-      const input = payload.value;
-      if (input === null || typeof input !== "object") return base(payload, ctx);
+        const input = payload.value;
+        if (input === null || typeof input !== "object") return base(payload, ctx);
 
-      let state = (ctx as WithState)[STATE];
-      if (!state) {
-        state = { buckets: new Map(), backEdges: undefined };
-        (ctx as WithState)[STATE] = state;
-      }
+        let state = (ctx as WithState)[STATE];
+        if (!state) {
+          state = { buckets: new Map(), backEdges: undefined };
+          (ctx as WithState)[STATE] = state;
+        }
 
-      let bucket: Map<object, Entry>;
-      if (m.ctx === ctx) {
-        bucket = m.bucket!;
-      } else {
-        bucket = bucketFor(state, inst);
-        m.ctx = ctx;
-        m.bucket = bucket;
-      }
-
-      const hit = bucket.get(input);
-      if (hit) {
-        payload.value = hit.value;
-        if (hit.issues) {
-          if (hit.issues.length) payload.issues.push(...cloneIssues(hit.issues));
+        let bucket: Map<object, Entry>;
+        if (lastCtx === ctx) {
+          bucket = lastBucket!;
         } else {
-          // Still being parsed: its own checks cover it, so skip them here.
-          payload.memo = true;
-          state.backEdges ??= new Set();
-          state.backEdges.add(hit.value as object);
+          bucket = bucketFor(state, inst);
+          lastCtx = ctx;
+          lastBucket = bucket;
         }
-        return payload;
-      }
 
-      m.handoff = bucket;
-      const depth = m.open.length;
-      const result = base(payload, ctx);
-      m.handoff = undefined;
-      // A container that rejected its input outright allocated nothing.
-      const entry = m.open.length > depth ? m.open.pop()! : undefined;
+        const hit = bucket.get(input);
+        if (hit) {
+          payload.value = hit.value;
+          if (hit.issues) {
+            if (hit.issues.length) payload.issues.push(...cloneIssues(hit.issues));
+          } else {
+            // Still being parsed: its own checks cover it, so skip them here.
+            payload.memo = true;
+            state.backEdges ??= new Set();
+            state.backEdges.add(hit.value as object);
+          }
+          return payload;
+        }
 
-      // Both paths written out so the sync one allocates no closure. It runs once per node, and capturing here cost more than everything else combined.
-      if (result instanceof Promise) {
-        return result.then((r) => {
-          if (entry) entry.issues = r.issues.length ? cloneIssues(r.issues) : NO_ISSUES;
-          return r;
-        });
-      }
-      if (entry) entry.issues = result.issues.length ? cloneIssues(result.issues) : NO_ISSUES;
-      return result;
-    };
+        handoff = bucket;
+        const depth = open.length;
+        const result = base(payload, ctx);
+        handoff = undefined;
+        // A container that rejected its input outright allocated nothing.
+        const entry = open.length > depth ? open.pop()! : undefined;
 
-    inst._zod.parse = wrapped;
-  });
+        // Both paths written out so the sync one allocates no closure. It runs once per node, and capturing here cost more than everything else combined.
+        if (result instanceof Promise) {
+          return result.then((r) => {
+            if (entry) entry.issues = r.issues.length ? cloneIssues(r.issues) : NO_ISSUES;
+            return r;
+          });
+        }
+        if (entry) entry.issues = result.issues.length ? cloneIssues(result.issues) : NO_ISSUES;
+        return result;
+      };
+
+      inst._zod.parse = wrapped;
+      if (inst._zod.run === base) inst._zod.run = wrapped;
+    });
+  },
+};
+
+/** The memoizer that gives containers cycle support. `zod` installs it by default; `zod/mini` opts in with `config({ memoizer: memoizer() })`. */
+export function memoizer(): $ZodMemoizer {
+  return memo;
 }
 
 /** Whether this value is a node a back-edge resolved to before it finished. */

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -104,6 +104,20 @@ const memo: $ZodMemoizer = {
     return empty;
   },
 
+  guard(inst) {
+    inst._zod.deferred ??= [];
+    inst._zod.deferred.push(() => {
+      const base = inst._zod.parse;
+      const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload> => {
+        // The value is a placeholder a back-edge is still waiting on, so the cycle closes through this transform. Its output can't exist in time to bind.
+        if (ctx.direction !== "backward" && isBackEdge(ctx, payload.value)) throw new $ZodCyclicError();
+        return base(payload, ctx);
+      };
+      inst._zod.parse = wrapped;
+      if (inst._zod.run === base) inst._zod.run = wrapped;
+    });
+  },
+
   attach(inst) {
     let isRecursiveInst: boolean | undefined;
     // `bucket` memoized for one parse; a recursive schema is re-entered many times and its bucket never changes

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -32,9 +32,9 @@ export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> ex
   readonly skipChecks?: boolean;
 }
 
-/** @internal Supplies the object a container builds into, registered before any
- * child is parsed so a reference back to the same input resolves to it. */
+/** Gives a container cycle support: `attach` wraps its parse, and `alloc` registers the object it builds into before any child is parsed so a reference back to the same input resolves to it. */
 export interface $ZodMemoizer {
+  attach(inst: $ZodType): void;
   alloc<T extends object>(inst: $ZodType, payload: ParsePayload, empty: T, ctx: ParseContextInternal): T;
 }
 
@@ -134,9 +134,6 @@ export interface _$ZodTypeInternals {
   optin?: "optional" | "defaulted" | undefined;
   /** @internal */
   optout?: "optional" | undefined;
-
-  /** @internal */
-  memoizer?: $ZodMemoizer | undefined;
 
   /** @internal The set of literal values that will pass validation. Must be an exhaustive set. Used to determine optionality in z.record().
    *
@@ -1787,7 +1784,8 @@ function handleArrayResult(result: ParsePayload<any>, final: ParsePayload<any[]>
 export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$constructor("$ZodArray", (inst, def) => {
   $ZodType.init(inst, def);
 
-  const memo = inst._zod.memoizer;
+  const memo = core.globalConfig.memoizer;
+  memo?.attach(inst);
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -2118,7 +2116,8 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
   const catchall = def.catchall;
 
   let value!: typeof _normalized.value;
-  const memo = inst._zod.memoizer;
+  const memo = core.globalConfig.memoizer;
+  memo?.attach(inst);
 
   inst._zod.parse = (payload, ctx) => {
     value ??= _normalized.value;
@@ -2169,7 +2168,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
     const superParse = inst._zod.parse;
     const _normalized = util.cached(() => normalizeDef(def));
 
-    const memo = inst._zod.memoizer;
+    const memo = core.globalConfig.memoizer;
 
     const generateFastpass = (shape: any) => {
       const normalized = _normalized.value;
@@ -2912,7 +2911,8 @@ export interface $ZodTuple<
 export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$constructor("$ZodTuple", (inst, def) => {
   $ZodType.init(inst, def);
   const items = def.items;
-  const memo = inst._zod.memoizer;
+  const memo = core.globalConfig.memoizer;
+  memo?.attach(inst);
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -3127,7 +3127,8 @@ export interface $ZodRecord<Key extends $ZodRecordKey = $ZodRecordKey, Value ext
 
 export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$constructor("$ZodRecord", (inst, def) => {
   $ZodType.init(inst, def);
-  const memo = inst._zod.memoizer;
+  const memo = core.globalConfig.memoizer;
+  memo?.attach(inst);
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -3329,7 +3330,8 @@ export interface $ZodMap<Key extends SomeType = $ZodType, Value extends SomeType
 
 export const $ZodMap: core.$constructor<$ZodMap> = /*@__PURE__*/ core.$constructor("$ZodMap", (inst, def) => {
   $ZodType.init(inst, def);
-  const memo = inst._zod.memoizer;
+  const memo = core.globalConfig.memoizer;
+  memo?.attach(inst);
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;
@@ -3434,7 +3436,8 @@ export interface $ZodSet<T extends SomeType = $ZodType> extends $ZodType {
 
 export const $ZodSet: core.$constructor<$ZodSet> = /*@__PURE__*/ core.$constructor("$ZodSet", (inst, def) => {
   $ZodType.init(inst, def);
-  const memo = inst._zod.memoizer;
+  const memo = core.globalConfig.memoizer;
+  memo?.attach(inst);
 
   inst._zod.parse = (payload, ctx) => {
     const input = payload.value;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -5,7 +5,6 @@ import * as core from "./core.js";
 import { Doc } from "./doc.js";
 import type * as errors from "./errors.js";
 import type * as JSONSchema from "./json-schema.js";
-import { $ZodCyclicError, isBackEdge } from "./memoizer.js";
 import { parse, parseAsync, safeParse, safeParseAsync } from "./parse.js";
 import * as regexes from "./regexes.js";
 import type { StandardSchemaV1 } from "./standard-schema.js";
@@ -36,6 +35,7 @@ export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> ex
 /** Gives a container cycle support: `attach` wraps its parse, and `alloc` registers the object it builds into before any child is parsed so a reference back to the same input resolves to it. */
 export interface $ZodMemoizer {
   attach(inst: $ZodType): void;
+  guard(inst: $ZodType): void;
   alloc<T extends object>(inst: $ZodType, payload: ParsePayload, empty: T, ctx: ParseContextInternal): T;
 }
 
@@ -3712,13 +3712,12 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
   (inst, def) => {
     $ZodType.init(inst, def);
     inst._zod.optin = "optional";
+    core.globalConfig.memoizer?.guard(inst);
+
     inst._zod.parse = (payload, ctx) => {
       if (ctx.direction === "backward") {
         throw new core.$ZodEncodeError(inst.constructor.name);
       }
-
-      // The value is a placeholder a back-edge is still waiting on, so the cycle closes through this transform. Its output can't exist in time to bind.
-      if (isBackEdge(ctx, payload.value)) throw new $ZodCyclicError();
 
       const _out = def.transform(payload.value, payload);
       if (ctx.async) {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -5,6 +5,7 @@ import * as core from "./core.js";
 import { Doc } from "./doc.js";
 import type * as errors from "./errors.js";
 import type * as JSONSchema from "./json-schema.js";
+import { $ZodCyclicError, isBackEdge } from "./memoizer.js";
 import { parse, parseAsync, safeParse, safeParseAsync } from "./parse.js";
 import * as regexes from "./regexes.js";
 import type { StandardSchemaV1 } from "./standard-schema.js";
@@ -3715,6 +3716,9 @@ export const $ZodTransform: core.$constructor<$ZodTransform> = /*@__PURE__*/ cor
       if (ctx.direction === "backward") {
         throw new core.$ZodEncodeError(inst.constructor.name);
       }
+
+      // The value is a placeholder a back-edge is still waiting on, so the cycle closes through this transform. Its output can't exist in time to bind.
+      if (isBackEdge(ctx, payload.value)) throw new $ZodCyclicError();
 
       const _out = def.transform(payload.value, payload);
       if (ctx.async) {

--- a/packages/zod/src/v4/mini/external.ts
+++ b/packages/zod/src/v4/mini/external.ts
@@ -12,6 +12,7 @@ export {
   globalRegistry,
   registry,
   config,
+  memoizer,
   $output,
   $input,
   $brand,

--- a/packages/zod/src/v4/mini/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/mini/tests/cyclic-data.test.ts
@@ -1,5 +1,10 @@
-import { expect, test } from "vitest";
+import { beforeEach, expect, test } from "vitest";
 import * as z from "zod/mini";
+
+// the config object lives on globalThis, so only file isolation protects it; pin the unset precondition explicitly
+beforeEach(() => {
+  delete z.config().memoizer;
+});
 
 const cyclic = (): any => {
   const input: any = { id: 1 };
@@ -37,4 +42,43 @@ test("the opt-in reaches every core container", () => {
   input.push(input);
   const out = Arr.parse(input);
   expect(out[0]).toBe(out);
+});
+
+test("rejects a cycle that closes through a transform", () => {
+  z.config({ memoizer: z.memoizer() });
+  const Inner: any = z.object({
+    name: z.string(),
+    get self() {
+      return Wrapped;
+    },
+  });
+  const Wrapped: any = z.pipe(
+    Inner,
+    z.transform((value: any) => ({ wrapped: value }))
+  );
+
+  const input: any = { name: "x" };
+  input.self = input;
+
+  expect(() => Wrapped.parse(input)).toThrow(/reference cycle/);
+});
+
+test("leaves a transform that is not on the cycle alone", () => {
+  z.config({ memoizer: z.memoizer() });
+  const Node: any = z.object({
+    n: z.pipe(
+      z.number(),
+      z.transform((value: number) => value * 2)
+    ),
+    get self() {
+      return Node;
+    },
+  });
+
+  const input: any = { n: 21 };
+  input.self = input;
+
+  const result = Node.parse(input);
+  expect(result.n).toBe(42);
+  expect(result.self).toBe(result);
 });

--- a/packages/zod/src/v4/mini/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/mini/tests/cyclic-data.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import * as z from "zod/mini";
+
+const cyclic = (): any => {
+  const input: any = { id: 1 };
+  input.self = input;
+  return input;
+};
+
+test("cyclic input needs the memoizer opt-in", () => {
+  const Before: any = z.object({
+    id: z.number(),
+    get self() {
+      return Before;
+    },
+  });
+  expect(() => Before.parse(cyclic())).toThrow(RangeError);
+
+  z.config({ memoizer: z.memoizer() });
+  const After: any = z.object({
+    id: z.number(),
+    get self() {
+      return After;
+    },
+  });
+  const out = After.parse(cyclic());
+  expect(out.self).toBe(out);
+  expect(out).not.toBe(cyclic());
+  // read at construction, so a schema built before the opt-in keeps none
+  expect(() => Before.parse(cyclic())).toThrow(RangeError);
+});
+
+test("the opt-in reaches every core container", () => {
+  z.config({ memoizer: z.memoizer() });
+  const Arr: any = z.array(z.lazy(() => Arr));
+  const input: any = [];
+  input.push(input);
+  const out = Arr.parse(input);
+  expect(out[0]).toBe(out);
+});


### PR DESCRIPTION
Follow-up to #6387. The cycle memoizer was wired into classic only — each container called `attachMemoizer` before its init — and `zod/mini` had no way to get it. It is now a config field, read when a schema is constructed:

```ts
import * as z from "zod/mini";

z.config({ memoizer: z.memoizer() });
```

Regular `zod` installs it by default on the first container construction, through the same hook as the default locale and for the same `sideEffects: false` reason.

One global memoizer replaces the per-instance objects. The handoff slot and the open-entry stack are module state — both are set and consumed in the synchronous part of one parse, so they nest across schemas — and the per-instance part (the recursive flag, the bucket cache) lives in the wrapper's closure. The `_zod.memoizer` field is gone. The wrap now runs after core's own `run = parse` deferred, so it patches `run` when core had copied the base parse into it.

The back-edge guard on a transform also rides the seam: the memoizer's `guard` wraps `$ZodTransform`'s parse when one is configured, so an opted-in mini rejects a cycle that closes through a transform exactly as classic does, and a mini bundle without the opt-in carries none of it.

The "cyclical data will cause an infinite loop" callout in the docs has been stale since #6387; it is replaced with a Zod / Zod Mini tabbed example that shows the opt-in inline.

Since the config is global, a process that loads both `zod` and `zod/mini` gives mini schemas the memoizer too once classic has built a container — same as the default locale.

Bundle (esbuild `--minify`, gzip -9):

| fixture | main | this PR |
|---|---|---|
| `zod-object` (classic) | 24223 | 24244 (+21) |
| `zod-mini-object` | 4497 | 4491 (−6) |
| `zod-mini-object` + `z.memoizer()` | — | 5099 (+602) |

Retained bytes per schema (`packages/bench/memory`):

| schema | main | this PR |
|---|---|---|
| `z.array(z.string())`, built | 1980 | 1828 (−152) |
| `z.array(z.string())`, parsed once | 2037 | 1821 (−216) |
| `z.object()` 3 keys, parsed once | 6160 | 5944 (−216) |
| recursive `z.object()`, parsed once | 7606 | 7000 (−606) |

Runtime (min of 7 samples × 5 interleaved rounds, separate processes, load 6–8):

| workload | main | this PR |
|---|---|---|
| flat object | 26.3 ns | 27.1 ns (+3.0%) |
| nested object | 64.8 ns | 65.9 ns (+1.7%) |
| array of 20 objects | 694 ns | 692 ns (−0.3%) |
| recursive schema, 364-node tree | 61.2 µs | 60.7 µs (−0.8%) |
| build `z.object()` 3 keys | 5.59 µs | 5.66 µs (+1.3%) |
| build `z.array(z.string())` | 1.90 µs | 1.73 µs (−9.0%) |
| build + first parse, object | 22.7 µs | 23.0 µs (+1.1%) |

The parse rows are noise: a non-recursive container unwraps itself on its first parse either way. Array construction drops the per-instance allocations.
