### PR TITLE
Accept enum-typed targets in z.toZod

### DIFF
--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -227,6 +227,18 @@ type Flatten<T> = { [K in keyof T]: T[K] } & {};
 z.toZod<Flatten<Entry>>()(z.object({ id: z.string() }).safeExtend({ label: z.string() })); // ✅
 ```
 
+An enum target matches `z.enum(...)`, and stays nominal — a plain literal union doesn't satisfy it:
+
+```ts
+enum Level {
+  Noob = "noob",
+  Pro = "pro",
+}
+
+z.toZod<{ level: Level }>()(z.object({ level: z.enum(Level) })); // ✅
+z.toZod<{ level: Level }>()(z.object({ level: z.enum(["noob", "pro"]) })); // ❌
+```
+
 ---
 
 Now that we have the basics covered, let's jump into the Schema API.

--- a/packages/zod/src/v4/classic/tests/assignability.test.ts
+++ b/packages/zod/src/v4/classic/tests/assignability.test.ts
@@ -237,6 +237,45 @@ test("toZod", () => {
   expectTypeOf<z.input<typeof Transformed>>().toEqualTypeOf<{ count: string }>();
   expectTypeOf<z.output<typeof Transformed>>().toEqualTypeOf<{ count: number }>();
 
+  // An enum target matches z.enum(...) even though the enum reference is not identical to the union of its members (#6524)
+  enum SkillLevel {
+    Noob = "noob",
+    Pro = "pro",
+  }
+  enum Rank {
+    First = 1,
+    Second = 2,
+  }
+
+  z.toZod<SkillLevel>()(z.enum(SkillLevel));
+  const Enums = z.toZod<{
+    skill: SkillLevel;
+    members: SkillLevel.Noob | SkillLevel.Pro;
+    rank: Rank;
+    maybe: SkillLevel | null;
+    list: SkillLevel[];
+    nested: { skill: SkillLevel };
+  }>()(
+    z.object({
+      skill: z.enum(SkillLevel),
+      members: z.enum(SkillLevel),
+      rank: z.enum(Rank),
+      maybe: z.enum(SkillLevel).nullable(),
+      list: z.array(z.enum(SkillLevel)),
+      nested: z.object({ skill: z.enum(SkillLevel) }),
+    })
+  );
+  expectTypeOf<z.output<typeof Enums>["skill"]>().toEqualTypeOf<SkillLevel>();
+
+  // @ts-expect-error a member subset is not the enum
+  z.toZod<{ skill: SkillLevel }>()(z.object({ skill: z.literal(SkillLevel.Noob) }));
+
+  // @ts-expect-error plain literals do not match a nominal enum target
+  z.toZod<{ skill: SkillLevel }>()(z.object({ skill: z.enum(["noob", "pro"]) }));
+
+  // @ts-expect-error an enum schema does not match a plain literal-union target
+  z.toZod<{ skill: "noob" | "pro" }>()(z.object({ skill: z.enum(SkillLevel) }));
+
   z.toZod<Company>()(
     // @ts-expect-error missing optional keys still fail exact output matching
     z.object({

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -98,11 +98,29 @@ type ToZodKeyMismatch<Expected, Received> = schemas.$ZodType & {
   "types do not match": { expected: Expected; received: Received };
 };
 
+// An enum reference and the union of exactly its members are mutually assignable but not identical, so `AssertEqual` alone rejects `z.enum(SomeEnum)` against a `SomeEnum` target. Rebuilding the string/number part of each side through a mapped type collapses that one difference and nothing else — plain literals against an enum, member subsets, brands and `any` all still fail.
+type ToZodNormalizeEnum<T> = { [K in Extract<T, EnumValue>]: K }[Extract<T, EnumValue>] | Exclude<T, EnumValue>;
+
+// Recurses only through types identical to their own homomorphic rebuild, which preserves the exactness guarantees: an intersection, a call signature and `readonly`/optional modifiers all survive or block the walk, so only enum leaves are normalized.
+type ToZodNormalize<T> = [T] extends [object]
+  ? AssertEqual<T, { [K in keyof T]: T[K] }> extends true
+    ? { [K in keyof T]: ToZodNormalize<T[K]> }
+    : T
+  : ToZodNormalizeEnum<T>;
+
+type ToZodEqual<Output, T> = AssertEqual<Output, T> extends true
+  ? true
+  : IsAny<Output> extends true
+    ? false
+    : IsAny<T> extends true
+      ? false
+      : AssertEqual<ToZodNormalize<Output>, ToZodNormalize<T>>;
+
 // Rebuilds the shape with a marker on each key that disagrees, so the diagnostic names the key instead of failing the whole schema at the top level. A key the target lacks reports `expected: never`; a key the schema lacks reports `received: never`.
 type ToZodShape<Shape, T> = {
   [K in keyof Shape]: Shape[K] extends schemas.$ZodType
     ? K extends keyof T
-      ? AssertEqual<Shape[K]["_zod"]["output"], T[K]> extends true
+      ? ToZodEqual<Shape[K]["_zod"]["output"], T[K]> extends true
         ? Shape[K]
         : ToZodKeyMismatch<T[K], Shape[K]["_zod"]["output"]>
       : ToZodKeyMismatch<never, Shape[K]["_zod"]["output"]>
@@ -232,7 +250,7 @@ export function assertNotEqual<A, B>(val: AssertNotEqual<A, B>): AssertNotEqual<
 }
 
 export function toZod<T>(): <S extends schemas.$ZodType>(
-  schema: AssertEqual<S["_zod"]["output"], T> extends true ? S : ToZodTarget<S, T>
+  schema: ToZodEqual<S["_zod"]["output"], T> extends true ? S : ToZodTarget<S, T>
 ) => S {
   return (schema) => schema as any;
 }


### PR DESCRIPTION
Fixes #6524.

`z.toZod<T>()` rejected `z.enum(SomeEnum)` against a property typed `SomeEnum`, with the unhelpful diagnostic `expected: SomeEnum, received: SomeEnum`. TypeScript doesn't consider an enum reference identical to the union of exactly its own members, and the union is the only output type `z.enum` can infer from `typeof SomeEnum` — so no schema could ever satisfy an enum-typed property. The equivalent member-union target worked, which is the asymmetry the issue reports. This was also flagged during review on #5913 and hit by a user in the first canary.

The fix keeps exact identity as the fast path and adds a fallback: rebuild the `string | number` part of each side through a mapped key type (`{ [K in T]: K }[T]`), which collapses the enum-reference/member-union difference and nothing else, then re-check identity. The walk recurses only through types identical to their own homomorphic rebuild, so every guarantee the exactness decision in #5913 protects is preserved — `any` (explicit guards), `readonly` and optional modifiers, intersection-vs-flat, brands, member subsets, and plain `"A" | "B"` literals against a nominal enum all still fail. Enum targets now work at any depth, including arrays, tuples, records, nullables, and recursive types.

Type-only change: zero runtime, memory, and bundle delta. The fallback only instantiates where the fast path already failed, so typecheck cost lands on error paths and newly-valid enum paths; the repo's own typecheck time is unchanged.
