### PR TITLE
fix(v4): release the parsed input once a failing safeParse builds its error

### DIFF
--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1,4 +1,6 @@
 import { inspect, types } from "node:util";
+import v8 from "node:v8";
+import vm from "node:vm";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import * as z from "zod/v4";
 
@@ -1014,5 +1016,34 @@ describe("safeParse builds the error on first read", () => {
     const replaced = new z.ZodError([]);
     (result as any).error = replaced;
     expect(result.error).toBe(replaced);
+  });
+
+  test("reading the error releases the parsed input", async () => {
+    // es2020 is the target, and its lib predates WeakRef
+    type Weak<T extends object> = { deref(): T | undefined };
+    const { WeakRef: Weak } = globalThis as unknown as { WeakRef: new <T extends object>(target: T) => Weak<T> };
+    // vitest carries no --expose-gc, so reach the collector the way node's own tests do
+    v8.setFlagsFromString("--expose-gc");
+    const gc = vm.runInNewContext("gc") as () => void;
+
+    const schema = z.string();
+    const refs: Weak<object>[] = [];
+    const results: unknown[] = [];
+    for (let i = 0; i < 50; i++) {
+      const input = { i, blob: new Array(500).fill(i) };
+      refs.push(new Weak(input));
+      const result = schema.safeParse(input);
+      void result.error;
+      results.push(result);
+    }
+    // the collector decides when it runs, so give it several passes; a retained input never clears no matter how many it gets
+    const live = () => refs.filter((ref) => ref.deref() !== undefined).length;
+    for (let attempt = 0; attempt < 10 && live() > 1; attempt++) {
+      // the loop's last input stays on the stack until a macrotask boundary
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      gc();
+    }
+    expect(live()).toBeLessThanOrEqual(1);
+    expect(results).toHaveLength(50);
   });
 });

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1033,7 +1033,9 @@ describe("safeParse builds the error on first read", () => {
       const input = { i, blob: new Array(500).fill(i) };
       refs.push(new Weak(input));
       const result = schema.safeParse(input);
-      void result.error;
+      // half read the error, half replace it without ever reading; both have to release
+      if (i % 2) void result.error;
+      else (result as { error: z.core.$ZodError }).error = new z.ZodError([]);
       results.push(result);
     }
     // the collector decides when it runs, so give it several passes; a retained input never clears no matter how many it gets

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -95,6 +95,9 @@ function failure(Err: $ZodErrorClass, issues: errors.$ZodRawIssue[], ctx: schema
     },
     set error(e: errors.$ZodError) {
       error = e;
+      // a replacement makes the getter's branch unreachable, so the captures have to go here too
+      issues = undefined as any;
+      ctx = undefined as any;
     },
   };
 }

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -85,7 +85,12 @@ function failure(Err: $ZodErrorClass, issues: errors.$ZodRawIssue[], ctx: schema
   return {
     success: false,
     get error() {
-      if (!error) error = new Err(issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())));
+      if (!error) {
+        error = new Err(issues.map((iss) => util.finalizeIssue(iss, ctx, core.config())));
+        // finalizeIssue drops `input`, so the built error holds nothing; keeping the raw issues past this point pins the parsed value for the life of the result
+        issues = undefined as any;
+        ctx = undefined as any;
+      }
       return error;
     },
     set error(e: errors.$ZodError) {


### PR DESCRIPTION
A failing `safeParse` result builds its error on the first read of `error`, so it closes over the raw issues until then. Those issues carry `input`, and the closure outlives the error, so a result that is kept alive pins whatever was parsed — a request body, an upload, an entire rejected batch — for as long as the result lives. Finalizing an issue drops `input`, so the error itself holds nothing; what retains is a closure with nothing left to do.

Both accessors release the captures: the getter once it has built the error, and the setter once a replacement is installed, which makes the getter's branch unreachable. Measured over 200 held failing results, counting how many inputs are still reachable after a full collection:

| | 4.5.4 | main | this PR |
| --- | --- | --- | --- |
| `error` read | 1/200 | 200/200 | 1/200 |
| replacement assigned to `error` | 1/200 | 200/200 | 1/200 |
| `error` never touched | 1/200 | 200/200 | 200/200 |

A result whose error is never read or replaced still pins, which is inherent to building the error late.

The assignments run once per failing result, and never on a parse that only reads `success`. Bundle cost:

| fixture | main | this PR |
| --- | --- | --- |
| mini boolean | 2994 | 3000 |
| mini string | 3446 | 3455 |
| mini object | 4567 | 4577 |
| classic object | 24773 | 24781 |

Gzipped, against the ceilings raised in #6536, which leave 18 bytes.

The alternative shape — finalizing at parse time and constructing the error object late — fixes the untouched row too, but it runs `finalizeIssue` on every failing parse whether or not anyone reads the error, which is exactly the work #6519 deferred. Not worth the untouched case.

Refs #6519
