### PR TITLE
Keep the runtime base64 regexes linear so composed parse paths cannot overflow

### DIFF
--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -293,11 +293,17 @@ test("big base64 and base64url", () => {
   const bigbase64url = randomBytes(1024 * 1024 * 10).toString("base64url");
   z.base64url().parse(bigbase64url);
 
-  // the exported regexes and template-literal composition run raw regexes on the parse path; the quantified block forms overflowed the regex stack here (#6528 review)
-  expect(z.regexes.base64.test(bigbase64)).toBe(true);
-  expect(z.regexes.base64url.test(bigbase64url)).toBe(true);
+  // template literals compose def.pattern and test it on every parse; the quantified block forms overflowed the regex stack here
   expect(z.templateLiteral(["id-", z.base64()]).safeParse(`id-${bigbase64}`).success).toBe(true);
   expect(z.templateLiteral(["id-", z.base64url()]).safeParse(`id-${bigbase64url}`).success).toBe(true);
+});
+
+test("template literal composes base64 without alternation leaks", () => {
+  // the ^$| alternation in regexes.base64 used to leak: "AAAA" matched with the prefix dropped and "id-AAAA" was rejected
+  const tl = z.templateLiteral(["id-", z.base64()]);
+  expect(tl.safeParse("id-AAAA").success).toBe(true);
+  expect(tl.safeParse("id-").success).toBe(true);
+  expect(tl.safeParse("AAAA").success).toBe(false);
 });
 
 function makeJwt(header: object, payload: object) {

--- a/packages/zod/src/v4/classic/tests/string.test.ts
+++ b/packages/zod/src/v4/classic/tests/string.test.ts
@@ -292,6 +292,12 @@ test("big base64 and base64url", () => {
   z.base64().parse(bigbase64);
   const bigbase64url = randomBytes(1024 * 1024 * 10).toString("base64url");
   z.base64url().parse(bigbase64url);
+
+  // the exported regexes and template-literal composition run raw regexes on the parse path; the quantified block forms overflowed the regex stack here (#6528 review)
+  expect(z.regexes.base64.test(bigbase64)).toBe(true);
+  expect(z.regexes.base64url.test(bigbase64url)).toBe(true);
+  expect(z.templateLiteral(["id-", z.base64()]).safeParse(`id-${bigbase64}`).success).toBe(true);
+  expect(z.templateLiteral(["id-", z.base64url()]).safeParse(`id-${bigbase64url}`).success).toBe(true);
 });
 
 function makeJwt(header: object, payload: object) {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -500,6 +500,21 @@ describe("toJSONSchema", () => {
     }
   });
 
+  test("base64 pattern agrees with parse", () => {
+    const schema = z.base64();
+    const pattern = new RegExp(z.toJSONSchema(schema).pattern!);
+    // the runtime def.pattern is lax; the emitted pattern must still carry the block structure parse enforces
+    for (const s of ["", "A", "AA", "AAA", "AAAA", "AAAAA", "AA==", "AAA=", "A===", "=", "AAAA=="]) {
+      expect(pattern.test(s)).toBe(schema.safeParse(s).success);
+    }
+  });
+
+  test("looseRecord with a format key emits the exact pattern", () => {
+    // recordProcessor reads bag.patterns directly; it must apply the same lax-to-exact swap as stringProcessor
+    const json = z.toJSONSchema(z.looseRecord(z.base64url(), z.number()));
+    expect(Object.keys(json.patternProperties!)).toEqual([z.regexes.base64url.source]);
+  });
+
   test("string patterns", () => {
     expect(
       z.toJSONSchema(

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -29,6 +29,12 @@ const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> =
 
 // ==================== SIMPLE TYPE PROCESSORS ====================
 
+// The runtime base64 regexes are linear-time and deliberately length-lax so composed parse paths cannot overflow the regex stack; the emitted JSON Schema swaps in the exact block-structured forms, which zod itself never executes.
+const exactPatterns: Map<RegExp, RegExp> = new Map([
+  [regexes.base64, /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/],
+  [regexes.base64url, /^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2,3})?$/],
+]);
+
 export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _json, _params) => {
   const json = _json as JSONSchema.StringSchema;
   json.type = "string";
@@ -48,7 +54,7 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
   }
   if (contentEncoding) json.contentEncoding = contentEncoding;
   if (patterns && patterns.size > 0) {
-    const patternList = [...patterns];
+    const patternList = [...patterns].map((p) => exactPatterns.get(p) ?? p);
     if (patternList.length === 1) json.pattern = patternList[0]!.source;
     else if (patternList.length > 1) {
       json.allOf = [

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -2,6 +2,7 @@ import type * as checks from "./checks.js";
 import type * as JSONSchema from "./json-schema.js";
 import * as regexes from "./regexes.js";
 import type { $ZodRegistry } from "./registries.js";
+import { base64Charset, base64urlCharset } from "./schemas.js";
 import type * as schemas from "./schemas.js";
 import {
   type ProcessParams,
@@ -29,11 +30,12 @@ const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> =
 
 // ==================== SIMPLE TYPE PROCESSORS ====================
 
-// The runtime base64 regexes are linear-time and deliberately length-lax so composed parse paths cannot overflow the regex stack; the emitted JSON Schema swaps in the exact block-structured forms, which zod itself never executes.
+// the runtime patterns are lax so parse paths never overflow the regex stack; the emitted schema swaps in the exact block forms, which zod itself never executes
 const exactPatterns: Map<RegExp, RegExp> = new Map([
-  [regexes.base64, /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/],
-  [regexes.base64url, /^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2,3})?$/],
+  [base64Charset, regexes.base64],
+  [base64urlCharset, regexes.base64url],
 ]);
+const exactPattern = (p: RegExp): RegExp => exactPatterns.get(p) ?? p;
 
 export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _json, _params) => {
   const json = _json as JSONSchema.StringSchema;
@@ -54,7 +56,7 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
   }
   if (contentEncoding) json.contentEncoding = contentEncoding;
   if (patterns && patterns.size > 0) {
-    const patternList = [...patterns].map((p) => exactPatterns.get(p) ?? p);
+    const patternList = [...patterns].map(exactPattern);
     if (patternList.length === 1) json.pattern = patternList[0]!.source;
     else if (patternList.length > 1) {
       json.allOf = [
@@ -580,7 +582,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
     });
     json.patternProperties = {};
     for (const pattern of patterns) {
-      assignProp(json.patternProperties, pattern.source, valueSchema);
+      assignProp(json.patternProperties, exactPattern(pattern).source, valueSchema);
     }
   } else {
     // Default behavior: use propertyNames + additionalProperties

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -79,9 +79,9 @@ export const cidrv4: RegExp =
 export const cidrv6: RegExp =
   /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/;
 
-// https://stackoverflow.com/questions/7860392/determine-if-string-is-in-base64-using-javascript
-export const base64: RegExp = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/;
-export const base64url: RegExp = /^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2,3})?$/;
+// Linear-time on purpose: the block-structured quantified forms overflow the regex stack on multi-MB input, and these regexes run on parse paths — template literals compose them, and `z.regexes` exports them. Length rules are enforced by `isValidBase64`/`isValidBase64URL`; `toJSONSchema` emits the exact block-structured patterns instead.
+export const base64: RegExp = /^[0-9a-zA-Z+/]*={0,2}$/;
+export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
 
 // based on https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
 // export const hostname: RegExp = /^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/;

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -79,9 +79,9 @@ export const cidrv4: RegExp =
 export const cidrv6: RegExp =
   /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))\/(12[0-8]|1[01][0-9]|[1-9]?[0-9])$/;
 
-// Linear-time on purpose: the block-structured quantified forms overflow the regex stack on multi-MB input, and these regexes run on parse paths — template literals compose them, and `z.regexes` exports them. Length rules are enforced by `isValidBase64`/`isValidBase64URL`; `toJSONSchema` emits the exact block-structured patterns instead.
-export const base64: RegExp = /^[0-9a-zA-Z+/]*={0,2}$/;
-export const base64url: RegExp = /^[A-Za-z0-9_-]*$/;
+// https://stackoverflow.com/questions/7860392/determine-if-string-is-in-base64-using-javascript
+export const base64: RegExp = /^$|^(?:[0-9a-zA-Z+/]{4})*(?:(?:[0-9a-zA-Z+/]{2}==)|(?:[0-9a-zA-Z+/]{3}=))?$/;
+export const base64url: RegExp = /^(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2,3})?$/;
 
 // based on https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
 // export const hostname: RegExp = /^([a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1028,10 +1028,13 @@ export interface $ZodBase64 extends $ZodType {
   _zod: $ZodBase64Internals;
 }
 
+// lax on purpose: the quantified regexes.base64 overflows the regex stack on multi-MB input and its leading ^$| alternation leaks through template-literal composition; isValidBase64 enforces length and padding
+export const base64Charset: RegExp = /^[0-9a-zA-Z+/]*={0,2}$/;
+
 export const $ZodBase64: core.$constructor<$ZodBase64> = /*@__PURE__*/ core.$constructor(
   "$ZodBase64",
   (inst, def): void => {
-    def.pattern ??= regexes.base64;
+    def.pattern ??= base64Charset;
     $ZodStringFormat.init(inst, def);
 
     inst._zod.bag.contentEncoding = "base64";
@@ -1051,8 +1054,11 @@ export const $ZodBase64: core.$constructor<$ZodBase64> = /*@__PURE__*/ core.$con
 );
 
 //////////////////////////////   ZodBase64URL   //////////////////////////////
+// lax on purpose: the quantified regexes.base64url overflows the regex stack on multi-MB input; isValidBase64 enforces length on the padded string
+export const base64urlCharset: RegExp = /^[A-Za-z0-9_-]*$/;
+
 export function isValidBase64URL(data: string): boolean {
-  if (!regexes.base64url.test(data)) return false;
+  if (!base64urlCharset.test(data)) return false;
   const base64 = data.replace(/[-_]/g, (c) => (c === "-" ? "+" : "/"));
   const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
   return isValidBase64(padded);
@@ -1068,7 +1074,7 @@ export interface $ZodBase64URL extends $ZodType {
 export const $ZodBase64URL: core.$constructor<$ZodBase64URL> = /*@__PURE__*/ core.$constructor(
   "$ZodBase64URL",
   (inst, def): void => {
-    def.pattern ??= regexes.base64url;
+    def.pattern ??= base64urlCharset;
     $ZodStringFormat.init(inst, def);
 
     inst._zod.bag.contentEncoding = "base64url";

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1051,11 +1051,8 @@ export const $ZodBase64: core.$constructor<$ZodBase64> = /*@__PURE__*/ core.$con
 );
 
 //////////////////////////////   ZodBase64URL   //////////////////////////////
-// charset only — the quantified regexes.base64url overflows the regex stack on multi-MB input; isValidBase64 enforces length on the padded string
-const base64urlCharset = /^[A-Za-z0-9_-]*$/;
-
 export function isValidBase64URL(data: string): boolean {
-  if (!base64urlCharset.test(data)) return false;
+  if (!regexes.base64url.test(data)) return false;
   const base64 = data.replace(/[-_]/g, (c) => (c === "-" ? "+" : "/"));
   const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
   return isValidBase64(padded);


### PR DESCRIPTION
Fixes the finding from the #6528 review: `z.templateLiteral(["id-", z.base64url()]).safeParse` threw `RangeError: Maximum call stack size exceeded` on multi-megabyte input. The quantified block forms (`(?:[...]{4})*`) recurse per block in V8's regex engine, so ~8M chars overflows the stack. `z.base64()` and `z.base64url()` were already mitigated internally, but template literals compose member `def.pattern`s and test them on every parse.

The split, reworked per review: the public `z.regexes.base64` and `z.regexes.base64url` keep their strict shipped semantics and are untouched. The lax linear forms (`/^[0-9a-zA-Z+/]*={0,2}$/`, `/^[A-Za-z0-9_-]*$/`) live module-local in `schemas.ts` and become `def.pattern` for the two formats — parse validation is unchanged because `isValidBase64`/`isValidBase64URL` enforce the length rules. The JSON Schema emitter swaps the lax patterns back to the strict exports by reference, at both consumer sites: `stringProcessor`'s `pattern`/`allOf` and `recordProcessor`'s `patternProperties` (the review caught that `z.looseRecord(z.base64url(), …)` would otherwise emit the lax key — now pinned by a test). `toJSONSchema(z.base64url())` still emits the length-aware pattern from #6527; its snapshot and agreement tests pass unchanged, and `base64` gains the symmetric agreement test. `templateLiteralProcessor` is deliberately left lax: its emitted pattern then agrees with the (length-lax) composed parse.

This also fixes a second bug the overflow investigation surfaced: `regexes.base64`'s leading `^$|` alternation leaked through template-literal composition, so on `main` `z.templateLiteral(["id-", z.base64()])` accepts `"AAAA"` with the prefix dropped and rejects the valid `"id-AAAA"`. Both directions are now pinned by a test. Composed base64url segments are length-lax again (`"id-A"` passes), as before #6527 — block length can't be meaningfully enforced mid-composition.

Verified with a controlled repro: on `main` the template-literal paths throw on 10MB input; on this branch they parse cleanly, and the big-input test now exercises them. Direct use of the strict `z.regexes.*` exports on multi-MB strings can still overflow — that's inherent to their quantified shape and out of scope here.

Axes: parse-path validator code is unchanged; template-literal parses get a simpler regex. Memory unchanged. Bundle, measured against `origin/main` with esbuild + gzip -9 on the treeshake fixtures: classic +47 B (classic retains the JSON Schema processors unconditionally via `processJSONSchema`), mini −2 B (mini shakes them until `toJSONSchema` is used).
