### PR TITLE
Rename the JSON Schema `process` helper so bundler polyfills cannot collide

### DIFF
--- a/packages/zod/src/v4/core/json-schema-generator.ts
+++ b/packages/zod/src/v4/core/json-schema-generator.ts
@@ -10,7 +10,7 @@ import {
   extractDefs,
   finalize,
   initializeContext,
-  process,
+  processSchema,
 } from "./to-json-schema.js";
 
 /**
@@ -102,7 +102,7 @@ export class JSONSchemaGenerator {
    * This must be called before emit().
    */
   process(schema: schemas.$ZodType, _params: ProcessParams = { path: [], schemaPath: [] }): JSONSchema.BaseSchema {
-    return process(schema, this.ctx, _params);
+    return processSchema(schema, this.ctx, _params);
   }
 
   /**

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -17,7 +17,7 @@ import {
   handleUnrepresentable,
   initializeContext,
   isTransforming,
-  process,
+  processSchema,
 } from "./to-json-schema.js";
 import { assignProp, getEnumValues } from "./util.js";
 
@@ -294,7 +294,7 @@ export const arrayProcessor: Processor<schemas.$ZodArray> = (schema, ctx, _json,
   if (typeof maximum === "number") json.maxItems = maximum;
 
   json.type = "array";
-  json.items = process(def.element, ctx as any, {
+  json.items = processSchema(def.element, ctx as any, {
     ...params,
     path: [...params.path, "items"],
   });
@@ -338,7 +338,7 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
     assignProp(
       json.properties,
       key,
-      process(shape[key]!, ctx as any, {
+      processSchema(shape[key]!, ctx as any, {
         ...params,
         path: [...params.path, "properties", key],
       })
@@ -370,7 +370,7 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
     // regular
     if (ctx.io === "output") json.additionalProperties = false;
   } else if (def.catchall) {
-    json.additionalProperties = process(def.catchall, ctx as any, {
+    json.additionalProperties = processSchema(def.catchall, ctx as any, {
       ...params,
       path: [...params.path, "additionalProperties"],
     });
@@ -414,7 +414,7 @@ export const propertiesProcessor: Processor<schemas.$ZodProperties> = (schema, c
     assignProp(
       json.properties,
       key,
-      process(def.shape[key]!, ctx as any, {
+      processSchema(def.shape[key]!, ctx as any, {
         ...params,
         path: [...params.path, "properties", key],
       })
@@ -430,7 +430,7 @@ export const unionProcessor: Processor<schemas.$ZodUnion> = (schema, ctx, json, 
   // Exclusive unions (inclusive === false) use oneOf (exactly one match) instead of anyOf (one or more matches). This includes both z.xor() and discriminated unions
   const isExclusive = def.inclusive === false;
   const options = def.options.map((x, i) =>
-    process(x, ctx as any, {
+    processSchema(x, ctx as any, {
       ...params,
       path: [...params.path, isExclusive ? "oneOf" : "anyOf", i],
     })
@@ -444,11 +444,11 @@ export const unionProcessor: Processor<schemas.$ZodUnion> = (schema, ctx, json, 
 
 export const intersectionProcessor: Processor<schemas.$ZodIntersection> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodIntersectionDef;
-  const a = process(def.left, ctx as any, {
+  const a = processSchema(def.left, ctx as any, {
     ...params,
     path: [...params.path, "allOf", 0],
   });
-  const b = process(def.right, ctx as any, {
+  const b = processSchema(def.right, ctx as any, {
     ...params,
     path: [...params.path, "allOf", 1],
   });
@@ -473,13 +473,13 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
     ctx.target === "draft-2020-12" ? "items" : ctx.target === "openapi-3.0" ? "items" : "additionalItems";
 
   const prefixItems = def.items.map((x, i) =>
-    process(x, ctx as any, {
+    processSchema(x, ctx as any, {
       ...params,
       path: [...params.path, prefixPath, i],
     })
   );
   const rest = def.rest
-    ? process(def.rest, ctx as any, {
+    ? processSchema(def.rest, ctx as any, {
         ...params,
         path: [...params.path, restPath, ...(ctx.target === "openapi-3.0" ? [def.items.length] : [])],
       })
@@ -625,7 +625,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
 
   if (def.mode === "loose" && patterns && patterns.size > 0) {
     // Use patternProperties for looseRecord with regex patterns
-    const valueSchema = process(def.valueType, ctx as any, {
+    const valueSchema = processSchema(def.valueType, ctx as any, {
       ...params,
       path: [...params.path, "patternProperties", "*"],
     });
@@ -636,7 +636,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
   } else {
     // Default behavior: use propertyNames + additionalProperties
     if (ctx.target === "draft-07" || ctx.target === "draft-2020-12") {
-      json.propertyNames = process(def.keyType, ctx as any, {
+      json.propertyNames = processSchema(def.keyType, ctx as any, {
         ...params,
         path: [...params.path, "propertyNames"],
       });
@@ -648,7 +648,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
       }
       pending.push(schema);
     }
-    json.additionalProperties = process(def.valueType, ctx as any, {
+    json.additionalProperties = processSchema(def.valueType, ctx as any, {
       ...params,
       path: [...params.path, "additionalProperties"],
     });
@@ -671,7 +671,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
 
 export const nullableProcessor: Processor<schemas.$ZodNullable> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodNullableDef;
-  const inner = process(def.innerType, ctx as any, params);
+  const inner = processSchema(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   if (ctx.target === "openapi-3.0") {
     seen.ref = def.innerType;
@@ -683,7 +683,7 @@ export const nullableProcessor: Processor<schemas.$ZodNullable> = (schema, ctx, 
 
 export const nonoptionalProcessor: Processor<schemas.$ZodNonOptional> = (schema, ctx, _json, params) => {
   const def = schema._zod.def as schemas.$ZodNonOptionalDef;
-  process(def.innerType, ctx as any, params);
+  processSchema(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
 };
@@ -712,7 +712,7 @@ function serializeDefaultValue(
 
 export const defaultProcessor: Processor<schemas.$ZodDefault> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodDefaultDef;
-  process(def.innerType, ctx as any, params);
+  processSchema(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
   const value = serializeDefaultValue(def.defaultValue, schema, ctx as ToJSONSchemaContext, json, params);
@@ -721,7 +721,7 @@ export const defaultProcessor: Processor<schemas.$ZodDefault> = (schema, ctx, js
 
 export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodPrefaultDef;
-  process(def.innerType, ctx as any, params);
+  processSchema(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
   if (ctx.io !== "input") return;
@@ -731,7 +731,7 @@ export const prefaultProcessor: Processor<schemas.$ZodPrefault> = (schema, ctx, 
 
 export const catchProcessor: Processor<schemas.$ZodCatch> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodCatchDef;
-  process(def.innerType, ctx as any, params);
+  processSchema(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
   let catchValue: any;
@@ -748,14 +748,14 @@ export const pipeProcessor: Processor<schemas.$ZodPipe> = (schema, ctx, _json, p
   const def = schema._zod.def as schemas.$ZodPipeDef;
   const inIsTransform = def.in._zod.traits.has("$ZodTransform");
   const innerType = ctx.io === "input" ? (inIsTransform ? def.out : def.in) : def.out;
-  process(innerType, ctx as any, params);
+  processSchema(innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = innerType;
 };
 
 export const readonlyProcessor: Processor<schemas.$ZodReadonly> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodReadonlyDef;
-  process(def.innerType, ctx as any, params);
+  processSchema(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
   json.readOnly = true;
@@ -763,21 +763,21 @@ export const readonlyProcessor: Processor<schemas.$ZodReadonly> = (schema, ctx, 
 
 export const promiseProcessor: Processor<schemas.$ZodPromise> = (schema, ctx, _json, params) => {
   const def = schema._zod.def as schemas.$ZodPromiseDef;
-  process(def.innerType, ctx as any, params);
+  processSchema(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
 };
 
 export const optionalProcessor: Processor<schemas.$ZodOptional> = (schema, ctx, _json, params) => {
   const def = schema._zod.def as schemas.$ZodOptionalDef;
-  process(def.innerType, ctx as any, params);
+  processSchema(def.innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = def.innerType;
 };
 
 export const lazyProcessor: Processor<schemas.$ZodLazy> = (schema, ctx, _json, params) => {
   const innerType = (schema as schemas.$ZodLazy)._zod.innerType;
-  process(innerType, ctx as any, params);
+  processSchema(innerType, ctx as any, params);
   const seen = ctx.seen.get(schema)!;
   seen.ref = innerType;
 };
@@ -850,7 +850,7 @@ export function toJSONSchema(
     // First pass: process all schemas to build the seen map
     for (const entry of registry._idmap.entries()) {
       const [_, schema] = entry;
-      process(schema, ctx as any);
+      processSchema(schema, ctx as any);
     }
 
     const schemas: Record<string, JSONSchema.BaseSchema> = {};
@@ -882,7 +882,7 @@ export function toJSONSchema(
 
   // Single schema case
   const ctx = initializeContext({ ...params, processors: allProcessors });
-  process(input, ctx as any);
+  processSchema(input, ctx as any);
   extractDefs(ctx as any, input);
   return finalize(ctx as any, input);
 }

--- a/packages/zod/src/v4/core/tests/polyfill-collision.test.ts
+++ b/packages/zod/src/v4/core/tests/polyfill-collision.test.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { build, transform } from "esbuild";
 import { expect, test } from "vitest";
+import * as core from "zod/v4/core";
 
 // Browser polyfills for node globals land as raw text in the bundle's top scope — an esbuild `banner`, a scope-unaware injector — so the bundler never sees the collision and the browser is the first thing to read both declarations. zod must therefore declare none of these names at module scope. The JSON Schema pass shipped an `export function process` for three minors before #6397 reported the white screen it caused.
 const INJECTED = ["process", "Buffer", "global", "__dirname", "__filename"];
@@ -12,8 +13,8 @@ const MINI = path.resolve(here, "../../../mini/index.ts");
 
 const polyfills = INJECTED.map((name) => `const ${name} = {};`).join("\n");
 
-// toJSONSchema has to be reachable: a bundle that only parses a schema tree-shakes the offending module away and would pass no matter what it declares
-const ENTRY = `import * as z from "%ENTRY%";\nglobalThis.__out = z.toJSONSchema(z.string());`;
+// toJSONSchema has to be reachable: a bundle that only parses a schema tree-shakes the offending module away and would pass no matter what it declares. `z.core.process` is the pre-rename export name, read as a namespace property so the entry itself declares no `process` binding.
+const ENTRY = `import * as z from "%ENTRY%";\nglobalThis.__out = [z.toJSONSchema(z.string()), z.core.process];`;
 
 test.each([
   ["classic", CLASSIC],
@@ -39,3 +40,7 @@ test.each([
   },
   30000
 );
+
+test("the pre-rename `process` export still resolves to the helper", () => {
+  expect(core.process).toBe(core.processSchema);
+});

--- a/packages/zod/src/v4/core/tests/polyfill-collision.test.ts
+++ b/packages/zod/src/v4/core/tests/polyfill-collision.test.ts
@@ -1,0 +1,41 @@
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { build, transform } from "esbuild";
+import { expect, test } from "vitest";
+
+// Browser polyfills for node globals land as raw text in the bundle's top scope — an esbuild `banner`, a scope-unaware injector — so the bundler never sees the collision and the browser is the first thing to read both declarations. zod must therefore declare none of these names at module scope. The JSON Schema pass shipped an `export function process` for three minors before #6397 reported the white screen it caused.
+const INJECTED = ["process", "Buffer", "global", "__dirname", "__filename"];
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const CLASSIC = path.resolve(here, "../../../index.ts");
+const MINI = path.resolve(here, "../../../mini/index.ts");
+
+const polyfills = INJECTED.map((name) => `const ${name} = {};`).join("\n");
+
+// toJSONSchema has to be reachable: a bundle that only parses a schema tree-shakes the offending module away and would pass no matter what it declares
+const ENTRY = `import * as z from "%ENTRY%";\nglobalThis.__out = z.toJSONSchema(z.string());`;
+
+test.each([
+  ["classic", CLASSIC],
+  ["mini", MINI],
+])(
+  "a %s bundle reaching toJSONSchema parses beside polyfilled node globals",
+  async (_flavor, entrypoint) => {
+    const result = await build({
+      stdin: { contents: ENTRY.replace("%ENTRY%", entrypoint), loader: "ts", resolveDir: here },
+      bundle: true,
+      format: "esm",
+      target: "es2020",
+      write: false,
+      logLevel: "silent",
+      banner: { js: polyfills },
+    });
+    const out = result.outputFiles[0]!.text;
+
+    expect(out).toContain("https://json-schema.org/draft/2020-12/schema");
+
+    // the banner is appended after esbuild has already renamed its own symbols, so this second pass is where a duplicate surfaces: `The symbol "process" has already been declared`
+    await expect(transform(out, { loader: "js", format: "esm" })).resolves.toBeTruthy();
+  },
+  30000
+);

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -290,6 +290,9 @@ export function processSchema<T extends schemas.$ZodType>(
   return _result.schema;
 }
 
+/** @deprecated Renamed to `processSchema`. An export alias declares no binding, so it is safe to keep. */
+export { processSchema as process };
+
 // Escape a reference token for use in a JSON Pointer fragment (RFC 6901): `~` becomes `~0` and `/` becomes `~1`. The `~` replacement must run first.
 function encodeJSONPointerSegment(segment: string): string {
   return segment.replace(/~/g, "~0").replace(/\//g, "~1");

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -128,7 +128,7 @@ export interface ToJSONSchemaContext {
    * covers both passes in `finalize`: the ref flattening and the `$defs` build.
    *
    * The passes are valid only while nothing they read has changed, so both are cleared in
-   * `process()` when the map grows, and in `JSONSchemaGenerator.emit()`, which can also change
+   * `processSchema()` when the map grows, and in `JSONSchemaGenerator.emit()`, which can also change
    * the `cycles` and `reused` they branch on.
    *
    * One case is deliberately not covered: an `override` callback that writes to
@@ -209,7 +209,8 @@ export function handleUnrepresentable(
   return true;
 }
 
-export function process<T extends schemas.$ZodType>(
+// never rename this back to `process`: bundler polyfills inject a top-level `const process` that a lexical declaration of the same name collides with (#6397)
+export function processSchema<T extends schemas.$ZodType>(
   schema: T,
   ctx: ToJSONSchemaContext,
   _params: ProcessParams = { path: [], schemaPath: [] }
@@ -264,7 +265,7 @@ export function process<T extends schemas.$ZodType>(
     if (parent) {
       // Also set ref if processor didn't (for inheritance)
       if (!result.ref) result.ref = parent;
-      process(parent, ctx, params);
+      processSchema(parent, ctx, params);
       ctx.seen.get(parent)!.isParent = true;
     }
   }
@@ -832,7 +833,7 @@ export const createToJSONSchemaMethod =
   <T extends schemas.$ZodType>(schema: T, processors: Record<string, Processor> = {}) =>
   (params?: ToJSONSchemaParams): ZodStandardJSONSchemaPayload<T> => {
     const ctx = initializeContext({ ...params, processors });
-    process(schema, ctx);
+    processSchema(schema, ctx);
     extractDefs(ctx, schema);
     return finalize(ctx, schema);
   };
@@ -847,7 +848,7 @@ export const createStandardJSONSchemaMethod =
   (params?: StandardJSONSchemaMethodParams): JSONSchema.BaseSchema => {
     const { libraryOptions, target } = params ?? {};
     const ctx = initializeContext({ ...(libraryOptions ?? {}), target, io, processors });
-    process(schema, ctx);
+    processSchema(schema, ctx);
     extractDefs(ctx, schema);
     return finalize(ctx, schema);
   };


### PR DESCRIPTION
`to-json-schema.ts` declares `export function process(...)` at module scope, and has shipped it since 4.2.0. A browser polyfill for node globals that lands as raw text in the bundle's top scope — an esbuild `banner`, a plugin that prepends a shim in `transform` — collides with it. The bundler appends its banner after renaming its own symbols, so it never sees the duplicate, and the browser is the first thing to read both declarations:

```
SyntaxError: Identifier 'process' has already been declared
```

Renamed to `processSchema`, with `process` kept as an export alias. An export specifier declares no local binding, so the old name stays importable from `zod/v4/core` without bringing the collision back. `JSONSchemaGenerator#process` is a class member rather than a top-level binding, so it is untouched, as are `processors`, `Processor` and `ProcessParams`.

Reproduced against the published 4.5.4 tarball with esbuild's `--banner:js`, and confirmed fixed. The reporter's own setup — Vite 5.4.14 dev with `NodeGlobalsPolyfillPlugin({ process: true })` — does not reproduce it: esbuild's `inject` is scope-aware, so it sees the conflict and renames Zod's declaration to `process2`. Something else in their build is injecting `process` as raw text, and the rename closes the whole class either way.

Bundle size is byte-identical, minified and gzipped, on classic and mini both with and without `toJSONSchema` reachable.

Fixes #6397
