### PR TITLE
fix(v4): reject component-only strings from z.emoji()

### DIFF
--- a/packages/zod/src/v4/classic/tests/continuability.test.ts
+++ b/packages/zod/src/v4/classic/tests/continuability.test.ts
@@ -230,7 +230,7 @@ test("continuability", () => {
         "message": "Invalid emoji",
         "origin": "string",
         "path": [],
-        "pattern": "/^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$/u",
+        "pattern": "/^(?=[\\s\\S]*[\\p{Extended_Pictographic}\\p{Regional_Indicator}\\u20E3])[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$/u",
       },
       {
         "code": "custom",

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -553,6 +553,18 @@ test("emoji validations", () => {
   expect(() => emoji.parse("😀 is an emoji")).toThrow();
   expect(() => emoji.parse("😀stuff")).toThrow();
   expect(() => emoji.parse("stuff😀")).toThrow();
+
+  emoji.parse("1\u{FE0F}\u{20E3}"); // keycap sequences stay valid
+  emoji.parse("#\u{FE0F}\u{20E3}");
+
+  // `\p{Emoji_Component}` alone covers ASCII digits, "#", "*", ZWJ, variation selectors and skin tone modifiers; none is an emoji without a base, so a component-only string is not one either
+  expect(() => emoji.parse("123")).toThrow();
+  expect(() => emoji.parse("#")).toThrow();
+  expect(() => emoji.parse("*")).toThrow();
+  expect(() => emoji.parse("\u{200D}")).toThrow();
+  expect(() => emoji.parse("\u{FE0F}")).toThrow();
+  expect(() => emoji.parse("\u{1F3FD}")).toThrow();
+  expect(() => emoji.parse("1\u{FE0F}")).toThrow();
 });
 
 test("nanoid", () => {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -240,7 +240,7 @@ describe("toJSONSchema", () => {
       {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "format": "emoji",
-        "pattern": "^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$",
+        "pattern": "^(?=[\\s\\S]*[\\p{Extended_Pictographic}\\p{Regional_Indicator}\\u20E3])[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$",
         "type": "string",
       }
     `);

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -60,8 +60,8 @@ export const browserEmail: RegExp =
   /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 // from https://thekevinscott.com/emojis-in-javascript/#writing-a-regular-expression
 
-// Single character class, not an alternation: the two properties overlap (U+1F9B0-U+1F9B3), so `(A|B)+` backtracks exponentially on a failed match.
-const _emoji: string = `^[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$`;
+// Single character class, not an alternation: the two properties overlap (U+1F9B0-U+1F9B3), so `(A|B)+` backtracks exponentially on a failed match. The leading lookahead then demands one anchor — a pictograph, a regional indicator, or the enclosing keycap — because `\p{Emoji_Component}` on its own covers ASCII digits, `#`, `*`, ZWJ, variation selectors and skin tone modifiers, none of which is an emoji without a base.
+const _emoji: string = `^(?=[\\s\\S]*[\\p{Extended_Pictographic}\\p{Regional_Indicator}\\u20E3])[\\p{Extended_Pictographic}\\p{Emoji_Component}]+$`;
 export function emoji(): RegExp {
   return new RegExp(_emoji, "u");
 }


### PR DESCRIPTION
Fixes #6515.

`z.emoji()` accepts strings built entirely from `\p{Emoji_Component}` — `"123"`, `"#"`, `"*"`, a lone ZWJ, variation selector, or skin tone modifier — because that class is the set of pieces that combine with an emoji, not emoji themselves. This adds a leading lookahead requiring at least one anchor (an `Extended_Pictographic`, a regional indicator, or the enclosing keycap that makes `1️⃣` an emoji), and keeps the single-class body from #6347 so matching stays linear.

The pattern is emitted into `z.toJSONSchema()` output, so the two snapshots carrying it are updated, and `⃣` is spelled portably for non-ECMAScript consumers. Bundle cost is ~28 B gzipped in classic and zero in `zod/mini` unless `emoji()` is used.

Authored by @oleg6k; landing it from their branch since PR creation is currently restricted to collaborators. @NektarTheo had offered to pick this up — thanks to both.
