### PR TITLE
refactor: collapse cachedInternal back into cached

### DIFF
--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2108,7 +2108,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
     });
   }
 
-  const _normalized = util.cachedInternal(() => normalizeDef(def));
+  const _normalized = util.cached(() => normalizeDef(def));
 
   util.defineLazyInternal(inst, "propValues", (zod) => {
     const shape = zod.def.shape;
@@ -2181,7 +2181,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
     $ZodObject.init(inst, def);
 
     const superParse = inst._zod.parse;
-    const _normalized = util.cachedInternal(() => normalizeDef(def));
+    const _normalized = util.cached(() => normalizeDef(def));
 
     const memo = core.globalConfig.memoizer;
 
@@ -2632,7 +2632,7 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
       }
     });
 
-    const disc = util.cachedInternal(() => {
+    const disc = util.cached(() => {
       const opts = def.options;
       const map: Map<util.Primitive, $ZodType> = new Map();
       for (const o of opts) {

--- a/packages/zod/src/v4/core/tests/cached.test.ts
+++ b/packages/zod/src/v4/core/tests/cached.test.ts
@@ -2,72 +2,53 @@ import { expect, test } from "vitest";
 
 import { util } from "zod/v4/core";
 
-// `cached` is public as `z.core.util.cached`, so its box shape is part of the contract; `cachedInternal` trades that shape for a fast prototype-backed box.
-for (const [name, make] of [
-  ["cached", util.cached],
-  ["cachedInternal", util.cachedInternal],
-] as const) {
-  test(`${name} defers the getter until the first read`, () => {
-    let runs = 0;
-    const box = make(() => ++runs);
-    expect(runs).toBe(0);
-    expect(box.value).toBe(1);
-    expect(box.value).toBe(1);
-    expect(runs).toBe(1);
-  });
-
-  test(`${name} memoizes an undefined result`, () => {
-    let runs = 0;
-    const box = make(() => {
-      runs++;
-      return undefined;
-    });
-    expect(box.value).toBeUndefined();
-    expect(box.value).toBeUndefined();
-    expect(runs).toBe(1);
-  });
-
-  test(`${name} retries after the getter throws`, () => {
-    let attempts = 0;
-    const box = make(() => {
-      if (++attempts < 2) throw new Error("boom");
-      return "recovered";
-    });
-    expect(() => box.value).toThrow("boom");
-    expect(box.value).toBe("recovered");
-    expect(attempts).toBe(2);
-  });
-
-  test(`${name} rejects assignment to value`, () => {
-    const box = make(() => 1);
-    expect(() => {
-      (box as { value: number }).value = 2;
-    }).toThrow(TypeError);
-  });
-}
-
-test("cached keeps its own enumerable value, before and after resolution", () => {
-  const box = util.cached(() => 1);
-  expect(Object.keys(box)).toEqual(["value"]);
-  // spread reads `value`, which resolves the box
-  expect({ ...box }).toEqual({ value: 1 });
-
-  const desc = Object.getOwnPropertyDescriptor(box, "value")!;
-  expect(desc.enumerable).toBe(true);
-  expect(desc.configurable).toBe(true);
-  expect(desc.writable).toBe(false);
-  expect(Object.keys(box)).toEqual(["value"]);
+test("cached defers the getter until the first read", () => {
+  let runs = 0;
+  const box = util.cached(() => ++runs);
+  expect(runs).toBe(0);
+  expect(box.value).toBe(1);
+  expect(box.value).toBe(1);
+  expect(runs).toBe(1);
 });
 
-test("cachedInternal inherits value and never exposes the getter through it", () => {
-  const box = util.cachedInternal(() => 1);
+test("cached memoizes an undefined result", () => {
+  let runs = 0;
+  const box = util.cached(() => {
+    runs++;
+    return undefined;
+  });
+  expect(box.value).toBeUndefined();
+  expect(box.value).toBeUndefined();
+  expect(runs).toBe(1);
+});
+
+test("cached retries after the getter throws", () => {
+  let attempts = 0;
+  const box = util.cached(() => {
+    if (++attempts < 2) throw new Error("boom");
+    return "recovered";
+  });
+  expect(() => box.value).toThrow("boom");
+  expect(box.value).toBe("recovered");
+  expect(attempts).toBe(2);
+});
+
+test("cached rejects assignment to value", () => {
+  const box = util.cached(() => 1);
+  expect(() => {
+    (box as { value: number }).value = 2;
+  }).toThrow(TypeError);
+});
+
+// the getter is inherited, so a box carries only its two state slots and stays out of dictionary mode
+test("cached keeps value on the prototype", () => {
+  const box = util.cached(() => 1);
   expect(Object.getOwnPropertyDescriptor(box, "value")).toBeUndefined();
   expect("value" in box).toBe(true);
   expect(box.value).toBe(1);
 });
 
-test("allowsEval keeps the cached box shape", () => {
+test("allowsEval reads through the same box", () => {
   expect(util.allowsEval.value).toBe(true);
-  expect(Object.keys(util.allowsEval)).toEqual(["value"]);
-  expect({ ...util.allowsEval }).toEqual({ value: true });
+  expect(util.allowsEval.value).toBe(true);
 });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -290,18 +290,7 @@ export function jsonStringifyReplacer(_: string, value: any): any {
   return value;
 }
 
-export function cached<T>(getter: () => T): { value: T } {
-  return {
-    get value() {
-      const value = getter();
-      // own, enumerable and configurable, matching the accessor it replaces; public as `z.core.util.cached`
-      Object.defineProperty(this, "value", { value });
-      return value;
-    },
-  };
-}
-
-// accessor on the prototype, not an own literal property: an own accessor puts the box in dictionary mode from birth (~360 B and a slow load per read against ~100 B and an inlined getter here). Not `cached`, whose own enumerable `value` is public as `z.core.util.cached`.
+// the accessor lives on a shared prototype: an own accessor makes every box a dictionary-mode object (~360 B and a slow load per read against ~100 B and an inlined getter here)
 class Cached<T> {
   _getter: (() => T) | undefined;
   _value: T | undefined;
@@ -321,7 +310,7 @@ class Cached<T> {
   }
 }
 
-export function cachedInternal<T>(getter: () => T): { value: T } {
+export function cached<T>(getter: () => T): { value: T } {
   return new Cached(getter);
 }
 


### PR DESCRIPTION
#6537 left two lazy-box helpers: `cached`, keeping an own enumerable `value` for anything outside zod that might enumerate or spread the box, and `cachedInternal`, the prototype-backed box the schema caches actually use.

Nothing outside zod uses the first one. Every external hit for `util.cached` is a vendored copy of zod's own source — bun caches, `vendor-node-modules`, benchmark checkouts — and the real consumers of `allowsEval` (`gajus/zod-compiler`, `pmatos/jsse`) only ever read `.value`, which is unchanged. So there is one helper again, and it is the fast one.

Measured against `bf990216`, both worktrees installed the same way:

| | main | this branch |
| --- | --- | --- |
| bundle gz, classic | 24686 B | 24653 B |
| bundle gz, mini | 4565 B | 4565 B |
| `z.object()` 3 keys retained | 4731 B | 4730 B |
| `z.discriminatedUnion` 2 options | 11025 B | 11024 B |
| `zod/mini` object 3 keys | 3464 B | 3464 B |

What changes for a caller reading `z.core.util.cached(fn).value`: nothing. What changes for one enumerating or spreading the returned box: it now carries `_getter` and `_value` and inherits `value`, so spreading no longer forces the getter.

A plain object was the obvious alternative to the class and measures worse both ways: a `__proto__` literal builds 2.5x slower (V8 slow path), and `Object.create` plus assignments is speed-neutral but costs 32 B more per object schema, because the box misses the in-object slots a constructor's map provides.

Refs #6517
