### PR TITLE
fix(docs): keep blog posts out of the docs collection

### DIFF
--- a/packages/docs/source.config.ts
+++ b/packages/docs/source.config.ts
@@ -2,6 +2,8 @@ import { defineCollections, defineConfig, defineDocs } from "fumadocs-mdx/config
 
 export const docs = defineDocs({
   dir: "content",
+  // posts belong to blogPosts only; here they would also prerender through the docs route, which has no Tab
+  docs: { files: ["**/*", "!blog/**"] },
 });
 
 // Blog collection (for content under `content/blog`)


### PR DESCRIPTION
The docs collection globbed everything under `content/`, so every blog post was also a docs page: the docs catch-all route prerendered it next to `/blog/[slug]`, and it appeared in the search index and `llms.txt`. That route supplies `Tabs` but not `Tab`, so the 4.5 announcement failed to prerender there whenever Next generated that route first. The production deploy was green at 62471c9, red at fb3af01 and green again at 0a69bcb with only a frontmatter date in between.

This excludes `blog/**` from the docs collection. Blog posts render only through `/blog/[slug]`, which already provides both components, and they drop out of the docs search index and `llms.txt`.
