### PR TITLE
Keep a numeric TS enum's reverse-mapping keys out of `.options`

### DIFF
--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2060,7 +2060,8 @@ export const ZodEnum: core.$constructor<ZodEnum> = /*@__PURE__*/ core.$construct
   inst._zod.processJSONSchema = (ctx, json, params) => processors.enumProcessor(inst, ctx, json, params);
 
   inst.enum = def.entries;
-  inst.options = Object.values(def.entries);
+  // reuse the parsed value set so a numeric TS enum's reverse-mapping keys stay out
+  inst.options = [...inst._zod.values] as util.EnumValue[];
 
   const keys = new Set(Object.keys(def.entries));
 

--- a/packages/zod/src/v4/classic/tests/enum.test.ts
+++ b/packages/zod/src/v4/classic/tests/enum.test.ts
@@ -87,6 +87,15 @@ test("enum from non-const inputs", () => {
 
 test("get options", () => {
   expect(z.enum(["tuna", "trout"]).options).toEqual(["tuna", "trout"]);
+
+  enum Fish {
+    Tuna = 0,
+    Trout = 1,
+  }
+
+  // numeric enums carry reverse-mapping keys; options lists only what parse accepts
+  expect(z.enum(Fish).options).toEqual([Fish.Tuna, Fish.Trout]);
+  expect(z.enum(Fish).safeParse("Tuna").success).toEqual(false);
 });
 
 test("readonly enum", () => {

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1362,7 +1362,8 @@ export const ZodMiniEnum: core.$constructor<ZodMiniEnum> = /*@__PURE__*/ core.$c
     core.$ZodEnum.init(inst, def);
     ZodMiniType.init(inst, def);
 
-    inst.options = Object.values(def.entries);
+    // reuse the parsed value set so a numeric TS enum's reverse-mapping keys stay out
+    inst.options = [...inst._zod.values] as util.EnumValue[];
   }
 );
 

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -491,6 +491,14 @@ test("z.enum - native", () => {
   // expect(a.enum.A).toEqual(NativeEnum.A);
   // expect(a.enum.B).toEqual(NativeEnum.B);
   // expect(a.enum.C).toEqual(NativeEnum.C);
+
+  enum NumericEnum {
+    A = 0,
+    B = 1,
+  }
+
+  // numeric enums carry reverse-mapping keys; options lists only what parse accepts
+  expect(z.enum(NumericEnum).options).toEqual([NumericEnum.A, NumericEnum.B]);
 });
 
 test("z.nativeEnum", () => {


### PR DESCRIPTION
A TypeScript enum passed to `z.enum()` carries both directions of its mapping at runtime. The parse set drops the reverse half via `util.getEnumValues`, but `.options` was assigned straight from the entries object, so a three-member numeric enum listed six values — three of which the schema rejects.

```ts
enum Country {
  UK,
  Germany,
  France,
}

z.enum(Country).options; // ["UK", "Germany", "France", 0, 1, 2]
z.enum(Country).safeParse("France"); // { success: false }
```

The declared type is `Array<T[keyof T]>`, so the names were never admissible there either. The assignment now reuses the value set `$ZodEnum` already builds, which is what the parser checks against. Classic and mini both carried the line.

A string enum is unchanged. A numeric enum now reports exactly what parse accepts.

Weighed on all three axes, measured against the parent commit:

| axis | result |
| --- | --- |
| bundle | −6 B raw on a classic and a mini enum fixture; gzipped within ±1 B either way |
| memory | unchanged — `z.enum(['a','b','c'])` retains 1432 B on both revisions |
| runtime | string enum construction unchanged; numeric enum construction ~6% faster, since the entries object is twice the size of the value set |

Runtime is min-of-12 over 100k constructions, alternating revisions round by round across three rounds; the numeric-enum ranges do not overlap. The machine was loaded, so treat the absolute times as soft.
