### PR TITLE
docs(blog): let the page show through the navbar in dark mode

### DIFF
--- a/packages/docs/app/blog/[slug]/page.tsx
+++ b/packages/docs/app/blog/[slug]/page.tsx
@@ -89,7 +89,7 @@ export default async function Page(props: { params: Promise<{ slug: string }> })
             <MetaLine author={author} date={date} minutes={minutes} />
           </footer>
         </article>
-        <aside className="hidden lg:block lg:sticky lg:top-24 self-start text-sm">
+        <aside className="hidden lg:block lg:sticky lg:top-[calc(var(--fd-banner-height)+6rem)] self-start text-sm">
           <dl className="grid gap-y-5">
             {date ? (
               <div>

--- a/packages/docs/app/global.css
+++ b/packages/docs/app/global.css
@@ -30,6 +30,11 @@ body {
   --color-fd-muted: hsl(0, 0%, 15%);
 }
 
+/* the black theme leaves nothing visible through an 80% bar, so the blog navbar lets more of the page through */
+.dark #nd-nav {
+  background-color: color-mix(in oklab, var(--color-fd-background) 50%, transparent);
+}
+
 aside {
   button[data-search-full] {
     font-weight: 200;


### PR DESCRIPTION
The floating navbar on the blog reads as a solid slab in dark mode. The black theme puts a 2%-lightness bar at 80% over a 2%-lightness page, so nothing behind it is visible and the blur has nothing to show. Dark mode now lets 50% of the page through; light mode keeps the fumadocs default, where the blur already reads.

While the 4.5 banner is showing, the bar also covered the top 10px of the post page's sticky sidebar and clipped its Published label. The sidebar now offsets by the banner height, which is 0 once the banner is dismissed.
