### PR TITLE
fix(v4): let a prototype method getter answer a bare call so vi.spyOn works

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -305,7 +305,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     },
     // `spa` is an alias: same function object as `safeParseAsync`, as before.
     get spa(): ZodType["safeParseAsync"] {
-      return this.safeParseAsync;
+      return this?.safeParseAsync;
     },
     set spa(value: ZodType["safeParseAsync"]) {
       util.own(this, "spa", value);
@@ -334,11 +334,8 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     async safeDecodeAsync(data, params) {
       return parse.safeDecodeAsync(this, data, params);
     },
-    get toJSONSchema(): ZodType["toJSONSchema"] {
-      return util.own(this, "toJSONSchema", createToJSONSchemaMethod(this, {}));
-    },
-    set toJSONSchema(value: ZodType["toJSONSchema"]) {
-      util.own(this, "toJSONSchema", value);
+    toJSONSchema(params) {
+      return createToJSONSchemaMethod(this, {})(params);
     },
     // Reads through to the registry on every access, so it must not cache.
     get description(): string | undefined {

--- a/packages/zod/src/v4/classic/tests/detached-methods.test.ts
+++ b/packages/zod/src/v4/classic/tests/detached-methods.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import * as z from "zod/v4";
 
 /**
@@ -194,4 +194,16 @@ test("broad sweep: detaching builder methods does not throw or produce a corrupt
   }
 
   expect(broken).toEqual([]);
+});
+
+test("vi.spyOn wraps a prototype method that was never read", () => {
+  const schema = z.object({ a: z.string() });
+  const spy = vi.spyOn(schema, "safeParse").mockReturnValue({ success: true, data: { a: "mocked" } });
+
+  expect(schema.safeParse({})).toEqual({ success: true, data: { a: "mocked" } });
+  expect(spy).toHaveBeenCalledOnce();
+
+  spy.mockRestore();
+  expect(schema.safeParse({ a: "x" })).toEqual({ success: true, data: { a: "x" } });
+  expect(schema.safeParse({}).success).toBe(false);
 });

--- a/packages/zod/src/v4/classic/tests/detached-methods.test.ts
+++ b/packages/zod/src/v4/classic/tests/detached-methods.test.ts
@@ -206,4 +206,16 @@ test("vi.spyOn wraps a prototype method that was never read", () => {
   spy.mockRestore();
   expect(schema.safeParse({ a: "x" })).toEqual({ success: true, data: { a: "x" } });
   expect(schema.safeParse({}).success).toBe(false);
+
+  const json = vi.spyOn(schema, "toJSONSchema").mockReturnValue({ type: "null" } as any);
+  expect(schema.toJSONSchema()).toEqual({ type: "null" });
+  json.mockRestore();
+  expect(schema.toJSONSchema().type).toBe("object");
+});
+
+test("a getter member answers a bare read without a receiver", () => {
+  const schema = z.string();
+  const get = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(schema), "spa")!.get!;
+  expect(get.call(undefined)).toBeUndefined();
+  expect(schema.spa).toBe(schema.safeParseAsync);
 });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1093,7 +1093,8 @@ function defineBound(proto: object, key: string, fn: AnyFunc): void {
   Object.defineProperty(proto, key, {
     configurable: true,
     get(this: any) {
-      return own(this, key, fn.bind(this));
+      // vitest's spyOn calls a prototype getter bare to find the function it wraps, so a nullish receiver answers the raw method
+      return this == null ? fn : own(this, key, fn.bind(this));
     },
     set(this: any, value: unknown) {
       own(this, key, value);


### PR DESCRIPTION
Since 4.5.0 `vi.spyOn(schema, "safeParse")` throws `TypeError: Object.defineProperty called on non-object` when the method has not been read yet. Vitest reads the descriptor off the prototype, sees a getter with no value, treats it as a Vite SSR export getter and calls it with no receiver, so the bound-member getter ran `Object.defineProperty` on `undefined`.

The getter now returns the raw method when the receiver is nullish. Vitest wraps that, installs its own accessor on the instance and calls through with the instance as `this`, so `mockReturnValue`, call-through and `mockRestore` all work. `toJSONSchema` becomes a plain table method so it takes the same guarded path, and `spa` answers a bare read with `undefined` (it keeps its getter for identity with `safeParseAsync`, so it stays unspyable rather than crashing).

Bundle against `main`: classic −63 B raw / −5 B gzip (the `toJSONSchema` getter/setter pair collapsed into one method), mini +13 B raw / +5 B gzip; memory unchanged.

Refs #6486
