### PR TITLE
fix(v4): parse recursive schemas built by a factory

### DIFF
--- a/packages/docs/components/github-star-pill.tsx
+++ b/packages/docs/components/github-star-pill.tsx
@@ -38,9 +38,9 @@ export async function GitHubStarPill({ repo }: { repo: string }) {
       aria-label={
         stars === undefined ? `Star ${repo} on GitHub` : `Star ${repo} on GitHub — ${formatStars(stars)} stars`
       }
-      className="group inline-flex items-center gap-2 h-9 rounded-full border border-fd-border bg-fd-card/60 ps-2.25 pe-2.5 text-sm font-medium text-fd-muted-foreground shadow-sm transition-colors hover:border-fd-primary hover:text-fd-foreground"
+      className="group inline-flex items-center gap-2 h-9 rounded-full border border-fd-border bg-fd-card/60 ps-1.75 pe-2.5 text-sm font-medium text-fd-muted-foreground shadow-sm transition-colors hover:border-fd-primary hover:text-fd-foreground"
     >
-      <GitHubMark className="size-4 text-fd-foreground" />
+      <GitHubMark className="size-5 text-fd-foreground" />
       <span className="flex items-center gap-1">
         <StarIcon className="size-3.5 shrink-0 transition-colors group-hover:text-fd-foreground" />
         {stars !== undefined && <span className="leading-none">{formatStars(stars)}</span>}

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -1635,19 +1635,20 @@ export const ZodObject: core.$constructor<ZodObject> = /*@__PURE__*/ core.$const
       return _enum(Object.keys(this._zod.def.shape));
     },
     catchall(catchall) {
-      return this.clone({ ...this._zod.def, catchall: catchall as any });
+      // `mergeDefs` rather than a spread: spreading reads `shape`, and resolving it can mint a whole fresh subtree
+      return this.clone(util.mergeDefs(this._zod.def, { catchall: catchall as any }));
     },
     passthrough() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
+      return this.clone(util.mergeDefs(this._zod.def, { catchall: unknown() }));
     },
     loose() {
-      return this.clone({ ...this._zod.def, catchall: unknown() });
+      return this.clone(util.mergeDefs(this._zod.def, { catchall: unknown() }));
     },
     strict() {
-      return this.clone({ ...this._zod.def, catchall: never() });
+      return this.clone(util.mergeDefs(this._zod.def, { catchall: never() }));
     },
     strip() {
-      return this.clone({ ...this._zod.def, catchall: undefined });
+      return this.clone(util.mergeDefs(this._zod.def, { catchall: undefined }));
     },
     extend(incoming) {
       return util.extend(this, incoming);

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -846,6 +846,27 @@ test("a builder that drops the recursive key ends up exact", () => {
   expect(z.core.isRecursiveSchema(kept)).toBe(true);
 });
 
+// resolving a lazy runs user code, which can re-enter the walk; a walk that kept its certainty outside its own frames would have the inner one clobber the outer
+test("a nested walk can't corrupt the one that resolved into it", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    self: z.lazy(() => {
+      z.compile(z.string(), { strict: true });
+      return z.optional(Node);
+    }),
+  });
+
+  const omitted = Node.omit({ self: true });
+  omitted.parse({ id: 1 });
+  expect(z.core.isRecursiveSchema(omitted)).toBe(false);
+  expect(() => z.compile(omitted, { strict: true })).not.toThrow();
+
+  const shared = { id: 1 };
+  const out: any = z.object({ a: omitted, b: omitted }).parse({ a: shared, b: shared });
+  expect(out.a).not.toBe(out.b);
+  expect(z.core.isRecursiveSchema(Node)).toBe(true);
+});
+
 test("detects a cycle that closes through a builder", () => {
   const Node: any = z
     .object({

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -718,3 +718,50 @@ test("detects a cycle through a user-defined container type", () => {
   const out: any = Node.parse(input);
   expect(out.boxed.v).toBe(out);
 });
+
+// #6526: a factory returns fresh instances, so the identity walk never revisits a node; without the depth cap it descends until the stack overflows
+test("parses a factory-built recursive schema", () => {
+  const Node = (): any =>
+    z.object({
+      id: z.number(),
+      get kids() {
+        return z.array(Node());
+      },
+    });
+
+  const S = z.object({ root: Node() });
+  const out = S.parse({ root: { id: 1, kids: [{ id: 2, kids: [] }] } });
+  expect(out.root.kids[0].id).toBe(2);
+  expect(S.safeParse({ root: { id: 1, kids: [{ id: "x", kids: [] }] } }).success).toBe(false);
+});
+
+test("parses a factory-built recursive discriminated union at the root and nested", () => {
+  const Geometry = (): any =>
+    z.discriminatedUnion("type", [
+      z.object({ type: z.literal("Point"), coordinates: z.array(z.number()) }),
+      z.looseObject({
+        type: z.literal("GeometryCollection"),
+        get geometries() {
+          return z.array(Geometry());
+        },
+      }),
+    ]);
+
+  const collection = { type: "GeometryCollection", geometries: [{ type: "Point", coordinates: [1, 2] }] };
+  expect(Geometry().parse(collection).geometries[0].coordinates).toEqual([1, 2]);
+  expect(z.object({ g: Geometry() }).parse({ g: collection }).g.type).toBe("GeometryCollection");
+});
+
+test("the depth cap keeps the walk exact below it", () => {
+  let deep: any = z.string();
+  for (let i = 0; i < 50; i++) deep = z.object({ v: deep });
+  expect(z.core.isRecursiveSchema(deep)).toBe(false);
+
+  const Node = (): any =>
+    z.object({
+      get self() {
+        return Node();
+      },
+    });
+  expect(z.core.isRecursiveSchema(Node())).toBe(true);
+});

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -769,7 +769,10 @@ test("the walk reports a cycle for a deferred edge instead of resolving it", () 
     },
   });
   expect(z.core.isRecursiveSchema(forward)).toBe(true);
-  expect(z.core.isRecursiveSchema(z.lazy(() => Leaf) as any)).toBe(true);
+
+  // a lazy is followed one hop, which is what lets z.compile see past it; past that hop it is deferred like any other edge
+  expect(z.core.isRecursiveSchema(z.lazy(() => Leaf) as any)).toBe(false);
+  expect(z.core.isRecursiveSchema(z.lazy(() => z.lazy(() => Leaf)) as any)).toBe(true);
 });
 
 // the builders answer `shape` from an accessor that resolves the source's getters, so the walk has to reach the source schema itself
@@ -870,12 +873,6 @@ test("a deferred edge stops being assumed a cycle once the graph resolves", () =
   Forward.parse({ a: { n: 1 } });
   // the parse resolved the getter, so the walk can follow it and drop the assumption
   expect(z.core.isRecursiveSchema(Forward)).toBe(false);
-
-  // same for a lazy edge, which caches its inner on the def once anything reads it
-  const Deferred: any = z.object({ a: z.lazy(() => Leaf) });
-  expect(z.core.isRecursiveSchema(Deferred)).toBe(true);
-  Deferred.parse({ a: { n: 1 } });
-  expect(z.core.isRecursiveSchema(Deferred)).toBe(false);
 
   // a factory hands back a fresh subtree every time, so no parse ever resolves it into a finite graph
   const Node = (): any =>

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -752,10 +752,15 @@ test("parses a factory-built recursive discriminated union at the root and neste
   expect(z.object({ g: Geometry() }).parse({ g: collection }).g.type).toBe("GeometryCollection");
 });
 
-test("the depth cap keeps the walk exact below it", () => {
-  let deep: any = z.string();
-  for (let i = 0; i < 50; i++) deep = z.object({ v: deep });
-  expect(z.core.isRecursiveSchema(deep)).toBe(false);
+test("the depth cap keeps the walk exact below it and conservative past it", () => {
+  // the leaf of an n-wrapper chain enters the walk at depth n, so 255 wrappers sit just under the cap and 256 just past it
+  const nest = (n: number) => {
+    let s: any = z.string();
+    for (let i = 0; i < n; i++) s = z.object({ v: s });
+    return s;
+  };
+  expect(z.core.isRecursiveSchema(nest(255))).toBe(false);
+  expect(z.core.isRecursiveSchema(nest(256))).toBe(true);
 
   const Node = (): any =>
     z.object({

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -818,6 +818,31 @@ test("an ordinary builder stays exact, so it still compiles", () => {
   }
 });
 
+// asking what a derived shape was built from over-approximates, since a builder can drop the branch carrying the cycle; the resolved shape has to be allowed to correct it
+test("a builder that drops the recursive key ends up exact", () => {
+  const Node: any = z.object({
+    id: z.number(),
+    get self() {
+      return z.optional(Node);
+    },
+  });
+
+  const derived: [string, any, any][] = [
+    ["omit", Node.omit({ self: true }), { id: 1 }],
+    ["pick", Node.pick({ id: true }), { id: 1 }],
+    ["extend overwrites it", Node.extend({ self: z.string() }), { id: 1, self: "x" }],
+  ];
+  for (const [name, schema, input] of derived) {
+    schema.parse(input);
+    expect(z.core.isRecursiveSchema(schema), name).toBe(false);
+    expect(() => z.compile(schema, { strict: true }), name).not.toThrow();
+  }
+
+  // the branch that stays is still found
+  const kept = Node.extend({ x: z.string() });
+  expect(z.core.isRecursiveSchema(kept)).toBe(true);
+});
+
 test("detects a cycle that closes through a builder", () => {
   const Node: any = z
     .object({

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -922,6 +922,28 @@ test("a deferred edge stops being assumed a cycle once the graph resolves", () =
   expect(z.core.isRecursiveSchema(Cyclic)).toBe(true);
 });
 
+// `z.object` resolves its shape by spread, so a non-enumerable key is no part of it; `z.properties` reads every own key, so one there is still parsed and can still close a cycle
+test("a non-enumerable key counts for z.properties and not for z.object", () => {
+  const props = (enumerable: boolean) => {
+    const shape: Record<string, any> = { id: z.number() };
+    const P = z.properties(shape);
+    Object.defineProperty(shape, "next", { value: z.lazy(() => z.optional(P)), enumerable, configurable: true });
+    return P;
+  };
+  expect(z.core.isRecursiveSchema(props(true) as any)).toBe(true);
+  expect(z.core.isRecursiveSchema(props(false) as any)).toBe(true);
+
+  const object = (enumerable: boolean) => {
+    const shape: Record<string, any> = { id: z.number() };
+    const O: any = z.object(shape);
+    Object.defineProperty(shape, "next", { value: z.lazy(() => z.optional(O)), enumerable, configurable: true });
+    return O;
+  };
+  expect(z.core.isRecursiveSchema(object(true))).toBe(true);
+  // the spread drops it, so nothing can ever parse it
+  expect(z.core.isRecursiveSchema(object(false))).toBe(false);
+});
+
 test("the walk stays exact where nothing is deferred", () => {
   let deep: any = z.string();
   for (let i = 0; i < 300; i++) deep = z.object({ v: deep });

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -752,7 +752,7 @@ test("parses a factory-built recursive discriminated union at the root and neste
   expect(z.object({ g: Geometry() }).parse({ g: collection }).g.type).toBe("GeometryCollection");
 });
 
-test("the walk flags a generative loop without resolving it to the bottom", () => {
+test("the walk reports a cycle for a deferred edge instead of resolving it", () => {
   const Node = (): any =>
     z.object({
       get self() {
@@ -761,32 +761,43 @@ test("the walk flags a generative loop without resolving it to the bottom", () =
     });
   expect(z.core.isRecursiveSchema(Node())).toBe(true);
 
-  // mutual factories: the loop closes over two getter sources
-  const A = (): any =>
-    z.object({
-      get b() {
-        return B();
-      },
-    });
-  const B = (): any =>
-    z.object({
-      get a() {
-        return A();
-      },
-    });
-  expect(z.core.isRecursiveSchema(A())).toBe(true);
-
-  // a lone forward-reference getter is not a loop
+  // conservative by design: a getter that closes no cycle is reported too, and pays only the memoizer it keeps
   const Leaf = z.object({ id: z.string() });
   const forward: any = z.object({
     get leaf() {
       return Leaf;
     },
   });
-  expect(z.core.isRecursiveSchema(forward)).toBe(false);
+  expect(z.core.isRecursiveSchema(forward)).toBe(true);
+  expect(z.core.isRecursiveSchema(z.lazy(() => Leaf) as any)).toBe(true);
 });
 
-test("the walk stays exact on deep acyclic nesting", () => {
+test("a deferred edge stops being assumed a cycle once the graph resolves", () => {
+  const Leaf = z.object({ n: z.number() });
+  const Forward: any = z.object({
+    get a() {
+      return Leaf;
+    },
+  });
+  expect(z.core.isRecursiveSchema(Forward)).toBe(true);
+  Forward.parse({ a: { n: 1 } });
+  // the parse resolved the getter, so the walk can follow it and drop the assumption
+  expect(z.core.isRecursiveSchema(Forward)).toBe(false);
+
+  // a factory hands back a fresh subtree every time, so no parse ever resolves it into a finite graph
+  const Node = (): any =>
+    z.object({
+      get kids() {
+        return z.array(Node());
+      },
+    });
+  const Generated = Node();
+  expect(z.core.isRecursiveSchema(Generated)).toBe(true);
+  Generated.parse({ kids: [] });
+  expect(z.core.isRecursiveSchema(Generated)).toBe(true);
+});
+
+test("the walk stays exact where nothing is deferred", () => {
   let deep: any = z.string();
   for (let i = 0; i < 300; i++) deep = z.object({ v: deep });
   expect(z.core.isRecursiveSchema(deep)).toBe(false);

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -786,6 +786,10 @@ test("parses a factory-built recursive schema through every object builder", () 
     ["pick", (b) => b().pick({ self: true })],
     ["omit", (b) => b().omit({ y: true })],
     ["chained", (b) => b().extend({ x: z.string() }).partial()],
+    // rebuilds the def without touching the shape, so the clone carries the source's accessor rather than a shape of its own
+    ["strict", (b) => b().extend({ x: z.string() }).strict()],
+    ["catchall", (b) => b().extend({ x: z.string() }).catchall(z.unknown())],
+    ["meta", (b) => b().extend({ x: z.string() }).meta({ id: "node" })],
   ];
 
   for (const [name, wrap] of wraps) {
@@ -814,6 +818,9 @@ test("an ordinary builder stays exact, so it still compiles", () => {
     ["required", plain.partial().required()],
     ["pick", plain.pick({ a: true })],
     ["omit", plain.omit({ a: true })],
+    ["strict", plain.extend({ c: z.boolean() }).strict()],
+    ["catchall", plain.extend({ c: z.boolean() }).catchall(z.unknown())],
+    ["meta", plain.extend({ c: z.boolean() }).meta({ id: "plain" })],
   ];
   for (const [name, schema] of derived) {
     expect(z.core.isRecursiveSchema(schema), name).toBe(false);
@@ -821,7 +828,7 @@ test("an ordinary builder stays exact, so it still compiles", () => {
   }
 });
 
-// asking what a derived shape was built from over-approximates, since a builder can drop the branch carrying the cycle; the resolved shape has to be allowed to correct it
+// a derived shape mirrors its source's descriptors, so dropping or overwriting the key that carries the cycle leaves nothing deferred and the walk is exact before anything parses
 test("a builder that drops the recursive key ends up exact", () => {
   const Node: any = z.object({
     id: z.number(),
@@ -836,9 +843,9 @@ test("a builder that drops the recursive key ends up exact", () => {
     ["extend overwrites it", Node.extend({ self: z.string() }), { id: 1, self: "x" }],
   ];
   for (const [name, schema, input] of derived) {
-    schema.parse(input);
     expect(z.core.isRecursiveSchema(schema), name).toBe(false);
     expect(() => z.compile(schema, { strict: true }), name).not.toThrow();
+    expect(schema.parse(input), name).toEqual(input);
   }
 
   // the branch that stays is still found

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -719,7 +719,7 @@ test("detects a cycle through a user-defined container type", () => {
   expect(out.boxed.v).toBe(out);
 });
 
-// #6526: a factory returns fresh instances, so the identity walk never revisits a node; without the depth cap it descends until the stack overflows
+// #6526: a factory returns fresh instances, so the identity walk never revisits a node; it descends until the stack overflows unless it stops at the deferred edge
 test("parses a factory-built recursive schema", () => {
   const Node = (): any =>
     z.object({
@@ -784,6 +784,12 @@ test("a deferred edge stops being assumed a cycle once the graph resolves", () =
   // the parse resolved the getter, so the walk can follow it and drop the assumption
   expect(z.core.isRecursiveSchema(Forward)).toBe(false);
 
+  // same for a lazy edge, which caches its inner on the def once anything reads it
+  const Deferred: any = z.object({ a: z.lazy(() => Leaf) });
+  expect(z.core.isRecursiveSchema(Deferred)).toBe(true);
+  Deferred.parse({ a: { n: 1 } });
+  expect(z.core.isRecursiveSchema(Deferred)).toBe(false);
+
   // a factory hands back a fresh subtree every time, so no parse ever resolves it into a finite graph
   const Node = (): any =>
     z.object({
@@ -795,6 +801,11 @@ test("a deferred edge stops being assumed a cycle once the graph resolves", () =
   expect(z.core.isRecursiveSchema(Generated)).toBe(true);
   Generated.parse({ kids: [] });
   expect(z.core.isRecursiveSchema(Generated)).toBe(true);
+
+  // a lazy that closes a real cycle stays recursive however often it resolves
+  const Cyclic: any = z.object({ id: z.number(), self: z.lazy(() => z.optional(Cyclic)) });
+  Cyclic.parse({ id: 1 });
+  expect(z.core.isRecursiveSchema(Cyclic)).toBe(true);
 });
 
 test("the walk stays exact where nothing is deferred", () => {

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -864,6 +864,8 @@ test("a nested walk can't corrupt the one that resolved into it", () => {
   });
 
   const omitted = Node.omit({ self: true });
+  // exact before anything parses: the mirrored shape kept only `id`, so nothing here is deferred
+  expect(z.core.isRecursiveSchema(omitted)).toBe(false);
   omitted.parse({ id: 1 });
   expect(z.core.isRecursiveSchema(omitted)).toBe(false);
   expect(() => z.compile(omitted, { strict: true })).not.toThrow();

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -752,16 +752,7 @@ test("parses a factory-built recursive discriminated union at the root and neste
   expect(z.object({ g: Geometry() }).parse({ g: collection }).g.type).toBe("GeometryCollection");
 });
 
-test("the depth cap keeps the walk exact below it and conservative past it", () => {
-  // the leaf of an n-wrapper chain enters the walk at depth n, so 255 wrappers sit just under the cap and 256 just past it
-  const nest = (n: number) => {
-    let s: any = z.string();
-    for (let i = 0; i < n; i++) s = z.object({ v: s });
-    return s;
-  };
-  expect(z.core.isRecursiveSchema(nest(255))).toBe(false);
-  expect(z.core.isRecursiveSchema(nest(256))).toBe(true);
-
+test("the walk flags a generative loop without resolving it to the bottom", () => {
   const Node = (): any =>
     z.object({
       get self() {
@@ -769,4 +760,45 @@ test("the depth cap keeps the walk exact below it and conservative past it", () 
       },
     });
   expect(z.core.isRecursiveSchema(Node())).toBe(true);
+
+  // mutual factories: the loop closes over two getter sources
+  const A = (): any =>
+    z.object({
+      get b() {
+        return B();
+      },
+    });
+  const B = (): any =>
+    z.object({
+      get a() {
+        return A();
+      },
+    });
+  expect(z.core.isRecursiveSchema(A())).toBe(true);
+
+  // a lone forward-reference getter is not a loop
+  const Leaf = z.object({ id: z.string() });
+  const forward: any = z.object({
+    get leaf() {
+      return Leaf;
+    },
+  });
+  expect(z.core.isRecursiveSchema(forward)).toBe(false);
+});
+
+test("the walk stays exact on deep acyclic nesting", () => {
+  let deep: any = z.string();
+  for (let i = 0; i < 300; i++) deep = z.object({ v: deep });
+  expect(z.core.isRecursiveSchema(deep)).toBe(false);
+});
+
+test("parses a factory-built recursive schema through z.lazy", () => {
+  const Node = (): any =>
+    z.object({
+      id: z.number(),
+      child: z.lazy(() => z.optional(Node())),
+    });
+
+  const out = z.object({ root: Node() }).parse({ root: { id: 1, child: { id: 2, child: undefined } } });
+  expect(out.root.child.id).toBe(2);
 });

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -772,6 +772,68 @@ test("the walk reports a cycle for a deferred edge instead of resolving it", () 
   expect(z.core.isRecursiveSchema(z.lazy(() => Leaf) as any)).toBe(true);
 });
 
+// the builders answer `shape` from an accessor that resolves the source's getters, so the walk has to reach the source schema itself
+test("parses a factory-built recursive schema through every object builder", () => {
+  const wraps: [string, (base: () => any) => any][] = [
+    ["extend", (b) => b().extend({ x: z.string() })],
+    ["safeExtend", (b) => b().safeExtend({ x: z.string() })],
+    ["merge", (b) => z.object({ x: z.string() }).merge(b())],
+    ["partial", (b) => b().partial()],
+    ["required", (b) => b().required()],
+    ["pick", (b) => b().pick({ self: true })],
+    ["omit", (b) => b().omit({ y: true })],
+    ["chained", (b) => b().extend({ x: z.string() }).partial()],
+  ];
+
+  for (const [name, wrap] of wraps) {
+    const Node = (): any =>
+      wrap(() =>
+        z.object({
+          y: z.string(),
+          get self() {
+            return z.optional(Node());
+          },
+        })
+      );
+    const S = z.object({ r: Node() });
+    for (const attempt of ["first", "second"]) {
+      expect(() => S.safeParse({ r: { y: "s", x: "s" } }), `${name} (${attempt} parse)`).not.toThrow();
+    }
+  }
+});
+
+test("an ordinary builder stays exact, so it still compiles", () => {
+  const plain = z.object({ a: z.string(), b: z.number() });
+  const derived: [string, any][] = [
+    ["extend", plain.extend({ c: z.boolean() })],
+    ["merge", plain.merge(z.object({ d: z.string() }))],
+    ["partial", plain.partial()],
+    ["required", plain.partial().required()],
+    ["pick", plain.pick({ a: true })],
+    ["omit", plain.omit({ a: true })],
+  ];
+  for (const [name, schema] of derived) {
+    expect(z.core.isRecursiveSchema(schema), name).toBe(false);
+    expect(() => z.compile(schema, { strict: true }), name).not.toThrow();
+  }
+});
+
+test("detects a cycle that closes through a builder", () => {
+  const Node: any = z
+    .object({
+      id: z.number(),
+      get self() {
+        return z.optional(Node);
+      },
+    })
+    .extend({ x: z.string() });
+
+  const input: any = { id: 1, x: "s" };
+  input.self = input;
+  const out = Node.parse(input);
+  expect(out.self).toBe(out);
+});
+
 test("a deferred edge stops being assumed a cycle once the graph resolves", () => {
   const Leaf = z.object({ n: z.number() });
   const Forward: any = z.object({

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -838,6 +838,13 @@ describe("__proto__ as a declared shape key", () => {
     expect(() => (schema[method] as any)(mask).shape).toThrow('Unrecognized key: "__proto__"');
   });
 
+  // the mask is checked against the source's declared keys, which reads without resolving them, so it throws where the mistake is
+  test.each(["pick", "omit", "partial", "required"] as const)("%s rejects an undeclared key at the call", (method) => {
+    const schema = z.object({ value: z.string() });
+
+    expect(() => (schema[method] as any)({ nope: true })).toThrow('Unrecognized key: "nope"');
+  });
+
   test("shape helpers preserve a declared key", () => {
     const shape = () =>
       Object.fromEntries([

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -845,6 +845,29 @@ describe("__proto__ as a declared shape key", () => {
     expect(() => (schema[method] as any)({ nope: true })).toThrow('Unrecognized key: "nope"');
   });
 
+  // a shape resolves by object spread, so a non-enumerable entry is no part of it and no builder may promote one into a derived shape
+  test("a non-enumerable shape entry stays out of every derived shape", () => {
+    const sym = Symbol("kept");
+    const hide = (target: Record<string, any>) =>
+      Object.defineProperty(target, "hidden", { value: z.string(), enumerable: false, configurable: true });
+    // each case needs a source whose shape is still unresolved, since resolving drops the entry on its own
+    const source = () => z.object(hide({ b: z.number(), [sym]: z.boolean() }) as any);
+
+    expect(Reflect.ownKeys(source().shape)).toEqual(["b", sym]);
+    expect(Reflect.ownKeys(source().extend({ c: z.boolean() }).shape)).toEqual(["b", "c", sym]);
+    expect(Reflect.ownKeys(source().partial().shape)).toEqual(["b", sym]);
+    expect(Reflect.ownKeys(source().merge(z.object({ c: z.boolean() })).shape)).toEqual(["b", "c", sym]);
+    expect(Object.keys(z.object({ b: z.number() }).extend(hide({}) as any).shape)).toEqual(["b"]);
+    expect(() => source().pick({ hidden: true } as any)).toThrow('Unrecognized key: "hidden"');
+
+    // promoting it would make a key the source ignores required
+    expect(
+      source()
+        .extend({ c: z.boolean() })
+        .safeParse({ b: 1, [sym]: true, c: true }).success
+    ).toBe(true);
+  });
+
   test("shape helpers preserve a declared key", () => {
     const shape = () =>
       Object.fromEntries([

--- a/packages/zod/src/v4/classic/tests/object.test.ts
+++ b/packages/zod/src/v4/classic/tests/object.test.ts
@@ -845,6 +845,32 @@ describe("__proto__ as a declared shape key", () => {
     expect(() => (schema[method] as any)({ nope: true })).toThrow('Unrecognized key: "nope"');
   });
 
+  // a derived shape is built key by key, and a plain assignment runs whatever setter answers to the key — `__proto__` always has one, and a polluted prototype can supply one for any name
+  test("an inherited setter cannot swallow a derived key", () => {
+    let swallowed: unknown;
+    Object.defineProperty(Object.prototype, "field", {
+      configurable: true,
+      set(v) {
+        swallowed = v;
+      },
+      get() {
+        return undefined;
+      },
+    });
+
+    try {
+      const derived = z.object({ field: z.string() }).extend({ extra: z.number() });
+
+      expect(Object.keys(derived.shape)).toEqual(["field", "extra"]);
+      expect(swallowed).toBeUndefined();
+      // the key is still validated; what a parse writes into its result is the ambient prototype's business, as it is without a builder
+      expect(derived.safeParse({ field: 123, extra: 1 }).success).toBe(false);
+      expect(derived.safeParse({ field: "a", extra: 1 }).success).toBe(true);
+    } finally {
+      delete (Object.prototype as any).field;
+    }
+  });
+
   // a shape resolves by object spread, so a non-enumerable entry is no part of it and no builder may promote one into a derived shape
   test("a non-enumerable shape entry stays out of every derived shape", () => {
     const sym = Symbol("kept");

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -34,12 +34,16 @@ function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
 
 const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
 
+// A factory-built recursive schema mints fresh instances on every getter read, so the identity walk below never revisits a node and would descend until the stack overflows. Past this depth, assume a cycle: a false positive only leaves the memoizer attached, which is what a true cycle gets anyway.
+const MAX_DEPTH = 256;
+
 /** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */
 function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
   const cached = recursive.get(inst);
   if (cached !== undefined) return cached;
   // Relative to the walk in progress, so not cached.
   if (stack.has(inst)) return true;
+  if (stack.size >= MAX_DEPTH) return true;
   stack.add(inst);
 
   let result = false;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -69,12 +69,15 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
   switch (kind) {
     case "object": {
       const raw = rawShape(def);
-      if (raw) shape(raw);
-      else {
-        // No raw entry means the def answers `shape` from its own accessor, which is a builder deriving it from another schema. Reading that resolves the source's getters, so ask what it was built from instead: the derived subtree is contained in theirs.
-        const sources = util.getShapeSources(def);
-        if (sources) for (const src of sources) (src as any)?._zod ? check(src) : shape(src as object);
-        else shape(def.shape);
+      const desc = raw ? undefined : Object.getOwnPropertyDescriptor(def, "shape");
+      const sources = desc?.get ? util.getShapeSources(def) : undefined;
+      if (sources) {
+        // The def answers `shape` from a builder's accessor that has not run yet, and reading it resolves the source's getters. Ask what it was built from instead: the derived subtree is contained in theirs. Only contained, though — a builder can drop or overwrite the very branch that carries the cycle — so this is an over-approximation, and marking it assumed is what lets the recheck below replace it with the resolved shape's exact answer.
+        assumed = true;
+        for (const src of sources) (src as any)?._zod ? check(src) : shape(src as object);
+      } else {
+        // Either the raw shape, or a builder accessor that has already self-cached its result: both hold resolved values, so neither runs user code.
+        shape(raw ?? def.shape);
       }
       check(def.catchall);
       break;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -44,7 +44,7 @@ const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
 let assumed = false;
 
 /** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */
-function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
+function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): boolean {
   const cached = recursive.get(inst);
   if (cached !== undefined) return cached;
   // Relative to the walk in progress, so not cached.
@@ -53,7 +53,7 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
 
   let result = false;
   const check = (child: any) => {
-    if (!result && child?._zod && isRecursive(child, stack)) result = true;
+    if (!result && child?._zod && isRecursive(child, stack, resolve)) result = true;
   };
 
   // `Reflect.ownKeys` rather than `Object.keys`, so a cycle through a declared symbol key is still seen
@@ -130,10 +130,14 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
       check(def.output);
       break;
     // `$ZodLazy` caches its inner on the def, so a resolved edge is followed exactly
-    case "lazy":
-      if (def._cachedInner) check(def._cachedInner);
-      else result = assumed = true;
+    case "lazy": {
+      const inner = def._cachedInner ?? (resolve ? (inst as any)._zod.innerType : undefined);
+      // one hop sees past the deferral; beyond it `resolve` is off, so a lazy yielding only another unresolved lazy is generative and stops here
+      if (inner) {
+        if (!result && isRecursive(inner, stack, false)) result = true;
+      } else result = assumed = true;
       break;
+    }
     // a leaf by choice: `parts` are regex fragments, not data positions
     case "template_literal":
     // leaves
@@ -186,7 +190,8 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
  */
 export function isRecursiveSchema(inst: $ZodType): boolean {
   assumed = false;
-  return isRecursive(inst, new Set());
+  // z.compile never parses, so nothing would ever resolve a lazy for it; it runs once and already treats a throw here as recursive
+  return isRecursive(inst, new Set(), true);
 }
 
 function bucketFor(state: State, inst: $ZodType): Map<object, Entry> {
@@ -244,7 +249,7 @@ const memo: $ZodMemoizer = {
       const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload> => {
         if (isRecursiveInst === undefined) {
           assumed = false;
-          const walked = isRecursive(inst, new Set());
+          const walked = isRecursive(inst, new Set(), false);
           if (!walked) {
             // Nothing here can ever fire, so take it back out.
             inst._zod.parse = base;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -62,12 +62,12 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): Answ
   };
 
   // `Reflect.ownKeys` rather than `Object.keys`, so a cycle through a declared symbol key is still seen
-  const shape = (sh: object): Answer => {
+  const shape = (sh: object, spread: boolean): Answer => {
     let answer: Answer = NONE;
     for (const key of Reflect.ownKeys(sh)) {
       const desc = Object.getOwnPropertyDescriptor(sh, key)!;
-      // a shape resolves by object spread, so a key it does not enumerate is never parsed
-      if (!desc.enumerable) continue;
+      // an object resolves its shape by spread, so a key it does not enumerate is never parsed; `z.properties` reads every own key and so keeps them all
+      if (spread && !desc.enumerable) continue;
       // resolving runs user code, and a factory mints a fresh subtree per read, so an edge the walk can't follow counts as a cycle
       const child = desc.get ? ASSUMED : desc.value?._zod ? isRecursive(desc.value, stack, resolve) : NONE;
       if (child > answer) answer = child;
@@ -85,12 +85,12 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): Answ
     case "object": {
       const raw = util.rawShape(def);
       // a def with no raw shape answers `shape` from an accessor of its own, and running that can mint a whole fresh subtree
-      merge(raw ? shape(raw) : ASSUMED);
+      merge(raw ? shape(raw, true) : ASSUMED);
       check(def.catchall);
       break;
     }
     case "properties":
-      merge(shape(def.shape));
+      merge(shape(def.shape, false));
       break;
     case "array":
       check(def.element);

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -35,8 +35,15 @@ function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
 
 const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
 
-/** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */
-function isRecursive(inst: $ZodType, stack: Set<object>, sources: Set<string>): boolean {
+// Set by a walk that reported a cycle it could not confirm, so the answer is not cached and the caller knows to ask again once the graph is resolved. The walk is synchronous and never re-enters, so one flag serves the whole traversal.
+let assumed = false;
+
+/**
+ * Whether this schema's subtree contains a cycle, so one parse can re-enter it.
+ *
+ * The walk resolves nothing that runs user code, and reports a cycle for every edge it therefore can't follow — a shape getter or a `z.lazy`. Identity is its only termination argument, and a deferred edge need not answer with the same schema twice: a factory-built recursive schema mints a fresh subtree per level, so a walk that resolved those would never revisit a node and would descend until the stack overflows. Erring toward a cycle costs such a schema only the memoizer it keeps attached; erring the other way is unsound.
+ */
+function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
   const cached = recursive.get(inst);
   if (cached !== undefined) return cached;
   // Relative to the walk in progress, so not cached.
@@ -45,40 +52,20 @@ function isRecursive(inst: $ZodType, stack: Set<object>, sources: Set<string>): 
 
   let result = false;
   const check = (child: any) => {
-    if (!result && child?._zod && isRecursive(child, stack, sources)) result = true;
-  };
-
-  // A factory-built recursive schema mints fresh instances on every getter read, so instance identity never sees the walk revisit a node and it would descend forever. What every minted level shares is the getter itself: a path that re-enters a getter whose source it is already resolving can only have been produced by a loop in user code, so treat the repeat as a back-edge and don't resolve it.
-  const follow = (source: string, read: () => unknown) => {
-    if (result) return;
-    if (sources.has(source)) {
-      result = true;
-      return;
-    }
-    sources.add(source);
-    check(read());
-    sources.delete(source);
+    if (!result && child?._zod && isRecursive(child, stack)) result = true;
   };
 
   const def = inst._zod.def as any;
   const kind = def.type as $ZodTypeDef["type"];
   switch (kind) {
     case "object": {
-      // The first `def.shape` read resolves every user getter at once via spread, so fingerprint the raw shape's getters before triggering it; a def without a raw entry was already resolved, and its shape holds plain values.
+      // Reading the raw shape's descriptors leaves the user's getters unresolved; a def with no raw entry was already resolved and holds plain values either way.
       const sh = rawShape(def) ?? def.shape;
-      const pending: [PropertyKey, string][] = [];
       // `Reflect.ownKeys` rather than `Object.keys`, so a cycle through a declared symbol key is still seen
       for (const key of Reflect.ownKeys(sh)) {
         const desc = Object.getOwnPropertyDescriptor(sh, key)!;
-        if (desc.get) pending.push([key, desc.get.toString()]);
+        if (desc.get) result = assumed = true;
         else check(desc.value);
-      }
-      if (pending.length) {
-        for (const [, source] of pending) if (sources.has(source)) result = true;
-        if (!result) {
-          const resolved = def.shape;
-          for (const [key, source] of pending) follow(source, () => resolved[key]);
-        }
       }
       check(def.catchall);
       break;
@@ -124,9 +111,8 @@ function isRecursive(inst: $ZodType, stack: Set<object>, sources: Set<string>): 
       check(def.input);
       check(def.output);
       break;
-    // reading `_zod.innerType` resolves the getter once and caches it
     case "lazy":
-      follow(def.getter.toString(), () => (inst as any)._zod.innerType);
+      result = assumed = true;
       break;
     // a leaf by choice: `parts` are regex fragments, not data positions
     case "template_literal":
@@ -167,7 +153,8 @@ function isRecursive(inst: $ZodType, stack: Set<object>, sources: Set<string>): 
   }
 
   stack.delete(inst);
-  recursive.set(inst, result);
+  // An assumed answer is only true of the graph as it stands, so it must not outlive the resolution that settles it.
+  if (!assumed) recursive.set(inst, result);
   return result;
 }
 
@@ -178,7 +165,8 @@ function isRecursive(inst: $ZodType, stack: Set<object>, sources: Set<string>): 
  * generated fast path has no context to key on.
  */
 export function isRecursiveSchema(inst: $ZodType): boolean {
-  return isRecursive(inst, new Set(), new Set());
+  assumed = false;
+  return isRecursive(inst, new Set());
 }
 
 function bucketFor(state: State, inst: $ZodType): Map<object, Entry> {
@@ -223,6 +211,7 @@ const memo: $ZodMemoizer = {
 
   attach(inst) {
     let isRecursiveInst: boolean | undefined;
+    let rechecked = false;
     // `bucket` memoized for one parse; a recursive schema is re-entered many times and its bucket never changes
     let lastCtx: object | undefined;
     let lastBucket: Map<object, Entry> | undefined;
@@ -234,13 +223,17 @@ const memo: $ZodMemoizer = {
 
       const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload> => {
         if (isRecursiveInst === undefined) {
-          isRecursiveInst = isRecursive(inst, new Set(), new Set());
-          if (!isRecursiveInst) {
+          assumed = false;
+          const walked = isRecursive(inst, new Set());
+          if (!walked) {
             // Nothing here can ever fire, so take it back out.
             inst._zod.parse = base;
             if (inst._zod.run === wrapped) inst._zod.run = base;
             return base(payload, ctx);
           }
+          // A cold walk can only assume a cycle across an edge it won't resolve. This parse resolves the ones on its own path, so leave the question open and ask again next time; a second assumed answer means the edge is still deferred and the wrapper stays for good.
+          if (!assumed || rechecked) isRecursiveInst = true;
+          else rechecked = true;
         }
 
         const input = payload.value;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -1,7 +1,7 @@
 import type * as errors from "./errors.js";
 import { rawShape } from "./schemas.js";
 import type { $ZodMemoizer, $ZodType, $ZodTypeDef, ParseContextInternal, ParsePayload } from "./schemas.js";
-import type * as util from "./util.js";
+import * as util from "./util.js";
 
 export class $ZodCyclicError extends Error {
   constructor() {
@@ -55,17 +55,26 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
     if (!result && child?._zod && isRecursive(child, stack)) result = true;
   };
 
+  // `Reflect.ownKeys` rather than `Object.keys`, so a cycle through a declared symbol key is still seen
+  const shape = (sh: object) => {
+    for (const key of Reflect.ownKeys(sh)) {
+      const desc = Object.getOwnPropertyDescriptor(sh, key)!;
+      if (desc.get) result = assumed = true;
+      else check(desc.value);
+    }
+  };
+
   const def = inst._zod.def as any;
   const kind = def.type as $ZodTypeDef["type"];
   switch (kind) {
     case "object": {
-      // Reading the raw shape's descriptors leaves the user's getters unresolved; a def with no raw entry answers `shape` from its own accessor (the object builders do), and resolving that is how a factory chain built through `.extend()` can still outrun the walk — see the note on `rawShape`.
-      const sh: any = rawShape(def) ?? def.shape;
-      // `Reflect.ownKeys` rather than `Object.keys`, so a cycle through a declared symbol key is still seen
-      for (const key of Reflect.ownKeys(sh)) {
-        const desc = Object.getOwnPropertyDescriptor(sh, key)!;
-        if (desc.get) result = assumed = true;
-        else check(desc.value);
+      const raw = rawShape(def);
+      if (raw) shape(raw);
+      else {
+        // No raw entry means the def answers `shape` from its own accessor, which is a builder deriving it from another schema. Reading that resolves the source's getters, so ask what it was built from instead: the derived subtree is contained in theirs.
+        const sources = util.getShapeSources(def);
+        if (sources) for (const src of sources) (src as any)?._zod ? check(src) : shape(src as object);
+        else shape(def.shape);
       }
       check(def.catchall);
       break;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -40,30 +40,42 @@ function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
 
 const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
 
-// the walk reported a cycle it couldn't confirm; it's synchronous and never re-enters, so one flag covers it
-let assumed = false;
+/** What the walk established, in order of certainty: ordered so the strongest answer among children wins. */
+const NONE = 0;
+const ASSUMED = 1;
+const PROVEN = 2;
+type Answer = typeof NONE | typeof ASSUMED | typeof PROVEN;
 
 /** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */
-function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): boolean {
+function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): Answer {
   const cached = recursive.get(inst);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) return cached ? PROVEN : NONE;
   // Relative to the walk in progress, so not cached.
-  if (stack.has(inst)) return true;
+  if (stack.has(inst)) return PROVEN;
   stack.add(inst);
 
-  let result = false;
+  let result: Answer = NONE;
   const check = (child: any) => {
-    if (!result && child?._zod && isRecursive(child, stack, resolve)) result = true;
+    if (result !== PROVEN && child?._zod) {
+      const answer = isRecursive(child, stack, resolve);
+      if (answer > result) result = answer;
+    }
   };
 
   // `Reflect.ownKeys` rather than `Object.keys`, so a cycle through a declared symbol key is still seen
-  const shape = (sh: object) => {
+  const shape = (sh: object): Answer => {
+    let answer: Answer = NONE;
     for (const key of Reflect.ownKeys(sh)) {
       const desc = Object.getOwnPropertyDescriptor(sh, key)!;
       // resolving runs user code, and a factory mints a fresh subtree per read, so an edge the walk can't follow counts as a cycle
-      if (desc.get) result = assumed = true;
-      else check(desc.value);
+      const child = desc.get ? ASSUMED : desc.value?._zod ? isRecursive(desc.value, stack, resolve) : NONE;
+      if (child > answer) answer = child;
     }
+    return answer;
+  };
+
+  const merge = (answer: Answer) => {
+    if (answer > result) result = answer;
   };
 
   const def = inst._zod.def as any;
@@ -74,12 +86,17 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): bool
       const desc = raw ? undefined : Object.getOwnPropertyDescriptor(def, "shape");
       const sources = desc?.get ? util.getShapeSources(def) : undefined;
       if (sources) {
-        // unresolved builder accessor: reading it runs the source's getters, so answer from what it derives from — contained but not equal, since a builder can drop the cyclic key, hence assumed
-        assumed = true;
-        for (const src of sources) (src as any)?._zod ? check(src) : shape(src as object);
+        // unresolved builder accessor: reading it runs the source's getters, so answer from what it derives from
+        let derived: Answer = NONE;
+        for (const src of sources) {
+          const answer = (src as any)?._zod ? isRecursive(src as any, stack, resolve) : shape(src as object);
+          if (answer > derived) derived = answer;
+        }
+        // containment only proves the acyclic case; a builder can drop the very key that carries the cycle, so never call that one proven
+        merge(derived === NONE ? NONE : ASSUMED);
       } else {
         // raw shape, or a builder accessor that already self-cached: both hold resolved values
-        shape(raw ?? def.shape);
+        merge(shape(raw ?? def.shape));
       }
       check(def.catchall);
       break;
@@ -132,10 +149,8 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): bool
     // `$ZodLazy` caches its inner on the def, so a resolved edge is followed exactly
     case "lazy": {
       const inner = def._cachedInner ?? (resolve ? (inst as any)._zod.innerType : undefined);
-      // one hop sees past the deferral; beyond it `resolve` is off, so a lazy yielding only another unresolved lazy is generative and stops here
-      if (inner) {
-        if (!result && isRecursive(inner, stack, false)) result = true;
-      } else result = assumed = true;
+      // walked with resolution off: one hop sees past the deferral, and a lazy that yields only another unresolved lazy is generative, so it stops there
+      merge(inner ? isRecursive(inner, stack, false) : ASSUMED);
       break;
     }
     // a leaf by choice: `parts` are regex fragments, not data positions
@@ -177,9 +192,13 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): bool
   }
 
   stack.delete(inst);
-  // an assumed answer must not outlive the resolution that settles it
-  if (!assumed) recursive.set(inst, result);
-  return result;
+  return settle(inst, result);
+}
+
+/** An assumed answer must not outlive the resolution that settles it, so only a certain one is cached. */
+function settle(inst: $ZodType, answer: Answer): Answer {
+  if (answer !== ASSUMED) recursive.set(inst, answer === PROVEN);
+  return answer;
 }
 
 /**
@@ -189,9 +208,8 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): bool
  * generated fast path has no context to key on.
  */
 export function isRecursiveSchema(inst: $ZodType): boolean {
-  assumed = false;
   // z.compile never parses, so nothing would ever resolve a lazy for it; it runs once and already treats a throw here as recursive
-  return isRecursive(inst, new Set(), true);
+  return isRecursive(inst, new Set(), true) !== NONE;
 }
 
 function bucketFor(state: State, inst: $ZodType): Map<object, Entry> {
@@ -248,16 +266,15 @@ const memo: $ZodMemoizer = {
 
       const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload> => {
         if (isRecursiveInst === undefined) {
-          assumed = false;
           const walked = isRecursive(inst, new Set(), false);
-          if (!walked) {
+          if (walked === NONE) {
             // Nothing here can ever fire, so take it back out.
             inst._zod.parse = base;
             if (inst._zod.run === wrapped) inst._zod.run = base;
             return base(payload, ctx);
           }
           // this parse resolves the deferred edges on its own path, so ask once more before latching
-          if (!assumed || rechecked) isRecursiveInst = true;
+          if (walked === PROVEN || rechecked) isRecursiveInst = true;
           else rechecked = true;
         }
 

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -1,5 +1,4 @@
 import type * as errors from "./errors.js";
-import { rawShape } from "./schemas.js";
 import type { $ZodMemoizer, $ZodType, $ZodTypeDef, ParseContextInternal, ParsePayload } from "./schemas.js";
 import * as util from "./util.js";
 
@@ -82,29 +81,15 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): Answ
   const kind = def.type as $ZodTypeDef["type"];
   switch (kind) {
     case "object": {
-      const raw = rawShape(def);
-      const desc = raw ? undefined : Object.getOwnPropertyDescriptor(def, "shape");
-      const sources = desc?.get ? util.getShapeSources(def) : undefined;
-      if (sources) {
-        // unresolved builder accessor: reading it runs the source's getters, so answer from what it derives from
-        let derived: Answer = NONE;
-        for (const src of sources) {
-          const answer = (src as any)?._zod ? isRecursive(src as any, stack, resolve) : shape(src as object);
-          if (answer > derived) derived = answer;
-        }
-        // containment only proves the acyclic case; a builder can drop the very key that carries the cycle, so never call that one proven
-        merge(derived === NONE ? NONE : ASSUMED);
-      } else {
-        // raw shape, or a builder accessor that already self-cached: both hold resolved values
-        merge(shape(raw ?? def.shape));
-      }
+      const raw = util.rawShape(def);
+      // a def with no raw shape answers `shape` from an accessor of its own, and running that can mint a whole fresh subtree
+      merge(raw ? shape(raw) : ASSUMED);
       check(def.catchall);
       break;
     }
-    case "properties": {
-      for (const key of Reflect.ownKeys(def.shape)) check(def.shape[key]);
+    case "properties":
+      merge(shape(def.shape));
       break;
-    }
     case "array":
       check(def.element);
       break;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -59,8 +59,8 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
   const kind = def.type as $ZodTypeDef["type"];
   switch (kind) {
     case "object": {
-      // Reading the raw shape's descriptors leaves the user's getters unresolved; a def with no raw entry was already resolved and holds plain values either way.
-      const sh = rawShape(def) ?? def.shape;
+      // Reading the raw shape's descriptors leaves the user's getters unresolved; a def with no raw entry answers `shape` from its own accessor (the object builders do), and resolving that is how a factory chain built through `.extend()` can still outrun the walk — see the note on `rawShape`.
+      const sh: any = rawShape(def) ?? def.shape;
       // `Reflect.ownKeys` rather than `Object.keys`, so a cycle through a declared symbol key is still seen
       for (const key of Reflect.ownKeys(sh)) {
         const desc = Object.getOwnPropertyDescriptor(sh, key)!;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -34,7 +34,7 @@ function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
 
 const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
 
-// A factory-built recursive schema mints fresh instances on every getter read, so the identity walk below never revisits a node and would descend until the stack overflows. Past this depth, assume a cycle: a false positive only leaves the memoizer attached, which is what a true cycle gets anyway.
+// A factory-built recursive schema mints fresh instances on every getter read, so the identity walk below never revisits a node and would descend until the stack overflows. Past this depth, assume a cycle: an acyclic schema nested this deep keeps the memoizer attached, so it dedupes output by input identity and `z.compile` declines it.
 const MAX_DEPTH = 256;
 
 /** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -66,6 +66,8 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): Answ
     let answer: Answer = NONE;
     for (const key of Reflect.ownKeys(sh)) {
       const desc = Object.getOwnPropertyDescriptor(sh, key)!;
+      // a shape resolves by object spread, so a key it does not enumerate is never parsed
+      if (!desc.enumerable) continue;
       // resolving runs user code, and a factory mints a fresh subtree per read, so an edge the walk can't follow counts as a cycle
       const child = desc.get ? ASSUMED : desc.value?._zod ? isRecursive(desc.value, stack, resolve) : NONE;
       if (child > answer) answer = child;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -35,14 +35,10 @@ function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
 
 const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
 
-// Set by a walk that reported a cycle it could not confirm, so the answer is not cached and the caller knows to ask again once the graph is resolved. The walk is synchronous and never re-enters, so one flag serves the whole traversal.
+// the walk reported a cycle it couldn't confirm; it's synchronous and never re-enters, so one flag covers it
 let assumed = false;
 
-/**
- * Whether this schema's subtree contains a cycle, so one parse can re-enter it.
- *
- * The walk resolves nothing that runs user code, and reports a cycle for every edge it therefore can't follow — a shape getter or a `z.lazy`. Identity is its only termination argument, and a deferred edge need not answer with the same schema twice: a factory-built recursive schema mints a fresh subtree per level, so a walk that resolved those would never revisit a node and would descend until the stack overflows. Erring toward a cycle costs such a schema only the memoizer it keeps attached; erring the other way is unsound.
- */
+/** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */
 function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
   const cached = recursive.get(inst);
   if (cached !== undefined) return cached;
@@ -59,6 +55,7 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
   const shape = (sh: object) => {
     for (const key of Reflect.ownKeys(sh)) {
       const desc = Object.getOwnPropertyDescriptor(sh, key)!;
+      // resolving runs user code, and a factory mints a fresh subtree per read, so an edge the walk can't follow counts as a cycle
       if (desc.get) result = assumed = true;
       else check(desc.value);
     }
@@ -72,11 +69,11 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
       const desc = raw ? undefined : Object.getOwnPropertyDescriptor(def, "shape");
       const sources = desc?.get ? util.getShapeSources(def) : undefined;
       if (sources) {
-        // The def answers `shape` from a builder's accessor that has not run yet, and reading it resolves the source's getters. Ask what it was built from instead: the derived subtree is contained in theirs. Only contained, though — a builder can drop or overwrite the very branch that carries the cycle — so this is an over-approximation, and marking it assumed is what lets the recheck below replace it with the resolved shape's exact answer.
+        // unresolved builder accessor: reading it runs the source's getters, so answer from what it derives from — contained but not equal, since a builder can drop the cyclic key, hence assumed
         assumed = true;
         for (const src of sources) (src as any)?._zod ? check(src) : shape(src as object);
       } else {
-        // Either the raw shape, or a builder accessor that has already self-cached its result: both hold resolved values, so neither runs user code.
+        // raw shape, or a builder accessor that already self-cached: both hold resolved values
         shape(raw ?? def.shape);
       }
       check(def.catchall);
@@ -123,7 +120,7 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
       check(def.input);
       check(def.output);
       break;
-    // `$ZodLazy` caches its resolved inner on the def, so once anything has read it the walk follows it exactly without invoking the getter itself
+    // `$ZodLazy` caches its inner on the def, so a resolved edge is followed exactly
     case "lazy":
       if (def._cachedInner) check(def._cachedInner);
       else result = assumed = true;
@@ -167,7 +164,7 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
   }
 
   stack.delete(inst);
-  // An assumed answer is only true of the graph as it stands, so it must not outlive the resolution that settles it.
+  // an assumed answer must not outlive the resolution that settles it
   if (!assumed) recursive.set(inst, result);
   return result;
 }
@@ -245,7 +242,7 @@ const memo: $ZodMemoizer = {
             if (inst._zod.run === wrapped) inst._zod.run = base;
             return base(payload, ctx);
           }
-          // A cold walk can only assume a cycle across an edge it won't resolve. This parse resolves the ones on its own path, so leave the question open and ask again next time; a second assumed answer means the edge is still deferred and the wrapper stays for good.
+          // this parse resolves the deferred edges on its own path, so ask once more before latching
           if (!assumed || rechecked) isRecursiveInst = true;
           else rechecked = true;
         }

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -1,4 +1,5 @@
 import type * as errors from "./errors.js";
+import { rawShape } from "./schemas.js";
 import type { $ZodMemoizer, $ZodType, $ZodTypeDef, ParseContextInternal, ParsePayload } from "./schemas.js";
 import type * as util from "./util.js";
 
@@ -34,29 +35,51 @@ function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
 
 const recursive: WeakMap<object, boolean> = /*@__PURE__*/ new WeakMap();
 
-// A factory-built recursive schema mints fresh instances on every getter read, so the identity walk below never revisits a node and would descend until the stack overflows. Past this depth, assume a cycle: an acyclic schema nested this deep keeps the memoizer attached, so it dedupes output by input identity and `z.compile` declines it.
-const MAX_DEPTH = 256;
-
 /** Whether this schema's subtree contains a cycle, so one parse can re-enter it. */
-function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
+function isRecursive(inst: $ZodType, stack: Set<object>, sources: Set<string>): boolean {
   const cached = recursive.get(inst);
   if (cached !== undefined) return cached;
   // Relative to the walk in progress, so not cached.
   if (stack.has(inst)) return true;
-  if (stack.size >= MAX_DEPTH) return true;
   stack.add(inst);
 
   let result = false;
   const check = (child: any) => {
-    if (!result && child?._zod && isRecursive(child, stack)) result = true;
+    if (!result && child?._zod && isRecursive(child, stack, sources)) result = true;
+  };
+
+  // A factory-built recursive schema mints fresh instances on every getter read, so instance identity never sees the walk revisit a node and it would descend forever. What every minted level shares is the getter itself: a path that re-enters a getter whose source it is already resolving can only have been produced by a loop in user code, so treat the repeat as a back-edge and don't resolve it.
+  const follow = (source: string, read: () => unknown) => {
+    if (result) return;
+    if (sources.has(source)) {
+      result = true;
+      return;
+    }
+    sources.add(source);
+    check(read());
+    sources.delete(source);
   };
 
   const def = inst._zod.def as any;
   const kind = def.type as $ZodTypeDef["type"];
   switch (kind) {
     case "object": {
+      // The first `def.shape` read resolves every user getter at once via spread, so fingerprint the raw shape's getters before triggering it; a def without a raw entry was already resolved, and its shape holds plain values.
+      const sh = rawShape(def) ?? def.shape;
+      const pending: [PropertyKey, string][] = [];
       // `Reflect.ownKeys` rather than `Object.keys`, so a cycle through a declared symbol key is still seen
-      for (const key of Reflect.ownKeys(def.shape)) check(def.shape[key]);
+      for (const key of Reflect.ownKeys(sh)) {
+        const desc = Object.getOwnPropertyDescriptor(sh, key)!;
+        if (desc.get) pending.push([key, desc.get.toString()]);
+        else check(desc.value);
+      }
+      if (pending.length) {
+        for (const [, source] of pending) if (sources.has(source)) result = true;
+        if (!result) {
+          const resolved = def.shape;
+          for (const [key, source] of pending) follow(source, () => resolved[key]);
+        }
+      }
       check(def.catchall);
       break;
     }
@@ -103,7 +126,7 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
       break;
     // reading `_zod.innerType` resolves the getter once and caches it
     case "lazy":
-      check((inst as any)._zod.innerType);
+      follow(def.getter.toString(), () => (inst as any)._zod.innerType);
       break;
     // a leaf by choice: `parts` are regex fragments, not data positions
     case "template_literal":
@@ -155,7 +178,7 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
  * generated fast path has no context to key on.
  */
 export function isRecursiveSchema(inst: $ZodType): boolean {
-  return isRecursive(inst, new Set());
+  return isRecursive(inst, new Set(), new Set());
 }
 
 function bucketFor(state: State, inst: $ZodType): Map<object, Entry> {
@@ -211,7 +234,7 @@ const memo: $ZodMemoizer = {
 
       const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload> => {
         if (isRecursiveInst === undefined) {
-          isRecursiveInst = isRecursive(inst, new Set());
+          isRecursiveInst = isRecursive(inst, new Set(), new Set());
           if (!isRecursiveInst) {
             // Nothing here can ever fire, so take it back out.
             inst._zod.parse = base;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -111,8 +111,10 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
       check(def.input);
       check(def.output);
       break;
+    // `$ZodLazy` caches its resolved inner on the def, so once anything has read it the walk follows it exactly without invoking the getter itself
     case "lazy":
-      result = assumed = true;
+      if (def._cachedInner) check(def._cachedInner);
+      else result = assumed = true;
       break;
     // a leaf by choice: `parts` are regex fragments, not data positions
     case "template_literal":

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2085,33 +2085,22 @@ function handleCatchall(
   });
 }
 
-// Whichever object a def's `shape` currently answers from: the one the caller passed until the first read, the frozen copy after it. Keyed by def, so a def rebuilt by a builder is simply absent rather than inheriting the source's. Read its keys with `Object.keys`, which does not invoke them — that is what lets a discriminated union check its discriminator without resolving an option whose getters reference the union being constructed.
-const propShapes = new WeakMap<object, Record<string, unknown>>();
-
-/** The shape a def answers from, getters unresolved; absent when `shape` is the def's own accessor, which the builders register sources for instead. */
-export function rawShape(def: object): Record<string, unknown> | undefined {
-  return propShapes.get(def);
-}
-
 export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$constructor("$ZodObject", (inst, def) => {
   // requires cast because technically $ZodObject doesn't extend
   $ZodType.init(inst, def);
-  // const sh = def.shape;
   const desc = Object.getOwnPropertyDescriptor(def, "shape");
-  if (!desc?.get) {
-    const sh = def.shape;
-    propShapes.set(def, sh);
-    Object.defineProperty(def, "shape", {
-      get: () => {
-        const newSh = { ...sh };
-        Object.defineProperty(def, "shape", {
-          value: newSh,
-        });
-        propShapes.set(def, newSh);
-
-        return newSh;
-      },
-    });
+  // a cloned def carries its source's accessor, which knows the shape it answers from; adopting that keeps the clone's keys readable without running it
+  const sh = desc?.get ? (desc.get as util.ShapeGetter).raw : (def.shape ?? {});
+  if (sh) {
+    // Freezes the shape on first read, so its getters resolve once and every later read sees the same schemas.
+    const get: util.ShapeGetter = () => {
+      const newSh = { ...sh };
+      Object.defineProperty(def, "shape", { value: newSh });
+      get.raw = newSh;
+      return newSh;
+    };
+    get.raw = sh;
+    Object.defineProperty(def, "shape", { get });
   }
 
   const _normalized = util.cached(() => normalizeDef(def));
@@ -2630,9 +2619,9 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
       return propValues;
     });
 
-    // Checked now rather than in the lookup map below, so an option that lacks the discriminator fails at the `discriminatedUnion` call instead of on the first object parsed. Options whose shape cannot be enumerated without resolving it — pipes, lazies, and objects rebuilt by a builder such as `.extend()` — are left to the map.
+    // Checked now rather than in the lookup map below, so an option that lacks the discriminator fails at the `discriminatedUnion` call instead of on the first object parsed. Options whose shape cannot be enumerated without resolving it — pipes and lazies — are left to the map.
     def.options.forEach((option, i) => {
-      const propShape = propShapes.get(option._zod.def);
+      const propShape = util.rawShape(option._zod.def);
       if (propShape && !Object.prototype.hasOwnProperty.call(propShape, def.discriminator)) {
         throw new Error(`Invalid discriminated union option at index "${i}"`);
       }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2080,7 +2080,7 @@ function handleCatchall(
 // Whichever object a def's `shape` currently answers from: the one the caller passed until the first read, the frozen copy after it. Keyed by def, so a def rebuilt by a builder is simply absent rather than inheriting the source's. Read its keys with `Object.keys`, which does not invoke them — that is what lets a discriminated union check its discriminator without resolving an option whose getters reference the union being constructed.
 const propShapes = new WeakMap<object, Record<string, unknown>>();
 
-/** The shape object this def currently answers from, without resolving its getters, so the cycle walk can see them before the first `def.shape` read spreads them away. Absent for a def whose `shape` is its own accessor — the object builders — because those resolve the source shape through a spread; a factory chain built through one can therefore still outrun the walk. Registering a descriptor-preserving shape from the builders would close that. */
+/** The shape object this def currently answers from, without resolving its getters, so the cycle walk can see them before the first `def.shape` read spreads them away. Absent for a def whose `shape` is its own accessor — the object builders — which register what they derive from instead, via `util.setShapeSources`. */
 export function rawShape(def: object): Record<string, unknown> | undefined {
   return propShapes.get(def);
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2080,7 +2080,7 @@ function handleCatchall(
 // Whichever object a def's `shape` currently answers from: the one the caller passed until the first read, the frozen copy after it. Keyed by def, so a def rebuilt by a builder is simply absent rather than inheriting the source's. Read its keys with `Object.keys`, which does not invoke them — that is what lets a discriminated union check its discriminator without resolving an option whose getters reference the union being constructed.
 const propShapes = new WeakMap<object, Record<string, unknown>>();
 
-/** The shape object this def currently answers from, without resolving its getters, so the cycle walk can see them before the first `def.shape` read spreads them away. Absent for a def whose `shape` is its own accessor — the object builders — which register what they derive from instead, via `util.setShapeSources`. */
+/** The shape a def answers from, getters unresolved; absent when `shape` is the def's own accessor, which the builders register sources for instead. */
 export function rawShape(def: object): Record<string, unknown> | undefined {
   return propShapes.get(def);
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2080,7 +2080,7 @@ function handleCatchall(
 // Whichever object a def's `shape` currently answers from: the one the caller passed until the first read, the frozen copy after it. Keyed by def, so a def rebuilt by a builder is simply absent rather than inheriting the source's. Read its keys with `Object.keys`, which does not invoke them — that is what lets a discriminated union check its discriminator without resolving an option whose getters reference the union being constructed.
 const propShapes = new WeakMap<object, Record<string, unknown>>();
 
-/** The shape object this def currently answers from, without resolving its getters. The cycle walk fingerprints these before the first `def.shape` read spreads them away. */
+/** The shape object this def currently answers from, without resolving its getters, so the cycle walk can see them before the first `def.shape` read spreads them away. Absent for a def whose `shape` is its own accessor — the object builders — because those resolve the source shape through a spread; a factory chain built through one can therefore still outrun the walk. Registering a descriptor-preserving shape from the builders would close that. */
 export function rawShape(def: object): Record<string, unknown> | undefined {
   return propShapes.get(def);
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2080,6 +2080,11 @@ function handleCatchall(
 // Whichever object a def's `shape` currently answers from: the one the caller passed until the first read, the frozen copy after it. Keyed by def, so a def rebuilt by a builder is simply absent rather than inheriting the source's. Read its keys with `Object.keys`, which does not invoke them — that is what lets a discriminated union check its discriminator without resolving an option whose getters reference the union being constructed.
 const propShapes = new WeakMap<object, Record<string, unknown>>();
 
+/** The shape object this def currently answers from, without resolving its getters. The cycle walk fingerprints these before the first `def.shape` read spreads them away. */
+export function rawShape(def: object): Record<string, unknown> | undefined {
+  return propShapes.get(def);
+}
+
 export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$constructor("$ZodObject", (inst, def) => {
   // requires cast because technically $ZodObject doesn't extend
   $ZodType.init(inst, def);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -393,7 +393,7 @@ export function rawShape(def: any): Record<PropertyKey, any> | undefined {
   return desc?.get ? (desc.get as ShapeGetter).raw : desc?.value;
 }
 
-// where a builder reads its source's keys and descriptors, resolving only a shape a def answers for itself
+// where a builder reads its source's keys and descriptors, resolving only a shape a def answers for itself. A shape resolves by object spread, so only its enumerable keys are ever part of it.
 function sourceShape(schema: schemas.$ZodObject): Record<PropertyKey, any> {
   return rawShape(schema._zod.def) ?? (schema._zod.def.shape as any);
 }
@@ -432,6 +432,7 @@ function mirrorShape(
   const raw = sourceShape(source);
   for (const key of keys) {
     const desc = Object.getOwnPropertyDescriptor(raw, key)!;
+    if (!desc.enumerable) continue;
     if (desc.get) {
       deferred = true;
       deferProp(target, key, () => {
@@ -447,6 +448,7 @@ function mirrorShape(
 function mirrorProps(target: object, source: Record<PropertyKey, any>, deferred: boolean): void {
   for (const key of Reflect.ownKeys(source)) {
     const desc = Object.getOwnPropertyDescriptor(source, key)!;
+    if (!desc.enumerable) continue;
     if (desc.get) deferProp(target, key, () => source[key as any]);
     else putProp(target, key, desc.value, deferred);
   }
@@ -773,7 +775,7 @@ function maskedKeys(schema: schemas.$ZodObject, mask: object): PropertyKey[] {
   const keys: PropertyKey[] = [];
   // `for...in` skips symbols, so a symbol in the mask would select nothing
   for (const key of Reflect.ownKeys(mask)) {
-    if (!Object.prototype.hasOwnProperty.call(raw, key)) {
+    if (!Object.getOwnPropertyDescriptor(raw, key)?.enumerable) {
       throw new Error(`Unrecognized key: "${String(key)}"`);
     }
     if ((mask as any)[key]) keys.push(key);

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -338,6 +338,17 @@ export function assignProp<T extends object, K extends PropertyKey>(
   });
 }
 
+// What a derived object's shape is built from, registered by the builders below. Each of them answers `shape` from an accessor that reads the source's — resolving the user's getters — so the cycle walk asks this instead: the derived subtree is contained in its sources', which are schemas it can reach by identity and shape objects whose descriptors it can read unresolved. Entries are `$ZodType`s or plain shapes.
+const shapeSources = new WeakMap<object, unknown[]>();
+
+export function setShapeSources(def: object, sources: unknown[]): void {
+  shapeSources.set(def, sources);
+}
+
+export function getShapeSources(def: object): unknown[] | undefined {
+  return shapeSources.get(def);
+}
+
 export function mergeDefs(...defs: Record<string, any>[]): any {
   const mergedDescriptors: Record<string, PropertyDescriptor> = {};
 
@@ -665,6 +676,7 @@ export function pick(schema: schemas.$ZodObject, mask: Record<string, unknown>):
     checks: [],
   });
 
+  setShapeSources(def, [schema]);
   return clone(schema, def) as any;
 }
 
@@ -694,6 +706,7 @@ export function omit(schema: schemas.$ZodObject, mask: object): any {
     checks: [],
   });
 
+  setShapeSources(def, [schema]);
   return clone(schema, def);
 }
 
@@ -721,6 +734,7 @@ export function extend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): an
       return _shape;
     },
   });
+  setShapeSources(def, [schema, shape]);
   return clone(schema, def) as any;
 }
 
@@ -735,6 +749,7 @@ export function safeExtend(schema: schemas.$ZodObject, shape: schemas.$ZodShape)
       return _shape;
     },
   });
+  setShapeSources(def, [schema, shape]);
   return clone(schema, def) as any;
 }
 
@@ -757,6 +772,7 @@ export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
     checks: b._zod.def.checks ?? [],
   });
 
+  setShapeSources(def, [a, b]);
   return clone(a, def) as any;
 }
 
@@ -811,6 +827,7 @@ export function partial(
     checks: [],
   });
 
+  setShapeSources(def, [schema]);
   return clone(schema, def) as any;
 }
 
@@ -851,6 +868,7 @@ export function required(
     },
   });
 
+  setShapeSources(def, [schema]);
   return clone(schema, def) as any;
 }
 

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -377,15 +377,70 @@ export function assignProp<T extends object, K extends PropertyKey>(
   });
 }
 
-// what a derived shape is built from, as schemas or plain shapes: its subtree is contained in these, so the cycle walk answers from them rather than resolving the builder's accessor
-const shapeSources = new WeakMap<object, unknown[]>();
-
-export function setShapeSources(def: object, sources: unknown[]): void {
-  shapeSources.set(def, sources);
+/** A def's `shape` accessor, carrying whichever object it currently answers from. */
+export interface ShapeGetter {
+  (): Record<PropertyKey, any>;
+  raw: Record<PropertyKey, any>;
 }
 
-export function getShapeSources(def: object): unknown[] | undefined {
-  return shapeSources.get(def);
+/**
+ * Whichever object a def's `shape` currently answers from: the one the caller passed until the first read, the frozen copy after it.
+ *
+ * Its keys and descriptors read without invoking anything, which is what lets a discriminated union check its discriminator, and the cycle walk read a shape, without resolving a getter that references the schema being constructed. A def that answers `shape` from an accessor of its own has none.
+ */
+export function rawShape(def: any): Record<PropertyKey, any> | undefined {
+  const desc = Object.getOwnPropertyDescriptor(def, "shape");
+  return desc?.get ? (desc.get as ShapeGetter).raw : desc?.value;
+}
+
+// where a builder reads its source's keys and descriptors, resolving only a shape a def answers for itself
+function sourceShape(schema: schemas.$ZodObject): Record<PropertyKey, any> {
+  return rawShape(schema._zod.def) ?? (schema._zod.def.shape as any);
+}
+
+// a key whose value is not settled yet, self-caching so every read after the first gets the same one
+function deferProp(target: object, key: PropertyKey, getter: () => any): void {
+  Object.defineProperty(target, key, {
+    get(this: any) {
+      const value = getter();
+      assignProp(this, key as any, value);
+      return value;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * Copies `keys` of `source`'s shape onto `target`, each value passed through `wrap`.
+ *
+ * A key the source has resolved is copied through now, so the derived shape states it outright and nothing has to resolve it to learn what it holds. A key the source still defers stays deferred, and reads back through the source's own `shape`, so it resolves once and both shapes get that one schema.
+ */
+function mirrorShape(
+  target: object,
+  source: schemas.$ZodObject,
+  keys: PropertyKey[],
+  wrap?: ((value: any, key: PropertyKey) => any) | null
+): void {
+  const raw = sourceShape(source);
+  for (const key of keys) {
+    const desc = Object.getOwnPropertyDescriptor(raw, key)!;
+    if (desc.get) {
+      deferProp(target, key, () => {
+        const value = (source._zod.def.shape as any)[key];
+        return wrap ? wrap(value, key) : value;
+      });
+    } else assignProp(target as any, key as any, wrap ? wrap(desc.value, key) : desc.value);
+  }
+}
+
+// same, for a plain shape a caller passed rather than a schema's
+function mirrorProps(target: object, source: Record<PropertyKey, any>): void {
+  for (const key of Reflect.ownKeys(source)) {
+    const desc = Object.getOwnPropertyDescriptor(source, key)!;
+    if (desc.get) deferProp(target, key, () => source[key as any]);
+    else assignProp(target as any, key as any, desc.value);
+  }
 }
 
 export function mergeDefs(...defs: Record<string, any>[]): any {
@@ -697,26 +752,24 @@ export function pick(schema: schemas.$ZodObject, mask: Record<string, unknown>):
     throw new Error(".pick() cannot be used on object schemas containing refinements");
   }
 
-  const def = mergeDefs(schema._zod.def, {
-    get shape() {
-      const newShape: Writeable<schemas.$ZodShape> = {};
-      // `for...in` skips symbols, so a symbol in the mask would select nothing
-      for (const key of Reflect.ownKeys(mask)) {
-        if (!Object.prototype.hasOwnProperty.call(currDef.shape, key)) {
-          throw new Error(`Unrecognized key: "${String(key)}"`);
-        }
-        if (!mask[key as string]) continue;
-        assignProp(newShape, key as string, (currDef.shape as any)[key]!);
-      }
+  const newShape: Writeable<schemas.$ZodShape> = {};
+  mirrorShape(newShape, schema, maskedKeys(schema, mask));
 
-      assignProp(this, "shape", newShape); // self-caching
-      return newShape;
-    },
-    checks: [],
-  });
+  return clone(schema, mergeDefs(currDef, { shape: newShape, checks: [] })) as any;
+}
 
-  setShapeSources(def, [schema]);
-  return clone(schema, def) as any;
+// the mask keys that select something, checked against the source's shape without resolving it
+function maskedKeys(schema: schemas.$ZodObject, mask: object): PropertyKey[] {
+  const raw = sourceShape(schema);
+  const keys: PropertyKey[] = [];
+  // `for...in` skips symbols, so a symbol in the mask would select nothing
+  for (const key of Reflect.ownKeys(mask)) {
+    if (!Object.prototype.hasOwnProperty.call(raw, key)) {
+      throw new Error(`Unrecognized key: "${String(key)}"`);
+    }
+    if ((mask as any)[key]) keys.push(key);
+  }
+  return keys;
 }
 
 export function omit(schema: schemas.$ZodObject, mask: object): any {
@@ -728,25 +781,15 @@ export function omit(schema: schemas.$ZodObject, mask: object): any {
     throw new Error(".omit() cannot be used on object schemas containing refinements");
   }
 
-  const def = mergeDefs(schema._zod.def, {
-    get shape() {
-      const newShape: Writeable<schemas.$ZodShape> = { ...schema._zod.def.shape };
-      for (const key of Reflect.ownKeys(mask)) {
-        if (!Object.prototype.hasOwnProperty.call(currDef.shape, key)) {
-          throw new Error(`Unrecognized key: "${String(key)}"`);
-        }
-        if (!(mask as any)[key]) continue;
+  const omitted = new Set(maskedKeys(schema, mask));
+  const newShape: Writeable<schemas.$ZodShape> = {};
+  mirrorShape(
+    newShape,
+    schema,
+    Reflect.ownKeys(sourceShape(schema)).filter((key) => !omitted.has(key))
+  );
 
-        delete newShape[key as string];
-      }
-      assignProp(this, "shape", newShape); // self-caching
-      return newShape;
-    },
-    checks: [],
-  });
-
-  setShapeSources(def, [schema]);
-  return clone(schema, def);
+  return clone(schema, mergeDefs(currDef, { shape: newShape, checks: [] }));
 }
 
 export function extend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): any {
@@ -758,7 +801,7 @@ export function extend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): an
   const hasChecks = checks && checks.length > 0;
   if (hasChecks) {
     // Only throw if new shape overlaps with existing shape. Use getOwnPropertyDescriptor to check key existence without accessing values
-    const existingShape = schema._zod.def.shape;
+    const existingShape = sourceShape(schema);
     for (const key of Reflect.ownKeys(shape)) {
       if (Object.getOwnPropertyDescriptor(existingShape, key) !== undefined) {
         throw new Error("Cannot overwrite keys on object schemas containing refinements. Use `.safeExtend()` instead.");
@@ -766,30 +809,22 @@ export function extend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): an
     }
   }
 
-  const def = mergeDefs(schema._zod.def, {
-    get shape() {
-      const _shape = { ...schema._zod.def.shape, ...shape };
-      assignProp(this, "shape", _shape); // self-caching
-      return _shape;
-    },
-  });
-  setShapeSources(def, [schema, shape]);
-  return clone(schema, def) as any;
+  return clone(schema, mergeDefs(schema._zod.def, { shape: extended(schema, shape) })) as any;
+}
+
+// the source's keys, then the caller's overlaid on top
+function extended(schema: schemas.$ZodObject, shape: schemas.$ZodShape): schemas.$ZodShape {
+  const newShape: Writeable<schemas.$ZodShape> = {};
+  mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)));
+  mirrorProps(newShape, shape);
+  return newShape;
 }
 
 export function safeExtend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): any {
   if (!isPlainObject(shape)) {
     throw new Error("Invalid input to safeExtend: expected a plain object");
   }
-  const def = mergeDefs(schema._zod.def, {
-    get shape() {
-      const _shape = { ...schema._zod.def.shape, ...shape };
-      assignProp(this, "shape", _shape); // self-caching
-      return _shape;
-    },
-  });
-  setShapeSources(def, [schema, shape]);
-  return clone(schema, def) as any;
+  return clone(schema, mergeDefs(schema._zod.def, { shape: extended(schema, shape) })) as any;
 }
 
 export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
@@ -799,19 +834,18 @@ export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
   if (a._zod.def.checks?.length) {
     throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
   }
+  const newShape: Writeable<schemas.$ZodShape> = {};
+  mirrorShape(newShape, a, Reflect.ownKeys(sourceShape(a)));
+  mirrorShape(newShape, b, Reflect.ownKeys(sourceShape(b)));
+
   const def = mergeDefs(a._zod.def, {
-    get shape() {
-      const _shape = { ...a._zod.def.shape, ...b._zod.def.shape };
-      assignProp(this, "shape", _shape); // self-caching
-      return _shape;
-    },
+    shape: newShape,
     get catchall() {
       return b._zod.def.catchall;
     },
     checks: b._zod.def.checks ?? [],
   });
 
-  setShapeSources(def, [a, b]);
   return clone(a, def) as any;
 }
 
@@ -828,46 +862,17 @@ export function partial(
     throw new Error(`.${name}() cannot be used on object schemas containing refinements`);
   }
 
-  const def = mergeDefs(schema._zod.def, {
-    get shape() {
-      const oldShape = schema._zod.def.shape;
-      const shape: Writeable<schemas.$ZodShape> = { ...oldShape };
+  const selected = mask ? new Set(maskedKeys(schema, mask)) : undefined;
+  const newShape: Writeable<schemas.$ZodShape> = {};
+  mirrorShape(
+    newShape,
+    schema,
+    Reflect.ownKeys(sourceShape(schema)),
+    Class &&
+      ((value, key) => (selected && !selected.has(key) ? value : new Class({ type: "optional", innerType: value })))
+  );
 
-      if (mask) {
-        for (const key of Reflect.ownKeys(mask)) {
-          if (!Object.prototype.hasOwnProperty.call(oldShape, key)) {
-            throw new Error(`Unrecognized key: "${String(key)}"`);
-          }
-          if (!(mask as any)[key]) continue;
-          // if (oldShape[key]!._zod.optin === "optional") continue;
-          (shape as any)[key] = Class
-            ? new Class({
-                type: "optional",
-                innerType: (oldShape as any)[key]!,
-              })
-            : (oldShape as any)[key]!;
-        }
-      } else {
-        // the spread copies symbol keys; `for...in` would not reach them
-        for (const key of Reflect.ownKeys(oldShape)) {
-          // if (oldShape[key]!._zod.optin === "optional") continue;
-          (shape as any)[key] = Class
-            ? new Class({
-                type: "optional",
-                innerType: (oldShape as any)[key]!,
-              })
-            : (oldShape as any)[key]!;
-        }
-      }
-
-      assignProp(this, "shape", shape); // self-caching
-      return shape;
-    },
-    checks: [],
-  });
-
-  setShapeSources(def, [schema]);
-  return clone(schema, def) as any;
+  return clone(schema, mergeDefs(schema._zod.def, { shape: newShape, checks: [] })) as any;
 }
 
 export function required(
@@ -875,40 +880,14 @@ export function required(
   schema: schemas.$ZodObject,
   mask: object | undefined
 ): any {
-  const def = mergeDefs(schema._zod.def, {
-    get shape() {
-      const oldShape = schema._zod.def.shape;
-      const shape: Writeable<schemas.$ZodShape> = { ...oldShape };
+  const selected = mask ? new Set(maskedKeys(schema, mask)) : undefined;
+  const newShape: Writeable<schemas.$ZodShape> = {};
+  mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)), (value, key) =>
+    // overwrite with non-optional
+    selected && !selected.has(key) ? value : new Class({ type: "nonoptional", innerType: value })
+  );
 
-      if (mask) {
-        for (const key of Reflect.ownKeys(mask)) {
-          if (!Object.prototype.hasOwnProperty.call(shape, key)) {
-            throw new Error(`Unrecognized key: "${String(key)}"`);
-          }
-          if (!(mask as any)[key]) continue;
-          // overwrite with non-optional
-          (shape as any)[key] = new Class({
-            type: "nonoptional",
-            innerType: (oldShape as any)[key]!,
-          });
-        }
-      } else {
-        for (const key of Reflect.ownKeys(oldShape)) {
-          // overwrite with non-optional
-          (shape as any)[key] = new Class({
-            type: "nonoptional",
-            innerType: (oldShape as any)[key]!,
-          });
-        }
-      }
-
-      assignProp(this, "shape", shape); // self-caching
-      return shape;
-    },
-  });
-
-  setShapeSources(def, [schema]);
-  return clone(schema, def) as any;
+  return clone(schema, mergeDefs(schema._zod.def, { shape: newShape })) as any;
 }
 
 export type Constructor<T, Def extends any[] = any[]> = new (...args: Def) => T;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -338,7 +338,7 @@ export function assignProp<T extends object, K extends PropertyKey>(
   });
 }
 
-// What a derived object's shape is built from, registered by the builders below. Each of them answers `shape` from an accessor that reads the source's — resolving the user's getters — so the cycle walk asks this instead: the derived subtree is contained in its sources', which are schemas it can reach by identity and shape objects whose descriptors it can read unresolved. Entries are `$ZodType`s or plain shapes.
+// what a derived shape is built from, as schemas or plain shapes: its subtree is contained in these, so the cycle walk answers from them rather than resolving the builder's accessor
 const shapeSources = new WeakMap<object, unknown[]>();
 
 export function setShapeSources(def: object, sources: unknown[]): void {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -411,9 +411,9 @@ function deferProp(target: object, key: PropertyKey, getter: () => any): void {
   });
 }
 
-// Writes a settled key. A plain assignment is much cheaper than `defineProperty` and produces the same descriptor, but it runs a setter — `__proto__` has one on every object, and a key this shape already deferred has one of its own.
-function putProp(target: any, key: PropertyKey, value: any, deferred: boolean): void {
-  if (deferred || key === "__proto__") assignProp(target, key as any, value);
+// Writes a settled key. A plain assignment is much cheaper than `defineProperty` and produces the same descriptor, but it runs whatever setter already answers to the key — an accessor this shape deferred, or an inherited one, which `__proto__` has on every object and prototype pollution can add for any name.
+function putProp(target: any, key: PropertyKey, value: any): void {
+  if (key in target) assignProp(target, key as any, value);
   else target[key] = value;
 }
 
@@ -426,31 +426,28 @@ function mirrorShape(
   target: object,
   source: schemas.$ZodObject,
   keys: PropertyKey[],
-  deferred: boolean,
   wrap?: ((value: any, key: PropertyKey) => any) | null
-): boolean {
+): void {
   const raw = sourceShape(source);
   for (const key of keys) {
     const desc = Object.getOwnPropertyDescriptor(raw, key)!;
     if (!desc.enumerable) continue;
     if (desc.get) {
-      deferred = true;
       deferProp(target, key, () => {
         const value = (source._zod.def.shape as any)[key];
         return wrap ? wrap(value, key) : value;
       });
-    } else putProp(target, key, wrap ? wrap(desc.value, key) : desc.value, deferred);
+    } else putProp(target, key, wrap ? wrap(desc.value, key) : desc.value);
   }
-  return deferred;
 }
 
 // same, for a plain shape a caller passed rather than a schema's
-function mirrorProps(target: object, source: Record<PropertyKey, any>, deferred: boolean): void {
+function mirrorProps(target: object, source: Record<PropertyKey, any>): void {
   for (const key of Reflect.ownKeys(source)) {
     const desc = Object.getOwnPropertyDescriptor(source, key)!;
     if (!desc.enumerable) continue;
     if (desc.get) deferProp(target, key, () => source[key as any]);
-    else putProp(target, key, desc.value, deferred);
+    else putProp(target, key, desc.value);
   }
 }
 
@@ -764,7 +761,7 @@ export function pick(schema: schemas.$ZodObject, mask: Record<string, unknown>):
   }
 
   const newShape: Writeable<schemas.$ZodShape> = {};
-  mirrorShape(newShape, schema, maskedKeys(schema, mask), false);
+  mirrorShape(newShape, schema, maskedKeys(schema, mask));
 
   return clone(schema, mergeDefs(currDef, { shape: newShape, checks: [] })) as any;
 }
@@ -797,8 +794,7 @@ export function omit(schema: schemas.$ZodObject, mask: object): any {
   mirrorShape(
     newShape,
     schema,
-    Reflect.ownKeys(sourceShape(schema)).filter((key) => !omitted.has(key)),
-    false
+    Reflect.ownKeys(sourceShape(schema)).filter((key) => !omitted.has(key))
   );
 
   return clone(schema, mergeDefs(currDef, { shape: newShape, checks: [] }));
@@ -827,8 +823,8 @@ export function extend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): an
 // the source's keys, then the caller's overlaid on top
 function extended(schema: schemas.$ZodObject, shape: schemas.$ZodShape): schemas.$ZodShape {
   const newShape: Writeable<schemas.$ZodShape> = {};
-  const deferred = mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)), false);
-  mirrorProps(newShape, shape, deferred);
+  mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)));
+  mirrorProps(newShape, shape);
   return newShape;
 }
 
@@ -847,8 +843,8 @@ export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
     throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
   }
   const newShape: Writeable<schemas.$ZodShape> = {};
-  const deferred = mirrorShape(newShape, a, Reflect.ownKeys(sourceShape(a)), false);
-  mirrorShape(newShape, b, Reflect.ownKeys(sourceShape(b)), deferred);
+  mirrorShape(newShape, a, Reflect.ownKeys(sourceShape(a)));
+  mirrorShape(newShape, b, Reflect.ownKeys(sourceShape(b)));
 
   const def = mergeDefs(a._zod.def, {
     shape: newShape,
@@ -880,7 +876,6 @@ export function partial(
     newShape,
     schema,
     Reflect.ownKeys(sourceShape(schema)),
-    false,
     Class &&
       ((value, key) => (selected && !selected.has(key) ? value : new Class({ type: "optional", innerType: value })))
   );
@@ -895,7 +890,7 @@ export function required(
 ): any {
   const selected = mask ? new Set(maskedKeys(schema, mask)) : undefined;
   const newShape: Writeable<schemas.$ZodShape> = {};
-  mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)), false, (value, key) =>
+  mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)), (value, key) =>
     // overwrite with non-optional
     selected && !selected.has(key) ? value : new Class({ type: "nonoptional", innerType: value })
   );

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -411,6 +411,12 @@ function deferProp(target: object, key: PropertyKey, getter: () => any): void {
   });
 }
 
+// Writes a settled key. A plain assignment is much cheaper than `defineProperty` and produces the same descriptor, but it runs a setter — `__proto__` has one on every object, and a key this shape already deferred has one of its own.
+function putProp(target: any, key: PropertyKey, value: any, deferred: boolean): void {
+  if (deferred || key === "__proto__") assignProp(target, key as any, value);
+  else target[key] = value;
+}
+
 /**
  * Copies `keys` of `source`'s shape onto `target`, each value passed through `wrap`.
  *
@@ -420,26 +426,29 @@ function mirrorShape(
   target: object,
   source: schemas.$ZodObject,
   keys: PropertyKey[],
+  deferred: boolean,
   wrap?: ((value: any, key: PropertyKey) => any) | null
-): void {
+): boolean {
   const raw = sourceShape(source);
   for (const key of keys) {
     const desc = Object.getOwnPropertyDescriptor(raw, key)!;
     if (desc.get) {
+      deferred = true;
       deferProp(target, key, () => {
         const value = (source._zod.def.shape as any)[key];
         return wrap ? wrap(value, key) : value;
       });
-    } else assignProp(target as any, key as any, wrap ? wrap(desc.value, key) : desc.value);
+    } else putProp(target, key, wrap ? wrap(desc.value, key) : desc.value, deferred);
   }
+  return deferred;
 }
 
 // same, for a plain shape a caller passed rather than a schema's
-function mirrorProps(target: object, source: Record<PropertyKey, any>): void {
+function mirrorProps(target: object, source: Record<PropertyKey, any>, deferred: boolean): void {
   for (const key of Reflect.ownKeys(source)) {
     const desc = Object.getOwnPropertyDescriptor(source, key)!;
     if (desc.get) deferProp(target, key, () => source[key as any]);
-    else assignProp(target as any, key as any, desc.value);
+    else putProp(target, key, desc.value, deferred);
   }
 }
 
@@ -753,7 +762,7 @@ export function pick(schema: schemas.$ZodObject, mask: Record<string, unknown>):
   }
 
   const newShape: Writeable<schemas.$ZodShape> = {};
-  mirrorShape(newShape, schema, maskedKeys(schema, mask));
+  mirrorShape(newShape, schema, maskedKeys(schema, mask), false);
 
   return clone(schema, mergeDefs(currDef, { shape: newShape, checks: [] })) as any;
 }
@@ -786,7 +795,8 @@ export function omit(schema: schemas.$ZodObject, mask: object): any {
   mirrorShape(
     newShape,
     schema,
-    Reflect.ownKeys(sourceShape(schema)).filter((key) => !omitted.has(key))
+    Reflect.ownKeys(sourceShape(schema)).filter((key) => !omitted.has(key)),
+    false
   );
 
   return clone(schema, mergeDefs(currDef, { shape: newShape, checks: [] }));
@@ -815,8 +825,8 @@ export function extend(schema: schemas.$ZodObject, shape: schemas.$ZodShape): an
 // the source's keys, then the caller's overlaid on top
 function extended(schema: schemas.$ZodObject, shape: schemas.$ZodShape): schemas.$ZodShape {
   const newShape: Writeable<schemas.$ZodShape> = {};
-  mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)));
-  mirrorProps(newShape, shape);
+  const deferred = mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)), false);
+  mirrorProps(newShape, shape, deferred);
   return newShape;
 }
 
@@ -835,8 +845,8 @@ export function merge(a: schemas.$ZodObject, b: schemas.$ZodObject): any {
     throw new Error(".merge() cannot be used on object schemas containing refinements. Use .safeExtend() instead.");
   }
   const newShape: Writeable<schemas.$ZodShape> = {};
-  mirrorShape(newShape, a, Reflect.ownKeys(sourceShape(a)));
-  mirrorShape(newShape, b, Reflect.ownKeys(sourceShape(b)));
+  const deferred = mirrorShape(newShape, a, Reflect.ownKeys(sourceShape(a)), false);
+  mirrorShape(newShape, b, Reflect.ownKeys(sourceShape(b)), deferred);
 
   const def = mergeDefs(a._zod.def, {
     shape: newShape,
@@ -868,6 +878,7 @@ export function partial(
     newShape,
     schema,
     Reflect.ownKeys(sourceShape(schema)),
+    false,
     Class &&
       ((value, key) => (selected && !selected.has(key) ? value : new Class({ type: "optional", innerType: value })))
   );
@@ -882,7 +893,7 @@ export function required(
 ): any {
   const selected = mask ? new Set(maskedKeys(schema, mask)) : undefined;
   const newShape: Writeable<schemas.$ZodShape> = {};
-  mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)), (value, key) =>
+  mirrorShape(newShape, schema, Reflect.ownKeys(sourceShape(schema)), false, (value, key) =>
     // overwrite with non-optional
     selected && !selected.has(key) ? value : new Class({ type: "nonoptional", innerType: value })
   );

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1094,7 +1094,8 @@ export function catchall<T extends ZodMiniObject, U extends SomeType>(
   inst: T,
   catchall: U
 ): ZodMiniObject<T["shape"], core.$catchall<U>> {
-  return inst.clone({ ...inst._zod.def, catchall: catchall as any }) as any;
+  // `mergeDefs` rather than a spread: spreading reads `shape`, and resolving it can mint a whole fresh subtree
+  return inst.clone(util.mergeDefs(inst._zod.def, { catchall: catchall as any })) as any;
 }
 
 // ZodMiniUnion


### PR DESCRIPTION
Fixes #6526.

A recursive schema built by a factory throws `RangeError: Maximum call stack size exceeded` on 4.5.x, after about eight seconds on the main thread. It parsed fine on 4.4.3. Published schemas hit it — `zod-geojson` builds its geometry schemas this way, so an empty feature collection crashes.

```ts
const Node = (): any =>
  z.object({
    id: z.number(),
    get child() {
      return z.array(Node()); // a fresh instance on every read
    },
  });

z.object({ root: Node() }).parse({ root: { id: 1, child: [] } }); // RangeError
```

The cycle walk added in #6387 decides whether a parse can re-enter the same schema, so the memoizer can detach when no cycle is possible. Instance identity is the only thing that terminates that walk: it marks what it enters and stops when it meets a mark. A factory returns a new instance per call, so resolving one getter mints a whole new subtree, the walk never revisits a node, and it constructs schemas until the stack runs out. Descent at parse time was always data-directed and therefore finite, which is why 4.4.3 was unaffected.

## The rule

The walk no longer resolves anything that runs user code, and reports a cycle for every edge it therefore cannot follow — a shape getter, or a `z.lazy` nobody has resolved. That terminates by construction and needs no depth limit. It errs in one direction only: it can report a cycle that does not exist, never the reverse. The same rule already governs `compile.ts`, which treats "can't tell" as recursive.

Left alone, that would pin the memoizer to every non-cyclic getter and `z.lazy` — about 2.3x on a small object parse. So the conservative answer is neither cached nor latched. The first parse resolves the getters along its path and `z.lazy` stores its inner type on the def, and one recheck then reads plain values and answers exactly. A forward reference detaches and runs at full speed; a factory never resolves into a finite graph, so it keeps the wrapper.

## The object builders

Every builder that derives a shape — `.extend()`, `.safeExtend()`, `.merge()`, `.partial()`, `.required()`, `.pick()`, `.omit()` — answered `shape` from an accessor of its own that reads the source shape, which runs the source's getters. A factory chained through any of them overflowed the same way, and nothing could read a derived shape's keys without triggering that.

Each builder now writes a plain shape whose descriptors mirror the source's. A key the source has resolved is copied through as a data property, so the derived shape states outright what it holds; only a key the source still defers stays deferred, and it reads back through the source's own `shape`, so it resolves once and both shapes get that one schema. Every object def therefore has a shape the walk can read without running anything, and the walk keeps a single rule.

That is more precise than asking what a derived shape was built from, which can only over-approximate: `Node.omit({ self: true })` drops the key carrying the cycle, and the mirrored shape has nothing deferred left in it, so it is exact before anything parses.

`.strict()`, `.loose()`, `.passthrough()`, `.strip()` and `.catchall()` had a second copy of the same bug, unrelated to the walk. They rebuilt the def with `{ ...def }`, and spreading reads `shape`. On a factory schema that resolves it mints a fresh subtree whose own `.strict()` spreads again, so the call overflowed at construction, before any parse — on `main` as well. They copy the descriptor now and leave the shape unread.

An object resolves its shape by object spread, so a non-enumerable entry is no part of it. The builders enumerate the source with `Reflect.ownKeys`, so they skip those entries too — copying one back as enumerable would promote a hidden key into the derived shape as a required one, and `.extend()` would then reject input its source accepts. Enumerable symbol keys are unaffected. That filter belongs to `z.object` alone: `z.properties` reads every own key, so a non-enumerable edge there is still parsed and the walk still has to see it.

A derived shape is built key by key, and a plain assignment runs whatever setter answers to that key, so a key is written with `defineProperty` whenever anything already does — an accessor this shape deferred, `__proto__`, or a setter prototype pollution put there. Without that last case a polluted prototype dropped the key from the derived shape entirely, and `.extend()` then accepted a value its source validates. The check costs about nothing: the builders stay within 3% of an unguarded assignment, where defining every key outright costs up to 23%.

One behavior change falls out of this. A mask key the shape does not declare is now rejected at the `.pick()`/`.omit()`/`.partial()`/`.required()` call rather than at the first read of `.shape`, since the check reads the source's declared keys without resolving them. The error is the same; it arrives where the mistake is.

## Three axes

Bundle, gzipped, against the base of this branch: classic +344 B on the object fixture, `zod/mini` +1 B on its object fixture and unchanged on boolean. Mini is the one that matters most here and it stays flat, because none of this reaches a bundle that only builds an object and parses it.

Steady-state parse is untouched, and not just within noise: the fastpass generated for `z.object({ a, b, c })` is byte-identical to the base's, and the memoizer wrapper still detaches after exactly one entry. Timed, it is 0.99x.

What moves is construction, and only for the builders. Building an eight-key object is 0.99x. Building a derived schema and reading its shape — the whole of the work, wherever it now happens — is 1.08x for `.pick()`, 1.16x for `.partial()`, 1.33x for `.merge()` and 1.34x for `.extend()`. Called without ever reading the shape, `.partial()` is 3.7x and retains 7.8 KB instead of 2.2 KB, because it now builds its wrappers up front; the same partial cost 7.3 KB once used before and 7.6 KB now.

Deferring each wrapped key behind a getter instead was measured and is worse on both counts: a closure and an accessor pair cost about what the wrapper they avoid costs.

Descriptors were diffed across nineteen builder cases, cold and warm, against the base. The only change is that a derived def's `shape` is `writable: false` once read, which is what a plain `z.object()` has always been — the builders were the odd ones out.
