### PR TITLE
feat(v4): make z.properties() a schema, and give z.instanceof() a .properties() method

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2286,19 +2286,34 @@ blobSchema.parse("hello there!"); // ✅
 blobSchema.parse("hello."); // ❌
 ```
 
-Use `z.properties()` to declare several property checks from an object literal. It returns an array to spread into `.check()`.
+Use `.properties()` to check several properties at once. Each call narrows the inferred type.
 
 ```ts
-const httpsUrl = z.instanceof(URL).check(
-  ...z.properties({
-    protocol: z.literal("https:" as string),
-    hostname: z.string().regex(z.regexes.domain),
-  })
-);
+const httpsUrl = z.instanceof(URL).properties({
+  protocol: z.literal("https:"),
+  hostname: z.string().regex(z.regexes.domain),
+});
 
 httpsUrl.parse(new URL("https://example.com")); // ✅
-httpsUrl.parse(new URL("http://localhost")); // ❌ protocol
+httpsUrl.parse(new URL("http://localhost")); // ❌ protocol + hostname
+
+type HttpsUrl = z.infer<typeof httpsUrl>;
+// => URL & { protocol: "https:"; hostname: string }
 ```
+
+The underlying `z.properties()` is a standalone schema. It asserts the named properties in place and returns its input untouched — unlike `z.object()`, it never builds a new object, so prototypes, unlisted keys, and object identity survive. (Transforms inside the shape are validated but never written back.)
+
+```ts
+const Named = z.properties({ name: z.string() });
+
+class Dog {
+  constructor(public name: string) {}
+}
+const rex = new Dog("Rex");
+Named.parse(rex); // => rex (the same instance)
+```
+
+Spreading into `.check()` works too: `z.instanceof(URL).check(...z.properties({ ... }))`.
 
 ## Refinements
 

--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2301,7 +2301,7 @@ type HttpsUrl = z.infer<typeof httpsUrl>;
 // => URL & { protocol: "https:"; hostname: string }
 ```
 
-The underlying `z.properties()` is a standalone schema. It asserts the named properties in place and returns its input untouched — unlike `z.object()`, it never builds a new object, so prototypes, unlisted keys, and object identity survive. (Transforms inside the shape are validated but never written back.)
+The underlying `z.properties()` is a standalone schema. It asserts the named properties in place and returns its input untouched — unlike `z.object()`, it never builds a new object, so prototypes, unlisted keys, and object identity survive. Schemas inside the shape are validated but their results are discarded, so a transform or a default never changes the parsed value.
 
 ```ts
 const Named = z.properties({ name: z.string() });

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -40,15 +40,16 @@ const BUILT_ENTRY = path.join(__dirname, "node_modules", "zod", "index.js");
 const CEILINGS: Record<string, number> = {
   // raised from 2903 / 3366 / 4437 by the commit that caused it: installing a trait's members from `$constructor` rather than from its initializer costs mini +70 / +83 / +95, and every bundle carries `core.ts`; measured 2946 / 3420 / 4503 plus 28 headroom, and the per-fixture notes below record what each already carried. About half of it is the guard that keeps the install off a user subclass's prototype; the rest is writing the members as `this`-methods, since `this` is not renameable and a block body cannot collapse to an arrow.
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
-  "zod-mini-boolean": 3002,
+  // Also carries the symbol-key loop in `util.members`, which every bundle pays for `$ZodProperties`'s `Symbol.iterator`: +15/+17/+17. Measured 2989 / 3472 / 4557 plus 28 headroom.
+  "zod-mini-boolean": 3017,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
-  "zod-mini-string": 3483,
+  "zod-mini-string": 3500,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
   // Also carries the memoizer seam from #6482: each container init reads `globalConfig.memoizer` and calls `attach`, which is what lets `zod/mini` opt into cycle support. Measured 4512 locally but 4533 on CI — the gzip stream differs across zlib builds — so the headroom rides on the CI number.
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
-  "zod-mini-object": 4568,
+  "zod-mini-object": 4585,
 };
 
 /**

--- a/packages/zod/src/v4/classic/checks.ts
+++ b/packages/zod/src/v4/classic/checks.ts
@@ -21,7 +21,6 @@ export {
   _startsWith as startsWith,
   _endsWith as endsWith,
   _property as property,
-  _properties as properties,
   _mime as mime,
   _overwrite as overwrite,
   _normalize as normalize,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2752,6 +2752,7 @@ export interface ZodProperties<Shape extends core.$ZodShape = core.$ZodShape>
 export const ZodProperties: core.$constructor<ZodProperties> = /*@__PURE__*/ core.$constructor(
   "ZodProperties",
   (inst, def) => {
+    _ensureDefaultMemoizer();
     core.$ZodProperties.init(inst, def);
     ZodType.init(inst, def);
   }

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2812,7 +2812,7 @@ export interface ZodInstanceOf<T = unknown> extends ZodCustom<T, T> {
   properties<Shape extends core.$ZodShape>(
     shape: Shape,
     params?: string | core.$ZodPropertiesParams
-  ): ZodInstanceOf<T & core.$InferObjectOutput<Shape, {}>>;
+  ): ZodInstanceOf<T & core.$InferObjectInput<Shape, {}>>;
 }
 export const ZodInstanceOf: core.$constructor<ZodInstanceOf> = /*@__PURE__*/ core.$constructor(
   "ZodInstanceOf",

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2743,6 +2743,27 @@ export const ZodCustom: core.$constructor<ZodCustom> = /*@__PURE__*/ core.$const
   inst._zod.processJSONSchema = (ctx, json, params) => processors.customProcessor(inst, ctx, json, params);
 });
 
+// ZodProperties
+export interface ZodProperties<Shape extends core.$ZodShape = core.$ZodShape>
+  extends _ZodType<core.$ZodPropertiesInternals<Shape>>,
+    core.$ZodProperties<Shape> {
+  "~standard": ZodStandardSchemaWithJSON<this>;
+}
+export const ZodProperties: core.$constructor<ZodProperties> = /*@__PURE__*/ core.$constructor(
+  "ZodProperties",
+  (inst, def) => {
+    core.$ZodProperties.init(inst, def);
+    ZodType.init(inst, def);
+  }
+);
+
+export function properties<Shape extends core.$ZodShape>(
+  shape: Shape,
+  params?: string | core.$ZodPropertiesParams
+): ZodProperties<Shape> {
+  return core._properties(ZodProperties, shape, params) as any;
+}
+
 // custom checks
 export function check<O = unknown>(fn: core.CheckFn<O>): core.$ZodCheck<O> {
   const ch = new core.$ZodCheck({
@@ -2785,14 +2806,35 @@ type ZodInstanceOfParams = core.Params<
   core.$ZodIssueCustom,
   "type" | "check" | "checks" | "fn" | "abort" | "error" | "params" | "path"
 >;
+
+// ZodInstanceOf
+export interface ZodInstanceOf<T = unknown> extends ZodCustom<T, T> {
+  properties<Shape extends core.$ZodShape>(
+    shape: Shape,
+    params?: string | core.$ZodPropertiesParams
+  ): ZodInstanceOf<T & core.$InferObjectOutput<Shape, {}>>;
+}
+export const ZodInstanceOf: core.$constructor<ZodInstanceOf> = /*@__PURE__*/ core.$constructor(
+  "ZodInstanceOf",
+  (inst, def) => {
+    ZodCustom.init(inst, def);
+  },
+  {
+    properties(shape: core.$ZodShape, params?: string | core.$ZodPropertiesParams) {
+      // asserts in place, so the narrowed output type is truthful without a wrapper
+      return this.check(properties(shape, params)) as any;
+    },
+  }
+);
+
 function _instanceof<T extends typeof util.Class>(
   cls: T,
   params: ZodInstanceOfParams = {}
-): ZodCustom<InstanceType<T>, InstanceType<T>> {
-  const inst = new ZodCustom({
+): ZodInstanceOf<InstanceType<T>> {
+  const inst = new ZodInstanceOf({
     type: "custom",
     check: "custom",
-    fn: (data) => data instanceof cls,
+    fn: (data: unknown) => data instanceof cls,
     abort: true,
     ...(util.normalizeParams(params) as any),
   });

--- a/packages/zod/src/v4/classic/tests/firstparty.test.ts
+++ b/packages/zod/src/v4/classic/tests/firstparty.test.ts
@@ -80,6 +80,8 @@ test("first party switch", () => {
       break;
     case "file":
       break;
+    case "properties":
+      break;
     case "lazy":
       break;
     case "function":
@@ -169,6 +171,8 @@ test("$ZodSchemaTypes", () => {
     case "file":
       break;
     case "lazy":
+      break;
+    case "properties":
       break;
     case "function":
       break;

--- a/packages/zod/src/v4/classic/tests/instanceof.test.ts
+++ b/packages/zod/src/v4/classic/tests/instanceof.test.ts
@@ -70,9 +70,9 @@ test("z.properties", () => {
   expectTypeOf<URL>().toEqualTypeOf<z.infer<typeof httpsUrl>>();
   expect(httpsUrl.safeParse(new URL("https://example.com")).success).toBe(true);
 
-  // Checks abort on the first failure, exactly as the equivalent chain of z.property() calls does.
+  // One check iterates the whole shape, so every failing property reports — unlike the equivalent chain of z.property() calls, which aborts on the first.
   const both = httpsUrl.safeParse(new URL("http://localhost"));
-  expect(both.error!.issues.map((i) => i.path)).toEqual([["protocol"]]);
+  expect(both.error!.issues.map((i) => i.path)).toEqual([["protocol"], ["hostname"]]);
 
   // A failing base schema yields its own issue and no property issues.
   for (const input of ["not a url", null]) {
@@ -85,12 +85,12 @@ test("z.properties", () => {
     .object({ a: z.string(), b: z.string() })
     .check(...z.properties({ a: z.literal("x"), b: z.literal("y") }));
   expect(obj.safeParse({ a: "x", b: "y" }).success).toBe(true);
-  expect(obj.safeParse({ a: "!", b: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"]]);
+  expect(obj.safeParse({ a: "!", b: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"], ["b"]]);
   for (const input of [null, undefined, 5]) {
     expect(obj.safeParse(input).error!.issues.map((i) => [i.code, i.path])).toEqual([["invalid_type", []]]);
   }
 
-  // Known looseness versus the longhand, pinned so it stays deliberate: every element is typed over the whole shape, and `$ZodCheckInternals.check()` is a method, so TypeScript compares it bivariantly and accepts a check type that is a subtype of the target. Naming a key the target lacks therefore compiles here and fails at parse time, where the equivalent chain of `z.property()` calls rejects it outright. Typing each element over only its own key fixes that and breaks every valid call, since a union argument must satisfy the target on its own.
+  // Known looseness versus the longhand, pinned so it stays deliberate: the schema-as-check is typed over the whole shape, and `$ZodCheckInternals.check()` is a method, so TypeScript compares it bivariantly and accepts a check type that is a subtype of the target. Naming a key the target lacks therefore compiles here and fails at parse time, where the equivalent chain of `z.property()` calls rejects it outright.
   z.object({ a: z.string() }).check(...z.properties({ a: z.literal("x"), b: z.literal("y") }));
   expect(
     z
@@ -100,8 +100,11 @@ test("z.properties", () => {
       .error!.issues.map((i) => [i.code, i.path])
   ).toEqual([["invalid_value", ["b"]]]);
 
-  // Plain property checks carry no `when`, so the schema stays on the compiled fast path.
+  // The properties check carries no `when`, so the schema stays on the compiled fast path.
   const compiled = z.compile(httpsUrl);
   expect(compiled.safeParse(new URL("https://example.com")).success).toBe(true);
-  expect(compiled.safeParse(new URL("http://localhost")).error!.issues.map((i) => i.path)).toEqual([["protocol"]]);
+  expect(compiled.safeParse(new URL("http://localhost")).error!.issues.map((i) => i.path)).toEqual([
+    ["protocol"],
+    ["hostname"],
+  ]);
 });

--- a/packages/zod/src/v4/classic/tests/properties.test.ts
+++ b/packages/zod/src/v4/classic/tests/properties.test.ts
@@ -100,3 +100,52 @@ test("z.properties async", async () => {
   const bad = await p.safeParseAsync({ a: "!" });
   expect(bad.error!.issues.map((i) => i.path)).toEqual([["a"]]);
 });
+
+test("z.properties infers the input side", () => {
+  // nothing is written back, so an output-typed inference would lie for every shape entry whose output differs from its input
+  const withDefault = z.properties({ a: z.string().default("x") });
+  expectTypeOf<z.infer<typeof withDefault>>().toEqualTypeOf<{ a?: string | undefined }>();
+  expect(withDefault.parse({})).toEqual({});
+
+  const withTransform = z.properties({ a: z.string().transform((s) => s.length) });
+  expectTypeOf<z.infer<typeof withTransform>>().toEqualTypeOf<{ a: string }>();
+  expect(withTransform.parse({ a: "hi" })).toEqual({ a: "hi" });
+
+  // a plain schema has the same input and output, so the documented narrowing is unchanged
+  const W = z.instanceof(URL).properties({ protocol: z.literal("https:") });
+  expectTypeOf<z.infer<typeof W>>().toEqualTypeOf<URL & { protocol: "https:" }>();
+});
+
+test("z.properties validates symbol keys", () => {
+  const sym = Symbol("tag");
+  const p = z.properties({ [sym]: z.string() });
+  expect(p.safeParse({ [sym]: "ok" }).success).toBe(true);
+  expect(p.safeParse({ [sym]: 123 }).error!.issues.map((i) => i.path)).toEqual([[sym]]);
+  expect(
+    z
+      .compile(p)
+      .safeParse({ [sym]: 123 })
+      .error!.issues.map((i) => i.path)
+  ).toEqual([[sym]]);
+});
+
+test("z.properties compiled and interpreted agree on a nullish value", () => {
+  // a base that permits null reaches the check role with one; the compiled property read must not throw where the runtime reports an issue
+  const s = z.any().check(...z.properties({ a: z.string() }));
+  const expected = [["invalid_type", []]];
+  expect(s.safeParse(null).error!.issues.map((i) => [i.code, i.path])).toEqual(expected);
+  expect(
+    z
+      .compile(s)
+      .safeParse(null)
+      .error!.issues.map((i) => [i.code, i.path])
+  ).toEqual(expected);
+});
+
+test("z.properties with a custom when refuses to compile", () => {
+  // `when` gates the assertion at runtime; a union branch compiled without it is absorbed as a branch failure rather than falling back
+  const p = z.properties({ a: z.literal("x") }, { when: () => false });
+  const s = z.union([p, z.object({ b: z.string() })]);
+  const input = { a: "wrong", b: "hello" };
+  expect(z.compile(s).safeParse(input)).toEqual(s.safeParse(input));
+});

--- a/packages/zod/src/v4/classic/tests/properties.test.ts
+++ b/packages/zod/src/v4/classic/tests/properties.test.ts
@@ -1,0 +1,102 @@
+import { expect, expectTypeOf, test } from "vitest";
+import * as z from "zod/v4";
+
+test("z.properties is a schema", () => {
+  const p = z.properties({ a: z.literal("x"), b: z.literal("y") });
+
+  expectTypeOf<z.infer<typeof p>>().toEqualTypeOf<{ a: "x"; b: "y" }>();
+
+  // asserts in place: the parse returns the input identity, extra keys pass
+  const ok = { a: "x", b: "y", extra: 1 };
+  expect(p.parse(ok)).toBe(ok);
+
+  // every failing key reports
+  expect(p.safeParse({ a: "!", b: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"], ["b"]]);
+
+  // property reads work on any non-nullish value, so only null and undefined are a type error
+  expect(z.properties({ length: z.number().min(3) }).parse("abc")).toBe("abc");
+  for (const input of [null, undefined]) {
+    expect(p.safeParse(input).error!.issues.map((i) => [i.code, i.path])).toEqual([["invalid_type", []]]);
+  }
+
+  // an optional key may be absent
+  const opt = z.properties({ a: z.string().optional() });
+  expect(opt.safeParse({}).success).toBe(true);
+  expectTypeOf<z.infer<typeof opt>>().toEqualTypeOf<{ a?: string | undefined }>();
+});
+
+test("z.properties discards transformed output", () => {
+  // asserts and never writes back, exactly as z.property() behaves; a nested object schema rebuilds its output even without transforms, so identity cannot distinguish the two
+  const p = z.properties({ a: z.string().transform((s) => s.toUpperCase()) });
+  const input = { a: "hi" };
+  expect(p.parse(input)).toBe(input);
+  expect(input.a).toBe("hi");
+});
+
+test("z.properties narrows through intersection", () => {
+  const httpsUrl = z.instanceof(URL).and(z.properties({ protocol: z.literal("https:") }));
+  expectTypeOf<z.infer<typeof httpsUrl>>().toEqualTypeOf<URL & { protocol: "https:" }>();
+
+  const u = new URL("https://example.com");
+  expect(httpsUrl.parse(u)).toBe(u);
+  expect(httpsUrl.safeParse(new URL("http://example.com")).success).toBe(false);
+});
+
+test("z.instanceof().properties()", () => {
+  const httpsUrl = z.instanceof(URL).properties({ protocol: z.literal("https:") });
+  expectTypeOf<z.infer<typeof httpsUrl>>().toEqualTypeOf<URL & { protocol: "https:" }>();
+
+  const u = new URL("https://example.com");
+  expect(httpsUrl.parse(u)).toBe(u);
+  expect(httpsUrl.safeParse(new URL("http://example.com")).error!.issues.map((i) => i.path)).toEqual([["protocol"]]);
+
+  // chains, and each call narrows further
+  const chained = httpsUrl.properties({ port: z.literal("") });
+  expectTypeOf<z.infer<typeof chained>>().toEqualTypeOf<URL & { protocol: "https:" } & { port: "" }>();
+  expect(chained.safeParse(u).success).toBe(true);
+  expect(chained.safeParse(new URL("https://example.com:8443")).error!.issues.map((i) => i.path)).toEqual([["port"]]);
+});
+
+test("z.properties spreads into .check()", () => {
+  // the pre-4.6 array call sites: the schema yields itself from Symbol.iterator
+  const p = z.properties({ a: z.literal("x") });
+  const spread = [...p];
+  expect(spread).toEqual([p]);
+
+  const s = z.object({ a: z.string() }).check(...z.properties({ a: z.literal("x") }));
+  expect(s.safeParse({ a: "x" }).success).toBe(true);
+  expect(s.safeParse({ a: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"]]);
+});
+
+test("z.properties JSON Schema", () => {
+  const p = z.properties({ a: z.string(), b: z.number().optional() });
+  expect(z.toJSONSchema(p)).toEqual({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    properties: { a: { type: "string" }, b: { type: "number" } },
+    required: ["a"],
+  });
+});
+
+test("z.properties compiles", () => {
+  const p = z.properties({ a: z.literal("x"), b: z.literal("y") });
+  const compiled = z.compile(p);
+  const ok = { a: "x", b: "y", extra: 1 };
+  expect(compiled.parse(ok)).toBe(ok);
+  expect(compiled.safeParse({ a: "!", b: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"], ["b"]]);
+  expect(compiled.safeParse(null).error!.issues.map((i) => [i.code, i.path])).toEqual([["invalid_type", []]]);
+
+  // nested in a container
+  const outer = z.compile(z.object({ url: z.instanceof(URL).properties({ protocol: z.literal("https:") }) }));
+  expect(outer.safeParse({ url: new URL("http://example.com") }).error!.issues.map((i) => i.path)).toEqual([
+    ["url", "protocol"],
+  ]);
+});
+
+test("z.properties async", async () => {
+  const p = z.properties({ a: z.string().refine(async (s) => s.length > 1) });
+  const ok = { a: "hi" };
+  await expect(p.parseAsync(ok)).resolves.toBe(ok);
+  const bad = await p.safeParseAsync({ a: "!" });
+  expect(bad.error!.issues.map((i) => i.path)).toEqual([["a"]]);
+});

--- a/packages/zod/src/v4/classic/tests/properties.test.ts
+++ b/packages/zod/src/v4/classic/tests/properties.test.ts
@@ -143,9 +143,28 @@ test("z.properties compiled and interpreted agree on a nullish value", () => {
 });
 
 test("z.properties with a custom when refuses to compile", () => {
-  // `when` gates the assertion at runtime; a union branch compiled without it is absorbed as a branch failure rather than falling back
-  const p = z.properties({ a: z.literal("x") }, { when: () => false });
-  const s = z.union([p, z.object({ b: z.string() })]);
+  // `when` is not publicly settable, since it gates a check inside the run loop and means nothing to a parsed schema. A hand-built def can still carry one, and compiling it must refuse rather than run the shape unconditionally: a union branch compiles to its own IIFE, so a wrong rejection is absorbed as a branch failure with no fallback.
+  const p = new z.core.$ZodProperties({
+    type: "properties",
+    check: "properties",
+    shape: { a: z.literal("x") },
+    when: () => false,
+  });
+  const s = z.union([p as unknown as z.ZodType, z.object({ b: z.string() })]);
   const input = { a: "wrong", b: "hello" };
   expect(z.compile(s).safeParse(input)).toEqual(s.safeParse(input));
+});
+
+test("z.properties parses cyclic input", () => {
+  // the input is its own output, so it registers as its own memo entry; without that a cycle re-enters forever
+  const Node: z.ZodType<{ id: string; next?: unknown }> = z.lazy(() =>
+    z.properties({ id: z.string(), next: Node.optional() })
+  );
+  const cyclic: Record<string, unknown> = { id: "a" };
+  cyclic.next = cyclic;
+  expect(Node.parse(cyclic)).toBe(cyclic);
+  expect(z.compile(Node).parse(cyclic)).toBe(cyclic);
+
+  // the cycle guard must not swallow a real failure further down
+  expect(Node.safeParse({ id: "a", next: { id: 1 } }).error!.issues.map((i) => i.path)).toEqual([["next", "id"]]);
 });

--- a/packages/zod/src/v4/classic/tests/properties.test.ts
+++ b/packages/zod/src/v4/classic/tests/properties.test.ts
@@ -168,3 +168,21 @@ test("z.properties parses cyclic input", () => {
   // the cycle guard must not swallow a real failure further down
   expect(Node.safeParse({ id: "a", next: { id: 1 } }).error!.issues.map((i) => i.path)).toEqual([["next", "id"]]);
 });
+
+test("z.properties asserts forward while encoding", () => {
+  // both sides declare the shape's input type, so encoding must still check the value against it; running the children backward would encode them and reject that type
+  const codec = z.codec(z.string(), z.number(), { decode: (s) => Number(s), encode: (n) => String(n) });
+  const p = z.properties({ a: codec, b: z.string().transform((s) => s.length) });
+  const value = { a: "1", b: "hi" };
+  expect(z.decode(p, value)).toBe(value);
+  expect(z.encode(p, value)).toBe(value);
+  expect(z.safeEncode(p, { a: 1, b: "hi" } as never).error!.issues.map((i) => i.path)).toEqual([["a"]]);
+});
+
+test("z.properties parses a cyclic callable", () => {
+  // property reads work on a function too, so the cycle guard has to recognize one as a reference
+  const Fn: z.ZodType<{ self?: unknown }> = z.lazy(() => z.properties({ self: Fn.optional() }));
+  const fn = (() => {}) as unknown as Record<string, unknown>;
+  fn.self = fn;
+  expect(Fn.parse(fn)).toBe(fn);
+});

--- a/packages/zod/src/v4/classic/tests/properties.test.ts
+++ b/packages/zod/src/v4/classic/tests/properties.test.ts
@@ -13,11 +13,21 @@ test("z.properties is a schema", () => {
   // every failing key reports
   expect(p.safeParse({ a: "!", b: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"], ["b"]]);
 
-  // property reads work on any non-nullish value, so only null and undefined are a type error
-  expect(z.properties({ length: z.number().min(3) }).parse("abc")).toBe("abc");
-  for (const input of [null, undefined]) {
+  // as a schema it is the type gate and infers an object shape, so a primitive is a type error
+  for (const input of [null, undefined, 5, "abc"]) {
     expect(p.safeParse(input).error!.issues.map((i) => [i.code, i.path])).toEqual([["invalid_type", []]]);
   }
+
+  // as a check the base already typed the value, so the properties are asserted on whatever it produced — a string's length, as z.property() does
+  const long = z.string().check(...z.properties({ length: z.number().min(3) }));
+  expect(long.parse("abc")).toBe("abc");
+  expect(long.safeParse("ab").error!.issues.map((i) => i.path)).toEqual([["length"]]);
+  expect(
+    z
+      .compile(long)
+      .safeParse("ab")
+      .error!.issues.map((i) => i.path)
+  ).toEqual([["length"]]);
 
   // an optional key may be absent
   const opt = z.properties({ a: z.string().optional() });
@@ -185,4 +195,31 @@ test("z.properties parses a cyclic callable", () => {
   const fn = (() => {}) as unknown as Record<string, unknown>;
   fn.self = fn;
   expect(Fn.parse(fn)).toBe(fn);
+});
+
+test("z.properties survives shape mutation", () => {
+  // key and schema are snapshotted together; caching one and reading the other live paired a stale key with a missing schema
+  const shape: Record<string, z.ZodType> = { a: z.string() };
+  const p = z.properties(shape);
+  expect(p.safeParse({ a: "x" }).success).toBe(true);
+  delete shape.a;
+  expect(p.safeParse({ a: "x" }).success).toBe(true);
+  shape.b = z.string();
+  expect(p.safeParse({ a: "x" }).success).toBe(true);
+});
+
+test("z.properties JSON Schema describes the input side", () => {
+  // the parsed value is the input, so a defaulted key that stays absent must not be required of the output either
+  const p = z.properties({ a: z.string().default("x") });
+  expect(p.parse({})).toEqual({});
+  expect(z.toJSONSchema(p, { io: "output" })).toEqual({
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    properties: { a: { default: "x", type: "string" } },
+  });
+
+  // an output mode emission for a transforming child would describe a value this schema never returns
+  const t = z.properties({ a: z.string().transform((s) => s.length) });
+  expect(() => z.toJSONSchema(t, { io: "output" })).toThrow(/cannot be represented/);
+  expect(z.toJSONSchema(t, { io: "input" })).toMatchObject({ properties: { a: { type: "string" } }, required: ["a"] });
 });

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1127,13 +1127,19 @@ export function _property<K extends string, T extends schemas.$ZodType>(
   });
 }
 
+export type $ZodPropertiesParams = CheckTypeParams<schemas.$ZodProperties, "shape">;
 // @__NO_SIDE_EFFECTS__
 export function _properties<Shape extends schemas.$ZodShape>(
-  shape: Shape
-): checks.$ZodCheckProperty<{ -readonly [k in keyof Shape]: core.output<Shape[k]> }>[] {
-  return Object.entries(shape).map(
-    ([property, schema]) => new checks.$ZodCheckProperty({ check: "property", property, schema })
-  ) as any;
+  Class: util.SchemaClass<schemas.$ZodProperties>,
+  shape: Shape,
+  params?: string | $ZodPropertiesParams
+): schemas.$ZodProperties<Shape> {
+  return new Class({
+    type: "properties",
+    check: "properties",
+    shape,
+    ...util.normalizeParams(params),
+  }) as any;
 }
 
 export type $ZodCheckMimeTypeParams = CheckParams<checks.$ZodCheckMimeType, "mime" | "when">;

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1127,7 +1127,8 @@ export function _property<K extends string, T extends schemas.$ZodType>(
   });
 }
 
-export type $ZodPropertiesParams = CheckTypeParams<schemas.$ZodProperties, "shape">;
+// `when` is omitted: it gates a check inside the run loop, so it means nothing when this is parsed as a schema, and honoring it in one role only would diverge silently
+export type $ZodPropertiesParams = CheckTypeParams<schemas.$ZodProperties, "shape" | "when">;
 // @__NO_SIDE_EFFECTS__
 export function _properties<Shape extends schemas.$ZodShape>(
   Class: util.SchemaClass<schemas.$ZodProperties>,

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -17,7 +17,7 @@ import {
   urlHostnameOk,
   urlProtocolOk,
 } from "./schemas.js";
-import type { $ZodProperties, ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
+import type { $ZodProperties, $ZodPropertiesDef, ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
 import * as util from "./util.js";
 
 /** @internal Sentinel the compiled fast path returns when validation fails. */
@@ -420,7 +420,7 @@ function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accesso
         generatePropertyCheck(doc, ctx, def, currentAccessor);
         break;
       case "properties":
-        generatePropertiesChecks(doc, ctx, def.shape as Record<string, SomeType>, currentAccessor);
+        generatePropertiesChecks(doc, ctx, def, currentAccessor);
         break;
       case "overwrite": {
         // Overwrite transforms the value - create new variable for transformed result
@@ -578,16 +578,20 @@ function generateMimeTypeCheck(
 }
 
 // asserts each named property in place; children compile assert-only because z.properties never rebuilds its input
-function generatePropertiesChecks(
-  doc: Doc,
-  ctx: CompileContext,
-  shape: Record<string, SomeType>,
-  accessor: string
-): void {
-  for (const key of Object.keys(shape)) {
+function generatePropertiesChecks(doc: Doc, ctx: CompileContext, def: $ZodPropertiesDef, accessor: string): void {
+  // a custom `when` gates the assertion at runtime; inside a union a wrongly-run branch is absorbed as a branch failure rather than falling back, so refuse at codegen the way the check role does
+  if (def.when) {
+    throw new ZodCompileUnsupportedError(`check with a custom "when" condition`);
+  }
+  // the runtime reports invalid_type for a nullish value; without this the generated property read throws instead
+  doc.write(`if (${accessor} == null) return INVALID;`);
+  const shape = def.shape as Record<string | symbol, SomeType>;
+  for (const key of Reflect.ownKeys(shape)) {
+    // a symbol has no source literal, so it is hoisted as a constant
+    const keyExpr = typeof key === "symbol" ? addConstant(ctx, key) : util.esc(key);
     // cache the property read so a getter runs exactly once, matching the runtime
     const inputVar = newVar(ctx);
-    doc.write(`const ${inputVar} = ${accessor}[${util.esc(key)}];`);
+    doc.write(`const ${inputVar} = ${accessor}[${keyExpr}];`);
     compileChild(doc, ctx, shape[key]!, inputVar, false);
   }
 }
@@ -1026,13 +1030,7 @@ function generateCheck(
       typeAccessor = generateCustomCheck(doc, ctx, schema, accessor);
       break;
     case "properties":
-      doc.write(`if (${accessor} == null) return INVALID;`);
-      generatePropertiesChecks(
-        doc,
-        ctx,
-        (schema as $ZodProperties)._zod.def.shape as Record<string, SomeType>,
-        accessor
-      );
+      generatePropertiesChecks(doc, ctx, (schema as $ZodProperties)._zod.def, accessor);
       typeAccessor = accessor;
       break;
     case "transform":

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -420,7 +420,7 @@ function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accesso
         generatePropertyCheck(doc, ctx, def, currentAccessor);
         break;
       case "properties":
-        generatePropertiesChecks(doc, ctx, def, currentAccessor);
+        generatePropertiesChecks(doc, ctx, def, currentAccessor, false);
         break;
       case "overwrite": {
         // Overwrite transforms the value - create new variable for transformed result
@@ -578,13 +578,23 @@ function generateMimeTypeCheck(
 }
 
 // asserts each named property in place; children compile assert-only because z.properties never rebuilds its input
-function generatePropertiesChecks(doc: Doc, ctx: CompileContext, def: $ZodPropertiesDef, accessor: string): void {
+function generatePropertiesChecks(
+  doc: Doc,
+  ctx: CompileContext,
+  def: $ZodPropertiesDef,
+  accessor: string,
+  schemaRole: boolean
+): void {
   // a custom `when` gates the assertion at runtime; inside a union a wrongly-run branch is absorbed as a branch failure rather than falling back, so refuse at codegen the way the check role does
   if (def.when) {
     throw new ZodCompileUnsupportedError(`check with a custom "when" condition`);
   }
-  // the runtime reports invalid_type for a nullish value; without this the generated property read throws instead
-  doc.write(`if (${accessor} == null) return INVALID;`);
+  // matches the runtime gate for whichever role this is: a schema rejects a primitive outright, a check only a nullish value
+  doc.write(
+    schemaRole
+      ? `if (${accessor} === null || (typeof ${accessor} !== "object" && typeof ${accessor} !== "function")) return INVALID;`
+      : `if (${accessor} == null) return INVALID;`
+  );
   const shape = def.shape as Record<string | symbol, SomeType>;
   for (const key of Reflect.ownKeys(shape)) {
     // a symbol has no source literal, so it is hoisted as a constant
@@ -1030,7 +1040,7 @@ function generateCheck(
       typeAccessor = generateCustomCheck(doc, ctx, schema, accessor);
       break;
     case "properties":
-      generatePropertiesChecks(doc, ctx, (schema as $ZodProperties)._zod.def, accessor);
+      generatePropertiesChecks(doc, ctx, (schema as $ZodProperties)._zod.def, accessor, true);
       typeAccessor = accessor;
       break;
     case "transform":

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -17,7 +17,7 @@ import {
   urlHostnameOk,
   urlProtocolOk,
 } from "./schemas.js";
-import type { ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
+import type { $ZodProperties, ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
 import * as util from "./util.js";
 
 /** @internal Sentinel the compiled fast path returns when validation fails. */
@@ -82,6 +82,7 @@ type SupportedCheck =
   | checks.$ZodCheckLengthEquals
   | checks.$ZodCheckStringFormat
   | checks.$ZodCheckProperty
+  | $ZodProperties
   | checks.$ZodCheckMimeType
   | checks.$ZodCheckOverwrite
   | { _zod: { def: { check: "custom"; fn?: (value: unknown) => boolean }; check?: (payload: unknown) => unknown } };
@@ -418,6 +419,9 @@ function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accesso
       case "property":
         generatePropertyCheck(doc, ctx, def, currentAccessor);
         break;
+      case "properties":
+        generatePropertiesChecks(doc, ctx, def.shape as Record<string, SomeType>, currentAccessor);
+        break;
       case "overwrite": {
         // Overwrite transforms the value - create new variable for transformed result
         const newAccessor = newVar(ctx);
@@ -570,6 +574,21 @@ function generateMimeTypeCheck(
   if (mimeTypes && mimeTypes.length > 0) {
     const mimeSet = addConstant(ctx, new Set(mimeTypes));
     doc.write(`if (!${mimeSet}.has(${accessor}.type)) return INVALID;`);
+  }
+}
+
+// asserts each named property in place; children compile assert-only because z.properties never rebuilds its input
+function generatePropertiesChecks(
+  doc: Doc,
+  ctx: CompileContext,
+  shape: Record<string, SomeType>,
+  accessor: string
+): void {
+  for (const key of Object.keys(shape)) {
+    // cache the property read so a getter runs exactly once, matching the runtime
+    const inputVar = newVar(ctx);
+    doc.write(`const ${inputVar} = ${accessor}[${util.esc(key)}];`);
+    compileChild(doc, ctx, shape[key]!, inputVar, false);
   }
 }
 
@@ -861,6 +880,7 @@ type SupportedSchemaType =
   | "lazy"
   | "pipe"
   | "custom"
+  | "properties"
   | "transform"
   | "catch";
 
@@ -1004,6 +1024,16 @@ function generateCheck(
       break;
     case "custom":
       typeAccessor = generateCustomCheck(doc, ctx, schema, accessor);
+      break;
+    case "properties":
+      doc.write(`if (${accessor} == null) return INVALID;`);
+      generatePropertiesChecks(
+        doc,
+        ctx,
+        (schema as $ZodProperties)._zod.def.shape as Record<string, SomeType>,
+        accessor
+      );
+      typeAccessor = accessor;
       break;
     case "transform":
       typeAccessor = generateTransformCheck(doc, ctx, schema, accessor);

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -372,6 +372,15 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
 export const propertiesProcessor: Processor<schemas.$ZodProperties> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.ObjectSchema;
   const def = schema._zod.def;
+
+  // dropping a symbol key silently would emit a schema that asserts less than this one does
+  if (
+    Object.getOwnPropertySymbols(def.shape).length &&
+    handleUnrepresentable(schema, ctx, json, params, "Symbol keys cannot be represented in JSON Schema")
+  ) {
+    return;
+  }
+
   json.type = "object";
   json.properties = {};
   for (const key in def.shape) {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -15,6 +15,7 @@ import {
   finalize,
   handleUnrepresentable,
   initializeContext,
+  isTransforming,
   process,
 } from "./to-json-schema.js";
 import { assignProp, getEnumValues } from "./util.js";
@@ -381,6 +382,24 @@ export const propertiesProcessor: Processor<schemas.$ZodProperties> = (schema, c
     return;
   }
 
+  // the parsed value is the input, so an output-mode emission would describe a transformed value this schema never returns
+  if (ctx.io === "output") {
+    for (const key in def.shape) {
+      if (
+        isTransforming(def.shape[key]!) &&
+        handleUnrepresentable(
+          schema,
+          ctx,
+          json,
+          params,
+          `z.properties() returns its input, so the output of a transforming schema at key "${key}" cannot be represented in JSON Schema`
+        )
+      ) {
+        return;
+      }
+    }
+  }
+
   json.type = "object";
   json.properties = {};
   for (const key in def.shape) {
@@ -393,10 +412,8 @@ export const propertiesProcessor: Processor<schemas.$ZodProperties> = (schema, c
       })
     );
   }
-  const required = Object.keys(def.shape).filter((key) => {
-    const field = def.shape[key]!;
-    return ctx.io === "input" ? inputOptin(field) === undefined : field._zod.optout === undefined;
-  });
+  // input-side optionality in both modes: the parsed value is the input, so a defaulted key that stays absent must not be required of the output either
+  const required = Object.keys(def.shape).filter((key) => inputOptin(def.shape[key]!) === undefined);
   if (required.length > 0) json.required = required;
 };
 

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -368,6 +368,29 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
   }
 };
 
+// asserts named properties in place and passes everything else through, so no additionalProperties constraint is emitted
+export const propertiesProcessor: Processor<schemas.$ZodProperties> = (schema, ctx, _json, params) => {
+  const json = _json as JSONSchema.ObjectSchema;
+  const def = schema._zod.def;
+  json.type = "object";
+  json.properties = {};
+  for (const key in def.shape) {
+    assignProp(
+      json.properties,
+      key,
+      process(def.shape[key]!, ctx as any, {
+        ...params,
+        path: [...params.path, "properties", key],
+      })
+    );
+  }
+  const required = Object.keys(def.shape).filter((key) => {
+    const field = def.shape[key]!;
+    return ctx.io === "input" ? inputOptin(field) === undefined : field._zod.optout === undefined;
+  });
+  if (required.length > 0) json.required = required;
+};
+
 export const unionProcessor: Processor<schemas.$ZodUnion> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodUnionDef;
   // Exclusive unions (inclusive === false) use oneOf (exactly one match) instead of anyOf (one or more matches). This includes both z.xor() and discriminated unions
@@ -747,6 +770,7 @@ export const allProcessors: Record<string, Processor<any>> = {
   file: fileProcessor,
   success: successProcessor,
   custom: customProcessor,
+  properties: propertiesProcessor,
   function: functionProcessor,
   transform: transformProcessor,
   map: mapProcessor,

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -56,6 +56,10 @@ function isRecursive(inst: $ZodType, stack: Set<object>): boolean {
       check(def.catchall);
       break;
     }
+    case "properties": {
+      for (const key of Reflect.ownKeys(def.shape)) check(def.shape[key]);
+      break;
+    }
     case "array":
       check(def.element);
       break;

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -27,7 +27,7 @@ type WithState = { [STATE]?: State };
 
 const NO_ISSUES: errors.$ZodRawIssue[] = [];
 
-// A value a cycle can close through. `z.properties()` asserts on any non-nullish value, so a callable is one too; every other container rejects a function before it gets here.
+// a value a cycle can close through; callables count, since z.properties asserts on one
 function isRef(value: unknown): value is object {
   return value !== null && (typeof value === "object" || typeof value === "function");
 }

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -27,6 +27,11 @@ type WithState = { [STATE]?: State };
 
 const NO_ISSUES: errors.$ZodRawIssue[] = [];
 
+// A value a cycle can close through. `z.properties()` asserts on any non-nullish value, so a callable is one too; every other container rejects a function before it gets here.
+function isRef(value: unknown): value is object {
+  return value !== null && (typeof value === "object" || typeof value === "function");
+}
+
 // Receivers prefix paths in place, so the cache and every hand-out need their own copies.
 function cloneIssues(issues: errors.$ZodRawIssue[]): errors.$ZodRawIssue[] {
   return issues.map((iss) => (iss.path ? { ...iss, path: iss.path.slice() } : { ...iss }));
@@ -221,7 +226,7 @@ const memo: $ZodMemoizer = {
         }
 
         const input = payload.value;
-        if (input === null || typeof input !== "object") return base(payload, ctx);
+        if (!isRef(input)) return base(payload, ctx);
 
         let state = (ctx as WithState)[STATE];
         if (!state) {
@@ -284,5 +289,5 @@ export function memoizer(): $ZodMemoizer {
 /** Whether this value is a node a back-edge resolved to before it finished. */
 export function isBackEdge(ctx: object, value: unknown): boolean {
   const backEdges = (ctx as WithState)[STATE]?.backEdges;
-  return backEdges !== undefined && value !== null && typeof value === "object" && backEdges.has(value);
+  return backEdges !== undefined && isRef(value) && backEdges.has(value);
 }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -5002,23 +5002,18 @@ function handlePropertiesResult(result: ParsePayload, payload: ParsePayload, key
 export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ core.$constructor(
   "$ZodProperties",
   (inst, def) => {
-    checks.$ZodCheck.init(inst, def);
+    // $ZodType.init prepends an instance that already carries the $ZodCheck trait to its own `checks`, which would run the shape a second time and cost the parse context. Initializing the check trait after it keeps the schema role in `parse`, where the context arrives.
     $ZodType.init(inst, def);
+    checks.$ZodCheck.init(inst, def);
 
-    // the base init runs a dual schema/check instance as its own first check, so parse is only the type gate and the shape loop lives in check, like $ZodCustom
-    inst._zod.parse = (payload, _) => {
-      // property reads work on any non-nullish value (string length, class instances), so only null and undefined are rejected outright
-      if (payload.value == null) {
-        payload.issues.push({ expected: "object", code: "invalid_type", input: payload.value, inst });
-      }
-      return payload;
-    };
+    const memo = core.globalConfig.memoizer;
+    memo?.attach(inst);
 
     let keys!: (string | symbol)[];
-    inst._zod.check = (payload) => {
+    const runShape = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<void> => {
       keys ??= Reflect.ownKeys(def.shape);
       const input = payload.value as any;
-      // reached with a nullish value only as a check on a base that allows one (z.any and friends); the schema role's own gate aborts before checks run
+      // property reads work on any non-nullish value (a string's length, a class instance), so only null and undefined are rejected outright
       if (input == null) {
         payload.issues.push({ expected: "object", code: "invalid_type", input, inst });
         return undefined;
@@ -5027,7 +5022,7 @@ export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ c
       for (const key of keys) {
         const result = (def.shape as Record<string | symbol, $ZodType>)[key]!._zod.run(
           { value: input[key], issues: [] },
-          {}
+          ctx
         );
         if (result instanceof Promise) {
           proms ??= [];
@@ -5039,6 +5034,18 @@ export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ c
       if (proms) return Promise.all(proms).then(() => undefined);
       return undefined;
     };
+
+    inst._zod.parse = (payload, ctx) => {
+      // the input is its own output here, so it registers as its own memo entry: a cycle re-entering this node hits the bucket instead of recursing forever
+      if (memo && payload.value !== null && typeof payload.value === "object") {
+        memo.alloc(inst, payload, payload.value, ctx);
+      }
+      const result = runShape(payload, ctx);
+      return result instanceof Promise ? result.then(() => payload) : payload;
+    };
+
+    // the check role gets no context of its own, matching z.property(); a cycle through a schema spread into `.check()` is not tracked
+    inst._zod.check = (payload) => runShape(payload, {});
   },
   {
     *[Symbol.iterator]() {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4977,9 +4977,10 @@ export interface $ZodPropertiesDef<Shape extends $ZodShape = $ZodShape> extends 
   shape: Shape;
 }
 
+// both sides infer the INPUT type: the shape is asserted and its results discarded, so a default, catch or transform inside it would make an output-typed inference a lie
 export interface $ZodPropertiesInternals<Shape extends $ZodShape = $ZodShape>
-  extends $ZodTypeInternals<$InferObjectOutput<Shape, {}>, $InferObjectInput<Shape, {}>>,
-    checks.$ZodCheckInternals<$InferObjectOutput<Shape, {}>> {
+  extends $ZodTypeInternals<$InferObjectInput<Shape, {}>, $InferObjectInput<Shape, {}>>,
+    checks.$ZodCheckInternals<$InferObjectInput<Shape, {}>> {
   def: $ZodPropertiesDef<Shape>;
   isst: errors.$ZodIssueInvalidType;
   issc: errors.$ZodIssue;
@@ -4992,7 +4993,7 @@ export interface $ZodProperties<Shape extends $ZodShape = $ZodShape> extends $Zo
 }
 
 // asserts in place: the child result's value is discarded, matching z.property(), because a nested object or array schema rebuilds its output even when nothing transformed
-function handlePropertiesResult(result: ParsePayload, payload: ParsePayload, key: string): void {
+function handlePropertiesResult(result: ParsePayload, payload: ParsePayload, key: string | symbol): void {
   if (result.issues.length) {
     payload.issues.push(...util.prefixIssues(key, result.issues));
   }
@@ -5013,9 +5014,9 @@ export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ c
       return payload;
     };
 
-    let keys!: string[];
+    let keys!: (string | symbol)[];
     inst._zod.check = (payload) => {
-      keys ??= Object.keys(def.shape);
+      keys ??= Reflect.ownKeys(def.shape);
       const input = payload.value as any;
       // reached with a nullish value only as a check on a base that allows one (z.any and friends); the schema role's own gate aborts before checks run
       if (input == null) {
@@ -5024,7 +5025,10 @@ export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ c
       }
       let proms: Promise<any>[] | undefined;
       for (const key of keys) {
-        const result = def.shape[key]!._zod.run({ value: input[key], issues: [] }, {});
+        const result = (def.shape as Record<string | symbol, $ZodType>)[key]!._zod.run(
+          { value: input[key], issues: [] },
+          {}
+        );
         if (result instanceof Promise) {
           proms ??= [];
           proms.push(result.then((result) => handlePropertiesResult(result, payload, key)));

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -5009,21 +5009,14 @@ export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ c
     const memo = core.globalConfig.memoizer;
     memo?.attach(inst);
 
-    let keys!: (string | symbol)[];
+    // key and schema snapshotted together: reading one live and the other cached lets a later mutation of the caller's shape object pair a stale key with a missing schema
+    let entries!: [string | symbol, $ZodType][];
     const runShape = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<void> => {
-      keys ??= Reflect.ownKeys(def.shape);
+      entries ??= Reflect.ownKeys(def.shape).map((key) => [key, (def.shape as any)[key] as $ZodType]);
       const input = payload.value as any;
-      // property reads work on any non-nullish value (a string's length, a class instance), so only null and undefined are rejected outright
-      if (input == null) {
-        payload.issues.push({ expected: "object", code: "invalid_type", input, inst });
-        return undefined;
-      }
       let proms: Promise<any>[] | undefined;
-      for (const key of keys) {
-        const result = (def.shape as Record<string | symbol, $ZodType>)[key]!._zod.run(
-          { value: input[key], issues: [] },
-          ctx
-        );
+      for (const [key, schema] of entries) {
+        const result = schema._zod.run({ value: input[key], issues: [] }, ctx);
         if (result instanceof Promise) {
           proms ??= [];
           proms.push(result.then((result) => handlePropertiesResult(result, payload, key)));
@@ -5036,22 +5029,28 @@ export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ c
     };
 
     inst._zod.parse = (payload, ctx) => {
+      const input = payload.value;
+      // as a schema this is the type gate, and it infers an object shape, so a primitive is a type error. A function passes: its properties read like any other object's, and z.instanceof allows one.
+      if (input === null || (typeof input !== "object" && typeof input !== "function")) {
+        payload.issues.push({ expected: "object", code: "invalid_type", input, inst });
+        return payload;
+      }
       // both sides declare the shape's input type, so the assertion runs forward in either direction; encoding the children backward would reject the very type this schema claims to take
       if (ctx.direction === "backward") ctx = { ...ctx, direction: "forward" };
       // the input is its own output here, so it registers as its own memo entry: a cycle re-entering this node hits the bucket instead of recursing forever
-      if (
-        memo &&
-        payload.value !== null &&
-        (typeof payload.value === "object" || typeof payload.value === "function")
-      ) {
-        memo.alloc(inst, payload, payload.value, ctx);
-      }
+      if (memo) memo.alloc(inst, payload, input, ctx);
       const result = runShape(payload, ctx);
       return result instanceof Promise ? result.then(() => payload) : payload;
     };
 
-    // the check role gets no context of its own, matching z.property(); a cycle through a schema spread into `.check()` is not tracked
-    inst._zod.check = (payload) => runShape(payload, {});
+    // as a check the base schema already typed the value, so this only asserts the properties — which read on a primitive too, matching z.property() on a string's length. It gets no context of its own, so a cycle through a spread schema is not tracked.
+    inst._zod.check = (payload) => {
+      if (payload.value == null) {
+        payload.issues.push({ expected: "object", code: "invalid_type", input: payload.value, inst });
+        return undefined;
+      }
+      return runShape(payload, {});
+    };
   },
   {
     *[Symbol.iterator]() {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -94,7 +94,8 @@ export interface $ZodTypeDef {
     | "promise"
     | "lazy"
     | "function"
-    | "custom";
+    | "custom"
+    | "properties";
   error?: errors.$ZodErrorMap<never> | undefined;
   checks?: checks.$ZodCheck<never>[];
 }
@@ -4963,6 +4964,85 @@ function handleRefineResult(result: unknown, payload: ParsePayload, input: unkno
   }
 }
 
+////////////////////////////////////////
+////////////////////////////////////////
+//////////                    //////////
+//////////  $ZodProperties    //////////
+//////////                    //////////
+////////////////////////////////////////
+////////////////////////////////////////
+export interface $ZodPropertiesDef<Shape extends $ZodShape = $ZodShape> extends $ZodTypeDef, checks.$ZodCheckDef {
+  type: "properties";
+  check: "properties";
+  shape: Shape;
+}
+
+export interface $ZodPropertiesInternals<Shape extends $ZodShape = $ZodShape>
+  extends $ZodTypeInternals<$InferObjectOutput<Shape, {}>, $InferObjectInput<Shape, {}>>,
+    checks.$ZodCheckInternals<$InferObjectOutput<Shape, {}>> {
+  def: $ZodPropertiesDef<Shape>;
+  isst: errors.$ZodIssueInvalidType;
+  issc: errors.$ZodIssue;
+}
+
+export interface $ZodProperties<Shape extends $ZodShape = $ZodShape> extends $ZodType {
+  _zod: $ZodPropertiesInternals<Shape>;
+  // yields the schema itself, so pre-4.6 `.check(...z.properties(shape))` spread call sites keep working
+  [Symbol.iterator](): Iterator<this>;
+}
+
+// asserts in place: the child result's value is discarded, matching z.property(), because a nested object or array schema rebuilds its output even when nothing transformed
+function handlePropertiesResult(result: ParsePayload, payload: ParsePayload, key: string): void {
+  if (result.issues.length) {
+    payload.issues.push(...util.prefixIssues(key, result.issues));
+  }
+}
+
+export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ core.$constructor(
+  "$ZodProperties",
+  (inst, def) => {
+    checks.$ZodCheck.init(inst, def);
+    $ZodType.init(inst, def);
+
+    // the base init runs a dual schema/check instance as its own first check, so parse is only the type gate and the shape loop lives in check, like $ZodCustom
+    inst._zod.parse = (payload, _) => {
+      // property reads work on any non-nullish value (string length, class instances), so only null and undefined are rejected outright
+      if (payload.value == null) {
+        payload.issues.push({ expected: "object", code: "invalid_type", input: payload.value, inst });
+      }
+      return payload;
+    };
+
+    let keys!: string[];
+    inst._zod.check = (payload) => {
+      keys ??= Object.keys(def.shape);
+      const input = payload.value as any;
+      // reached with a nullish value only as a check on a base that allows one (z.any and friends); the schema role's own gate aborts before checks run
+      if (input == null) {
+        payload.issues.push({ expected: "object", code: "invalid_type", input, inst });
+        return undefined;
+      }
+      let proms: Promise<any>[] | undefined;
+      for (const key of keys) {
+        const result = def.shape[key]!._zod.run({ value: input[key], issues: [] }, {});
+        if (result instanceof Promise) {
+          proms ??= [];
+          proms.push(result.then((result) => handlePropertiesResult(result, payload, key)));
+        } else {
+          handlePropertiesResult(result, payload, key);
+        }
+      }
+      if (proms) return Promise.all(proms).then(() => undefined);
+      return undefined;
+    };
+  },
+  {
+    *[Symbol.iterator]() {
+      yield this;
+    },
+  }
+);
+
 export type $ZodTypes =
   | $ZodString
   | $ZodNumber
@@ -4995,6 +5075,7 @@ export type $ZodTypes =
   | $ZodPrefault
   | $ZodTemplateLiteral
   | $ZodCustom
+  | $ZodProperties
   | $ZodTransform
   | $ZodNonOptional
   | $ZodReadonly

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -5036,8 +5036,14 @@ export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ c
     };
 
     inst._zod.parse = (payload, ctx) => {
+      // both sides declare the shape's input type, so the assertion runs forward in either direction; encoding the children backward would reject the very type this schema claims to take
+      if (ctx.direction === "backward") ctx = { ...ctx, direction: "forward" };
       // the input is its own output here, so it registers as its own memo entry: a cycle re-entering this node hits the bucket instead of recursing forever
-      if (memo && payload.value !== null && typeof payload.value === "object") {
+      if (
+        memo &&
+        payload.value !== null &&
+        (typeof payload.value === "object" || typeof payload.value === "function")
+      ) {
         memo.alloc(inst, payload, payload.value, ctx);
       }
       const result = runShape(payload, ctx);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -753,7 +753,7 @@ export function finalize<T extends schemas.$ZodType>(
   }
 }
 
-function isTransforming(
+export function isTransforming(
   _schema: schemas.$ZodType,
   _ctx?: {
     seen: Set<schemas.$ZodType>;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1076,20 +1076,24 @@ export function members(proto: object, table: object): void {
     // a method materializes bound on first read, which is what keeps a detached member working: `const opt = schema.optional; opt()`
     else defineBound(proto, key, desc.value);
   }
+  // for..in sees no symbol keys, so well-known members like Symbol.iterator install here
+  for (const sym of Object.getOwnPropertySymbols(table)) {
+    defineBound(proto, sym, (table as any)[sym]);
+  }
 }
 
 /** Shadows a prototype member with an own value, so a getter that builds from the instance runs once. */
-export function own<T>(inst: object, key: string, value: T, enumerable = true): T {
+export function own<T>(inst: object, key: PropertyKey, value: T, enumerable = true): T {
   Object.defineProperty(inst, key, { configurable: true, writable: true, enumerable, value });
   return value;
 }
 
 /** Like {@link own}, for a member that was never an own data property and has to stay out of `Object.keys`. */
-export function hide<T>(inst: object, key: string, value: T): T {
+export function hide<T>(inst: object, key: PropertyKey, value: T): T {
   return own(inst, key, value, false);
 }
 
-function defineBound(proto: object, key: string, fn: AnyFunc): void {
+function defineBound(proto: object, key: PropertyKey, fn: AnyFunc): void {
   Object.defineProperty(proto, key, {
     configurable: true,
     get(this: any) {

--- a/packages/zod/src/v4/core/visit.ts
+++ b/packages/zod/src/v4/core/visit.ts
@@ -159,6 +159,17 @@ export function visit(schema: schemas.SomeType, fnOrHandlers: VisitFn | VisitHan
         return clone(s, { ...rest, getter: () => run(original()) });
       }
       // A leaf by choice: `parts` are regex fragments, not data positions.
+      case "properties": {
+        const oldShape = def.shape as Record<string, AnyZod>;
+        let changed = false;
+        const newShape: Record<string, AnyZod> = {};
+        for (const k of Object.keys(oldShape)) {
+          const mapped = run(oldShape[k]!);
+          if (mapped !== oldShape[k]) changed = true;
+          newShape[k] = mapped;
+        }
+        return changed ? clone(s, { ...def, shape: newShape }) : s;
+      }
       case "template_literal":
       // Leaves.
       case "string":

--- a/packages/zod/src/v4/core/visit.ts
+++ b/packages/zod/src/v4/core/visit.ts
@@ -158,18 +158,18 @@ export function visit(schema: schemas.SomeType, fnOrHandlers: VisitFn | VisitHan
         const { _cachedInner, ...rest } = def;
         return clone(s, { ...rest, getter: () => run(original()) });
       }
-      // A leaf by choice: `parts` are regex fragments, not data positions.
       case "properties": {
-        const oldShape = def.shape as Record<string, AnyZod>;
+        const oldShape = def.shape as Record<string | symbol, AnyZod>;
         let changed = false;
-        const newShape: Record<string, AnyZod> = {};
-        for (const k of Object.keys(oldShape)) {
+        const newShape: Record<string | symbol, AnyZod> = {};
+        for (const k of Reflect.ownKeys(oldShape)) {
           const mapped = run(oldShape[k]!);
           if (mapped !== oldShape[k]) changed = true;
           newShape[k] = mapped;
         }
         return changed ? clone(s, { ...def, shape: newShape }) : s;
       }
+      // A leaf by choice: `parts` are regex fragments, not data positions.
       case "template_literal":
       // Leaves.
       case "string":

--- a/packages/zod/src/v4/mini/checks.ts
+++ b/packages/zod/src/v4/mini/checks.ts
@@ -23,7 +23,6 @@ export {
   _startsWith as startsWith,
   _endsWith as endsWith,
   _property as property,
-  _properties as properties,
   _mime as mime,
   _overwrite as overwrite,
   _normalize as normalize,

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1849,6 +1849,25 @@ export const ZodMiniCustom: core.$constructor<ZodMiniCustom> = /*@__PURE__*/ cor
   }
 );
 
+// ZodMiniProperties
+export interface ZodMiniProperties<Shape extends core.$ZodShape = core.$ZodShape>
+  extends _ZodMiniType<core.$ZodPropertiesInternals<Shape>>,
+    core.$ZodProperties<Shape> {}
+export const ZodMiniProperties: core.$constructor<ZodMiniProperties> = /*@__PURE__*/ core.$constructor(
+  "ZodMiniProperties",
+  (inst, def) => {
+    core.$ZodProperties.init(inst, def);
+    ZodMiniType.init(inst, def);
+  }
+);
+
+export function properties<Shape extends core.$ZodShape>(
+  shape: Shape,
+  params?: string | core.$ZodPropertiesParams
+): ZodMiniProperties<Shape> {
+  return core._properties(ZodMiniProperties, shape, params) as any;
+}
+
 // custom checks
 // @__NO_SIDE_EFFECTS__
 export function check<O = unknown>(fn: core.CheckFn<O>, params?: string | core.$ZodCustomParams): core.$ZodCheck<O> {


### PR DESCRIPTION
`z.properties(shape)` now constructs a real schema instead of an array of `z.property()` checks. It asserts the named properties in place and returns its input untouched — no new object, so prototypes, unlisted keys, and object identity survive. And because it's a schema, it finally infers. Follows up on #5912, which landed the check form; an array of checks can never narrow the type, and that was the reason to revisit it.

```ts
const httpsUrl = z.instanceof(URL).properties({
  protocol: z.literal("https:"),
  hostname: z.string().regex(z.regexes.domain),
});

type HttpsUrl = z.infer<typeof httpsUrl>;
// => URL & { protocol: "https:"; hostname: string }
```

What's in here:

- **`$ZodProperties`**, a core schema that is also a check, the way `$ZodCustom` is. As a schema it is the type gate — an object or a function, never a primitive — reports every failing key, and parses cyclic input — it returns the input identity, so the input registers as its own memo entry. It has cases in `z.compile()` (both roles), `z.toJSONSchema()` (`type: "object"` + `properties` + `required`, no `additionalProperties`; a symbol key is reported unrepresentable, as `z.object()` does), the memoizer, and `visit`.
- **The 4.5 spread still works.** The schema yields itself from `Symbol.iterator`, so `z.instanceof(URL).check(...z.properties({ ... }))` keeps compiling and running; TypeScript infers the spread element type from the iterator. The spread now reports every failing property instead of stopping at the first, since one check iterates the whole shape. One caveat: consumers on `target: es5` lose the spread form (spreading a non-array iterable requires ES2015); the schema forms work everywhere.
- **`z.instanceof()` returns a dedicated `ZodInstanceOf` class** with a `.properties()` method that narrows and chains. `z.instanceof(URL).and(z.properties({ ... }))` narrows too — intersection returns the left value when both sides come back identical.
- **As a check it asserts on whatever the base produced**, so `z.string().check(...z.properties({ length: z.number().min(3) }))` reads a string's length, exactly as `z.property()` does. The base has already typed the value there; standalone, this schema types it itself.
- **The shape is asserted and its results discarded**, exactly as `z.property()` behaves — identity can't distinguish a transform from a nested object schema rebuilding its output, so there's no cheap honest detection. Both sides therefore infer the **input** type: an output-typed inference would lie for every entry whose output differs from its input (`z.properties({ a: z.string().default("x") })` would claim `{ a: string }` and return `{}`). A plain schema has identical input and output, so the narrowing example above is unchanged.
- `z.core._properties` changes signature from `(shape)` to `(Class, shape, params?)`, matching the other schema factories. The old form shipped 12 days ago in 4.5.0.
- `when` is not settable on `z.properties()`. It gates a check inside the run loop, so it means nothing to a parsed schema, and honoring it in one role only would diverge silently.

Three axes, measured against `main` at bf990216 (gzipped bytes; retained bytes per instance over 20k instances under `--expose-gc`; parse/construction as min-of-7 fixed-count rounds):

| | main | this PR |
|---|---|---|
| parse: `z.instanceof(URL).check(...z.properties({...}))` | 140 ns | 140 ns |
| construction: same schema | 7.9 µs | 9.2 µs (+16%; a real schema costs more to build than two plain check objects) |
| construction: bare `z.instanceof(URL)` | 1.32 µs | 1.34 µs |
| memory: `z.instanceof(URL)` | 2.0 KB | 2.0 KB |
| memory: `z.properties()` (2 keys) | — | 3.0 KB |
| bundle: `zod-object` / `zod-string` | 24949 / 20867 | 24977 (+28) / 20906 (+39) |
| bundle: `zod-mini-object` / `-string` / `-boolean` | 4598 / 3497 / 3021 | 4611 (+13) / 3516 (+19) / 3036 (+15) |
| bundle: instanceof + properties call site | 21470 | 21746 (+276) |

The flat +15–17 B on every bundle is the symbol-key loop added to `util.members`, which is what installs `Symbol.iterator` on the per-constructor prototype; the mini ceilings are re-measured against `main` and raised in this branch. Classic pays ~10 B more for the memoizer's shared reference predicate, which mini treeshakes. `dict-mode.ts` reports every instance `fast`.
