### PR TITLE
Stop re-exporting the compile internals from zod/v4/core

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -78,7 +78,9 @@
       ".next",
 
       "packages/treeshake",
-      ".source"
+      ".source",
+      ".frizz",
+      ".triage"
     ]
   }
 }

--- a/packages/bench/compile-base64-inline-vs-hoist.ts
+++ b/packages/bench/compile-base64-inline-vs-hoist.ts
@@ -1,6 +1,7 @@
 import * as z from "zod/v4";
 import * as zcore from "zod/v4/core";
 import { isValidBase64 } from "zod/v4/core";
+import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 const INVALID = Symbol("invalid");
@@ -10,7 +11,7 @@ const INVALID_WHITESPACE = "SGVsbG8gV29ybGQ= ";
 
 const base64 = z.base64();
 const compiled = zcore.compile(base64);
-const compiledFn = zcore.compileFn(base64);
+const compiledFn = zcompile.compileFn(base64);
 
 const F = Function;
 
@@ -63,7 +64,7 @@ for (const value of [VALID, INVALID_LENGTH, INVALID_WHITESPACE]) {
   console.log(value, {
     runtime: base64.safeParse(value).success,
     helper: isValidBase64(value),
-    compiledFn: compiledFn(value) !== zcore.INVALID,
+    compiledFn: compiledFn(value) !== zcompile.INVALID,
     hoisted: manualHoisted(value) !== INVALID,
     inline: manualInline(value) !== INVALID,
     inlineHoistedRegex: manualInlineHoistedRegex(value) !== INVALID,

--- a/packages/bench/compile-codec-direction.ts
+++ b/packages/bench/compile-codec-direction.ts
@@ -1,5 +1,6 @@
 import * as z from "zod/v4";
 import * as zcore from "zod/v4/core";
+import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 const INVALID = Symbol("invalid");
@@ -36,7 +37,7 @@ const codec = z.codec(inputSchema, outputSchema, {
 });
 
 const compiled = zcore.compile(codec);
-const forward = zcore.compileFn(codec);
+const forward = zcompile.compileFn(codec);
 
 const input = {
   id: "abc",

--- a/packages/bench/compile-helper-scope.ts
+++ b/packages/bench/compile-helper-scope.ts
@@ -1,6 +1,7 @@
 import * as z from "zod/v4";
 import * as zcore from "zod/v4/core";
-import { isValidBase64URL, isValidJWT, parseValidURL } from "zod/v4/core";
+import { isValidBase64URL, isValidJWT, parseURLObject, urlHostnameOk, urlProtocolOk } from "zod/v4/core";
+import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 const DATA = Array.from({ length: 1000 }, () => "SGVsbG8gV29ybGQ");
@@ -9,15 +10,15 @@ const URL_DATA = Array.from({ length: 1000 }, () => "  https://example.com/path?
 
 const base64url = z.string().base64url();
 const compiledBase64url = zcore.compile(base64url);
-const fastBase64url = zcore.compileFn(base64url);
+const fastBase64url = zcompile.compileFn(base64url);
 
 const jwt = z.jwt();
 const compiledJwt = zcore.compile(jwt);
-const fastJwt = zcore.compileFn(jwt);
+const fastJwt = zcompile.compileFn(jwt);
 
 const url = z.url();
 const compiledUrl = zcore.compile(url);
-const fastUrl = zcore.compileFn(url);
+const fastUrl = zcompile.compileFn(url);
 
 function makeScopedValidator(extraConstants: number) {
   const names = ["helper"];
@@ -38,7 +39,7 @@ const scoped50 = makeScopedValidator(50);
 console.log("=== Correctness ===");
 console.log("base64url runtime:", base64url.safeParse(DATA[0]).success);
 console.log("base64url compiled:", compiledBase64url.safeParse(DATA[0]).success);
-console.log("base64url fast:", fastBase64url(DATA[0]) !== zcore.INVALID);
+console.log("base64url fast:", fastBase64url(DATA[0]) !== zcompile.INVALID);
 console.log("jwt runtime:", jwt.safeParse(JWT_DATA[0]).success);
 console.log("jwt compiled:", compiledJwt.safeParse(JWT_DATA[0]).success);
 console.log("url runtime:", url.safeParse(URL_DATA[0]).success);
@@ -71,7 +72,14 @@ await metabench("compiled string-format helpers", {
     for (const d of JWT_DATA) jwt.safeParse(d);
   },
   "url direct helper"() {
-    for (const d of URL_DATA) parseValidURL(d, url._zod.def as any);
+    // the runtime's own sequence: trim, parse, then the hostname and protocol predicates
+    const def = url._zod.def;
+    for (const d of URL_DATA) {
+      const u = parseURLObject(d.trim(), def);
+      if (typeof u !== "object") continue;
+      if (def.hostname) urlHostnameOk(u, def.hostname);
+      if (def.protocol) urlProtocolOk(u, def.protocol);
+    }
   },
   "url compileFn"() {
     for (const d of URL_DATA) fastUrl(d);

--- a/packages/bench/compile-matrix.ts
+++ b/packages/bench/compile-matrix.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import * as z from "zod";
-import { INVALID, ZodCompileUnsupportedError, compile, compileFn } from "zod/v4/core";
+import { ZodCompileUnsupportedError, compile } from "zod/v4/core";
+import { INVALID, compileFn } from "../zod/src/v4/core/compile.js";
 
 // Broad compiled-vs-runtime sweep across schema categories.
 //

--- a/packages/bench/compile-vs-arktype.ts
+++ b/packages/bench/compile-vs-arktype.ts
@@ -1,6 +1,7 @@
 import { type } from "arktype";
 import * as z from "zod/v4";
 import * as zcore from "zod/v4/core";
+import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 const caseOrder = ["simple", "nested", "array", "array-objects", "du", "intersection", "xor"] as const;
@@ -210,15 +211,15 @@ const zodXorCompiled = (() => {
   }
 })();
 
-const zodSimpleFn = zcore.compileFn(zodSimple);
-const zodNestedFn = zcore.compileFn(zodNested);
-const zodArrayFn = zcore.compileFn(zodArray);
-const zodArrayOfObjectsFn = zcore.compileFn(zodArrayOfObjects);
-const zodDiscriminatedFn = zcore.compileFn(zodDiscriminated);
-const zodIntersectionFn = zcore.compileFn(zodIntersection);
+const zodSimpleFn = zcompile.compileFn(zodSimple);
+const zodNestedFn = zcompile.compileFn(zodNested);
+const zodArrayFn = zcompile.compileFn(zodArray);
+const zodArrayOfObjectsFn = zcompile.compileFn(zodArrayOfObjects);
+const zodDiscriminatedFn = zcompile.compileFn(zodDiscriminated);
+const zodIntersectionFn = zcompile.compileFn(zodIntersection);
 const zodXorFn = (() => {
   try {
-    return zcore.compileFn(zodXor);
+    return zcompile.compileFn(zodXor);
   } catch {
     return (d: unknown) => zodXor.safeParse(d);
   }
@@ -310,7 +311,7 @@ if (selectedCaseSet.has("simple") || selectedCaseSet.has("nested")) {
   if (selectedCaseSet.has("simple")) {
     console.log("Zod safeParse simple:", zodSimple.safeParse(simpleData).success);
     console.log("z.compile() simple:", zodSimpleCompiled.safeParse(simpleData).success);
-    console.log("z.compileFn() simple:", zodSimpleFn(simpleData) !== zcore.INVALID);
+    console.log("z.compileFn() simple:", zodSimpleFn(simpleData) !== zcompile.INVALID);
     console.log("Arktype simple:", !(arktypeSimple(simpleData) instanceof type.errors));
     console.log("Handwritten simple:", handwrittenSimple(simpleData) !== INVALID);
     console.log("");
@@ -318,7 +319,7 @@ if (selectedCaseSet.has("simple") || selectedCaseSet.has("nested")) {
   if (selectedCaseSet.has("nested")) {
     console.log("Zod safeParse nested:", zodNested.safeParse(nestedData).success);
     console.log("z.compile() nested:", zodNestedCompiled.safeParse(nestedData).success);
-    console.log("z.compileFn() nested:", zodNestedFn(nestedData) !== zcore.INVALID);
+    console.log("z.compileFn() nested:", zodNestedFn(nestedData) !== zcompile.INVALID);
     console.log("Arktype nested:", !(arktypeNested(nestedData) instanceof type.errors));
     console.log("Handwritten nested:", handwrittenNested(nestedData) !== INVALID);
     console.log("");

--- a/packages/bench/compile.ts
+++ b/packages/bench/compile.ts
@@ -1,5 +1,6 @@
 import * as z4 from "zod/v4";
 import * as z4core from "zod/v4/core";
+import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 // Schema for benchmarking - same as moltar benchmark
@@ -20,7 +21,7 @@ const schema = z4.strictObject({
 // AOT compiled schema (wraps fast path + runtime fallback)
 const compiledSchema = z4core.compile(schema);
 // Raw fast-path function (no fallback wrapper) for direct comparison
-const aotValidator = z4core.compileFn(schema);
+const aotValidator = zcompile.compileFn(schema);
 
 // Test data
 const DATA = Array.from({ length: 1000 }, () =>

--- a/packages/bench/moltar-libs.ts
+++ b/packages/bench/moltar-libs.ts
@@ -4,8 +4,8 @@ import { Schema } from "effect";
 import * as v from "valibot";
 import * as yup from "yup";
 import * as z from "zod";
-import { INVALID, compileFn } from "zod/v4/core";
 import * as z3 from "zod3";
+import { INVALID, compileFn } from "../zod/src/v4/core/compile.js";
 
 // Cross-library throughput on the fixture and the categories from moltar/typescript-runtime-type-benchmarks.
 //

--- a/packages/zod/src/v4/core/index.ts
+++ b/packages/zod/src/v4/core/index.ts
@@ -11,7 +11,8 @@ export * as regexes from "./regexes.js";
 export * as locales from "../locales/index.js";
 export * from "./registries.js";
 export * from "./doc.js";
-export * from "./compile.js";
+// only the public surface: the parser contract (`compileFn`, `INVALID`) stays internal so it can change without a major
+export { compile, ZodCompileAsyncError, ZodCompileUnsupportedError, type CompileOptions } from "./compile.js";
 export * from "./api.js";
 export * from "./to-json-schema.js";
 export { toJSONSchema } from "./json-schema-processors.js";

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -34,6 +34,11 @@ function invalid(schema: z.ZodType, value: unknown) {
 
 // === Primitives ===
 
+test("parser contract stays off the core namespace", () => {
+  expect("compileFn" in z.core).toBe(false);
+  expect("INVALID" in z.core).toBe(false);
+});
+
 test("string", () => {
   const aot = compile(z.string());
   expect(valid(aot, "hello")).toBe("hello");


### PR DESCRIPTION
`zod/v4/core` re-exported everything from the compile module with a star, which made `z.core.compileFn` and `z.core.INVALID` reachable from user code. That is the parser contract — a generated function returning the output or a sentinel — and it isn't settled: the compiled path may move to full error reporting. Keeping it reachable would turn that change into a breaking one.

The re-export now names only `compile`, `CompileOptions`, and the two strict-mode error classes. Nothing inside the package went through the core namespace for the internals, so runtime behavior and bundle size are unchanged; the emitted `v4/core` types no longer mention the sentinel or the generator.

Also adds `.frizz` and `.triage` to biome's ignore list — the `postbuild` format sweep was reformatting scratch checkouts under those directories.

Refs #6498
