### PR TITLE
Emit a length-aware base64url pattern in toJSONSchema

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -264,6 +264,7 @@ test("base64url validations", () => {
 
   const invalidBase64URLStrings = [
     "w7/Dv8O+w74K", // Has + and / characters (is base64)
+    "A", // Invalid length (1 mod 4 carries no whole byte)
     "12345", // Invalid length (not a multiple of 4 characters when adding allowed number of padding characters)
     "12345===", // Not padded correctly
     "!UGF0aWVuY2UgaXMgdGhlIGtleSB0byBzdWNjZXNz", // Invalid character '!'

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -218,6 +218,15 @@ describe("toJSONSchema", () => {
         "type": "string",
       }
     `);
+    expect(z.toJSONSchema(z.base64url())).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "contentEncoding": "base64url",
+        "format": "base64url",
+        "pattern": "^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2,3})?$",
+        "type": "string",
+      }
+    `);
     expect(z.toJSONSchema(z.cuid())).toMatchInlineSnapshot(`
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -480,6 +489,15 @@ describe("toJSONSchema", () => {
         "type": "string",
       }
     `);
+  });
+
+  test("base64url pattern agrees with parse", () => {
+    const schema = z.base64url();
+    const pattern = new RegExp(z.toJSONSchema(schema).pattern!);
+    // lengths 1 (mod 4) carry no whole byte; the emitted pattern must reject them like parse does
+    for (const s of ["", "A", "AA", "AAA", "AAAA", "AAAAA"]) {
+      expect(pattern.test(s)).toBe(schema.safeParse(s).success);
+    }
   });
 
   test("string patterns", () => {

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -81,7 +81,7 @@ export const cidrv6: RegExp =
 
 // https://stackoverflow.com/questions/7860392/determine-if-string-is-in-base64-using-javascript
 export const base64: RegExp = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/;
-export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
+export const base64url: RegExp = /^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2,3})?$/;
 
 // based on https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
 // export const hostname: RegExp = /^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1050,7 +1050,7 @@ export const $ZodBase64: core.$constructor<$ZodBase64> = /*@__PURE__*/ core.$con
   }
 );
 
-//////////////////////////////   ZodBase64   //////////////////////////////
+//////////////////////////////   ZodBase64URL   //////////////////////////////
 // charset only — the quantified regexes.base64url overflows the regex stack on multi-MB input; isValidBase64 enforces length on the padded string
 const base64urlCharset = /^[A-Za-z0-9_-]*$/;
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1051,8 +1051,11 @@ export const $ZodBase64: core.$constructor<$ZodBase64> = /*@__PURE__*/ core.$con
 );
 
 //////////////////////////////   ZodBase64   //////////////////////////////
+// charset only — the quantified regexes.base64url overflows the regex stack on multi-MB input; isValidBase64 enforces length on the padded string
+const base64urlCharset = /^[A-Za-z0-9_-]*$/;
+
 export function isValidBase64URL(data: string): boolean {
-  if (!regexes.base64url.test(data)) return false;
+  if (!base64urlCharset.test(data)) return false;
   const base64 = data.replace(/[-_]/g, (c) => (c === "-" ? "+" : "/"));
   const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
   return isValidBase64(padded);


### PR DESCRIPTION
Fixes #6516.

z.base64url() rejects strings whose length is 1 (mod 4) — no encoder can produce them — but `def.pattern` held the charset-only regex, so `toJSONSchema()` emitted a pattern that accepts input parse rejects (`"A"`, `"AAAAA"`). This gives base64url the same split base64 already has: `regexes.base64url` is now the strict form and lands in the emitted schema, while `isValidBase64URL()` keeps a flat charset test — the quantified form overflows the regex stack on multi-MB input (the existing 10 MB test catches this), and the length rule is already enforced when the padded string reaches `isValidBase64()`. Parse behavior is unchanged; the compiled path reuses `isValidBase64URL()` and needs no change.

On the three axes: runtime is unchanged (the executed charset regex is identical; interleaved parse bench deltas sat inside same-revision spread), retained memory per schema is unchanged (~2,305 B both revisions), and bundle grows only for base64url users — classic full +52 B raw / +16 B gz, mini with base64url +56 B raw / +21 B gz, mini without it byte-identical.
