### PR TITLE
Collapse toZod's enum leaf normalizer to a dummy union

### DIFF
--- a/packages/zod/src/v4/classic/tests/assignability.test.ts
+++ b/packages/zod/src/v4/classic/tests/assignability.test.ts
@@ -276,6 +276,9 @@ test("toZod", () => {
   // @ts-expect-error an enum schema does not match a plain literal-union target
   z.toZod<{ skill: "noob" | "pro" }>()(z.object({ skill: z.enum(SkillLevel) }));
 
+  // @ts-expect-error plain numeric literals do not match a numeric enum target either
+  z.toZod<{ rank: Rank }>()(z.object({ rank: z.union([z.literal(1), z.literal(2)]) }));
+
   z.toZod<Company>()(
     // @ts-expect-error missing optional keys still fail exact output matching
     z.object({

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -98,15 +98,15 @@ type ToZodKeyMismatch<Expected, Received> = schemas.$ZodType & {
   "types do not match": { expected: Expected; received: Received };
 };
 
-// An enum reference and the union of exactly its members are mutually assignable but not identical, so `AssertEqual` alone rejects `z.enum(SomeEnum)` against a `SomeEnum` target. Rebuilding the string/number part of each side through a mapped type collapses that one difference and nothing else — plain literals against an enum, member subsets, brands and `any` all still fail.
-type ToZodNormalizeEnum<T> = { [K in Extract<T, EnumValue>]: K }[Extract<T, EnumValue>] | Exclude<T, EnumValue>;
+// An enum reference and the union of exactly its members are mutually assignable but not identical, so `AssertEqual` alone rejects `z.enum(SomeEnum)` against a `SomeEnum` target. Unioning each side with a private dummy forces the union to be rebuilt, which collapses that one difference and nothing else — plain literals against an enum, member subsets, brands and `any` all still fail. The symbol is not exported, so no user type can smuggle it in and cancel a real difference.
+declare const toZodDummy: unique symbol;
 
-// Recurses only through types identical to their own homomorphic rebuild, which preserves the exactness guarantees: an intersection, a call signature and `readonly`/optional modifiers all survive or block the walk, so only enum leaves are normalized.
+// Recurses only through types identical to their own homomorphic rebuild, which preserves the exactness guarantees: an intersection, a call signature and `readonly`/optional modifiers all survive or block the walk, so only leaves are normalized.
 type ToZodNormalize<T> = [T] extends [object]
   ? AssertEqual<T, { [K in keyof T]: T[K] }> extends true
     ? { [K in keyof T]: ToZodNormalize<T[K]> }
     : T
-  : ToZodNormalizeEnum<T>;
+  : T | typeof toZodDummy;
 
 type ToZodEqual<Output, T> = AssertEqual<Output, T> extends true
   ? true


### PR DESCRIPTION
Follow-up to #6528, from the request to find a smaller formulation than the mapped-key normalizer.

The enum-leaf machinery reduces to a single union. `{ [K in Extract<T, EnumValue>]: K }[Extract<T, EnumValue>] | Exclude<T, EnumValue>` becomes `T | typeof toZodDummy`, where `toZodDummy` is a private, unexported `unique symbol`. Unioning either side with anything forces TypeScript to rebuild the union, and the rebuilt unions compare identical — `E | D` and `E.A | E.B | D` are the same type, while everything else the exactness check distinguishes stays distinguished. No index-signature lookup, no `Extract`/`Exclude` split. The recursive walk with its flat-rebuild guard stays: it is what keeps intersections, call signatures, classes with private members, and `readonly`/optional modifiers strict, and no leaf-level trick can reach a nested enum without it.

Verified differentially: both implementations were run side by side over 35 probes — every fixed case (flat, nested, arrays, tuples, records, nullable, optional), every guarantee (`any`, `unknown`, brands, subsets, plain string literals vs a nominal enum, plain numeric literals vs a numeric enum, intersection-vs-flat, `readonly`, class instances with private members, enums nested in generics and function signatures) — with identical results on TypeScript 5.5, 6, and 7.0.2. The probe files live in the triage directory for #6524. The test suite gains one negative control: plain `1 | 2` does not satisfy a numeric enum target, which is the distinction the union rebuild had to preserve and the one place the two enum flavors differ (numeric enums are mutually *assignable* with their literals; identity still separates them).

Type-only change; zero runtime, memory, and bundle delta.
