### PR TITLE
feat(v4): add .validate() and .validateAsync() to Zod Classic

### DIFF
--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -130,14 +130,14 @@ await schema.safeParseAsync("hello");
 ```
 </Callout>
 
-When you only need to know whether an input is acceptable, use the top-level `z.validate()` function. It returns a boolean, never builds an error, and acts as a type guard on the schema's input type. On invalid input it is up to 16x faster than `.safeParse().success`.
+When you only need to know whether an input is acceptable, use `.validate()`. It returns a boolean, never builds an error, and acts as a type guard on the schema's input type. On invalid input it is up to 16x faster than `.safeParse().success`.
 
 ```ts
-z.validate(Player, { username: "billie", xp: 100 }); // true
-z.validate(Player, { username: 42, xp: "100" });     // false
+Player.validate({ username: "billie", xp: 100 }); // true
+Player.validate({ username: 42, xp: "100" });     // false
 ```
 
-Use `z.validateAsync()` for schemas with async refinements or transforms. On a [compiled schema](/compile), `z.validate()` answers directly from the compiled fast path.
+Use `.validateAsync()` for schemas with async refinements or transforms. On a [compiled schema](/compile), `.validate()` answers directly from the compiled fast path. The top-level `z.validate(schema, data)` does the same thing and is the form `zod/mini` uses.
 
 ## Inferring types
 

--- a/packages/docs/content/basics.mdx
+++ b/packages/docs/content/basics.mdx
@@ -130,14 +130,14 @@ await schema.safeParseAsync("hello");
 ```
 </Callout>
 
-When you only need to know whether an input is acceptable, use `.validate()`. It returns a boolean, never builds an error, and acts as a type guard on the schema's input type. On invalid input it is up to 16x faster than `.safeParse().success`.
+When you only need to know whether an input is acceptable, use `.validate()` — or the top-level `z.validate(schema, data)`, which is the form `zod/mini` uses. It returns a boolean, never builds an error, and acts as a type guard on the schema's input type. On invalid input it is up to 16x faster than `.safeParse().success`.
 
 ```ts
 Player.validate({ username: "billie", xp: 100 }); // true
 Player.validate({ username: 42, xp: "100" });     // false
 ```
 
-Use `.validateAsync()` for schemas with async refinements or transforms. On a [compiled schema](/compile), `.validate()` answers directly from the compiled fast path. The top-level `z.validate(schema, data)` does the same thing and is the form `zod/mini` uses.
+Use `.validateAsync()` for schemas with async refinements or transforms. On a [compiled schema](/compile), `.validate()` answers directly from the compiled fast path.
 
 ## Inferring types
 

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -78,6 +78,8 @@ export interface ZodType<
     data: unknown,
     params?: core.ParseContext<core.$ZodIssue>
   ) => Promise<parse.ZodSafeParseResult<core.output<this>>>;
+  validate(data: unknown, params?: core.ParseContext<core.$ZodIssue>): data is core.input<this>;
+  validateAsync(data: unknown, params?: core.ParseContext<core.$ZodIssue>): Promise<boolean>;
 
   // encoding/decoding
   encode(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>): core.input<this>;
@@ -309,6 +311,12 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     },
     set spa(value: ZodType["safeParseAsync"]) {
       util.own(this, "spa", value);
+    },
+    validate(data, params) {
+      return parse.validate(this, data, params);
+    },
+    async validateAsync(data, params) {
+      return parse.validateAsync(this, data, params);
     },
     encode: function _encode(data, params) {
       return parse.encode(this, data, params, { callee: _encode });

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -315,7 +315,7 @@ export const ZodType: core.$constructor<ZodType> = /*@__PURE__*/ core.$construct
     validate(data, params) {
       return parse.validate(this, data, params);
     },
-    async validateAsync(data, params) {
+    validateAsync(data, params) {
       return parse.validateAsync(this, data, params);
     },
     encode: function _encode(data, params) {

--- a/packages/zod/src/v4/classic/tests/validate.test.ts
+++ b/packages/zod/src/v4/classic/tests/validate.test.ts
@@ -263,3 +263,53 @@ test("validate is exported from zod/mini", () => {
   expect(zm.validate(zm.string(), 1)).toBe(false);
   expect(zm.validate(zm.object({ a: zm.number() }), { a: 1 })).toBe(true);
 });
+
+test("the validate method matches the top-level function", () => {
+  expect(z.string().validate("asdf")).toBe(true);
+  expect(z.string().validate(12)).toBe(false);
+  expect(z.object({ a: z.string() }).validate({ a: "x" })).toBe(true);
+  expect(z.object({ a: z.string() }).validate({ a: 1 })).toBe(false);
+  expect(z.compile(z.object({ a: z.string() })).validate({ a: "x" })).toBe(true);
+});
+
+test("the validate method narrows to the input type", () => {
+  const value: unknown = "hi";
+  if (z.string().validate(value)) {
+    expectTypeOf(value).toEqualTypeOf<string>();
+  }
+  const transforming = z.string().transform((s) => s.length);
+  if (transforming.validate(value)) {
+    expectTypeOf(value).toEqualTypeOf<string>();
+    expectTypeOf(value).not.toEqualTypeOf<number>();
+  }
+});
+
+test("the validate method takes a params argument", () => {
+  let calls = 0;
+  const error = () => {
+    calls++;
+    return "bad";
+  };
+  expect(z.string().validate(12, { error })).toBe(false);
+  expect(z.string().validate("ok", { error })).toBe(true);
+  // a ctx defeats the compiled definite shortcut, so this is the fallback answering
+  expect(z.compile(z.string()).validate(12, { error })).toBe(false);
+  expect(z.string().validate("ok", { jitless: true })).toBe(true);
+  // no issue is ever finalized, so an error map never runs
+  expect(calls).toBe(0);
+});
+
+test("the validateAsync method handles async schemas the method form throws on", async () => {
+  const schema = z.string().refine(async (s) => s.length > 2);
+  expect(() => schema.validate("asdf")).toThrow(z.core.$ZodAsyncError);
+  await expect(schema.validateAsync("asdf")).resolves.toBe(true);
+  await expect(schema.validateAsync("a")).resolves.toBe(false);
+  await expect(z.string().validateAsync(12)).resolves.toBe(false);
+});
+
+test("zod/mini has no validate method", () => {
+  const schema = zm.string();
+  expect("parse" in schema).toBe(true);
+  expect("validate" in schema).toBe(false);
+  expect("validateAsync" in schema).toBe(false);
+});


### PR DESCRIPTION
`z.validate()` and `z.validateAsync()` shipped in 4.5 as top-level functions only. Classic reaches for methods everywhere else, so this adds `.validate()` and `.validateAsync()` to `ZodType` as thin delegates.

```ts
const Player = z.object({ username: z.string(), xp: z.number() });

if (Player.validate(data)) {
  data.username; // narrowed
}
```

The predicate lives on the interface, not in the member table — `util.ProtoOf<T>` maps a type-predicate signature's `infer R` to plain `boolean`, so the implementation needs no cast. Narrowing goes to the schema's **input** type: `z.string().transform(s => s.length).validate(v)` narrows `v` to `string`, never `number`.

`zod/mini` deliberately does not get these. It stays a top-level-function API, and a test pins that.

## Three axes

**Bundle** — the one that got worse. esbuild `--minify --conditions=@zod/source`, gzip -9, against a pristine `origin/main` worktree:

| fixture | main | branch | delta |
| --- | --- | --- | --- |
| `zod-mini-boolean` / `-string` / `-object` / `-simple-object` / `-full` | — | — | **+0** |
| `zod-boolean` | 17003 | 17177 | +174 |
| `zod-string` | 21035 | 21224 | +189 |
| `zod-object` | 25113 | 25288 | +175 |
| `zod-full` | 25106 | 25286 | +180 |
| `zod-named-import` | 89192 | 89220 | +28 |

A prototype reference to `parse.validate` retains the validate implementation that a tree-shaken classic bundle used to drop; `zod.compile.fallback` and `zod.compile.invalid` go from absent to present. That is the same trade `encode`/`decode` already make, and it is unavoidable for a method form. `zod/mini` is byte-identical on every fixture, which is the line that matters most on this axis. The `packages/treeshake` ceilings cover mini only, so none needed raising.

**Memory** — no change, and this one is structural rather than timed. The prototype gains exactly two descriptors, `validate` and `validateAsync`, both `accessor g=true s=true e=false c=true` — identical in shape to `parse`, `safeParse`, `encode` and `decode`. A fresh instance still carries 6 own properties, unchanged, and well under the 12-property step where V8 resizes the backing store. `schema-footprint` moves within ±11 B in both directions across 29 cases, and `dict-mode` output is byte-identical to baseline with every instance `fast`.

**Runtime** — no regression. One process per revision, alternating round by round, every case warmed before any is timed, min of 9 rounds, load 7.6 to 8.9:

| case | main | branch | ratio | spread |
| --- | --- | --- | --- | --- |
| construct object, 3 keys | 4983.9 ns | 5045.7 ns | 1.012x | 10% / 5% |
| construct string leaf | 697.2 ns | 703.8 ns | 1.009x | 13% / 8% |
| construct + first validate | 16239.2 ns | 16213.8 ns | 0.998x | 3% / 3% |
| `z.validate()` valid | 56.9 ns | 57.4 ns | 1.009x | 22% / 18% |
| `z.validate()` invalid | 104.3 ns | 104.2 ns | 1.000x | 10% / 6% |
| `z.validateAsync()` | 245.4 ns | 244.1 ns | 0.995x | 7% / 10% |
| *control:* `.parse()` valid | 54.2 ns | 52.8 ns | 0.974x | 21% / 11% |
| *control:* `.safeParse().success` invalid | 451.0 ns | 466.1 ns | 1.033x | 10% / 4% |

**Read the two controls first.** Both run code neither revision touches, and they land at 0.974x and 1.033x — so the floor is about ±3%, and nothing can be claimed inside that band. Every measured case falls inside it, including both construction cases, which is the axis actually at risk from two new prototype members.

The method form is indistinguishable from the function form on the branch: 58.0 against 57.4 ns valid, 103.9 against 104.2 ns invalid, 245.8 against 244.1 ns async.

An earlier version of this PR reported numbers taken at load 58, which is worthless under the `AGENTS.md` threshold and is what the table above replaces.

## Two things worth recording

**`validateAsync` does not need `async`.** It only forwards a promise, so the keyword bought a second promise and a microtask hop — 64.3 ns against 31.9 ns per call in isolation. It is gone. `safeParseAsync` has the same removable wrapper on a hotter path; that is left for its own PR rather than smuggled in here.

**`validate` never invokes an error map.** `validateFallback` returns `issues.length === 0` and never calls `util.finalizeIssue`, which is the only consumer — that is precisely why it is fast on invalid input. So no `ParseContext` field can change a `validate` verdict. A test asserts it.

Docs: `basics.mdx` led classic users to the top-level function, which is no longer the shortest path. It leads with the method now and names the top-level form in the same sentence, since `Player` on that page is defined in a Zod/Zod Mini tab pair and a Mini reader has no method to call.
