### PR TITLE
Collapse toZod's normalizer and move its docs to the API reference

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -3445,3 +3445,59 @@ const schema = z.string().apply(withDefault, "anonymous");
 schema.parse(undefined); // => "anonymous"
 schema.parse("sandwich"); // => "sandwich"
 ```
+
+## Matching an existing type
+
+Sometimes the type comes first: a database model, a type from a generated client, an interface you don't own. Pass it to `z.toZod<T>()` and TypeScript checks that the schema's output type is exactly `T`.
+
+```ts
+type Player = {
+  username: string;
+  xp: number;
+};
+
+const Player = z.toZod<Player>()(
+  z.object({
+    username: z.string(),
+    xp: z.number(),
+  })
+);
+
+Player.shape.username; // ZodString — the schema is returned unchanged
+```
+
+The check is exact type equality, so any drift from the type is a compile error:
+
+```ts
+z.toZod<Player>()(
+  z.object({
+    username: z.string(),
+    xp: z.number(),
+    admin: z.boolean(), // ❌ extra key
+  })
+);
+```
+
+The usual alternative is `satisfies z.ZodType<Player>`, which only checks assignability. It catches a missing required key, but extra keys, omitted optional keys, and a bare `z.any()` all slip through:
+
+```ts
+z.object({
+  username: z.string(),
+  xp: z.number(),
+  admin: z.boolean(),
+}) satisfies z.ZodType<Player>; // ✅ no error
+
+z.any() satisfies z.ZodType<Player>; // ✅ no error
+```
+
+An enum target matches `z.enum(...)`, and stays nominal — a plain literal union doesn't satisfy it:
+
+```ts
+enum Level {
+  Noob = "noob",
+  Pro = "pro",
+}
+
+z.toZod<{ level: Level }>()(z.object({ level: z.enum(Level) })); // ✅
+z.toZod<{ level: Level }>()(z.object({ level: z.enum(["noob", "pro"]) })); // ❌
+```

--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -1,6 +1,6 @@
 ---
 title: Basic usage
-description: "Basic usage guide covering schema definition, parsing data, error handling, type inference, and matching an existing type"
+description: "Basic usage guide covering schema definition, parsing data, error handling, and type inference"
 ---
 
 import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
@@ -166,67 +166,6 @@ type MySchemaIn = z.input<typeof mySchema>;
 
 type MySchemaOut = z.output<typeof mySchema>; // equivalent to z.infer<typeof mySchema>
 // number
-```
-
-## Matching an existing type
-
-Sometimes the type comes first: a database model, a type from a generated client, an interface you don't own. Pass it to `z.toZod<T>()` and TypeScript checks that the schema's output type is exactly `T`.
-
-```ts
-type Player = {
-  username: string;
-  xp: number;
-};
-
-const Player = z.toZod<Player>()(
-  z.object({
-    username: z.string(),
-    xp: z.number(),
-  })
-);
-
-Player.shape.username; // ZodString — the schema is returned unchanged
-```
-
-The check is exact type equality, so any drift from the type is a compile error:
-
-```ts
-z.toZod<Player>()(
-  z.object({
-    username: z.string(),
-    xp: z.number(),
-    admin: z.boolean(), // ❌ extra key
-  })
-);
-```
-
-The usual alternative is `satisfies z.ZodType<Player>`, which only checks assignability. It catches a missing required key, but extra keys, omitted optional keys, and a bare `z.any()` all slip through:
-
-```ts
-z.object({
-  username: z.string(),
-  xp: z.number(),
-  admin: z.boolean(),
-}) satisfies z.ZodType<Player>; // ✅ no error
-
-z.any() satisfies z.ZodType<Player>; // ✅ no error
-```
-
-Exactness applies to the type as TypeScript wrote it, so an intersection target matches `.and()` rather than `.safeExtend()`:
-
-```ts
-type Entry = { id: string } & { label: string };
-
-z.toZod<Entry>()(z.object({ id: z.string() }).and(z.object({ label: z.string() }))); // ✅
-z.toZod<Entry>()(z.object({ id: z.string() }).safeExtend({ label: z.string() })); // ❌
-```
-
-Flatten the target and `.safeExtend()` matches instead:
-
-```ts
-type Flatten<T> = { [K in keyof T]: T[K] } & {};
-
-z.toZod<Flatten<Entry>>()(z.object({ id: z.string() }).safeExtend({ label: z.string() })); // ✅
 ```
 
 ---

--- a/packages/zod/src/v4/classic/tests/assignability.test.ts
+++ b/packages/zod/src/v4/classic/tests/assignability.test.ts
@@ -333,6 +333,18 @@ test("toZod", () => {
 
   // @ts-expect-error a missing key is still a missing key
   z.toZod<Intersected>()(z.object({ a: z.number() }));
+
+  // `keyof` a function is `never`, so the normalizer must not walk into one — mapping it would erase the signature and make every callable compare equal
+  z.toZod<() => string>()(z.custom<() => string>());
+
+  // @ts-expect-error an incompatible callable output is still rejected
+  z.toZod<() => string>()(z.custom<() => number>());
+
+  // @ts-expect-error and so is an incompatible function-valued property
+  z.toZod<{ cb: (x: number) => void }>()(z.object({ cb: z.custom<(x: string) => void>() }));
+
+  // @ts-expect-error a method-bearing generic keeps its type arguments
+  z.toZod<{ m: Map<string, number> }>()(z.object({ m: z.custom<Map<string, string>>() }));
 });
 
 test("checks", () => {

--- a/packages/zod/src/v4/classic/tests/assignability.test.ts
+++ b/packages/zod/src/v4/classic/tests/assignability.test.ts
@@ -319,24 +319,20 @@ test("toZod", () => {
   // @ts-expect-error toZod checks output, not input
   z.toZod<string>()(z.string().transform((value) => value.length));
 
-  // Exact equality is deliberately the only mode. A bidirectional-assignability mode would accept both of the two cases above — `any` is assignable in both directions by construction, and `readonly` is not part of assignability — so it would silently drop the guarantees the rest of this test pins. The cost is the asymmetry below: an intersection target matches `.and()` but not `.safeExtend()`, and a flat target matches `.safeExtend()` but not `.and()`. Flattening the target with a mapped type switches which spelling matches rather than accepting both.
+  // Exact equality is deliberately the only mode. A bidirectional-assignability mode would accept both of the two cases above — `any` is assignable in both directions by construction, and `readonly` is not part of assignability — so it would silently drop the guarantees the rest of this test pins.
+
+  // An intersection and the flat object with the same keys are interchangeable as targets, since the normalizer flattens both.
   type Intersected = { a: number } & { b: string };
-  type Flatten<T> = { [K in keyof T]: T[K] } & {};
   const viaAnd = z.object({ a: z.number() }).and(z.object({ b: z.string() }));
   const viaExtend = z.object({ a: z.number() }).safeExtend({ b: z.string() });
 
   z.toZod<Intersected>()(viaAnd);
-  z.toZod<{ a: number; b: string }>()(viaExtend);
-  z.toZod<Flatten<Intersected>>()(viaExtend);
-
-  // @ts-expect-error flattening the target does not make `.and()` match as well
-  z.toZod<Flatten<Intersected>>()(viaAnd);
-
-  // @ts-expect-error .safeExtend() produces a flat object type, not an intersection
   z.toZod<Intersected>()(viaExtend);
-
-  // @ts-expect-error .and() produces an intersection, not a flat object type
   z.toZod<{ a: number; b: string }>()(viaAnd);
+  z.toZod<{ a: number; b: string }>()(viaExtend);
+
+  // @ts-expect-error a missing key is still a missing key
+  z.toZod<Intersected>()(z.object({ a: z.number() }));
 });
 
 test("checks", () => {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -101,12 +101,8 @@ type ToZodKeyMismatch<Expected, Received> = schemas.$ZodType & {
 // An enum reference and the union of exactly its members are mutually assignable but not identical, so `AssertEqual` alone rejects `z.enum(SomeEnum)` against a `SomeEnum` target. Unioning each side with a private dummy forces the union to be rebuilt, which collapses that one difference and nothing else — plain literals against an enum, member subsets, brands and `any` all still fail. The symbol is not exported, so no user type can smuggle it in and cancel a real difference.
 declare const toZodDummy: unique symbol;
 
-// Recurses only through types identical to their own homomorphic rebuild, which preserves the exactness guarantees: an intersection, a call signature and `readonly`/optional modifiers all survive or block the walk, so only leaves are normalized.
-type ToZodNormalize<T> = [T] extends [object]
-  ? AssertEqual<T, { [K in keyof T]: T[K] }> extends true
-    ? { [K in keyof T]: ToZodNormalize<T[K]> }
-    : T
-  : T | typeof toZodDummy;
+// Homomorphic, so `readonly` and optional modifiers survive the rebuild and only leaves are normalized. An intersection flattens here, which is why an intersection target and the flat object with the same keys match each other.
+type ToZodNormalize<T> = [T] extends [object] ? { [K in keyof T]: ToZodNormalize<T[K]> } : T | typeof toZodDummy;
 
 type ToZodEqual<Output, T> = AssertEqual<Output, T> extends true
   ? true

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -101,8 +101,12 @@ type ToZodKeyMismatch<Expected, Received> = schemas.$ZodType & {
 // An enum reference and the union of exactly its members are mutually assignable but not identical, so `AssertEqual` alone rejects `z.enum(SomeEnum)` against a `SomeEnum` target. Unioning each side with a private dummy forces the union to be rebuilt, which collapses that one difference and nothing else — plain literals against an enum, member subsets, brands and `any` all still fail. The symbol is not exported, so no user type can smuggle it in and cancel a real difference.
 declare const toZodDummy: unique symbol;
 
-// Homomorphic, so `readonly` and optional modifiers survive the rebuild and only leaves are normalized. An intersection flattens here, which is why an intersection target and the flat object with the same keys match each other.
-type ToZodNormalize<T> = [T] extends [object] ? { [K in keyof T]: ToZodNormalize<T[K]> } : T | typeof toZodDummy;
+// Homomorphic, so `readonly` and optional modifiers survive the rebuild and only leaves are normalized. An intersection flattens here, which is why an intersection target and the flat object with the same keys match each other. A callable stops the walk because `keyof` a function is `never`, so mapping one would erase its signature and make every function compare equal.
+type ToZodNormalize<T> = [T] extends [(...args: any[]) => any]
+  ? T
+  : [T] extends [object]
+    ? { [K in keyof T]: ToZodNormalize<T[K]> }
+    : T | typeof toZodDummy;
 
 type ToZodEqual<Output, T> = AssertEqual<Output, T> extends true
   ? true


### PR DESCRIPTION
Two changes, both from maintainer review of #6533.

**The normalizer collapses to one line.** The recursive walk guarded each step with `AssertEqual<T, { [K in keyof T]: T[K] }>`, recursing only into types identical to their own homomorphic rebuild. Measured against a 35-case battery and the full suite, that guard has exactly one effect: it keeps an intersection type distinguishable from the flat object with the same keys. Nothing else depends on it — `any`, brands, `readonly`, optional modifiers, member subsets, and plain literals against a nominal enum are all preserved by the homomorphic mapping itself.

Dropping it makes an intersection target and a flat target interchangeable, so all four pairings of `.and()` / `.safeExtend()` against either spelling now match. That removes the asymmetry the docs previously described along with the `Flatten` workaround they prescribed for it. Three assertions in `assignability.test.ts` flip from rejected to accepted; the pairs involved describe structurally identical data.

For the record, the alternatives that do not work, since the obvious instinct is to change the equality idiom instead. Four idioms were compared over the same battery, including expect-type's `StrictEqualUsingTSInternalIdenticalToOperator`. Two of them fix a *bare* enum target with no added machinery, but none fixes an enum nested in an object, array, tuple or record, which is what #6524 reports. The tell is that `{ e: SomeEnum | null }` and `{ e: A | B | null }` already compare identical under the unmodified idiom: a union at the leaf is rebuilt and the two spellings converge. The rebuild only works where it is applied, and no whole-type comparison reaches into a property, so reaching leaves requires recursion.

**`z.toZod` moves out of Basics.** It is a sophisticated pattern, not an introductory one, so its section moves verbatim to the API reference, minus the now-false intersection paragraphs.

Type-only change: zero runtime, memory and bundle delta. Full suite green — 575 files, 7879 tests, no type errors.
