### PR TITLE
Mark the compile internals @internal instead of hiding them

### DIFF
--- a/packages/bench/compile-base64-inline-vs-hoist.ts
+++ b/packages/bench/compile-base64-inline-vs-hoist.ts
@@ -1,7 +1,6 @@
 import * as z from "zod/v4";
 import * as zcore from "zod/v4/core";
 import { isValidBase64 } from "zod/v4/core";
-import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 const INVALID = Symbol("invalid");
@@ -11,7 +10,7 @@ const INVALID_WHITESPACE = "SGVsbG8gV29ybGQ= ";
 
 const base64 = z.base64();
 const compiled = zcore.compile(base64);
-const compiledFn = zcompile.compileFn(base64);
+const compiledFn = zcore.compileFn(base64);
 
 const F = Function;
 
@@ -64,7 +63,7 @@ for (const value of [VALID, INVALID_LENGTH, INVALID_WHITESPACE]) {
   console.log(value, {
     runtime: base64.safeParse(value).success,
     helper: isValidBase64(value),
-    compiledFn: compiledFn(value) !== zcompile.INVALID,
+    compiledFn: compiledFn(value) !== zcore.INVALID,
     hoisted: manualHoisted(value) !== INVALID,
     inline: manualInline(value) !== INVALID,
     inlineHoistedRegex: manualInlineHoistedRegex(value) !== INVALID,

--- a/packages/bench/compile-codec-direction.ts
+++ b/packages/bench/compile-codec-direction.ts
@@ -1,6 +1,5 @@
 import * as z from "zod/v4";
 import * as zcore from "zod/v4/core";
-import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 const INVALID = Symbol("invalid");
@@ -37,7 +36,7 @@ const codec = z.codec(inputSchema, outputSchema, {
 });
 
 const compiled = zcore.compile(codec);
-const forward = zcompile.compileFn(codec);
+const forward = zcore.compileFn(codec);
 
 const input = {
   id: "abc",

--- a/packages/bench/compile-helper-scope.ts
+++ b/packages/bench/compile-helper-scope.ts
@@ -1,7 +1,6 @@
 import * as z from "zod/v4";
 import * as zcore from "zod/v4/core";
 import { isValidBase64URL, isValidJWT, parseURLObject, urlHostnameOk, urlProtocolOk } from "zod/v4/core";
-import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 const DATA = Array.from({ length: 1000 }, () => "SGVsbG8gV29ybGQ");
@@ -10,15 +9,15 @@ const URL_DATA = Array.from({ length: 1000 }, () => "  https://example.com/path?
 
 const base64url = z.string().base64url();
 const compiledBase64url = zcore.compile(base64url);
-const fastBase64url = zcompile.compileFn(base64url);
+const fastBase64url = zcore.compileFn(base64url);
 
 const jwt = z.jwt();
 const compiledJwt = zcore.compile(jwt);
-const fastJwt = zcompile.compileFn(jwt);
+const fastJwt = zcore.compileFn(jwt);
 
 const url = z.url();
 const compiledUrl = zcore.compile(url);
-const fastUrl = zcompile.compileFn(url);
+const fastUrl = zcore.compileFn(url);
 
 function makeScopedValidator(extraConstants: number) {
   const names = ["helper"];
@@ -39,7 +38,7 @@ const scoped50 = makeScopedValidator(50);
 console.log("=== Correctness ===");
 console.log("base64url runtime:", base64url.safeParse(DATA[0]).success);
 console.log("base64url compiled:", compiledBase64url.safeParse(DATA[0]).success);
-console.log("base64url fast:", fastBase64url(DATA[0]) !== zcompile.INVALID);
+console.log("base64url fast:", fastBase64url(DATA[0]) !== zcore.INVALID);
 console.log("jwt runtime:", jwt.safeParse(JWT_DATA[0]).success);
 console.log("jwt compiled:", compiledJwt.safeParse(JWT_DATA[0]).success);
 console.log("url runtime:", url.safeParse(URL_DATA[0]).success);

--- a/packages/bench/compile-matrix.ts
+++ b/packages/bench/compile-matrix.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from "node:child_process";
 import * as z from "zod";
-import { ZodCompileUnsupportedError, compile } from "zod/v4/core";
-import { INVALID, compileFn } from "../zod/src/v4/core/compile.js";
+import { INVALID, ZodCompileUnsupportedError, compile, compileFn } from "zod/v4/core";
 
 // Broad compiled-vs-runtime sweep across schema categories.
 //

--- a/packages/bench/compile-tuple.ts
+++ b/packages/bench/compile-tuple.ts
@@ -4,11 +4,11 @@ import { metabench } from "./metabench.js";
 
 // Tuple without rest
 const tupleNoRest = z4.tuple([z4.string(), z4.number(), z4.boolean()]);
-const aotNoRest = z4core.compile(tupleNoRest);
+const aotNoRest = z4core.compileFn(tupleNoRest, { debug: true });
 
 // Tuple with rest
 const tupleWithRest = z4.tuple([z4.string(), z4.number()]).rest(z4.boolean());
-const aotWithRest = z4core.compile(tupleWithRest);
+const aotWithRest = z4core.compileFn(tupleWithRest, { debug: true });
 
 // Test data
 const validNoRest = Array.from({ length: 1000 }, () => ["hello", 42, true]);

--- a/packages/bench/compile-vs-arktype.ts
+++ b/packages/bench/compile-vs-arktype.ts
@@ -1,7 +1,6 @@
 import { type } from "arktype";
 import * as z from "zod/v4";
 import * as zcore from "zod/v4/core";
-import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 const caseOrder = ["simple", "nested", "array", "array-objects", "du", "intersection", "xor"] as const;
@@ -211,15 +210,15 @@ const zodXorCompiled = (() => {
   }
 })();
 
-const zodSimpleFn = zcompile.compileFn(zodSimple);
-const zodNestedFn = zcompile.compileFn(zodNested);
-const zodArrayFn = zcompile.compileFn(zodArray);
-const zodArrayOfObjectsFn = zcompile.compileFn(zodArrayOfObjects);
-const zodDiscriminatedFn = zcompile.compileFn(zodDiscriminated);
-const zodIntersectionFn = zcompile.compileFn(zodIntersection);
+const zodSimpleFn = zcore.compileFn(zodSimple);
+const zodNestedFn = zcore.compileFn(zodNested);
+const zodArrayFn = zcore.compileFn(zodArray);
+const zodArrayOfObjectsFn = zcore.compileFn(zodArrayOfObjects);
+const zodDiscriminatedFn = zcore.compileFn(zodDiscriminated);
+const zodIntersectionFn = zcore.compileFn(zodIntersection);
 const zodXorFn = (() => {
   try {
-    return zcompile.compileFn(zodXor);
+    return zcore.compileFn(zodXor);
   } catch {
     return (d: unknown) => zodXor.safeParse(d);
   }
@@ -311,7 +310,7 @@ if (selectedCaseSet.has("simple") || selectedCaseSet.has("nested")) {
   if (selectedCaseSet.has("simple")) {
     console.log("Zod safeParse simple:", zodSimple.safeParse(simpleData).success);
     console.log("z.compile() simple:", zodSimpleCompiled.safeParse(simpleData).success);
-    console.log("z.compileFn() simple:", zodSimpleFn(simpleData) !== zcompile.INVALID);
+    console.log("z.compileFn() simple:", zodSimpleFn(simpleData) !== zcore.INVALID);
     console.log("Arktype simple:", !(arktypeSimple(simpleData) instanceof type.errors));
     console.log("Handwritten simple:", handwrittenSimple(simpleData) !== INVALID);
     console.log("");
@@ -319,7 +318,7 @@ if (selectedCaseSet.has("simple") || selectedCaseSet.has("nested")) {
   if (selectedCaseSet.has("nested")) {
     console.log("Zod safeParse nested:", zodNested.safeParse(nestedData).success);
     console.log("z.compile() nested:", zodNestedCompiled.safeParse(nestedData).success);
-    console.log("z.compileFn() nested:", zodNestedFn(nestedData) !== zcompile.INVALID);
+    console.log("z.compileFn() nested:", zodNestedFn(nestedData) !== zcore.INVALID);
     console.log("Arktype nested:", !(arktypeNested(nestedData) instanceof type.errors));
     console.log("Handwritten nested:", handwrittenNested(nestedData) !== INVALID);
     console.log("");

--- a/packages/bench/compile.ts
+++ b/packages/bench/compile.ts
@@ -1,6 +1,5 @@
 import * as z4 from "zod/v4";
 import * as z4core from "zod/v4/core";
-import * as zcompile from "../zod/src/v4/core/compile.js";
 import { metabench } from "./metabench.js";
 
 // Schema for benchmarking - same as moltar benchmark
@@ -21,7 +20,7 @@ const schema = z4.strictObject({
 // AOT compiled schema (wraps fast path + runtime fallback)
 const compiledSchema = z4core.compile(schema);
 // Raw fast-path function (no fallback wrapper) for direct comparison
-const aotValidator = zcompile.compileFn(schema);
+const aotValidator = z4core.compileFn(schema);
 
 // Test data
 const DATA = Array.from({ length: 1000 }, () =>

--- a/packages/bench/moltar-libs.ts
+++ b/packages/bench/moltar-libs.ts
@@ -4,8 +4,8 @@ import { Schema } from "effect";
 import * as v from "valibot";
 import * as yup from "yup";
 import * as z from "zod";
+import { INVALID, compileFn } from "zod/v4/core";
 import * as z3 from "zod3";
-import { INVALID, compileFn } from "../zod/src/v4/core/compile.js";
 
 // Cross-library throughput on the fixture and the categories from moltar/typescript-runtime-type-benchmarks.
 //

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -20,8 +20,9 @@ import {
 import type { ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
 import * as util from "./util.js";
 
-/** Sentinel value returned by the compiled fast path when validation fails. Internal. */
+/** @internal Sentinel the compiled fast path returns when validation fails. */
 export const INVALID: unique symbol = Symbol.for("zod.compile.invalid");
+/** @internal */
 export type INVALID = typeof INVALID;
 
 // Set on the parse ctx when a compiled wrapper falls back to the runtime, so nested compiled wrappers skip their fast paths for the rest of that parse.
@@ -204,9 +205,8 @@ function installCompiledUserMethods<T extends SomeType>(
 }
 
 /**
- * Generate the standalone compiled function: a parser by default, a validator under
- * `assertOnly`. Returns either the parsed value, `true` where nothing reads the output,
- * or the `INVALID` sentinel. Internal — consumers should use `compile()`.
+ * @internal Generate the standalone compiled function: a parser by default, a validator under
+ * `assertOnly`. Returns the parsed value, `true` where nothing reads the output, or `INVALID`. Consumers use `compile()`.
  */
 export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOptions): CompiledFn<core.output<T>> {
   // Cycle-breaking is keyed on the parse context, which generated code never receives. `shape` can be a getter that throws (z.pick() with an unrecognized mask key), so treat "can't tell" as recursive.

--- a/packages/zod/src/v4/core/index.ts
+++ b/packages/zod/src/v4/core/index.ts
@@ -11,8 +11,7 @@ export * as regexes from "./regexes.js";
 export * as locales from "../locales/index.js";
 export * from "./registries.js";
 export * from "./doc.js";
-// only the public surface: the parser contract (`compileFn`, `INVALID`) stays internal so it can change without a major
-export { compile, ZodCompileAsyncError, ZodCompileUnsupportedError, type CompileOptions } from "./compile.js";
+export * from "./compile.js";
 export * from "./api.js";
 export * from "./to-json-schema.js";
 export { toJSONSchema } from "./json-schema-processors.js";

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -34,11 +34,6 @@ function invalid(schema: z.ZodType, value: unknown) {
 
 // === Primitives ===
 
-test("parser contract stays off the core namespace", () => {
-  expect("compileFn" in z.core).toBe(false);
-  expect("INVALID" in z.core).toBe(false);
-});
-
 test("string", () => {
   const aot = compile(z.string());
   expect(valid(aot, "hello")).toBe("hello");


### PR DESCRIPTION
Reverts the re-export narrowing from #6511 and takes the lighter route: `compileFn` and `INVALID` stay reachable from `zod/v4/core`, tagged `@internal`, so the parser contract (a generated function returning the output or a sentinel) carries no semver promise and can change in a minor. `compile`, `CompileOptions`, and the two strict-mode error classes are unchanged and remain the public surface.

The bench files go back to importing the internals from the package. The `compile-helper-scope` repair from #6511 stays — it had been calling `parseValidURL`, removed in 898c4461 — as does the biome ignore for scratch directories.

Refs #6498
