### PR TITLE
fix(v4): derive JSON Schema constraints by folding checks in the converter

### DIFF
--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -47,8 +47,7 @@ const CEILINGS: Record<string, number> = {
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
-  // Lowered by the measured −105 when checks stopped writing metadata into the bag at attach time: the string length/format closures and the per-instance bounded regex left every string bundle, and the template literal now derives its own part patterns.
-  "zod-mini-string": 3429,
+  "zod-mini-string": 3534,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
   // Also carries the memoizer seam from #6482: each container init reads `globalConfig.memoizer` and calls `attach`, which is what lets `zod/mini` opt into cycle support. Measured 4512 locally but 4533 on CI — the gzip stream differs across zlib builds — so the headroom rides on the CI number.
@@ -56,8 +55,7 @@ const CEILINGS: Record<string, number> = {
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
   // Also carries the guards `validate` parses under: an `aborted` check in each container loop, and two early exits in the generated object parser. Only a bundle containing a container pays — boolean is byte-identical to main and string measures three bytes smaller — so this ceiling rises by the measured +76 and the other two do not move. Measured 4696 locally plus 18 headroom.
-  // Lowered by the measured −69 for the same bag strip: the string and number inits no longer carry pattern derivation or attach-time metadata writes.
-  "zod-mini-object": 4645,
+  "zod-mini-object": 4714,
 };
 
 /**

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -47,7 +47,8 @@ const CEILINGS: Record<string, number> = {
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
-  "zod-mini-string": 3534,
+  // Lowered by the measured −105 when checks stopped writing metadata into the bag at attach time: the string length/format closures and the per-instance bounded regex left every string bundle, and the template literal now derives its own part patterns.
+  "zod-mini-string": 3429,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
   // Also carries the memoizer seam from #6482: each container init reads `globalConfig.memoizer` and calls `attach`, which is what lets `zod/mini` opt into cycle support. Measured 4512 locally but 4533 on CI — the gzip stream differs across zlib builds — so the headroom rides on the CI number.
@@ -55,7 +56,8 @@ const CEILINGS: Record<string, number> = {
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
   // Also carries the guards `validate` parses under: an `aborted` check in each container loop, and two early exits in the generated object parser. Only a bundle containing a container pays — boolean is byte-identical to main and string measures three bytes smaller — so this ceiling rises by the measured +76 and the other two do not move. Measured 4696 locally plus 18 headroom.
-  "zod-mini-object": 4714,
+  // Lowered by the measured −69 for the same bag strip: the string and number inits no longer carry pattern derivation or attach-time metadata writes.
+  "zod-mini-object": 4645,
 };
 
 /**

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -392,72 +392,60 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
 
     inst._zod.processJSONSchema = (ctx, json, params) => processors.stringProcessor(inst, ctx, json, params);
   },
-  {
-    // derived from the checks on first read, then shadowed as own data; the setters keep assignment shadowing the same way, as when these were own properties
-    get format() {
-      return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
+  /*@__PURE__*/ util.derived<_ZodString>(
+    {
+      format: (inst) => processors.aggregateChecks(inst).format ?? null,
+      minLength: (inst) => processors.aggregateChecks<number>(inst).minimum ?? null,
+      maxLength: (inst) => processors.aggregateChecks<number>(inst).maximum ?? null,
     },
-    set format(v) {
-      util.own(this, "format", v);
-    },
-    get minLength() {
-      return util.own(this, "minLength", (processors.aggregateChecks(this).minimum as number | undefined) ?? null);
-    },
-    set minLength(v) {
-      util.own(this, "minLength", v);
-    },
-    get maxLength() {
-      return util.own(this, "maxLength", (processors.aggregateChecks(this).maximum as number | undefined) ?? null);
-    },
-    set maxLength(v) {
-      util.own(this, "maxLength", v);
-    },
-    regex(...args) {
-      return this.check((checks.regex as any)(...args));
-    },
-    includes(...args) {
-      return this.check((checks.includes as any)(...args));
-    },
-    startsWith(...args) {
-      return this.check((checks.startsWith as any)(...args));
-    },
-    endsWith(...args) {
-      return this.check((checks.endsWith as any)(...args));
-    },
-    min(...args) {
-      return this.check((checks.minLength as any)(...args));
-    },
-    max(...args) {
-      return this.check((checks.maxLength as any)(...args));
-    },
-    length(...args) {
-      return this.check((checks.length as any)(...args));
-    },
-    nonempty(...args) {
-      return this.check((checks.minLength as any)(1, ...args));
-    },
-    lowercase(params) {
-      return this.check(checks.lowercase(params));
-    },
-    uppercase(params) {
-      return this.check(checks.uppercase(params));
-    },
-    trim() {
-      return this.check(checks.trim());
-    },
-    normalize(...args) {
-      return this.check(checks.normalize(...args));
-    },
-    toLowerCase() {
-      return this.check(checks.toLowerCase());
-    },
-    toUpperCase() {
-      return this.check(checks.toUpperCase());
-    },
-    slugify() {
-      return this.check(checks.slugify());
-    },
-  }
+    {
+      regex(...args) {
+        return this.check((checks.regex as any)(...args));
+      },
+      includes(...args) {
+        return this.check((checks.includes as any)(...args));
+      },
+      startsWith(...args) {
+        return this.check((checks.startsWith as any)(...args));
+      },
+      endsWith(...args) {
+        return this.check((checks.endsWith as any)(...args));
+      },
+      min(...args) {
+        return this.check((checks.minLength as any)(...args));
+      },
+      max(...args) {
+        return this.check((checks.maxLength as any)(...args));
+      },
+      length(...args) {
+        return this.check((checks.length as any)(...args));
+      },
+      nonempty(...args) {
+        return this.check((checks.minLength as any)(1, ...args));
+      },
+      lowercase(params) {
+        return this.check(checks.lowercase(params));
+      },
+      uppercase(params) {
+        return this.check(checks.uppercase(params));
+      },
+      trim() {
+        return this.check(checks.trim());
+      },
+      normalize(...args) {
+        return this.check(checks.normalize(...args));
+      },
+      toLowerCase() {
+        return this.check(checks.toLowerCase());
+      },
+      toUpperCase() {
+        return this.check(checks.toUpperCase());
+      },
+      slugify() {
+        return this.check(checks.slugify());
+      },
+    }
+  )
 );
 
 export interface ZodString extends _ZodString<core.$ZodStringInternals<string>> {
@@ -1147,89 +1135,70 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
     inst._zod.processJSONSchema = (ctx, json, params) => processors.numberProcessor(inst, ctx, json, params);
     inst.isFinite = true;
   },
-  {
-    // derived from the checks on first read, then shadowed as own data
-    get minValue() {
-      const agg = processors.aggregateChecks(this) as { minimum?: number; exclusiveMinimum?: number };
-      return util.own(
-        this,
-        "minValue",
-        Math.max(agg.minimum ?? Number.NEGATIVE_INFINITY, agg.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null
-      );
+  /*@__PURE__*/ util.derived<ZodNumber>(
+    {
+      minValue: (inst) => {
+        const { minimum, exclusiveMinimum } = processors.aggregateChecks<number>(inst);
+        return Math.max(minimum ?? Number.NEGATIVE_INFINITY, exclusiveMinimum ?? Number.NEGATIVE_INFINITY);
+      },
+      maxValue: (inst) => {
+        const { maximum, exclusiveMaximum } = processors.aggregateChecks<number>(inst);
+        return Math.min(maximum ?? Number.POSITIVE_INFINITY, exclusiveMaximum ?? Number.POSITIVE_INFINITY);
+      },
+      isInt: (inst) => {
+        const { isInt, multipleOf } = processors.aggregateChecks(inst);
+        return !!isInt || !!multipleOf?.some(Number.isSafeInteger);
+      },
+      format: (inst) => processors.aggregateChecks(inst).format ?? null,
     },
-    get maxValue() {
-      const agg = processors.aggregateChecks(this) as { maximum?: number; exclusiveMaximum?: number };
-      return util.own(
-        this,
-        "maxValue",
-        Math.min(agg.maximum ?? Number.POSITIVE_INFINITY, agg.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null
-      );
-    },
-    set minValue(v) {
-      util.own(this, "minValue", v);
-    },
-    set maxValue(v) {
-      util.own(this, "maxValue", v);
-    },
-    get isInt() {
-      const agg = processors.aggregateChecks(this);
-      return util.own(this, "isInt", !!agg.isInt || !!agg.multipleOf?.some(Number.isSafeInteger));
-    },
-    set isInt(v) {
-      util.own(this, "isInt", v);
-    },
-    get format() {
-      return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
-    },
-    set format(v) {
-      util.own(this, "format", v);
-    },
-    gt(value, params) {
-      return this.check(checks.gt(value, params));
-    },
-    gte(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    min(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    lt(value, params) {
-      return this.check(checks.lt(value, params));
-    },
-    lte(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    max(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    int(params) {
-      return this.check(int(params));
-    },
-    safe(params) {
-      return this.check(int(params));
-    },
-    positive(params) {
-      return this.check(checks.gt(0, params));
-    },
-    nonnegative(params) {
-      return this.check(checks.gte(0, params));
-    },
-    negative(params) {
-      return this.check(checks.lt(0, params));
-    },
-    nonpositive(params) {
-      return this.check(checks.lte(0, params));
-    },
-    multipleOf(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-    step(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-    finite() {
-      return this;
-    },
-  }
+    {
+      gt(value, params) {
+        return this.check(checks.gt(value, params));
+      },
+      gte(value, params) {
+        return this.check(checks.gte(value, params));
+      },
+      min(value, params) {
+        return this.check(checks.gte(value, params));
+      },
+      lt(value, params) {
+        return this.check(checks.lt(value, params));
+      },
+      lte(value, params) {
+        return this.check(checks.lte(value, params));
+      },
+      max(value, params) {
+        return this.check(checks.lte(value, params));
+      },
+      int(params) {
+        return this.check(int(params));
+      },
+      safe(params) {
+        return this.check(int(params));
+      },
+      positive(params) {
+        return this.check(checks.gt(0, params));
+      },
+      nonnegative(params) {
+        return this.check(checks.gte(0, params));
+      },
+      negative(params) {
+        return this.check(checks.lt(0, params));
+      },
+      nonpositive(params) {
+        return this.check(checks.lte(0, params));
+      },
+      multipleOf(value, params) {
+        return this.check(checks.multipleOf(value, params));
+      },
+      step(value, params) {
+        return this.check(checks.multipleOf(value, params));
+      },
+      finite() {
+        return this;
+      },
+    }
+  )
 );
 
 export function number(params?: string | core.$ZodNumberParams): ZodNumber {
@@ -1320,60 +1289,48 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => processors.bigintProcessor(inst, ctx, json, params);
   },
-  {
-    // derived from the checks on first read, then shadowed as own data
-    get minValue() {
-      return util.own(this, "minValue", (processors.aggregateChecks(this).minimum as bigint | undefined) ?? null);
+  /*@__PURE__*/ util.derived<ZodBigInt>(
+    {
+      minValue: (inst) => processors.aggregateChecks<bigint>(inst).minimum ?? null,
+      maxValue: (inst) => processors.aggregateChecks<bigint>(inst).maximum ?? null,
+      format: (inst) => processors.aggregateChecks(inst).format ?? null,
     },
-    set minValue(v) {
-      util.own(this, "minValue", v);
-    },
-    get maxValue() {
-      return util.own(this, "maxValue", (processors.aggregateChecks(this).maximum as bigint | undefined) ?? null);
-    },
-    set maxValue(v) {
-      util.own(this, "maxValue", v);
-    },
-    get format() {
-      return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
-    },
-    set format(v) {
-      util.own(this, "format", v);
-    },
-    gte(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    min(value, params) {
-      return this.check(checks.gte(value, params));
-    },
-    gt(value, params) {
-      return this.check(checks.gt(value, params));
-    },
-    lt(value, params) {
-      return this.check(checks.lt(value, params));
-    },
-    lte(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    max(value, params) {
-      return this.check(checks.lte(value, params));
-    },
-    positive(params) {
-      return this.check(checks.gt(BigInt(0), params));
-    },
-    negative(params) {
-      return this.check(checks.lt(BigInt(0), params));
-    },
-    nonpositive(params) {
-      return this.check(checks.lte(BigInt(0), params));
-    },
-    nonnegative(params) {
-      return this.check(checks.gte(BigInt(0), params));
-    },
-    multipleOf(value, params) {
-      return this.check(checks.multipleOf(value, params));
-    },
-  }
+    {
+      gte(value, params) {
+        return this.check(checks.gte(value, params));
+      },
+      min(value, params) {
+        return this.check(checks.gte(value, params));
+      },
+      gt(value, params) {
+        return this.check(checks.gt(value, params));
+      },
+      lt(value, params) {
+        return this.check(checks.lt(value, params));
+      },
+      lte(value, params) {
+        return this.check(checks.lte(value, params));
+      },
+      max(value, params) {
+        return this.check(checks.lte(value, params));
+      },
+      positive(params) {
+        return this.check(checks.gt(BigInt(0), params));
+      },
+      negative(params) {
+        return this.check(checks.lt(BigInt(0), params));
+      },
+      nonpositive(params) {
+        return this.check(checks.lte(BigInt(0), params));
+      },
+      nonnegative(params) {
+        return this.check(checks.gte(BigInt(0), params));
+      },
+      multipleOf(value, params) {
+        return this.check(checks.multipleOf(value, params));
+      },
+    }
+  )
 );
 
 export function bigint(params?: string | core.$ZodBigIntParams): ZodBigInt {
@@ -1517,23 +1474,19 @@ export const ZodDate: core.$constructor<ZodDate> = /*@__PURE__*/ core.$construct
     inst.min = (value, params) => inst.check(checks.gte(value, params));
     inst.max = (value, params) => inst.check(checks.lte(value, params));
   },
-  {
-    // derived from the checks on first read, then shadowed as own data
-    get minDate() {
-      const { minimum } = processors.aggregateChecks(this);
-      return util.own(this, "minDate", minimum ? new Date(minimum as Date) : null);
+  /*@__PURE__*/ util.derived<ZodDate>(
+    {
+      minDate: (inst) => {
+        const { minimum } = processors.aggregateChecks<Date>(inst);
+        return minimum ? new Date(minimum) : null;
+      },
+      maxDate: (inst) => {
+        const { maximum } = processors.aggregateChecks<Date>(inst);
+        return maximum ? new Date(maximum) : null;
+      },
     },
-    set minDate(v) {
-      util.own(this, "minDate", v);
-    },
-    get maxDate() {
-      const { maximum } = processors.aggregateChecks(this);
-      return util.own(this, "maxDate", maximum ? new Date(maximum as Date) : null);
-    },
-    set maxDate(v) {
-      util.own(this, "maxDate", v);
-    },
-  }
+    {}
+  )
 );
 
 export function date(params?: string | core.$ZodDateParams): ZodDate {

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -393,15 +393,24 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
     inst._zod.processJSONSchema = (ctx, json, params) => processors.stringProcessor(inst, ctx, json, params);
   },
   {
-    // derived from the checks on first read, then shadowed as own data
+    // derived from the checks on first read, then shadowed as own data; the setters keep assignment shadowing the same way, as when these were own properties
     get format() {
       return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
+    },
+    set format(v) {
+      util.own(this, "format", v);
     },
     get minLength() {
       return util.own(this, "minLength", (processors.aggregateChecks(this).minimum as number | undefined) ?? null);
     },
+    set minLength(v) {
+      util.own(this, "minLength", v);
+    },
     get maxLength() {
       return util.own(this, "maxLength", (processors.aggregateChecks(this).maximum as number | undefined) ?? null);
+    },
+    set maxLength(v) {
+      util.own(this, "maxLength", v);
     },
     regex(...args) {
       return this.check((checks.regex as any)(...args));
@@ -1156,12 +1165,24 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
         Math.min(agg.maximum ?? Number.POSITIVE_INFINITY, agg.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null
       );
     },
+    set minValue(v) {
+      util.own(this, "minValue", v);
+    },
+    set maxValue(v) {
+      util.own(this, "maxValue", v);
+    },
     get isInt() {
       const agg = processors.aggregateChecks(this);
       return util.own(this, "isInt", !!agg.isInt || !!agg.multipleOf?.some(Number.isSafeInteger));
     },
+    set isInt(v) {
+      util.own(this, "isInt", v);
+    },
     get format() {
       return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
+    },
+    set format(v) {
+      util.own(this, "format", v);
     },
     gt(value, params) {
       return this.check(checks.gt(value, params));
@@ -1304,11 +1325,20 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
     get minValue() {
       return util.own(this, "minValue", (processors.aggregateChecks(this).minimum as bigint | undefined) ?? null);
     },
+    set minValue(v) {
+      util.own(this, "minValue", v);
+    },
     get maxValue() {
       return util.own(this, "maxValue", (processors.aggregateChecks(this).maximum as bigint | undefined) ?? null);
     },
+    set maxValue(v) {
+      util.own(this, "maxValue", v);
+    },
     get format() {
       return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
+    },
+    set format(v) {
+      util.own(this, "format", v);
     },
     gte(value, params) {
       return this.check(checks.gte(value, params));
@@ -1493,9 +1523,15 @@ export const ZodDate: core.$constructor<ZodDate> = /*@__PURE__*/ core.$construct
       const { minimum } = processors.aggregateChecks(this);
       return util.own(this, "minDate", minimum ? new Date(minimum as Date) : null);
     },
+    set minDate(v) {
+      util.own(this, "minDate", v);
+    },
     get maxDate() {
       const { maximum } = processors.aggregateChecks(this);
       return util.own(this, "maxDate", maximum ? new Date(maximum as Date) : null);
+    },
+    set maxDate(v) {
+      util.own(this, "maxDate", v);
     },
   }
 );

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -391,13 +391,18 @@ export const _ZodString: core.$constructor<_ZodString> = /*@__PURE__*/ core.$con
     ZodType.init(inst, def);
 
     inst._zod.processJSONSchema = (ctx, json, params) => processors.stringProcessor(inst, ctx, json, params);
-
-    const bag = inst._zod.bag;
-    inst.format = bag.format ?? null;
-    inst.minLength = bag.minimum ?? null;
-    inst.maxLength = bag.maximum ?? null;
   },
   {
+    // derived from the checks on first read, then shadowed as own data
+    get format() {
+      return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
+    },
+    get minLength() {
+      return util.own(this, "minLength", (processors.aggregateChecks(this).minimum as number | undefined) ?? null);
+    },
+    get maxLength() {
+      return util.own(this, "maxLength", (processors.aggregateChecks(this).maximum as number | undefined) ?? null);
+    },
     regex(...args) {
       return this.check((checks.regex as any)(...args));
     },
@@ -1131,17 +1136,33 @@ export const ZodNumber: core.$constructor<ZodNumber> = /*@__PURE__*/ core.$const
     ZodType.init(inst, def);
 
     inst._zod.processJSONSchema = (ctx, json, params) => processors.numberProcessor(inst, ctx, json, params);
-
-    const bag = inst._zod.bag;
-    inst.minValue =
-      Math.max(bag.minimum ?? Number.NEGATIVE_INFINITY, bag.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null;
-    inst.maxValue =
-      Math.min(bag.maximum ?? Number.POSITIVE_INFINITY, bag.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null;
-    inst.isInt = (bag.format ?? "").includes("int") || Number.isSafeInteger(bag.multipleOf ?? 0.5);
     inst.isFinite = true;
-    inst.format = bag.format ?? null;
   },
   {
+    // derived from the checks on first read, then shadowed as own data
+    get minValue() {
+      const agg = processors.aggregateChecks(this) as { minimum?: number; exclusiveMinimum?: number };
+      return util.own(
+        this,
+        "minValue",
+        Math.max(agg.minimum ?? Number.NEGATIVE_INFINITY, agg.exclusiveMinimum ?? Number.NEGATIVE_INFINITY) ?? null
+      );
+    },
+    get maxValue() {
+      const agg = processors.aggregateChecks(this) as { maximum?: number; exclusiveMaximum?: number };
+      return util.own(
+        this,
+        "maxValue",
+        Math.min(agg.maximum ?? Number.POSITIVE_INFINITY, agg.exclusiveMaximum ?? Number.POSITIVE_INFINITY) ?? null
+      );
+    },
+    get isInt() {
+      const agg = processors.aggregateChecks(this);
+      return util.own(this, "isInt", !!agg.isInt || !!agg.multipleOf?.some(Number.isSafeInteger));
+    },
+    get format() {
+      return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
+    },
     gt(value, params) {
       return this.check(checks.gt(value, params));
     },
@@ -1277,13 +1298,18 @@ export const ZodBigInt: core.$constructor<ZodBigInt> = /*@__PURE__*/ core.$const
     core.$ZodBigInt.init(inst, def);
     ZodType.init(inst, def);
     inst._zod.processJSONSchema = (ctx, json, params) => processors.bigintProcessor(inst, ctx, json, params);
-
-    const bag = inst._zod.bag;
-    inst.minValue = bag.minimum ?? null;
-    inst.maxValue = bag.maximum ?? null;
-    inst.format = bag.format ?? null;
   },
   {
+    // derived from the checks on first read, then shadowed as own data
+    get minValue() {
+      return util.own(this, "minValue", (processors.aggregateChecks(this).minimum as bigint | undefined) ?? null);
+    },
+    get maxValue() {
+      return util.own(this, "maxValue", (processors.aggregateChecks(this).maximum as bigint | undefined) ?? null);
+    },
+    get format() {
+      return util.own(this, "format", processors.aggregateChecks(this).format ?? null);
+    },
     gte(value, params) {
       return this.check(checks.gte(value, params));
     },
@@ -1451,18 +1477,28 @@ export interface _ZodDate<T extends core.$ZodDateInternals = core.$ZodDateIntern
 }
 
 export interface ZodDate extends _ZodDate<core.$ZodDateInternals<Date>> {}
-export const ZodDate: core.$constructor<ZodDate> = /*@__PURE__*/ core.$constructor("ZodDate", (inst, def) => {
-  core.$ZodDate.init(inst, def);
-  ZodType.init(inst, def);
-  inst._zod.processJSONSchema = (ctx, json, params) => processors.dateProcessor(inst, ctx, json, params);
+export const ZodDate: core.$constructor<ZodDate> = /*@__PURE__*/ core.$constructor<ZodDate>(
+  "ZodDate",
+  (inst, def) => {
+    core.$ZodDate.init(inst, def);
+    ZodType.init(inst, def);
+    inst._zod.processJSONSchema = (ctx, json, params) => processors.dateProcessor(inst, ctx, json, params);
 
-  inst.min = (value, params) => inst.check(checks.gte(value, params));
-  inst.max = (value, params) => inst.check(checks.lte(value, params));
-
-  const c = inst._zod.bag;
-  inst.minDate = c.minimum ? new Date(c.minimum) : null;
-  inst.maxDate = c.maximum ? new Date(c.maximum) : null;
-});
+    inst.min = (value, params) => inst.check(checks.gte(value, params));
+    inst.max = (value, params) => inst.check(checks.lte(value, params));
+  },
+  {
+    // derived from the checks on first read, then shadowed as own data
+    get minDate() {
+      const { minimum } = processors.aggregateChecks(this);
+      return util.own(this, "minDate", minimum ? new Date(minimum as Date) : null);
+    },
+    get maxDate() {
+      const { maximum } = processors.aggregateChecks(this);
+      return util.own(this, "maxDate", maximum ? new Date(maximum as Date) : null);
+    },
+  }
+);
 
 export function date(params?: string | core.$ZodDateParams): ZodDate {
   return core._date(ZodDate, params);

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -225,6 +225,12 @@ test("a hand-written getter member accepts assignment", () => {
   const mini: any = zm.string();
   mini.with = () => "WITH";
   expect(mini.with()).toBe("WITH");
+
+  // a derived metadata member accepts assignment before its first read, as it did as an own property
+  const derived = z.number().min(2);
+  derived.minValue = 99;
+  expect(derived.minValue).toBe(99);
+  expect(Object.keys(derived)).toContain("minValue");
 });
 
 test("shape is lazy and stays out of Object.keys", () => {

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -231,6 +231,10 @@ test("a hand-written getter member accepts assignment", () => {
   derived.minValue = 99;
   expect(derived.minValue).toBe(99);
   expect(Object.keys(derived)).toContain("minValue");
+
+  // and, like every prototype member, recomputes after deletion rather than staying absent
+  delete (derived as any).minValue;
+  expect(derived.minValue).toBe(2);
 });
 
 test("shape is lazy and stays out of Object.keys", () => {

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -152,6 +152,8 @@ test("a live member keeps the descriptor a prototype member had", () => {
   const proto = Object.getPrototypeOf(z.string());
   expect(Object.getOwnPropertyDescriptor(proto, "description")?.enumerable).toBe(false);
   expect(Object.getOwnPropertyDescriptor(proto, "_def")?.enumerable).toBe(false);
+  // a derived member installs like a literal's accessor: not enumerable, still configurable
+  expect(Object.getOwnPropertyDescriptor(proto, "minLength")).toMatchObject({ enumerable: false, configurable: true });
 
   // the derived metadata members live on the prototype and shadow as own data on first read
   const schema = z.string();

--- a/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
+++ b/packages/zod/src/v4/classic/tests/instance-footprint.test.ts
@@ -153,9 +153,13 @@ test("a live member keeps the descriptor a prototype member had", () => {
   expect(Object.getOwnPropertyDescriptor(proto, "description")?.enumerable).toBe(false);
   expect(Object.getOwnPropertyDescriptor(proto, "_def")?.enumerable).toBe(false);
 
+  // the derived metadata members live on the prototype and shadow as own data on first read
+  const schema = z.string();
   const keys: string[] = [];
-  for (const k in z.string()) keys.push(k);
-  expect(keys).toEqual(["def", "type", "format", "minLength", "maxLength"]);
+  for (const k in schema) keys.push(k);
+  expect(keys).toEqual(["def", "type"]);
+  expect(schema.minLength).toBe(null);
+  expect(Object.keys(schema)).toContain("minLength");
 });
 
 test("a live member is not cached per instance", () => {

--- a/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
+++ b/packages/zod/src/v4/classic/tests/optin-ladder.test.ts
@@ -222,7 +222,8 @@ test("ladder: the rung values themselves", () => {
 
 test("exactOptional overrides the values and pattern optional installs", () => {
   expect(z.exactOptional(z.enum(["a", "b"]))._zod.values).toEqual(new Set(["a", "b"]));
-  expect(z.exactOptional(z.string().regex(/^abc$/))._zod.pattern).toEqual(/^abc$/);
+  // a format carries its pattern on its def; a chained `.regex()` no longer folds into the inner `_zod.pattern`, the template literal derives that itself
+  expect(z.exactOptional(z.stringFormat("abc", /^abc$/))._zod.pattern).toEqual(/^abc$/);
   expect(z.templateLiteral(["a", z.exactOptional(z.literal("b"))]).safeParse("a").success).toEqual(false);
 });
 
@@ -230,5 +231,5 @@ test("exactOptional overrides the values and pattern optional installs", () => {
 test("exactOptional's override holds for later instances", () => {
   z.exactOptional(z.enum(["a", "b"]));
   expect(z.exactOptional(z.enum(["c", "d"]))._zod.values).toEqual(new Set(["c", "d"]));
-  expect(z.exactOptional(z.string().regex(/^xyz$/))._zod.pattern).toEqual(/^xyz$/);
+  expect(z.exactOptional(z.stringFormat("xyz", /^xyz$/))._zod.pattern).toEqual(/^xyz$/);
 });

--- a/packages/zod/src/v4/classic/tests/template-literal.test.ts
+++ b/packages/zod/src/v4/classic/tests/template-literal.test.ts
@@ -796,4 +796,9 @@ test("part patterns fold checks through wrappers and unions", () => {
   // an empty length range matches nothing rather than building an invalid quantifier
   const empty = z.templateLiteral(["", z.string().min(8).length(5)]);
   expect(empty.safeParse("abcde").success).toBe(false);
+
+  // lazy resolves its inner schema on the internals, not the def
+  const lazy = z.templateLiteral(["", z.lazy(() => z.string().min(2)).optional()]);
+  expect(lazy.safeParse("x").success).toBe(false);
+  expect(lazy.safeParse("xy").success).toBe(true);
 });

--- a/packages/zod/src/v4/classic/tests/template-literal.test.ts
+++ b/packages/zod/src/v4/classic/tests/template-literal.test.ts
@@ -778,3 +778,22 @@ test("template literal parsing - failure - issue format", () => {
     }
   `);
 });
+
+test("part patterns fold checks through wrappers and unions", () => {
+  // a constrained string keeps its bounds under a wrapper and inside a union
+  const wrapped = z.templateLiteral(["a-", z.string().min(2).max(3).optional()]);
+  expect(wrapped.safeParse("a-").success).toBe(true);
+  expect(wrapped.safeParse("a-xy").success).toBe(true);
+  expect(wrapped.safeParse("a-x").success).toBe(false);
+  expect(wrapped.safeParse("a-wxyz").success).toBe(false);
+
+  const union = z.templateLiteral(["", z.union([z.string().regex(/^[a-c]+$/), z.number().int()])]);
+  expect(union.safeParse("abc").success).toBe(true);
+  expect(union.safeParse("12").success).toBe(true);
+  expect(union.safeParse("xyz").success).toBe(false);
+  expect(union.safeParse("1.5").success).toBe(false);
+
+  // an empty length range matches nothing rather than building an invalid quantifier
+  const empty = z.templateLiteral(["", z.string().min(8).length(5)]);
+  expect(empty.safeParse("abcde").success).toBe(false);
+});

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -805,6 +805,46 @@ describe("toJSONSchema", () => {
     `);
   });
 
+  test("an integer format keeps the emitted type integer whatever format lands last", () => {
+    // runtime rejects 1.5 in both orders, so both must emit type integer
+    const after = z.number().int().check(z.float32());
+    expect(after.safeParse(1.5).success).toBe(false);
+    expect(z.toJSONSchema(after).type).toBe("integer");
+    expect(z.toJSONSchema(z.number().check(z.float32()).int()).type).toBe("integer");
+  });
+
+  test("disjoint mime checks emit a false schema, not an unconstrained file", () => {
+    const file = z.file().mime("image/png").mime("text/plain");
+    expect(z.toJSONSchema(file)).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "contentEncoding": "binary",
+        "format": "binary",
+        "not": {},
+        "type": "string",
+      }
+    `);
+  });
+
+  test("a custom mime narrowing via onattach intersects with built-in mime checks", () => {
+    const check = {
+      _zod: {
+        def: { check: "custom_mime" },
+        onattach: [
+          (inst: any) => {
+            inst._zod.bag.mime = ["text/plain"];
+          },
+        ],
+        check: () => {},
+      },
+    };
+    const file = z
+      .file()
+      .mime(["image/png", "text/plain"])
+      .check(check as any);
+    expect(z.toJSONSchema(file).contentMediaType).toBe("text/plain");
+  });
+
   test("a custom check contributing via onattach still lands", () => {
     // third-party checks have no converter handler; their bag writes are merged in as a fallback
     const check = {

--- a/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
+++ b/packages/zod/src/v4/classic/tests/to-json-schema.test.ts
@@ -777,6 +777,57 @@ describe("toJSONSchema", () => {
     `);
   });
 
+  test("chained multipleOf divisors emit the whole conjunction", () => {
+    // runtime rejects 4 (not a multiple of 3), so the emitted schema must too
+    expect(z.toJSONSchema(z.number().multipleOf(2).multipleOf(3))).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+          {
+            "multipleOf": 3,
+          },
+        ],
+        "multipleOf": 2,
+        "type": "number",
+      }
+    `);
+  });
+
+  test("length() does not overwrite a tighter earlier bound", () => {
+    // min(8) + length(5) matches nothing at runtime; the emitted bounds stay honest about that
+    expect(z.toJSONSchema(z.string().min(8).length(5))).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "maxLength": 5,
+        "minLength": 8,
+        "type": "string",
+      }
+    `);
+  });
+
+  test("a custom check contributing via onattach still lands", () => {
+    // third-party checks have no converter handler; their bag writes are merged in as a fallback
+    const check = {
+      _zod: {
+        def: { check: "custom_range" },
+        onattach: [
+          (inst: any) => {
+            const bag = inst._zod.bag;
+            if (bag.minimum === undefined || 5 > bag.minimum) bag.minimum = 5;
+          },
+        ],
+        check: () => {},
+      },
+    };
+    expect(z.toJSONSchema(z.number().check(check as any))).toMatchInlineSnapshot(`
+      {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "minimum": 5,
+        "type": "number",
+      }
+    `);
+  });
+
   test("target normalization draft-04 and draft-07", () => {
     // Test that both old (draft-4, draft-7) and new (draft-04, draft-07) target formats work
 

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -253,6 +253,13 @@ export interface $ZodCheckNumberFormat<Format extends $ZodNumberFormats = $ZodNu
   _zod: $ZodCheckNumberFormatInternals<Format>;
 }
 
+// a check's pattern becomes the schema's own on attach, so wrappers and template literals compose it like any other pattern; the last attached wins
+const attachPattern = (inst: $ZodCheck, def: { pattern?: RegExp | undefined }): void => {
+  inst._zod.onattach.push((s) => {
+    if (def.pattern) s._zod.bag.pattern = def.pattern;
+  });
+};
+
 export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /*@__PURE__*/ core.$constructor(
   "$ZodCheckNumberFormat",
   (inst, def) => {
@@ -262,6 +269,7 @@ export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /
     const isInt = def.format?.includes("int");
     const origin = isInt ? "int" : "number";
     const [minimum, maximum] = util.NUMBER_FORMAT_RANGES[def.format];
+    if (isInt) attachPattern(inst, { pattern: regexes.integer });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -564,6 +572,11 @@ export const $ZodCheckMaxLength: core.$constructor<$ZodCheckMaxLength> = /*@__PU
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasLength;
+    // tightest bound wins, so the string's pattern is the same whatever the chain order
+    inst._zod.onattach.push((s) => {
+      const bag = s._zod.bag as { maximum?: number };
+      if (bag.maximum === undefined || def.maximum < bag.maximum) bag.maximum = def.maximum;
+    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -609,6 +622,10 @@ export const $ZodCheckMinLength: core.$constructor<$ZodCheckMinLength> = /*@__PU
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasLength;
+    inst._zod.onattach.push((s) => {
+      const bag = s._zod.bag as { minimum?: number };
+      if (bag.minimum === undefined || def.minimum > bag.minimum) bag.minimum = def.minimum;
+    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -658,6 +675,11 @@ export const $ZodCheckLengthEquals: core.$constructor<$ZodCheckLengthEquals> = /
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasLength;
+    inst._zod.onattach.push((s) => {
+      const bag = s._zod.bag as { minimum?: number; maximum?: number };
+      if (bag.minimum === undefined || def.length > bag.minimum) bag.minimum = def.length;
+      if (bag.maximum === undefined || def.length < bag.maximum) bag.maximum = def.length;
+    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -737,6 +759,7 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
   "$ZodCheckStringFormat",
   (inst, def) => {
     $ZodCheck.init(inst, def);
+    attachPattern(inst, def);
 
     if (def.pattern)
       inst._zod.check ??= (payload) => {
@@ -902,6 +925,7 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     // (`{N,}`), not exactly `position` chars (`{N}`).
     const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position},}${escapedRegex}` : escapedRegex);
     def.pattern = pattern;
+    attachPattern(inst, def);
     inst._zod.check = (payload) => {
       if (payload.value.includes(def.includes, def.position)) return;
       payload.issues.push({
@@ -940,6 +964,7 @@ export const $ZodCheckStartsWith: core.$constructor<$ZodCheckStartsWith> = /*@__
 
     const pattern = new RegExp(`^${util.escapeRegex(def.prefix)}.*`);
     def.pattern ??= pattern;
+    attachPattern(inst, def);
     inst._zod.check = (payload) => {
       if (payload.value.startsWith(def.prefix)) return;
       payload.issues.push({
@@ -978,6 +1003,7 @@ export const $ZodCheckEndsWith: core.$constructor<$ZodCheckEndsWith> = /*@__PURE
 
     const pattern = new RegExp(`.*${util.escapeRegex(def.suffix)}$`);
     def.pattern ??= pattern;
+    attachPattern(inst, def);
     inst._zod.check = (payload) => {
       if (payload.value.endsWith(def.suffix)) return;
       payload.issues.push({

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -79,15 +79,6 @@ export const $ZodCheckLessThan: core.$constructor<$ZodCheckLessThan> = /*@__PURE
     $ZodCheck.init(inst, def);
     const origin = numericOriginMap[typeof def.value as "number" | "bigint" | "object"];
 
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag;
-      const curr = (def.inclusive ? bag.maximum : bag.exclusiveMaximum) ?? Number.POSITIVE_INFINITY;
-      if (def.value < curr) {
-        if (def.inclusive) bag.maximum = def.value;
-        else bag.exclusiveMaximum = def.value;
-      }
-    });
-
     inst._zod.check = (payload) => {
       if (def.inclusive ? payload.value <= def.value : payload.value < def.value) {
         return;
@@ -130,15 +121,6 @@ export const $ZodCheckGreaterThan: core.$constructor<$ZodCheckGreaterThan> = /*@
     $ZodCheck.init(inst, def);
     const origin = numericOriginMap[typeof def.value as "number" | "bigint" | "object"];
 
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag;
-      const curr = (def.inclusive ? bag.minimum : bag.exclusiveMinimum) ?? Number.NEGATIVE_INFINITY;
-      if (def.value > curr) {
-        if (def.inclusive) bag.minimum = def.value;
-        else bag.exclusiveMinimum = def.value;
-      }
-    });
-
     inst._zod.check = (payload) => {
       if (def.inclusive ? payload.value >= def.value : payload.value > def.value) {
         return;
@@ -180,10 +162,6 @@ export interface $ZodCheckMultipleOf<T extends number | bigint = number | bigint
 export const $ZodCheckMultipleOf: core.$constructor<$ZodCheckMultipleOf<number | bigint>> =
   /*@__PURE__*/ core.$constructor("$ZodCheckMultipleOf", (inst, def) => {
     $ZodCheck.init(inst, def);
-
-    inst._zod.onattach.push((inst) => {
-      inst._zod.bag.multipleOf ??= def.value;
-    });
 
     inst._zod.check = (payload) => {
       if (typeof payload.value !== typeof def.value)
@@ -284,17 +262,6 @@ export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /
     const isInt = def.format?.includes("int");
     const origin = isInt ? "int" : "number";
     const [minimum, maximum] = util.NUMBER_FORMAT_RANGES[def.format];
-
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag;
-      bag.format = def.format;
-      // narrow against bounds an earlier .min()/.max() already stored, rather than overwriting them with this format's (wider) range
-      const curMin = (bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
-      if (minimum > curMin) bag.minimum = minimum;
-      const curMax = (bag.maximum ?? Number.POSITIVE_INFINITY) as number;
-      if (maximum < curMax) bag.maximum = maximum;
-      if (isInt) bag.pattern = regexes.integer;
-    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -416,16 +383,6 @@ export const $ZodCheckBigIntFormat: core.$constructor<$ZodCheckBigIntFormat> = /
 
     const [minimum, maximum] = util.BIGINT_FORMAT_RANGES[def.format];
 
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag;
-      bag.format = def.format;
-      // narrow against bounds an earlier .min()/.max() already stored, rather than overwriting them with this format's (wider) range
-      const curMin = (bag.minimum ?? Number.NEGATIVE_INFINITY) as bigint | number;
-      if (minimum > curMin) bag.minimum = minimum;
-      const curMax = (bag.maximum ?? Number.POSITIVE_INFINITY) as bigint | number;
-      if (maximum < curMax) bag.maximum = maximum;
-    });
-
     inst._zod.check = (payload) => {
       const input = payload.value;
 
@@ -480,11 +437,6 @@ export const $ZodCheckMaxSize: core.$constructor<$ZodCheckMaxSize> = /*@__PURE__
 
     inst._zod.def.when ??= _whenHasSize;
 
-    inst._zod.onattach.push((inst) => {
-      const curr = (inst._zod.bag.maximum ?? Number.POSITIVE_INFINITY) as number;
-      if (def.maximum < curr) inst._zod.bag.maximum = def.maximum;
-    });
-
     inst._zod.check = (payload) => {
       const input = payload.value;
       const size = input.size;
@@ -527,11 +479,6 @@ export const $ZodCheckMinSize: core.$constructor<$ZodCheckMinSize> = /*@__PURE__
 
     inst._zod.def.when ??= _whenHasSize;
 
-    inst._zod.onattach.push((inst) => {
-      const curr = (inst._zod.bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
-      if (def.minimum > curr) inst._zod.bag.minimum = def.minimum;
-    });
-
     inst._zod.check = (payload) => {
       const input = payload.value;
       const size = input.size;
@@ -573,13 +520,6 @@ export const $ZodCheckSizeEquals: core.$constructor<$ZodCheckSizeEquals> = /*@__
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasSize;
-
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag;
-      bag.minimum = def.size;
-      bag.maximum = def.size;
-      bag.size = def.size;
-    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -625,11 +565,6 @@ export const $ZodCheckMaxLength: core.$constructor<$ZodCheckMaxLength> = /*@__PU
 
     inst._zod.def.when ??= _whenHasLength;
 
-    inst._zod.onattach.push((inst) => {
-      const curr = (inst._zod.bag.maximum ?? Number.POSITIVE_INFINITY) as number;
-      if (def.maximum < curr) inst._zod.bag.maximum = def.maximum;
-    });
-
     inst._zod.check = (payload) => {
       const input = payload.value;
       const units = input.length;
@@ -674,11 +609,6 @@ export const $ZodCheckMinLength: core.$constructor<$ZodCheckMinLength> = /*@__PU
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasLength;
-
-    inst._zod.onattach.push((inst) => {
-      const curr = (inst._zod.bag.minimum ?? Number.NEGATIVE_INFINITY) as number;
-      if (def.minimum > curr) inst._zod.bag.minimum = def.minimum;
-    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -728,13 +658,6 @@ export const $ZodCheckLengthEquals: core.$constructor<$ZodCheckLengthEquals> = /
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasLength;
-
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag;
-      bag.minimum = def.length;
-      bag.maximum = def.length;
-      bag.length = def.length;
-    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -814,15 +737,6 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
   "$ZodCheckStringFormat",
   (inst, def) => {
     $ZodCheck.init(inst, def);
-
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      bag.format = def.format;
-      if (def.pattern) {
-        bag.patterns ??= new Set();
-        bag.patterns.add(def.pattern);
-      }
-    });
 
     if (def.pattern)
       inst._zod.check ??= (payload) => {
@@ -988,12 +902,6 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     // (`{N,}`), not exactly `position` chars (`{N}`).
     const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position},}${escapedRegex}` : escapedRegex);
     def.pattern = pattern;
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      bag.patterns ??= new Set();
-      bag.patterns.add(pattern);
-    });
-
     inst._zod.check = (payload) => {
       if (payload.value.includes(def.includes, def.position)) return;
       payload.issues.push({
@@ -1032,12 +940,6 @@ export const $ZodCheckStartsWith: core.$constructor<$ZodCheckStartsWith> = /*@__
 
     const pattern = new RegExp(`^${util.escapeRegex(def.prefix)}.*`);
     def.pattern ??= pattern;
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      bag.patterns ??= new Set();
-      bag.patterns.add(pattern);
-    });
-
     inst._zod.check = (payload) => {
       if (payload.value.startsWith(def.prefix)) return;
       payload.issues.push({
@@ -1076,12 +978,6 @@ export const $ZodCheckEndsWith: core.$constructor<$ZodCheckEndsWith> = /*@__PURE
 
     const pattern = new RegExp(`.*${util.escapeRegex(def.suffix)}$`);
     def.pattern ??= pattern;
-    inst._zod.onattach.push((inst) => {
-      const bag = inst._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-      bag.patterns ??= new Set();
-      bag.patterns.add(pattern);
-    });
-
     inst._zod.check = (payload) => {
       if (payload.value.endsWith(def.suffix)) return;
       payload.issues.push({
@@ -1170,9 +1066,6 @@ export const $ZodCheckMimeType: core.$constructor<$ZodCheckMimeType> = /*@__PURE
   (inst, def) => {
     $ZodCheck.init(inst, def);
     const mimeSet = new Set(def.mime);
-    inst._zod.onattach.push((inst) => {
-      inst._zod.bag.mime = def.mime;
-    });
     inst._zod.check = (payload) => {
       if (mimeSet.has(payload.value.type)) return;
       payload.issues.push({

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -253,13 +253,6 @@ export interface $ZodCheckNumberFormat<Format extends $ZodNumberFormats = $ZodNu
   _zod: $ZodCheckNumberFormatInternals<Format>;
 }
 
-// a check's pattern becomes the schema's own on attach, so wrappers and template literals compose it like any other pattern; the last attached wins
-const attachPattern = (inst: $ZodCheck, def: { pattern?: RegExp | undefined }): void => {
-  inst._zod.onattach.push((s) => {
-    if (def.pattern) s._zod.bag.pattern = def.pattern;
-  });
-};
-
 export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /*@__PURE__*/ core.$constructor(
   "$ZodCheckNumberFormat",
   (inst, def) => {
@@ -269,7 +262,6 @@ export const $ZodCheckNumberFormat: core.$constructor<$ZodCheckNumberFormat> = /
     const isInt = def.format?.includes("int");
     const origin = isInt ? "int" : "number";
     const [minimum, maximum] = util.NUMBER_FORMAT_RANGES[def.format];
-    if (isInt) attachPattern(inst, { pattern: regexes.integer });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -572,11 +564,6 @@ export const $ZodCheckMaxLength: core.$constructor<$ZodCheckMaxLength> = /*@__PU
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasLength;
-    // tightest bound wins, so the string's pattern is the same whatever the chain order
-    inst._zod.onattach.push((s) => {
-      const bag = s._zod.bag as { maximum?: number };
-      if (bag.maximum === undefined || def.maximum < bag.maximum) bag.maximum = def.maximum;
-    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -622,10 +609,6 @@ export const $ZodCheckMinLength: core.$constructor<$ZodCheckMinLength> = /*@__PU
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasLength;
-    inst._zod.onattach.push((s) => {
-      const bag = s._zod.bag as { minimum?: number };
-      if (bag.minimum === undefined || def.minimum > bag.minimum) bag.minimum = def.minimum;
-    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -675,11 +658,6 @@ export const $ZodCheckLengthEquals: core.$constructor<$ZodCheckLengthEquals> = /
     $ZodCheck.init(inst, def);
 
     inst._zod.def.when ??= _whenHasLength;
-    inst._zod.onattach.push((s) => {
-      const bag = s._zod.bag as { minimum?: number; maximum?: number };
-      if (bag.minimum === undefined || def.length > bag.minimum) bag.minimum = def.length;
-      if (bag.maximum === undefined || def.length < bag.maximum) bag.maximum = def.length;
-    });
 
     inst._zod.check = (payload) => {
       const input = payload.value;
@@ -759,7 +737,6 @@ export const $ZodCheckStringFormat: core.$constructor<$ZodCheckStringFormat> = /
   "$ZodCheckStringFormat",
   (inst, def) => {
     $ZodCheck.init(inst, def);
-    attachPattern(inst, def);
 
     if (def.pattern)
       inst._zod.check ??= (payload) => {
@@ -925,7 +902,6 @@ export const $ZodCheckIncludes: core.$constructor<$ZodCheckIncludes> = /*@__PURE
     // (`{N,}`), not exactly `position` chars (`{N}`).
     const pattern = new RegExp(typeof def.position === "number" ? `^.{${def.position},}${escapedRegex}` : escapedRegex);
     def.pattern = pattern;
-    attachPattern(inst, def);
     inst._zod.check = (payload) => {
       if (payload.value.includes(def.includes, def.position)) return;
       payload.issues.push({
@@ -964,7 +940,6 @@ export const $ZodCheckStartsWith: core.$constructor<$ZodCheckStartsWith> = /*@__
 
     const pattern = new RegExp(`^${util.escapeRegex(def.prefix)}.*`);
     def.pattern ??= pattern;
-    attachPattern(inst, def);
     inst._zod.check = (payload) => {
       if (payload.value.startsWith(def.prefix)) return;
       payload.issues.push({
@@ -1003,7 +978,6 @@ export const $ZodCheckEndsWith: core.$constructor<$ZodCheckEndsWith> = /*@__PURE
 
     const pattern = new RegExp(`.*${util.escapeRegex(def.suffix)}$`);
     def.pattern ??= pattern;
-    attachPattern(inst, def);
     inst._zod.check = (payload) => {
       if (payload.value.endsWith(def.suffix)) return;
       payload.issues.push({

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -31,6 +31,8 @@ interface CheckAggregate {
   exclusiveMaximum?: number | bigint | Date;
   multipleOf?: number[];
   format?: string;
+  // ORed across formats: any integer format keeps the conjunction integer, whatever format lands last
+  isInt?: boolean;
   patterns?: Set<RegExp>;
   mime?: string[];
 }
@@ -60,6 +62,7 @@ const contributors: Record<string, (agg: CheckAggregate, def: any) => void> = {
   number_format: (agg, def) => {
     // last-wins, matching the bag's historical write order
     agg.format = def.format;
+    if ((def.format as string).includes("int")) agg.isInt = true;
     const [minimum, maximum] = NUMBER_FORMAT_RANGES[def.format as checks.$ZodNumberFormats];
     narrowMin(agg, "minimum", minimum);
     narrowMax(agg, "maximum", maximum);
@@ -104,7 +107,7 @@ function aggregateChecks(schema: schemas.$ZodType): CheckAggregate {
     if (!agg.multipleOf.includes(bag.multipleOf)) agg.multipleOf.push(bag.multipleOf);
   }
   if (agg.format === undefined && bag.format !== undefined) agg.format = bag.format;
-  if (agg.mime === undefined && bag.mime !== undefined) agg.mime = bag.mime;
+  if (bag.mime !== undefined) agg.mime = agg.mime ? agg.mime.filter((m) => bag.mime!.includes(m)) : bag.mime;
   if (bag.patterns) {
     agg.patterns ??= new Set();
     for (const p of bag.patterns) agg.patterns.add(p);
@@ -165,10 +168,10 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
 
 export const numberProcessor: Processor<schemas.$ZodNumber> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.NumberSchema | JSONSchema.IntegerSchema;
-  const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum } = aggregateChecks(
+  const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum, isInt } = aggregateChecks(
     schema
   ) as CheckAggregate & { minimum?: number; maximum?: number; exclusiveMinimum?: number; exclusiveMaximum?: number };
-  if (typeof format === "string" && format.includes("int")) json.type = "integer";
+  if (isInt || (typeof format === "string" && format.includes("int"))) json.type = "integer";
   else json.type = "number";
 
   // when both minimum and exclusiveMinimum exist, pick the more restrictive one
@@ -347,7 +350,11 @@ export const fileProcessor: Processor<schemas.$ZodFile> = (schema, _ctx, json, _
   const { minimum, maximum, mime } = aggregateChecks(schema);
   if (typeof minimum === "number") file.minLength = minimum;
   if (typeof maximum === "number") file.maxLength = maximum;
-  if (mime?.length) {
+  // an empty intersection means the mime checks share no value, so nothing passes at runtime; `anyOf` must be non-empty, so the false schema is `not: {}`
+  if (mime && mime.length === 0) {
+    Object.assign(_json, file);
+    _json.not = {};
+  } else if (mime?.length) {
     if (mime.length === 1) {
       file.contentMediaType = mime[0]!;
       Object.assign(_json, file);

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -24,11 +24,13 @@ import { BIGINT_FORMAT_RANGES, NUMBER_FORMAT_RANGES, assignProp, getEnumValues }
 // ==================== CHECK AGGREGATION ====================
 
 // constraint metadata comes from folding `def.checks` here, not from trusting `_zod.bag`: the bag is written by each check's own `onattach` in chain order, which has repeatedly produced order-dependent and lossy values (#6550). runtime checks are a conjunction, so every merge below is the conjunction's — tightest bound wins, patterns union, divisors collect, mime lists intersect
-interface CheckAggregate {
-  minimum?: number | bigint | Date;
-  maximum?: number | bigint | Date;
-  exclusiveMinimum?: number | bigint | Date;
-  exclusiveMaximum?: number | bigint | Date;
+type Bound = number | bigint | Date;
+
+interface CheckAggregate<N extends Bound = Bound> {
+  minimum?: N;
+  maximum?: N;
+  exclusiveMinimum?: N;
+  exclusiveMaximum?: N;
   multipleOf?: number[];
   format?: string;
   // ORed across formats: any integer format keeps the conjunction integer, whatever format lands last
@@ -40,63 +42,67 @@ interface CheckAggregate {
   laxFormat?: boolean;
 }
 
-const narrowMin = (agg: CheckAggregate, key: "minimum" | "exclusiveMinimum", value: number | bigint | Date): void => {
-  if (agg[key] === undefined || value > agg[key]!) agg[key] = value;
+const narrowMin = (agg: CheckAggregate, key: "minimum" | "exclusiveMinimum", value: Bound): void => {
+  if (agg[key] === undefined || value > agg[key]) agg[key] = value;
 };
-const narrowMax = (agg: CheckAggregate, key: "maximum" | "exclusiveMaximum", value: number | bigint | Date): void => {
-  if (agg[key] === undefined || value < agg[key]!) agg[key] = value;
+const narrowMax = (agg: CheckAggregate, key: "maximum" | "exclusiveMaximum", value: Bound): void => {
+  if (agg[key] === undefined || value < agg[key]) agg[key] = value;
 };
-
 const narrowBoth = (agg: CheckAggregate, value: number): void => {
   narrowMin(agg, "minimum", value);
   narrowMax(agg, "maximum", value);
 };
+const addDivisor = (agg: CheckAggregate, value: number): void => {
+  agg.multipleOf ??= [];
+  if (!agg.multipleOf.includes(value)) agg.multipleOf.push(value);
+};
+const addPattern = (agg: CheckAggregate, pattern: RegExp): void => {
+  agg.patterns ??= new Set();
+  agg.patterns.add(pattern);
+};
+const intersectMime = (agg: CheckAggregate, mime: string[]): void => {
+  agg.mime = agg.mime ? agg.mime.filter((m) => mime.includes(m)) : [...mime];
+};
+// last-wins, matching the bag's historical write order; the flag keeps an integer format from being lost to a later float one
+const setFormat = (agg: CheckAggregate, format: string): void => {
+  agg.format = format;
+  if (format.includes("int")) agg.isInt = true;
+};
 
-const minContributor = (agg: CheckAggregate, def: any): void => narrowMin(agg, "minimum", def.minimum);
-const maxContributor = (agg: CheckAggregate, def: any): void => narrowMax(agg, "maximum", def.maximum);
-
-const contributors: Record<string, (agg: CheckAggregate, def: any) => void> = {
-  greater_than: (agg, def) => narrowMin(agg, def.inclusive ? "minimum" : "exclusiveMinimum", def.value),
-  less_than: (agg, def) => narrowMax(agg, def.inclusive ? "maximum" : "exclusiveMaximum", def.value),
-  multiple_of: (agg, def) => {
-    agg.multipleOf ??= [];
-    if (!agg.multipleOf.includes(def.value)) agg.multipleOf.push(def.value);
-  },
-  number_format: (agg, def) => {
-    // last-wins, matching the bag's historical write order
-    agg.format = def.format;
-    if ((def.format as string).includes("int")) agg.isInt = true;
-    const [minimum, maximum] = NUMBER_FORMAT_RANGES[def.format as checks.$ZodNumberFormats];
+type Contributor = (agg: CheckAggregate, def: any) => void;
+const minContributor: Contributor = (agg, def) => narrowMin(agg, "minimum", def.minimum);
+const maxContributor: Contributor = (agg, def) => narrowMax(agg, "maximum", def.maximum);
+const formatContributor =
+  (ranges: Record<string, [Bound, Bound]>): Contributor =>
+  (agg, def) => {
+    setFormat(agg, def.format);
+    const [minimum, maximum] = ranges[def.format]!;
     narrowMin(agg, "minimum", minimum);
     narrowMax(agg, "maximum", maximum);
-  },
+  };
+
+const contributors: Record<string, Contributor> = {
+  greater_than: (agg, def) => narrowMin(agg, def.inclusive ? "minimum" : "exclusiveMinimum", def.value),
+  less_than: (agg, def) => narrowMax(agg, def.inclusive ? "maximum" : "exclusiveMaximum", def.value),
+  multiple_of: (agg, def) => addDivisor(agg, def.value),
+  number_format: formatContributor(NUMBER_FORMAT_RANGES),
+  bigint_format: formatContributor(BIGINT_FORMAT_RANGES),
   min_length: minContributor,
   max_length: maxContributor,
   length_equals: (agg, def) => narrowBoth(agg, def.length),
   min_size: minContributor,
   max_size: maxContributor,
   size_equals: (agg, def) => narrowBoth(agg, def.size),
-  bigint_format: (agg, def) => {
-    agg.format = def.format;
-    const [minimum, maximum] = BIGINT_FORMAT_RANGES[def.format as checks.$ZodBigIntFormats];
-    narrowMin(agg, "minimum", minimum);
-    narrowMax(agg, "maximum", maximum);
-  },
   string_format: (agg, def) => {
-    agg.format = def.format;
-    if (def.pattern) {
-      agg.patterns ??= new Set();
-      agg.patterns.add(def.pattern);
-    }
+    setFormat(agg, def.format);
+    if (def.pattern) addPattern(agg, def.pattern);
     if (def.format === "base64" || def.format === "base64url") agg.contentEncoding = def.format;
     if (def.local || def.precision === -1) agg.laxFormat = true;
   },
-  mime_type: (agg, def) => {
-    agg.mime = agg.mime ? agg.mime.filter((m) => def.mime.includes(m)) : [...def.mime];
-  },
+  mime_type: (agg, def) => intersectMime(agg, def.mime),
 };
 
-export function aggregateChecks(schema: schemas.$ZodType): CheckAggregate {
+export function aggregateChecks<N extends Bound = Bound>(schema: schemas.$ZodType): CheckAggregate<N> {
   const agg: CheckAggregate = {};
   const def = schema._zod.def;
   // a format schema is its own first check, same rule as $ZodType init
@@ -107,23 +113,18 @@ export function aggregateChecks(schema: schemas.$ZodType): CheckAggregate {
 
   // reconcile with the bag so third-party onattach contributions still land; first-party residue is never tighter than the fold, so merging it back is idempotent for one and additive for the other
   const bag = schema._zod.bag as Omit<CheckAggregate, "multipleOf"> & { multipleOf?: number };
-  for (const key of ["minimum", "exclusiveMinimum"] as const) {
-    if (bag[key] !== undefined) narrowMin(agg, key, bag[key]!);
+  if (bag.minimum !== undefined) narrowMin(agg, "minimum", bag.minimum);
+  if (bag.exclusiveMinimum !== undefined) narrowMin(agg, "exclusiveMinimum", bag.exclusiveMinimum);
+  if (bag.maximum !== undefined) narrowMax(agg, "maximum", bag.maximum);
+  if (bag.exclusiveMaximum !== undefined) narrowMax(agg, "exclusiveMaximum", bag.exclusiveMaximum);
+  if (bag.multipleOf !== undefined) addDivisor(agg, bag.multipleOf);
+  if (bag.format !== undefined) {
+    agg.format ??= bag.format;
+    if (bag.format.includes("int")) agg.isInt = true;
   }
-  for (const key of ["maximum", "exclusiveMaximum"] as const) {
-    if (bag[key] !== undefined) narrowMax(agg, key, bag[key]!);
-  }
-  if (bag.multipleOf !== undefined) {
-    agg.multipleOf ??= [];
-    if (!agg.multipleOf.includes(bag.multipleOf)) agg.multipleOf.push(bag.multipleOf);
-  }
-  if (agg.format === undefined && bag.format !== undefined) agg.format = bag.format;
-  if (bag.mime !== undefined) agg.mime = agg.mime ? agg.mime.filter((m) => bag.mime!.includes(m)) : bag.mime;
-  if (bag.patterns) {
-    agg.patterns ??= new Set();
-    for (const p of bag.patterns) agg.patterns.add(p);
-  }
-  return agg;
+  if (bag.mime) intersectMime(agg, bag.mime);
+  for (const pattern of bag.patterns ?? []) addPattern(agg, pattern);
+  return agg as CheckAggregate<N>;
 }
 
 const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> = {
@@ -178,11 +179,8 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
 
 export const numberProcessor: Processor<schemas.$ZodNumber> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.NumberSchema | JSONSchema.IntegerSchema;
-  const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum, isInt } = aggregateChecks(
-    schema
-  ) as CheckAggregate & { minimum?: number; maximum?: number; exclusiveMinimum?: number; exclusiveMaximum?: number };
-  if (isInt || (typeof format === "string" && format.includes("int"))) json.type = "integer";
-  else json.type = "number";
+  const { minimum, maximum, multipleOf, exclusiveMaximum, exclusiveMinimum, isInt } = aggregateChecks<number>(schema);
+  json.type = isInt ? "integer" : "number";
 
   // when both minimum and exclusiveMinimum exist, pick the more restrictive one
   const exMin = typeof exclusiveMinimum === "number" && exclusiveMinimum >= (minimum ?? Number.NEGATIVE_INFINITY);
@@ -226,7 +224,7 @@ export const numberProcessor: Processor<schemas.$ZodNumber> = (schema, ctx, _jso
         );
     }
     // chained divisors are a conjunction the keyword cannot carry alone, so extras ride an allOf, same as stacked patterns
-    const [first, ...rest] = [...divisors];
+    const [first, ...rest] = divisors;
     if (first !== undefined) json.multipleOf = first;
     if (rest.length) json.allOf = [...(json.allOf ?? []), ...rest.map((m) => ({ multipleOf: m }))];
   }
@@ -351,30 +349,19 @@ export const templateLiteralProcessor: Processor<schemas.$ZodTemplateLiteral> = 
 
 export const fileProcessor: Processor<schemas.$ZodFile> = (schema, _ctx, json, _params) => {
   const _json = json as JSONSchema.StringSchema;
-  const file: JSONSchema.StringSchema = {
-    type: "string",
-    format: "binary",
-    contentEncoding: "binary",
-  };
+  _json.type = "string";
+  _json.format = "binary";
+  _json.contentEncoding = "binary";
 
-  const { minimum, maximum, mime } = aggregateChecks(schema);
-  if (typeof minimum === "number") file.minLength = minimum;
-  if (typeof maximum === "number") file.maxLength = maximum;
+  const { minimum, maximum, mime } = aggregateChecks<number>(schema);
+  if (minimum !== undefined) _json.minLength = minimum;
+  if (maximum !== undefined) _json.maxLength = maximum;
+  if (!mime) return;
   // an empty intersection means the mime checks share no value, so nothing passes at runtime; `anyOf` must be non-empty, so the false schema is `not: {}`
-  if (mime && mime.length === 0) {
-    Object.assign(_json, file);
-    _json.not = {};
-  } else if (mime?.length) {
-    if (mime.length === 1) {
-      file.contentMediaType = mime[0]!;
-      Object.assign(_json, file);
-    } else {
-      Object.assign(_json, file); // shared props at root
-      _json.anyOf = mime.map((m) => ({ contentMediaType: m })); // only contentMediaType differs
-    }
-  } else {
-    Object.assign(_json, file);
-  }
+  if (mime.length === 0) _json.not = {};
+  else if (mime.length === 1) _json.contentMediaType = mime[0]!;
+  // only contentMediaType differs, so the shared props stay at the root
+  else _json.anyOf = mime.map((m) => ({ contentMediaType: m }));
 };
 
 export const successProcessor: Processor<schemas.$ZodSuccess> = (_schema, _ctx, json, _params) => {

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -19,7 +19,7 @@ import {
   isTransforming,
   processSchema,
 } from "./to-json-schema.js";
-import { NUMBER_FORMAT_RANGES, assignProp, getEnumValues } from "./util.js";
+import { BIGINT_FORMAT_RANGES, NUMBER_FORMAT_RANGES, assignProp, getEnumValues } from "./util.js";
 
 // ==================== CHECK AGGREGATION ====================
 
@@ -35,6 +35,9 @@ interface CheckAggregate {
   isInt?: boolean;
   patterns?: Set<RegExp>;
   mime?: string[];
+  contentEncoding?: string;
+  // a datetime that drops the offset or the seconds accepts what `date-time` forbids, so the keyword is withheld
+  laxFormat?: boolean;
 }
 
 const narrowMin = (agg: CheckAggregate, key: "minimum" | "exclusiveMinimum", value: number | bigint | Date): void => {
@@ -73,19 +76,27 @@ const contributors: Record<string, (agg: CheckAggregate, def: any) => void> = {
   min_size: minContributor,
   max_size: maxContributor,
   size_equals: (agg, def) => narrowBoth(agg, def.size),
+  bigint_format: (agg, def) => {
+    agg.format = def.format;
+    const [minimum, maximum] = BIGINT_FORMAT_RANGES[def.format as checks.$ZodBigIntFormats];
+    narrowMin(agg, "minimum", minimum);
+    narrowMax(agg, "maximum", maximum);
+  },
   string_format: (agg, def) => {
     agg.format = def.format;
     if (def.pattern) {
       agg.patterns ??= new Set();
       agg.patterns.add(def.pattern);
     }
+    if (def.format === "base64" || def.format === "base64url") agg.contentEncoding = def.format;
+    if (def.local || def.precision === -1) agg.laxFormat = true;
   },
   mime_type: (agg, def) => {
     agg.mime = agg.mime ? agg.mime.filter((m) => def.mime.includes(m)) : [...def.mime];
   },
 };
 
-function aggregateChecks(schema: schemas.$ZodType): CheckAggregate {
+export function aggregateChecks(schema: schemas.$ZodType): CheckAggregate {
   const agg: CheckAggregate = {};
   const def = schema._zod.def;
   // a format schema is its own first check, same rule as $ZodType init
@@ -135,8 +146,7 @@ const exactPattern = (p: RegExp): RegExp => exactPatterns.get(p) ?? p;
 export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _json, _params) => {
   const json = _json as JSONSchema.StringSchema;
   json.type = "string";
-  const { contentEncoding, laxFormat } = schema._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
-  const { minimum, maximum, format, patterns } = aggregateChecks(schema);
+  const { minimum, maximum, format, patterns, contentEncoding, laxFormat } = aggregateChecks(schema);
   if (typeof minimum === "number") json.minLength = minimum;
   if (typeof maximum === "number") json.maxLength = maximum;
   // custom pattern overrides format

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -19,7 +19,98 @@ import {
   isTransforming,
   processSchema,
 } from "./to-json-schema.js";
-import { assignProp, getEnumValues } from "./util.js";
+import { NUMBER_FORMAT_RANGES, assignProp, getEnumValues } from "./util.js";
+
+// ==================== CHECK AGGREGATION ====================
+
+// constraint metadata comes from folding `def.checks` here, not from trusting `_zod.bag`: the bag is written by each check's own `onattach` in chain order, which has repeatedly produced order-dependent and lossy values (#6550). runtime checks are a conjunction, so every merge below is the conjunction's — tightest bound wins, patterns union, divisors collect, mime lists intersect
+interface CheckAggregate {
+  minimum?: number | bigint | Date;
+  maximum?: number | bigint | Date;
+  exclusiveMinimum?: number | bigint | Date;
+  exclusiveMaximum?: number | bigint | Date;
+  multipleOf?: number[];
+  format?: string;
+  patterns?: Set<RegExp>;
+  mime?: string[];
+}
+
+const narrowMin = (agg: CheckAggregate, key: "minimum" | "exclusiveMinimum", value: number | bigint | Date): void => {
+  if (agg[key] === undefined || value > agg[key]!) agg[key] = value;
+};
+const narrowMax = (agg: CheckAggregate, key: "maximum" | "exclusiveMaximum", value: number | bigint | Date): void => {
+  if (agg[key] === undefined || value < agg[key]!) agg[key] = value;
+};
+
+const narrowBoth = (agg: CheckAggregate, value: number): void => {
+  narrowMin(agg, "minimum", value);
+  narrowMax(agg, "maximum", value);
+};
+
+const minContributor = (agg: CheckAggregate, def: any): void => narrowMin(agg, "minimum", def.minimum);
+const maxContributor = (agg: CheckAggregate, def: any): void => narrowMax(agg, "maximum", def.maximum);
+
+const contributors: Record<string, (agg: CheckAggregate, def: any) => void> = {
+  greater_than: (agg, def) => narrowMin(agg, def.inclusive ? "minimum" : "exclusiveMinimum", def.value),
+  less_than: (agg, def) => narrowMax(agg, def.inclusive ? "maximum" : "exclusiveMaximum", def.value),
+  multiple_of: (agg, def) => {
+    agg.multipleOf ??= [];
+    if (!agg.multipleOf.includes(def.value)) agg.multipleOf.push(def.value);
+  },
+  number_format: (agg, def) => {
+    // last-wins, matching the bag's historical write order
+    agg.format = def.format;
+    const [minimum, maximum] = NUMBER_FORMAT_RANGES[def.format as checks.$ZodNumberFormats];
+    narrowMin(agg, "minimum", minimum);
+    narrowMax(agg, "maximum", maximum);
+  },
+  min_length: minContributor,
+  max_length: maxContributor,
+  length_equals: (agg, def) => narrowBoth(agg, def.length),
+  min_size: minContributor,
+  max_size: maxContributor,
+  size_equals: (agg, def) => narrowBoth(agg, def.size),
+  string_format: (agg, def) => {
+    agg.format = def.format;
+    if (def.pattern) {
+      agg.patterns ??= new Set();
+      agg.patterns.add(def.pattern);
+    }
+  },
+  mime_type: (agg, def) => {
+    agg.mime = agg.mime ? agg.mime.filter((m) => def.mime.includes(m)) : [...def.mime];
+  },
+};
+
+function aggregateChecks(schema: schemas.$ZodType): CheckAggregate {
+  const agg: CheckAggregate = {};
+  const def = schema._zod.def;
+  // a format schema is its own first check, same rule as $ZodType init
+  const list: checks.$ZodCheck[] = schema._zod.traits.has("$ZodCheck")
+    ? [schema as unknown as checks.$ZodCheck, ...(def.checks ?? [])]
+    : (def.checks ?? []);
+  for (const ch of list) contributors[ch._zod.def.check]?.(agg, ch._zod.def);
+
+  // reconcile with the bag so third-party onattach contributions still land; first-party residue is never tighter than the fold, so merging it back is idempotent for one and additive for the other
+  const bag = schema._zod.bag as Omit<CheckAggregate, "multipleOf"> & { multipleOf?: number };
+  for (const key of ["minimum", "exclusiveMinimum"] as const) {
+    if (bag[key] !== undefined) narrowMin(agg, key, bag[key]!);
+  }
+  for (const key of ["maximum", "exclusiveMaximum"] as const) {
+    if (bag[key] !== undefined) narrowMax(agg, key, bag[key]!);
+  }
+  if (bag.multipleOf !== undefined) {
+    agg.multipleOf ??= [];
+    if (!agg.multipleOf.includes(bag.multipleOf)) agg.multipleOf.push(bag.multipleOf);
+  }
+  if (agg.format === undefined && bag.format !== undefined) agg.format = bag.format;
+  if (agg.mime === undefined && bag.mime !== undefined) agg.mime = bag.mime;
+  if (bag.patterns) {
+    agg.patterns ??= new Set();
+    for (const p of bag.patterns) agg.patterns.add(p);
+  }
+  return agg;
+}
 
 const formatMap: Partial<Record<checks.$ZodStringFormats, string | undefined>> = {
   guid: "uuid",
@@ -41,8 +132,8 @@ const exactPattern = (p: RegExp): RegExp => exactPatterns.get(p) ?? p;
 export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _json, _params) => {
   const json = _json as JSONSchema.StringSchema;
   json.type = "string";
-  const { minimum, maximum, format, patterns, contentEncoding, laxFormat } = schema._zod
-    .bag as schemas.$ZodStringInternals<unknown>["bag"];
+  const { contentEncoding, laxFormat } = schema._zod.bag as schemas.$ZodStringInternals<unknown>["bag"];
+  const { minimum, maximum, format, patterns } = aggregateChecks(schema);
   if (typeof minimum === "number") json.minLength = minimum;
   if (typeof maximum === "number") json.maxLength = maximum;
   // custom pattern overrides format
@@ -74,7 +165,9 @@ export const stringProcessor: Processor<schemas.$ZodString> = (schema, ctx, _jso
 
 export const numberProcessor: Processor<schemas.$ZodNumber> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.NumberSchema | JSONSchema.IntegerSchema;
-  const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum } = schema._zod.bag;
+  const { minimum, maximum, format, multipleOf, exclusiveMaximum, exclusiveMinimum } = aggregateChecks(
+    schema
+  ) as CheckAggregate & { minimum?: number; maximum?: number; exclusiveMinimum?: number; exclusiveMaximum?: number };
   if (typeof format === "string" && format.includes("int")) json.type = "integer";
   else json.type = "number";
 
@@ -105,17 +198,24 @@ export const numberProcessor: Processor<schemas.$ZodNumber> = (schema, ctx, _jso
     json.maximum = maximum;
   }
 
-  if (typeof multipleOf === "number") {
+  if (multipleOf) {
     // JSON Schema requires a divisor strictly greater than zero, and a non-finite one does not survive JSON at all. A negative divisor accepts exactly what its absolute value accepts, so it still maps; zero, NaN and Infinity have no keyword form.
-    if (Number.isFinite(multipleOf) && multipleOf !== 0) json.multipleOf = Math.abs(multipleOf);
-    else
-      handleUnrepresentable(
-        schema,
-        ctx,
-        json,
-        params,
-        `A multipleOf divisor of ${multipleOf} cannot be represented in JSON Schema`
-      );
+    const divisors = new Set<number>();
+    for (const divisor of multipleOf) {
+      if (Number.isFinite(divisor) && divisor !== 0) divisors.add(Math.abs(divisor));
+      else
+        handleUnrepresentable(
+          schema,
+          ctx,
+          json,
+          params,
+          `A multipleOf divisor of ${divisor} cannot be represented in JSON Schema`
+        );
+    }
+    // chained divisors are a conjunction the keyword cannot carry alone, so extras ride an allOf, same as stacked patterns
+    const [first, ...rest] = [...divisors];
+    if (first !== undefined) json.multipleOf = first;
+    if (rest.length) json.allOf = [...(json.allOf ?? []), ...rest.map((m) => ({ multipleOf: m }))];
   }
 };
 
@@ -244,10 +344,10 @@ export const fileProcessor: Processor<schemas.$ZodFile> = (schema, _ctx, json, _
     contentEncoding: "binary",
   };
 
-  const { minimum, maximum, mime } = schema._zod.bag as schemas.$ZodFileInternals["bag"];
-  if (minimum !== undefined) file.minLength = minimum;
-  if (maximum !== undefined) file.maxLength = maximum;
-  if (mime) {
+  const { minimum, maximum, mime } = aggregateChecks(schema);
+  if (typeof minimum === "number") file.minLength = minimum;
+  if (typeof maximum === "number") file.maxLength = maximum;
+  if (mime?.length) {
     if (mime.length === 1) {
       file.contentMediaType = mime[0]!;
       Object.assign(_json, file);
@@ -289,7 +389,7 @@ export const setProcessor: Processor<schemas.$ZodSet> = (schema, ctx, json, para
 export const arrayProcessor: Processor<schemas.$ZodArray> = (schema, ctx, _json, params) => {
   const json = _json as JSONSchema.ArraySchema;
   const def = schema._zod.def as schemas.$ZodArrayDef;
-  const { minimum, maximum } = schema._zod.bag;
+  const { minimum, maximum } = aggregateChecks(schema);
   if (typeof minimum === "number") json.minItems = minimum;
   if (typeof maximum === "number") json.maxItems = maximum;
 
@@ -526,10 +626,7 @@ export const tupleProcessor: Processor<schemas.$ZodTuple> = (schema, ctx, _json,
   }
 
   // explicit user-defined length checks take precedence
-  const { minimum, maximum } = schema._zod.bag as {
-    minimum?: number;
-    maximum?: number;
-  };
+  const { minimum, maximum } = aggregateChecks(schema);
   if (typeof minimum === "number") json.minItems = minimum;
   if (typeof maximum === "number") json.maxItems = maximum;
 };
@@ -620,8 +717,7 @@ export const recordProcessor: Processor<schemas.$ZodRecord> = (schema, ctx, _jso
 
   // For looseRecord with regex patterns, use patternProperties. This correctly represents "only validate keys matching the pattern" semantics and composes well with allOf (intersections)
   const keyType = def.keyType as schemas.$ZodTypes;
-  const keyBag = keyType._zod.bag as schemas.$ZodStringInternals<unknown>["bag"] | undefined;
-  const patterns = keyBag?.patterns;
+  const patterns = aggregateChecks(keyType).patterns;
 
   if (def.mode === "loose" && patterns && patterns.size > 0) {
     // Use patternProperties for looseRecord with regex patterns

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -147,12 +147,11 @@ export function datetime(args: {
   return new RegExp(`^${dateSource}T(?:${timeRegex})$`);
 }
 
-// the unbounded form of `string()` as a literal, so every plain string shares one instance instead of building its own
-export const anyString: RegExp = /^[\s\S]{0,}$/;
-
 export const string = (params?: { minimum?: number | undefined; maximum?: number | undefined }): RegExp => {
-  const regex = params ? `[\\s\\S]{${params?.minimum ?? 0},${params?.maximum ?? ""}}` : `[\\s\\S]*`;
-  return new RegExp(`^${regex}$`);
+  const minimum = params?.minimum ?? 0;
+  const maximum = params?.maximum;
+  // an empty range matches nothing at runtime, and `{8,5}` is not a legal quantifier
+  return minimum > maximum! ? /(?!)/ : new RegExp(`^[\\s\\S]{${minimum},${maximum ?? ""}}$`);
 };
 
 export const bigint: RegExp = /^-?\d+n?$/;

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -147,6 +147,9 @@ export function datetime(args: {
   return new RegExp(`^${dateSource}T(?:${timeRegex})$`);
 }
 
+// the unbounded form of `string()` as a literal, so every plain string shares one instance instead of building its own
+export const anyString: RegExp = /^[\s\S]{0,}$/;
+
 export const string = (params?: { minimum?: number | undefined; maximum?: number | undefined }): RegExp => {
   const regex = params ? `[\\s\\S]{${params?.minimum ?? 0},${params?.maximum ?? ""}}` : `[\\s\\S]*`;
   return new RegExp(`^${regex}$`);

--- a/packages/zod/src/v4/core/regexes.ts
+++ b/packages/zod/src/v4/core/regexes.ts
@@ -147,11 +147,12 @@ export function datetime(args: {
   return new RegExp(`^${dateSource}T(?:${timeRegex})$`);
 }
 
+// the unbounded form of `string()` as a literal, so every plain string shares one instance instead of building its own
+export const anyString: RegExp = /^[\s\S]{0,}$/;
+
 export const string = (params?: { minimum?: number | undefined; maximum?: number | undefined }): RegExp => {
-  const minimum = params?.minimum ?? 0;
-  const maximum = params?.maximum;
-  // an empty range matches nothing at runtime, and `{8,5}` is not a legal quantifier
-  return minimum > maximum! ? /(?!)/ : new RegExp(`^[\\s\\S]{${minimum},${maximum ?? ""}}$`);
+  const regex = params ? `[\\s\\S]{${params?.minimum ?? 0},${params?.maximum ?? ""}}` : `[\\s\\S]*`;
+  return new RegExp(`^${regex}$`);
 };
 
 export const bigint: RegExp = /^-?\d+n?$/;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4633,11 +4633,12 @@ function partPattern(schema: $ZodType): RegExp | string | undefined {
     checks?: checks.$ZodCheck[];
   };
   const src = (p: RegExp | string) => (p instanceof RegExp ? p.source : p);
-  // a wrapper's pattern embeds its inner pattern's source verbatim, so the check-aware form is substituted in place without knowing the wrapper's own composition
-  if (def.innerType) {
+  // a wrapper's pattern embeds its inner pattern's source verbatim, so the check-aware form is substituted in place without knowing the wrapper's own composition. lazy resolves its inner on the internals, not the def
+  const inner = def.innerType ?? (schema._zod as { innerType?: $ZodType }).innerType;
+  if (inner) {
     const own = schema._zod.pattern;
-    const before = def.innerType._zod.pattern;
-    const after = partPattern(def.innerType);
+    const before = inner._zod.pattern;
+    const after = partPattern(inner);
     if (own && before && after && after !== before) {
       return own.source.replace(util.cleanRegex(before.source), () => util.cleanRegex(src(after)));
     }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -400,7 +400,7 @@ export interface $ZodString<Input = unknown> extends _$ZodType<$ZodStringInterna
 export const $ZodString: core.$constructor<$ZodString> = /*@__PURE__*/ core.$constructor("$ZodString", (inst, def) => {
   $ZodType.init(inst, def);
   // a format's own pattern, else unbounded; a template literal derives the check-aware form itself
-  inst._zod.pattern = (def as { pattern?: RegExp }).pattern ?? regexes.anyString;
+  inst._zod.pattern = (def as $ZodStringFormatDef).pattern ?? regexes.anyString;
   inst._zod.parse = (payload, _) => {
     if (def.coerce)
       try {
@@ -4623,8 +4623,8 @@ export type $PartsToTemplateLiteral<Parts extends $ZodTemplateLiteralPart[]> = [
       : never
     : never;
 
-// a part's pattern with its checks folded in: the last pattern-carrying check wins, else length bounds narrow the catch-all, else an integer format narrows the number form. read off the defs since checks no longer write the bag; options recurse so a union of constrained parts keeps its precision
-function partPattern(schema: $ZodType): RegExp | string | undefined {
+// a part's pattern source with its checks folded in: the last pattern-carrying check wins, else length bounds narrow the catch-all, else an integer format narrows the number form. read off the defs since checks no longer write the bag; options recurse so a union of constrained parts keeps its precision
+function partPattern(schema: $ZodType): string | undefined {
   const def = schema._zod.def as {
     pattern?: RegExp;
     format?: string;
@@ -4632,23 +4632,20 @@ function partPattern(schema: $ZodType): RegExp | string | undefined {
     options?: $ZodType[];
     checks?: checks.$ZodCheck[];
   };
-  const src = (p: RegExp | string) => (p instanceof RegExp ? p.source : p);
+  const own = schema._zod.pattern;
   // a wrapper's pattern embeds its inner pattern's source verbatim, so the check-aware form is substituted in place without knowing the wrapper's own composition. lazy resolves its inner on the internals, not the def
   const inner = def.innerType ?? (schema._zod as { innerType?: $ZodType }).innerType;
   if (inner) {
-    const own = schema._zod.pattern;
     const before = inner._zod.pattern;
     const after = partPattern(inner);
-    if (own && before && after && after !== before) {
-      return own.source.replace(util.cleanRegex(before.source), () => util.cleanRegex(src(after)));
+    if (own && before && after && after !== before.source) {
+      return own.source.replace(util.cleanRegex(before.source), () => util.cleanRegex(after));
     }
-    return own;
+    return own?.source;
   }
   if (def.options) {
-    const patterns = def.options.map(partPattern);
-    if (patterns.every(Boolean)) {
-      return new RegExp(`^(${patterns.map((p) => util.cleanRegex(src(p!))).join("|")})$`);
-    }
+    const sources = def.options.map(partPattern);
+    if (sources.every(Boolean)) return `^(${sources.map((s) => util.cleanRegex(s!)).join("|")})$`;
   }
   let pattern = def.pattern;
   let isInt = !!def.format?.includes("int");
@@ -4660,15 +4657,14 @@ function partPattern(schema: $ZodType): RegExp | string | undefined {
     isInt ||= !!d.format?.includes("int");
     const lo = d.minimum ?? d.length;
     const hi = d.maximum ?? d.length;
-    if (lo !== undefined && !(minimum! > lo)) minimum = lo;
-    if (hi !== undefined && !(maximum! < hi)) maximum = hi;
+    if (lo !== undefined && (minimum === undefined || lo > minimum)) minimum = lo;
+    if (hi !== undefined && (maximum === undefined || hi < maximum)) maximum = hi;
   }
-  if (pattern) return pattern;
+  if (pattern) return pattern.source;
   // an empty range matches nothing at runtime, and `{8,5}` is not a legal quantifier
-  if (minimum !== undefined && maximum !== undefined && minimum > maximum) return /(?!)/;
-  if (minimum !== undefined || maximum !== undefined) return regexes.string({ minimum, maximum });
-  const own = schema._zod.pattern;
-  return isInt && own === regexes.number ? regexes.integer : own;
+  if (minimum !== undefined && maximum !== undefined && minimum > maximum) return "(?!)";
+  if (minimum !== undefined || maximum !== undefined) return regexes.string({ minimum, maximum }).source;
+  return (isInt && own === regexes.number ? regexes.integer : own)?.source;
 }
 
 export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__PURE__*/ core.$constructor(
@@ -4679,19 +4675,11 @@ export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__
     for (const part of def.parts) {
       if (typeof part === "object" && part !== null) {
         // is Zod schema
-        const pattern = partPattern(part);
-        if (!pattern) {
-          // if (!source)
+        const source = partPattern(part);
+        if (!source) {
           throw new Error(`Invalid template literal part, no pattern found: ${[...(part as any)._zod.traits].shift()}`);
         }
-
-        const source = pattern instanceof RegExp ? pattern.source : pattern;
-
-        if (!source) throw new Error(`Invalid template literal part: ${part._zod.traits}`);
-
-        const start = source.startsWith("^") ? 1 : 0;
-        const end = source.endsWith("$") ? source.length - 1 : source.length;
-        regexParts.push(source.slice(start, end));
+        regexParts.push(util.cleanRegex(source));
       } else if (part === null || util.primitiveTypes.has(typeof part)) {
         regexParts.push(util.escapeRegex(`${part}`));
       } else {

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -4623,30 +4623,9 @@ export type $PartsToTemplateLiteral<Parts extends $ZodTemplateLiteralPart[]> = [
       : never
     : never;
 
-// a part's pattern source with its checks folded in: the last pattern-carrying check wins, else length bounds narrow the catch-all, else an integer format narrows the number form. read off the defs since checks no longer write the bag; options recurse so a union of constrained parts keeps its precision
-function partPattern(schema: $ZodType): string | undefined {
-  const def = schema._zod.def as {
-    pattern?: RegExp;
-    format?: string;
-    innerType?: $ZodType;
-    options?: $ZodType[];
-    checks?: checks.$ZodCheck[];
-  };
-  const own = schema._zod.pattern;
-  // a wrapper's pattern embeds its inner pattern's source verbatim, so the check-aware form is substituted in place without knowing the wrapper's own composition. lazy resolves its inner on the internals, not the def
-  const inner = def.innerType ?? (schema._zod as { innerType?: $ZodType }).innerType;
-  if (inner) {
-    const before = inner._zod.pattern;
-    const after = partPattern(inner);
-    if (own && before && after && after !== before.source) {
-      return own.source.replace(util.cleanRegex(before.source), () => util.cleanRegex(after));
-    }
-    return own?.source;
-  }
-  if (def.options) {
-    const sources = def.options.map(partPattern);
-    if (sources.every(Boolean)) return `^(${sources.map((s) => util.cleanRegex(s!)).join("|")})$`;
-  }
+// a leaf's pattern source with its own checks folded in: the last pattern-carrying check wins, else length bounds narrow the catch-all, else an integer format narrows the number form. the fold lives here instead of on `_zod.pattern` so a bundle without template literals never pays for it
+function leafPattern(schema: $ZodType): string | undefined {
+  const def = schema._zod.def as { pattern?: RegExp; format?: string; checks?: checks.$ZodCheck[] };
   let pattern = def.pattern;
   let isInt = !!def.format?.includes("int");
   let minimum: number | undefined;
@@ -4664,7 +4643,29 @@ function partPattern(schema: $ZodType): string | undefined {
   // an empty range matches nothing at runtime, and `{8,5}` is not a legal quantifier
   if (minimum !== undefined && maximum !== undefined && minimum > maximum) return "(?!)";
   if (minimum !== undefined || maximum !== undefined) return regexes.string({ minimum, maximum }).source;
+  const own = schema._zod.pattern;
   return (isInt && own === regexes.number ? regexes.integer : own)?.source;
+}
+
+// a part's pattern source. a wrapper's pattern embeds its inner pattern's source verbatim, so the folded form is substituted in place without knowing the wrapper's own composition; a union's options are joined the way the union builds its own pattern
+function partPattern(schema: $ZodType): string | undefined {
+  const def = schema._zod.def as { innerType?: $ZodType; options?: $ZodType[] };
+  const own = schema._zod.pattern?.source;
+  // lazy resolves its inner on the internals, not the def
+  const inner = def.innerType ?? (schema._zod as { innerType?: $ZodType }).innerType;
+  if (inner) {
+    const before = inner._zod.pattern?.source;
+    const after = partPattern(inner);
+    if (own && before && after && after !== before) {
+      return own.replace(util.cleanRegex(before), () => util.cleanRegex(after));
+    }
+    return own;
+  }
+  if (def.options) {
+    const sources = def.options.map(partPattern);
+    if (sources.every(Boolean)) return `^(${sources.map((s) => util.cleanRegex(s!)).join("|")})$`;
+  }
+  return leafPattern(schema);
 }
 
 export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__PURE__*/ core.$constructor(

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -385,6 +385,7 @@ export interface $ZodStringInternals<Input> extends $ZodTypeInternals<string, In
   bag: util.LoosePartial<{
     minimum: number;
     maximum: number;
+    pattern: RegExp;
     patterns: Set<RegExp>;
     format: string;
     contentEncoding: string;
@@ -399,8 +400,9 @@ export interface $ZodString<Input = unknown> extends _$ZodType<$ZodStringInterna
 
 export const $ZodString: core.$constructor<$ZodString> = /*@__PURE__*/ core.$constructor("$ZodString", (inst, def) => {
   $ZodType.init(inst, def);
-  // a format's own pattern, else unbounded; a template literal derives the check-aware form itself
-  inst._zod.pattern = (def as $ZodStringFormatDef).pattern ?? regexes.anyString;
+  // the checks declare their pattern and length bounds on attach; a pattern wins, else the bounds narrow the catch-all
+  const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
+  inst._zod.pattern = bag.pattern ?? regexes.string(bag);
   inst._zod.parse = (payload, _) => {
     if (def.coerce)
       try {
@@ -1260,7 +1262,7 @@ export interface $ZodNumber<Input = unknown> extends $ZodType {
 export const $ZodNumber: core.$constructor<$ZodNumber> = /*@__PURE__*/ core.$constructor("$ZodNumber", (inst, def) => {
   $ZodType.init(inst, def);
 
-  inst._zod.pattern = regexes.number;
+  inst._zod.pattern = inst._zod.bag.pattern ?? regexes.number;
   inst._zod.parse = (payload, _ctx) => {
     if (def.coerce)
       try {
@@ -4623,51 +4625,6 @@ export type $PartsToTemplateLiteral<Parts extends $ZodTemplateLiteralPart[]> = [
       : never
     : never;
 
-// a leaf's pattern source with its own checks folded in: the last pattern-carrying check wins, else length bounds narrow the catch-all, else an integer format narrows the number form. the fold lives here instead of on `_zod.pattern` so a bundle without template literals never pays for it
-function leafPattern(schema: $ZodType): string | undefined {
-  const def = schema._zod.def as { pattern?: RegExp; format?: string; checks?: checks.$ZodCheck[] };
-  let pattern = def.pattern;
-  let isInt = !!def.format?.includes("int");
-  let minimum: number | undefined;
-  let maximum: number | undefined;
-  for (const ch of def.checks ?? []) {
-    const d = ch._zod.def as { pattern?: RegExp; format?: string; minimum?: number; maximum?: number; length?: number };
-    if (d.pattern) pattern = d.pattern;
-    isInt ||= !!d.format?.includes("int");
-    const lo = d.minimum ?? d.length;
-    const hi = d.maximum ?? d.length;
-    if (lo !== undefined && (minimum === undefined || lo > minimum)) minimum = lo;
-    if (hi !== undefined && (maximum === undefined || hi < maximum)) maximum = hi;
-  }
-  if (pattern) return pattern.source;
-  // an empty range matches nothing at runtime, and `{8,5}` is not a legal quantifier
-  if (minimum !== undefined && maximum !== undefined && minimum > maximum) return "(?!)";
-  if (minimum !== undefined || maximum !== undefined) return regexes.string({ minimum, maximum }).source;
-  const own = schema._zod.pattern;
-  return (isInt && own === regexes.number ? regexes.integer : own)?.source;
-}
-
-// a part's pattern source. a wrapper's pattern embeds its inner pattern's source verbatim, so the folded form is substituted in place without knowing the wrapper's own composition; a union's options are joined the way the union builds its own pattern
-function partPattern(schema: $ZodType): string | undefined {
-  const def = schema._zod.def as { innerType?: $ZodType; options?: $ZodType[] };
-  const own = schema._zod.pattern?.source;
-  // lazy resolves its inner on the internals, not the def
-  const inner = def.innerType ?? (schema._zod as { innerType?: $ZodType }).innerType;
-  if (inner) {
-    const before = inner._zod.pattern?.source;
-    const after = partPattern(inner);
-    if (own && before && after && after !== before) {
-      return own.replace(util.cleanRegex(before), () => util.cleanRegex(after));
-    }
-    return own;
-  }
-  if (def.options) {
-    const sources = def.options.map(partPattern);
-    if (sources.every(Boolean)) return `^(${sources.map((s) => util.cleanRegex(s!)).join("|")})$`;
-  }
-  return leafPattern(schema);
-}
-
 export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__PURE__*/ core.$constructor(
   "$ZodTemplateLiteral",
   (inst, def) => {
@@ -4676,7 +4633,7 @@ export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__
     for (const part of def.parts) {
       if (typeof part === "object" && part !== null) {
         // is Zod schema
-        const source = partPattern(part);
+        const source = part._zod.pattern?.source;
         if (!source) {
           throw new Error(`Invalid template literal part, no pattern found: ${[...(part as any)._zod.traits].shift()}`);
         }

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -399,7 +399,8 @@ export interface $ZodString<Input = unknown> extends _$ZodType<$ZodStringInterna
 
 export const $ZodString: core.$constructor<$ZodString> = /*@__PURE__*/ core.$constructor("$ZodString", (inst, def) => {
   $ZodType.init(inst, def);
-  inst._zod.pattern = [...(inst?._zod.bag?.patterns ?? [])].pop() ?? regexes.string(inst._zod.bag);
+  // a format's own pattern, else unbounded; a template literal derives the check-aware form itself
+  inst._zod.pattern = (def as { pattern?: RegExp }).pattern ?? regexes.anyString;
   inst._zod.parse = (payload, _) => {
     if (def.coerce)
       try {
@@ -788,14 +789,6 @@ export const $ZodISODateTime: core.$constructor<$ZodISODateTime> = /*@__PURE__*/
   (inst, def): void => {
     def.pattern ??= regexes.datetime(def);
     $ZodStringFormat.init(inst, def);
-
-    // these two drop the offset or seconds `date-time` requires — on the bag not the def, since `z.string().check(...)` lands the format on a different schema
-    if (def.local || def.precision === -1) {
-      inst._zod.bag.laxFormat = true;
-      inst._zod.onattach.push((s) => {
-        (s._zod.bag as $ZodStringInternals<unknown>["bag"]).laxFormat = true;
-      });
-    }
   }
 );
 
@@ -872,8 +865,6 @@ export interface $ZodIPv4 extends $ZodType {
 export const $ZodIPv4: core.$constructor<$ZodIPv4> = /*@__PURE__*/ core.$constructor("$ZodIPv4", (inst, def): void => {
   def.pattern ??= regexes.ipv4;
   $ZodStringFormat.init(inst, def);
-
-  inst._zod.bag.format = `ipv4`;
 });
 
 //////////////////////////////   ZodIPv6   //////////////////////////////
@@ -908,8 +899,6 @@ export const $ZodIPv6: core.$constructor<$ZodIPv6> = /*@__PURE__*/ core.$constru
   def.pattern ??= regexes.ipv6;
   $ZodStringFormat.init(inst, def);
 
-  inst._zod.bag.format = `ipv6`;
-
   inst._zod.check = (payload) => {
     if (!isValidIPv6(payload.value)) {
       payload.issues.push({
@@ -939,8 +928,6 @@ export interface $ZodMAC extends $ZodType {
 export const $ZodMAC: core.$constructor<$ZodMAC> = /*@__PURE__*/ core.$constructor("$ZodMAC", (inst, def): void => {
   def.pattern ??= regexes.mac(def.delimiter);
   $ZodStringFormat.init(inst, def);
-
-  inst._zod.bag.format = `mac`;
 });
 
 //////////////////////////////   ZodCIDRv4   //////////////////////////////
@@ -1041,8 +1028,6 @@ export const $ZodBase64: core.$constructor<$ZodBase64> = /*@__PURE__*/ core.$con
     def.pattern ??= base64Charset;
     $ZodStringFormat.init(inst, def);
 
-    inst._zod.bag.contentEncoding = "base64";
-
     inst._zod.check = (payload) => {
       if (isValidBase64(payload.value)) return;
 
@@ -1080,8 +1065,6 @@ export const $ZodBase64URL: core.$constructor<$ZodBase64URL> = /*@__PURE__*/ cor
   (inst, def): void => {
     def.pattern ??= base64urlCharset;
     $ZodStringFormat.init(inst, def);
-
-    inst._zod.bag.contentEncoding = "base64url";
 
     inst._zod.check = (payload) => {
       if (isValidBase64URL(payload.value)) return;
@@ -1277,7 +1260,7 @@ export interface $ZodNumber<Input = unknown> extends $ZodType {
 export const $ZodNumber: core.$constructor<$ZodNumber> = /*@__PURE__*/ core.$constructor("$ZodNumber", (inst, def) => {
   $ZodType.init(inst, def);
 
-  inst._zod.pattern = inst._zod.bag.pattern ?? regexes.number;
+  inst._zod.pattern = regexes.number;
   inst._zod.parse = (payload, _ctx) => {
     if (def.coerce)
       try {
@@ -4640,6 +4623,53 @@ export type $PartsToTemplateLiteral<Parts extends $ZodTemplateLiteralPart[]> = [
       : never
     : never;
 
+// a part's pattern with its checks folded in: the last pattern-carrying check wins, else length bounds narrow the catch-all, else an integer format narrows the number form. read off the defs since checks no longer write the bag; options recurse so a union of constrained parts keeps its precision
+function partPattern(schema: $ZodType): RegExp | string | undefined {
+  const def = schema._zod.def as {
+    pattern?: RegExp;
+    format?: string;
+    innerType?: $ZodType;
+    options?: $ZodType[];
+    checks?: checks.$ZodCheck[];
+  };
+  const src = (p: RegExp | string) => (p instanceof RegExp ? p.source : p);
+  // a wrapper's pattern embeds its inner pattern's source verbatim, so the check-aware form is substituted in place without knowing the wrapper's own composition
+  if (def.innerType) {
+    const own = schema._zod.pattern;
+    const before = def.innerType._zod.pattern;
+    const after = partPattern(def.innerType);
+    if (own && before && after && after !== before) {
+      return own.source.replace(util.cleanRegex(before.source), () => util.cleanRegex(src(after)));
+    }
+    return own;
+  }
+  if (def.options) {
+    const patterns = def.options.map(partPattern);
+    if (patterns.every(Boolean)) {
+      return new RegExp(`^(${patterns.map((p) => util.cleanRegex(src(p!))).join("|")})$`);
+    }
+  }
+  let pattern = def.pattern;
+  let isInt = !!def.format?.includes("int");
+  let minimum: number | undefined;
+  let maximum: number | undefined;
+  for (const ch of def.checks ?? []) {
+    const d = ch._zod.def as { pattern?: RegExp; format?: string; minimum?: number; maximum?: number; length?: number };
+    if (d.pattern) pattern = d.pattern;
+    isInt ||= !!d.format?.includes("int");
+    const lo = d.minimum ?? d.length;
+    const hi = d.maximum ?? d.length;
+    if (lo !== undefined && !(minimum! > lo)) minimum = lo;
+    if (hi !== undefined && !(maximum! < hi)) maximum = hi;
+  }
+  if (pattern) return pattern;
+  // an empty range matches nothing at runtime, and `{8,5}` is not a legal quantifier
+  if (minimum !== undefined && maximum !== undefined && minimum > maximum) return /(?!)/;
+  if (minimum !== undefined || maximum !== undefined) return regexes.string({ minimum, maximum });
+  const own = schema._zod.pattern;
+  return isInt && own === regexes.number ? regexes.integer : own;
+}
+
 export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__PURE__*/ core.$constructor(
   "$ZodTemplateLiteral",
   (inst, def) => {
@@ -4648,12 +4678,13 @@ export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__
     for (const part of def.parts) {
       if (typeof part === "object" && part !== null) {
         // is Zod schema
-        if (!part._zod.pattern) {
+        const pattern = partPattern(part);
+        if (!pattern) {
           // if (!source)
           throw new Error(`Invalid template literal part, no pattern found: ${[...(part as any)._zod.traits].shift()}`);
         }
 
-        const source = part._zod.pattern instanceof RegExp ? part._zod.pattern.source : part._zod.pattern;
+        const source = pattern instanceof RegExp ? pattern.source : pattern;
 
         if (!source) throw new Error(`Invalid template literal part: ${part._zod.traits}`);
 

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -385,7 +385,6 @@ export interface $ZodStringInternals<Input> extends $ZodTypeInternals<string, In
   bag: util.LoosePartial<{
     minimum: number;
     maximum: number;
-    pattern: RegExp;
     patterns: Set<RegExp>;
     format: string;
     contentEncoding: string;
@@ -400,9 +399,8 @@ export interface $ZodString<Input = unknown> extends _$ZodType<$ZodStringInterna
 
 export const $ZodString: core.$constructor<$ZodString> = /*@__PURE__*/ core.$constructor("$ZodString", (inst, def) => {
   $ZodType.init(inst, def);
-  // the checks declare their pattern and length bounds on attach; a pattern wins, else the bounds narrow the catch-all
-  const bag = inst._zod.bag as $ZodStringInternals<unknown>["bag"];
-  inst._zod.pattern = bag.pattern ?? regexes.string(bag);
+  // a format's own pattern, else unbounded; a template literal derives the check-aware form itself
+  inst._zod.pattern = (def as $ZodStringFormatDef).pattern ?? regexes.anyString;
   inst._zod.parse = (payload, _) => {
     if (def.coerce)
       try {
@@ -1262,7 +1260,7 @@ export interface $ZodNumber<Input = unknown> extends $ZodType {
 export const $ZodNumber: core.$constructor<$ZodNumber> = /*@__PURE__*/ core.$constructor("$ZodNumber", (inst, def) => {
   $ZodType.init(inst, def);
 
-  inst._zod.pattern = inst._zod.bag.pattern ?? regexes.number;
+  inst._zod.pattern = regexes.number;
   inst._zod.parse = (payload, _ctx) => {
     if (def.coerce)
       try {
@@ -4625,6 +4623,51 @@ export type $PartsToTemplateLiteral<Parts extends $ZodTemplateLiteralPart[]> = [
       : never
     : never;
 
+// a leaf's pattern source with its own checks folded in: the last pattern-carrying check wins, else length bounds narrow the catch-all, else an integer format narrows the number form. the fold lives here instead of on `_zod.pattern` so a bundle without template literals never pays for it
+function leafPattern(schema: $ZodType): string | undefined {
+  const def = schema._zod.def as { pattern?: RegExp; format?: string; checks?: checks.$ZodCheck[] };
+  let pattern = def.pattern;
+  let isInt = !!def.format?.includes("int");
+  let minimum: number | undefined;
+  let maximum: number | undefined;
+  for (const ch of def.checks ?? []) {
+    const d = ch._zod.def as { pattern?: RegExp; format?: string; minimum?: number; maximum?: number; length?: number };
+    if (d.pattern) pattern = d.pattern;
+    isInt ||= !!d.format?.includes("int");
+    const lo = d.minimum ?? d.length;
+    const hi = d.maximum ?? d.length;
+    if (lo !== undefined && (minimum === undefined || lo > minimum)) minimum = lo;
+    if (hi !== undefined && (maximum === undefined || hi < maximum)) maximum = hi;
+  }
+  if (pattern) return pattern.source;
+  // an empty range matches nothing at runtime, and `{8,5}` is not a legal quantifier
+  if (minimum !== undefined && maximum !== undefined && minimum > maximum) return "(?!)";
+  if (minimum !== undefined || maximum !== undefined) return regexes.string({ minimum, maximum }).source;
+  const own = schema._zod.pattern;
+  return (isInt && own === regexes.number ? regexes.integer : own)?.source;
+}
+
+// a part's pattern source. a wrapper's pattern embeds its inner pattern's source verbatim, so the folded form is substituted in place without knowing the wrapper's own composition; a union's options are joined the way the union builds its own pattern
+function partPattern(schema: $ZodType): string | undefined {
+  const def = schema._zod.def as { innerType?: $ZodType; options?: $ZodType[] };
+  const own = schema._zod.pattern?.source;
+  // lazy resolves its inner on the internals, not the def
+  const inner = def.innerType ?? (schema._zod as { innerType?: $ZodType }).innerType;
+  if (inner) {
+    const before = inner._zod.pattern?.source;
+    const after = partPattern(inner);
+    if (own && before && after && after !== before) {
+      return own.replace(util.cleanRegex(before), () => util.cleanRegex(after));
+    }
+    return own;
+  }
+  if (def.options) {
+    const sources = def.options.map(partPattern);
+    if (sources.every(Boolean)) return `^(${sources.map((s) => util.cleanRegex(s!)).join("|")})$`;
+  }
+  return leafPattern(schema);
+}
+
 export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__PURE__*/ core.$constructor(
   "$ZodTemplateLiteral",
   (inst, def) => {
@@ -4633,7 +4676,7 @@ export const $ZodTemplateLiteral: core.$constructor<$ZodTemplateLiteral> = /*@__
     for (const part of def.parts) {
       if (typeof part === "object" && part !== null) {
         // is Zod schema
-        const source = part._zod.pattern?.source;
+        const source = partPattern(part);
         if (!source) {
           throw new Error(`Invalid template literal part, no pattern found: ${[...(part as any)._zod.traits].shift()}`);
         }

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1137,6 +1137,26 @@ export function hide<T>(inst: object, key: PropertyKey, value: T): T {
   return own(inst, key, value, false);
 }
 
+/** Adds members a table derives from the instance: each builds on first read and shadows as own data, and assignment shadows the same way, as when these were own properties. */
+export /*@__NO_SIDE_EFFECTS__*/ function derived<T>(
+  computes: { [K in keyof T]?: (inst: T) => T[K] },
+  table: ProtoOf<T>
+): ProtoOf<T> {
+  for (const key in computes) {
+    const compute = computes[key]!;
+    Object.defineProperty(table, key, {
+      enumerable: true,
+      get(this: T) {
+        return own(this as object, key, compute(this));
+      },
+      set(this: T, value: T[typeof key]) {
+        own(this as object, key, value);
+      },
+    });
+  }
+  return table;
+}
+
 function defineBound(proto: object, key: PropertyKey, fn: AnyFunc): void {
   Object.defineProperty(proto, key, {
     configurable: true,

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1144,7 +1144,9 @@ export /*@__NO_SIDE_EFFECTS__*/ function derived<T>(
 ): ProtoOf<T> {
   for (const key in computes) {
     const compute = computes[key]!;
+    // an object literal's accessor is configurable and enumerable, and `members` copies the descriptor as written
     Object.defineProperty(table, key, {
+      configurable: true,
       enumerable: true,
       get(this: T) {
         return own(this as object, key, compute(this));

--- a/packages/zod/src/v4/mini/tests/computed.test.ts
+++ b/packages/zod/src/v4/mini/tests/computed.test.ts
@@ -2,35 +2,29 @@ import { expect, test } from "vitest";
 import * as z from "zod/mini";
 import { util as zc } from "zod/v4/core";
 
+// checks no longer write metadata into the bag at attach time; the converter folds the checks itself, so the derived values are asserted through it
+
 test("min/max", () => {
   const a = z.number().check(z.minimum(5), z.minimum(6), z.minimum(7), z.maximum(10), z.maximum(11), z.maximum(12));
-
-  expect(a._zod.bag.minimum).toEqual(7);
-  expect(a._zod.bag.maximum).toEqual(10);
+  expect(z.toJSONSchema(a)).toMatchObject({ minimum: 7, maximum: 10 });
+  expect(a._zod.bag).toEqual({});
 });
 
 test("multipleOf", () => {
   const b = z.number().check(z.multipleOf(5));
-  expect(b._zod.bag.multipleOf).toEqual(5);
-});
-
-test("int64 format", () => {
-  const c = z.int64();
-  expect(c._zod.bag.format).toEqual("int64");
-  expect(c._zod.bag.minimum).toEqual(zc.BIGINT_FORMAT_RANGES.int64[0]);
-  expect(c._zod.bag.maximum).toEqual(zc.BIGINT_FORMAT_RANGES.int64[1]);
+  expect(z.toJSONSchema(b)).toMatchObject({ multipleOf: 5 });
 });
 
 test("int32 format", () => {
   const d = z.int32();
-  expect(d._zod.bag.format).toEqual("int32");
-  expect(d._zod.bag.minimum).toEqual(zc.NUMBER_FORMAT_RANGES.int32[0]);
-  expect(d._zod.bag.maximum).toEqual(zc.NUMBER_FORMAT_RANGES.int32[1]);
+  expect(z.toJSONSchema(d)).toMatchObject({
+    type: "integer",
+    minimum: zc.NUMBER_FORMAT_RANGES.int32[0],
+    maximum: zc.NUMBER_FORMAT_RANGES.int32[1],
+  });
 });
 
 test("array size", () => {
   const e = z.array(z.string()).check(z.length(5));
-  expect(e._zod.bag.length).toEqual(5);
-  expect(e._zod.bag.minimum).toEqual(5);
-  expect(e._zod.bag.maximum).toEqual(5);
+  expect(z.toJSONSchema(e)).toMatchObject({ minItems: 5, maxItems: 5 });
 });


### PR DESCRIPTION
The JSON Schema converter now derives constraint metadata by folding `def.checks` directly, through a per-check handler map that lives in the converter's own chunk, instead of trusting the values each check's `onattach` folded into `_zod.bag`. The bag fold ran in chain order with per-check hand-rolled merge semantics, which is the root of a long line of order-dependence and clobbering bugs (#6550 most recently, #4309 originally). Runtime checks are a conjunction, so the converter's merge is the conjunction's: tightest bound wins, patterns union, divisors collect, mime lists intersect.

With the converter self-sufficient, the metadata plumbing leaves the schemas themselves:

- All sixteen constraint-writing `onattach` closures are gone from the checks, along with the `laxFormat`, ipv4/ipv6/mac `format` and base64 `contentEncoding` bag writes in core. `onattach` stays as third-party infrastructure, and the converter still merges bag values in as a fallback, so a custom check that writes the bag keeps working.
- The classic `format`/`minLength`/`maxLength`/`minValue`/`maxValue`/`isInt`/`minDate`/`maxDate` getters are prototype members that derive from the checks and shadow as own data on first read, instead of eager own properties on every instance. Classic already bundles the converter, so they reuse its fold. Before the first read they are not enumerable own keys, and deleting one exposes the getter again so the next read recomputes, the same contract every other prototype member here has — the two public-surface changes, both pinned in `instance-footprint`. Assignment shadows as own data as before.
- A string's `_zod.pattern` is its format's own pattern or a shared unbounded constant, and a number's is the plain number form. The template literal is the only consumer that needs check-aware part patterns, so it derives them at its own construction: a leaf folds its own checks (last pattern wins, else length bounds narrow the catch-all, else an integer format), and a wrapper or union composes the folded inner source in place. An empty length range matches nothing rather than building an invalid quantifier. This is a deliberate trade: a bundle with a template literal pays for the fold (+264 B gzipped in mini), and every bundle without one stops paying for pattern derivation it never used.

Two divergences that were live on `main` are fixed: `z.number().multipleOf(2).multipleOf(3)` emitted `multipleOf: 2`, which accepts 4 while the runtime rejects it, and now emits the whole conjunction; `z.string().min(8).length(5)` emitted `minLength: 5`, dropping the tighter earlier bound. Integer conjunctions survive format order (`.int().check(z.float32())` stays `integer`), a disjoint mime chain emits a false schema, and a custom mime narrowing intersects with built-in ones.

On the three axes, measured against `main`:

- bundle (gzipped, from source): mini-boolean byte-identical, mini-string −112 B, mini-object −70 B, mini-full −71 B (the ceilings are lowered to match); where the checks actually live the saving is larger — a string with min/max/regex −162 B, a number with min/max/multipleOf −114 B, an object mixing string, number, int32, array, email, file and datetime checks −340 B. Classic boolean +491 B and full +208 B, since a namespace `z` import retains the converter under both esbuild and rollup — that is the cost of the fix, and it lands only where the converter is already bundled.
- memory (`schema-footprint`, retained bytes per instance): `z.string()` 784 → 760, `z.number()` 707 → 643, `z.email()` 2228 → 2095, a three-key object 4746 → 4657; mini unchanged.
- runtime: parse is untouched. Construction sheds the per-clone `onattach` re-runs: an interleaved fixed-iteration bench (min of 7 samples, 3 rounds per side, load < 6) put `z.string().min(1).max(5)` construction at 1805 → 1636 ms per 300k (−9%), and `z.number().min(0).max(23).int()` at 1795 → 1768 ms per 200k, inside the round-to-round spread.

All existing JSON Schema snapshots pass unchanged; the mini `computed` test now asserts through the converter since the bag it read is empty by design.

Refs #6550.
