### PR TITLE
Build literal and enum pattern regexes lazily

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3523,12 +3523,13 @@ export const $ZodEnum: core.$constructor<$ZodEnum> = /*@__PURE__*/ core.$constru
   const valuesSet = new Set<util.Primitive>(values);
   inst._zod.values = valuesSet;
 
-  const patternValues = values.filter((k) => util.propertyKeyTypes.has(typeof k));
-
-  // unmatchable fallback, RE2-safe: an empty alternation would compile to /^()$/, which matches ""
-  inst._zod.pattern = new RegExp(
-    patternValues.length ? `^(${patternValues.map((o) => util.escapeRegex(o.toString())).join("|")})$` : "^[^\\s\\S]$"
-  );
+  util.defineLazyInternal(inst, "pattern", (zod) => {
+    const patternValues = util.getEnumValues(zod.def.entries).filter((k) => util.propertyKeyTypes.has(typeof k));
+    // unmatchable fallback, RE2-safe: an empty alternation would compile to /^()$/, which matches ""
+    return new RegExp(
+      patternValues.length ? `^(${patternValues.map((o) => util.escapeRegex(o.toString())).join("|")})$` : "^[^\\s\\S]$"
+    );
+  });
 
   inst._zod.parse = (payload, _ctx) => {
     const input = payload.value;
@@ -3578,14 +3579,19 @@ export const $ZodLiteral: core.$constructor<$ZodLiteral> = /*@__PURE__*/ core.$c
     const values = new Set<util.Literal>(def.values);
     inst._zod.values = values;
 
-    // unmatchable fallback, RE2-safe: an empty alternation would compile to /^()$/, which matches ""
-    inst._zod.pattern = new RegExp(
-      def.values.length
-        ? `^(${def.values
-            .map((o) => (typeof o === "string" ? util.escapeRegex(o) : o ? util.escapeRegex(o.toString()) : String(o)))
-            .join("|")})$`
-        : "^[^\\s\\S]$"
-    );
+    util.defineLazyInternal(inst, "pattern", (zod) => {
+      const vals = zod.def.values;
+      // unmatchable fallback, RE2-safe: an empty alternation would compile to /^()$/, which matches ""
+      return new RegExp(
+        vals.length
+          ? `^(${vals
+              .map((o: util.Literal) =>
+                typeof o === "string" ? util.escapeRegex(o) : o ? util.escapeRegex(o.toString()) : String(o)
+              )
+              .join("|")})$`
+          : "^[^\\s\\S]$"
+      );
+    });
 
     inst._zod.parse = (payload, _ctx) => {
       const input = payload.value;


### PR DESCRIPTION
Builds `_zod.pattern` on literal and enum schemas lazily through `defineLazyInternal`, the mechanism union and the wrapper types already use. The parse path never reads `pattern`, so the alternation regex and its `escapeRegex` work now only happen when template literals, `toJSONSchema()`, or union pattern derivation ask for it.

Measured on all three axes: memory −88 B per literal and −99 B per enum schema; bundle +0 B gzip on every `zod/mini` fixture (no ceiling change) and +17 B on classic; construction roughly −37% for `z.literal` and −49% for `z.enum`.

This is the literal/enum half of the proposal in #6513 — the shared string regex and the `pop()` rewrite are declined there since both cost `zod/mini` bytes. Closes #6513.
