### PR TITLE
feat(mini): publish Zod Mini as the standalone @zod/mini package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,29 +128,6 @@ jobs:
           echo "zod@$VERSION is not on the registry after 10 minutes; stopping before the GitHub release and the JSR publish"
           exit 1
 
-      # @zod/mini ships in lockstep with zod and is a no-op when its version is already on the registry, so it runs unconditionally: the first release of the scoped package rides on a merge that does not bump zod itself
-      - id: publish_mini
-        name: Publish @zod/mini to NPM
-        uses: JS-DevTools/npm-publish@v4
-        with:
-          provenance: true
-          package: ./packages/mini
-
-      - name: Verify @zod/mini is live on npm
-        if: ${{ steps.publish_mini.outputs.type }}
-        env:
-          VERSION: ${{ steps.publish_mini.outputs.version }}
-        run: |
-          for i in $(seq 1 40); do
-            if curl -sf "https://registry.npmjs.org/@zod%2fmini/$VERSION" > /dev/null; then
-              echo "@zod/mini@$VERSION is live"
-              exit 0
-            fi
-            sleep 15
-          done
-          echo "@zod/mini@$VERSION is not on the registry after 10 minutes"
-          exit 1
-
       - name: Configure changelog
         if: ${{ steps.publish.outputs.type }}
         run: |
@@ -189,3 +166,26 @@ jobs:
       - run: pnpm jsr publish --allow-slow-types # --dry-run
         if: ${{ steps.publish.outputs.type }}
         working-directory: ./packages/zod
+
+      # @zod/mini ships in lockstep with zod and is a no-op when its version is already on the registry, so it runs unconditionally (the first release of the scoped package rides on a merge that does not bump zod itself) and last, so a failed mini publish cannot cost zod its tag, GitHub release or JSR publish
+      - id: publish_mini
+        name: Publish @zod/mini to NPM
+        uses: JS-DevTools/npm-publish@v4
+        with:
+          provenance: true
+          package: ./packages/mini
+
+      - name: Verify @zod/mini is live on npm
+        if: ${{ steps.publish_mini.outputs.type }}
+        env:
+          VERSION: ${{ steps.publish_mini.outputs.version }}
+        run: |
+          for i in $(seq 1 40); do
+            if curl -sf "https://registry.npmjs.org/@zod%2fmini/$VERSION" > /dev/null; then
+              echo "@zod/mini@$VERSION is live"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "@zod/mini@$VERSION is not on the registry after 10 minutes"
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,17 @@ on:
       - "packages/zod/package.json"
       - "packages/mini/package.json"
       - ".github/workflows/release.yml"
+  # back-publish @zod/mini at an x.y.z that zod already shipped without it; the peer floor becomes ^x.y.0
+  workflow_dispatch:
+    inputs:
+      mini_version:
+        description: "Publish @zod/mini at this x.y.z (must be an existing zod version)"
+        required: true
+        type: string
 
 jobs:
   test-node:
+    if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -39,6 +47,7 @@ jobs:
       - run: pnpm run --filter @zod/integration test:all
 
   lint:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -55,6 +64,7 @@ jobs:
       - run: pnpm lint:check
 
   check-circular:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Check for circular dependencies
     steps:
@@ -67,6 +77,7 @@ jobs:
       - run: pnpm check:circular
 
   build_and_publish:
+    if: github.event_name == 'push'
     needs: [test-node, lint, check-circular]
     runs-on: ubuntu-latest
     permissions:
@@ -173,6 +184,63 @@ jobs:
         uses: JS-DevTools/npm-publish@v4
         with:
           provenance: true
+          package: ./packages/mini
+
+      - name: Verify @zod/mini is live on npm
+        if: ${{ steps.publish_mini.outputs.type }}
+        env:
+          VERSION: ${{ steps.publish_mini.outputs.version }}
+        run: |
+          for i in $(seq 1 40); do
+            if curl -sf "https://registry.npmjs.org/@zod%2fmini/$VERSION" > /dev/null; then
+              echo "@zod/mini@$VERSION is live"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "@zod/mini@$VERSION is not on the registry after 10 minutes"
+          exit 1
+
+  backpublish_mini:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "latest"
+          registry-url: https://registry.npmjs.org/
+      - name: Upgrade npm to latest (required for trusted publishing >=11.5.1)
+        run: npm install -g npm@latest
+      - uses: pnpm/action-setup@v6
+      - run: pnpm install
+      - name: Set the @zod/mini version and peer floor
+        env:
+          VERSION: ${{ inputs.mini_version }}
+        working-directory: ./packages/mini
+        run: |
+          if ! [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+            echo "mini_version must be x.y.z, got '$VERSION'"
+            exit 1
+          fi
+          if ! curl -sf "https://registry.npmjs.org/zod/$VERSION" > /dev/null; then
+            echo "zod@$VERSION is not on npm; @zod/mini only ships versions zod shipped"
+            exit 1
+          fi
+          npm pkg set version="$VERSION" peerDependencies.zod="^${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.0"
+          cat package.json
+      - run: pnpm build
+
+      # the lockstep check in prepublishOnly is deliberately skipped: this version is older than versions.ts by design
+      - id: publish_mini
+        name: Publish @zod/mini to NPM
+        uses: JS-DevTools/npm-publish@v4
+        with:
+          provenance: true
+          ignore-scripts: true
           package: ./packages/mini
 
       - name: Verify @zod/mini is live on npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,13 +234,14 @@ jobs:
           cat package.json
       - run: pnpm build
 
-      # the lockstep check in prepublishOnly is deliberately skipped: this version is older than versions.ts by design
+      # the lockstep check in prepublishOnly is deliberately skipped: this version is older than versions.ts by design. npm refuses a bare publish of a version below latest, so it goes out under a throwaway dist-tag that leaves latest alone; remove it afterwards with `npm dist-tag rm @zod/mini backfill`
       - id: publish_mini
         name: Publish @zod/mini to NPM
         uses: JS-DevTools/npm-publish@v4
         with:
           provenance: true
           ignore-scripts: true
+          tag: backfill
           package: ./packages/mini
 
       - name: Verify @zod/mini is live on npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - "packages/zod/package.json"
+      - "packages/mini/package.json"
       - ".github/workflows/release.yml"
 
 jobs:
@@ -95,6 +96,8 @@ jobs:
       - run: pnpm run --filter @zod/resolution test:all
       - run: pnpm run prepublishOnly
         working-directory: ./packages/zod
+      - run: pnpm run prepublishOnly
+        working-directory: ./packages/mini
 
       - id: publish
         name: Publish to NPM
@@ -123,6 +126,29 @@ jobs:
             sleep 15
           done
           echo "zod@$VERSION is not on the registry after 10 minutes; stopping before the GitHub release and the JSR publish"
+          exit 1
+
+      # @zod/mini ships in lockstep with zod and is a no-op when its version is already on the registry, so it runs unconditionally: the first release of the scoped package rides on a merge that does not bump zod itself
+      - id: publish_mini
+        name: Publish @zod/mini to NPM
+        uses: JS-DevTools/npm-publish@v4
+        with:
+          provenance: true
+          package: ./packages/mini
+
+      - name: Verify @zod/mini is live on npm
+        if: ${{ steps.publish_mini.outputs.type }}
+        env:
+          VERSION: ${{ steps.publish_mini.outputs.version }}
+        run: |
+          for i in $(seq 1 40); do
+            if curl -sf "https://registry.npmjs.org/@zod%2fmini/$VERSION" > /dev/null; then
+              echo "@zod/mini@$VERSION is live"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "@zod/mini@$VERSION is not on the registry after 10 minutes"
           exit 1
 
       - name: Configure changelog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,8 @@ To publish `@zod/mini` at a version zod already shipped without it, dispatch the
 gh workflow run release.yml -f mini_version=4.5.2
 ```
 
+The back-published version goes out under a `backfill` dist-tag, because npm refuses to publish below `latest` without one. Remove the tag once the backfill is done: `npm dist-tag rm @zod/mini backfill`.
+
 ## Format validators: spec compliance is not the bar
 
 Zod's format validators — `z.iso.*`, `z.email()`, `z.url()`, `z.uuid()`, and the rest — are named after specs but do not implement them. Each one matches the profile that real producers emit and real consumers accept, which is almost always far narrower than what the grammar permits. That narrowness is the product, not a gap in it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,12 @@ git push origin main
 
 The release workflow only fires on changes under `packages/zod/package.json`, `packages/mini/package.json` or the workflow file itself, so the bump must include `package.json`. It publishes `zod`, then tags and releases it, then publishes `@zod/mini` last. Watch the Actions tab to confirm `build_and_publish` succeeds.
 
+To publish `@zod/mini` at a version zod already shipped without it, dispatch the same workflow; it publishes only the scoped package, with the peer floor set to that minor:
+
+```bash
+gh workflow run release.yml -f mini_version=4.5.2
+```
+
 ## Format validators: spec compliance is not the bar
 
 Zod's format validators — `z.iso.*`, `z.email()`, `z.url()`, `z.uuid()`, and the rest — are named after specs but do not implement them. Each one matches the profile that real producers emit and real consumers accept, which is almost always far narrower than what the grammar permits. That narrowness is the product, not a gap in it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Procedure:
 # Make sure main is clean and up to date first.
 git checkout main && git pull
 
-# Bump all three files to the new x.y.z, then:
+# Bump all four files to the new x.y.z (and the @zod/mini peer floor on a minor), then:
 git add packages/zod/package.json packages/zod/jsr.json packages/zod/src/v4/core/versions.ts packages/mini/package.json
 git commit -m "<x.y.z>"   # commit message is just the version, e.g. "4.4.3"
 git push origin main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,11 +84,12 @@ If you touch that machinery, three things bite:
 
 Only do this when the user explicitly asks. Pushing a version bump to `main` triggers `.github/workflows/release.yml`, which publishes to npm + JSR and creates a `v<version>` GitHub release. There is no undo.
 
-Three files must be bumped together — `pnpm check:semver` runs in pre-commit and `prepublishOnly`, and will fail the commit if they disagree:
+Four files must be bumped together — `pnpm check:semver` runs in pre-commit and `prepublishOnly`, and will fail the commit if they disagree:
 
 - `packages/zod/package.json` — `version`
 - `packages/zod/jsr.json` — `version`
 - `packages/zod/src/v4/core/versions.ts` — `major` / `minor` / `patch`
+- `packages/mini/package.json` — `version` (same x.y.z; `@zod/mini` ships in lockstep) and `peerDependencies.zod` (`^x.y.0`, the minor being released — bump it on every minor)
 
 Procedure:
 
@@ -97,12 +98,12 @@ Procedure:
 git checkout main && git pull
 
 # Bump all three files to the new x.y.z, then:
-git add packages/zod/package.json packages/zod/jsr.json packages/zod/src/v4/core/versions.ts
+git add packages/zod/package.json packages/zod/jsr.json packages/zod/src/v4/core/versions.ts packages/mini/package.json
 git commit -m "<x.y.z>"   # commit message is just the version, e.g. "4.4.3"
 git push origin main
 ```
 
-The release workflow only fires on changes under `packages/zod/package.json` or the workflow file itself, so the bump must include `package.json`. Watch the Actions tab to confirm `build_and_publish` succeeds.
+The release workflow only fires on changes under `packages/zod/package.json`, `packages/mini/package.json` or the workflow file itself, so the bump must include `package.json`. It publishes `zod`, then tags and releases it, then publishes `@zod/mini` last. Watch the Actions tab to confirm `build_and_publish` succeeds.
 
 ## Format validators: spec compliance is not the bar
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "lint": "biome lint --write .",
     "lint:check": "biome lint .",
     "clean": "pnpm run -r clean",
-    "build": "pnpm run -r --filter zod build",
+    "build": "pnpm run -r --filter zod --filter @zod/mini build",
     "test:watch": "vitest",
     "test": "vitest run",
     "test:compile": "vitest run --config vitest.compile.config.ts",

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -22,6 +22,16 @@ To import it:
 import * as z from "zod/mini";
 ```
 
+The same API is published as a standalone package, `@zod/mini`, that re-exports `zod/mini` from a peer dependency on `zod`. Its version tracks `zod`.
+
+```sh
+npm install zod @zod/mini
+```
+
+```ts
+import * as z from "@zod/mini";
+```
+
 Zod Mini implements the exact same functionality as `zod`, but using a *functional*, *tree-shakable* API. If you're coming from `zod`, this means you generally will use *functions* in place of methods.
 
 ```ts

--- a/packages/integration/fixtures/internal-types/mini-cjs-test.cts
+++ b/packages/integration/fixtures/internal-types/mini-cjs-test.cts
@@ -1,0 +1,20 @@
+// This fixture tests @zod/mini's .d.cts types in a CommonJS context
+
+import * as z from "@zod/mini";
+
+const userSchema = z.object({
+  name: z.string(),
+  age: z.number().check(z.int(), z.positive()),
+  tags: z.array(z.string()),
+});
+
+type User = z.infer<typeof userSchema>;
+
+const result = z.safeParse(userSchema, { name: "Alice", age: 30, tags: [] });
+
+if (result.success) {
+  const user: User = result.data;
+  console.log(user.name);
+}
+
+export { userSchema };

--- a/packages/integration/fixtures/internal-types/mini.ts
+++ b/packages/integration/fixtures/internal-types/mini.ts
@@ -1,0 +1,33 @@
+// This fixture tests that @zod/mini's built types resolve onto the peer's
+// declarations with no internal errors when compiled with skipLibCheck: false
+
+import * as z from "@zod/mini";
+import type * as zm from "zod/mini";
+
+const userSchema = z.object({
+  name: z.string(),
+  age: z.number().check(z.int(), z.positive()),
+  tags: z.array(z.string()),
+  role: z.enum(["admin", "user", "guest"]),
+  metadata: z.record(z.string(), z.unknown()),
+});
+
+type User = z.infer<typeof userSchema>;
+
+const result = z.safeParse(userSchema, {
+  name: "Alice",
+  age: 30,
+  tags: ["developer"],
+  role: "admin",
+  metadata: { foo: "bar" },
+});
+
+if (result.success) {
+  const user: User = result.data;
+  console.log(user.name);
+}
+
+// the scoped package and the subpath are one declaration tree
+const _sameTree: zm.ZodMiniObject = userSchema;
+
+export { userSchema };

--- a/packages/integration/fixtures/internal-types/tsconfig.node16-cjs.json
+++ b/packages/integration/fixtures/internal-types/tsconfig.node16-cjs.json
@@ -10,5 +10,5 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["./cjs-test.cts"]
+  "include": ["./cjs-test.cts", "./mini-cjs-test.cts"]
 }

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -18,6 +18,7 @@
     "test:built": "tsc --project fixtures/internal-types/tsconfig.bundler.json && tsc --project fixtures/internal-types/tsconfig.nodenext.json && tsc --project fixtures/internal-types/tsconfig.node16-cjs.json"
   },
   "dependencies": {
-    "zod": "workspace:*"
+    "zod": "workspace:*",
+    "@zod/mini": "workspace:*"
   }
 }

--- a/packages/mini/.gitignore
+++ b/packages/mini/.gitignore
@@ -1,0 +1,4 @@
+/index.js
+/index.cjs
+/index.d.ts
+/index.d.cts

--- a/packages/mini/LICENSE
+++ b/packages/mini/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/mini/README.md
+++ b/packages/mini/README.md
@@ -1,0 +1,20 @@
+# @zod/mini
+
+Zod Mini as a standalone package. It re-exports [`zod/mini`](https://zod.dev/packages/mini) from a peer dependency on `zod`, so every schema it creates is a `zod` schema.
+
+```sh
+npm install zod @zod/mini
+```
+
+```ts
+import * as z from "@zod/mini";
+
+const User = z.object({
+  name: z.string(),
+  age: z.number().check(z.int(), z.positive()),
+});
+
+z.parse(User, { name: "Colin", age: 30 });
+```
+
+The version tracks `zod`: each `@zod/mini@4.x.y` requires `zod@^4.x.0`.

--- a/packages/mini/package.json
+++ b/packages/mini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zod/mini",
-  "version": "4.5.1",
+  "version": "4.5.3",
   "type": "module",
   "license": "MIT",
   "author": "Colin McDonnell <zod@colinhacks.com>",

--- a/packages/mini/package.json
+++ b/packages/mini/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@zod/mini",
+  "version": "4.5.1",
+  "type": "module",
+  "license": "MIT",
+  "author": "Colin McDonnell <zod@colinhacks.com>",
+  "description": "Zod Mini as a standalone package: the tree-shakable, functional variant of Zod",
+  "homepage": "https://zod.dev/packages/mini",
+  "funding": "https://github.com/sponsors/colinhacks",
+  "sideEffects": false,
+  "files": [
+    "src",
+    "index.js",
+    "index.cjs",
+    "index.d.ts",
+    "index.d.cts"
+  ],
+  "keywords": [
+    "typescript",
+    "schema",
+    "validation",
+    "type",
+    "inference",
+    "zod",
+    "tree-shaking"
+  ],
+  "main": "./index.cjs",
+  "types": "./index.d.cts",
+  "module": "./index.js",
+  "zshy": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": "./src/index.ts"
+    },
+    "conditions": {
+      "@zod/source": "src"
+    }
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@zod/source": "./src/index.ts",
+      "types": "./index.d.cts",
+      "import": "./index.js",
+      "require": "./index.cjs"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/colinhacks/zod.git",
+    "directory": "packages/mini"
+  },
+  "bugs": {
+    "url": "https://github.com/colinhacks/zod/issues"
+  },
+  "peerDependencies": {
+    "zod": "^4.5.0"
+  },
+  "devDependencies": {
+    "zod": "workspace:*"
+  },
+  "scripts": {
+    "clean": "git clean -xdf . -e node_modules",
+    "build": "zshy --project tsconfig.build.json",
+    "postbuild": "pnpm biome check --write .",
+    "test": "pnpm vitest run",
+    "prepublishOnly": "tsx ../../scripts/check-versions.ts"
+  }
+}

--- a/packages/mini/package.json
+++ b/packages/mini/package.json
@@ -53,6 +53,11 @@
   "bugs": {
     "url": "https://github.com/colinhacks/zod/issues"
   },
+  "support": {
+    "backing": {
+      "npm-funding": true
+    }
+  },
   "peerDependencies": {
     "zod": "^4.5.0"
   },

--- a/packages/mini/src/index.ts
+++ b/packages/mini/src/index.ts
@@ -1,0 +1,1 @@
+export * from "zod/mini";

--- a/packages/mini/src/tests/index.test.ts
+++ b/packages/mini/src/tests/index.test.ts
@@ -1,0 +1,17 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as zm from "zod/mini";
+import * as mini from "../index.js";
+
+test("re-exports zod/mini verbatim", () => {
+  expect(Object.keys(mini).sort()).toEqual(Object.keys(zm).sort());
+  expect(mini.string).toBe(zm.string);
+  expect(mini.z).toBe(zm.z);
+});
+
+test("schemas are the peer's zod/mini schemas", () => {
+  const schema = mini.object({ name: mini.string(), tags: mini.array(mini.string()) });
+  expect(schema).toBeInstanceOf(zm.ZodMiniObject);
+  expect(zm.parse(schema, { name: "a", tags: [] })).toEqual({ name: "a", tags: [] });
+  expectTypeOf(schema).toEqualTypeOf(zm.object({ name: zm.string(), tags: zm.array(zm.string()) }));
+  expectTypeOf<mini.infer<typeof schema>>().toEqualTypeOf<{ name: string; tags: string[] }>();
+});

--- a/packages/mini/tsconfig.build.json
+++ b/packages/mini/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../.configs/tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": ".",
+    "customConditions": ["@zod/source"]
+  }
+}

--- a/packages/mini/tsconfig.json
+++ b/packages/mini/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../.configs/tsconfig.base.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "customConditions": ["@zod/source"],
+    "noEmit": true,
+    "types": ["vitest"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/mini/vitest.config.ts
+++ b/packages/mini/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineProject, mergeConfig } from "vitest/config";
+import rootConfig from "../../vitest.config.js";
+
+export default mergeConfig(
+  rootConfig,
+  defineProject({
+    resolve: {
+      conditions: ["@zod/source", "default"],
+    },
+    test: {
+      typecheck: {
+        tsconfig: "./tsconfig.json",
+      },
+    },
+  })
+);

--- a/packages/resolution/attw.test.ts
+++ b/packages/resolution/attw.test.ts
@@ -156,4 +156,55 @@ describe("Are The Types Wrong (attw) tests", () => {
       ***********************************"
     `);
   }, 120000); // 30 second timeout for the command
+
+  it("should run attw --pack node_modules/@zod/mini and check output", async () => {
+    const miniIndexPath = path.join(__dirname, "node_modules", "@zod", "mini", "index.js");
+    if (!existsSync(miniIndexPath)) {
+      // @zod/mini has not been built
+      return;
+    }
+
+    try {
+      await execa("pnpm", ["attw", "--version"], { cwd: __dirname, timeout: 5000 });
+    } catch (_: any) {
+      console.warn("attw not available, skipping test");
+      return;
+    }
+
+    const miniPackagePath = path.join(__dirname, "node_modules", "@zod", "mini");
+    const result = await execa("pnpm", ["attw", "--pack", miniPackagePath, "--format", "ascii"], {
+      cwd: __dirname,
+      reject: false,
+    });
+
+    const stderr = result.stderr
+      .split("\n")
+      .filter((line) => !/^\s*WARN\b/.test(line))
+      .join("\n")
+      .trim();
+    const output = result.stdout + (stderr ? "\n" + stderr : "");
+    const outputWithoutFirstLine = output.split("\n").slice(2).join("\n").trim();
+    expect(outputWithoutFirstLine).toMatchInlineSnapshot(`
+      "🎭 Import resolved to a CommonJS type declaration file, but an ESM JavaScript file. https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md
+
+
+      "@zod/mini/package.json"
+
+      node10: 🟢 (JSON)
+      node16 (from CJS): 🟢 (JSON)
+      node16 (from ESM): 🟢 (JSON)
+      bundler: 🟢 (JSON)
+
+      ***********************************
+
+      "@zod/mini"
+
+      node10: 🟢 
+      node16 (from CJS): 🟢 (CJS)
+      node16 (from ESM): 🎭 Masquerading as CJS
+      bundler: 🟢 
+
+      ***********************************"
+    `);
+  }, 120000);
 });

--- a/packages/resolution/package.json
+++ b/packages/resolution/package.json
@@ -29,6 +29,7 @@
     }
   },
   "dependencies": {
-    "zod": "workspace:*"
+    "zod": "workspace:*",
+    "@zod/mini": "workspace:*"
   }
 }

--- a/packages/resolution/src/index.cts
+++ b/packages/resolution/src/index.cts
@@ -1,3 +1,4 @@
+import * as z9 from "@zod/mini";
 import * as z1 from "zod";
 import z2 from "zod";
 import { z as z3 } from "zod";
@@ -16,6 +17,7 @@ console.log(z5.string().parse("Hello, world!"));
 console.log(z6.string().parse("Hello, world!"));
 console.log(z7.string().parse("Hello, world!"));
 console.log(z8.string().parse("Hello, world!"));
+console.log(z9.string().parse("Hello, world!"));
 
 z4.config(fr());
 const schema = z4.object({

--- a/packages/resolution/src/index.mts
+++ b/packages/resolution/src/index.mts
@@ -1,3 +1,4 @@
+import * as z9 from "@zod/mini";
 import * as z1 from "zod";
 import z2 from "zod";
 import { z as z3 } from "zod";
@@ -16,6 +17,7 @@ console.log(z5.string().parse("Hello, world!"));
 console.log(z6.string().parse("Hello, world!"));
 console.log(z7.string().parse("Hello, world!"));
 console.log(z8.string().parse("Hello, world!"));
+console.log(z9.string().parse("Hello, world!"));
 
 z4.config(fr());
 const schema = z4.object({

--- a/packages/resolution/src/index.ts
+++ b/packages/resolution/src/index.ts
@@ -1,3 +1,4 @@
+import * as z9 from "@zod/mini";
 import * as z1 from "zod";
 import z2 from "zod";
 import { z as z3 } from "zod";
@@ -16,6 +17,7 @@ console.log(z5.string().parse("Hello, world!"));
 console.log(z6.string().parse("Hello, world!"));
 console.log(z7.string().parse("Hello, world!"));
 console.log(z8.string().parse("Hello, world!"));
+console.log(z9.string().parse("Hello, world!"));
 
 z4.config(fr());
 const schema = z4.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
 
   packages/integration:
     dependencies:
+      '@zod/mini':
+        specifier: workspace:*
+        version: link:../mini
       zod:
         specifier: workspace:*
         version: link:../zod
@@ -254,8 +257,17 @@ importers:
         specifier: ^5.8.2
         version: 5.9.2
 
+  packages/mini:
+    devDependencies:
+      zod:
+        specifier: workspace:*
+        version: link:../zod
+
   packages/resolution:
     dependencies:
+      '@zod/mini':
+        specifier: workspace:*
+        version: link:../mini
       zod:
         specifier: workspace:*
         version: link:../zod

--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -61,3 +61,18 @@ if (!isPackageJsonValid || !isJsrJsonValid) {
     console.log(`✅ Versions match: ${packageJsonVersion} starts with ${versionsVersion}`);
   }
 }
+
+// @zod/mini ships in lockstep with zod and its peer floor is the minor it shipped with
+const miniPackageJson = JSON.parse(readFileSync(join(__dirname, "..", "packages", "mini", "package.json"), "utf8"));
+const miniVersion = miniPackageJson.version as string;
+const miniPeer = miniPackageJson.peerDependencies?.zod as string | undefined;
+const expectedMiniPeer = `^${version.major}.${version.minor}.0`;
+const isMiniVersionValid = tag === "latest" ? miniVersion === versionsVersion : miniVersion.startsWith(versionsVersion);
+if (!isMiniVersionValid || miniPeer !== expectedMiniPeer) {
+  console.error(`❌ @zod/mini version mismatch:`);
+  console.error(`   packages/mini/package.json version: ${miniVersion} (expected ${versionsVersion})`);
+  console.error(`   packages/mini/package.json peerDependencies.zod: ${miniPeer} (expected ${expectedMiniPeer})`);
+  process.exit(1);
+} else {
+  console.log(`✅ @zod/mini ${miniVersion} with peer zod@${miniPeer}`);
+}

--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -62,17 +62,22 @@ if (!isPackageJsonValid || !isJsrJsonValid) {
   }
 }
 
-// @zod/mini ships in lockstep with zod and its peer floor is the minor it shipped with
-const miniPackageJson = JSON.parse(readFileSync(join(__dirname, "..", "packages", "mini", "package.json"), "utf8"));
-const miniVersion = miniPackageJson.version as string;
-const miniPeer = miniPackageJson.peerDependencies?.zod as string | undefined;
-const expectedMiniPeer = `^${version.major}.${version.minor}.0`;
-const isMiniVersionValid = tag === "latest" ? miniVersion === versionsVersion : miniVersion.startsWith(versionsVersion);
-if (!isMiniVersionValid || miniPeer !== expectedMiniPeer) {
-  console.error(`❌ @zod/mini version mismatch:`);
-  console.error(`   packages/mini/package.json version: ${miniVersion} (expected ${versionsVersion})`);
-  console.error(`   packages/mini/package.json peerDependencies.zod: ${miniPeer} (expected ${expectedMiniPeer})`);
-  process.exit(1);
+// @zod/mini ships in lockstep with zod and its peer floor is the minor it shipped with; only latest releases are checked, since a caret floor is unsatisfiable by a prerelease and zod's own prereleases must not be blocked by a stale mini
+if (tag !== "latest") {
+  if (process.env.npm_package_name === "@zod/mini") {
+    console.error(`❌ @zod/mini is not published on prerelease tags (tag: ${tag})`);
+    process.exit(1);
+  }
 } else {
+  const miniPackageJson = JSON.parse(readFileSync(join(__dirname, "..", "packages", "mini", "package.json"), "utf8"));
+  const miniVersion = miniPackageJson.version as string;
+  const miniPeer = miniPackageJson.peerDependencies?.zod as string | undefined;
+  const expectedMiniPeer = `^${version.major}.${version.minor}.0`;
+  if (miniVersion !== versionsVersion || miniPeer !== expectedMiniPeer) {
+    console.error(`❌ @zod/mini version mismatch:`);
+    console.error(`   packages/mini/package.json version: ${miniVersion} (expected ${versionsVersion})`);
+    console.error(`   packages/mini/package.json peerDependencies.zod: ${miniPeer} (expected ${expectedMiniPeer})`);
+    process.exit(1);
+  }
   console.log(`✅ @zod/mini ${miniVersion} with peer zod@${miniPeer}`);
 }


### PR DESCRIPTION
Publishes Zod Mini as a standalone package, `@zod/mini`, from a new `packages/mini` workspace package. It is a thin re-export of `zod/mini` with `zod` as a peer dependency, so with the peer range satisfied a schema built with `@zod/mini` is the host install's `zod` schema: one declaration tree for TypeScript, one class identity at runtime.

Versioning: `@zod/mini` ships in lockstep with `zod` (`4.5.3` now) and its peer floor is the minor it shipped with (`^4.5.0`). The semver check enforces both, so a release bump fails pre-commit unless `packages/mini/package.json` moves with it.

Packaging follows zod's zshy layout with a single `types` condition, which keeps a CJS-typed consumer and an ESM app on the same declaration files (the #4422 / vercel/ai#7431 failure class). The resolution suite runs ATTW against the built package, and the integration fixtures type-check `@zod/mini` under `bundler`, `nodenext` and `node16` CJS with `skipLibCheck: false`.

Release: the workflow publishes `./packages/mini` as its last step, after zod's tag, GitHub release and JSR publish, so a failed mini publish cannot cost zod any of those. The step runs unconditionally because the publish action is a no-op when the version already exists; that is how the first publish, `4.5.3`, happens on this merge without bumping zod. A `workflow_dispatch` input, `mini_version`, publishes the scoped package alone at an x.y.z that zod already shipped, with the peer floor set to that minor, so `4.5.0` through `4.5.2` can be back-published with provenance under the same trusted publisher (`gh workflow run release.yml -f mini_version=4.5.2`). Those go out under a `backfill` dist-tag, since npm refuses a bare publish below `latest`; the tag is removed by hand afterwards. Prerelease tags are out of scope for `@zod/mini`: the version check skips it on a zod prerelease and refuses a prerelease publish of the scoped package itself. There is no JSR publish for `@zod/mini`; JSR consumers reach the same API through `@zod/zod`'s `./mini` export.

Before merging: `@zod/mini` already exists on npm (`4.0.0-beta.*` from the 4.0 beta period, `latest` pointing at `4.0.0-beta.0`), so the trusted publisher for this repo's release workflow has to be configured for it on npmjs.com; the publish step fails otherwise. The `latest` tag moves to `4.5.3` on the first publish; the deprecation message on the old betas stays until it is cleared or replaced by hand.

Refs #4371.
