### PR TITLE
feat(v4): install methods as own properties under a test runner

### DIFF
--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -39,13 +39,14 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
  */
 const CEILINGS: Record<string, number> = {
   // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +70 / +83 / +95, and every bundle carries `core.ts`; measured 2946 / 3420 / 4503 plus 28 headroom, and the per-fixture notes below record what each already carried. About half of it is the guard that keeps the install off a user subclass's prototype; the rest is writing the members as `this`-methods, since `this` is not renameable and a block body cannot collapse to an arrow.
-  "zod-mini-boolean": 2974,
+  // raised from 2974 / 3448 / 4561 by the commit that caused it: the eager member layout under a test runner costs mini +50 / +48 / +50, since every bundle carries the `NODE_ENV` read in `core.ts` and the bound-instance branch in `members()`; measured 3003 / 3479 / 4568 plus 28 headroom, and object also keeps the +21 CI drift noted below.
+  "zod-mini-boolean": 3031,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
-  "zod-mini-string": 3448,
+  "zod-mini-string": 3507,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
   // Also carries the memoizer seam from #6482: each container init reads `globalConfig.memoizer` and calls `attach`, which is what lets `zod/mini` opt into cycle support. Measured 4512 locally but 4533 on CI — the gzip stream differs across zlib builds — so the headroom rides on the CI number.
-  "zod-mini-object": 4561,
+  "zod-mini-object": 4617,
 };
 
 /**

--- a/packages/zod/src/v4/classic/tests/eager-members.fixture.ts
+++ b/packages/zod/src/v4/classic/tests/eager-members.fixture.ts
@@ -1,0 +1,4 @@
+// a module that exports a schema, automocked by eager-members.test.ts the way a user's schema module is
+import * as z from "zod/v4";
+
+export const Fixture = z.object({ content: z.string().optional() });

--- a/packages/zod/src/v4/classic/tests/eager-members.test.ts
+++ b/packages/zod/src/v4/classic/tests/eager-members.test.ts
@@ -1,0 +1,47 @@
+import { expect, test, vi } from "vitest";
+import * as z from "zod/v4";
+import { Fixture } from "./eager-members.fixture.js";
+
+// the suite pins the lazy layout in scripts/pin-member-layout.ts; this file runs the eager one a test runner turns on, from before the first schema is built
+vi.hoisted(() => {
+  const g = globalThis as any;
+  g.__zod_globalConfig ??= {};
+  g.__zod_globalConfig.eager = true;
+});
+vi.mock("./eager-members.fixture.js");
+
+test("vi.mock automocks a schema's methods", () => {
+  expect(vi.isMockFunction(Fixture.safeParse)).toBe(true);
+  vi.mocked(Fixture.safeParse).mockReturnValue({ success: true, data: { content: "mocked" } });
+  expect(Fixture.safeParse(1)).toEqual({ success: true, data: { content: "mocked" } });
+});
+
+test("methods are hidden own bound properties and the schema still compares equal", () => {
+  const schema = z.object({ a: z.string() });
+  const desc = Object.getOwnPropertyDescriptor(schema, "safeParse")!;
+  expect(typeof desc.value).toBe("function");
+  expect(desc.enumerable).toBe(false);
+  expect(Object.keys(schema)).not.toContain("safeParse");
+  expect(schema).toEqual(z.object({ a: z.string() }));
+
+  const { parse, optional } = schema;
+  expect(parse({ a: "x" })).toEqual({ a: "x" });
+  expect(optional()).toBeInstanceOf(z.ZodOptional);
+  expect(schema.spa).toBe(schema.safeParseAsync);
+
+  const spy = vi.spyOn(schema, "safeParse").mockReturnValue({ success: true, data: { a: "mocked" } });
+  expect(schema.safeParse({})).toEqual({ success: true, data: { a: "mocked" } });
+  spy.mockRestore();
+  expect(schema.safeParse({}).success).toBe(false);
+});
+
+test("a subclass keeps its override", () => {
+  class Custom extends z.ZodString {
+    override parse(..._args: unknown[]): any {
+      return "override";
+    }
+  }
+  const custom = new Custom(z.string()._zod.def);
+  expect(custom.parse("x")).toBe("override");
+  expect(custom.safeParse("x")).toEqual({ success: true, data: "x" });
+});

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -5,6 +5,8 @@ import * as z from "zod/v4";
 import * as core from "zod/v4/core";
 
 // V8 sizes an instance's property backing store in steps, and schema instances get no in-object slots (their constructor assigns nothing itself): 12 own properties cost 128 bytes, 13 cost 848, 21 cost 1616. Methods therefore live on the prototype and materialize per instance on first read. These bounds are what keeps a schema graph small; crossing one silently multiplies its memory by 6x.
+
+// measures the shipped lazy layout, which scripts/pin-member-layout.ts keeps on for the suite; eager-members.test.ts covers the own-property layout a test runner turns on
 const MAX_OWN_PROPS = 12;
 
 test("schema instances stay under V8's property-count step", () => {

--- a/packages/zod/src/v4/core/core.ts
+++ b/packages/zod/src/v4/core/core.ts
@@ -96,7 +96,9 @@ export /*@__NO_SIDE_EFFECTS__*/ function $constructor<T extends ZodTrait, D = T[
       let up: object | null = own;
       while (up && up !== ctorProto) up = Object.getPrototypeOf(up);
       const target = up ?? own;
-      if (!initialized.has(target)) {
+      // eager: every construction installs, since the methods land on the instance and the prototype carries only the getters
+      if (globalConfig.eager) installMembers(target, protoMembers!, inst);
+      else if (!initialized.has(target)) {
         initialized.add(target);
         installMembers(target, protoMembers!);
       }
@@ -207,6 +209,8 @@ export interface $ZodConfig {
    * @internal
    */
   postProcessor?: ((inst: any) => void) | undefined;
+  /** Internal: methods become own properties of every new schema, the layout a test mocker can wrap. Defaults to on under a test runner. @internal */
+  eager?: boolean | undefined;
 }
 
 interface GlobalThisWithConfig {
@@ -225,6 +229,11 @@ interface GlobalThisWithConfig {
 
 (globalThis as GlobalThisWithConfig).__zod_globalConfig ??= {};
 export const globalConfig: $ZodConfig = (globalThis as GlobalThisWithConfig).__zod_globalConfig!;
+// type-only: the build has no runtime types, and the identifier has to stay `process.env.NODE_ENV` for a bundler to fold it
+declare const process: { env: Record<string, string | undefined> } | undefined;
+declare const Deno: unknown;
+// a test runner sets NODE_ENV=test, and its automocker can only wrap a method that is an own property. skipped in Deno, where reading an env var without permission prompts or throws
+globalConfig.eager ??= typeof Deno === "undefined" && typeof process !== "undefined" && process.env.NODE_ENV === "test";
 
 export function config(newConfig?: Partial<$ZodConfig>): $ZodConfig {
   if (newConfig) Object.assign(globalConfig, newConfig);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1068,11 +1068,15 @@ export abstract class Class {
  *
  * Call this from a `proto` initializer, which runs once per prototype — never per instance.
  */
-export function members(proto: object, table: object): void {
+export function members(proto: object, table: object, inst?: object): void {
   for (const key in table) {
     const desc = Object.getOwnPropertyDescriptor(table, key)!;
-    // a getter installs as written, so it stays live: `description` reads through to the registry on every access. not enumerable: an object literal's is, and a prototype member never was
+    // a getter installs as written, so it stays live: `description` reads through to the registry on every access. not enumerable: an object literal's is, and a prototype member never was. an identical redefinition is a no-op by spec, so the eager path can repeat it per construction
     if (desc.get) Object.defineProperty(proto, key, { ...desc, enumerable: false });
+    // eager: the method lands bound on the instance as a hidden own property, the pre-4.5 layout a test mocker can wrap, and never on the prototype. one a subclass overrides already answers `in` and is left alone
+    else if (inst) {
+      if (!(key in inst)) hide(inst, key, desc.value.bind(inst));
+    }
     // a method materializes bound on first read, which is what keeps a detached member working: `const opt = schema.optional; opt()`
     else defineBound(proto, key, desc.value);
   }

--- a/scripts/pin-member-layout.ts
+++ b/scripts/pin-member-layout.ts
@@ -1,0 +1,2 @@
+// Vitest sets NODE_ENV=test, which switches zod to installing every method as an own property so a test mocker can wrap it. The suite covers the shipped lazy layout, so pin that before zod loads; the test for the eager layout turns it on itself.
+(globalThis as any).__zod_globalConfig = { eager: false };

--- a/vitest.compile.config.ts
+++ b/vitest.compile.config.ts
@@ -26,7 +26,11 @@ export default defineConfig({
     isolate: true,
     silent: true,
     include: ["packages/zod/src/**/*.test.ts"],
-    setupFiles: [resolve(__dirname, "scripts/fail-on-console.ts"), resolve(__dirname, "scripts/enable-compile.ts")],
+    setupFiles: [
+      resolve(__dirname, "scripts/pin-member-layout.ts"),
+      resolve(__dirname, "scripts/fail-on-console.ts"),
+      resolve(__dirname, "scripts/enable-compile.ts"),
+    ],
     typecheck: { enabled: false },
   },
 }) as ViteUserConfig;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     projects: ["packages/*", "./vitest.compile.config.ts"],
     watch: false,
     isolate: true,
-    setupFiles: [resolve(__dirname, "scripts/fail-on-console.ts")],
+    setupFiles: [resolve(__dirname, "scripts/pin-member-layout.ts"), resolve(__dirname, "scripts/fail-on-console.ts")],
     typecheck: {
       include: ["**/*.test.ts"],
       enabled: true,


### PR DESCRIPTION
Since 4.5 a schema's methods are accessors on the prototype that bind on first read. Vitest's and Jest's automockers replace any prototype accessor with a no-op getter and never call it, so `vi.mock("./schema")` yields no mock for `safeParse` on an automocked schema; a factory mock or `vi.spyOn` (fixed in #6488) is the only way through, and neither is discoverable from the failure.

When `NODE_ENV` is `test`, every method now lands bound on the instance at construction as a hidden own property — the pre-4.5 layout a mocker can wrap — so the reporter's repro passes with no setup on their side. Getters (`~standard`, `description`, `_def`, `spa`) stay on the prototype, so instances keep V8 fast properties (`dict-mode.ts` reports `fast` for every instance and the prototype) and `expect(a).toEqual(b)` between two schemas still holds. A method a subclass overrides already answers `in` and is left alone, so an override is never shadowed. Deno is skipped: reading an env var there without permission prompts or throws at import. Outside a test runner nothing changes; `z.object({ a: z.string() })` still has 3 own properties (57 under `test`).

The check runs once at module load and a pre-populated `globalThis.__zod_globalConfig` overrides it, which is how the suite pins the shipped lazy layout for itself (`scripts/pin-member-layout.ts`) while `eager-members.test.ts` runs the eager one from before the first schema is built, `vi.mock` automock included. `instance-footprint.test.ts` measures the lazy layout only and says so. `spa` keeps its getter for identity with `safeParseAsync`, so it remains the one member a spy cannot wrap, and a per-type prototype such as `z.ZodString.prototype` carries no methods under the eager layout, so a class-level `vi.spyOn(z.ZodString.prototype, "parse")` has nothing to wrap there, as it had nothing in 4.4.

Three axes against `main`:

- Bundle, built package through esbuild `--minify` and gzip -9 (the ceiling test's method): mini +50 / +48 / +50 B gzip (boolean / string / object), classic +50 / +52 B gzip (object / string), about +125 B raw each. The three mini ceilings move up in the same commit.
- Runtime: outside tests one boolean read per construction and nothing on the parse path. Under `NODE_ENV=test` a schema is built about 15x slower (20k `z.object({ a, b })`: 80 ms → 1.4 s, one `bind` per method per instance) and hot `parse` is unchanged; the eager pass re-runs `Object.defineProperty` for the getters on the prototype each construction, which is a no-op by spec for an identical descriptor.
- Memory: unchanged outside tests. Under `NODE_ENV=test` retained bytes per schema are those of an own-property layout: `z.string()` 784 → 7073 B, `z.string().min(1).max(5)` 6.1 → 24.9 KB (`schema-footprint.ts`).

Refs #6486
