### PR TITLE
fix(v4): emit record numeric keys as strings in toJSONSchema

### DIFF
--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1263,6 +1263,18 @@ describe("toJSONSchema", () => {
     ).toEqual({ $ref: "#/$defs/Keys" });
   });
 
+  test("record with a heterogeneous key stringifies only its numeric members", () => {
+    // a mixed key carries no `type`, so the numeric members are caught by value rather than by type
+    expect(z.toJSONSchema(z.record(z.literal(["a", 1]), z.boolean()))).toMatchObject({
+      propertyNames: { enum: ["a", "1"] },
+      required: ["a", "1"],
+    });
+    // a member no key can spell is left as it was, since the parser only ever retries a key as a number
+    expect(z.toJSONSchema(z.record(z.literal(["a", true]) as any, z.boolean())).propertyNames).toEqual({
+      enum: ["a", true],
+    });
+  });
+
   test("record stringifies required for every target", () => {
     const schema = z.record(z.literal([1, 2]), z.boolean());
     for (const target of ["draft-2020-12", "draft-7", "draft-4", "openapi-3.0"] as const) {
@@ -3112,6 +3124,28 @@ test("large registry converts in linear time", () => {
   const folded = convert(true);
   expect(folded.schemas.Inter).toMatchObject({ type: "object", properties: { a: {}, b: {} } });
   expect(folded.elapsed).toBeLessThan(plain.elapsed * 4 + 100);
+});
+
+test("a registry of records with numeric keys converts in linear time", () => {
+  const count = 2000;
+  const convert = (key: () => z.core.$ZodType) => {
+    const registry = z.registry<{ id: string }>();
+    for (let i = 0; i < count; i++) {
+      registry.add(z.object({ m: z.record(key() as z.core.$ZodRecordKey, z.boolean()) }), { id: `Type${i}` });
+    }
+    const start = performance.now();
+    const { schemas } = z.toJSONSchema(registry, { uri: (id) => `https://example.com/${id}.json` });
+    return { schemas, elapsed: performance.now() - start };
+  };
+
+  // The key rewrite has to find every carrier the flatten copied `propertyNames` onto, which means a pass over the whole seen map. Running that once per record rather than once per conversion cost ~10x at this size. The string key needs no rewrite at all, so comparing against it keeps this independent of how fast the machine is.
+  const numeric = convert(() => z.number());
+  expect(numeric.schemas.Type0).toMatchObject({
+    properties: { m: { propertyNames: { type: "string", pattern: "^-?\\d+(?:\\.\\d+)?$" } } },
+  });
+
+  const string = convert(() => z.string());
+  expect(numeric.elapsed).toBeLessThan(string.elapsed * 4 + 100);
 });
 
 test("registry extracts unregistered subschemas into __shared", () => {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1149,7 +1149,7 @@ describe("toJSONSchema", () => {
     ]);
   });
 
-  test("record filters enum values to strings and numbers for required", () => {
+  test("record stringifies numeric enum keys for propertyNames and required", () => {
     enum NumberEnum {
       Zero = 0,
       One = 1,
@@ -1164,18 +1164,38 @@ describe("toJSONSchema", () => {
         },
         "propertyNames": {
           "enum": [
-            0,
-            1,
+            "0",
+            "1",
           ],
-          "type": "number",
+          "type": "string",
         },
         "required": [
-          0,
-          1,
+          "0",
+          "1",
         ],
         "type": "object",
       }
     `);
+  });
+
+  test("record with a numeric key emits propertyNames over the numeric-string form", () => {
+    expect(z.toJSONSchema(z.record(z.number(), z.boolean())).propertyNames).toEqual({
+      type: "string",
+      pattern: "^-?\\d+(?:\\.\\d+)?$",
+    });
+    // range checks can't apply to a key, so only the integer shape survives
+    expect(z.toJSONSchema(z.record(z.int32(), z.boolean())).propertyNames).toEqual({
+      type: "string",
+      pattern: "^-?\\d+$",
+    });
+    expect(z.toJSONSchema(z.record(z.literal([1, 2]), z.boolean()))).toMatchObject({
+      propertyNames: { type: "string", enum: ["1", "2"] },
+      required: ["1", "2"],
+    });
+    expect(z.toJSONSchema(z.record(z.literal(1), z.boolean())).propertyNames).toEqual({
+      type: "string",
+      const: "1",
+    });
   });
 
   test("strict record with regex key uses propertyNames", () => {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -3128,24 +3128,30 @@ test("large registry converts in linear time", () => {
 
 test("a registry of records with numeric keys converts in linear time", () => {
   const count = 2000;
-  const convert = (key: () => z.core.$ZodType) => {
+  const convert = (key: (i: number) => z.core.$ZodType) => {
     const registry = z.registry<{ id: string }>();
     for (let i = 0; i < count; i++) {
-      registry.add(z.object({ m: z.record(key() as z.core.$ZodRecordKey, z.boolean()) }), { id: `Type${i}` });
+      registry.add(z.object({ m: z.record(key(i) as z.core.$ZodRecordKey, z.boolean()) }), { id: `Type${i}` });
     }
     const start = performance.now();
     const { schemas } = z.toJSONSchema(registry, { uri: (id) => `https://example.com/${id}.json` });
     return { schemas, elapsed: performance.now() - start };
   };
 
-  // The key rewrite has to find every carrier the flatten copied `propertyNames` onto, which means a pass over the whole seen map. Running that once per record rather than once per conversion cost ~10x at this size. The string key needs no rewrite at all, so comparing against it keeps this independent of how fast the machine is.
+  const string = convert(() => z.string());
   const numeric = convert(() => z.number());
   expect(numeric.schemas.Type0).toMatchObject({
     properties: { m: { propertyNames: { type: "string", pattern: "^-?\\d+(?:\\.\\d+)?$" } } },
   });
 
-  const string = convert(() => z.string());
-  expect(numeric.elapsed).toBeLessThan(string.elapsed * 4 + 100);
+  // The rewrite has to find every carrier the flatten copied `propertyNames` onto, which means a pass over the whole seen map. Running that once per record rather than once per conversion cost ~10x at this size. A string key needs no rewrite at all, so comparing against it keeps this independent of how fast the machine is.
+  expect(numeric.elapsed).toBeLessThan(string.elapsed * 2 + 50);
+
+  // An extracted key resolves through a map built once per conversion rather than a search per reference. There is no stable timing control for that — extraction has its own $defs cost, which swamps the difference — so this only pins the shape.
+  const extracted = convert((i) => z.number().meta({ id: `Key${i}` }));
+  expect(extracted.schemas.Type0).toMatchObject({
+    properties: { m: { propertyNames: { type: "string", pattern: "^-?\\d+(?:\\.\\d+)?$" } } },
+  });
 });
 
 test("registry extracts unregistered subschemas into __shared", () => {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1198,6 +1198,53 @@ describe("toJSONSchema", () => {
     });
   });
 
+  test("record key rewrite reaches through wrappers and union branches", () => {
+    const numericString = { type: "string", pattern: "^-?\\d+(?:\\.\\d+)?$" };
+    // a wrapper only carries its inner type once the refs are flattened, so this is decided after the record itself is emitted
+    expect(
+      z.toJSONSchema(
+        z.record(
+          z.lazy(() => z.number()),
+          z.boolean()
+        )
+      ).propertyNames
+    ).toEqual(numericString);
+    expect(z.toJSONSchema(z.record(z.number().pipe(z.number()), z.boolean())).propertyNames).toEqual(numericString);
+    expect(z.toJSONSchema(z.record(z.number().readonly(), z.boolean())).propertyNames).toMatchObject(numericString);
+    expect(z.toJSONSchema(z.record(z.union([z.literal("Tuna"), z.literal(21)]), z.string()))).toMatchObject({
+      propertyNames: {
+        anyOf: [
+          { type: "string", const: "Tuna" },
+          { type: "string", const: "21" },
+        ],
+      },
+      required: ["Tuna", "21"],
+    });
+  });
+
+  test("record with a numeric key inlines an extracted key, and leaves a string one referenced", () => {
+    expect(z.toJSONSchema(z.record(z.number().meta({ id: "Num" }), z.boolean())).propertyNames).toEqual({
+      type: "string",
+      pattern: "^-?\\d+(?:\\.\\d+)?$",
+    });
+    expect(z.toJSONSchema(z.record(z.string().meta({ id: "Str" }), z.boolean())).propertyNames).toEqual({
+      $ref: "#/$defs/Str",
+    });
+    // the value position still wants the number form, so the two cannot share one def
+    const key = z.number().meta({ id: "Shared" });
+    expect(z.toJSONSchema(z.object({ a: key, b: z.record(key, z.string()) }))).toMatchObject({
+      properties: { a: { $ref: "#/$defs/Shared" }, b: { propertyNames: { type: "string" } } },
+      $defs: { Shared: { type: "number" } },
+    });
+  });
+
+  test("record stringifies required for every target", () => {
+    const schema = z.record(z.literal([1, 2]), z.boolean());
+    for (const target of ["draft-2020-12", "draft-7", "draft-4", "openapi-3.0"] as const) {
+      expect(z.toJSONSchema(schema, { target }).required).toEqual(["1", "2"]);
+    }
+  });
+
   test("strict record with regex key uses propertyNames", () => {
     const schema = z.record(z.string().regex(/^label:[a-z]{2}$/), z.string());
 

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -1238,6 +1238,31 @@ describe("toJSONSchema", () => {
     });
   });
 
+  test("record key rewrite reaches a wrapped record", () => {
+    // the flatten copies a record's properties onto its wrapper by reference, so the rewrite has to find every copy
+    expect(z.toJSONSchema(z.record(z.number(), z.boolean()).optional()).propertyNames).toEqual({
+      type: "string",
+      pattern: "^-?\\d+(?:\\.\\d+)?$",
+    });
+    expect(z.toJSONSchema(z.object({ a: z.record(z.literal([1, 2]), z.boolean()).optional() }))).toMatchObject({
+      properties: { a: { propertyNames: { type: "string", enum: ["1", "2"] }, required: ["1", "2"] } },
+    });
+  });
+
+  test("record with a recursive key converts without looping", () => {
+    const numeric: any = z.lazy(() => z.union([z.number(), numeric]));
+    expect(z.toJSONSchema(z.record(numeric, z.boolean())).propertyNames).toMatchObject({
+      anyOf: [{ type: "string", pattern: "^-?\\d+(?:\\.\\d+)?$" }, { $ref: "#/$defs/__schema0" }],
+    });
+    // a key with nothing to re-express keeps the reference it had
+    const stringy: any = z.lazy(() => z.union([z.string(), stringy]));
+    expect(z.toJSONSchema(z.record(stringy, z.boolean())).propertyNames).toEqual({ $ref: "#/$defs/__schema0" });
+    expect(
+      z.toJSONSchema(z.record(z.union([z.literal("a"), z.literal("b")]).meta({ id: "Keys" }), z.boolean()))
+        .propertyNames
+    ).toEqual({ $ref: "#/$defs/Keys" });
+  });
+
   test("record stringifies required for every target", () => {
     const schema = z.record(z.literal([1, 2]), z.boolean());
     for (const target of ["draft-2020-12", "draft-7", "draft-4", "openapi-3.0"] as const) {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -479,12 +479,19 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
 /** JSON object keys are always strings, so a numeric record key schema is re-expressed over the
  * numeric-string form the record parser matches. Deferred to `finalize`, after the flatten: a key
  * behind a wrapper only carries its own `type` before then, and a union key only has its branches. */
-function stringifyKeyNames(ctx: ToJSONSchemaContext, json: JSONSchema.BaseSchema): JSONSchema.BaseSchema {
+function stringifyKeyNames(
+  ctx: ToJSONSchemaContext,
+  json: JSONSchema.BaseSchema,
+  visited: Set<JSONSchema.BaseSchema>
+): JSONSchema.BaseSchema {
   // an extracted key that rewrites cannot go on sharing its definition — the string form a key position needs is not the number form every other reference wants — so it inlines. One that does not rewrite keeps the `$ref`.
   if (json.$ref) {
+    // a recursive key holds its own reference inside its definition, so a node already on the path is left alone rather than resolved again
+    if (visited.has(json)) return json;
+    visited.add(json);
     for (const seen of ctx.seen.values()) {
       if (seen.schema !== json || !seen.def) continue;
-      const inlined = stringifyKeyNames(ctx, seen.def);
+      const inlined = stringifyKeyNames(ctx, seen.def, visited);
       return inlined === seen.def ? json : inlined;
     }
     return json;
@@ -493,7 +500,9 @@ function stringifyKeyNames(ctx: ToJSONSchemaContext, json: JSONSchema.BaseSchema
   for (const keyword of ["anyOf", "oneOf"] as const) {
     const branches = json[keyword];
     if (!Array.isArray(branches)) continue;
-    json = { ...json, [keyword]: branches.map((branch) => stringifyKeyNames(ctx, branch)) };
+    const mapped = branches.map((branch) => stringifyKeyNames(ctx, branch, visited));
+    // rebuilding regardless would detach a key that had nothing to re-express, dropping its `$ref` and leaking the internal `id`
+    if (mapped.some((branch, i) => branch !== branches[i])) json = { ...json, [keyword]: mapped };
   }
 
   // a member that already admits a string leaves the key unconstrained, so there is nothing to re-express
@@ -537,10 +546,15 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
       });
       ctx.deferred.push(() => {
         const seen = ctx.seen.get(schema)!;
-        // the extracted body is a copy taken before the rewrite runs, so both carriers need it
-        for (const carrier of [seen.schema, seen.def]) {
-          const names = carrier?.propertyNames;
-          if (names && names !== true) carrier!.propertyNames = stringifyKeyNames(ctx, names);
+        const names = (seen.def ?? seen.schema).propertyNames;
+        if (!names || names === true) return;
+        const rewritten = stringifyKeyNames(ctx, names, new Set());
+        if (rewritten === names) return;
+        // the flatten has already copied this record's own properties onto every wrapper by reference, and its extracted body is another such copy, so every carrier holding the key needs the rewrite
+        for (const entry of ctx.seen.values()) {
+          for (const carrier of [entry.schema, entry.def]) {
+            if (carrier?.propertyNames === names) carrier.propertyNames = rewritten;
+          }
         }
       });
     }

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -1,5 +1,6 @@
 import type * as checks from "./checks.js";
 import type * as JSONSchema from "./json-schema.js";
+import * as regexes from "./regexes.js";
 import type { $ZodRegistry } from "./registries.js";
 import type * as schemas from "./schemas.js";
 import {
@@ -475,6 +476,18 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
   if (typeof maximum === "number") json.maxItems = maximum;
 };
 
+// JSON object keys are always strings, so a numeric key schema is re-expressed over the numeric-string form the record parser matches
+function keyNameSchema(json: JSONSchema.BaseSchema): JSONSchema.BaseSchema {
+  if (json.type !== "number" && json.type !== "integer") return json;
+  // the copy escapes the `$defs` extraction that would otherwise wipe `id` off the original
+  const { minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf, format, id, ...rest } = json;
+  rest.type = "string";
+  if (rest.enum) rest.enum = rest.enum.map(String);
+  else if (rest.const !== undefined) rest.const = String(rest.const);
+  else rest.pattern = (json.type === "integer" ? regexes.integer : regexes.number).source;
+  return rest;
+}
+
 export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.ObjectSchema;
   const def = schema._zod.def as schemas.$ZodRecordDef;
@@ -498,10 +511,12 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
   } else {
     // Default behavior: use propertyNames + additionalProperties
     if (ctx.target === "draft-07" || ctx.target === "draft-2020-12") {
-      json.propertyNames = process(def.keyType, ctx as any, {
-        ...params,
-        path: [...params.path, "propertyNames"],
-      });
+      json.propertyNames = keyNameSchema(
+        process(def.keyType, ctx as any, {
+          ...params,
+          path: [...params.path, "propertyNames"],
+        })
+      );
     }
     json.additionalProperties = process(def.valueType, ctx as any, {
       ...params,
@@ -519,7 +534,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
     );
 
     if (validKeyValues.length > 0) {
-      json.required = validKeyValues as string[];
+      json.required = validKeyValues.map(String);
     }
   }
 };

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -505,16 +505,44 @@ function stringifyKeyNames(
     if (mapped.some((branch, i) => branch !== branches[i])) json = { ...json, [keyword]: mapped };
   }
 
-  // a member that already admits a string leaves the key unconstrained, so there is nothing to re-express
+  // a member that already admits a string leaves the key unconstrained, so the node's own type re-expresses only when every member is numeric
   const types = Array.isArray(json.type) ? json.type : [json.type];
-  if (types.includes("string") || !types.some((t) => t === "number" || t === "integer")) return json;
+  const numericType = !types.includes("string") && types.some((t) => t === "number" || t === "integer");
+  // a heterogeneous key carries no type at all, so its numeric members are caught here instead
+  const values = json.enum ?? (json.const !== undefined ? [json.const] : undefined);
+  if (!numericType && !values?.some((v) => typeof v === "number")) return json;
 
   const { minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf, format, id, ...rest } = json;
+  if (rest.enum) rest.enum = rest.enum.map((v) => (typeof v === "number" ? String(v) : v));
+  else if (typeof rest.const === "number") rest.const = String(rest.const);
+  // a heterogeneous key keeps its absent type: the stringified members already say what a key may be
+  if (!numericType) return rest;
   rest.type = "string";
-  if (rest.enum) rest.enum = rest.enum.map(String);
-  else if (rest.const !== undefined) rest.const = String(rest.const);
-  else rest.pattern = (types.includes("number") ? regexes.number : regexes.integer).source;
+  if (!values) rest.pattern = (types.includes("number") ? regexes.number : regexes.integer).source;
   return rest;
+}
+
+/** Every record of one conversion, so the carriers are found in a single pass rather than once per record. */
+const pendingRecords = new WeakMap<ToJSONSchemaContext, schemas.$ZodType[]>();
+
+function rewriteKeyNames(ctx: ToJSONSchemaContext): void {
+  const rewrites = new Map<JSONSchema.BaseSchema, JSONSchema.BaseSchema>();
+  for (const record of pendingRecords.get(ctx) ?? []) {
+    const seen = ctx.seen.get(record);
+    const names = (seen?.def ?? seen?.schema)?.propertyNames;
+    if (!names || names === true || rewrites.has(names)) continue;
+    const rewritten = stringifyKeyNames(ctx, names, new Set());
+    if (rewritten !== names) rewrites.set(names, rewritten);
+  }
+  if (!rewrites.size) return;
+
+  // the flatten has already copied each record's own properties onto every wrapper by reference, and an extracted body is another such copy, so every carrier holding a rewritten key is updated together
+  for (const entry of ctx.seen.values()) {
+    for (const carrier of [entry.schema, entry.def]) {
+      const rewritten = carrier && rewrites.get(carrier.propertyNames as JSONSchema.BaseSchema);
+      if (rewritten) carrier!.propertyNames = rewritten;
+    }
+  }
 }
 
 export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _json, params) => {
@@ -544,19 +572,13 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
         ...params,
         path: [...params.path, "propertyNames"],
       });
-      ctx.deferred.push(() => {
-        const seen = ctx.seen.get(schema)!;
-        const names = (seen.def ?? seen.schema).propertyNames;
-        if (!names || names === true) return;
-        const rewritten = stringifyKeyNames(ctx, names, new Set());
-        if (rewritten === names) return;
-        // the flatten has already copied this record's own properties onto every wrapper by reference, and its extracted body is another such copy, so every carrier holding the key needs the rewrite
-        for (const entry of ctx.seen.values()) {
-          for (const carrier of [entry.schema, entry.def]) {
-            if (carrier?.propertyNames === names) carrier.propertyNames = rewritten;
-          }
-        }
-      });
+      let pending = pendingRecords.get(ctx);
+      if (!pending) {
+        pending = [];
+        pendingRecords.set(ctx, pending);
+        ctx.deferred.push(() => rewriteKeyNames(ctx));
+      }
+      pending.push(schema);
     }
     json.additionalProperties = process(def.valueType, ctx as any, {
       ...params,

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -47,11 +47,11 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
   }
   if (contentEncoding) json.contentEncoding = contentEncoding;
   if (patterns && patterns.size > 0) {
-    const regexes = [...patterns];
-    if (regexes.length === 1) json.pattern = regexes[0]!.source;
-    else if (regexes.length > 1) {
+    const patternList = [...patterns];
+    if (patternList.length === 1) json.pattern = patternList[0]!.source;
+    else if (patternList.length > 1) {
       json.allOf = [
-        ...regexes.map((regex) => ({
+        ...patternList.map((regex) => ({
           ...(ctx.target === "draft-07" || ctx.target === "draft-04" || ctx.target === "openapi-3.0"
             ? ({ type: "string" } as const)
             : {}),
@@ -476,15 +476,35 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
   if (typeof maximum === "number") json.maxItems = maximum;
 };
 
-// JSON object keys are always strings, so a numeric key schema is re-expressed over the numeric-string form the record parser matches
-function keyNameSchema(json: JSONSchema.BaseSchema): JSONSchema.BaseSchema {
-  if (json.type !== "number" && json.type !== "integer") return json;
-  // the copy escapes the `$defs` extraction that would otherwise wipe `id` off the original
+/** JSON object keys are always strings, so a numeric record key schema is re-expressed over the
+ * numeric-string form the record parser matches. Deferred to `finalize`, after the flatten: a key
+ * behind a wrapper only carries its own `type` before then, and a union key only has its branches. */
+function stringifyKeyNames(ctx: ToJSONSchemaContext, json: JSONSchema.BaseSchema): JSONSchema.BaseSchema {
+  // an extracted key that rewrites cannot go on sharing its definition — the string form a key position needs is not the number form every other reference wants — so it inlines. One that does not rewrite keeps the `$ref`.
+  if (json.$ref) {
+    for (const seen of ctx.seen.values()) {
+      if (seen.schema !== json || !seen.def) continue;
+      const inlined = stringifyKeyNames(ctx, seen.def);
+      return inlined === seen.def ? json : inlined;
+    }
+    return json;
+  }
+
+  for (const keyword of ["anyOf", "oneOf"] as const) {
+    const branches = json[keyword];
+    if (!Array.isArray(branches)) continue;
+    json = { ...json, [keyword]: branches.map((branch) => stringifyKeyNames(ctx, branch)) };
+  }
+
+  // a member that already admits a string leaves the key unconstrained, so there is nothing to re-express
+  const types = Array.isArray(json.type) ? json.type : [json.type];
+  if (types.includes("string") || !types.some((t) => t === "number" || t === "integer")) return json;
+
   const { minimum, maximum, exclusiveMinimum, exclusiveMaximum, multipleOf, format, id, ...rest } = json;
   rest.type = "string";
   if (rest.enum) rest.enum = rest.enum.map(String);
   else if (rest.const !== undefined) rest.const = String(rest.const);
-  else rest.pattern = (json.type === "integer" ? regexes.integer : regexes.number).source;
+  else rest.pattern = (types.includes("number") ? regexes.number : regexes.integer).source;
   return rest;
 }
 
@@ -511,12 +531,18 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
   } else {
     // Default behavior: use propertyNames + additionalProperties
     if (ctx.target === "draft-07" || ctx.target === "draft-2020-12") {
-      json.propertyNames = keyNameSchema(
-        process(def.keyType, ctx as any, {
-          ...params,
-          path: [...params.path, "propertyNames"],
-        })
-      );
+      json.propertyNames = process(def.keyType, ctx as any, {
+        ...params,
+        path: [...params.path, "propertyNames"],
+      });
+      ctx.deferred.push(() => {
+        const seen = ctx.seen.get(schema)!;
+        // the extracted body is a copy taken before the rewrite runs, so both carriers need it
+        for (const carrier of [seen.schema, seen.def]) {
+          const names = carrier?.propertyNames;
+          if (names && names !== true) carrier!.propertyNames = stringifyKeyNames(ctx, names);
+        }
+      });
     }
     json.additionalProperties = process(def.valueType, ctx as any, {
       ...params,

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -531,9 +531,11 @@ function stringifyKeyNames(
 const pendingRecords = new WeakMap<ToJSONSchemaContext, schemas.$ZodType[]>();
 
 function rewriteKeyNames(ctx: ToJSONSchemaContext): void {
-  // an extracted key is resolved by the object `extractToDef` left in its place, so the map is built once rather than searched per reference
+  // an extracted key is resolved by the object `extractToDef` left in its place, so the map is built once rather than searched per reference. `_zod.toJSONSchema` can hand the same object to two schemas, so the first entry carrying a body wins, as a search would have found it.
   const bySchema = new Map<JSONSchema.BaseSchema, Seen>();
-  for (const entry of ctx.seen.values()) bySchema.set(entry.schema, entry);
+  for (const entry of ctx.seen.values()) {
+    if (entry.def && !bySchema.has(entry.schema)) bySchema.set(entry.schema, entry);
+  }
 
   const rewrites = new Map<JSONSchema.BaseSchema, JSONSchema.BaseSchema>();
   for (const record of pendingRecords.get(ctx) ?? []) {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -7,6 +7,7 @@ import {
   type ProcessParams,
   type Processor,
   type RegistryToJSONSchemaParams,
+  type Seen,
   type ToJSONSchemaContext,
   type ToJSONSchemaParams,
   type ZodStandardJSONSchemaPayload,
@@ -478,9 +479,15 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
 
 /** JSON object keys are always strings, so a numeric record key schema is re-expressed over the
  * numeric-string form the record parser matches. Deferred to `finalize`, after the flatten: a key
- * behind a wrapper only carries its own `type` before then, and a union key only has its branches. */
+ * behind a wrapper only carries its own `type` before then, and a union key only has its branches.
+ *
+ * A numeric bound cannot apply to a property name, so `minimum` and its siblings are dropped rather
+ * than carried over: keeping them beside `type: "string"` reproduces the match-nothing schema this
+ * exists to fix. A key that carries one therefore emits wider than the record parses — `z.record(z.number().min(5), V)`
+ * accepts `"3"` — which is the deliberate trade, since throwing on it would reject an ordinary schema
+ * outright. */
 function stringifyKeyNames(
-  ctx: ToJSONSchemaContext,
+  bySchema: Map<JSONSchema.BaseSchema, Seen>,
   json: JSONSchema.BaseSchema,
   visited: Set<JSONSchema.BaseSchema>
 ): JSONSchema.BaseSchema {
@@ -489,18 +496,16 @@ function stringifyKeyNames(
     // a recursive key holds its own reference inside its definition, so a node already on the path is left alone rather than resolved again
     if (visited.has(json)) return json;
     visited.add(json);
-    for (const seen of ctx.seen.values()) {
-      if (seen.schema !== json || !seen.def) continue;
-      const inlined = stringifyKeyNames(ctx, seen.def, visited);
-      return inlined === seen.def ? json : inlined;
-    }
-    return json;
+    const def = bySchema.get(json)?.def;
+    if (!def) return json;
+    const inlined = stringifyKeyNames(bySchema, def, visited);
+    return inlined === def ? json : inlined;
   }
 
   for (const keyword of ["anyOf", "oneOf"] as const) {
     const branches = json[keyword];
     if (!Array.isArray(branches)) continue;
-    const mapped = branches.map((branch) => stringifyKeyNames(ctx, branch, visited));
+    const mapped = branches.map((branch) => stringifyKeyNames(bySchema, branch, visited));
     // rebuilding regardless would detach a key that had nothing to re-express, dropping its `$ref` and leaking the internal `id`
     if (mapped.some((branch, i) => branch !== branches[i])) json = { ...json, [keyword]: mapped };
   }
@@ -526,12 +531,16 @@ function stringifyKeyNames(
 const pendingRecords = new WeakMap<ToJSONSchemaContext, schemas.$ZodType[]>();
 
 function rewriteKeyNames(ctx: ToJSONSchemaContext): void {
+  // an extracted key is resolved by the object `extractToDef` left in its place, so the map is built once rather than searched per reference
+  const bySchema = new Map<JSONSchema.BaseSchema, Seen>();
+  for (const entry of ctx.seen.values()) bySchema.set(entry.schema, entry);
+
   const rewrites = new Map<JSONSchema.BaseSchema, JSONSchema.BaseSchema>();
   for (const record of pendingRecords.get(ctx) ?? []) {
     const seen = ctx.seen.get(record);
     const names = (seen?.def ?? seen?.schema)?.propertyNames;
     if (!names || names === true || rewrites.has(names)) continue;
-    const rewritten = stringifyKeyNames(ctx, names, new Set());
+    const rewritten = stringifyKeyNames(bySchema, names, new Set());
     if (rewritten !== names) rewrites.set(names, rewritten);
   }
   if (!rewrites.size) return;

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -142,6 +142,8 @@ export interface ToJSONSchemaContext {
   reused: "ref" | "inline";
   /** The `allOf` array of each intersection encountered during traversal, innermost first. `finalize` folds every emitted object holding one; see `foldIntersection`. */
   intersections: JSONSchema.BaseSchema[][];
+  /** Rewrites a processor deferred to `finalize`, where the flatten has resolved every ref and the union branches are in place. */
+  deferred: (() => void)[];
   external?:
     | {
         registry: $ZodRegistry<{ id?: string | undefined }>;
@@ -180,6 +182,7 @@ export function initializeContext(params: JSONSchemaGeneratorParams): ToJSONSche
     cycles: params?.cycles ?? "ref",
     reused: params?.reused ?? "inline",
     intersections: [],
+    deferred: [],
     external: params?.external ?? undefined,
   };
 }
@@ -659,6 +662,8 @@ export function finalize<T extends schemas.$ZodType>(
         compactTypeUnion(entry[1].def ?? entry[1].schema);
       }
     }
+
+    for (const rewrite of ctx.deferred) rewrite();
 
     // After flattening, every member that was extracted is a `$ref`, so the fold sees the final shape. A schema that inherits an intersection — through `z.lazy`, or any `ref` chain — holds the same `allOf` array, so fold by array identity to catch every copy.
     if (ctx.intersections.length) {


### PR DESCRIPTION
JSON object keys are always strings, so `propertyNames: { type: "number" }` matches no key. A record with a numeric key emitted a schema that accepts only `{}`, while the Zod schema accepts `{ "1": 2 }`.

A numeric-literal key was worse. `z.record(z.literal([1, 2]), z.number())` emitted `required: [1, 2]`, and `required` is an array of strings in every draft — Ajv refuses to compile it. That one affected all four targets, including `openapi-3.0`.

Both are string positions now. Discrete numeric key values are stringified, and a bare numeric key type is re-expressed as a string carrying the same regex the record parser gates on before it retries a key as a number, so the output for a `z.number()` key is exact rather than approximate. Numeric-only keywords like `minimum` are dropped, since they cannot constrain a string.

```ts
z.toJSONSchema(z.record(z.number(), z.boolean())).propertyNames;
// before: { type: "number" }
// after:  { type: "string", pattern: "^-?\\d+(?:\\.\\d+)?$" }
```

The rewrite runs from `finalize` rather than at emit time, because a key behind `z.lazy`, `.pipe()` or `.readonly()` has no `type` of its own until the flatten merges the inner one, and a union key keeps its branches under `anyOf`. It recurses into those branches, resolves an extracted key through its definition — inlining the string form a key position needs, while a key with nothing to re-express keeps its `$ref` — and updates every carrier the flatten copied `propertyNames` onto, so a wrapped record does not keep the old shape. A recursive key terminates on revisit instead of looping.

Verified by emitting 33 record shapes on `main` and on this branch, compiling each with Ajv and comparing against the schema's own `safeParse`: no case is worse here, 24 are better, and the six schemas `main` cannot compile at all now compile. Bundle is +13 B gz on `zod-object` and -3 B on `zod-mini-object`; conversion of a record-heavy registry stays linear, with a new guard alongside the existing one.

Closes #6496
