### PR TITLE
ci: publish @zod/mini to JSR in lockstep with npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
         working-directory: ./packages/mini
         run: |
           VERSION=$(node -p 'require("./jsr.json").version')
-          if curl -sf "https://jsr.io/@zod/mini/${VERSION}_meta.json" > /dev/null; then
+          if curl -sfL "https://jsr.io/@zod/mini/${VERSION}_meta.json" > /dev/null; then
             echo "@zod/mini@$VERSION is already on JSR"
           else
             pnpm jsr publish --allow-slow-types
@@ -320,7 +320,7 @@ jobs:
         env:
           VERSION: ${{ inputs.mini_version }}
         run: |
-          if curl -sf "https://jsr.io/@zod/mini/${VERSION}_meta.json" > /dev/null; then
+          if curl -sfL "https://jsr.io/@zod/mini/${VERSION}_meta.json" > /dev/null; then
             echo "@zod/mini@$VERSION is already on JSR"
           else
             pnpm jsr publish --allow-slow-types --allow-dirty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,17 @@ jobs:
           echo "@zod/mini@$VERSION never reached the registry; see the publish step for why"
           exit 1
 
+      # JSR refuses a version that already exists, so the step checks first; this also lets the first JSR publish of a version already on npm ride on a merge that publishes nothing to npm
+      - name: Publish @zod/mini to JSR
+        working-directory: ./packages/mini
+        run: |
+          VERSION=$(node -p 'require("./jsr.json").version')
+          if curl -sf "https://jsr.io/@zod/mini/${VERSION}_meta.json" > /dev/null; then
+            echo "@zod/mini@$VERSION is already on JSR"
+          else
+            pnpm jsr publish --allow-slow-types
+          fi
+
       # every zod release from 4.5.0 on must have an @zod/mini twin on npm, whichever of the two publishes above ran
       - run: pnpm check:lockstep --wait
 
@@ -254,8 +265,16 @@ jobs:
             echo "zod@$VERSION is not on npm; @zod/mini only ships versions zod shipped"
             exit 1
           fi
-          npm pkg set version="$VERSION" peerDependencies.zod="^${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.0"
-          cat package.json
+          export MAJOR="${BASH_REMATCH[1]}" MINOR="${BASH_REMATCH[2]}"
+          npm pkg set version="$VERSION" peerDependencies.zod="^${MAJOR}.${MINOR}.0"
+          node -e '
+            const fs = require("fs");
+            const jsr = JSON.parse(fs.readFileSync("jsr.json", "utf8"));
+            jsr.version = process.env.VERSION;
+            jsr.imports["zod/mini"] = `jsr:@zod/zod@^${process.env.MAJOR}.${process.env.MINOR}.0/mini`;
+            fs.writeFileSync("jsr.json", JSON.stringify(jsr, null, 2) + "\n");
+          '
+          cat package.json jsr.json
       - run: pnpm build
 
       # npm refuses a bare publish of a version below latest, so an older version goes out under a throwaway dist-tag that leaves latest alone (remove it afterwards with `npm dist-tag rm @zod/mini backfill`); the version that IS zod's latest takes latest, so the lockstep check can pass
@@ -294,5 +313,17 @@ jobs:
           done
           echo "@zod/mini@$VERSION never reached the registry; see the publish step for why"
           exit 1
+
+      # the version edit above leaves the tree dirty by design
+      - name: Publish @zod/mini to JSR
+        working-directory: ./packages/mini
+        env:
+          VERSION: ${{ inputs.mini_version }}
+        run: |
+          if curl -sf "https://jsr.io/@zod/mini/${VERSION}_meta.json" > /dev/null; then
+            echo "@zod/mini@$VERSION is already on JSR"
+          else
+            pnpm jsr publish --allow-slow-types --allow-dirty
+          fi
 
       - run: pnpm check:lockstep --wait

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ gh workflow run release.yml -f mini_version=4.5.2
 
 A back-published version below `latest` goes out under a `backfill` dist-tag, because npm refuses to publish below `latest` without one; remove the tag once the backfill is done: `npm dist-tag rm @zod/mini backfill`. A version that is zod's `latest` is published under `latest` instead. Dispatch one version at a time and let each run finish — concurrent publishes to one package fail with npm `E409` while the previous packument write is still processing.
 
-Both release paths end with `pnpm check:lockstep --wait`, and `.github/workflows/lockstep.yml` runs it daily. It reads npm and fails when any `zod` release from `4.5.0` on lacks an `@zod/mini` twin, when a `@zod/mini` version has no `zod` twin, or when the two `latest` tags differ. Run `pnpm check:lockstep` by hand after any manual publish; `--wait` retries for six minutes while the registry cache catches up.
+Both release paths end with `pnpm check:lockstep --wait`, and `.github/workflows/lockstep.yml` runs it daily. It reads npm and JSR and fails when any `zod` release from `4.5.0` on lacks an `@zod/mini` twin on either registry, when a `@zod/mini` version has no `zod` twin, or when the `latest` tags differ. A `zod` version present on npm but missing on JSR is only warned about, since that publish is recovered by hand and must not hold a release red. Run `pnpm check:lockstep` by hand after any manual publish; `--wait` retries for six minutes while the registry cache catches up.
 
 ## Format validators: spec compliance is not the bar
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,12 +84,13 @@ If you touch that machinery, three things bite:
 
 Only do this when the user explicitly asks. Pushing a version bump to `main` triggers `.github/workflows/release.yml`, which publishes to npm + JSR and creates a `v<version>` GitHub release. There is no undo.
 
-Four files must be bumped together — `pnpm check:semver` runs in pre-commit and `prepublishOnly`, and will fail the commit if they disagree:
+Five files must be bumped together — `pnpm check:semver` runs in pre-commit and `prepublishOnly`, and will fail the commit if they disagree:
 
 - `packages/zod/package.json` — `version`
 - `packages/zod/jsr.json` — `version`
 - `packages/zod/src/v4/core/versions.ts` — `major` / `minor` / `patch`
 - `packages/mini/package.json` — `version` (same x.y.z; `@zod/mini` ships in lockstep) and `peerDependencies.zod` (`^x.y.0`, the minor being released — bump it on every minor)
+- `packages/mini/jsr.json` — `version` and the `imports["zod/mini"]` range (`jsr:@zod/zod@^x.y.0/mini`, same rule)
 
 Procedure:
 
@@ -97,13 +98,13 @@ Procedure:
 # Make sure main is clean and up to date first.
 git checkout main && git pull
 
-# Bump all four files to the new x.y.z (and the @zod/mini peer floor on a minor), then:
-git add packages/zod/package.json packages/zod/jsr.json packages/zod/src/v4/core/versions.ts packages/mini/package.json
+# Bump all five files to the new x.y.z (and the @zod/mini peer floor + JSR import range on a minor), then:
+git add packages/zod/package.json packages/zod/jsr.json packages/zod/src/v4/core/versions.ts packages/mini/package.json packages/mini/jsr.json
 git commit -m "<x.y.z>"   # commit message is just the version, e.g. "4.4.3"
 git push origin main
 ```
 
-The release workflow only fires on changes under `packages/zod/package.json`, `packages/mini/package.json` or the workflow file itself, so the bump must include `package.json`. It publishes `zod`, then tags and releases it, then publishes `@zod/mini` last. Watch the Actions tab to confirm `build_and_publish` succeeds.
+The release workflow only fires on changes under `packages/zod/package.json`, `packages/mini/package.json` or the workflow file itself, so the bump must include `package.json`. It publishes `zod`, then tags and releases it, then publishes `@zod/mini` to npm and JSR last. Watch the Actions tab to confirm `build_and_publish` succeeds.
 
 To publish `@zod/mini` at a version zod already shipped without it, dispatch the same workflow; it publishes only the scoped package, with the peer floor set to that minor:
 

--- a/packages/mini/jsr.json
+++ b/packages/mini/jsr.json
@@ -1,0 +1,21 @@
+{
+  "name": "@zod/mini",
+  "version": "4.5.4",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts"
+  },
+  "imports": {
+    "zod/mini": "jsr:@zod/zod@^4.5.0/mini"
+  },
+  "publish": {
+    "include": [
+      "src",
+      "LICENSE",
+      "README.md"
+    ],
+    "exclude": [
+      "**/tests/**"
+    ]
+  }
+}

--- a/packages/mini/jsr.json
+++ b/packages/mini/jsr.json
@@ -12,6 +12,7 @@
     "include": [
       "src",
       "LICENSE",
+      "package.json",
       "README.md"
     ],
     "exclude": [

--- a/scripts/check-lockstep.ts
+++ b/scripts/check-lockstep.ts
@@ -1,32 +1,56 @@
 import semver from "semver";
 
-// every zod release from 4.5.0 on must have an @zod/mini twin on npm, and every @zod/mini 4.x must have a zod twin; latest must agree. `--wait` retries for up to ~6 minutes, since the packument endpoint is CDN-cached for five
+// every zod release from 4.5.0 on must have an @zod/mini twin on npm and on JSR, and every @zod/mini 4.x must have a zod twin; latest must agree. `--wait` retries for up to ~6 minutes, since the npm packument endpoint is CDN-cached for five
 const FLOOR = "4.5.0";
 const attempts = process.argv.includes("--wait") ? 13 : 1;
 
-async function releases(name: string): Promise<{ versions: string[]; latest: string }> {
+type Releases = { name: string; versions: string[]; latest: string };
+
+function stable(versions: string[]): string[] {
+  return versions.filter((v) => semver.valid(v) && !semver.prerelease(v) && semver.gte(v, FLOOR));
+}
+
+async function npmReleases(name: string): Promise<Releases> {
   const res = await fetch(`https://registry.npmjs.org/${name.replace("/", "%2f")}`, {
     headers: { accept: "application/vnd.npm.install-v1+json" },
   });
   if (!res.ok) throw new Error(`npm registry ${res.status} for ${name}`);
   const body = (await res.json()) as { versions: Record<string, unknown>; "dist-tags": Record<string, string> };
-  const versions = Object.keys(body.versions).filter(
-    (v) => semver.valid(v) && !semver.prerelease(v) && semver.gte(v, FLOOR)
-  );
-  return { versions, latest: body["dist-tags"].latest };
+  return { name, versions: stable(Object.keys(body.versions)), latest: body["dist-tags"].latest };
+}
+
+// a 404 means the package has no versions on JSR yet
+async function jsrReleases(name: string): Promise<Releases> {
+  const res = await fetch(`https://jsr.io/${name}/meta.json`);
+  if (res.status === 404) return { name: `jsr:${name}`, versions: [], latest: "" };
+  if (!res.ok) throw new Error(`jsr ${res.status} for ${name}`);
+  const body = (await res.json()) as { versions: Record<string, unknown>; latest: string };
+  return { name: `jsr:${name}`, versions: stable(Object.keys(body.versions)), latest: body.latest };
+}
+
+function twins(a: Releases, b: Releases): string[] {
+  const out: string[] = [];
+  const missing = a.versions.filter((v) => !b.versions.includes(v)).sort(semver.compare);
+  const stray = b.versions.filter((v) => !a.versions.includes(v)).sort(semver.compare);
+  if (missing.length) out.push(`${a.name} versions with no ${b.name} twin: ${missing.join(", ")}`);
+  if (stray.length) out.push(`${b.name} versions with no ${a.name} twin: ${stray.join(", ")}`);
+  if (a.latest !== b.latest) out.push(`latest differs: ${a.name}@${a.latest} vs ${b.name}@${b.latest}`);
+  return out;
 }
 
 async function problems(): Promise<string[]> {
-  const [zod, mini] = await Promise.all([releases("zod"), releases("@zod/mini")]);
-  const missingMini = zod.versions.filter((v) => !mini.versions.includes(v)).sort(semver.compare);
-  const strayMini = mini.versions.filter((v) => !zod.versions.includes(v)).sort(semver.compare);
-  const out: string[] = [];
-  if (missingMini.length) out.push(`zod versions with no @zod/mini twin: ${missingMini.join(", ")}`);
-  if (strayMini.length) out.push(`@zod/mini versions with no zod twin: ${strayMini.join(", ")}`);
-  if (zod.latest !== mini.latest) out.push(`latest differs: zod@${zod.latest} vs @zod/mini@${mini.latest}`);
+  const [zod, mini, jsrZod, jsrMini] = await Promise.all([
+    npmReleases("zod"),
+    npmReleases("@zod/mini"),
+    jsrReleases("@zod/zod"),
+    jsrReleases("@zod/mini"),
+  ]);
+  const out = [...twins(zod, mini), ...twins(jsrZod, jsrMini)];
+  // npm is the source of truth and JSR follows it; a gap here is reported, not fatal, because that publish is recovered by hand and must not hold a release red
+  for (const gap of twins(zod, jsrZod)) console.warn(`⚠️  ${gap}`);
   if (!out.length) {
     console.log(
-      `✅ zod and @zod/mini are in lockstep on npm (${zod.versions.length} versions since ${FLOOR}, latest ${zod.latest})`
+      `✅ zod and @zod/mini are in lockstep on npm and JSR (${zod.versions.length} versions since ${FLOOR}, latest ${zod.latest})`
     );
   }
   return out;
@@ -39,7 +63,7 @@ for (let i = 1; i < attempts && found.length; i++) {
   found = await problems();
 }
 if (found.length) {
-  console.error(`❌ zod and @zod/mini are out of lockstep on npm:`);
+  console.error(`❌ zod and @zod/mini are out of lockstep:`);
   for (const p of found) console.error(`   ${p}`);
   process.exit(1);
 }

--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -70,14 +70,27 @@ if (tag !== "latest") {
   }
 } else {
   const miniPackageJson = JSON.parse(readFileSync(join(__dirname, "..", "packages", "mini", "package.json"), "utf8"));
+  const miniJsrJson = JSON.parse(readFileSync(join(__dirname, "..", "packages", "mini", "jsr.json"), "utf8"));
   const miniVersion = miniPackageJson.version as string;
+  const miniJsrVersion = miniJsrJson.version as string;
   const miniPeer = miniPackageJson.peerDependencies?.zod as string | undefined;
+  const miniJsrImport = miniJsrJson.imports?.["zod/mini"] as string | undefined;
   const expectedMiniPeer = `^${version.major}.${version.minor}.0`;
-  if (miniVersion !== versionsVersion || miniPeer !== expectedMiniPeer) {
+  const expectedMiniJsrImport = `jsr:@zod/zod@${expectedMiniPeer}/mini`;
+  if (
+    miniVersion !== versionsVersion ||
+    miniJsrVersion !== versionsVersion ||
+    miniPeer !== expectedMiniPeer ||
+    miniJsrImport !== expectedMiniJsrImport
+  ) {
     console.error(`❌ @zod/mini version mismatch:`);
     console.error(`   packages/mini/package.json version: ${miniVersion} (expected ${versionsVersion})`);
+    console.error(`   packages/mini/jsr.json version: ${miniJsrVersion} (expected ${versionsVersion})`);
     console.error(`   packages/mini/package.json peerDependencies.zod: ${miniPeer} (expected ${expectedMiniPeer})`);
+    console.error(
+      `   packages/mini/jsr.json imports["zod/mini"]: ${miniJsrImport} (expected ${expectedMiniJsrImport})`
+    );
     process.exit(1);
   }
-  console.log(`✅ @zod/mini ${miniVersion} with peer zod@${miniPeer}`);
+  console.log(`✅ @zod/mini ${miniVersion} with peer zod@${miniPeer} (npm + jsr)`);
 }


### PR DESCRIPTION
Publishes `@zod/mini` to JSR alongside npm. `packages/mini/jsr.json` maps the bare `zod/mini` re-export to `jsr:@zod/zod@^4.5.0/mini`; `jsr publish` rewrites that specifier into the published source, so JSR consumers get `@zod/zod` as a regular dependency resolved by range (JSR has no peer dependencies). A dry run from `packages/mini` type-checks and simulates the publish.

The semver check now keeps the JSR manifest's version and import range in lockstep with the other four files. Both release paths publish to JSR after the npm publish when the version is not on JSR yet, which is also how the first JSR publish of `4.5.4` rides on this merge; the backfill dispatch sets `jsr.json` too and publishes with `--allow-dirty`. Slow types are allowed for the same reason as for `zod`: the package re-exports zod's types.

Before merging: the `@zod/mini` package exists on jsr.io but has no GitHub repository linked yet, and the tokenless publish needs `colinhacks/zod` linked in its settings.

Refs #6491.
