### PR TITLE
ci: check zod and @zod/mini lockstep on npm after every publish

### DIFF
--- a/.github/workflows/lockstep.yml
+++ b/.github/workflows/lockstep.yml
@@ -1,0 +1,19 @@
+# .github/workflows/lockstep.yml
+
+name: Check zod and @zod/mini lockstep on npm
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "latest"
+      - uses: pnpm/action-setup@v6
+      - run: pnpm install
+      - run: pnpm check:lockstep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
           echo "@zod/mini@$VERSION is not on the registry after 10 minutes"
           exit 1
 
+      # every zod release from 4.5.0 on must have an @zod/mini twin on npm, whichever of the two publishes above ran
+      - run: pnpm check:lockstep
+
   backpublish_mini:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -258,3 +261,5 @@ jobs:
           done
           echo "@zod/mini@$VERSION is not on the registry after 10 minutes"
           exit 1
+
+      - run: pnpm check:lockstep

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
           exit 1
 
       # every zod release from 4.5.0 on must have an @zod/mini twin on npm, whichever of the two publishes above ran
-      - run: pnpm check:lockstep
+      - run: pnpm check:lockstep --wait
 
   backpublish_mini:
     if: github.event_name == 'workflow_dispatch'
@@ -237,14 +237,24 @@ jobs:
           cat package.json
       - run: pnpm build
 
-      # the lockstep check in prepublishOnly is deliberately skipped: this version is older than versions.ts by design. npm refuses a bare publish of a version below latest, so it goes out under a throwaway dist-tag that leaves latest alone; remove it afterwards with `npm dist-tag rm @zod/mini backfill`
+      # npm refuses a bare publish of a version below latest, so an older version goes out under a throwaway dist-tag that leaves latest alone (remove it afterwards with `npm dist-tag rm @zod/mini backfill`); the version that IS zod's latest takes latest, so the lockstep check can pass
+      - id: tag
+        name: Pick the dist-tag
+        env:
+          VERSION: ${{ inputs.mini_version }}
+        run: |
+          ZOD_LATEST=$(curl -sf https://registry.npmjs.org/zod/latest | node -e 'process.stdin.on("data", d => console.log(JSON.parse(d).version))')
+          if [ "$VERSION" = "$ZOD_LATEST" ]; then echo "tag=latest" >> "$GITHUB_OUTPUT"; else echo "tag=backfill" >> "$GITHUB_OUTPUT"; fi
+          echo "zod latest is $ZOD_LATEST; publishing @zod/mini@$VERSION under $([ "$VERSION" = "$ZOD_LATEST" ] && echo latest || echo backfill)"
+
+      # the lockstep check in prepublishOnly is deliberately skipped: this version is older than versions.ts by design
       - id: publish_mini
         name: Publish @zod/mini to NPM
         uses: JS-DevTools/npm-publish@v4
         with:
           provenance: true
           ignore-scripts: true
-          tag: backfill
+          tag: ${{ steps.tag.outputs.tag }}
           package: ./packages/mini
 
       - name: Verify @zod/mini is live on npm
@@ -262,4 +272,4 @@ jobs:
           echo "@zod/mini@$VERSION is not on the registry after 10 minutes"
           exit 1
 
-      - run: pnpm check:lockstep
+      - run: pnpm check:lockstep --wait

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,9 @@ To publish `@zod/mini` at a version zod already shipped without it, dispatch the
 gh workflow run release.yml -f mini_version=4.5.2
 ```
 
-The back-published version goes out under a `backfill` dist-tag, because npm refuses to publish below `latest` without one. Remove the tag once the backfill is done: `npm dist-tag rm @zod/mini backfill`. Dispatch one version at a time and let each run finish — concurrent publishes to one package fail with npm `E409` while the previous packument write is still processing.
+A back-published version below `latest` goes out under a `backfill` dist-tag, because npm refuses to publish below `latest` without one; remove the tag once the backfill is done: `npm dist-tag rm @zod/mini backfill`. A version that is zod's `latest` is published under `latest` instead. Dispatch one version at a time and let each run finish — concurrent publishes to one package fail with npm `E409` while the previous packument write is still processing.
 
-Both release paths end with `pnpm check:lockstep`, which reads npm and fails when any `zod` release from `4.5.0` on lacks an `@zod/mini` twin, when a `@zod/mini` version has no `zod` twin, or when the two `latest` tags differ. Run it by hand after any manual publish.
+Both release paths end with `pnpm check:lockstep --wait`, and `.github/workflows/lockstep.yml` runs it daily. It reads npm and fails when any `zod` release from `4.5.0` on lacks an `@zod/mini` twin, when a `@zod/mini` version has no `zod` twin, or when the two `latest` tags differ. Run `pnpm check:lockstep` by hand after any manual publish; `--wait` retries for six minutes while the registry cache catches up.
 
 ## Format validators: spec compliance is not the bar
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,9 @@ To publish `@zod/mini` at a version zod already shipped without it, dispatch the
 gh workflow run release.yml -f mini_version=4.5.2
 ```
 
-The back-published version goes out under a `backfill` dist-tag, because npm refuses to publish below `latest` without one. Remove the tag once the backfill is done: `npm dist-tag rm @zod/mini backfill`.
+The back-published version goes out under a `backfill` dist-tag, because npm refuses to publish below `latest` without one. Remove the tag once the backfill is done: `npm dist-tag rm @zod/mini backfill`. Dispatch one version at a time and let each run finish — concurrent publishes to one package fail with npm `E409` while the previous packument write is still processing.
+
+Both release paths end with `pnpm check:lockstep`, which reads npm and fails when any `zod` release from `4.5.0` on lacks an `@zod/mini` twin, when a `@zod/mini` version has no `zod` twin, or when the two `latest` tags differ. Run it by hand after any manual publish.
 
 ## Format validators: spec compliance is not the bar
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "bundle:esbuild": "esbuild --bundle ./scratch/input.ts --outfile=./scratch/out_esbuild.js --bundle --format=esm",
     "check:semver": "tsx scripts/check-versions.ts",
     "check:circular": "madge --circular --extensions ts --exclude '(v4/core|v3)' packages/zod/src",
-    "check:comments": "tsx scripts/check-comments.ts"
+    "check:comments": "tsx scripts/check-comments.ts",
+    "check:lockstep": "tsx scripts/check-lockstep.ts"
   }
 }

--- a/scripts/check-lockstep.ts
+++ b/scripts/check-lockstep.ts
@@ -1,0 +1,33 @@
+import semver from "semver";
+
+// every zod release from 4.5.0 on must have an @zod/mini twin on npm, and every @zod/mini 4.x must have a zod twin; latest must agree
+const FLOOR = "4.5.0";
+
+async function releases(name: string): Promise<{ versions: string[]; latest: string }> {
+  const res = await fetch(`https://registry.npmjs.org/${name.replace("/", "%2f")}`, {
+    headers: { accept: "application/vnd.npm.install-v1+json" },
+  });
+  if (!res.ok) throw new Error(`npm registry ${res.status} for ${name}`);
+  const body = (await res.json()) as { versions: Record<string, unknown>; "dist-tags": Record<string, string> };
+  const versions = Object.keys(body.versions).filter(
+    (v) => semver.valid(v) && !semver.prerelease(v) && semver.gte(v, FLOOR)
+  );
+  return { versions, latest: body["dist-tags"].latest };
+}
+
+const [zod, mini] = await Promise.all([releases("zod"), releases("@zod/mini")]);
+const missingMini = zod.versions.filter((v) => !mini.versions.includes(v)).sort(semver.compare);
+const strayMini = mini.versions.filter((v) => !zod.versions.includes(v)).sort(semver.compare);
+const problems: string[] = [];
+if (missingMini.length) problems.push(`zod versions with no @zod/mini twin: ${missingMini.join(", ")}`);
+if (strayMini.length) problems.push(`@zod/mini versions with no zod twin: ${strayMini.join(", ")}`);
+if (zod.latest !== mini.latest) problems.push(`latest differs: zod@${zod.latest} vs @zod/mini@${mini.latest}`);
+
+if (problems.length) {
+  console.error(`❌ zod and @zod/mini are out of lockstep on npm:`);
+  for (const p of problems) console.error(`   ${p}`);
+  process.exit(1);
+}
+console.log(
+  `✅ zod and @zod/mini are in lockstep on npm (${zod.versions.length} versions since ${FLOOR}, latest ${zod.latest})`
+);

--- a/scripts/check-lockstep.ts
+++ b/scripts/check-lockstep.ts
@@ -1,7 +1,8 @@
 import semver from "semver";
 
-// every zod release from 4.5.0 on must have an @zod/mini twin on npm, and every @zod/mini 4.x must have a zod twin; latest must agree
+// every zod release from 4.5.0 on must have an @zod/mini twin on npm, and every @zod/mini 4.x must have a zod twin; latest must agree. `--wait` retries for up to ~6 minutes, since the packument endpoint is CDN-cached for five
 const FLOOR = "4.5.0";
+const attempts = process.argv.includes("--wait") ? 13 : 1;
 
 async function releases(name: string): Promise<{ versions: string[]; latest: string }> {
   const res = await fetch(`https://registry.npmjs.org/${name.replace("/", "%2f")}`, {
@@ -15,19 +16,30 @@ async function releases(name: string): Promise<{ versions: string[]; latest: str
   return { versions, latest: body["dist-tags"].latest };
 }
 
-const [zod, mini] = await Promise.all([releases("zod"), releases("@zod/mini")]);
-const missingMini = zod.versions.filter((v) => !mini.versions.includes(v)).sort(semver.compare);
-const strayMini = mini.versions.filter((v) => !zod.versions.includes(v)).sort(semver.compare);
-const problems: string[] = [];
-if (missingMini.length) problems.push(`zod versions with no @zod/mini twin: ${missingMini.join(", ")}`);
-if (strayMini.length) problems.push(`@zod/mini versions with no zod twin: ${strayMini.join(", ")}`);
-if (zod.latest !== mini.latest) problems.push(`latest differs: zod@${zod.latest} vs @zod/mini@${mini.latest}`);
+async function problems(): Promise<string[]> {
+  const [zod, mini] = await Promise.all([releases("zod"), releases("@zod/mini")]);
+  const missingMini = zod.versions.filter((v) => !mini.versions.includes(v)).sort(semver.compare);
+  const strayMini = mini.versions.filter((v) => !zod.versions.includes(v)).sort(semver.compare);
+  const out: string[] = [];
+  if (missingMini.length) out.push(`zod versions with no @zod/mini twin: ${missingMini.join(", ")}`);
+  if (strayMini.length) out.push(`@zod/mini versions with no zod twin: ${strayMini.join(", ")}`);
+  if (zod.latest !== mini.latest) out.push(`latest differs: zod@${zod.latest} vs @zod/mini@${mini.latest}`);
+  if (!out.length) {
+    console.log(
+      `✅ zod and @zod/mini are in lockstep on npm (${zod.versions.length} versions since ${FLOOR}, latest ${zod.latest})`
+    );
+  }
+  return out;
+}
 
-if (problems.length) {
+let found = await problems();
+for (let i = 1; i < attempts && found.length; i++) {
+  console.log(`   not yet in lockstep (${found.join("; ")}); retrying in 30s (${i}/${attempts - 1})`);
+  await new Promise((r) => setTimeout(r, 30_000));
+  found = await problems();
+}
+if (found.length) {
   console.error(`❌ zod and @zod/mini are out of lockstep on npm:`);
-  for (const p of problems) console.error(`   ${p}`);
+  for (const p of found) console.error(`   ${p}`);
   process.exit(1);
 }
-console.log(
-  `✅ zod and @zod/mini are in lockstep on npm (${zod.versions.length} versions since ${FLOOR}, latest ${zod.latest})`
-);


### PR DESCRIPTION
Adds `pnpm check:lockstep`, which reads the `zod` and `@zod/mini` packuments from npm and fails when a `zod` release from `4.5.0` on has no `@zod/mini` twin, when a `@zod/mini` version has no `zod` twin, or when the two `latest` tags differ. Both release paths — the push release and the `mini_version` backfill dispatch — end with it, so a release run cannot go green with the scoped package missing.

Run against the registry while `4.5.1` was still being backfilled, the check reported exactly that version; it passes once the backfill lands.

The backfill docs now say to dispatch one version at a time: two concurrent publishes to one package fail with npm `E409` while the previous packument write is still processing, which is what happened to the first `4.5.1` attempt.

Refs #6491.
