### PR TITLE
ci: gate the GitHub release and JSR publish on the version being live on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,22 @@ jobs:
         run: |
           echo "Published ${{ steps.publish.outputs.type }} version: ${{ steps.publish.outputs.version }}"
 
+      # npm can accept a publish and never finish processing it (4.5.0 sat in a phantom "staged" state); the action still reports success, so nothing below may run until the registry actually serves the version
+      - name: Verify the version is live on npm
+        if: ${{ steps.publish.outputs.type }}
+        env:
+          VERSION: ${{ steps.publish.outputs.version }}
+        run: |
+          for i in $(seq 1 40); do
+            if curl -sf "https://registry.npmjs.org/zod/$VERSION" > /dev/null; then
+              echo "zod@$VERSION is live"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "zod@$VERSION is not on the registry after 10 minutes; stopping before the GitHub release and the JSR publish"
+          exit 1
+
       - name: Set canary version
         if: ${{ !steps.publish.outputs.type }}
         working-directory: ./packages/zod


### PR DESCRIPTION
The release workflow gates the changelog, the GitHub release and the JSR publish on `steps.publish.outputs.type`, which the npm-publish action sets whenever `npm publish` returns a success payload. Today npm accepted `zod@4.5.0` into a phantom staged state and never finished processing it — the CLI got a success-shaped response with no version id, the action reported `type: minor`, and the tag, the release and `@zod/zod@4.5.0` on JSR all went out for a version npm still does not serve (npm/cli#9889).

This adds a step after the publish that polls the registry for up to ten minutes and fails the job if the exact version is not served. A failed step stops everything after it, so the release and the JSR publish only happen once `npm i zod@<version>` would actually work.