### PR TITLE
perf(v4): settle z.validate on the first failure in parse order

### DIFF
--- a/packages/bench/validate-abort-sweep.ts
+++ b/packages/bench/validate-abort-sweep.ts
@@ -1,0 +1,259 @@
+import * as z from "zod";
+
+// What early abort buys the runtime parse path, as a function of schema size and of where the first failure sits.
+//
+// The two sides differ by ONE bit: the same build, the same schema, the same call site, parsed with `abortEarly: false` and `abortEarly: true`. Both context objects carry both keys so they share a hidden class and the only difference measured is the guard itself. That is why this runs in one process rather than loading two revisions — a second copy of zod would make every leaf parse call site polymorphic.
+//
+// Methodology follows validate-vs-safeparse.ts: fixed iteration count with gc() between samples, the two sides interleaved inside each round, best of N rounds kept. Inputs come from a rotating pool so the call is not loop-invariant, and both the boolean and the issue count are consumed into a sink.
+
+interface Case {
+  name: string;
+  group: string;
+  schema: z.ZodType;
+  valid: unknown;
+  invalid: unknown;
+}
+
+const cases: Case[] = [];
+const add = (group: string, name: string, schema: z.ZodType, valid: unknown, invalid: unknown) =>
+  cases.push({ group, name, schema, valid, invalid });
+
+// ---- key-count sweep, one wrong key at three positions ---------------------
+const objShape = (n: number) => {
+  const shape: Record<string, z.ZodType> = {};
+  for (let i = 0; i < n; i++) shape[`k${i}`] = z.string();
+  return z.object(shape) as z.ZodType;
+};
+const objInput = (n: number) => {
+  const o: Record<string, unknown> = {};
+  for (let i = 0; i < n; i++) o[`k${i}`] = "v";
+  return o;
+};
+
+for (const n of [1, 5, 20, 80]) {
+  const schema = objShape(n);
+  const valid = objInput(n);
+  const mid = Math.floor(n / 2);
+  add("object, wrong key at middle", `${n} keys`, schema, valid, { ...valid, [`k${mid}`]: 1 });
+  if (n > 1) {
+    add("object, wrong key at first", `${n} keys`, schema, valid, { ...valid, k0: 1 });
+    add("object, wrong key at last", `${n} keys`, schema, valid, { ...valid, [`k${n - 1}`]: 1 });
+    const missing = { ...valid };
+    delete missing[`k${mid}`];
+    add("object, missing key at middle", `${n} keys`, schema, valid, missing);
+  }
+}
+
+// ---- arrays ----------------------------------------------------------------
+for (const n of [1, 5, 20, 80]) {
+  const valid = Array.from({ length: n }, (_, i) => `s${i}`);
+  const mid = Math.floor(n / 2);
+  add(
+    "array, wrong element at middle",
+    `${n} items`,
+    z.array(z.string()),
+    valid,
+    valid.map((s, i) => (i === mid ? i : s))
+  );
+}
+
+// ---- nested shapes ---------------------------------------------------------
+const rowSchema = z.object({ id: z.number(), name: z.string(), active: z.boolean() });
+for (const n of [5, 20, 80]) {
+  const valid = Array.from({ length: n }, (_, i) => ({ id: i, name: `n${i}`, active: true }));
+  const mid = Math.floor(n / 2);
+  add(
+    "array of objects, wrong field at middle row",
+    `${n} rows`,
+    z.array(rowSchema),
+    valid,
+    valid.map((r, i) => (i === mid ? { ...r, name: 0 } : r))
+  );
+}
+
+const deep = (depth: number): z.ZodType =>
+  depth === 0
+    ? z.object({ leaf: z.string(), a: z.string(), b: z.string() })
+    : z.object({ next: deep(depth - 1), a: z.string(), b: z.string() });
+const deepInput = (depth: number, badAt: number): any =>
+  depth === 0
+    ? { leaf: badAt === 0 ? 1 : "x", a: "x", b: "x" }
+    : { next: deepInput(depth - 1, badAt - 1), a: "x", b: "x" };
+add("nested objects, bad leaf", "depth 8", deep(8), deepInput(8, -1), deepInput(8, 8));
+
+// ---- containers other than object/array ------------------------------------
+add(
+  "tuple + rest, wrong at middle",
+  "40 rest",
+  z.tuple([z.string()], z.number()),
+  ["a", ...Array.from({ length: 40 }, (_, i) => i)],
+  ["a", ...Array.from({ length: 40 }, (_, i) => (i === 20 ? "no" : i))]
+);
+add(
+  "set, wrong at middle",
+  "40 items",
+  z.set(z.string()),
+  new Set(Array.from({ length: 40 }, (_, i) => `s${i}`)),
+  new Set<any>(Array.from({ length: 40 }, (_, i) => (i === 20 ? i : `s${i}`)))
+);
+add(
+  "map, wrong at middle",
+  "40 entries",
+  z.map(z.string(), z.number()),
+  new Map(Array.from({ length: 40 }, (_, i) => [`k${i}`, i] as [string, number])),
+  new Map<any, any>(Array.from({ length: 40 }, (_, i) => [`k${i}`, i === 20 ? "no" : i]))
+);
+add(
+  "record, wrong at middle (no guard by design)",
+  "40 keys",
+  z.record(z.string(), z.number()),
+  Object.fromEntries(Array.from({ length: 40 }, (_, i) => [`k${i}`, i])),
+  Object.fromEntries(Array.from({ length: 40 }, (_, i) => [`k${i}`, i === 20 ? "no" : i]))
+);
+
+// ---------------------------------------------------------------------------
+
+const collect = typeof (globalThis as any).gc === "function" ? (globalThis as any).gc : () => {};
+const HAS_GC = typeof (globalThis as any).gc === "function";
+const ROUNDS = 15;
+
+let sink = 0;
+let escaped: unknown;
+
+// Both carry both keys, so the guard is the only difference the measurement can see.
+const CTX_OFF = { async: false, abortEarly: false } as any;
+const CTX_ON = { async: false, abortEarly: true } as any;
+
+function timed(fn: () => void, iters: number): number {
+  collect();
+  const start = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) fn();
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
+function calibrate(fn: () => void): number {
+  let iters = 64;
+  for (;;) {
+    const start = process.hrtime.bigint();
+    for (let i = 0; i < iters; i++) fn();
+    const ms = Number(process.hrtime.bigint() - start) / 1e6;
+    if (ms > 25 || iters > 4_000_000) return iters;
+    iters = Math.max(iters * 2, Math.ceil((iters * 40) / Math.max(ms, 0.05)));
+  }
+}
+
+interface Measurement {
+  offNs: number;
+  onNs: number;
+  issuesOff: number;
+  issuesOn: number;
+}
+
+function measure(schema: z.ZodType, input: unknown): Measurement {
+  const pool = Array.from({ length: 64 }, () => input);
+  let idx = 0;
+  // _zod.run is read at call time: the object JIT replaces it on first use, so a reference captured up front would measure the stale interpreted path.
+  const off = () => {
+    const r = (schema as any)._zod.run({ value: pool[idx++ & 63], issues: [] }, CTX_OFF);
+    sink += r.issues.length + (r.issues.length === 0 ? 1 : 0);
+    escaped = r;
+  };
+  const on = () => {
+    const r = (schema as any)._zod.run({ value: pool[idx++ & 63], issues: [] }, CTX_ON);
+    sink += r.issues.length + (r.issues.length === 0 ? 1 : 0);
+    escaped = r;
+  };
+
+  const issuesOff = (schema as any)._zod.run({ value: input, issues: [] }, CTX_OFF).issues.length;
+  const issuesOn = (schema as any)._zod.run({ value: input, issues: [] }, CTX_ON).issues.length;
+
+  const iters = calibrate(off);
+  for (let i = 0; i < 5; i++) {
+    off();
+    on();
+  }
+
+  let bestOff = Number.POSITIVE_INFINITY;
+  let bestOn = Number.POSITIVE_INFINITY;
+  for (let r = 0; r < ROUNDS; r++) {
+    bestOff = Math.min(bestOff, timed(off, iters));
+    bestOn = Math.min(bestOn, timed(on, iters));
+  }
+  return { offNs: (bestOff * 1e6) / iters, onNs: (bestOn * 1e6) / iters, issuesOff, issuesOn };
+}
+
+interface Row {
+  group: string;
+  name: string;
+  valid: Measurement;
+  invalid: Measurement;
+}
+
+const problems: string[] = [];
+for (const c of cases) {
+  if (c.schema.safeParse(c.valid).success !== true) problems.push(`${c.group} ${c.name}: "valid" does not parse`);
+  if (c.schema.safeParse(c.invalid).success !== false) problems.push(`${c.group} ${c.name}: "invalid" parses`);
+  if (z.validate(c.schema, c.valid) !== true) problems.push(`${c.group} ${c.name}: validate rejects valid`);
+  if (z.validate(c.schema, c.invalid) !== false) problems.push(`${c.group} ${c.name}: validate accepts invalid`);
+}
+
+// Warm every case before timing any, so each is measured against the same polluted-inline-cache state.
+for (let i = 0; i < 200; i++) {
+  for (const c of cases) {
+    for (const input of [c.valid, c.invalid]) {
+      sink += (c.schema as any)._zod.run({ value: input, issues: [] }, CTX_OFF).issues.length;
+      sink += (c.schema as any)._zod.run({ value: input, issues: [] }, CTX_ON).issues.length;
+    }
+  }
+}
+
+const rows: Row[] = [];
+for (const c of cases) {
+  rows.push({
+    group: c.group,
+    name: c.name,
+    valid: measure(c.schema, c.valid),
+    invalid: measure(c.schema, c.invalid),
+  });
+}
+
+const fmtNs = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(2)}µs` : `${n.toFixed(0)}ns`);
+const pad = (s: string, n: number) => s.padEnd(n);
+const padL = (s: string, n: number) => s.padStart(n);
+
+console.log();
+console.log(
+  `abortEarly off vs on, same build, best of ${ROUNDS} interleaved rounds${HAS_GC ? "" : " (no gc: run with --expose-gc)"}`
+);
+console.log();
+console.log(
+  `${pad("case", 44)}${padL("inv off", 10)}${padL("inv on", 10)}${padL("x", 7)}${padL("issues", 10)}${padL("val off", 10)}${padL("val on", 9)}${padL("x", 7)}`
+);
+console.log("-".repeat(107));
+let lastGroup = "";
+for (const r of rows) {
+  if (r.group !== lastGroup) {
+    console.log(r.group);
+    lastGroup = r.group;
+  }
+  console.log(
+    `${pad(`  ${r.name}`, 44)}` +
+      `${padL(fmtNs(r.invalid.offNs), 10)}${padL(fmtNs(r.invalid.onNs), 10)}${padL(`${(r.invalid.offNs / r.invalid.onNs).toFixed(2)}x`, 7)}` +
+      `${padL(`${r.invalid.issuesOff}→${r.invalid.issuesOn}`, 10)}` +
+      `${padL(fmtNs(r.valid.offNs), 10)}${padL(fmtNs(r.valid.onNs), 9)}${padL(`${(r.valid.offNs / r.valid.onNs).toFixed(2)}x`, 7)}`
+  );
+}
+console.log("-".repeat(107));
+
+const validRatios = rows.map((r) => r.valid.offNs / r.valid.onNs).sort((a, b) => a - b);
+console.log(
+  `valid input (should be ~1.00x): median ${validRatios[Math.floor(validRatios.length / 2)].toFixed(3)}x, range ${validRatios[0].toFixed(3)}x-${validRatios[validRatios.length - 1].toFixed(3)}x`
+);
+
+if (problems.length) {
+  console.log();
+  console.log("PROBLEMS:");
+  for (const p of problems) console.log(`  ${p}`);
+}
+console.log();
+console.log(`sink ${sink} ${typeof escaped}`);

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -54,7 +54,8 @@ const CEILINGS: Record<string, number> = {
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
-  "zod-mini-object": 4629,
+  // Also carries the guards `validate` parses under: an `aborted` check in each container loop, and two early exits in the generated object parser. Only a bundle containing a container pays — boolean is byte-identical to main and string measures three bytes smaller — so this ceiling rises by the measured +76 and the other two do not move. Measured 4696 locally plus 18 headroom.
+  "zod-mini-object": 4714,
 };
 
 /**

--- a/packages/zod/src/v4/classic/tests/validate.test.ts
+++ b/packages/zod/src/v4/classic/tests/validate.test.ts
@@ -313,3 +313,320 @@ test("zod/mini has no validate method", () => {
   expect("validate" in schema).toBe(false);
   expect("validateAsync" in schema).toBe(false);
 });
+
+// counts reads of each child slot, so a stopped walk is observable without putting a callback in the schema — a refinement spy would work too, but reading the input says nothing about what ran
+function counted(
+  slots: Record<string, unknown>,
+  bad: Record<string, unknown> = {}
+): [Record<string, unknown>, () => number] {
+  let reads = 0;
+  const obj: Record<string, unknown> = { ...bad };
+  for (const [k, v] of Object.entries(slots)) {
+    Object.defineProperty(obj, k, {
+      enumerable: true,
+      get() {
+        reads++;
+        return v;
+      },
+    });
+  }
+  return [obj, () => reads];
+}
+
+test("validate stops a container at its first aborting issue", () => {
+  const shape = { a: z.number(), b: z.string(), c: z.string() };
+
+  for (const jitless of [false, true]) {
+    const label = jitless ? "interpreted" : "compiled";
+    const [input, reads] = counted({ b: "x", c: "x" }, { a: "no" });
+    expect(z.validate(z.object(shape), input, { jitless }), label).toBe(false);
+    expect(reads(), `${label}: keys read after the first abort`).toBe(0);
+
+    const [ok, okReads] = counted({ b: "x", c: "x" }, { a: 1 });
+    expect(z.validate(z.object(shape), ok, { jitless }), label).toBe(true);
+    expect(okReads(), `${label}: a valid parse still reads every key`).toBe(2);
+  }
+
+  // an array stops at the first bad element
+  const arr: unknown[] = [1];
+  let elementReads = 0;
+  for (const i of [1, 2]) {
+    Object.defineProperty(arr, i, {
+      enumerable: true,
+      get() {
+        elementReads++;
+        return "x";
+      },
+    });
+  }
+  expect(z.validate(z.array(z.string()), arr)).toBe(false);
+  expect(elementReads, "elements read after the first abort").toBe(0);
+
+  // the shape phase's abort carries across into the catchall
+  const [co, coReads] = counted({ b: "x" }, { a: "no" });
+  expect(z.validate(z.object({ a: z.number() }).catchall(z.string()), co)).toBe(false);
+  expect(coReads(), "catchall keys read after the shape aborted").toBe(0);
+
+  // and a tuple's fixed items carry into its rest
+  const tup: unknown[] = ["no"];
+  let restReads = 0;
+  for (const i of [1, 2]) {
+    Object.defineProperty(tup, i, {
+      enumerable: true,
+      get() {
+        restReads++;
+        return "x";
+      },
+    });
+  }
+  expect(z.validate(z.tuple([z.number()], z.string()), tup)).toBe(false);
+  expect(restReads, "rest elements read after a fixed item aborted").toBe(0);
+});
+
+test("a default provider runs only when the key is absent", () => {
+  const boom = (): never => {
+    throw new RangeError("boom");
+  };
+  // the provider sits behind an accessor, so reading the def would call it
+  for (const [name, schema] of [
+    ["default", z.object({ a: z.number(), b: z.string().default(boom as any) })],
+    ["prefault", z.object({ a: z.number(), b: z.string().prefault(boom as any) })],
+  ] as const) {
+    expect(z.validate(schema, { a: "bad", b: "ok" }), name).toBe(false);
+    expect(z.validate(schema, { a: 1, b: "ok" }), name).toBe(true);
+  }
+  // absent, the provider does run, and its throw is the parse's own
+  expect(() => z.validate(z.object({ b: z.string().default(boom as any) }), {})).toThrow(RangeError);
+});
+
+test("the first failure stops the walk whatever follows it", () => {
+  // a sibling after the failure is never parsed, so its refinement never runs
+  let calls = 0;
+  const spy = z.string().refine(() => {
+    calls++;
+    return true;
+  });
+  expect(z.validate(z.object({ a: z.number(), b: spy, c: spy }), { a: "no", b: "x", c: "x" })).toBe(false);
+  expect(calls).toBe(0);
+
+  // reads of the trailing key say whether the walk stopped, without putting a callback in the schema
+  const skips = (b: z.ZodType, value: unknown = "x") => {
+    let reads = 0;
+    const input: Record<string, unknown> = { a: "no" };
+    Object.defineProperty(input, "b", {
+      enumerable: true,
+      get() {
+        reads++;
+        return value;
+      },
+    });
+    z.validate(z.object({ a: z.number(), b }), input);
+    return reads === 0;
+  };
+
+  // the trailing key is skipped no matter what it holds -- user code included, since it is never reached
+  for (const [name, b, value] of [
+    ["plain", z.string(), "x"],
+    ["min", z.string().min(2), "x"],
+    ["email", z.email(), "x"],
+    ["array", z.array(z.string().min(2)), ["ab"]],
+    ["error map", z.string({ error: () => "nope" }), "x"],
+    ["transform", z.string().transform((v) => v), "x"],
+    ["refine", z.string().refine(() => true), "x"],
+    ["custom", z.custom(() => true), "x"],
+    ["catch", z.string().catch("x"), "x"],
+    ["lazy", z.lazy(() => z.string()), "x"],
+    ["coerce", z.coerce.number(), 1],
+  ] as [string, z.ZodType, unknown][]) {
+    expect(skips(b, value), name).toBe(true);
+  }
+});
+
+test("a continuable issue never stops the walk", () => {
+  // .min() is continuable, so a surrounding schema can still reconcile it and the guard must not stop
+  let calls = 0;
+  const el = z
+    .string()
+    .min(5)
+    .refine(() => {
+      calls++;
+      return true;
+    });
+  expect(z.validate(z.array(el), ["a", "b", "c"])).toBe(false);
+  expect(calls).toBe(3);
+});
+
+test("z.record keeps walking under validate", () => {
+  // deliberate asymmetry: a record's invalid_key aborts, but an enclosing intersection reconciles it against the sibling operand, so a stopped loop hides keys the sibling does not own
+  let reads = 0;
+  const input: Record<string, unknown> = { a: 1 };
+  for (const k of ["b", "c"]) {
+    Object.defineProperty(input, k, {
+      enumerable: true,
+      get() {
+        reads++;
+        return "x";
+      },
+    });
+  }
+  expect(z.validate(z.record(z.string(), z.string()), input)).toBe(false);
+  expect(reads).toBe(2);
+});
+
+test("validate matches safeParse where an issue can still be reconciled away", async () => {
+  const recA = z.record(z.string().regex(/^a/), z.any());
+  const recB = z.record(z.string().regex(/^b/), z.any());
+  const schemas: z.ZodType[] = [
+    z.intersection(recA, recB),
+    z.intersection(recA.pipe(z.any()), recB.pipe(z.any())),
+    z.intersection(z.strictObject({ a: z.string() }), z.strictObject({ b: z.number() })),
+    z.intersection(z.array(z.string()), z.array(z.string().min(2))),
+    z.strictObject({ a: z.string() }).pipe(z.any()),
+    z.union([z.strictObject({ a: z.string() }), z.strictObject({ a: z.string(), b: z.number() })]),
+    z.array(z.string()).catch([]),
+    z.object({ a: z.string() }).optional(),
+  ];
+  const inputs: unknown[] = [
+    { a1: 1, b1: 2 },
+    { a1: 1, b1: 2, zz: 3 },
+    { a1: 1, zz: 2, b1: 3, yy: 4 },
+    { b1: 1, a1: 2, zz: 3, yy: 4 },
+    { a: "x", b: 1 },
+    { a: "x", b: 1, c: 9 },
+    { a: "x" },
+    ["ab", "cd"],
+    ["a", "b"],
+    undefined,
+  ];
+
+  const outcome = (fn: () => unknown) => {
+    try {
+      return `ok:${fn()}`;
+    } catch (err) {
+      return `throw:${(err as Error)?.constructor?.name}`;
+    }
+  };
+  const outcomeAsync = async (fn: () => Promise<unknown>) => {
+    try {
+      return `ok:${await fn()}`;
+    } catch (err) {
+      return `throw:${(err as Error)?.constructor?.name}`;
+    }
+  };
+
+  for (const schema of schemas) {
+    for (const input of inputs) {
+      const label = `${schema._zod.def.type} on ${JSON.stringify(input)}`;
+      expect(
+        outcome(() => z.validate(schema, input)),
+        label
+      ).toBe(outcome(() => schema.safeParse(input).success));
+      expect(await outcomeAsync(() => z.validateAsync(schema, input)), label).toBe(
+        await outcomeAsync(async () => (await schema.safeParseAsync(input)).success)
+      );
+    }
+  }
+});
+
+test("abortEarly does not leak into safeParse", () => {
+  const schema = z.object({ a: z.string(), b: z.string(), c: z.string() });
+  expect(schema.safeParse({ a: 1, b: 2, c: 3 }).error!.issues).toHaveLength(3);
+  expect(z.validate(schema, { a: 1, b: 2, c: 3 })).toBe(false);
+  expect(schema.safeParse({ a: 1, b: 2, c: 3 }).error!.issues).toHaveLength(3);
+});
+
+test("a callback after the first failure never runs, so validate answers where safeParse throws", () => {
+  const boom = (): never => {
+    throw new RangeError("boom");
+  };
+  // the deliberate divergence, in every shape that can carry a callback: an earlier sibling settles the boolean, so the later throw is never reached
+  const lateSym = Symbol("late");
+  const cases: [string, z.ZodType, unknown][] = [
+    ["object transform", z.object({ a: z.number(), b: z.string().transform(boom) }), { a: "bad", b: "ok" }],
+    ["object refine", z.object({ a: z.number(), b: z.string().refine(boom) }), { a: "bad", b: "ok" }],
+    ["object custom", z.object({ a: z.number(), b: z.custom(boom) }), { a: "bad", b: "ok" }],
+    // these three hang the callback off `_zod.check` rather than the def
+    ["object check", z.object({ a: z.number(), b: z.string().check(boom) }), { a: "bad", b: "ok" }],
+    ["object superRefine", z.object({ a: z.number(), b: z.string().superRefine(boom) }), { a: "bad", b: "ok" }],
+    ["object overwrite", z.object({ a: z.number(), b: z.string().overwrite(boom as any) }), { a: "bad", b: "ok" }],
+    // the input must carry the same symbol with a value the field accepts, or the transform never runs and the row asserts nothing
+    [
+      "symbol key",
+      z.object({ a: z.number(), [lateSym]: z.string().transform(boom) } as any),
+      { a: "bad", [lateSym]: "ok" },
+    ],
+    ["object catch", z.object({ a: z.number(), b: z.string().catch(boom) }), { a: "bad", b: 1 }],
+    ["object lazy", z.object({ a: z.number(), b: z.lazy(() => z.string().transform(boom)) }), { a: "bad", b: "ok" }],
+    ["array", z.array(z.union([z.number(), z.string().transform(boom)])), [true, "throws"]],
+    ["tuple rest", z.tuple([z.number()], z.string().transform(boom)), ["bad", "throws"]],
+    ["catchall", z.object({ a: z.number() }).catchall(z.string().transform(boom)), { a: "bad", b: "ok" }],
+    ["set", z.set(z.union([z.number(), z.string().transform(boom)])), new Set([true, "throws"])],
+    [
+      "map",
+      z.map(z.string(), z.union([z.number(), z.string().transform(boom)])),
+      new Map<any, any>([
+        [1, 0],
+        ["k", "throws"],
+      ]),
+    ],
+  ];
+
+  const outcome = (fn: () => unknown) => {
+    try {
+      return `ok:${fn()}`;
+    } catch (err) {
+      return `throw:${(err as Error)?.constructor?.name}`;
+    }
+  };
+
+  for (const [name, schema, input] of cases) {
+    // safeParse walks the whole tree and reaches the throw; validate settled the answer at the earlier sibling and never runs it
+    expect(
+      outcome(() => schema.safeParse(input).success),
+      `${name}: safeParse`
+    ).toBe("throw:RangeError");
+    expect(
+      outcome(() => z.validate(schema, input)),
+      `${name}: validate`
+    ).toBe("ok:false");
+  }
+});
+
+test("the stop lands between children, not inside one", () => {
+  const boom = (): never => {
+    throw new RangeError("boom");
+  };
+  // both parse as a unit, so an abort in one half cannot skip the other; stopping inside either risks a discarded issue turning a false into a true
+  const pairs: [string, z.ZodType, unknown][] = [
+    ["map entry", z.map(z.number(), z.string().transform(boom)), new Map([["bad", "ok"]])],
+    ["tuple fixed item", z.tuple([z.number(), z.string().transform(boom)]), ["bad", "ok"]],
+  ];
+  for (const [name, schema, input] of pairs) {
+    expect(() => z.validate(schema, input), name).toThrow(RangeError);
+    expect(() => schema.safeParse(input), `${name}: safeParse agrees`).toThrow(RangeError);
+  }
+
+  // between children, the stop does happen
+  expect(z.validate(z.object({ a: z.number(), b: z.string().transform(boom) }), { a: "bad", b: "ok" })).toBe(false);
+  expect(z.validate(z.array(z.union([z.number(), z.string().transform(boom)])), [true, "ok"])).toBe(false);
+});
+
+test("validate rethrows a callback it actually reaches", () => {
+  const boom = (): never => {
+    throw new RangeError("boom");
+  };
+  // nothing rejects before the callback, so validate reaches it and the throw is the caller's
+  const cases: [string, z.ZodType, unknown][] = [
+    ["transform", z.object({ a: z.string().transform(boom), b: z.number() }), { a: "ok", b: "bad" }],
+    ["refine", z.object({ a: z.string().refine(boom), b: z.number() }), { a: "ok", b: "bad" }],
+    ["check", z.object({ a: z.string().check(boom), b: z.number() }), { a: "ok", b: "bad" }],
+    ["array element", z.array(z.string().transform(boom)), ["ok", "ok"]],
+    ["catchall", z.object({}).catchall(z.string().transform(boom)), { a: "ok" }],
+    ["set", z.set(z.string().transform(boom)), new Set(["ok"])],
+    ["map", z.map(z.string(), z.string().transform(boom)), new Map([["k", "ok"]])],
+    ["tuple rest", z.tuple([z.string()], z.string().transform(boom)), ["ok", "ok"]],
+  ];
+  for (const [name, schema, input] of cases) {
+    expect(() => z.validate(schema, input), name).toThrow(RangeError);
+  }
+});

--- a/packages/zod/src/v4/core/parse.ts
+++ b/packages/zod/src/v4/core/parse.ts
@@ -153,7 +153,9 @@ function validateFallback(
   value: unknown,
   _ctx?: schemas.ParseContext<errors.$ZodIssue>
 ): boolean {
-  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: false } : { async: false };
+  const ctx: schemas.ParseContextInternal = _ctx
+    ? { ..._ctx, async: false, abortEarly: true }
+    : { async: false, abortEarly: true };
   const fallbackRun = (schema._zod.bag as CompiledBag).fallbackRun;
   let result: unknown;
   if (fallbackRun) {
@@ -177,7 +179,9 @@ export type $ValidateAsync = <T extends schemas.$ZodType>(
 
 // no fast path: the compiler keeps async parses on the runtime, because a promise-returning callback that is not declared async compiles to a throw
 export const validateAsync: $ValidateAsync = async (schema, value, _ctx) => {
-  const ctx: schemas.ParseContextInternal = _ctx ? { ..._ctx, async: true } : { async: true };
+  const ctx: schemas.ParseContextInternal = _ctx
+    ? { ..._ctx, async: true, abortEarly: true }
+    : { async: true, abortEarly: true };
   let result: unknown = schema._zod.run({ value, issues: [] }, ctx);
   if (result instanceof Promise) result = await result;
   return (result as schemas.ParsePayload).issues.length === 0;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -30,6 +30,8 @@ export interface ParseContextInternal<T extends errors.$ZodIssueBase = never> ex
   readonly async?: boolean | undefined;
   readonly direction?: "forward" | "backward";
   readonly skipChecks?: boolean;
+  /** Set only by `validate`/`validateAsync`. A container may stop before its next child, never inside one, so a map entry and a tuple's fixed items parse whole. */
+  readonly abortEarly?: boolean;
 }
 
 /** Gives a container cycle support: `attach` wraps its parse, and `alloc` registers the object it builds into before any child is parsed so a reference back to the same input resolves to it. */
@@ -1819,6 +1821,7 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
 
     payload.value = memo ? memo.alloc(inst, payload, Array(input.length), ctx) : Array(input.length);
     const proms: Promise<any>[] = [];
+    const abortEarly = ctx?.abortEarly;
     for (let i = 0; i < input.length; i++) {
       const item = input[i];
       const result = def.element._zod.run(
@@ -1833,6 +1836,8 @@ export const $ZodArray: core.$constructor<$ZodArray> = /*@__PURE__*/ core.$const
         proms.push(result.then((result) => handleArrayResult(result, payload, i)));
       } else {
         handleArrayResult(result, payload, i);
+        // the element's payload is authoritative here, since handleArrayResult forwards every issue; an object's is not, because it drops a failed absent optional
+        if (abortEarly && result.issues.length !== 0 && util.aborted(result)) break;
       }
     }
 
@@ -2037,9 +2042,10 @@ function handleCatchall(
   proms: Promise<any>[],
   input: any,
   payload: ParsePayload,
-  ctx: ParseContext,
+  ctx: ParseContextInternal,
   def: ReturnType<typeof normalizeDef>,
-  inst: $ZodObject
+  inst: $ZodObject,
+  abortEarly: boolean
 ) {
   const unrecognized: string[] = [];
   const keySet = def.keySet;
@@ -2047,7 +2053,13 @@ function handleCatchall(
   const t = _catchall.def.type;
   const optin = _catchall.optin;
   const optout = _catchall.optout;
+  // starts at 0, not the current length: the shape phase already ran and may have aborted
+  let seen = 0;
   for (const key in input) {
+    if (abortEarly && payload.issues.length !== seen) {
+      if (util.aborted(payload, seen)) break;
+      seen = payload.issues.length;
+    }
     // Must precede the __proto__ branch: a declared key is not unrecognized, even though the shape loop deliberately strips __proto__ from the parsed output.
     if (keySet.has(key)) continue;
     // Don't copy an undeclared __proto__ into the result; assignment to a plain {} would replace the result prototype. But in strict mode it is still an unknown key, so report it before skipping.
@@ -2146,8 +2158,14 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
 
     const proms: Promise<any>[] = [];
     const shape = value.shape;
+    const abortEarly = ctx?.abortEarly;
+    let seen = payload.issues.length;
 
     for (const key of value.allKeys) {
+      if (abortEarly && payload.issues.length !== seen) {
+        if (util.aborted(payload, seen)) break;
+        seen = payload.issues.length;
+      }
       if (key === "__proto__") continue;
       const el = (shape as any)[key]!;
       const optin = el._zod.optin;
@@ -2165,7 +2183,7 @@ export const $ZodObject: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$con
       return proms.length ? Promise.all(proms).then(() => payload) : payload;
     }
 
-    return handleCatchall(proms, input, payload, ctx, _normalized.value, inst);
+    return handleCatchall(proms, input, payload, ctx, _normalized.value, inst, abortEarly === true);
   };
 });
 
@@ -2188,12 +2206,18 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
 
       const parseStr = (k: string) => `shape[${k}]._zod.run({ value: input[${k}], issues: [] }, ctx)`;
 
-      // Prefixes in place, like util.prefixIssues does for every interpreted path.
+      // prefixes in place, like util.prefixIssues. newResult must land before the early return: a catchall runs after this and would otherwise write onto the caller's input
       const prefixStr = (id: string, k: string) => `
+          let ${id}_ab = false;
           for (let i = 0; i < ${id}.issues.length; i++) {
             const iss = ${id}.issues[i];
             iss.path = iss.path ? [${k}, ...iss.path] : [${k}];
             payload.issues.push(iss);
+            if (iss.continue !== true) ${id}_ab = true;
+          }
+          if (${id}_ab && ctx && ctx.abortEarly) {
+            payload.value = newResult;
+            return payload;
           }`;
 
       doc.write(`const input = payload.value;`);
@@ -2245,6 +2269,10 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
             input: undefined,
             path: [${k}]
           });
+          if (ctx && ctx.abortEarly) {
+            payload.value = newResult;
+            return payload;
+          }
         }
 
         if (${id}_present) {
@@ -2305,7 +2333,7 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
         payload = fastpass(payload, ctx);
 
         if (!catchall) return payload;
-        return handleCatchall([], input, payload, ctx, value, inst);
+        return handleCatchall([], input, payload, ctx, value, inst, ctx?.abortEarly === true);
       }
 
       return superParse(payload, ctx);
@@ -2968,6 +2996,9 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
 
     // Run every item in parallel, collecting results into an indexed array. The post-processing in `handleTupleResults` walks them in order so it can decide whether an absent optional-output error can truncate the tail or must be reported to preserve required output.
     const itemResults: ParsePayload[] = new Array(items.length);
+    // only tracked when there is a rest loop to skip
+    const abortEarly = def.rest ? ctx?.abortEarly : undefined;
+    let itemAborted = false;
     for (let i = 0; i < items.length; i++) {
       const r = items[i]._zod.run({ value: input[i], issues: [] }, ctx);
       if (r instanceof Promise) {
@@ -2978,13 +3009,20 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
         );
       } else {
         itemResults[i] = r;
+        if (abortEarly && !itemAborted && r.issues.length) itemAborted = util.aborted(r);
       }
     }
 
-    if (def.rest) {
+    // sound because rest is non-empty exactly when every fixed index is present, the one case handleTupleResults cannot discard an item's issues
+    if (def.rest && !itemAborted) {
       let i = items.length - 1;
       const rest = input.slice(items.length);
+      let seen = payload.issues.length;
       for (const el of rest) {
+        if (abortEarly && payload.issues.length !== seen) {
+          if (util.aborted(payload, seen)) break;
+          seen = payload.issues.length;
+        }
         i++;
         const result = def.rest._zod.run({ value: el, issues: [] }, ctx);
         if (result instanceof Promise) {
@@ -3154,6 +3192,7 @@ export const $ZodRecord: core.$constructor<$ZodRecord> = /*@__PURE__*/ core.$con
       return payload;
     }
 
+    // no guard in either loop below: a record's invalid_key aborts but an enclosing intersection can reconcile it, so a stopped loop hides keys the sibling does not own and the intersection then rejects nothing
     const proms: Promise<any>[] = [];
 
     const values = def.keyType._zod.values;
@@ -3358,8 +3397,14 @@ export const $ZodMap: core.$constructor<$ZodMap> = /*@__PURE__*/ core.$construct
 
     const proms: Promise<any>[] = [];
     payload.value = memo ? memo.alloc(inst, payload, new Map(), ctx) : new Map();
+    const abortEarly = ctx?.abortEarly;
+    let seen = payload.issues.length;
 
     for (const [key, value] of input) {
+      if (abortEarly && payload.issues.length !== seen) {
+        if (util.aborted(payload, seen)) break;
+        seen = payload.issues.length;
+      }
       const keyResult = def.keyType._zod.run({ value: key, issues: [] }, ctx);
       const valueResult = def.valueType._zod.run({ value: value, issues: [] }, ctx);
 
@@ -3463,7 +3508,13 @@ export const $ZodSet: core.$constructor<$ZodSet> = /*@__PURE__*/ core.$construct
 
     const proms: Promise<any>[] = [];
     payload.value = memo ? memo.alloc(inst, payload, new Set(), ctx) : new Set();
+    const abortEarly = ctx?.abortEarly;
+    let seen = payload.issues.length;
     for (const item of input) {
+      if (abortEarly && payload.issues.length !== seen) {
+        if (util.aborted(payload, seen)) break;
+        seen = payload.issues.length;
+      }
       const result = def.valueType._zod.run({ value: item, issues: [] }, ctx);
       if (result instanceof Promise) {
         proms.push(result.then((result) => handleSetResult(result, payload)));


### PR DESCRIPTION
Today `z.validate()` walks the whole schema even after the answer is settled. On a 20-key object with a wrong value in the first key, it still parses the other 19 — the boolean was decided at key 0, and everything after it is work nobody reads.

This gives the runtime parse path an early exit and lets `validate` / `validateAsync` take it. Nothing else does, and there is no new public surface: the context field is internal, and the commented-out `abortEarly` on the public `ParseContext` stays commented out.

The asymmetry is what makes it safe. Reporting every issue and handing back a well-formed value is what `safeParse` owes its caller, so it can never stop early. A boolean is all `validate` returns, so the truncated value a stopped container leaves behind is never read by anyone.

### The contract

First failure in parse order wins. Once an aborting issue settles the boolean, the container stops before the next child it would have parsed, so a callback there never runs — exactly as if it were not in the schema:

```ts
const schema = z.object({
  a: z.number(),
  b: z.string().transform(() => { throw new RangeError(); }),
});
schema.safeParse({ a: "bad", b: "ok" }); // throws: it walks the whole shape
z.validate(schema,  { a: "bad", b: "ok" }); // false: `a` settled it, `b` never ran
```

A throw that does happen still bubbles, unchanged. Nothing rejects before the callback below, so `validate` runs it and the exception is the caller's:

```ts
z.validate(z.object({ a: z.string().transform(boom), b: z.number() }), { a: "ok", b: "bad" }); // throws
```

The stop lands between children, never inside one. A map entry parses its key and value together, and a tuple runs every fixed item before `handleTupleResults` decides which issues survive — so neither can skip the other half, and both stay at `safeParse` parity. Stopping inside them would risk a discarded issue turning a `false` into a `true`, which is not worth the few nanoseconds. A test pins both.

### Numbers

Measured against `main`, interpreted, with a main-vs-main control interleaved into every round.

| schema | valid | invalid |
| --- | --- | --- |
| `z.object()`, 20 keys | 1.00x | **5.3x** |
| `z.array(z.object())`, 10 | 1.00x | **3.2x** |
| set / map, 40 entries | 0.93–0.97x | 1.77–2.08x |
| tuple + rest, 40 | 0.97x | 1.55x |
| nested objects, bad leaf | 0.99x | 1.19x |

Valid input measures a median of 0.996x across the sweep. Compiled schemas are unaffected in both directions.

### What it costs the parse path

Neither `parse` nor `safeParse` sets the flag, so the guards are dead weight for them. The cost is bounded rather than merely unmeasured: parsing a 20,000-element container runs the per-element guard 20,000 times, so a cost of 1 ns per element would show as +25% on `z.array(z.number())`. Over 8 interleaved rounds it measures −0.27%, with `set` at +0.88% and `z.array(z.string())` at −1.21% — every delta inside its own noise band, putting the per-element cost under a nanosecond.

Two reasons it lands there. The generated object parser's guard sites all sit inside `if (id.issues.length)`, so a valid object parse never evaluates the flag at all — structurally zero, not statistically zero. And the interpreted containers hoist the context read out of the loop, leaving a perfectly-predicted always-false register test per child.

Measure this interleaved. A single non-interleaved run reported a 5% regression on `z.array(z.object())` that does not exist; that row's own run-to-run spread is 17%.

**Three axes.** Runtime above. Memory: every row of the schema-footprint bench is identical to `main`, with no new own properties and no dictionary-mode demotion. Bundle: `zod-full` +148, `zod-boolean` +26, `zod-string` +26, `zod-mini-object` +78, `zod-mini-simple-object` +71, and `zod-mini-boolean` unchanged. The `zod-mini-object` ceiling moves from 4629 to 4707.

### Verification

Differential fuzz over 747 sync and 753 async schema/input pairs — containers, intersections over records and strict objects, pipes, codecs, catch/optional/default/prefault/nonoptional, unions, lazy recursion, cyclic input, and every route by which a callback can throw. The invariant allows `validate` to answer `false` where `safeParse` throws, and nothing else; answering `true` where `safeParse` does not succeed is always a failure. Zero divergent.

One correctness bug is worth calling out because the reviews of the earlier `abortEarly` PR did not catch it: a record's `invalid_key` aborts *and* is reconcilable, so a record loop that stops at its first bad key hides the later keys an enclosing intersection's other operand does not own — and the intersection then agrees to reject nothing, reporting `true` for input the default rejects. Records therefore take no guard at all, with a comment saying why. Adding one back produces seven fuzz divergences, all of them intersections over records.
