### PR TITLE
feat(v4): add z.minProperties() and z.maxProperties() checks

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2065,6 +2065,13 @@ type Input = z.input<typeof Person>; // { id?: string; name?: string }
 type Output = z.output<typeof Person>; // { id: string; name: string }
 ```
 
+To constrain the number of keys, use the `z.minProperties()` and `z.maxProperties()` checks. They count the keys of the parsed value, so they also work on `z.object()` schemas.
+
+```ts
+z.record(z.string(), z.number()).check(z.minProperties(1)); // must have 1 or more keys
+z.record(z.string(), z.number()).check(z.maxProperties(5)); // must have 5 or fewer keys
+```
+
 ### `z.partialRecord`
 
 

--- a/packages/docs/content/packages/mini.mdx
+++ b/packages/docs/content/packages/mini.mdx
@@ -169,6 +169,8 @@ z.multipleOf(value);
 z.maxSize(value);
 z.minSize(value);
 z.size(value);
+z.maxProperties(value);
+z.minProperties(value);
 z.maxLength(value);
 z.minLength(value);
 z.length(value);

--- a/packages/zod/src/v4/classic/checks.ts
+++ b/packages/zod/src/v4/classic/checks.ts
@@ -11,6 +11,8 @@ export {
   _maxSize as maxSize,
   _minSize as minSize,
   _size as size,
+  _maxProperties as maxProperties,
+  _minProperties as minProperties,
   _maxLength as maxLength,
   _minLength as minLength,
   _length as length,

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -518,6 +518,14 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         }
       }
 
+      // counted on the parsed object, so a key synthesized by a property `default` counts and a dropped `__proto__` does not
+      if (typeof schema.minProperties === "number") {
+        zodSchema = zodSchema.check(z.minProperties(schema.minProperties));
+      }
+      if (typeof schema.maxProperties === "number") {
+        zodSchema = zodSchema.check(z.maxProperties(schema.maxProperties));
+      }
+
       // propertyNames constrains key *names* only, and says nothing about which keys are required or how their values validate. Layering it on top of the result keeps properties/patternProperties/additionalProperties composing underneath. `true` allows every name, so it needs no guard.
       if (schema.propertyNames !== undefined && schema.propertyNames !== true) {
         // Keys are always strings, so a propertyNames subschema that omits `type` still constrains them — without this it would convert to z.any().

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1308,3 +1308,35 @@ test("__proto__ annotation key reaches the registry", () => {
   expect(Object.prototype.hasOwnProperty.call(meta, "__proto__")).toBe(true);
   expect(meta.__proto__).toEqual({ custom: 1 });
 });
+
+test("minProperties and maxProperties", () => {
+  const schema = fromJSONSchema({
+    type: "object",
+    properties: { a: { type: "string" } },
+    minProperties: 1,
+    maxProperties: 2,
+  });
+  expect(schema.safeParse({ a: "x" }).success).toBe(true);
+  expect(schema.safeParse({}).error!.issues[0]).toMatchObject({ code: "too_small", origin: "object", minimum: 1 });
+  expect(schema.safeParse({ a: "x", b: 1, c: 2 }).error!.issues[0]).toMatchObject({
+    code: "too_big",
+    origin: "object",
+    maximum: 2,
+  });
+  expect(z.toJSONSchema(schema)).toMatchObject({ minProperties: 1, maxProperties: 2 });
+  // counted on the parsed object, so a defaulted property satisfies the minimum
+  const defaulted = fromJSONSchema({
+    type: "object",
+    properties: { a: { type: "string", default: "x" } },
+    minProperties: 1,
+  });
+  expect(defaulted.safeParse({}).success).toBe(true);
+});
+
+test("minProperties composes with propertyNames", () => {
+  const schema = fromJSONSchema({ type: "object", propertyNames: { pattern: "^a" }, minProperties: 1 });
+  expect(schema.safeParse({}).error!.issues[0]!.code).toBe("too_small");
+  expect(schema.safeParse({ b: 1 }).error!.issues[0]!.code).toBe("invalid_key");
+  expect(schema.safeParse({ a: 1 }).success).toBe(true);
+  expect(z.toJSONSchema(schema)).toMatchObject({ propertyNames: { pattern: "^a" }, minProperties: 1 });
+});

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1340,3 +1340,14 @@ test("minProperties composes with propertyNames", () => {
   expect(schema.safeParse({ a: 1 }).success).toBe(true);
   expect(z.toJSONSchema(schema)).toMatchObject({ propertyNames: { pattern: "^a" }, minProperties: 1 });
 });
+
+test("minProperties survives the round trip on the properties + patternProperties path", () => {
+  const schema = fromJSONSchema({
+    type: "object",
+    properties: { a: { type: "string" } },
+    patternProperties: { "^b": { type: "number" } },
+    minProperties: 1,
+  });
+  expect(schema.safeParse({}).success).toBe(false);
+  expect(z.toJSONSchema(schema)).toMatchObject({ minProperties: 1 });
+});

--- a/packages/zod/src/v4/classic/tests/record.test.ts
+++ b/packages/zod/src/v4/classic/tests/record.test.ts
@@ -883,3 +883,24 @@ test("a finite __proto__ key is ignored whether present or missing", () => {
   expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(false);
   expect(schema.parse(Object.fromEntries([["__proto__", 123]]))).toEqual({});
 });
+
+test("minProperties / maxProperties checks", () => {
+  const rec = z.record(z.string(), z.number()).check(z.minProperties(1), z.maxProperties(2));
+  expect(rec.safeParse({ a: 1 }).success).toBe(true);
+  expect(rec.safeParse({ a: 1, b: 2 }).success).toBe(true);
+  expect(rec.safeParse({}).error!.issues[0]).toMatchObject({
+    code: "too_small",
+    origin: "object",
+    minimum: 1,
+    message: "Too small: expected object to have >=1 properties",
+  });
+  expect(rec.safeParse({ a: 1, b: 2, c: 3 }).error!.issues[0]).toMatchObject({
+    code: "too_big",
+    origin: "object",
+    maximum: 2,
+    message: "Too big: expected object to have <=2 properties",
+  });
+  // counted on the parsed value, so a strip object drops unknown keys before the check runs
+  expect(z.object({ a: z.number() }).check(z.maxProperties(1)).safeParse({ a: 1, b: 2 }).success).toBe(true);
+  expect(z.looseObject({ a: z.number() }).check(z.maxProperties(1)).safeParse({ a: 1, b: 2 }).success).toBe(false);
+});

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -4403,3 +4403,11 @@ describe("intersection folding declines", () => {
     expect(allOf(schema)).toHaveLength(3);
   });
 });
+
+test("minProperties / maxProperties", () => {
+  const rec = z.record(z.string(), z.number()).check(z.minProperties(1), z.maxProperties(3));
+  expect(z.toJSONSchema(rec)).toMatchObject({ type: "object", minProperties: 1, maxProperties: 3 });
+  const obj = z.object({ a: z.string() }).check(z.minProperties(1));
+  expect(z.toJSONSchema(obj)).toMatchObject({ type: "object", minProperties: 1 });
+  expect(z.toJSONSchema(obj)).not.toHaveProperty("maxProperties");
+});

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -4410,4 +4410,10 @@ test("minProperties / maxProperties", () => {
   const obj = z.object({ a: z.string() }).check(z.minProperties(1));
   expect(z.toJSONSchema(obj)).toMatchObject({ type: "object", minProperties: 1 });
   expect(z.toJSONSchema(obj)).not.toHaveProperty("maxProperties");
+  // the bound rides on the intersection's own bag, and never on the length slot of a sibling check
+  const both = z.intersection(z.object({ a: z.string() }), z.object({ b: z.string() })).check(z.maxProperties(2));
+  expect(z.toJSONSchema(both)).toMatchObject({ maxProperties: 2 });
+  const arr = z.array(z.string()).check(z.minLength(1), z.minProperties(1));
+  expect(z.toJSONSchema(arr)).toMatchObject({ minItems: 1 });
+  expect(z.toJSONSchema(arr)).not.toHaveProperty("minProperties");
 });

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -991,6 +991,32 @@ export function _minSize(
   });
 }
 
+export type $ZodCheckMaxPropertiesParams = CheckParams<checks.$ZodCheckMaxProperties, "maximum" | "when">;
+// @__NO_SIDE_EFFECTS__
+export function _maxProperties(
+  maximum: number,
+  params?: string | $ZodCheckMaxPropertiesParams
+): checks.$ZodCheckMaxProperties<object> {
+  return new checks.$ZodCheckMaxProperties({
+    check: "max_properties",
+    ...util.normalizeParams(params),
+    maximum,
+  });
+}
+
+export type $ZodCheckMinPropertiesParams = CheckParams<checks.$ZodCheckMinProperties, "minimum" | "when">;
+// @__NO_SIDE_EFFECTS__
+export function _minProperties(
+  minimum: number,
+  params?: string | $ZodCheckMinPropertiesParams
+): checks.$ZodCheckMinProperties<object> {
+  return new checks.$ZodCheckMinProperties({
+    check: "min_properties",
+    ...util.normalizeParams(params),
+    minimum,
+  });
+}
+
 export type $ZodCheckSizeEqualsParams = CheckParams<checks.$ZodCheckSizeEquals, "size" | "when">;
 // @__NO_SIDE_EFFECTS__
 export function _size(

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -621,9 +621,10 @@ export const $ZodCheckMaxProperties: core.$constructor<$ZodCheckMaxProperties> =
 
     inst._zod.def.when ??= _whenIsObject;
 
+    // own bag keys, not `maximum`: that slot is a length bound on an array or string, and an intersection or wrapper can carry both
     inst._zod.onattach.push((inst) => {
-      const curr = (inst._zod.bag.maximum ?? Number.POSITIVE_INFINITY) as number;
-      if (def.maximum < curr) inst._zod.bag.maximum = def.maximum;
+      const curr = (inst._zod.bag.maxProperties ?? Number.POSITIVE_INFINITY) as number;
+      if (def.maximum < curr) inst._zod.bag.maxProperties = def.maximum;
     });
 
     inst._zod.check = (payload) => {
@@ -667,8 +668,8 @@ export const $ZodCheckMinProperties: core.$constructor<$ZodCheckMinProperties> =
     inst._zod.def.when ??= _whenIsObject;
 
     inst._zod.onattach.push((inst) => {
-      const curr = (inst._zod.bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
-      if (def.minimum > curr) inst._zod.bag.minimum = def.minimum;
+      const curr = (inst._zod.bag.minProperties ?? Number.NEGATIVE_INFINITY) as number;
+      if (def.minimum > curr) inst._zod.bag.minProperties = def.minimum;
     });
 
     inst._zod.check = (payload) => {

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -50,6 +50,9 @@ const _whenHasLength = (payload: schemas.ParsePayload): boolean => {
   return !util.nullish(val) && (val as any).length !== undefined;
 };
 
+/** Default `when` for property-count checks: run only on non-array objects. */
+const _whenIsObject = (payload: schemas.ParsePayload): boolean => util.isObject(payload.value);
+
 ///////////////////////////////////////
 /////      $ZodCheckLessThan      /////
 ///////////////////////////////////////
@@ -587,6 +590,96 @@ export const $ZodCheckSizeEquals: core.$constructor<$ZodCheckSizeEquals> = /*@__
         inclusive: true,
         exact: true,
         input: payload.value,
+        inst,
+        continue: !def.abort,
+      });
+    };
+  }
+);
+
+/////////////////////////////////////
+/////    $ZodCheckMaxProperties    /////
+/////////////////////////////////////
+export interface $ZodCheckMaxPropertiesDef extends $ZodCheckDef {
+  check: "max_properties";
+  maximum: number;
+}
+
+export interface $ZodCheckMaxPropertiesInternals<T extends object = object> extends $ZodCheckInternals<T> {
+  def: $ZodCheckMaxPropertiesDef;
+  issc: errors.$ZodIssueTooBig<T>;
+}
+
+export interface $ZodCheckMaxProperties<T extends object = object> extends $ZodCheck<T> {
+  _zod: $ZodCheckMaxPropertiesInternals<T>;
+}
+
+export const $ZodCheckMaxProperties: core.$constructor<$ZodCheckMaxProperties> = /*@__PURE__*/ core.$constructor(
+  "$ZodCheckMaxProperties",
+  (inst, def) => {
+    $ZodCheck.init(inst, def);
+
+    inst._zod.def.when ??= _whenIsObject;
+
+    inst._zod.onattach.push((inst) => {
+      const curr = (inst._zod.bag.maximum ?? Number.POSITIVE_INFINITY) as number;
+      if (def.maximum < curr) inst._zod.bag.maximum = def.maximum;
+    });
+
+    inst._zod.check = (payload) => {
+      const input = payload.value;
+      if (Object.keys(input).length <= def.maximum) return;
+      payload.issues.push({
+        origin: "object",
+        code: "too_big",
+        maximum: def.maximum,
+        inclusive: true,
+        input,
+        inst,
+        continue: !def.abort,
+      });
+    };
+  }
+);
+
+/////////////////////////////////////
+/////    $ZodCheckMinProperties    /////
+/////////////////////////////////////
+export interface $ZodCheckMinPropertiesDef extends $ZodCheckDef {
+  check: "min_properties";
+  minimum: number;
+}
+
+export interface $ZodCheckMinPropertiesInternals<T extends object = object> extends $ZodCheckInternals<T> {
+  def: $ZodCheckMinPropertiesDef;
+  issc: errors.$ZodIssueTooSmall<T>;
+}
+
+export interface $ZodCheckMinProperties<T extends object = object> extends $ZodCheck<T> {
+  _zod: $ZodCheckMinPropertiesInternals<T>;
+}
+
+export const $ZodCheckMinProperties: core.$constructor<$ZodCheckMinProperties> = /*@__PURE__*/ core.$constructor(
+  "$ZodCheckMinProperties",
+  (inst, def) => {
+    $ZodCheck.init(inst, def);
+
+    inst._zod.def.when ??= _whenIsObject;
+
+    inst._zod.onattach.push((inst) => {
+      const curr = (inst._zod.bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
+      if (def.minimum > curr) inst._zod.bag.minimum = def.minimum;
+    });
+
+    inst._zod.check = (payload) => {
+      const input = payload.value;
+      if (Object.keys(input).length >= def.minimum) return;
+      payload.issues.push({
+        origin: "object",
+        code: "too_small",
+        minimum: def.minimum,
+        inclusive: true,
+        input,
         inst,
         continue: !def.abort,
       });
@@ -1288,6 +1381,8 @@ export type $ZodChecks =
   | $ZodCheckMaxSize
   | $ZodCheckMinSize
   | $ZodCheckSizeEquals
+  | $ZodCheckMaxProperties
+  | $ZodCheckMinProperties
   | $ZodCheckMaxLength
   | $ZodCheckMinLength
   | $ZodCheckLengthEquals

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -76,6 +76,8 @@ type SupportedCheck =
   | checks.$ZodCheckMaxSize
   | checks.$ZodCheckMinSize
   | checks.$ZodCheckSizeEquals
+  | checks.$ZodCheckMaxProperties
+  | checks.$ZodCheckMinProperties
   | checks.$ZodCheckMaxLength
   | checks.$ZodCheckMinLength
   | checks.$ZodCheckLengthEquals
@@ -335,6 +337,8 @@ const WHEN_DEFAULTED_CHECKS = new Set([
   "max_size",
   "min_size",
   "size_equals",
+  "max_properties",
+  "min_properties",
   "max_length",
   "min_length",
   "length_equals",
@@ -402,6 +406,16 @@ function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accesso
         break;
       case "size_equals":
         doc.write(`if (${currentAccessor}.size !== ${numericOperand(def.size, "size_equals")}) return INVALID;`);
+        break;
+      case "min_properties":
+        doc.write(
+          `if (Object.keys(${currentAccessor}).length < ${numericOperand(def.minimum, "min_properties")}) return INVALID;`
+        );
+        break;
+      case "max_properties":
+        doc.write(
+          `if (Object.keys(${currentAccessor}).length > ${numericOperand(def.maximum, "max_properties")}) return INVALID;`
+        );
         break;
       case "string_format":
         currentAccessor = generateStringFormatCheck(doc, ctx, def, currentAccessor);

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -49,7 +49,17 @@ export interface $ZodIssueInvalidType<Input = unknown> extends $ZodIssueBase {
 
 export interface $ZodIssueTooBig<Input = unknown> extends $ZodIssueBase {
   readonly code: "too_big";
-  readonly origin: "number" | "int" | "bigint" | "date" | "string" | "array" | "set" | "file" | (string & {});
+  readonly origin:
+    | "number"
+    | "int"
+    | "bigint"
+    | "date"
+    | "string"
+    | "array"
+    | "set"
+    | "file"
+    | "object"
+    | (string & {});
   readonly maximum: number | bigint;
   readonly inclusive?: boolean;
   readonly exact?: boolean;
@@ -58,7 +68,17 @@ export interface $ZodIssueTooBig<Input = unknown> extends $ZodIssueBase {
 
 export interface $ZodIssueTooSmall<Input = unknown> extends $ZodIssueBase {
   readonly code: "too_small";
-  readonly origin: "number" | "int" | "bigint" | "date" | "string" | "array" | "set" | "file" | (string & {});
+  readonly origin:
+    | "number"
+    | "int"
+    | "bigint"
+    | "date"
+    | "string"
+    | "array"
+    | "set"
+    | "file"
+    | "object"
+    | (string & {});
   readonly minimum: number | bigint;
   /** True if the allowable range includes the minimum */
   readonly inclusive?: boolean;

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -305,6 +305,12 @@ function inputOptin(schema: schemas.$ZodType): "optional" | "defaulted" | undefi
   return schema._zod.optin;
 }
 
+function emitPropertyBounds(schema: schemas.$ZodType, json: JSONSchema.ObjectSchema): void {
+  const { minProperties, maxProperties } = schema._zod.bag;
+  if (typeof minProperties === "number") json.minProperties = minProperties;
+  if (typeof maxProperties === "number") json.maxProperties = maxProperties;
+}
+
 export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.ObjectSchema;
   const def = schema._zod.def as schemas.$ZodObjectDef;
@@ -322,9 +328,7 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
   json.type = "object";
   json.properties = {};
 
-  const { minimum, maximum } = schema._zod.bag;
-  if (typeof minimum === "number") json.minProperties = minimum;
-  if (typeof maximum === "number") json.maxProperties = maximum;
+  emitPropertyBounds(schema, json);
 
   for (const key in shape) {
     // assignProp so a __proto__ key becomes an own property instead of hitting the inherited setter on the plain {} we build into
@@ -404,6 +408,8 @@ export const intersectionProcessor: Processor<schemas.$ZodIntersection> = (schem
     ...(isSimpleIntersection(b) ? (b.allOf as any[]) : [b]),
   ];
   json.allOf = allOf;
+  // a property-count check attached to the intersection itself lives on its bag, not on either branch
+  emitPropertyBounds(schema, json as JSONSchema.ObjectSchema);
   // Recorded innermost first, so a nested intersection has already folded by the time this one is considered. The array is the handle rather than the schema, because a wrapper that inherits this schema shares the same array; `finalize` folds every object holding it. See `foldIntersection`.
   ctx.intersections.push(allOf);
 };
@@ -484,9 +490,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
   const def = schema._zod.def as schemas.$ZodRecordDef;
   json.type = "object";
 
-  const { minimum, maximum } = schema._zod.bag;
-  if (typeof minimum === "number") json.minProperties = minimum;
-  if (typeof maximum === "number") json.maxProperties = maximum;
+  emitPropertyBounds(schema, json);
 
   // For looseRecord with regex patterns, use patternProperties. This correctly represents "only validate keys matching the pattern" semantics and composes well with allOf (intersections)
   const keyType = def.keyType as schemas.$ZodTypes;

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -322,6 +322,10 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
   json.type = "object";
   json.properties = {};
 
+  const { minimum, maximum } = schema._zod.bag;
+  if (typeof minimum === "number") json.minProperties = minimum;
+  if (typeof maximum === "number") json.maxProperties = maximum;
+
   for (const key in shape) {
     // assignProp so a __proto__ key becomes an own property instead of hitting the inherited setter on the plain {} we build into
     assignProp(
@@ -479,6 +483,10 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
   const json = _json as JSONSchema.ObjectSchema;
   const def = schema._zod.def as schemas.$ZodRecordDef;
   json.type = "object";
+
+  const { minimum, maximum } = schema._zod.bag;
+  if (typeof minimum === "number") json.minProperties = minimum;
+  if (typeof maximum === "number") json.maxProperties = maximum;
 
   // For looseRecord with regex patterns, use patternProperties. This correctly represents "only validate keys matching the pattern" semantics and composes well with allOf (intersections)
   const keyType = def.keyType as schemas.$ZodTypes;

--- a/packages/zod/src/v4/core/tests/locales/parity.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/parity.test.ts
@@ -53,8 +53,12 @@ test("every locale's Sizable table carries each key en's does", () => {
   const gaps = readdirSync(localesDir)
     .filter((f) => f.endsWith(".ts") && f !== "index.ts")
     .flatMap((f) => {
-      const keys = keysIn(readFileSync(`${localesDir}${f}`, "utf8"), "Sizable");
-      return keys ? required.filter((k) => !keys.includes(k)).map((k) => `${f}.${k}`) : [];
+      const source = readFileSync(`${localesDir}${f}`, "utf8");
+      // a deprecated alias re-exports another locale and has no table of its own
+      if (!source.includes("const Sizable")) return [];
+      const keys = keysIn(source, "Sizable");
+      if (!keys) throw new Error(`could not read Sizable out of ${f}`);
+      return required.filter((k) => !keys.includes(k)).map((k) => `${f}.${k}`);
     });
   expect(gaps).toEqual([]);
 });

--- a/packages/zod/src/v4/core/tests/locales/parity.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/parity.test.ts
@@ -47,17 +47,19 @@ test.each([
   expect(gaps).toEqual([]);
 });
 
-// The rendered-message check above cannot see a missing `Sizable` key in a locale that translates the origin name through its own dictionary, since the real and sentinel messages then differ for an unrelated reason — which is how five locales sat without `map` and rendered a bare or `undefined` unit. This reads the tables out of the source instead.
-test("every locale's Sizable table carries each key en's does", () => {
-  const required = keysOf("Sizable");
+// The rendered-message check above cannot see a missing key in a locale that renders the origin or format through its own branch, since the real and sentinel messages then differ for an unrelated reason — which is how five locales sat without `Sizable.map` and rendered a bare or `undefined` unit. This reads the tables out of the source instead.
+test.each(["FormatDictionary", "Sizable"])("every locale's %s table carries each key en's does", (block) => {
+  // a key en maps to its own name renders the same whether or not a locale defines it
+  const selfNamed = new Set([...enSource.matchAll(/^\s{4}([a-z_0-9]+): "\1"/gm)].map((m) => m[1]!));
+  const required = keysOf(block).filter((k) => !selfNamed.has(k));
   const gaps = readdirSync(localesDir)
     .filter((f) => f.endsWith(".ts") && f !== "index.ts")
     .flatMap((f) => {
       const source = readFileSync(`${localesDir}${f}`, "utf8");
-      // a deprecated alias re-exports another locale and has no table of its own
-      if (!source.includes("const Sizable")) return [];
-      const keys = keysIn(source, "Sizable");
-      if (!keys) throw new Error(`could not read Sizable out of ${f}`);
+      // a deprecated alias re-exports another locale and has no tables of its own
+      if (!source.includes(`const ${block}`)) return [];
+      const keys = keysIn(source, block);
+      if (!keys) throw new Error(`could not read ${block} out of ${f}`);
       return required.filter((k) => !keys.includes(k)).map((k) => `${f}.${k}`);
     });
   expect(gaps).toEqual([]);

--- a/packages/zod/src/v4/core/tests/locales/parity.test.ts
+++ b/packages/zod/src/v4/core/tests/locales/parity.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
 import { z } from "../../../../index.js";
@@ -7,12 +7,18 @@ import { z } from "../../../../index.js";
 //
 // The key lists are read out of `en.ts` rather than hardcoded, so adding a format to `en` extends this test automatically. That is the whole point: a hand-maintained list here would miss the next one exactly the way the last four were missed.
 
-const enSource = readFileSync(fileURLToPath(new URL("../../../locales/en.ts", import.meta.url)), "utf8");
+const localesDir = fileURLToPath(new URL("../../../locales/", import.meta.url));
+const enSource = readFileSync(`${localesDir}en.ts`, "utf8");
+
+function keysIn(source: string, block: string): string[] | null {
+  const body = source.match(new RegExp(`const ${block}[^=]*= \\{([\\s\\S]*?)\\n  \\};`))?.[1];
+  return body ? [...body.matchAll(/^\s{4}([a-z_0-9]+):/gm)].map((m) => m[1]!) : null;
+}
 
 function keysOf(block: string): string[] {
-  const body = enSource.match(new RegExp(`const ${block}[^=]*= \\{([\\s\\S]*?)\\n  \\};`))?.[1];
-  if (!body) throw new Error(`could not read ${block} out of en.ts`);
-  return [...body.matchAll(/^\s{4}([a-z_0-9]+):/gm)].map((m) => m[1]!);
+  const keys = keysIn(enSource, block);
+  if (!keys) throw new Error(`could not read ${block} out of en.ts`);
+  return keys;
 }
 
 const locales = z.locales as unknown as Record<string, () => { localeError: z.core.$ZodErrorMap }>;
@@ -38,5 +44,17 @@ test.each([
   const required = keys.filter((k) => !fallsThrough("en", k, build));
   const gaps = required.flatMap((k) => names.filter((n) => fallsThrough(n, k, build)).map((n) => `${n}.${k}`));
 
+  expect(gaps).toEqual([]);
+});
+
+// The rendered-message check above cannot see a missing `Sizable` key in a locale that translates the origin name through its own dictionary, since the real and sentinel messages then differ for an unrelated reason — which is how five locales sat without `map` and rendered a bare or `undefined` unit. This reads the tables out of the source instead.
+test("every locale's Sizable table carries each key en's does", () => {
+  const required = keysOf("Sizable");
+  const gaps = readdirSync(localesDir)
+    .filter((f) => f.endsWith(".ts") && f !== "index.ts")
+    .flatMap((f) => {
+      const keys = keysIn(readFileSync(`${localesDir}${f}`, "utf8"), "Sizable");
+      return keys ? required.filter((k) => !keys.includes(k)).map((k) => `${f}.${k}`) : [];
+    });
   expect(gaps).toEqual([]);
 });

--- a/packages/zod/src/v4/locales/ar.ts
+++ b/packages/zod/src/v4/locales/ar.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "عنصر", verb: "أن يحوي" },
     set: { unit: "عنصر", verb: "أن يحوي" },
     map: { unit: "عنصر", verb: "أن يحوي" },
+    object: { unit: "خصائص", verb: "أن يحوي" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/az.ts
+++ b/packages/zod/src/v4/locales/az.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "element", verb: "olmalıdır" },
     set: { unit: "element", verb: "olmalıdır" },
     map: { unit: "element", verb: "olmalıdır" },
+    object: { unit: "xüsusiyyət", verb: "olmalıdır" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/be.ts
+++ b/packages/zod/src/v4/locales/be.ts
@@ -64,6 +64,14 @@ const error: () => errors.$ZodErrorMap = () => {
       },
       verb: "мець",
     },
+    object: {
+      unit: {
+        one: "уласцівасць",
+        few: "уласцівасці",
+        many: "уласцівасцей",
+      },
+      verb: "мець",
+    },
     file: {
       unit: {
         one: "байт",

--- a/packages/zod/src/v4/locales/bg.ts
+++ b/packages/zod/src/v4/locales/bg.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "елемента", verb: "да съдържа" },
     set: { unit: "елемента", verb: "да съдържа" },
     map: { unit: "елемента", verb: "да съдържа" },
+    object: { unit: "свойства", verb: "да съдържа" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/bn.ts
+++ b/packages/zod/src/v4/locales/bn.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "আইটেম", verb: "থাকতে হবে" },
     set: { unit: "আইটেম", verb: "থাকতে হবে" },
     map: { unit: "এন্ট্রি", verb: "থাকতে হবে" },
+    object: { unit: "প্রপার্টি", verb: "থাকতে হবে" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ca.ts
+++ b/packages/zod/src/v4/locales/ca.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elements", verb: "contenir" },
     set: { unit: "elements", verb: "contenir" },
     map: { unit: "elements", verb: "contenir" },
+    object: { unit: "propietats", verb: "contenir" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ckb.ts
+++ b/packages/zod/src/v4/locales/ckb.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "دانە", verb: "بێت" },
     set: { unit: "دانە", verb: "بێت" },
     map: { unit: "دانە", verb: "بێت" },
+    object: { unit: "تایبەتمەندی", verb: "بێت" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/cs.ts
+++ b/packages/zod/src/v4/locales/cs.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "prvků", verb: "mít" },
     set: { unit: "prvků", verb: "mít" },
     map: { unit: "prvků", verb: "mít" },
+    object: { unit: "vlastností", verb: "mít" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/da.ts
+++ b/packages/zod/src/v4/locales/da.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementer", verb: "indeholdt" },
     set: { unit: "elementer", verb: "indeholdt" },
     map: { unit: "elementer", verb: "indeholdt" },
+    object: { unit: "egenskaber", verb: "indeholdt" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/de.ts
+++ b/packages/zod/src/v4/locales/de.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "Elemente", verb: "zu haben" },
     set: { unit: "Elemente", verb: "zu haben" },
     map: { unit: "Elemente", verb: "zu haben" },
+    object: { unit: "Eigenschaften", verb: "zu haben" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/el.ts
+++ b/packages/zod/src/v4/locales/el.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "στοιχεία", verb: "να έχει" },
     set: { unit: "στοιχεία", verb: "να έχει" },
     map: { unit: "καταχωρήσεις", verb: "να έχει" },
+    object: { unit: "ιδιότητες", verb: "να έχει" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/en.ts
+++ b/packages/zod/src/v4/locales/en.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "items", verb: "to have" },
     set: { unit: "items", verb: "to have" },
     map: { unit: "entries", verb: "to have" },
+    object: { unit: "properties", verb: "to have" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/eo.ts
+++ b/packages/zod/src/v4/locales/eo.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementojn", verb: "havi" },
     set: { unit: "elementojn", verb: "havi" },
     map: { unit: "elementojn", verb: "havi" },
+    object: { unit: "ecojn", verb: "havi" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/es.ts
+++ b/packages/zod/src/v4/locales/es.ts
@@ -8,6 +8,8 @@ const error: () => errors.$ZodErrorMap = () => {
     file: { unit: "bytes", verb: "tener" },
     array: { unit: "elementos", verb: "tener" },
     set: { unit: "elementos", verb: "tener" },
+    map: { unit: "entradas", verb: "tener" },
+    object: { unit: "propiedades", verb: "tener" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/fa.ts
+++ b/packages/zod/src/v4/locales/fa.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "آیتم", verb: "داشته باشد" },
     set: { unit: "آیتم", verb: "داشته باشد" },
     map: { unit: "آیتم", verb: "داشته باشد" },
+    object: { unit: "ویژگی", verb: "داشته باشد" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/fi.ts
+++ b/packages/zod/src/v4/locales/fi.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "alkiota", subject: "listan" },
     set: { unit: "alkiota", subject: "joukon" },
     map: { unit: "alkiota", subject: "kuvauksen" },
+    object: { unit: "ominaisuutta", subject: "objektin" },
     number: { unit: "", subject: "luvun" },
     bigint: { unit: "", subject: "suuren kokonaisluvun" },
     int: { unit: "", subject: "kokonaisluvun" },

--- a/packages/zod/src/v4/locales/fr-CA.ts
+++ b/packages/zod/src/v4/locales/fr-CA.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "éléments", verb: "avoir" },
     set: { unit: "éléments", verb: "avoir" },
     map: { unit: "éléments", verb: "avoir" },
+    object: { unit: "propriétés", verb: "avoir" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/fr.ts
+++ b/packages/zod/src/v4/locales/fr.ts
@@ -8,6 +8,8 @@ const error: () => errors.$ZodErrorMap = () => {
     file: { unit: "octets", verb: "avoir" },
     array: { unit: "éléments", verb: "avoir" },
     set: { unit: "éléments", verb: "avoir" },
+    map: { unit: "entrées", verb: "avoir" },
+    object: { unit: "propriétés", verb: "avoir" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/gu.ts
+++ b/packages/zod/src/v4/locales/gu.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "આઇટમ", verb: "હોવા જોઈએ" },
     set: { unit: "આઇટમ", verb: "હોવા જોઈએ" },
     map: { unit: "એન્ટ્રી", verb: "હોવા જોઈએ" },
+    object: { unit: "પ્રોપર્ટી", verb: "હોવા જોઈએ" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/he.ts
+++ b/packages/zod/src/v4/locales/he.ts
@@ -31,6 +31,8 @@ const error: () => errors.$ZodErrorMap = () => {
     file: { unit: "בייטים", shortLabel: "קטן", longLabel: "גדול" },
     array: { unit: "פריטים", shortLabel: "קטן", longLabel: "גדול" },
     set: { unit: "פריטים", shortLabel: "קטן", longLabel: "גדול" },
+    map: { unit: "ערכים", shortLabel: "קטן", longLabel: "גדול" },
+    object: { unit: "מאפיינים", shortLabel: "קטן", longLabel: "גדול" },
     number: { unit: "", shortLabel: "קטן", longLabel: "גדול" }, // no unit
   };
 

--- a/packages/zod/src/v4/locales/hi.ts
+++ b/packages/zod/src/v4/locales/hi.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "तत्व", verb: "रखने के लिए" },
     set: { unit: "तत्व", verb: "रखने के लिए" },
     map: { unit: "प्रविष्टियाँ", verb: "रखने के लिए" },
+    object: { unit: "प्रॉपर्टी", verb: "रखने के लिए" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/hr.ts
+++ b/packages/zod/src/v4/locales/hr.ts
@@ -8,6 +8,8 @@ const error: () => errors.$ZodErrorMap = () => {
     file: { unit: "bajtova", verb: "imati" },
     array: { unit: "stavki", verb: "imati" },
     set: { unit: "stavki", verb: "imati" },
+    map: { unit: "unosa", verb: "imati" },
+    object: { unit: "svojstava", verb: "imati" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/hu.ts
+++ b/packages/zod/src/v4/locales/hu.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elem", verb: "legyen" },
     set: { unit: "elem", verb: "legyen" },
     map: { unit: "elem", verb: "legyen" },
+    object: { unit: "tulajdonság", verb: "legyen" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/hy.ts
+++ b/packages/zod/src/v4/locales/hy.ts
@@ -58,6 +58,13 @@ const error: () => errors.$ZodErrorMap = () => {
       },
       verb: "ունենալ",
     },
+    object: {
+      unit: {
+        one: "հատկություն",
+        many: "հատկություններ",
+      },
+      verb: "ունենալ",
+    },
   };
 
   function getSizing(origin: string): ArmenianSizable | null {

--- a/packages/zod/src/v4/locales/id.ts
+++ b/packages/zod/src/v4/locales/id.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "item", verb: "memiliki" },
     set: { unit: "item", verb: "memiliki" },
     map: { unit: "item", verb: "memiliki" },
+    object: { unit: "properti", verb: "memiliki" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/is.ts
+++ b/packages/zod/src/v4/locales/is.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "hluti", verb: "að hafa" },
     set: { unit: "hluti", verb: "að hafa" },
     map: { unit: "hluti", verb: "að hafa" },
+    object: { unit: "eiginleika", verb: "að hafa" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/it.ts
+++ b/packages/zod/src/v4/locales/it.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementi", verb: "avere" },
     set: { unit: "elementi", verb: "avere" },
     map: { unit: "elementi", verb: "avere" },
+    object: { unit: "proprietà", verb: "avere" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ja.ts
+++ b/packages/zod/src/v4/locales/ja.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "要素", verb: "である" },
     set: { unit: "要素", verb: "である" },
     map: { unit: "要素", verb: "である" },
+    object: { unit: "プロパティ", verb: "である" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ka.ts
+++ b/packages/zod/src/v4/locales/ka.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "ელემენტი", verb: "უნდა შეიცავდეს" },
     set: { unit: "ელემენტი", verb: "უნდა შეიცავდეს" },
     map: { unit: "ელემენტი", verb: "უნდა შეიცავდეს" },
+    object: { unit: "თვისება", verb: "უნდა შეიცავდეს" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/km.ts
+++ b/packages/zod/src/v4/locales/km.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "ធាតុ", verb: "គួរមាន" },
     set: { unit: "ធាតុ", verb: "គួរមាន" },
     map: { unit: "ធាតុ", verb: "គួរមាន" },
+    object: { unit: "លក្ខណៈសម្បត្តិ", verb: "គួរមាន" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/kn.ts
+++ b/packages/zod/src/v4/locales/kn.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "ವಸ್ತುಗಳು", verb: "ಹೊಂದಲು" },
     set: { unit: "ವಸ್ತುಗಳು", verb: "ಹೊಂದಲು" },
     map: { unit: "entries", verb: "ಹೊಂದಲು" },
+    object: { unit: "ಗುಣಲಕ್ಷಣಗಳು", verb: "ಹೊಂದಲು" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ko.ts
+++ b/packages/zod/src/v4/locales/ko.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "개", verb: "to have" },
     set: { unit: "개", verb: "to have" },
     map: { unit: "개", verb: "to have" },
+    object: { unit: "개", verb: "to have" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/lt.ts
+++ b/packages/zod/src/v4/locales/lt.ts
@@ -95,6 +95,40 @@ const error: () => errors.$ZodErrorMap = () => {
         },
       },
     },
+    map: {
+      unit: {
+        one: "įrašą",
+        few: "įrašus",
+        many: "įrašų",
+      },
+      verb: {
+        smaller: {
+          inclusive: "turi turėti ne daugiau kaip",
+          notInclusive: "turi turėti mažiau kaip",
+        },
+        bigger: {
+          inclusive: "turi turėti ne mažiau kaip",
+          notInclusive: "turi turėti daugiau kaip",
+        },
+      },
+    },
+    object: {
+      unit: {
+        one: "savybę",
+        few: "savybes",
+        many: "savybių",
+      },
+      verb: {
+        smaller: {
+          inclusive: "turi turėti ne daugiau kaip",
+          notInclusive: "turi turėti mažiau kaip",
+        },
+        bigger: {
+          inclusive: "turi turėti ne mažiau kaip",
+          notInclusive: "turi turėti daugiau kaip",
+        },
+      },
+    },
   };
 
   function getSizing(

--- a/packages/zod/src/v4/locales/mk.ts
+++ b/packages/zod/src/v4/locales/mk.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "ставки", verb: "да имаат" },
     set: { unit: "ставки", verb: "да имаат" },
     map: { unit: "ставки", verb: "да имаат" },
+    object: { unit: "својства", verb: "да имаат" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ms.ts
+++ b/packages/zod/src/v4/locales/ms.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elemen", verb: "mempunyai" },
     set: { unit: "elemen", verb: "mempunyai" },
     map: { unit: "elemen", verb: "mempunyai" },
+    object: { unit: "sifat", verb: "mempunyai" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ne.ts
+++ b/packages/zod/src/v4/locales/ne.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "तत्व", verb: "हुनुपर्छ" },
     set: { unit: "तत्व", verb: "हुनुपर्छ" },
     map: { unit: "प्रविष्टि", verb: "हुनुपर्छ" },
+    object: { unit: "प्रोपर्टी", verb: "हुनुपर्छ" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/nl.ts
+++ b/packages/zod/src/v4/locales/nl.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementen", verb: "heeft" },
     set: { unit: "elementen", verb: "heeft" },
     map: { unit: "elementen", verb: "heeft" },
+    object: { unit: "eigenschappen", verb: "heeft" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/nn.ts
+++ b/packages/zod/src/v4/locales/nn.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "element", verb: "å innehalde" },
     set: { unit: "element", verb: "å innehalde" },
     map: { unit: "element", verb: "å innehalde" },
+    object: { unit: "eigenskapar", verb: "å innehalde" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/no.ts
+++ b/packages/zod/src/v4/locales/no.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementer", verb: "å inneholde" },
     set: { unit: "elementer", verb: "å inneholde" },
     map: { unit: "elementer", verb: "å inneholde" },
+    object: { unit: "egenskaper", verb: "å inneholde" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ota.ts
+++ b/packages/zod/src/v4/locales/ota.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "unsur", verb: "olmalıdır" },
     set: { unit: "unsur", verb: "olmalıdır" },
     map: { unit: "unsur", verb: "olmalıdır" },
+    object: { unit: "hususiyet", verb: "olmalıdır" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/pl.ts
+++ b/packages/zod/src/v4/locales/pl.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementów", verb: "mieć" },
     set: { unit: "elementów", verb: "mieć" },
     map: { unit: "elementów", verb: "mieć" },
+    object: { unit: "właściwości", verb: "mieć" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ps.ts
+++ b/packages/zod/src/v4/locales/ps.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "توکي", verb: "ولري" },
     set: { unit: "توکي", verb: "ولري" },
     map: { unit: "توکي", verb: "ولري" },
+    object: { unit: "ځانګړتیاوې", verb: "ولري" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/pt-BR.ts
+++ b/packages/zod/src/v4/locales/pt-BR.ts
@@ -10,6 +10,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementos" },
     set: { unit: "elementos" },
     map: { unit: "entradas" },
+    object: { unit: "propriedades" },
   };
 
   function getSizing(origin: string): { unit: string } | null {

--- a/packages/zod/src/v4/locales/pt.ts
+++ b/packages/zod/src/v4/locales/pt.ts
@@ -10,6 +10,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementos" },
     set: { unit: "elementos" },
     map: { unit: "entradas" },
+    object: { unit: "propriedades" },
   };
 
   function getSizing(origin: string): { unit: string } | null {

--- a/packages/zod/src/v4/locales/ro.ts
+++ b/packages/zod/src/v4/locales/ro.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elemente", verb: "să aibă" },
     set: { unit: "elemente", verb: "să aibă" },
     map: { unit: "intrări", verb: "să aibă" },
+    object: { unit: "proprietăți", verb: "să aibă" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ru.ts
+++ b/packages/zod/src/v4/locales/ru.ts
@@ -72,6 +72,14 @@ const error: () => errors.$ZodErrorMap = () => {
       },
       verb: "иметь",
     },
+    object: {
+      unit: {
+        one: "свойство",
+        few: "свойства",
+        many: "свойств",
+      },
+      verb: "иметь",
+    },
   };
 
   function getSizing(origin: string): RussianSizable | null {

--- a/packages/zod/src/v4/locales/sk.ts
+++ b/packages/zod/src/v4/locales/sk.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "prvkov", verb: "mať" },
     set: { unit: "prvkov", verb: "mať" },
     map: { unit: "položiek", verb: "mať" },
+    object: { unit: "vlastností", verb: "mať" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/sl.ts
+++ b/packages/zod/src/v4/locales/sl.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementov", verb: "imeti" },
     set: { unit: "elementov", verb: "imeti" },
     map: { unit: "elementov", verb: "imeti" },
+    object: { unit: "lastnosti", verb: "imeti" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/sv.ts
+++ b/packages/zod/src/v4/locales/sv.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "objekt", verb: "att innehålla" },
     set: { unit: "objekt", verb: "att innehålla" },
     map: { unit: "objekt", verb: "att innehålla" },
+    object: { unit: "egenskaper", verb: "att innehålla" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ta.ts
+++ b/packages/zod/src/v4/locales/ta.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "உறுப்புகள்", verb: "கொண்டிருக்க வேண்டும்" },
     set: { unit: "உறுப்புகள்", verb: "கொண்டிருக்க வேண்டும்" },
     map: { unit: "உறுப்புகள்", verb: "கொண்டிருக்க வேண்டும்" },
+    object: { unit: "பண்புகள்", verb: "கொண்டிருக்க வேண்டும்" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/th.ts
+++ b/packages/zod/src/v4/locales/th.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "รายการ", verb: "ควรมี" },
     set: { unit: "รายการ", verb: "ควรมี" },
     map: { unit: "รายการ", verb: "ควรมี" },
+    object: { unit: "คุณสมบัติ", verb: "ควรมี" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/tk.ts
+++ b/packages/zod/src/v4/locales/tk.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "elementler", verb: "bolmaly" },
     set: { unit: "elementler", verb: "bolmaly" },
     map: { unit: "elementler", verb: "bolmaly" },
+    object: { unit: "häsiýet", verb: "bolmaly" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/tr.ts
+++ b/packages/zod/src/v4/locales/tr.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "öğe", verb: "olmalı" },
     set: { unit: "öğe", verb: "olmalı" },
     map: { unit: "öğe", verb: "olmalı" },
+    object: { unit: "özellik", verb: "olmalı" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/uk.ts
+++ b/packages/zod/src/v4/locales/uk.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "елементів", verb: "матиме" },
     set: { unit: "елементів", verb: "матиме" },
     map: { unit: "елементів", verb: "матиме" },
+    object: { unit: "властивостей", verb: "матиме" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/ur.ts
+++ b/packages/zod/src/v4/locales/ur.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "آئٹمز", verb: "ہونا" },
     set: { unit: "آئٹمز", verb: "ہونا" },
     map: { unit: "آئٹمز", verb: "ہونا" },
+    object: { unit: "خصوصیات", verb: "ہونا" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/uz.ts
+++ b/packages/zod/src/v4/locales/uz.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "element", verb: "bo‘lishi kerak" },
     set: { unit: "element", verb: "bo‘lishi kerak" },
     map: { unit: "yozuv", verb: "bo‘lishi kerak" },
+    object: { unit: "xususiyat", verb: "bo‘lishi kerak" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/vi.ts
+++ b/packages/zod/src/v4/locales/vi.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "phần tử", verb: "có" },
     set: { unit: "phần tử", verb: "có" },
     map: { unit: "phần tử", verb: "có" },
+    object: { unit: "thuộc tính", verb: "có" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/yo.ts
+++ b/packages/zod/src/v4/locales/yo.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "nkan", verb: "ní" },
     set: { unit: "nkan", verb: "ní" },
     map: { unit: "nkan", verb: "ní" },
+    object: { unit: "ohun-ini", verb: "ní" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/zh-CN.ts
+++ b/packages/zod/src/v4/locales/zh-CN.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "项", verb: "包含" },
     set: { unit: "项", verb: "包含" },
     map: { unit: "项", verb: "包含" },
+    object: { unit: "个属性", verb: "包含" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/locales/zh-TW.ts
+++ b/packages/zod/src/v4/locales/zh-TW.ts
@@ -9,6 +9,7 @@ const error: () => errors.$ZodErrorMap = () => {
     array: { unit: "項目", verb: "擁有" },
     set: { unit: "項目", verb: "擁有" },
     map: { unit: "項目", verb: "擁有" },
+    object: { unit: "個屬性", verb: "擁有" },
   };
 
   function getSizing(origin: string): { unit: string; verb: string } | null {

--- a/packages/zod/src/v4/mini/checks.ts
+++ b/packages/zod/src/v4/mini/checks.ts
@@ -13,6 +13,8 @@ export {
   _maxSize as maxSize,
   _minSize as minSize,
   _size as size,
+  _maxProperties as maxProperties,
+  _minProperties as minProperties,
   _maxLength as maxLength,
   _minLength as minLength,
   _length as length,

--- a/packages/zod/src/v4/mini/tests/checks.test.ts
+++ b/packages/zod/src/v4/mini/tests/checks.test.ts
@@ -71,6 +71,14 @@ test("z.minLength", () => {
   expect(z.safeParse(a, ["a", "b", "c"]).success).toEqual(true);
 });
 
+// minProperties / maxProperties;
+test("z.minProperties / z.maxProperties", () => {
+  const a = z.record(z.string(), z.number()).check(z.minProperties(1), z.maxProperties(2));
+  expect(z.safeParse(a, {}).success).toEqual(false);
+  expect(z.safeParse(a, { a: 1 }).success).toEqual(true);
+  expect(z.safeParse(a, { a: 1, b: 2, c: 3 }).success).toEqual(false);
+});
+
 // size;
 test("z.length", () => {
   const a = z.array(z.string()).check(z.length(3));


### PR DESCRIPTION
`fromJSONSchema` listed `minProperties` and `maxProperties` as recognized keywords and then dropped them, so `{ type: "object", minProperties: 1 }` accepted `{}`. Rather than a converter-only guard, this adds the property count as a first-class check, so hand-written schemas get it too and `toJSONSchema` can emit it.

```ts
z.record(z.string(), z.number()).check(z.minProperties(1), z.maxProperties(5));
z.object({ a: z.string() }).check(z.maxProperties(3));
// Too small: expected object to have >=1 properties
```

The checks count the keys of the parsed value, like every other check. `toJSONSchema` reads the bounds off the bag and emits `minProperties`/`maxProperties` on object and record schemas; `fromJSONSchema` attaches the checks to the converted object, which means a key synthesized by a property `default` counts toward the minimum. The compiler handles both check kinds inline. Every locale gains an `object` entry in its Sizable table, which the parity test requires.

The bounds ride on their own bag keys, `minProperties`/`maxProperties`, rather than the `minimum`/`maximum` slot a length check writes, so a schema carrying both emits both keywords correctly.

Bundle against `main`, esbuild `--minify` + gzip: `zod/mini` boolean and object fixtures +0 B; classic boolean +48 B, classic object +49 B. No parse-path change for schemas that do not attach a check, and no per-instance property.

Closes #6463, closes #3802
