### PR TITLE
perf(v4): read Luhn digits with charCodeAt instead of string indexing

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1111,7 +1111,7 @@ function isLuhnAlgo(digits: string): boolean {
   let bit = 1;
   let sum = 0;
   while (length) {
-    const value = +digits[--length]!;
+    const value = digits.charCodeAt(--length) - 48;
     bit ^= 1;
     sum += bit ? [0, 2, 4, 6, 8, 1, 3, 5, 7, 9][value]! : value;
   }


### PR DESCRIPTION
Closes #6521.

The Luhn helper read each digit with a string index, which allocates a one-character string and then coerces it to a number; reading the char code directly avoids the allocation. This is safe because the shape regex runs before the checksum and separators are stripped first, so the string is digits-only by construction — a differential check over 500k random digit strings found no disagreement between the two versions.

Benchmarked in #6521: the checksum helper roughly doubles (9.7 → 21.6 M ops/s), and the full credit card check gains about 25% end to end, since the regex and separator strip dominate. Bundle cost is +13 B raw / +4 B gzipped, and only in bundles that include the credit card validator; memory is unchanged.
