### PR TITLE
perf: move util.cached's accessor to a prototype

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2104,7 +2104,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     });
   }
 
-  const _normalized = util.cached(() => normalizeDef(def));
+  const _normalized = util.cachedInternal(() => normalizeDef(def));
 
   util.defineLazyInternal(inst, "propValues", (zod) => {
     const shape = zod.def.shape;
@@ -2177,7 +2177,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
     $ZodObject.init(inst, def);
 
     const superParse = inst._zod.parse;
-    const _normalized = util.cached(() => normalizeDef(def));
+    const _normalized = util.cachedInternal(() => normalizeDef(def));
 
     const memo = core.globalConfig.memoizer;
 
@@ -2628,7 +2628,7 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
       }
     });
 
-    const disc = util.cached(() => {
+    const disc = util.cachedInternal(() => {
       const opts = def.options;
       const map: Map<util.Primitive, $ZodType> = new Map();
       for (const o of opts) {

--- a/packages/zod/src/v4/core/tests/cached.test.ts
+++ b/packages/zod/src/v4/core/tests/cached.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "vitest";
+
+import { util } from "zod/v4/core";
+
+// `cached` is public as `z.core.util.cached`, so its box shape is part of the contract; `cachedInternal` trades that shape for a fast prototype-backed box.
+for (const [name, make] of [
+  ["cached", util.cached],
+  ["cachedInternal", util.cachedInternal],
+] as const) {
+  test(`${name} defers the getter until the first read`, () => {
+    let runs = 0;
+    const box = make(() => ++runs);
+    expect(runs).toBe(0);
+    expect(box.value).toBe(1);
+    expect(box.value).toBe(1);
+    expect(runs).toBe(1);
+  });
+
+  test(`${name} memoizes an undefined result`, () => {
+    let runs = 0;
+    const box = make(() => {
+      runs++;
+      return undefined;
+    });
+    expect(box.value).toBeUndefined();
+    expect(box.value).toBeUndefined();
+    expect(runs).toBe(1);
+  });
+
+  test(`${name} retries after the getter throws`, () => {
+    let attempts = 0;
+    const box = make(() => {
+      if (++attempts < 2) throw new Error("boom");
+      return "recovered";
+    });
+    expect(() => box.value).toThrow("boom");
+    expect(box.value).toBe("recovered");
+    expect(attempts).toBe(2);
+  });
+
+  test(`${name} rejects assignment to value`, () => {
+    const box = make(() => 1);
+    expect(() => {
+      (box as { value: number }).value = 2;
+    }).toThrow(TypeError);
+  });
+}
+
+test("cached keeps its own enumerable value, before and after resolution", () => {
+  const box = util.cached(() => 1);
+  expect(Object.keys(box)).toEqual(["value"]);
+  // spread reads `value`, which resolves the box
+  expect({ ...box }).toEqual({ value: 1 });
+
+  const desc = Object.getOwnPropertyDescriptor(box, "value")!;
+  expect(desc.enumerable).toBe(true);
+  expect(desc.configurable).toBe(true);
+  expect(desc.writable).toBe(false);
+  expect(Object.keys(box)).toEqual(["value"]);
+});
+
+test("cachedInternal inherits value and never exposes the getter through it", () => {
+  const box = util.cachedInternal(() => 1);
+  expect(Object.getOwnPropertyDescriptor(box, "value")).toBeUndefined();
+  expect("value" in box).toBe(true);
+  expect(box.value).toBe(1);
+});
+
+test("allowsEval keeps the cached box shape", () => {
+  expect(util.allowsEval.value).toBe(true);
+  expect(Object.keys(util.allowsEval)).toEqual(["value"]);
+  expect({ ...util.allowsEval }).toEqual({ value: true });
+});

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -290,7 +290,18 @@ export function jsonStringifyReplacer(_: string, value: any): any {
   return value;
 }
 
-// accessor on the prototype, not an own literal property: an own accessor puts the box in dictionary mode from birth (~360 B and a slow load per read against ~100 B and an inlined getter here)
+export function cached<T>(getter: () => T): { value: T } {
+  return {
+    get value() {
+      const value = getter();
+      // own, enumerable and configurable, matching the accessor it replaces; public as `z.core.util.cached`
+      Object.defineProperty(this, "value", { value });
+      return value;
+    },
+  };
+}
+
+// accessor on the prototype, not an own literal property: an own accessor puts the box in dictionary mode from birth (~360 B and a slow load per read against ~100 B and an inlined getter here). Not `cached`, whose own enumerable `value` is public as `z.core.util.cached`.
 class Cached<T> {
   _getter: (() => T) | undefined;
   _value: T | undefined;
@@ -310,7 +321,7 @@ class Cached<T> {
   }
 }
 
-export function cached<T>(getter: () => T): { value: T } {
+export function cachedInternal<T>(getter: () => T): { value: T } {
   return new Cached(getter);
 }
 
@@ -440,16 +451,7 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
   return typeof data === "object" && data !== null && !Array.isArray(data);
 }
 
-// public as `z.core.util.allowsEval`, so it keeps its own box rather than a Cached: the shape stays `{ value }` under Object.keys and spread, and one box per process gains nothing from the prototype accessor
-export const allowsEval: { value: boolean } = {
-  get value(): boolean {
-    const value = probeEval();
-    Object.defineProperty(this, "value", { value });
-    return value;
-  },
-};
-
-function probeEval(): boolean {
+export const allowsEval: { value: boolean } = /* @__PURE__*/ cached(() => {
   // Skip the probe under `jitless`: strict CSPs report the caught `new Function` as a `securitypolicyviolation` even though the throw is swallowed.
   if (globalConfig.jitless) {
     return false;
@@ -467,7 +469,7 @@ function probeEval(): boolean {
   } catch (_) {
     return false;
   }
-}
+});
 
 export function isPlainObject(o: any): o is Record<PropertyKey, unknown> {
   if (isObject(o) === false) return false;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -440,7 +440,16 @@ export function isObject(data: any): data is Record<PropertyKey, unknown> {
   return typeof data === "object" && data !== null && !Array.isArray(data);
 }
 
-export const allowsEval: { value: boolean } = /* @__PURE__*/ cached(() => {
+// public as `z.core.util.allowsEval`, so it keeps its own box rather than a Cached: the shape stays `{ value }` under Object.keys and spread, and one box per process gains nothing from the prototype accessor
+export const allowsEval: { value: boolean } = {
+  get value(): boolean {
+    const value = probeEval();
+    Object.defineProperty(this, "value", { value });
+    return value;
+  },
+};
+
+function probeEval(): boolean {
   // Skip the probe under `jitless`: strict CSPs report the caught `new Function` as a `securitypolicyviolation` even though the throw is swallowed.
   if (globalConfig.jitless) {
     return false;
@@ -458,7 +467,7 @@ export const allowsEval: { value: boolean } = /* @__PURE__*/ cached(() => {
   } catch (_) {
     return false;
   }
-});
+}
 
 export function isPlainObject(o: any): o is Record<PropertyKey, unknown> {
   if (isObject(o) === false) return false;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -290,18 +290,28 @@ export function jsonStringifyReplacer(_: string, value: any): any {
   return value;
 }
 
+// accessor on the prototype, not an own literal property: an own accessor puts the box in dictionary mode from birth (~360 B and a slow load per read against ~100 B and an inlined getter here)
+class Cached<T> {
+  _getter: (() => T) | undefined;
+  _value: T | undefined;
+
+  constructor(getter: () => T) {
+    this._getter = getter;
+    this._value = undefined;
+  }
+
+  get value(): T {
+    const getter = this._getter;
+    if (getter !== undefined) {
+      this._value = getter();
+      this._getter = undefined;
+    }
+    return this._value as T;
+  }
+}
+
 export function cached<T>(getter: () => T): { value: T } {
-  const set = false;
-  return {
-    get value() {
-      if (!set) {
-        const value = getter();
-        Object.defineProperty(this, "value", { value });
-        return value;
-      }
-      throw new Error("cached value already set");
-    },
-  };
+  return new Cached(getter);
 }
 
 export function nullish(input: any): boolean {


### PR DESCRIPTION
`util.cached` returned an object literal carrying its own `get value()` accessor. V8 puts such an object in dictionary mode at creation and keeps it there, so each box cost ~360 B retained, and the data property the getter redefines itself into was a dictionary load on every subsequent read — the opposite of what the self-redefine is for.

`cachedInternal` is that box with the accessor on a prototype instead, which makes each one a two-slot fast object. The three schema call sites use it; `cached` itself is unchanged, because it is public as `z.core.util.cached` and a prototype-backed box changes what callers observe — `Object.keys` goes from `["value"]` to `["_getter","_value"]`, and spreading an unresolved box stops forcing the getter and exposes the callback instead. `allowsEval` stays on `cached` too. The one edit inside `cached` drops its `set` guard, whose `throw` could never run.

Both boxes defer the getter to the first read, memoize the result including `undefined`, and retry if it throws. Tests pin that, plus the enumerable surface of each.

Measured against `bc1157e7`:

| | base | this branch |
| --- | --- | --- |
| `z.object({})` retained | 3176 B | 2632 B |
| `z.object()` 3 keys | 5274 B | 4730 B |
| `z.discriminatedUnion` 2 options | 12529 B | 11025 B |
| `zod/mini` object 3 keys | 3736 B | 3464 B |
| realworld catalogue, per resource | 112.5 KB | 108.2 KB |
| construct `z.object()` 3 keys | 8211 ns | 6554 ns |
| `z.discriminatedUnion` parse | 41.4 ns | 40.0 ns |
| bundle gz, classic | 24555 B | 24579 B |
| bundle gz, mini | 4502 B | 4521 B |

Both bundles grow — +24 B gz classic and +19 B gz mini — which is the price of carrying the fast box alongside the public one.

Parse timing is min-of-seven with the revisions alternating round by round, one revision per process, under a load average below 8; the branch was ahead in six of the seven. Read speed of a resolved box is 1.6–4.2 ns against 6.3–14.5 ns across many boxes, and 5.8 ns against 7.1 ns with a single hot box. Only the discriminated-union parse reads a box per parse; the two object boxes are read once and cached into closures.

`packages/bench/memory/dict-mode.ts` reports `fast` for every instance and `_zod` on both revisions.

Refs #6517, refs #6514
