### PR TITLE
test(v4): pin the lazy safeParse error's stack behavior

### DIFF
--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1048,4 +1048,30 @@ describe("safeParse builds the error on first read", () => {
     expect(live()).toBeLessThanOrEqual(1);
     expect(results).toHaveLength(50);
   });
+
+  test("no reader frames leak into the error, however late it is read", async () => {
+    const result = z.string().safeParse(12) as { error: z.core.$ZodError };
+
+    // the constructor runs at THIS read: a macrotask later and twenty frames deeper than the parse
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const readDeep = (n: number): z.core.$ZodError => (n ? readDeep(n - 1) : result.error);
+    const error = readDeep(20) as unknown as Error;
+
+    expect(error.stack!.startsWith("ZodError: [")).toBe(true);
+    expect(error.stack!.split("\n").some((line) => line.trim().startsWith("at "))).toBe(false);
+    expect(error.stack!).not.toContain("readDeep");
+  });
+
+  test("a lazy build gives back the caller's stackTraceLimit, not the parse-time one", () => {
+    const result = z.string().safeParse(12) as { error: z.core.$ZodError };
+    const ambient = Error.stackTraceLimit;
+    // changed between the parse and the read, so restoring a value captured at parse time would clobber it
+    Error.stackTraceLimit = ambient + 7;
+    try {
+      void result.error;
+      expect(Error.stackTraceLimit).toBe(ambient + 7);
+    } finally {
+      Error.stackTraceLimit = ambient;
+    }
+  });
 });

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1054,8 +1054,13 @@ describe("safeParse builds the error on first read", () => {
 
     // the constructor runs at THIS read: a macrotask later and twenty frames deeper than the parse
     await new Promise((resolve) => setTimeout(resolve, 0));
-    const readDeep = (n: number): z.core.$ZodError => (n ? readDeep(n - 1) : result.error);
-    const error = readDeep(20) as unknown as Error;
+    const readDeep = <T>(n: number, make: () => T): T => (n ? readDeep(n - 1, make) : make());
+    const error = readDeep(20, () => result.error) as unknown as Error;
+
+    // control: a plain Error at that same depth does carry the frames, so the assertions below discriminate rather than pass vacuously
+    const control = readDeep(20, () => new Error("control"));
+    expect(control.stack!.split("\n").some((line) => line.trim().startsWith("at "))).toBe(true);
+    expect(control.stack!).toContain("readDeep");
 
     expect(error.stack!.startsWith("ZodError: [")).toBe(true);
     expect(error.stack!.split("\n").some((line) => line.trim().startsWith("at "))).toBe(false);


### PR DESCRIPTION
Answers a question raised while reviewing the 4.6 post: now that `failure()` builds the `ZodError` on first read, does the reader's call site end up on the error instead of the parser's?

It does not. `newError()` sets `Error.stackTraceLimit = 0` around the construction, so the error is built with no frames whenever that happens, and `.parse()` never takes the lazy path at all — it builds eagerly and puts the frames back with `captureStackTrace(e, callee)`, still pointing at the caller.

Two cases were unpinned, and both are the ones deferral actually put at risk:

- **A read long after the parse, deep in someone else's stack.** A macrotask later and twenty frames down, the error still carries no `at ` frames and never mentions the reader.
- **A `stackTraceLimit` changed between the parse and the read.** The getter has to borrow and restore the value that is live *at the read*. An implementation that captured it at parse time would silently clobber a caller's setting, and nothing caught that before.

Both assertions were checked against a control: a plain `Error` constructed at the same depth does carry the `readDeep` frames, so passing is evidence rather than a vacuous green. Tests only — no source change.
