### PR TITLE
fix(v4): enforce the six JSON Schema keywords fromJSONSchema silently dropped

### DIFF
--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -253,11 +253,15 @@ function canonicalKey(value: unknown, seen: Set<object>): string | null {
   }
 }
 
+// keywords whose value is instance data, where a `$ref` property is a plain key rather than a reference
+const INSTANCE_KEYWORDS = /*@__PURE__*/ new Set(["default", "const", "enum", "examples"]);
+
 // a carried subschema travels without the root `$defs` its `$ref`s point into
 function containsRef(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
-  if (!Array.isArray(value) && typeof (value as any).$ref === "string") return true;
-  return Object.values(value).some(containsRef);
+  if (Array.isArray(value)) return value.some(containsRef);
+  if (typeof (value as any).$ref === "string") return true;
+  return Object.entries(value).some(([key, sub]) => !INSTANCE_KEYWORDS.has(key) && containsRef(sub));
 }
 
 function plural(n: number): string {

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -214,17 +214,43 @@ function checkObjectGuards(
   return guard.pipe(objectSchema);
 }
 
-// structural equality over JSON data, so two objects with the same entries in different key order are duplicates
-function jsonDeepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
-    return a.every((item, i) => jsonDeepEqual(item, b[i]));
+/**
+ * An injective string for JSON data: two values share a key exactly when `uniqueItems` calls them
+ * equal, so duplicate detection is a Map lookup rather than a pairwise walk. Strings and keys are
+ * length-prefixed so no value can spell another one. `null` means "never equal to anything" — a
+ * cycle or a NaN, neither of which JSON can express.
+ */
+function canonicalKey(value: unknown, seen: Set<object>): string | null {
+  if (value === null) return "z";
+  const type = typeof value;
+  if (type !== "object") {
+    if (type === "number" && Number.isNaN(value)) return null;
+    const raw = String(value);
+    return `${type[0]}${raw.length}:${raw}`;
   }
-  const keys = Object.keys(a);
-  if (keys.length !== Object.keys(b).length) return false;
-  return keys.every((k) => Object.prototype.hasOwnProperty.call(b, k) && jsonDeepEqual((a as any)[k], (b as any)[k]));
+  if (seen.has(value as object)) return null;
+  seen.add(value as object);
+  try {
+    if (Array.isArray(value)) {
+      const parts: string[] = [];
+      for (const item of value) {
+        const key = canonicalKey(item, seen);
+        if (key === null) return null;
+        parts.push(key);
+      }
+      return `a${parts.length}:[${parts.join(",")}]`;
+    }
+    const keys = Object.keys(value as object).sort();
+    const parts: string[] = [];
+    for (const k of keys) {
+      const key = canonicalKey((value as any)[k], seen);
+      if (key === null) return null;
+      parts.push(`${k.length}:${k}=${key}`);
+    }
+    return `o${parts.length}:{${parts.join(",")}}`;
+  } finally {
+    seen.delete(value as object);
+  }
 }
 
 function plural(n: number): string {
@@ -254,22 +280,27 @@ function checkArrayGuards(
       const items = payload.value;
       if (!Array.isArray(items)) return;
       if (guards.uniqueItems === true) {
-        outer: for (let i = 1; i < items.length; i++) {
-          for (let j = 0; j < i; j++) {
-            if (!jsonDeepEqual(items[i], items[j])) continue;
-            payload.issues.push({
-              code: "custom",
-              message: `Array items must be unique: element at index ${i} duplicates the one at index ${j}`,
-              input: items,
-              path: [i],
-              continue: true,
-            });
-            continue outer;
+        const firstSeen = new Map<string, number>();
+        for (let i = 0; i < items.length; i++) {
+          const key = canonicalKey(items[i], new Set());
+          if (key === null) continue;
+          const first = firstSeen.get(key);
+          if (first === undefined) {
+            firstSeen.set(key, i);
+            continue;
           }
+          payload.issues.push({
+            code: "custom",
+            message: `Array items must be unique: element at index ${i} duplicates the one at index ${first}`,
+            input: items,
+            path: [i],
+            continue: true,
+          });
         }
       }
       if (guards.containsSchema) {
         const minContains = guards.minContains ?? 1;
+        // counted in full rather than stopped at the ceiling, since the message names the exact number
         let matches = 0;
         for (const item of items) {
           if (guards.containsSchema.safeParse(item).success) matches++;

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -273,11 +273,12 @@ const SCHEMA_KEYWORDS = /*@__PURE__*/ new Set([
   "contentSchema",
 ]);
 
-// keywords whose value maps names to schemas
+// keywords whose value maps names to schemas. draft-7 `dependencies` also allows an array of property names, which holds no schema to walk
 const SCHEMA_MAP_KEYWORDS = /*@__PURE__*/ new Set([
   "properties",
   "patternProperties",
   "dependentSchemas",
+  "dependencies",
   "$defs",
   "definitions",
 ]);

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -253,6 +253,13 @@ function canonicalKey(value: unknown, seen: Set<object>): string | null {
   }
 }
 
+// a carried subschema travels without the root `$defs` its `$ref`s point into
+function containsRef(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  if (!Array.isArray(value) && typeof (value as any).$ref === "string") return true;
+  return Object.values(value).some(containsRef);
+}
+
 function plural(n: number): string {
   return n === 1 ? "element" : "elements";
 }
@@ -300,12 +307,14 @@ function checkArrayGuards(
       }
       if (guards.containsSchema) {
         const minContains = guards.minContains ?? 1;
-        // counted in full rather than stopped at the ceiling, since the message names the exact number
+        // one past the ceiling already proves the failure, and nothing above it changes the verdict
+        const ceiling = guards.maxContains !== undefined ? guards.maxContains + 1 : Number.POSITIVE_INFINITY;
         let matches = 0;
         for (const item of items) {
-          if (guards.containsSchema.safeParse(item).success) matches++;
+          if (guards.containsSchema.safeParse(item).success && ++matches >= ceiling) break;
         }
         if (matches < minContains) {
+          // the scan ran to the end, so this count is exact
           payload.issues.push({
             code: "custom",
             message: `Array must contain at least ${minContains} matching ${plural(minContains)}; found ${matches}`,
@@ -316,7 +325,7 @@ function checkArrayGuards(
         if (guards.maxContains !== undefined && matches > guards.maxContains) {
           payload.issues.push({
             code: "custom",
-            message: `Array must contain at most ${guards.maxContains} matching ${plural(guards.maxContains)}; found ${matches}`,
+            message: `Array must contain at most ${guards.maxContains} matching ${plural(guards.maxContains)}`,
             input: items,
             continue: true,
           });
@@ -826,19 +835,20 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
     }
   }
 
-  // `propertyNames` is enforced by a key guard, which `toJSONSchema` cannot infer, so the original keyword is carried as metadata to keep the round-trip lossless. Only where it was actually applied: on any other type it is inert, and on a `$ref` the metadata would land on the target every reference shares.
-  if (schema.propertyNames !== undefined && schema.type === "object" && schema.$ref === undefined) {
-    extraMeta.propertyNames = schema.propertyNames;
-  }
-
-  // Same carry for the other guard-enforced keywords.
+  // `propertyNames` and `contains` are enforced by a guard, which `toJSONSchema` cannot infer, so the original keyword is carried as metadata to keep the round-trip lossless. Only where it was actually applied: on any other type it is inert, and on a `$ref` the metadata would land on the target every reference shares. A carried subschema is copied verbatim while the root `$defs` stay behind, so one holding a `$ref` is dropped rather than emitted as a dangling reference.
   if (schema.type === "object" && schema.$ref === undefined) {
+    if (schema.propertyNames !== undefined && !containsRef(schema.propertyNames)) {
+      extraMeta.propertyNames = schema.propertyNames;
+    }
     for (const key of ["minProperties", "maxProperties"] as const) {
       if (schema[key] !== undefined) extraMeta[key] = schema[key];
     }
   }
   if (schema.type === "array" && schema.$ref === undefined) {
-    for (const key of ["uniqueItems", "contains", "minContains", "maxContains"] as const) {
+    if (schema.contains !== undefined && !containsRef(schema.contains)) {
+      extraMeta.contains = schema.contains;
+    }
+    for (const key of ["uniqueItems", "minContains", "maxContains"] as const) {
       if (schema[key] !== undefined) extraMeta[key] = schema[key];
     }
   }

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -234,7 +234,9 @@ function plural(n: number): string {
 /**
  * Enforces `uniqueItems` and the `contains` family before `arraySchema` runs, for the same reason
  * `checkObjectGuards` runs pre-pipe: an item parse can apply a nested `default`, so the parsed
- * array is not the instance the keywords are defined over.
+ * array is not the instance the keywords are defined over. A guard issue aborts the pipe, so
+ * `minItems`/`maxItems` are not also reported on the same parse — instance correctness is worth
+ * more than co-reporting two issues.
  */
 function checkArrayGuards(
   arraySchema: ZodType,

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -155,32 +155,74 @@ function resolveRef(ref: string, ctx: ConversionContext): JSONSchema.JSONSchema 
 }
 
 /**
- * Rejects every own key that fails `keySchema`, before `objectSchema` runs. The
- * guard has to see the raw input: an object parse drops `__proto__` and can add
- * keys from a property `default`, so its output is not the set of names the
- * instance actually carried.
+ * Enforces the keywords that constrain an object's own keys — `propertyNames`,
+ * `minProperties`, `maxProperties` — before `objectSchema` runs. The guard has
+ * to see the raw input: an object parse drops `__proto__` and can add keys from
+ * a property `default`, so its output is not the set of names the instance
+ * actually carried.
  */
-function checkPropertyNames(objectSchema: ZodType, keySchema: ZodType): ZodType {
+function checkObjectGuards(
+  objectSchema: ZodType,
+  guards: { keySchema?: ZodType | undefined; minProperties?: number | undefined; maxProperties?: number | undefined }
+): ZodType {
   // An identity transform, not z.any(), so `toJSONSchema` reports the object on both the input and the output side of the pipe.
   const guard = z
     .transform((value: unknown) => value)
     .check((payload) => {
       const value = payload.value;
       if (typeof value !== "object" || value === null || Array.isArray(value)) return;
-      for (const key of Object.getOwnPropertyNames(value)) {
-        const result = keySchema.safeParse(key);
-        if (result.success) continue;
+      const keys = Object.getOwnPropertyNames(value);
+      if (guards.minProperties !== undefined && keys.length < guards.minProperties) {
         payload.issues.push({
-          code: "invalid_key",
-          origin: "record",
-          issues: result.error.issues,
-          input: key,
-          path: [key],
+          origin: "object",
+          code: "too_small",
+          minimum: guards.minProperties,
+          inclusive: true,
+          input: value,
+          inst: objectSchema,
           continue: true,
         });
       }
+      if (guards.maxProperties !== undefined && keys.length > guards.maxProperties) {
+        payload.issues.push({
+          origin: "object",
+          code: "too_big",
+          maximum: guards.maxProperties,
+          inclusive: true,
+          input: value,
+          inst: objectSchema,
+          continue: true,
+        });
+      }
+      if (guards.keySchema) {
+        for (const key of keys) {
+          const result = guards.keySchema.safeParse(key);
+          if (result.success) continue;
+          payload.issues.push({
+            code: "invalid_key",
+            origin: "record",
+            issues: result.error.issues,
+            input: key,
+            path: [key],
+            continue: true,
+          });
+        }
+      }
     });
   return guard.pipe(objectSchema);
+}
+
+// structural equality over JSON data, so two objects with the same entries in different key order are duplicates
+function jsonDeepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => jsonDeepEqual(item, b[i]));
+  }
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every((k) => Object.prototype.hasOwnProperty.call(b, k) && jsonDeepEqual((a as any)[k], (b as any)[k]));
 }
 
 function getTupleRest(restSchema: JSONSchema._JSONSchema | undefined, ctx: ConversionContext): ZodType | undefined {
@@ -519,20 +561,25 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
       }
 
       // propertyNames constrains key *names* only, and says nothing about which keys are required or how their values validate. Layering it on top of the result keeps properties/patternProperties/additionalProperties composing underneath. `true` allows every name, so it needs no guard.
-      if (schema.propertyNames !== undefined && schema.propertyNames !== true) {
-        // Keys are always strings, so a propertyNames subschema that omits `type` still constrains them — without this it would convert to z.any().
-        const keyJSONSchema =
-          typeof schema.propertyNames === "object" && schema.propertyNames.type === undefined
-            ? { type: "string", ...schema.propertyNames }
-            : schema.propertyNames;
-        zodSchema = checkPropertyNames(zodSchema, convertSchema(keyJSONSchema as JSONSchema.JSONSchema, ctx));
+      const hasKeyGuard = schema.propertyNames !== undefined && schema.propertyNames !== true;
+      const minProperties = typeof schema.minProperties === "number" ? schema.minProperties : undefined;
+      const maxProperties = typeof schema.maxProperties === "number" ? schema.maxProperties : undefined;
+      if (hasKeyGuard || minProperties !== undefined || maxProperties !== undefined) {
+        let keySchema: ZodType | undefined;
+        if (hasKeyGuard) {
+          // Keys are always strings, so a propertyNames subschema that omits `type` still constrains them — without this it would convert to z.any().
+          const keyJSONSchema =
+            typeof schema.propertyNames === "object" && schema.propertyNames.type === undefined
+              ? { type: "string", ...schema.propertyNames }
+              : schema.propertyNames;
+          keySchema = convertSchema(keyJSONSchema as JSONSchema.JSONSchema, ctx);
+        }
+        zodSchema = checkObjectGuards(zodSchema, { keySchema, minProperties, maxProperties });
       }
       break;
     }
 
     case "array": {
-      // TODO: uniqueItems and contains/minContains/maxContains are not supported
-
       // Check if this is a tuple (prefixItems or items as array)
       const prefixItems = schema.prefixItems;
       const items = schema.items;
@@ -584,6 +631,55 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
       } else {
         // No items specified - array of any
         zodSchema = z.array(z.any());
+      }
+
+      if (schema.uniqueItems === true) {
+        zodSchema = zodSchema.check((payload) => {
+          const items = payload.value as unknown[];
+          outer: for (let i = 1; i < items.length; i++) {
+            for (let j = 0; j < i; j++) {
+              if (!jsonDeepEqual(items[i], items[j])) continue;
+              payload.issues.push({
+                code: "custom",
+                message: `Array items must be unique: element at index ${i} duplicates the one at index ${j}`,
+                input: payload.value,
+                path: [i],
+                continue: true,
+              });
+              continue outer;
+            }
+          }
+        });
+      }
+
+      // minContains/maxContains only constrain anything when `contains` itself is present
+      if (schema.contains !== undefined) {
+        const containsSchema = convertSchema(schema.contains as JSONSchema.JSONSchema, ctx);
+        const minContains = typeof schema.minContains === "number" ? schema.minContains : 1;
+        const maxContains = typeof schema.maxContains === "number" ? schema.maxContains : undefined;
+        zodSchema = zodSchema.check((payload) => {
+          let matches = 0;
+          for (const item of payload.value as unknown[]) {
+            if (containsSchema.safeParse(item).success) matches++;
+          }
+          const plural = (n: number) => (n === 1 ? "element" : "elements");
+          if (matches < minContains) {
+            payload.issues.push({
+              code: "custom",
+              message: `Array must contain at least ${minContains} matching ${plural(minContains)}; found ${matches}`,
+              input: payload.value,
+              continue: true,
+            });
+          }
+          if (maxContains !== undefined && matches > maxContains) {
+            payload.issues.push({
+              code: "custom",
+              message: `Array must contain at most ${maxContains} matching ${plural(maxContains)}; found ${matches}`,
+              input: payload.value,
+              continue: true,
+            });
+          }
+        });
       }
       break;
     }
@@ -669,6 +765,18 @@ function convertSchema(schema: JSONSchema.JSONSchema | boolean, ctx: ConversionC
   // `propertyNames` is enforced by a key guard, which `toJSONSchema` cannot infer, so the original keyword is carried as metadata to keep the round-trip lossless. Only where it was actually applied: on any other type it is inert, and on a `$ref` the metadata would land on the target every reference shares.
   if (schema.propertyNames !== undefined && schema.type === "object" && schema.$ref === undefined) {
     extraMeta.propertyNames = schema.propertyNames;
+  }
+
+  // Same carry for the other guard-enforced keywords.
+  if (schema.type === "object" && schema.$ref === undefined) {
+    for (const key of ["minProperties", "maxProperties"] as const) {
+      if (schema[key] !== undefined) extraMeta[key] = schema[key];
+    }
+  }
+  if (schema.type === "array" && schema.$ref === undefined) {
+    for (const key of ["uniqueItems", "contains", "minContains", "maxContains"] as const) {
+      if (schema[key] !== undefined) extraMeta[key] = schema[key];
+    }
   }
 
   for (const key of Object.keys(schema)) {

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -253,15 +253,49 @@ function canonicalKey(value: unknown, seen: Set<object>): string | null {
   }
 }
 
-// keywords whose value is instance data, where a `$ref` property is a plain key rather than a reference
-const INSTANCE_KEYWORDS = /*@__PURE__*/ new Set(["default", "const", "enum", "examples"]);
+// keywords whose value is a schema or an array of them
+const SCHEMA_KEYWORDS = /*@__PURE__*/ new Set([
+  "items",
+  "prefixItems",
+  "additionalItems",
+  "additionalProperties",
+  "contains",
+  "propertyNames",
+  "not",
+  "if",
+  "then",
+  "else",
+  "allOf",
+  "anyOf",
+  "oneOf",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+  "contentSchema",
+]);
 
-// a carried subschema travels without the root `$defs` its `$ref`s point into
+// keywords whose value maps names to schemas
+const SCHEMA_MAP_KEYWORDS = /*@__PURE__*/ new Set([
+  "properties",
+  "patternProperties",
+  "dependentSchemas",
+  "$defs",
+  "definitions",
+]);
+
+/**
+ * True when a subschema holds a `$ref` anywhere a schema can appear. Only those positions are
+ * walked: `$ref` under `default` or an `x-` annotation is instance data with an ordinary key, and
+ * reading it as a reference would drop a constraint that resolves perfectly well.
+ */
 function containsRef(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
   if (Array.isArray(value)) return value.some(containsRef);
   if (typeof (value as any).$ref === "string") return true;
-  return Object.entries(value).some(([key, sub]) => !INSTANCE_KEYWORDS.has(key) && containsRef(sub));
+  return Object.entries(value).some(([key, sub]) => {
+    if (SCHEMA_KEYWORDS.has(key)) return containsRef(sub);
+    if (!SCHEMA_MAP_KEYWORDS.has(key) || typeof sub !== "object" || sub === null) return false;
+    return Object.values(sub).some(containsRef);
+  });
 }
 
 function plural(n: number): string {

--- a/packages/zod/src/v4/classic/from-json-schema.ts
+++ b/packages/zod/src/v4/classic/from-json-schema.ts
@@ -178,6 +178,7 @@ function checkObjectGuards(
           code: "too_small",
           minimum: guards.minProperties,
           inclusive: true,
+          message: `Too small: expected object to have >=${guards.minProperties} properties`,
           input: value,
           inst: objectSchema,
           continue: true,
@@ -189,6 +190,7 @@ function checkObjectGuards(
           code: "too_big",
           maximum: guards.maxProperties,
           inclusive: true,
+          message: `Too big: expected object to have <=${guards.maxProperties} properties`,
           input: value,
           inst: objectSchema,
           continue: true,
@@ -223,6 +225,72 @@ function jsonDeepEqual(a: unknown, b: unknown): boolean {
   const keys = Object.keys(a);
   if (keys.length !== Object.keys(b).length) return false;
   return keys.every((k) => Object.prototype.hasOwnProperty.call(b, k) && jsonDeepEqual((a as any)[k], (b as any)[k]));
+}
+
+function plural(n: number): string {
+  return n === 1 ? "element" : "elements";
+}
+
+/**
+ * Enforces `uniqueItems` and the `contains` family before `arraySchema` runs, for the same reason
+ * `checkObjectGuards` runs pre-pipe: an item parse can apply a nested `default`, so the parsed
+ * array is not the instance the keywords are defined over.
+ */
+function checkArrayGuards(
+  arraySchema: ZodType,
+  guards: {
+    uniqueItems?: boolean | undefined;
+    containsSchema?: ZodType | undefined;
+    minContains?: number | undefined;
+    maxContains?: number | undefined;
+  }
+): ZodType {
+  // An identity transform, not z.any(), so `toJSONSchema` reports the array on both the input and the output side of the pipe.
+  const guard = z
+    .transform((value: unknown) => value)
+    .check((payload) => {
+      const items = payload.value;
+      if (!Array.isArray(items)) return;
+      if (guards.uniqueItems === true) {
+        outer: for (let i = 1; i < items.length; i++) {
+          for (let j = 0; j < i; j++) {
+            if (!jsonDeepEqual(items[i], items[j])) continue;
+            payload.issues.push({
+              code: "custom",
+              message: `Array items must be unique: element at index ${i} duplicates the one at index ${j}`,
+              input: items,
+              path: [i],
+              continue: true,
+            });
+            continue outer;
+          }
+        }
+      }
+      if (guards.containsSchema) {
+        const minContains = guards.minContains ?? 1;
+        let matches = 0;
+        for (const item of items) {
+          if (guards.containsSchema.safeParse(item).success) matches++;
+        }
+        if (matches < minContains) {
+          payload.issues.push({
+            code: "custom",
+            message: `Array must contain at least ${minContains} matching ${plural(minContains)}; found ${matches}`,
+            input: items,
+            continue: true,
+          });
+        }
+        if (guards.maxContains !== undefined && matches > guards.maxContains) {
+          payload.issues.push({
+            code: "custom",
+            message: `Array must contain at most ${guards.maxContains} matching ${plural(guards.maxContains)}; found ${matches}`,
+            input: items,
+            continue: true,
+          });
+        }
+      }
+    });
+  return guard.pipe(arraySchema);
 }
 
 function getTupleRest(restSchema: JSONSchema._JSONSchema | undefined, ctx: ConversionContext): ZodType | undefined {
@@ -633,54 +701,17 @@ function convertBaseSchema(schema: JSONSchema.JSONSchema, ctx: ConversionContext
         zodSchema = z.array(z.any());
       }
 
-      if (schema.uniqueItems === true) {
-        zodSchema = zodSchema.check((payload) => {
-          const items = payload.value as unknown[];
-          outer: for (let i = 1; i < items.length; i++) {
-            for (let j = 0; j < i; j++) {
-              if (!jsonDeepEqual(items[i], items[j])) continue;
-              payload.issues.push({
-                code: "custom",
-                message: `Array items must be unique: element at index ${i} duplicates the one at index ${j}`,
-                input: payload.value,
-                path: [i],
-                continue: true,
-              });
-              continue outer;
-            }
-          }
+      // minContains/maxContains only constrain anything when `contains` itself is present
+      if (schema.uniqueItems === true || schema.contains !== undefined) {
+        zodSchema = checkArrayGuards(zodSchema, {
+          uniqueItems: schema.uniqueItems === true,
+          containsSchema:
+            schema.contains !== undefined ? convertSchema(schema.contains as JSONSchema.JSONSchema, ctx) : undefined,
+          minContains: typeof schema.minContains === "number" ? schema.minContains : undefined,
+          maxContains: typeof schema.maxContains === "number" ? schema.maxContains : undefined,
         });
       }
 
-      // minContains/maxContains only constrain anything when `contains` itself is present
-      if (schema.contains !== undefined) {
-        const containsSchema = convertSchema(schema.contains as JSONSchema.JSONSchema, ctx);
-        const minContains = typeof schema.minContains === "number" ? schema.minContains : 1;
-        const maxContains = typeof schema.maxContains === "number" ? schema.maxContains : undefined;
-        zodSchema = zodSchema.check((payload) => {
-          let matches = 0;
-          for (const item of payload.value as unknown[]) {
-            if (containsSchema.safeParse(item).success) matches++;
-          }
-          const plural = (n: number) => (n === 1 ? "element" : "elements");
-          if (matches < minContains) {
-            payload.issues.push({
-              code: "custom",
-              message: `Array must contain at least ${minContains} matching ${plural(minContains)}; found ${matches}`,
-              input: payload.value,
-              continue: true,
-            });
-          }
-          if (maxContains !== undefined && matches > maxContains) {
-            payload.issues.push({
-              code: "custom",
-              message: `Array must contain at most ${maxContains} matching ${plural(maxContains)}; found ${matches}`,
-              input: payload.value,
-              continue: true,
-            });
-          }
-        });
-      }
       break;
     }
 

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1445,6 +1445,18 @@ test("a carried subschema that references $defs is dropped rather than emitted d
     expect(annotated.safeParse(["x"]).success).toBe(false);
     expect(z.toJSONSchema(annotated)).toMatchObject({ contains: { type: "integer" } });
   }
+  // draft-7 `dependencies` is a schema map; its array form names properties and holds no reference
+  const dependent = fromJSONSchema({
+    type: "array",
+    contains: { type: "object", dependencies: { a: { $ref: "#/definitions/Hit" } } },
+    definitions: { Hit: { type: "object" } },
+  });
+  expect(z.toJSONSchema(dependent)).not.toHaveProperty("contains");
+  const named = fromJSONSchema({
+    type: "array",
+    contains: { type: "object", dependencies: { a: ["b"] } },
+  });
+  expect(z.toJSONSchema(named)).toMatchObject({ contains: { dependencies: { a: ["b"] } } });
   // a reference nested in a schema position is still caught
   const nested = fromJSONSchema({
     type: "array",

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1308,3 +1308,67 @@ test("__proto__ annotation key reaches the registry", () => {
   expect(Object.prototype.hasOwnProperty.call(meta, "__proto__")).toBe(true);
   expect(meta.__proto__).toEqual({ custom: 1 });
 });
+
+test("minProperties and maxProperties count the raw input", () => {
+  const schema = fromJSONSchema({
+    type: "object",
+    properties: { a: { type: "string" } },
+    minProperties: 1,
+    maxProperties: 2,
+  });
+  expect(schema.safeParse({ a: "x" }).success).toBe(true);
+  expect(schema.safeParse({}).error!.issues[0]).toMatchObject({ code: "too_small", origin: "object", minimum: 1 });
+  expect(schema.safeParse({ a: "x", b: 1, c: 2 }).error!.issues[0]).toMatchObject({
+    code: "too_big",
+    origin: "object",
+    maximum: 2,
+  });
+  // raw input: a defaulted property does not satisfy the minimum, and a dropped __proto__ still counts
+  const defaulted = fromJSONSchema({
+    type: "object",
+    properties: { a: { type: "string", default: "x" } },
+    minProperties: 1,
+  });
+  expect(defaulted.safeParse({}).success).toBe(false);
+  const capped = fromJSONSchema({ type: "object", maxProperties: 1 });
+  expect(capped.safeParse(JSON.parse('{"__proto__":1,"a":1}')).success).toBe(false);
+  expect(z.toJSONSchema(schema)).toMatchObject({ minProperties: 1, maxProperties: 2 });
+});
+
+test("minProperties composes with propertyNames in one guard", () => {
+  const schema = fromJSONSchema({ type: "object", propertyNames: { pattern: "^a" }, minProperties: 1 });
+  expect(schema.safeParse({}).error!.issues[0]!.code).toBe("too_small");
+  expect(schema.safeParse({ b: 1 }).error!.issues[0]!.code).toBe("invalid_key");
+  expect(schema.safeParse({ a: 1 }).success).toBe(true);
+});
+
+test("uniqueItems rejects structural duplicates", () => {
+  const schema = fromJSONSchema({ type: "array", uniqueItems: true });
+  expect(
+    schema.safeParse([
+      { a: 1, b: 2 },
+      { b: 2, a: 1 },
+    ]).error!.issues[0]
+  ).toMatchObject({
+    code: "custom",
+    path: [1],
+  });
+  expect(schema.safeParse([1, "1", true, 1]).success).toBe(false);
+  expect(schema.safeParse([{ a: 1 }, { a: 2 }, [1], [2]]).success).toBe(true);
+  expect(z.toJSONSchema(schema)).toMatchObject({ uniqueItems: true });
+});
+
+test("contains with minContains and maxContains", () => {
+  const schema = fromJSONSchema({ type: "array", contains: { type: "integer" } });
+  expect(schema.safeParse(["a"]).success).toBe(false);
+  expect(schema.safeParse(["a", 1]).success).toBe(true);
+  const bounded = fromJSONSchema({ type: "array", contains: { type: "integer" }, minContains: 2, maxContains: 3 });
+  expect(bounded.safeParse([1, "a"]).success).toBe(false);
+  expect(bounded.safeParse([1, 2, "a"]).success).toBe(true);
+  expect(bounded.safeParse([1, 2, 3, 4]).success).toBe(false);
+  // minContains: 0 accepts an array with no matches at all
+  expect(fromJSONSchema({ type: "array", contains: { type: "integer" }, minContains: 0 }).safeParse([]).success).toBe(
+    true
+  );
+  expect(z.toJSONSchema(bounded)).toMatchObject({ contains: { type: "integer" }, minContains: 2, maxContains: 3 });
+});

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1439,4 +1439,11 @@ test("a carried subschema that references $defs is dropped rather than emitted d
   // an inline subschema is self-contained, so it still round-trips
   const inline = fromJSONSchema({ type: "array", contains: { type: "integer" } });
   expect(z.toJSONSchema(inline)).toMatchObject({ contains: { type: "integer" } });
+  // a `$ref` key inside instance data is a plain key, not a reference, so the constraint still travels
+  const annotated = fromJSONSchema({
+    type: "array",
+    contains: { type: "integer", default: { $ref: "literal" } },
+  });
+  expect(annotated.safeParse(["x"]).success).toBe(false);
+  expect(z.toJSONSchema(annotated)).toMatchObject({ contains: { type: "integer" } });
 });

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1424,3 +1424,19 @@ test("uniqueItems equality follows JSON semantics", () => {
   cyclic.self = cyclic;
   expect(schema.safeParse([cyclic, cyclic]).success).toBe(true);
 });
+
+test("a carried subschema that references $defs is dropped rather than emitted dangling", () => {
+  const schema = fromJSONSchema({
+    type: "array",
+    contains: { $ref: "#/$defs/Hit" },
+    $defs: { Hit: { type: "object", properties: { id: { type: "string" } }, required: ["id"] } },
+  });
+  // enforcement is unaffected; only the round trip gives the keyword up
+  expect(schema.safeParse([{ id: "a" }]).success).toBe(true);
+  expect(schema.safeParse([{}]).success).toBe(false);
+  expect(JSON.stringify(z.toJSONSchema(schema))).not.toContain("$ref");
+  expect(z.toJSONSchema(schema)).not.toHaveProperty("contains");
+  // an inline subschema is self-contained, so it still round-trips
+  const inline = fromJSONSchema({ type: "array", contains: { type: "integer" } });
+  expect(z.toJSONSchema(inline)).toMatchObject({ contains: { type: "integer" } });
+});

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1439,11 +1439,17 @@ test("a carried subschema that references $defs is dropped rather than emitted d
   // an inline subschema is self-contained, so it still round-trips
   const inline = fromJSONSchema({ type: "array", contains: { type: "integer" } });
   expect(z.toJSONSchema(inline)).toMatchObject({ contains: { type: "integer" } });
-  // a `$ref` key inside instance data is a plain key, not a reference, so the constraint still travels
-  const annotated = fromJSONSchema({
+  // only schema positions are walked, so a `$ref` key in instance data or an unknown annotation still travels
+  for (const annotation of [{ default: { $ref: "literal" } }, { "x-note": { $ref: "literal" } }]) {
+    const annotated = fromJSONSchema({ type: "array", contains: { type: "integer", ...annotation } });
+    expect(annotated.safeParse(["x"]).success).toBe(false);
+    expect(z.toJSONSchema(annotated)).toMatchObject({ contains: { type: "integer" } });
+  }
+  // a reference nested in a schema position is still caught
+  const nested = fromJSONSchema({
     type: "array",
-    contains: { type: "integer", default: { $ref: "literal" } },
+    contains: { type: "array", items: { $ref: "#/$defs/Hit" } },
+    $defs: { Hit: { type: "string" } },
   });
-  expect(annotated.safeParse(["x"]).success).toBe(false);
-  expect(z.toJSONSchema(annotated)).toMatchObject({ contains: { type: "integer" } });
+  expect(z.toJSONSchema(nested)).not.toHaveProperty("contains");
 });

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1388,3 +1388,20 @@ test("uniqueItems and contains see the raw instance, not the parsed output", () 
   expect(unique.safeParse([{ a: "x" }, {}]).success).toBe(true);
   expect(unique.safeParse([{}, {}]).error!.issues[0]).toMatchObject({ code: "custom", path: [1] });
 });
+
+test("a guard keyword takes precedence over the length keywords", () => {
+  const schema = fromJSONSchema({ type: "array", items: { type: "integer" }, minItems: 3, uniqueItems: true });
+  // the guard runs on the input side of the pipe, so its issue aborts before minItems is reached
+  expect(schema.safeParse([1, 1]).error!.issues.map((i) => i.code)).toEqual(["custom"]);
+  expect(schema.safeParse([1, 2]).error!.issues.map((i) => i.code)).toEqual(["too_small"]);
+});
+
+test("a guard keyword drops default and examples from the input-mode document", () => {
+  // the guard is a transform on the pipe's input side, and toJSONSchema strips annotations from a transforming schema in input mode
+  const schema = fromJSONSchema({ type: "array", uniqueItems: true, default: [], examples: [[1]] });
+  expect(z.toJSONSchema(schema, { io: "input" })).not.toHaveProperty("default");
+  expect(z.toJSONSchema(schema, { io: "output" })).toMatchObject({ default: [], examples: [[1]] });
+  // without a guard keyword both modes carry them
+  const plain = fromJSONSchema({ type: "array", default: [], examples: [[1]] });
+  expect(z.toJSONSchema(plain, { io: "input" })).toMatchObject({ default: [], examples: [[1]] });
+});

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1372,3 +1372,19 @@ test("contains with minContains and maxContains", () => {
   );
   expect(z.toJSONSchema(bounded)).toMatchObject({ contains: { type: "integer" }, minContains: 2, maxContains: 3 });
 });
+
+test("uniqueItems and contains see the raw instance, not the parsed output", () => {
+  const items = { type: "object", properties: { a: { type: "string", default: "x" } } } as const;
+  // no instance item carries `a`; the default must not synthesize the match
+  const contains = fromJSONSchema({
+    type: "array",
+    items,
+    contains: { type: "object", properties: { a: { const: "x" } }, required: ["a"] },
+  });
+  expect(contains.safeParse([{}]).success).toBe(false);
+  expect(contains.safeParse([{ a: "x" }]).success).toBe(true);
+  // the instance items differ; the default must not collapse them into duplicates
+  const unique = fromJSONSchema({ type: "array", items, uniqueItems: true });
+  expect(unique.safeParse([{ a: "x" }, {}]).success).toBe(true);
+  expect(unique.safeParse([{}, {}]).error!.issues[0]).toMatchObject({ code: "custom", path: [1] });
+});

--- a/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/from-json-schema.test.ts
@@ -1405,3 +1405,22 @@ test("a guard keyword drops default and examples from the input-mode document", 
   const plain = fromJSONSchema({ type: "array", default: [], examples: [[1]] });
   expect(z.toJSONSchema(plain, { io: "input" })).toMatchObject({ default: [], examples: [[1]] });
 });
+
+test("uniqueItems equality follows JSON semantics", () => {
+  const schema = fromJSONSchema({ type: "array", uniqueItems: true });
+  expect(schema.safeParse([1, "1", true, null]).success).toBe(true);
+  expect(schema.safeParse([{ a: undefined }, {}]).success).toBe(true);
+  expect(
+    schema.safeParse([
+      [1, [2]],
+      [1, [2]],
+    ]).success
+  ).toBe(false);
+  expect(schema.safeParse([{ a: "b=c" }, { "a=b": "c" }]).success).toBe(true);
+  // every duplicate is reported against the first element it matches
+  expect(schema.safeParse([1, 1, 1]).error!.issues.map((i) => i.path[0])).toEqual([1, 2]);
+  // a cycle cannot be compared, so it is never called a duplicate rather than hanging
+  const cyclic: any = {};
+  cyclic.self = cyclic;
+  expect(schema.safeParse([cyclic, cyclic]).success).toBe(true);
+});


### PR DESCRIPTION
`fromJSONSchema` lists six validation keywords in `RECOGNIZED_KEYS` and silently drops them: `minProperties`, `maxProperties`, `uniqueItems`, `contains`, `minContains`, `maxContains`. A converted schema accepts data the source schema rejects, which is the worst failure mode for a validating converter — the file already throws for `not` and `if/then/else` rather than ignoring them.

```ts
const schema = z.fromJSONSchema({ type: "object", minProperties: 1 });
schema.safeParse({}).success; // main: true — now false
```

All six are now enforced inside the converter, with no new public API — nothing to undo when the @zod/json push happens. The property counts fold into the pre-pipe guard that already enforces `propertyNames`, so they see the raw input: a key synthesized by a property `default` does not satisfy `minProperties`, and a dropped `__proto__` still counts, matching how JSON Schema validators see the instance. `uniqueItems` and the `contains` family run as checks on the converted array schema, with structural equality (two objects with the same entries in different key order are duplicates). Each keyword is also carried into metadata the way `propertyNames` already is, so `toJSONSchema` round-trips all of them.

The `uniqueItems`/`contains` issues are `code: "custom"` with explicit messages, since no built-in issue code describes a match count; explicit messages bypass error maps, which seems acceptable for an experimental converter. `contentEncoding`/`contentMediaType`/`contentSchema` already flow into metadata on main and needed no change.

Three boundaries are deliberate rather than accidental. The keywords apply only under an explicit single `type`, matching how the converter already treats a typeless `minLength` or `minimum`; and on a union `type` like `["array", "null"]` they are enforced but not carried into metadata, the same round-trip gap `propertyNames` has today. And because the guard sits on the input side of a pipe, a guard issue aborts before `minItems`/`maxItems` are reported, and `toJSONSchema` strips `default`/`examples` from the `io: "input"` document — the price of evaluating the keywords against the raw instance, which the `propertyNames` guard has paid since it shipped. All of these, plus re-emitting a carried `contains` that points into `$defs`, belong to the converter's existing contract and the future @zod/json work; each is pinned by a test so it reads as a decision.

The two cardinality issues carry an explicit English `message`. `origin: "object"` has no `Sizable` entry in any locale, so the structured pipeline renders "expected object to be >=2" — a value comparison rather than a count, wrong in all 62 locales. An accurate message in one language beats a misleading one in every language; giving the locales an `object` entry is the fix, and it belongs with the first-class checks rather than here.

## Three axes

Measured against the merge-base with esbuild `--minify` and `gzip -9 -n` under `--conditions=@zod/source`:

| axis | result |
| --- | --- |
| bundle, classic importing `fromJSONSchema` | 36,736 → 37,567 B gz (+831; raw +2,878) |
| bundle, classic `z.object()` and `zod/mini` | +0 B — neither reaches the converter |
| construction, guarded object | 12.6 → 20.9 µs, once per schema |
| parse, guarded object | 0.03 → 0.07 µs |
| parse, 10-element array | 0.30 µs plain, 1.39 µs `uniqueItems`, 0.71 µs `contains` |
| retained per schema | 6.8 KB plain, 10.9 KB with the object guard, 9.9 KB with the array guard |

The whole cost is opt-in twice over: only a document that writes one of these keywords builds a guard, and only a bundle that imports `fromJSONSchema` carries the code. Machine load was elevated throughout, so the timings are ratios rather than absolutes; they held across two runs, and the memory figures were byte-identical.

Everything lands in `from-json-schema.ts`, so mini pays nothing and classic bundles that never import `fromJSONSchema` are byte-identical; the cost lands only on its users.

Closes #6463
