### PR TITLE
perf: answer z.validate from the compiled fast path on invalid input

### DIFF
--- a/packages/zod/src/v4/classic/tests/validate.test.ts
+++ b/packages/zod/src/v4/classic/tests/validate.test.ts
@@ -155,6 +155,8 @@ test("compiled validate agrees with the interpreter, verdict and throw alike", (
       z.number().min(10),
       z.number().transform((x) => x + 1)
     ),
+    // unmergeable with no user callback in it, so only the intersection itself can clear the flag
+    z.intersection(z.string().default("a"), z.string().default("b")),
     z.lazy(() => z.object({ a: z.string() })),
     z.number().catch(0),
     z.nonoptional(z.string().optional()),
@@ -169,6 +171,9 @@ test("compiled validate agrees with the interpreter, verdict and throw alike", (
     z.custom(thenable),
     z.string().refine(thenable),
     z.string().pipe(z.string().min(3)),
+    // a codec's decode is the pipe branch's transform, and a plain function can still hand back a promise
+    z.codec(z.string(), z.number(), { decode: thenable, encode: String }),
+    z.object({ first: z.string(), second: z.codec(z.string(), z.number(), { decode: thenable, encode: String }) }),
     // a user callback can throw, and compiled code can reject an earlier sibling before ever reaching it
     z.object({
       first: z.string(),
@@ -182,6 +187,14 @@ test("compiled validate agrees with the interpreter, verdict and throw alike", (
         throw new TypeError("u");
       }),
     }),
+    // superRefine and check take the other branch of the refine generator than refine does
+    z.object({
+      first: z.string(),
+      second: z.string().superRefine(() => {
+        throw new RangeError("u");
+      }),
+    }),
+    z.string().superRefine(thenable as never),
     z.object({
       first: z.string(),
       second: z.string().transform(() => {
@@ -214,6 +227,12 @@ test("compiled validate agrees with the interpreter, verdict and throw alike", (
     new Map(),
     new Set(["a"]),
     "true",
+    // the exposing shape: an earlier field the compiled path rejects before it reaches the throwing one
+    { first: 1, second: "s" },
+    { first: "s", second: "s" },
+    { first: 1 },
+    [1, "x"],
+    ["s", "x"],
   ];
   const outcome = (fn: () => unknown) => {
     try {

--- a/packages/zod/src/v4/classic/tests/validate.test.ts
+++ b/packages/zod/src/v4/classic/tests/validate.test.ts
@@ -72,8 +72,8 @@ test("validate agrees with the compiled fast path and keeps the callback bound",
   expect(z.validate(schema, { name: "ok" })).toBe(true);
 });
 
-test("compiled validate still throws where parsing throws", () => {
-  // both sides pass but the outputs conflict, which the interpreter answers with a throw — a definitive false would misreport a schema bug
+test("compiled validate keeps the fallback where INVALID is not a decidable rejection", () => {
+  // an intersection answers INVALID for an unmergeable merge, which the interpreter answers with a throw — a fast false would misreport a schema bug
   const unmergeable = z.compile(
     z.intersection(
       z.number(),
@@ -83,12 +83,25 @@ test("compiled validate still throws where parsing throws", () => {
   );
   expect(() => z.validate(unmergeable, 1234)).toThrow("Unmergable intersection");
 
-  // an async child behind a when-gated check islands at codegen; its thenable at parse time throws like the interpreter
+  // a when-gated check islands at codegen, and an island answers INVALID for an async run too
   const gated = z.number().refine(() => Promise.resolve(true));
   (gated._zod.def.checks![0]!._zod.def as { when?: unknown }).when = () => true;
   const compiled = z.compile(z.object({ n: gated }), { strict: true });
   expect(() => z.validate(compiled, { n: 3 })).toThrow(z.core.$ZodAsyncError);
   expect(() => z.validate(z.object({ n: gated }), { n: 3 })).toThrow(z.core.$ZodAsyncError);
+
+  // a plain function handing back a promise answers INVALID for union parity, so a transform is never a decidable rejection
+  const piped = z.string().transform(() => Promise.resolve(1));
+  expect(() => z.validate(z.compile(piped, { strict: true }), "x")).toThrow(z.core.$ZodAsyncError);
+  expect(() => z.validate(piped, "x")).toThrow(z.core.$ZodAsyncError);
+
+  // a continuable child issue short-circuits the compiled intersection before its merge, but the interpreter reaches the merge and throws
+  const continuable = z.intersection(
+    z.number().min(10),
+    z.number().transform((x) => x + 1)
+  );
+  expect(() => z.validate(z.compile(continuable, { strict: true }), 1)).toThrow("Unmergable intersection");
+  expect(() => z.validate(continuable, 1)).toThrow("Unmergable intersection");
 });
 
 test("validate is exported from zod/mini", () => {

--- a/packages/zod/src/v4/classic/tests/validate.test.ts
+++ b/packages/zod/src/v4/classic/tests/validate.test.ts
@@ -63,13 +63,43 @@ test("validate agrees with the compiled fast path and keeps the callback bound",
 
   calls = 0;
   expect(z.validate(compiled, { name: "x" })).toBe(false);
-  // the compiled rejection is definitive, so the interpreted fallback never runs and the callback fires once
-  expect(calls).toBe(1);
+  // a user callback can throw, so its rejection is not decidable and the fallback still runs
+  expect(calls).toBeLessThanOrEqual(2);
 
   expect(z.validate(compiled, { name: 42 })).toBe(false);
-  // a ctx can change the verdict, so it still takes the interpreted path
   expect(z.validate(compiled, { name: "x" }, {})).toBe(false);
   expect(z.validate(schema, { name: "ok" })).toBe(true);
+});
+
+test("the validate shortcut is taken for callback-free schemas only", () => {
+  const definite = (s: z.ZodType) => (z.compile(s, { strict: true }) as any)._zod.bag.validator?.definite;
+
+  // nothing here can throw, so a compiled rejection is proof the runtime would reject
+  expect(definite(z.object({ a: z.string().min(1), b: z.number().max(3), c: z.email() }))).toBe(true);
+  expect(definite(z.array(z.enum(["a", "b"])))).toBe(true);
+
+  // each of these can answer INVALID for something the interpreter throws on
+  expect(definite(z.object({ a: z.string().refine(() => true) }))).toBe(false);
+  expect(definite(z.string().transform((v) => v))).toBe(false);
+  expect(definite(z.custom(() => true))).toBe(false);
+  expect(definite(z.number().catch(0))).toBe(false);
+  expect(definite(z.lazy(() => z.string()))).toBe(false);
+  expect(
+    definite(
+      z.intersection(
+        z.number(),
+        z.number().transform((x) => x + 1)
+      )
+    )
+  ).toBe(false);
+  expect(
+    definite(
+      z.record(
+        z.string().transform((k) => k),
+        z.number()
+      )
+    )
+  ).toBe(false);
 });
 
 test("compiled validate keeps the fallback where INVALID is not a decidable rejection", () => {
@@ -113,6 +143,9 @@ test("compiled validate agrees with the interpreter, verdict and throw alike", (
     z.array(z.string().min(1)),
     z.tuple([z.string()], z.number()),
     z.record(z.string(), z.number()),
+    // a record key compiles in its own context, so its definiteness has to be carried out
+    z.record(z.string().transform(thenable), z.number()),
+    z.record(z.email(), z.number()),
     z.union([z.string(), z.number()]),
     z.intersection(
       z.number(),
@@ -136,6 +169,32 @@ test("compiled validate agrees with the interpreter, verdict and throw alike", (
     z.custom(thenable),
     z.string().refine(thenable),
     z.string().pipe(z.string().min(3)),
+    // a user callback can throw, and compiled code can reject an earlier sibling before ever reaching it
+    z.object({
+      first: z.string(),
+      second: z.string().refine(() => {
+        throw new RangeError("u");
+      }),
+    }),
+    z.object({
+      first: z.string(),
+      second: z.custom(() => {
+        throw new TypeError("u");
+      }),
+    }),
+    z.object({
+      first: z.string(),
+      second: z.string().transform(() => {
+        throw new RangeError("u");
+      }),
+    }),
+    z.object({ first: z.string(), second: z.custom(thenable) }),
+    z.tuple([
+      z.string(),
+      z.number().catch(() => {
+        throw new RangeError("u");
+      }),
+    ]),
   ];
   const inputs = [
     "x",

--- a/packages/zod/src/v4/classic/tests/validate.test.ts
+++ b/packages/zod/src/v4/classic/tests/validate.test.ts
@@ -104,6 +104,82 @@ test("compiled validate keeps the fallback where INVALID is not a decidable reje
   expect(() => z.validate(continuable, 1)).toThrow("Unmergable intersection");
 });
 
+test("compiled validate agrees with the interpreter, verdict and throw alike", () => {
+  // guards the `definite` flag: a new generator that answers INVALID for something the interpreter throws on must clear it, or this fails
+  const thenable = () => Promise.resolve(1) as never;
+  const schemas: z.ZodType[] = [
+    z.object({ a: z.string(), b: z.number().min(1) }),
+    z.strictObject({ a: z.string() }),
+    z.array(z.string().min(1)),
+    z.tuple([z.string()], z.number()),
+    z.record(z.string(), z.number()),
+    z.union([z.string(), z.number()]),
+    z.intersection(
+      z.number(),
+      z.number().transform((x) => x + 1)
+    ),
+    z.intersection(
+      z.number().min(10),
+      z.number().transform((x) => x + 1)
+    ),
+    z.lazy(() => z.object({ a: z.string() })),
+    z.number().catch(0),
+    z.nonoptional(z.string().optional()),
+    z.map(z.string(), z.number()),
+    z.set(z.string().min(2)),
+    z.templateLiteral(["a", z.number()]),
+    z.coerce.number(),
+    z.stringbool(),
+    z.string().transform(thenable),
+    z.union([z.string().transform(thenable), z.number()]),
+    z.array(z.string().transform(thenable)),
+    z.custom(thenable),
+    z.string().refine(thenable),
+    z.string().pipe(z.string().min(3)),
+  ];
+  const inputs = [
+    "x",
+    "ab",
+    "",
+    0,
+    1,
+    Number.NaN,
+    true,
+    null,
+    undefined,
+    {},
+    { a: "x" },
+    { a: 1 },
+    [],
+    ["x"],
+    new Map(),
+    new Set(["a"]),
+    "true",
+  ];
+  const outcome = (fn: () => unknown) => {
+    try {
+      return `ok:${fn()}`;
+    } catch (err) {
+      return `throw:${(err as Error)?.constructor?.name}`;
+    }
+  };
+
+  for (const schema of schemas) {
+    let compiled: z.ZodType;
+    try {
+      compiled = z.compile(schema, { strict: true });
+    } catch {
+      continue; // refused at codegen, so there is no fast path to disagree
+    }
+    for (const input of inputs) {
+      expect(
+        outcome(() => z.validate(compiled, input)),
+        `${JSON.stringify(input)} on ${schema._zod.def.type}`
+      ).toBe(outcome(() => z.validate(schema, input)));
+    }
+  }
+});
+
 test("validate is exported from zod/mini", () => {
   expect(zm.validate(zm.string(), "a")).toBe(true);
   expect(zm.validate(zm.string(), 1)).toBe(false);

--- a/packages/zod/src/v4/classic/tests/validate.test.ts
+++ b/packages/zod/src/v4/classic/tests/validate.test.ts
@@ -63,10 +63,32 @@ test("validate agrees with the compiled fast path and keeps the callback bound",
 
   calls = 0;
   expect(z.validate(compiled, { name: "x" })).toBe(false);
-  expect(calls).toBeLessThanOrEqual(2);
+  // the compiled rejection is definitive, so the interpreted fallback never runs and the callback fires once
+  expect(calls).toBe(1);
 
   expect(z.validate(compiled, { name: 42 })).toBe(false);
+  // a ctx can change the verdict, so it still takes the interpreted path
+  expect(z.validate(compiled, { name: "x" }, {})).toBe(false);
   expect(z.validate(schema, { name: "ok" })).toBe(true);
+});
+
+test("compiled validate still throws where parsing throws", () => {
+  // both sides pass but the outputs conflict, which the interpreter answers with a throw — a definitive false would misreport a schema bug
+  const unmergeable = z.compile(
+    z.intersection(
+      z.number(),
+      z.number().transform((x) => x + 1)
+    ),
+    { strict: true }
+  );
+  expect(() => z.validate(unmergeable, 1234)).toThrow("Unmergable intersection");
+
+  // an async child behind a when-gated check islands at codegen; its thenable at parse time throws like the interpreter
+  const gated = z.number().refine(() => Promise.resolve(true));
+  (gated._zod.def.checks![0]!._zod.def as { when?: unknown }).when = () => true;
+  const compiled = z.compile(z.object({ n: gated }), { strict: true });
+  expect(() => z.validate(compiled, { n: 3 })).toThrow(z.core.$ZodAsyncError);
+  expect(() => z.validate(z.object({ n: gated }), { n: 3 })).toThrow(z.core.$ZodAsyncError);
 });
 
 test("validate is exported from zod/mini", () => {

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -14,7 +14,6 @@ import {
   mergeValues,
   parseURLObject,
   stripTabAndNewline,
-  throwUnmergable,
   urlHostnameOk,
   urlProtocolOk,
 } from "./schemas.js";
@@ -35,7 +34,11 @@ interface CompileFnOptions {
   assertOnly?: boolean | undefined;
 }
 
-type CompiledFn<T> = ((input: unknown) => T | INVALID) & { code?: string | undefined };
+type CompiledFn<T> = ((input: unknown) => T | INVALID) & {
+  code?: string | undefined;
+  /** False when this function's INVALID does not strictly mean "the runtime would reject". */
+  definite?: boolean | undefined;
+};
 
 /** Raised when the schema contains async refinements or transforms. Surfaces only under `compile(schema, { strict: true })`. */
 export class ZodCompileAsyncError extends Error {
@@ -66,6 +69,8 @@ interface CompileContext {
   constants: Map<string, unknown>;
   constantCounter: number;
   varCounter: number;
+  /** Cleared when a construct can return INVALID for something the interpreter throws on, so `validate` keeps its fallback. */
+  definite: boolean;
 }
 
 // Union of all check types we support in AOT compilation
@@ -92,9 +97,9 @@ type SupportedCheck =
  * dropped. A schema the flag cannot express reuses the parser, which still answers correctly — it
  * just builds a value nothing reads.
  */
-function compileValidator(schema: SomeType, parser: (input: unknown) => unknown): (input: unknown) => unknown {
+function compileValidator(schema: SomeType, parser: CompiledFn<unknown>): CompiledFn<unknown> {
   try {
-    return compileFn(schema, { assertOnly: true }) as (input: unknown) => unknown;
+    return compileFn(schema, { assertOnly: true }) as CompiledFn<unknown>;
   } catch {
     return parser;
   }
@@ -160,7 +165,7 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
     // Let later compiles of (or through) this run unwrap to the true runtime — both the global shim and repeated z.compile calls rely on this. The bag also carries the parser and the validator, so the standalone validate can skip the payload and wrapper on the happy path.
     (wrapped as { __originalRun?: typeof originalRun }).__originalRun = originalRun;
     clone._zod.bag.fallbackRun = originalRun;
-    clone._zod.bag.validator = compileValidator(schema, parser as (input: unknown) => unknown);
+    clone._zod.bag.validator = compileValidator(schema, parser as CompiledFn<unknown>);
     clone._zod.run = wrapped;
 
     // The fast parse/safeParse closures fall back through the source schema's methods. If the source is shim- or wrapper-managed, those methods route into a compiled run and would execute user callbacks a third time on invalid input — the plain method → wrapper path is exactly 2x, so skip.
@@ -223,6 +228,7 @@ export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOpti
     constants: new Map(),
     constantCounter: 0,
     varCounter: 0,
+    definite: true,
   };
 
   const doc = new Doc(["input"]);
@@ -254,6 +260,7 @@ export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOpti
   if (options?.debug) {
     fn.code = fullCode;
   }
+  fn.definite = ctx.definite;
   return fn;
 }
 
@@ -271,13 +278,13 @@ function newVar(ctx: CompileContext): string {
   return `v${ctx.varCounter++}`;
 }
 
-// Runs a child schema as a black box: its value, or INVALID for a failure. A thenable is an async child reached synchronously — throw like generated code does, because INVALID must keep meaning "the runtime would reject": a union reads it as a rejected branch, and validate reads it as a definitive false.
+// Runs a child schema as a black box: its value, or INVALID for a failure or an async run.
 function runtimeRun(schema: SomeType, value: unknown): unknown {
   const result = (schema._zod.run as (p: ParsePayload, c: ParseContextInternal) => any)(
     { value, issues: [] },
     {} as ParseContextInternal
   );
-  if (result && typeof (result as Promise<unknown>).then === "function") throw new $ZodAsyncError();
+  if (result && typeof (result as Promise<unknown>).then === "function") return INVALID;
   const r = result as { value: unknown; issues: unknown[] };
   return r.issues.length === 0 ? r.value : INVALID;
 }
@@ -323,6 +330,8 @@ function compileChild(
 }
 
 function emitRuntimeIsland(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  // an islanded child answers INVALID for an async run too, which the interpreter throws for
+  ctx.definite = false;
   const schemaConst = addConstant(ctx, schema);
   const runConst = addConstant(ctx, runtimeRun);
   const outVar = newVar(ctx);
@@ -1834,15 +1843,16 @@ function literalEquality(ctx: CompileContext, accessor: string, value: unknown):
 
 function generateIntersectionCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
   const def = schema._zod.def as unknown as { left: SomeType; right: SomeType };
+  // An unmergeable merge, and a child failing before the merge is even reached, both return INVALID for a case the interpreter answers with a throw.
+  ctx.definite = false;
   const leftOutput = compileChild(doc, ctx, def.left, accessor);
   const rightOutput = compileChild(doc, ctx, def.right, accessor);
 
-  // Hoist the runtime merge helper so recursive object/array merge semantics stay in one place. Both children already passed here, which is exactly the case the interpreter answers with a throw — INVALID must keep meaning "the runtime would reject", so a schema bug throws instead.
+  // Hoist the runtime merge helper so recursive object/array merge semantics stay in one place. If the merge is invalid, return INVALID and let the runtime fallback construct canonical errors.
   const mergeConst = addConstant(ctx, mergeValues);
   const mergedVar = newVar(ctx);
   doc.write(`const ${mergedVar} = ${mergeConst}(${leftOutput}, ${rightOutput});`);
-  const throwConst = addConstant(ctx, throwUnmergable);
-  doc.write(`if (!${mergedVar}.valid) ${throwConst}(${mergedVar}.mergeErrorPath);`);
+  doc.write(`if (!${mergedVar}.valid) return INVALID;`);
   return `${mergedVar}.data`;
 }
 
@@ -2062,7 +2072,8 @@ function generatePipeCheck(doc: Doc, ctx: CompileContext, schema: SomeType, acce
   const inputOutput = generateCheck(doc, ctx, def.in, accessor);
 
   if (def.transform) {
-    // Apply transform and validate output. The transform may read its second `payload` argument (codec transforms like z.stringbool() push issues there) so wrap the call in a helper that spoofs a payload. Pushed issues signal INVALID and the wrapper falls back to the runtime.
+    // Apply transform and validate output. The transform may read its second `payload` argument (codec transforms like z.stringbool() push issues there) so wrap the call in a helper that spoofs a payload. Pushed issues signal INVALID and the wrapper falls back to the runtime, and a plain function handing back a promise answers INVALID too — union parity, but not a decidable rejection at the top level.
+    ctx.definite = false;
     if (isAsyncFunction(def.transform)) {
       throw new ZodCompileAsyncError("z.compile: async transforms in pipes are not supported");
     }
@@ -2165,6 +2176,8 @@ function generateTransformCheck(doc: Doc, ctx: CompileContext, schema: SomeType,
   };
 
   if (def.transform) {
+    // as in the pipe helper: a thenable answers INVALID, which is union parity but not a decidable rejection
+    ctx.definite = false;
     // Check for async transform
     if (isAsyncFunction(def.transform)) {
       throw new ZodCompileAsyncError("z.compile: async transforms are not supported");

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -274,6 +274,12 @@ function addConstant(ctx: CompileContext, value: unknown): string {
   return name;
 }
 
+/** Hoists a user-supplied callback. Anything the schema's author wrote can throw, and generated code can reject an earlier sibling before ever reaching it, so this clears `definite` — a rejection is then no longer proof that the interpreter would have rejected rather than thrown. */
+function addUserConstant(ctx: CompileContext, fn: unknown): string {
+  ctx.definite = false;
+  return addConstant(ctx, fn);
+}
+
 function newVar(ctx: CompileContext): string {
   return `v${ctx.varCounter++}`;
 }
@@ -636,7 +642,7 @@ function generateCustomRefineCheck(doc: Doc, ctx: CompileContext, check: CustomC
     if (isAsyncFunction(def.fn)) {
       throw new ZodCompileAsyncError("z.compile: async .refine() predicates are not supported");
     }
-    const fnConst = addConstant(ctx, def.fn);
+    const fnConst = addUserConstant(ctx, def.fn);
     const throwAsyncConst = addConstant(ctx, throwAsync);
     const resVar = newVar(ctx);
     doc.write(`const ${resVar} = ${fnConst}(${accessor});`);
@@ -663,7 +669,7 @@ function generateCustomRefineCheck(doc: Doc, ctx: CompileContext, check: CustomC
       if (result instanceof Promise) throwAsync();
       return fakePayload.issues.length === 0 ? fakePayload.value : INVALID;
     };
-    const helperConst = addConstant(ctx, helperFn);
+    const helperConst = addUserConstant(ctx, helperFn);
     const outVar = newVar(ctx);
     doc.write(`const ${outVar} = ${helperConst}(${accessor});`);
     doc.write(`if (${outVar} === INVALID) return INVALID;`);
@@ -1924,7 +1930,10 @@ function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
     // The runtime runs it against each own enumerable key and writes the value
     // under the key it produced, so compile it once and call it per key.
     const isLoose = (def as { mode?: string }).mode === "loose";
-    const keyFast = addConstant(ctx, compileFn(def.keyType));
+    // the key compiles in its own context, so carry its verdict out: a key schema that can answer INVALID undecidably makes this validator undecidable too
+    const keyFn = compileFn(def.keyType);
+    if (keyFn.definite === false) ctx.definite = false;
+    const keyFast = addConstant(ctx, keyFn);
     const numericConst = addConstant(ctx, regexes.number);
     const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
     const outKeyVar = newVar(ctx);
@@ -2039,7 +2048,7 @@ function generateTemplateLiteralCheck(doc: Doc, ctx: CompileContext, schema: Som
 function generateLazyCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
   // For lazy schemas, we use a cached parser that falls back to runtime Zod parsing This handles recursive schemas correctly by avoiding infinite compilation loops
   const def = schema._zod.def as unknown as { getter: () => SomeType };
-  const getterConst = addConstant(ctx, def.getter);
+  const getterConst = addUserConstant(ctx, def.getter);
   const cacheConst = addConstant(ctx, { parser: null as ((input: unknown) => unknown) | null });
 
   doc.write(`if (!${cacheConst}.parser) {`);
@@ -2073,7 +2082,6 @@ function generatePipeCheck(doc: Doc, ctx: CompileContext, schema: SomeType, acce
 
   if (def.transform) {
     // Apply transform and validate output. The transform may read its second `payload` argument (codec transforms like z.stringbool() push issues there) so wrap the call in a helper that spoofs a payload. Pushed issues signal INVALID and the wrapper falls back to the runtime, and a plain function handing back a promise answers INVALID too — union parity, but not a decidable rejection at the top level.
-    ctx.definite = false;
     if (isAsyncFunction(def.transform)) {
       throw new ZodCompileAsyncError("z.compile: async transforms in pipes are not supported");
     }
@@ -2086,7 +2094,7 @@ function generatePipeCheck(doc: Doc, ctx: CompileContext, schema: SomeType, acce
       if (result instanceof Promise) return INVALID;
       return fakePayload.issues.length === 0 ? result : INVALID;
     };
-    const helperConst = addConstant(ctx, helperFn);
+    const helperConst = addUserConstant(ctx, helperFn);
     const transformedVar = newVar(ctx);
     doc.write(`const ${transformedVar} = ${helperConst}(${inputOutput});`);
     doc.write(`if (${transformedVar} === INVALID) return INVALID;`);
@@ -2114,7 +2122,7 @@ function generateCustomCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
       throw new ZodCompileAsyncError("z.compile: async custom predicates are not supported");
     }
     // Custom schema with a predicate function (e.g. z.instanceof). `isAsyncFunction` above is syntactic, so a plain function returning a promise reaches here, and a promise is truthy — it would read as a pass where the interpreter throws.
-    const fnConst = addConstant(ctx, def.fn);
+    const fnConst = addUserConstant(ctx, def.fn);
     const throwAsyncConst = addConstant(ctx, throwAsync);
     const resVar = newVar(ctx);
     doc.write(`const ${resVar} = ${fnConst}(${accessor});`);
@@ -2159,7 +2167,7 @@ function generateCatchCheck(doc: Doc, ctx: CompileContext, schema: SomeType, acc
   doc.write(`})();`);
 
   const innerConst = addConstant(ctx, def.innerType);
-  const catchConst = addConstant(ctx, def.catchValue);
+  const catchConst = addUserConstant(ctx, def.catchValue);
   const catchHelperConst = addConstant(ctx, runtimeCatch);
   doc.write(`if (${outputVar} === INVALID) {`);
   doc.indented((d) => {
@@ -2176,8 +2184,6 @@ function generateTransformCheck(doc: Doc, ctx: CompileContext, schema: SomeType,
   };
 
   if (def.transform) {
-    // as in the pipe helper: a thenable answers INVALID, which is union parity but not a decidable rejection
-    ctx.definite = false;
     // Check for async transform
     if (isAsyncFunction(def.transform)) {
       throw new ZodCompileAsyncError("z.compile: async transforms are not supported");
@@ -2192,7 +2198,7 @@ function generateTransformCheck(doc: Doc, ctx: CompileContext, schema: SomeType,
       if (result instanceof Promise) return INVALID;
       return fakePayload.issues.length === 0 ? result : INVALID;
     };
-    const helperConst = addConstant(ctx, helperFn);
+    const helperConst = addUserConstant(ctx, helperFn);
     const outputVar = newVar(ctx);
     doc.write(`const ${outputVar} = ${helperConst}(${accessor});`);
     doc.write(`if (${outputVar} === INVALID) return INVALID;`);

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -14,6 +14,7 @@ import {
   mergeValues,
   parseURLObject,
   stripTabAndNewline,
+  throwUnmergable,
   urlHostnameOk,
   urlProtocolOk,
 } from "./schemas.js";
@@ -270,13 +271,13 @@ function newVar(ctx: CompileContext): string {
   return `v${ctx.varCounter++}`;
 }
 
-// Runs a child schema as a black box: its value, or INVALID for a failure or an async run.
+// Runs a child schema as a black box: its value, or INVALID for a failure. A thenable is an async child reached synchronously — throw like generated code does, because INVALID must keep meaning "the runtime would reject": a union reads it as a rejected branch, and validate reads it as a definitive false.
 function runtimeRun(schema: SomeType, value: unknown): unknown {
   const result = (schema._zod.run as (p: ParsePayload, c: ParseContextInternal) => any)(
     { value, issues: [] },
     {} as ParseContextInternal
   );
-  if (result && typeof (result as Promise<unknown>).then === "function") return INVALID;
+  if (result && typeof (result as Promise<unknown>).then === "function") throw new $ZodAsyncError();
   const r = result as { value: unknown; issues: unknown[] };
   return r.issues.length === 0 ? r.value : INVALID;
 }
@@ -1836,11 +1837,12 @@ function generateIntersectionCheck(doc: Doc, ctx: CompileContext, schema: SomeTy
   const leftOutput = compileChild(doc, ctx, def.left, accessor);
   const rightOutput = compileChild(doc, ctx, def.right, accessor);
 
-  // Hoist the runtime merge helper so recursive object/array merge semantics stay in one place. If the merge is invalid, return INVALID and let the runtime fallback construct canonical errors.
+  // Hoist the runtime merge helper so recursive object/array merge semantics stay in one place. Both children already passed here, which is exactly the case the interpreter answers with a throw — INVALID must keep meaning "the runtime would reject", so a schema bug throws instead.
   const mergeConst = addConstant(ctx, mergeValues);
   const mergedVar = newVar(ctx);
   doc.write(`const ${mergedVar} = ${mergeConst}(${leftOutput}, ${rightOutput});`);
-  doc.write(`if (!${mergedVar}.valid) return INVALID;`);
+  const throwConst = addConstant(ctx, throwUnmergable);
+  doc.write(`if (!${mergedVar}.valid) ${throwConst}(${mergedVar}.mergeErrorPath);`);
   return `${mergedVar}.data`;
 }
 

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -132,7 +132,11 @@ export const validate: $Validate = ((
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
 ): boolean => {
   const validator = (schema._zod.bag as CompiledBag).validator;
-  if (validator !== undefined && validator(value) !== COMPILE_INVALID) return true;
+  if (validator !== undefined) {
+    if (validator(value) !== COMPILE_INVALID) return true;
+    // the sentinel is definitive — generated code throws for anything it cannot decide — so the interpreted re-parse is only needed when a ctx might change the answer
+    if (_ctx === undefined) return false;
+  }
   return validateFallback(schema, value, _ctx);
 }) as $Validate;
 

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -115,7 +115,7 @@ const COMPILE_INVALID = /* @__PURE__ */ Symbol.for("zod.compile.invalid");
 const COMPILE_FALLBACK = /* @__PURE__ */ Symbol.for("zod.compile.fallback");
 
 interface CompiledBag {
-  validator?: (input: unknown) => unknown;
+  validator?: ((input: unknown) => unknown) & { definite?: boolean | undefined };
   fallbackRun?: (payload: schemas.ParsePayload, ctx: schemas.ParseContextInternal) => unknown;
 }
 
@@ -134,8 +134,8 @@ export const validate: $Validate = ((
   const validator = (schema._zod.bag as CompiledBag).validator;
   if (validator !== undefined) {
     if (validator(value) !== COMPILE_INVALID) return true;
-    // the sentinel is definitive — generated code throws for anything it cannot decide — so the interpreted re-parse is only needed when a ctx might change the answer
-    if (_ctx === undefined) return false;
+    // a definite sentinel means the runtime would reject, so skip the re-parse; a ctx can still change the answer
+    if (validator.definite === true && _ctx === undefined) return false;
   }
   return validateFallback(schema, value, _ctx);
 }) as $Validate;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2742,6 +2742,11 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
   }
 );
 
+/** Shared with the compiler, which emits a hoisted call so both paths raise the identical error. */
+export function throwUnmergable(mergeErrorPath: PropertyKey[]): never {
+  throw new Error(`Unmergable intersection. Error path: ` + `${JSON.stringify(mergeErrorPath)}`);
+}
+
 export function mergeValues(
   a: any,
   b: any
@@ -2849,7 +2854,7 @@ function handleIntersectionResults(result: ParsePayload, left: ParsePayload, rig
 
   if (!merged.valid) {
     if (util.aborted(result)) return result;
-    throw new Error(`Unmergable intersection. Error path: ` + `${JSON.stringify(merged.mergeErrorPath)}`);
+    throwUnmergable(merged.mergeErrorPath);
   }
 
   result.value = merged.data;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2742,11 +2742,6 @@ export const $ZodIntersection: core.$constructor<$ZodIntersection> = /*@__PURE__
   }
 );
 
-/** Shared with the compiler, which emits a hoisted call so both paths raise the identical error. */
-export function throwUnmergable(mergeErrorPath: PropertyKey[]): never {
-  throw new Error(`Unmergable intersection. Error path: ` + `${JSON.stringify(mergeErrorPath)}`);
-}
-
 export function mergeValues(
   a: any,
   b: any
@@ -2854,7 +2849,7 @@ function handleIntersectionResults(result: ParsePayload, left: ParsePayload, rig
 
   if (!merged.valid) {
     if (util.aborted(result)) return result;
-    throwUnmergable(merged.mergeErrorPath);
+    throw new Error(`Unmergable intersection. Error path: ` + `${JSON.stringify(merged.mergeErrorPath)}`);
   }
 
   result.value = merged.data;

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 
 import * as z from "../../index.js";
 import { ZodCompileAsyncError, ZodCompileUnsupportedError, compile } from "../compile.js";
+import { $ZodAsyncError } from "../core.js";
 
 // Differential helper: assert compiled schema matches the original on a value.
 function expectMatch(schema: z.ZodType, value: unknown) {
@@ -1415,6 +1416,26 @@ test("xor and custom when-gated checks force runtime fallback", () => {
   (gated._zod.def.checks![0]!._zod.def as { when?: unknown }).when = () => false;
   expect(() => compile(gated, { strict: true })).toThrow(ZodCompileUnsupportedError);
   expectMatch(z.object({ n: gated }), { n: 3 }); // runtime skips the gated check
+});
+
+test("fast path throws where the runtime throws instead of bailing to INVALID", () => {
+  // unmergeable intersection: both children passed, which is exactly the case the interpreter answers with a throw
+  const unmergeable = compile(
+    z.intersection(
+      z.number(),
+      z.number().transform((x) => x + 1)
+    ),
+    { strict: true }
+  );
+  expect(() => unmergeable.parse(1234)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Unmergable intersection. Error path: []]`
+  );
+
+  // an async child behind a when-gated check islands at codegen; its thenable at parse time throws like the interpreter
+  const gated = z.number().refine(() => Promise.resolve(true));
+  (gated._zod.def.checks![0]!._zod.def as { when?: unknown }).when = () => true;
+  const compiled = compile(z.object({ n: gated }), { strict: true });
+  expect(() => compiled.parse({ n: 3 })).toThrow($ZodAsyncError);
 });
 
 test("strict objects reject inherited enumerable keys like the runtime", () => {

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1418,8 +1418,8 @@ test("xor and custom when-gated checks force runtime fallback", () => {
   expectMatch(z.object({ n: gated }), { n: 3 }); // runtime skips the gated check
 });
 
-test("fast path throws where the runtime throws instead of bailing to INVALID", () => {
-  // unmergeable intersection: both children passed, which is exactly the case the interpreter answers with a throw
+test("compiled parse surfaces the interpreter's throws through the fallback", () => {
+  // an unmergeable intersection bails to INVALID, and the fallback it hands to raises the interpreter's own error
   const unmergeable = compile(
     z.intersection(
       z.number(),
@@ -1431,7 +1431,7 @@ test("fast path throws where the runtime throws instead of bailing to INVALID", 
     `[Error: Unmergable intersection. Error path: []]`
   );
 
-  // an async child behind a when-gated check islands at codegen; its thenable at parse time throws like the interpreter
+  // a when-gated check islands at codegen, and the island's INVALID for an async run reaches the same fallback
   const gated = z.number().refine(() => Promise.resolve(true));
   (gated._zod.def.checks![0]!._zod.def as { when?: unknown }).when = () => true;
   const compiled = compile(z.object({ n: gated }), { strict: true });

--- a/wiki/compile.md
+++ b/wiki/compile.md
@@ -19,7 +19,9 @@ There is no `z.compile()` no-arg form. Different shapes for different jobs: expl
 
 The compiled fast path is a happy-path validator. It returns the parsed/transformed output or an `INVALID` sentinel. On `INVALID`, the wrapper calls the original `_zod.run` to produce the canonical `ZodError`.
 
-`INVALID` is not uniformly a rejection. A union reads it as one, so several constructs return it for a case the interpreter throws on: a transform handing back a thenable (union parity — the interpreter's own union falls through there), a runtime island running async, and an intersection whose merge is unmergeable. Codegen therefore tracks a `definite` flag, cleared by exactly those three, and `z.validate` skips its interpreted fallback only when the flag survives. Everything else — type, range and format checks, enums, unions, object and array members, and refinements, which throw on a thenable rather than bailing — leaves it set.
+`INVALID` is not uniformly a rejection, so codegen tracks a `definite` flag and `z.validate` skips its interpreted fallback only while it survives. Two things clear it. Any hoisted **user callback** — a refine, transform, custom predicate, catch value or lazy getter — clears it through `addUserConstant`, because that callback can throw and generated code can reject an earlier sibling before ever reaching it, so the rejection is no longer proof the interpreter would have rejected rather than thrown. A **runtime island**, an **intersection**, and a **record key whose own compile is not definite** clear it directly, for the same reason applied to a construct rather than a callback. What survives is the callback-free subset — type, range and format checks, enums, literals, unions, and object, array and tuple members — which is the shape a type guard is usually asked about.
+
+The transform case is why the flag exists rather than a throw in generated code: a transform handing back a thenable must keep answering `INVALID`, because the interpreter's own union falls through to the next branch there instead of propagating. `compile-differential` pins that.
 
 Consequences:
 

--- a/wiki/compile.md
+++ b/wiki/compile.md
@@ -19,7 +19,7 @@ There is no `z.compile()` no-arg form. Different shapes for different jobs: expl
 
 The compiled fast path is a happy-path validator. It returns the parsed/transformed output or an `INVALID` sentinel. On `INVALID`, the wrapper calls the original `_zod.run` to produce the canonical `ZodError`.
 
-`INVALID` strictly means "the runtime would reject". Anything generated code cannot decide throws instead of bailing — an async child reached synchronously throws `$ZodAsyncError`, an unmergeable intersection throws the interpreter's own `Unmergable intersection` error. Unions depend on this (a branch's `INVALID` is read as a rejection), and it is what lets `z.validate` answer `false` on `INVALID` without the interpreted fallback.
+`INVALID` is not uniformly a rejection. A union reads it as one, so several constructs return it for a case the interpreter throws on: a transform handing back a thenable (union parity — the interpreter's own union falls through there), a runtime island running async, and an intersection whose merge is unmergeable. Codegen therefore tracks a `definite` flag, cleared by exactly those three, and `z.validate` skips its interpreted fallback only when the flag survives. Everything else — type, range and format checks, enums, unions, object and array members, and refinements, which throw on a thenable rather than bailing — leaves it set.
 
 Consequences:
 

--- a/wiki/compile.md
+++ b/wiki/compile.md
@@ -19,6 +19,8 @@ There is no `z.compile()` no-arg form. Different shapes for different jobs: expl
 
 The compiled fast path is a happy-path validator. It returns the parsed/transformed output or an `INVALID` sentinel. On `INVALID`, the wrapper calls the original `_zod.run` to produce the canonical `ZodError`.
 
+`INVALID` strictly means "the runtime would reject". Anything generated code cannot decide throws instead of bailing — an async child reached synchronously throws `$ZodAsyncError`, an unmergeable intersection throws the interpreter's own `Unmergable intersection` error. Unions depend on this (a branch's `INVALID` is read as a rejection), and it is what lets `z.validate` answer `false` on `INVALID` without the interpreted fallback.
+
 Consequences:
 
 - 100% error parity with uncompiled Zod by construction. The fast path never produces errors; the runtime is the only source of `ZodError`s. We don't maintain a second error-path implementation, which is the main reason this design is preferable to arktype's dual `Allows` + `Apply` codegen.


### PR DESCRIPTION
`z.validate` on a compiled schema re-ran the entire schema through the interpreter whenever the compiled validator rejected, just to reach the verdict the fast path had already produced.

Often that second pass is dead work, because the compiled `INVALID` already means the runtime would reject — which is why a union can read a branch's `INVALID` as a rejection. Codegen now tracks a `definite` flag and `validate` skips the interpreted pass only while it survives. A call that passes a parse context still takes the interpreted path, since a context can change the verdict.

Two things clear the flag. Any hoisted **user callback** — a refine, transform, custom predicate, catch value or lazy getter — clears it, because that callback can throw and generated code can reject an earlier sibling before ever reaching it, so the rejection is no longer proof that the interpreter would have rejected rather than thrown. A **runtime island**, an **intersection**, and a **record key whose own compile is not definite** clear it directly. User code reaches generated code through a single `addUserConstant` helper that clears the flag, so a generator added later cannot quietly miss it.

What keeps the fast path is the callback-free subset: type, range and format checks, enums, literals, unions, and object, array and tuple members. That is the shape a type guard is usually asked about.

Compiled parsing semantics are untouched. The transform case is why this is a flag rather than a throw in generated code: a transform handing back a thenable has to keep answering `INVALID`, because the interpreter's own union falls through to the next branch there instead of propagating, and `compile-differential` pins that.

Invalid input to a compiled callback-free schema, minimum of 7 samples across 3 interleaved rounds:

| case | before | after |
| --- | --- | --- |
| failure in the last field | 856.2 ns | 89.8 ns |
| failure in the first field | 767.7 ns | 6.5 ns |
| valid input (unchanged path) | 109.8 ns | 110.1 ns |

Failure position sets the size of the win: the compiled validator stops at the first bad field, while the interpreted pass it used to trigger walked the whole value collecting every issue. Uncompiled `validate` measures flat to within 0.6% on a separate focused run, including `z.string()` at ~5 ns/op where any loss of inlining would show immediately.

Parity is fuzzed rather than argued: every risky construct in every container, against the interpreter, comparing the verdict and the thrown error class. The new test is that fuzz, and disabling the flag makes it fail.

Bundle: classic unchanged, `zod/mini` +2 B gz. Schema memory footprints are byte-identical.
