### PR TITLE
Widen literal inputs in property check types

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2268,7 +2268,7 @@ To validate a particular property of a class instance against a Zod schema:
 
 ```ts
 const blobSchema = z.instanceof(URL).check(
-  z.property("protocol", z.literal("https:" as string, "Only HTTPS allowed"))
+  z.property("protocol", z.literal("https:", "Only HTTPS allowed"))
 );
 
 blobSchema.parse(new URL("https://example.com")); // ✅
@@ -2291,7 +2291,7 @@ Use `z.properties()` to declare several property checks from an object literal. 
 ```ts
 const httpsUrl = z.instanceof(URL).check(
   ...z.properties({
-    protocol: z.literal("https:" as string),
+    protocol: z.literal("https:"),
     hostname: z.string().regex(z.regexes.domain),
   })
 );

--- a/packages/docs/content/blog/zod-4-5.mdx
+++ b/packages/docs/content/blog/zod-4-5.mdx
@@ -134,7 +134,7 @@ The multi-property counterpart to `z.property()`. ([#5912](https://github.com/co
 ```ts
 const httpsUrl = z.instanceof(URL).check(
   ...z.properties({
-    protocol: z.literal("https:" as string),
+    protocol: z.literal("https:"),
     hostname: z.string().regex(z.regexes.domain),
   })
 );

--- a/packages/zod/src/v4/classic/tests/instanceof.test.ts
+++ b/packages/zod/src/v4/classic/tests/instanceof.test.ts
@@ -62,7 +62,7 @@ test("instanceof respects customError", () => {
 test("z.properties", () => {
   const httpsUrl = z.instanceof(URL).check(
     ...z.properties({
-      protocol: z.literal("https:" as string),
+      protocol: z.literal("https:"),
       hostname: z.string().regex(z.regexes.domain),
     })
   );
@@ -99,6 +99,13 @@ test("z.properties", () => {
       .safeParse({ a: "ok" })
       .error!.issues.map((i) => [i.code, i.path])
   ).toEqual([["invalid_value", ["b"]]]);
+
+  // literal and enum inputs widen to their primitive, so a `string`/`boolean` property accepts them without a cast, while a genuine type mismatch or an unknown key still fails to compile
+  z.instanceof(Request).check(...z.properties({ method: z.enum(["POST", "PUT"]), bodyUsed: z.literal(false) }));
+  // @ts-expect-error length is a number
+  z.string().check(z.property("length", z.string()));
+  // @ts-expect-error no such key
+  z.instanceof(URL).check(z.property("nope", z.string()));
 
   // Plain property checks carry no `when`, so the schema stays on the compiled fast path.
   const compiled = z.compile(httpsUrl);

--- a/packages/zod/src/v4/classic/tests/instanceof.test.ts
+++ b/packages/zod/src/v4/classic/tests/instanceof.test.ts
@@ -109,19 +109,13 @@ test("z.properties", () => {
   z.instanceof(URL).check(z.property("nope", z.string()));
 
   // the check feeds the property value into its schema, so it is typed over the input side rather than the output
-  z.object({ a: z.string() }).check(
-    z.property(
-      "a",
-      z.string().transform((s) => s.length)
-    )
+  const stringToLength = z.property(
+    "a",
+    z.string().transform((s) => s.length)
   );
+  z.object({ a: z.string() }).check(stringToLength);
   // @ts-expect-error a is a number, the schema takes a string
-  z.object({ a: z.number() }).check(
-    z.property(
-      "a",
-      z.string().transform((s) => s.length)
-    )
-  );
+  z.object({ a: z.number() }).check(stringToLength);
 
   // Plain property checks carry no `when`, so the schema stays on the compiled fast path.
   const compiled = z.compile(httpsUrl);

--- a/packages/zod/src/v4/classic/tests/instanceof.test.ts
+++ b/packages/zod/src/v4/classic/tests/instanceof.test.ts
@@ -101,11 +101,27 @@ test("z.properties", () => {
   ).toEqual([["invalid_value", ["b"]]]);
 
   // literal and enum inputs widen to their primitive, so a `string`/`boolean` property accepts them without a cast, while a genuine type mismatch or an unknown key still fails to compile
+  z.instanceof(URL).check(z.property("protocol", z.literal("https:")));
   z.instanceof(Request).check(...z.properties({ method: z.enum(["POST", "PUT"]), bodyUsed: z.literal(false) }));
   // @ts-expect-error length is a number
   z.string().check(z.property("length", z.string()));
   // @ts-expect-error no such key
   z.instanceof(URL).check(z.property("nope", z.string()));
+
+  // the check feeds the property value into its schema, so it is typed over the input side rather than the output
+  z.object({ a: z.string() }).check(
+    z.property(
+      "a",
+      z.string().transform((s) => s.length)
+    )
+  );
+  // @ts-expect-error a is a number, the schema takes a string
+  z.object({ a: z.number() }).check(
+    z.property(
+      "a",
+      z.string().transform((s) => s.length)
+    )
+  );
 
   // Plain property checks carry no `when`, so the schema stays on the compiled fast path.
   const compiled = z.compile(httpsUrl);

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1118,7 +1118,7 @@ export function _property<K extends string, T extends schemas.$ZodType>(
   property: K,
   schema: T,
   params?: string | $ZodCheckPropertyParams
-): checks.$ZodCheckProperty<{ [k in K]: core.output<T> }> {
+): checks.$ZodCheckProperty<{ [k in K]: util.Widen<core.input<T>> }> {
   return new checks.$ZodCheckProperty({
     check: "property",
     property,
@@ -1130,7 +1130,7 @@ export function _property<K extends string, T extends schemas.$ZodType>(
 // @__NO_SIDE_EFFECTS__
 export function _properties<Shape extends schemas.$ZodShape>(
   shape: Shape
-): checks.$ZodCheckProperty<{ -readonly [k in keyof Shape]: core.output<Shape[k]> }>[] {
+): checks.$ZodCheckProperty<{ -readonly [k in keyof Shape]: util.Widen<core.input<Shape[k]>> }>[] {
   return Object.entries(shape).map(
     ([property, schema]) => new checks.$ZodCheckProperty({ check: "property", property, schema })
   ) as any;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -129,6 +129,17 @@ export type MakeRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K
 export type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
 export type NoUndefined<T> = T extends undefined ? never : T;
 export type Whatever = {} | undefined | null;
+// literal inputs widen to their primitive so a property check over `"https:"` accepts a `string` property
+export type Widen<T> = T extends string
+  ? string
+  : T extends number
+    ? number
+    : T extends boolean
+      ? boolean
+      : T extends bigint
+        ? bigint
+        : T;
+
 export type LoosePartial<T extends object> = InexactPartial<T> & {
   [k: string]: unknown;
 };

--- a/packages/zod/src/v4/mini/tests/checks.test.ts
+++ b/packages/zod/src/v4/mini/tests/checks.test.ts
@@ -141,7 +141,7 @@ test("z.overwrite", () => {
 // property
 
 test("z.properties", () => {
-  const a = z.instanceof(URL).check(...z.properties({ protocol: z.literal("https:" as string), hostname: z.string() }));
+  const a = z.instanceof(URL).check(...z.properties({ protocol: z.literal("https:"), hostname: z.string() }));
   expect(z.safeParse(a, new URL("https://example.com")).success).toEqual(true);
   expect(z.safeParse(a, new URL("http://example.com")).error!.issues.map((i) => i.path)).toEqual([["protocol"]]);
 });


### PR DESCRIPTION
`z.property("protocol", z.literal("https:"))` on a `URL` did not compile: the check was typed over `{ protocol: "https:" }`, and a `string` property is not assignable to that. Every literal, enum or boolean property check needed an `as string` / `as boolean` cast, and the docs have been showing one since #4863.

The check is now typed over the widened input of its schema, so `"https:"` becomes `string` and `false` becomes `boolean`:

```ts
z.instanceof(Request).check(
  ...z.properties({
    method: z.enum(["POST", "PUT"]),
    bodyUsed: z.literal(false),
  })
);
```

A genuine mismatch (`z.property("length", z.string())` on a string) and an unknown key still fail to compile; both are pinned in the test. Type-only change, so no runtime, memory or bundle impact. The casts are dropped from the docs, the 4.5 blog post and the tests.

Refs #5912
