### PR TITLE
ci: drop canary publishing from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
       - main
     paths:
       - "packages/zod/package.json"
-      - "packages/zod/src/**"
       - ".github/workflows/release.yml"
 
 jobs:
@@ -126,28 +125,6 @@ jobs:
           echo "zod@$VERSION is not on the registry after 10 minutes; stopping before the GitHub release and the JSR publish"
           exit 1
 
-      - name: Set canary version
-        if: ${{ !steps.publish.outputs.type }}
-        working-directory: ./packages/zod
-        run: |
-          npm --no-git-tag-version version minor
-          npm --no-git-tag-version version $(npm pkg get version | sed 's/"//g')-canary.$(date +'%Y%m%dT%H%M%S')
-
-      - name: Publish canary
-        if: ${{ !steps.publish.outputs.type }}
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          dry-run: false
-          provenance: true
-          tag: canary
-          package: ./packages/zod
-      
-      - name: Done with canary
-        if: ${{ !steps.publish.outputs.type }}
-        run: |
-          echo "Canary published."
-          exit 0
-     
       - name: Configure changelog
         if: ${{ steps.publish.outputs.type }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ git commit -m "<x.y.z>"   # commit message is just the version, e.g. "4.4.3"
 git push origin main
 ```
 
-The release workflow only fires on changes under `packages/zod/package.json`, `packages/zod/src/**`, or the workflow file itself, so the bump must include `package.json`. Watch the Actions tab to confirm `build_and_publish` succeeds.
+The release workflow only fires on changes under `packages/zod/package.json` or the workflow file itself, so the bump must include `package.json`. Watch the Actions tab to confirm `build_and_publish` succeeds.
 
 ## Format validators: spec compliance is not the bar
 

--- a/packages/docs-v3/README_KO.md
+++ b/packages/docs-v3/README_KO.md
@@ -606,16 +606,6 @@ bun add zod           # bun
 pnpm add zod          # pnpm
 ```
 
-Zod는 모든 커밋마다 카나리(canary) 버전도 배포합니다. 카나리 버전을 설치하려면:
-
-```sh
-npm install zod@canary       # npm
-deno add npm:zod@canary      # deno
-yarn add zod@canary          # yarn
-bun add zod@canary           # bun
-pnpm add zod@canary          # pnpm
-```
-
 > 이 README의 나머지 부분은 여러분이 npm을 사용하고 `"zod"` 패키지에서 직접 임포트한다고 가정합니다.
 
 ## 기본 사용법

--- a/packages/docs-v3/home.md
+++ b/packages/docs-v3/home.md
@@ -636,16 +636,6 @@ bun add zod           # bun
 pnpm add zod          # pnpm
 ```
 
-Zod also publishes a canary version on every commit. To install the canary:
-
-```sh
-npm install zod@canary       # npm
-deno add npm:zod@canary      # deno
-yarn add zod@canary          # yarn
-bun add zod@canary           # bun
-pnpm add zod@canary          # pnpm
-```
-
 > The rest of this README assumes you are using npm and importing directly from the `"zod"` package.
 
 <br/>

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -115,8 +115,6 @@ await schema.parseAsync("hello");
 
 ### AOT compilation
 
-**Canary only** — compilation has not shipped in a stable release yet. Install with `npm install zod@canary`.
-
 For hot validation paths, `z.compile(schema)` returns a schema clone with an ahead-of-time compiled fast path. Valid inputs take the compiled path; invalid inputs fall back to the regular parser so error reporting stays identical.
 
 Across a 55-schema benchmark the median speedup is **2.4x**, and it scales with how much work the schema does per parse: a large array of objects is ~9x, a 20-key object ~9x, a nested object ~4.5x, while a bare `z.string()` gains nothing — compilation removes per-node dispatch and allocation, and a single `typeof` has none to remove.


### PR DESCRIPTION
Every push to `main` that didn't bump the version published a `-canary` build under the `canary` dist-tag: 459 canary versions on npm, 131 of them for 4.5.0 alone, ~30 a week in August, for about 0.01% of weekly downloads. That is the OIDC publish path running unattended on every merge, which is the exact surface #6106 is worried about, and it makes the release workflow duplicate `test.yml` on every push.

This removes the canary steps and narrows the trigger to `packages/zod/package.json` and the workflow file, so the release workflow only runs on a version bump. The README callout pointing at `zod@canary` for compilation goes too, since `z.compile()` shipped in 4.5.

Follow-up outside this PR: `npm dist-tag rm zod canary` so the tag stops pointing at the last canary build. The `next`, `alpha` and `beta` tags are stale in the same way.

Refs #6106
