### PR TITLE
feat(compile): compiled issue generation by default, on per-subclass emitters

### DIFF
--- a/packages/bench/compile-cold-call.ts
+++ b/packages/bench/compile-cold-call.ts
@@ -1,0 +1,128 @@
+// Where a compiled failing walk spends its time on the shapes that sit below their ceiling: the fast parser's rejection, the issue parser's walk, and the cold call that produces one issue. Fixed iterations, gc between samples, min of 7 interleaved rounds.
+import * as z from "zod";
+import { INVALID, coldParse, compileFn } from "../zod/src/v4/core/compile.js";
+
+declare global {
+  var gc: undefined | (() => void);
+}
+if (!globalThis.gc) {
+  console.error("run with --expose-gc");
+  process.exit(1);
+}
+
+interface Case {
+  name: string;
+  schema: z.ZodType;
+  valid: unknown;
+  invalid: unknown;
+  iters: number;
+}
+const cases: Case[] = [
+  {
+    name: "nested-3deep",
+    schema: z.object({ a: z.object({ b: z.object({ c: z.string() }) }) }),
+    valid: { a: { b: { c: "ok" } } },
+    invalid: { a: { b: { c: 42 } } },
+    iters: 200_000,
+  },
+  {
+    name: "array-20",
+    schema: z.array(z.number()),
+    valid: Array.from({ length: 20 }, (_, i) => i),
+    invalid: Array.from({ length: 20 }, (_, i) => (i === 10 ? "x" : i)),
+    iters: 100_000,
+  },
+  {
+    name: "tuple-4",
+    schema: z.tuple([z.string(), z.number(), z.boolean(), z.string()]),
+    valid: ["a", 1, true, "b"],
+    invalid: ["a", "no", true, "b"],
+    iters: 200_000,
+  },
+];
+
+let sink = 0;
+function sample(fn: () => unknown, iters: number): number {
+  globalThis.gc!();
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) if (fn()) sink++;
+  return Number(process.hrtime.bigint() - t0) / iters;
+}
+function minOf(variants: Array<[string, () => unknown]>, iters: number): Map<string, number> {
+  const mins = new Map<string, number>();
+  for (const [, fn] of variants) sample(fn, iters / 10);
+  for (let r = 0; r < 7; r++) {
+    for (const [name, fn] of variants) {
+      const v = sample(fn, iters);
+      if (!mins.has(name) || v < mins.get(name)!) mins.set(name, v);
+    }
+  }
+  return mins;
+}
+
+for (const c of cases) {
+  const fast = compileFn(c.schema as never) as (v: unknown) => unknown;
+  const issues = compileFn(c.schema as never, { issues: true } as never) as unknown as (
+    v: unknown,
+    p: { value: unknown; issues: unknown[] },
+    ctx: undefined
+  ) => unknown;
+  const run = c.schema._zod.run as (p: { value: unknown; issues: unknown[] }, ctx: object) => { issues: unknown[] };
+  const ctx = {};
+  const mins = minOf(
+    [
+      ["fast, valid input", () => fast(c.valid) !== INVALID],
+      ["fast, invalid input (rejects)", () => fast(c.invalid) === INVALID],
+      ["issue parser, valid input", () => issues(c.valid, { value: c.valid, issues: [] }, undefined) !== INVALID],
+      [
+        "issue parser, invalid input",
+        () => {
+          const p = { value: c.invalid, issues: [] as unknown[] };
+          issues(c.invalid, p, undefined);
+          return p.issues.length === 1;
+        },
+      ],
+      ["runtime _zod.run, invalid input", () => run({ value: c.invalid, issues: [] }, ctx).issues.length === 1],
+    ],
+    c.iters
+  );
+  console.log(c.name);
+  for (const [name, v] of mins) console.log(`  ${name.padEnd(32)} ${v.toFixed(1)} ns`);
+}
+
+// one issue's cold call against an inline push of the same raw shape (what a hand-built leaf site would cost)
+const str = z.string();
+const strParse = str._zod.parse as never;
+const path = ["a", "b", "c"];
+const micro = minOf(
+  [
+    [
+      "coldParse(42, string) + path",
+      () => {
+        const p = { value: 42, issues: [] as unknown[] };
+        coldParse(42, strParse, p as never, undefined, path);
+        return p.issues.length === 1;
+      },
+    ],
+    [
+      "inline push of the raw issue",
+      () => {
+        const p = { value: 42, issues: [] as unknown[] };
+        p.issues.push({ expected: "string", code: "invalid_type", input: 42, inst: str, path: [...path] });
+        return p.issues.length === 1;
+      },
+    ],
+    [
+      "string._zod.parse alone",
+      () => {
+        const p = { value: 42, issues: [] as unknown[] };
+        str._zod.parse(p as never, {} as never);
+        return p.issues.length === 1;
+      },
+    ],
+  ],
+  300_000
+);
+console.log("one issue");
+for (const [name, v] of micro) console.log(`  ${name.padEnd(32)} ${v.toFixed(1)} ns`);
+console.log(`sink=${sink}`);

--- a/packages/bench/compile-issues-decomposition.ts
+++ b/packages/bench/compile-issues-decomposition.ts
@@ -1,4 +1,4 @@
-// Decomposes a failing safeParse into walk vs error construction, per wrapper mode. `walk` = _zod.run returning raw issues (no finalizeIssue, no ZodError, no result object); error construction = total − walk, and it is contractually identical in every mode. The theoretical ceiling column is the speedup with a FREE walk — what any compiler tops out at while the error contract stands.
+// Decomposes a failing safeParse into walk vs everything after it, per wrapper mode. `walk` = _zod.run returning raw issues; `err-cost` = total − walk is what safeParse adds around the walk (the result object; the ZodError itself is built lazily on the first read of `.error`), identical in every mode. `ceiling` is the speedup with a FREE walk. The last three columns read `.error.issues` too, which is what a caller that reports the failure pays.
 import * as z from "zod";
 import { compile } from "../zod/src/v4/core/compile.js";
 
@@ -99,6 +99,16 @@ function sampleSafe(schema: z.ZodType, input: unknown, iters: number): number {
   }
   return Number(process.hrtime.bigint() - t0) / iters;
 }
+// the error is built on the first read of `.error` (finalizeIssue per issue + the ZodError), so a caller that reports the failure pays this on top of the `.success`-only figure
+function sampleSafeRead(schema: z.ZodType, input: unknown, iters: number): number {
+  globalThis.gc!();
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) {
+    const r = schema.safeParse(input) as any;
+    if (r.success || r.error.issues.length === 0) sink++;
+  }
+  return Number(process.hrtime.bigint() - t0) / iters;
+}
 function sampleRun(schema: z.ZodType, input: unknown, iters: number): number {
   const run = (schema as any)._zod.run;
   const zod = (schema as any)._zod;
@@ -112,7 +122,9 @@ function sampleRun(schema: z.ZodType, input: unknown, iters: number): number {
 }
 
 const ROUNDS = 7;
-console.log("shape           issues  rt-total  rt-walk  err-cost  ceiling  dual-total  dual-walk  achieved");
+console.log(
+  "shape           issues  rt-total  rt-walk  err-cost  ceiling  dual-total  dual-walk  achieved | rt+error  dual+error  achieved"
+);
 for (const c of cases) {
   const dual = compile(c.schema as any) as z.ZodType;
   const rtRes = c.schema.safeParse(c.invalid) as any;
@@ -127,6 +139,8 @@ for (const c of cases) {
     ["B", () => sampleRun(c.schema, c.invalid, c.iters)],
     ["C", () => sampleSafe(dual, c.invalid, c.iters)],
     ["D", () => sampleRun(dual, c.invalid, c.iters)],
+    ["E", () => sampleSafeRead(c.schema, c.invalid, c.iters)],
+    ["F", () => sampleSafeRead(dual, c.invalid, c.iters)],
   ];
   // warmup
   for (const [, f] of kinds) f();
@@ -141,10 +155,12 @@ for (const c of cases) {
   const B = mins.get("B")!;
   const C = mins.get("C")!;
   const D = mins.get("D")!;
+  const E = mins.get("E")!;
+  const F = mins.get("F")!;
   const err = A - B;
   const ceiling = A / Math.max(err, 1);
   console.log(
-    `${c.name.padEnd(15)} ${String(nIssues).padStart(5)}  ${A.toFixed(0).padStart(8)}  ${B.toFixed(0).padStart(7)}  ${err.toFixed(0).padStart(8)}  ${ceiling.toFixed(2).padStart(6)}x  ${C.toFixed(0).padStart(9)}  ${D.toFixed(0).padStart(9)}  ${(A / C).toFixed(2).padStart(7)}x`
+    `${c.name.padEnd(15)} ${String(nIssues).padStart(5)}  ${A.toFixed(0).padStart(8)}  ${B.toFixed(0).padStart(7)}  ${err.toFixed(0).padStart(8)}  ${ceiling.toFixed(2).padStart(6)}x  ${C.toFixed(0).padStart(9)}  ${D.toFixed(0).padStart(9)}  ${(A / C).toFixed(2).padStart(7)}x | ${E.toFixed(0).padStart(8)}  ${F.toFixed(0).padStart(10)}  ${(E / F).toFixed(2).padStart(7)}x`
   );
 }
 console.log(`sink=${sink}`);

--- a/packages/bench/compile-issues-decomposition.ts
+++ b/packages/bench/compile-issues-decomposition.ts
@@ -1,0 +1,150 @@
+// Decomposes a failing safeParse into walk vs error construction, per wrapper mode. `walk` = _zod.run returning raw issues (no finalizeIssue, no ZodError, no result object); error construction = total − walk, and it is contractually identical in every mode. The theoretical ceiling column is the speedup with a FREE walk — what any compiler tops out at while the error contract stands.
+import * as z from "zod";
+import { compile } from "../zod/src/v4/core/compile.js";
+
+declare global {
+  var gc: undefined | (() => void);
+}
+if (!globalThis.gc) {
+  console.error("run with --expose-gc");
+  process.exit(1);
+}
+
+function nested(depth: number, fanout: number): z.ZodType {
+  if (depth === 0) return z.string();
+  const shape: Record<string, z.ZodType> = {};
+  for (let i = 0; i < fanout; i++) shape[`k${i}`] = nested(depth - 1, fanout);
+  return z.object(shape);
+}
+function fill(depth: number, fanout: number, leaf: unknown): unknown {
+  if (depth === 0) return leaf;
+  const o: Record<string, unknown> = {};
+  for (let i = 0; i < fanout; i++) o[`k${i}`] = fill(depth - 1, fanout, leaf);
+  return o;
+}
+const big = nested(5, 3);
+const bigSparse = fill(5, 3, "x") as any;
+bigSparse.k1.k2.k0.k1.k2 = 42;
+
+interface Case {
+  name: string;
+  schema: z.ZodType;
+  invalid: unknown;
+  iters: number;
+}
+const cases: Case[] = [
+  { name: "string", schema: z.string(), invalid: 42, iters: 200_000 },
+  {
+    name: "object-5key",
+    schema: z.object({ a: z.string(), b: z.number(), c: z.boolean(), d: z.string(), e: z.number() }),
+    invalid: { a: "x", b: 1, c: true, d: 5, e: 2 },
+    iters: 100_000,
+  },
+  {
+    name: "nested-3deep",
+    schema: z.object({ a: z.object({ b: z.object({ c: z.string() }) }) }),
+    invalid: { a: { b: { c: 42 } } },
+    iters: 100_000,
+  },
+  {
+    name: "array-20",
+    schema: z.array(z.number()),
+    invalid: Array.from({ length: 20 }, (_, i) => (i === 10 ? "x" : i)),
+    iters: 50_000,
+  },
+  {
+    name: "tuple-4",
+    schema: z.tuple([z.string(), z.number(), z.boolean(), z.string()]),
+    invalid: ["a", "no", true, "b"],
+    iters: 100_000,
+  },
+  {
+    name: "union-3",
+    schema: z.union([z.string(), z.number(), z.boolean()]),
+    invalid: { nope: 1 },
+    iters: 50_000,
+  },
+  {
+    name: "union-3obj",
+    schema: z.union([z.object({ a: z.string() }), z.object({ b: z.number() }), z.object({ c: z.boolean() })]),
+    invalid: { c: "wrong" },
+    iters: 50_000,
+  },
+  {
+    name: "discunion-3",
+    schema: z.discriminatedUnion("t", [
+      z.object({ t: z.literal("a"), x: z.string() }),
+      z.object({ t: z.literal("b"), y: z.number() }),
+      z.object({ t: z.literal("c"), z: z.boolean() }),
+    ]),
+    invalid: { t: "b", y: "no" },
+    iters: 100_000,
+  },
+  {
+    name: "record",
+    schema: z.record(z.string(), z.number()),
+    invalid: { a: 1, b: "x", c: 3 },
+    iters: 50_000,
+  },
+  { name: "leaf-243-sparse", schema: big, invalid: bigSparse, iters: 3_000 },
+  { name: "leaf-243-dense", schema: big, invalid: fill(5, 3, 42), iters: 1_000 },
+];
+
+let sink = 0;
+function sampleSafe(schema: z.ZodType, input: unknown, iters: number): number {
+  globalThis.gc!();
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) {
+    if (schema.safeParse(input).success) sink++;
+  }
+  return Number(process.hrtime.bigint() - t0) / iters;
+}
+function sampleRun(schema: z.ZodType, input: unknown, iters: number): number {
+  const run = (schema as any)._zod.run;
+  const zod = (schema as any)._zod;
+  globalThis.gc!();
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) {
+    const r = run.call(zod, { value: input, issues: [] }, { async: false });
+    if (r.issues.length === 0) sink++;
+  }
+  return Number(process.hrtime.bigint() - t0) / iters;
+}
+
+const ROUNDS = 7;
+console.log("shape           issues  rt-total  rt-walk  err-cost  ceiling  dual-total  dual-walk  achieved");
+for (const c of cases) {
+  const dual = compile(c.schema as any) as z.ZodType;
+  const rtRes = c.schema.safeParse(c.invalid) as any;
+  const dualRes = dual.safeParse(c.invalid) as any;
+  if (rtRes.success || dualRes.success) throw new Error(`${c.name}: expected failure`);
+  if (JSON.stringify(rtRes.error.issues) !== JSON.stringify(dualRes.error.issues))
+    throw new Error(`${c.name}: issue mismatch`);
+  const nIssues = rtRes.error.issues.length;
+
+  const kinds: Array<[string, () => number]> = [
+    ["A", () => sampleSafe(c.schema, c.invalid, c.iters)],
+    ["B", () => sampleRun(c.schema, c.invalid, c.iters)],
+    ["C", () => sampleSafe(dual, c.invalid, c.iters)],
+    ["D", () => sampleRun(dual, c.invalid, c.iters)],
+  ];
+  // warmup
+  for (const [, f] of kinds) f();
+  const mins = new Map<string, number>();
+  for (let r = 0; r < ROUNDS; r++) {
+    for (const [k, f] of kinds) {
+      const v = f();
+      if (!mins.has(k) || v < mins.get(k)!) mins.set(k, v);
+    }
+  }
+  const A = mins.get("A")!;
+  const B = mins.get("B")!;
+  const C = mins.get("C")!;
+  const D = mins.get("D")!;
+  const err = A - B;
+  const ceiling = A / Math.max(err, 1);
+  console.log(
+    `${c.name.padEnd(15)} ${String(nIssues).padStart(5)}  ${A.toFixed(0).padStart(8)}  ${B.toFixed(0).padStart(7)}  ${err.toFixed(0).padStart(8)}  ${ceiling.toFixed(2).padStart(6)}x  ${C.toFixed(0).padStart(9)}  ${D.toFixed(0).padStart(9)}  ${(A / C).toFixed(2).padStart(7)}x`
+  );
+}
+console.log(`sink=${sink}`);

--- a/packages/bench/compile-issues-modes.ts
+++ b/packages/bench/compile-issues-modes.ts
@@ -1,0 +1,142 @@
+// Compares failing- and valid-parse cost across the wrapper configurations: plain runtime, z.compile({ issues: false }) (the runtime re-parse fallback), and z.compile (compiled issues). Fixed iteration counts with gc() between samples and min-of-samples, per the benchmarking traps in AGENTS.md — failing safeParse allocates, so a time-boxed loop samples the collector instead of the code.
+import * as z from "zod";
+import { compile } from "../zod/src/v4/core/compile.js";
+
+declare global {
+  var gc: undefined | (() => void);
+}
+if (!globalThis.gc) {
+  console.error("run with --expose-gc");
+  process.exit(1);
+}
+
+function nested(depth: number, fanout: number): z.ZodType {
+  if (depth === 0) return z.string();
+  const shape: Record<string, z.ZodType> = {};
+  for (let i = 0; i < fanout; i++) shape[`k${i}`] = nested(depth - 1, fanout);
+  return z.object(shape);
+}
+
+function fill(depth: number, fanout: number, leaf: unknown): unknown {
+  if (depth === 0) return leaf;
+  const o: Record<string, unknown> = {};
+  for (let i = 0; i < fanout; i++) o[`k${i}`] = fill(depth - 1, fanout, leaf);
+  return o;
+}
+
+const big = nested(5, 3); // 243 leaves
+const bigValid = fill(5, 3, "x");
+const bigInvalid = fill(5, 3, "x") as any;
+bigInvalid.k0.k0.k0.k0.k0 = 42;
+
+const fiveKey = z.object({ a: z.string(), b: z.number(), c: z.boolean(), d: z.string(), e: z.number() });
+const deep3 = z.object({ a: z.object({ b: z.object({ c: z.string() }) }) });
+
+interface Case {
+  name: string;
+  schema: z.ZodType;
+  valid: unknown;
+  invalid: unknown;
+  iters: number;
+}
+const cases: Case[] = [
+  { name: "string", schema: z.string(), valid: "hello", invalid: 42, iters: 200_000 },
+  {
+    name: "object-5key",
+    schema: fiveKey,
+    valid: { a: "x", b: 1, c: true, d: "y", e: 2 },
+    invalid: { a: "x", b: 1, c: true, d: 5, e: 2 },
+    iters: 100_000,
+  },
+  {
+    name: "nested-3deep",
+    schema: deep3,
+    valid: { a: { b: { c: "x" } } },
+    invalid: { a: { b: { c: 42 } } },
+    iters: 100_000,
+  },
+  {
+    name: "array-20",
+    schema: z.array(z.number()),
+    valid: Array.from({ length: 20 }, (_, i) => i),
+    invalid: Array.from({ length: 20 }, (_, i) => (i === 10 ? "x" : i)),
+    iters: 50_000,
+  },
+  { name: "leaf-243", schema: big, valid: bigValid, invalid: bigInvalid, iters: 2_000 },
+  {
+    name: "tuple-4",
+    schema: z.tuple([z.string(), z.number(), z.boolean(), z.string()]),
+    valid: ["a", 1, true, "b"],
+    invalid: ["a", "no", true, "b"],
+    iters: 100_000,
+  },
+  {
+    name: "union-3obj",
+    schema: z.union([z.object({ a: z.string() }), z.object({ b: z.number() }), z.object({ c: z.boolean() })]),
+    valid: { c: true },
+    invalid: { c: "wrong" },
+    iters: 50_000,
+  },
+  {
+    name: "discunion-3",
+    schema: z.discriminatedUnion("t", [
+      z.object({ t: z.literal("a"), x: z.string() }),
+      z.object({ t: z.literal("b"), y: z.number() }),
+      z.object({ t: z.literal("c"), z: z.boolean() }),
+    ]),
+    valid: { t: "b", y: 1 },
+    invalid: { t: "b", y: "no" },
+    iters: 100_000,
+  },
+];
+
+type Variant = { name: string; schema: z.ZodType };
+
+function variants(schema: z.ZodType): Variant[] {
+  return [
+    { name: "runtime ", schema },
+    { name: "fallback", schema: compile(schema as any, { issues: false }) as z.ZodType },
+    { name: "compiled", schema: compile(schema as any) as z.ZodType },
+  ];
+}
+
+let sink = 0;
+
+function sample(schema: z.ZodType, input: unknown, iters: number): number {
+  globalThis.gc!();
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) {
+    const r = schema.safeParse(input);
+    if (r.success) sink++;
+  }
+  const t1 = process.hrtime.bigint();
+  return Number(t1 - t0) / iters;
+}
+
+const ROUNDS = 7;
+for (const c of cases) {
+  const vs = variants(c.schema);
+  for (const kind of ["invalid", "valid"] as const) {
+    const input = kind === "invalid" ? c.invalid : c.valid;
+    // sanity: all variants agree
+    const expected = c.schema.safeParse(input).success;
+    for (const v of vs) {
+      if (v.schema.safeParse(input).success !== expected) throw new Error(`verdict mismatch ${c.name} ${v.name}`);
+    }
+    const mins = new Map<string, number>(vs.map((v) => [v.name, Number.POSITIVE_INFINITY]));
+    // warmup
+    for (const v of vs) sample(v.schema, input, Math.max(1000, c.iters / 10));
+    for (let r = 0; r < ROUNDS; r++) {
+      for (const v of vs) {
+        const ns = sample(v.schema, input, c.iters);
+        if (ns < mins.get(v.name)!) mins.set(v.name, ns);
+      }
+    }
+    const base = mins.get("runtime ")!;
+    const line = vs
+      .map((v) => `${v.name.trim()}=${mins.get(v.name)!.toFixed(0)}ns (${(base / mins.get(v.name)!).toFixed(2)}x)`)
+      .join("  ");
+    console.log(`${c.name.padEnd(14)} ${kind.padEnd(7)} ${line}`);
+  }
+}
+console.log(`sink=${sink}`);

--- a/packages/bench/compile-issues-tierup.ts
+++ b/packages/bench/compile-issues-tierup.ts
@@ -1,0 +1,71 @@
+// Cold vs peak failing-parse cost on the 243-leaf schema, runtime vs compiled issues. V8 sizes a function's optimization budget by its bytecode, so a single huge issue parser runs unoptimized for thousands of rejections; the compiler splits subtrees over a size threshold into functions of their own so each tiers up alone. `cold` is the mean over the first COLD calls on a freshly compiled schema (a fresh schema per sample, since `new Function` shares compiled code across identical sources); `peak` is min-of-samples after 20,000 warmup calls.
+import * as z from "zod";
+import { compile, compileFn } from "../zod/src/v4/core/compile.js";
+
+declare global {
+  var gc: undefined | (() => void);
+}
+if (!globalThis.gc) {
+  console.error("run with --expose-gc");
+  process.exit(1);
+}
+
+function nested(depth: number, fanout: number): z.ZodType {
+  if (depth === 0) return z.string();
+  const shape: Record<string, z.ZodType> = {};
+  for (let i = 0; i < fanout; i++) shape[`k${i}`] = nested(depth - 1, fanout);
+  return z.object(shape);
+}
+function fill(depth: number, fanout: number, leaf: unknown): unknown {
+  if (depth === 0) return leaf;
+  const o: Record<string, unknown> = {};
+  for (let i = 0; i < fanout; i++) o[`k${i}`] = fill(depth - 1, fanout, leaf);
+  return o;
+}
+const first = fill(5, 3, "x") as any;
+first.k0.k0.k0.k0.k0 = 42;
+const middle = fill(5, 3, "x") as any;
+middle.k1.k1.k1.k1.k1 = 42;
+const last = fill(5, 3, "x") as any;
+last.k2.k2.k2.k2.k2 = 42;
+const valid = fill(5, 3, "x");
+
+const code = compileFn(nested(5, 3), { issues: true, debug: true }).code!;
+console.log(
+  `issue parser source ${code.length} chars, hoisted functions ${code.match(/^function f\w+\(/gm)?.length ?? 0}`
+);
+
+let successes = 0;
+function run(schema: z.ZodType, input: unknown, iters: number): number {
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) if (schema.safeParse(input).success) successes++;
+  return Number(process.hrtime.bigint() - t0) / iters;
+}
+
+const COLD = Number(process.env.COLD ?? 2000);
+const kinds = ["runtime", "compiled"] as const;
+for (const [name, input] of [
+  ["first", first],
+  ["middle", middle],
+  ["last", last],
+  ["valid", valid],
+] as const) {
+  const cold = { runtime: Number.POSITIVE_INFINITY, compiled: Number.POSITIVE_INFINITY };
+  const peak = { runtime: Number.POSITIVE_INFINITY, compiled: Number.POSITIVE_INFINITY };
+  for (let r = 0; r < 5; r++) {
+    for (const kind of kinds) {
+      const schema = kind === "runtime" ? nested(5, 3) : (compile(nested(5, 3)) as z.ZodType);
+      globalThis.gc!();
+      cold[kind] = Math.min(cold[kind], run(schema, input, COLD));
+      run(schema, input, 20_000);
+      for (let s = 0; s < 5; s++) {
+        globalThis.gc!();
+        peak[kind] = Math.min(peak[kind], run(schema, input, 2000));
+      }
+    }
+  }
+  const fmt = (t: { runtime: number; compiled: number }) =>
+    `runtime=${t.runtime.toFixed(0)}ns compiled=${t.compiled.toFixed(0)}ns (${(t.runtime / t.compiled).toFixed(2)}x)`;
+  console.log(`${name.padEnd(7)} cold(${COLD}) ${fmt(cold)}   peak ${fmt(peak)}`);
+}
+console.log(`(${successes} successful parses consumed)`);

--- a/packages/bench/error-construction-breakdown.ts
+++ b/packages/bench/error-construction-breakdown.ts
@@ -1,0 +1,83 @@
+// Where the time goes when a caller reads `.error` on a failing safeParse: finalizeIssue per issue, the ZodError construction, and the plain Error baseline. Fixed iterations, gc between samples, min of 7 interleaved rounds.
+import * as z from "zod";
+import * as core from "../zod/src/v4/core/index.js";
+import * as util from "../zod/src/v4/core/util.js";
+
+declare global {
+  var gc: undefined | (() => void);
+}
+if (!globalThis.gc) {
+  console.error("run with --expose-gc");
+  process.exit(1);
+}
+
+const inst = z.string();
+const raw = () => ({ code: "invalid_type", expected: "string", input: 42, inst }) as unknown as core.$ZodRawIssue;
+const ctx = { async: false } as core.ParseContextInternal;
+const finalized = util.finalizeIssue(raw(), ctx, core.config());
+const finalizedList = [finalized];
+
+let sink = 0;
+function sample(fn: () => unknown, iters: number): number {
+  globalThis.gc!();
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) if (fn()) sink++;
+  return Number(process.hrtime.bigint() - t0) / iters;
+}
+
+// candidate finalizeIssue bodies, same output: object rest (shipped) vs an explicit copy loop
+const SKIP = new Set(["inst", "schema", "continue", "input"]);
+function finalizeLoop(iss: any, c: any, cfg: any): any {
+  const traits: Set<string> | undefined = iss.inst?._zod?.traits;
+  if (traits?.has("$ZodType")) {
+    if (traits.has("$ZodCheck")) iss.schema ??= iss.inst;
+    else iss.schema = iss.inst;
+  }
+  const schemaError = iss.schema !== iss.inst ? iss.schema?._zod.def?.error : undefined;
+  const message = iss.message
+    ? iss.message
+    : (util.unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ??
+      util.unwrapMessage(schemaError?.(iss)) ??
+      util.unwrapMessage(c?.error?.(iss)) ??
+      util.unwrapMessage(cfg.customError?.(iss)) ??
+      util.unwrapMessage(cfg.localeError?.(iss)) ??
+      "Invalid input");
+  const out: any = {};
+  for (const k in iss) if (!SKIP.has(k)) out[k] = iss[k];
+  out.path ??= [];
+  out.message = message;
+  if (c?.reportInput) out.input = iss.input;
+  return out;
+}
+const localeError = core.config().localeError!;
+
+const variants: Array<[string, () => unknown]> = [
+  ["finalizeIssue: copy loop variant", () => finalizeLoop(raw(), ctx, core.config())],
+  ["localeError(raw) alone", () => localeError(raw() as never)],
+  [
+    "object rest of a raw issue",
+    () => {
+      const { inst: _i, schema: _s, continue: _c, input: _n, ...rest } = raw() as any;
+      return rest;
+    },
+  ],
+  ["finalizeIssue(one raw issue)", () => util.finalizeIssue(raw(), ctx, core.config())],
+  ["config() alone", () => core.config()],
+  ["new Error('x')", () => new Error("x")],
+  ["new core.$ZodRealError([issue])", () => new core.$ZodRealError(finalizedList)],
+  ["new z.ZodError([issue]) (classic)", () => new z.ZodError(finalizedList)],
+  ["new z.ZodError + read .issues", () => new z.ZodError(finalizedList).issues],
+  ["new z.ZodError + read .message", () => new z.ZodError(finalizedList).message.length],
+  ["safeParse(42).error.issues.length", () => (inst.safeParse(42) as any).error.issues.length],
+];
+const ITERS = 300_000;
+const mins = new Map<string, number>();
+for (const [, fn] of variants) sample(fn, ITERS / 10);
+for (let r = 0; r < 7; r++) {
+  for (const [name, fn] of variants) {
+    const v = sample(fn, ITERS);
+    if (!mins.has(name) || v < mins.get(name)!) mins.set(name, v);
+  }
+}
+for (const [name] of variants) console.log(`${name.padEnd(38)} ${mins.get(name)!.toFixed(1)} ns`);
+console.log(`sink=${sink}`);

--- a/packages/bench/failure-result-shape.ts
+++ b/packages/bench/failure-result-shape.ts
@@ -1,0 +1,140 @@
+// What a failing safeParse costs BEFORE anyone reads `.error`: the result object. Compares the shipped literal-with-accessors shape against alternatives with the same own-property surface (an own, enumerable, configurable `error` accessor) and, for reference, the shapes that change it. Fixed iterations, gc between samples, min of 7 interleaved rounds.
+import * as z from "zod";
+
+declare global {
+  var gc: undefined | (() => void);
+}
+if (!globalThis.gc) {
+  console.error("run with --expose-gc");
+  process.exit(1);
+}
+
+const issues = [{ code: "invalid_type", expected: "string", input: 42, inst: null }];
+const ctx = { async: false };
+class Err {
+  issues: unknown[];
+  constructor(i: unknown[]) {
+    this.issues = i;
+  }
+}
+const finalize = (iss: any) => ({ code: iss.code, expected: iss.expected, path: [], message: "Invalid input" });
+
+// 1. shipped: literal with get/set closures
+function literalAccessors(iss: any[], c: any): any {
+  let error: any;
+  return {
+    success: false,
+    get error() {
+      if (!error) {
+        error = new Err(iss.map(finalize));
+        iss = undefined as any;
+        c = undefined as any;
+      }
+      return error;
+    },
+    set error(e: any) {
+      error = e;
+      iss = undefined as any;
+      c = undefined as any;
+    },
+  };
+}
+
+// 2. own accessor via a shared descriptor; state in a hidden symbol slot
+const STATE = Symbol("state");
+const sharedDesc: PropertyDescriptor = {
+  enumerable: true,
+  configurable: true,
+  get(this: any) {
+    const st = this[STATE];
+    if (st.error === undefined) {
+      st.error = new Err(st.issues.map(finalize));
+      st.issues = undefined;
+      st.ctx = undefined;
+    }
+    return st.error;
+  },
+  set(this: any, e: any) {
+    const st = this[STATE];
+    st.error = e;
+    st.issues = undefined;
+    st.ctx = undefined;
+  },
+};
+function sharedDescriptor(iss: any[], c: any): any {
+  const r: any = { success: false, [STATE]: { issues: iss, ctx: c, error: undefined } };
+  Object.defineProperty(r, "error", sharedDesc);
+  return r;
+}
+
+// 3. prototype accessor (NOT own: changes Object.keys / spread / JSON) — reference only
+class Failure {
+  success = false as const;
+  private _issues: any[] | undefined;
+  private _ctx: any;
+  private _error: any;
+  constructor(iss: any[], c: any) {
+    this._issues = iss;
+    this._ctx = c;
+  }
+  get error() {
+    if (this._error === undefined) {
+      this._error = new Err(this._issues!.map(finalize));
+      this._issues = undefined;
+      this._ctx = undefined;
+    }
+    return this._error;
+  }
+  set error(e: any) {
+    this._error = e;
+    this._issues = undefined;
+    this._ctx = undefined;
+  }
+}
+function prototypeAccessor(iss: any[], c: any): any {
+  return new Failure(iss, c);
+}
+
+// 4. eager plain object (pre-#6519) — reference
+function eager(iss: any[], _c: any): any {
+  return { success: false, error: new Err(iss.map(finalize)) };
+}
+
+// 5. shipped zod safeParse end to end, for scale
+const schema = z.string();
+function zodSafeParse(): any {
+  return schema.safeParse(42);
+}
+
+let sink = 0;
+function sample(fn: () => any, readError: boolean, iters: number): number {
+  globalThis.gc!();
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) {
+    const r = fn();
+    if (readError ? r.error.issues.length === 0 : r.success) sink++;
+  }
+  return Number(process.hrtime.bigint() - t0) / iters;
+}
+
+const variants: Array<[string, () => any]> = [
+  ["literal accessors (shipped)", () => literalAccessors(issues, ctx)],
+  ["shared descriptor + slot", () => sharedDescriptor(issues, ctx)],
+  ["prototype accessor (ref)", () => prototypeAccessor(issues, ctx)],
+  ["eager object (ref)", () => eager(issues, ctx)],
+  ["z.string().safeParse(42)", zodSafeParse],
+];
+const ITERS = 1_000_000;
+for (const readError of [false, true]) {
+  const mins = new Map<string, number>();
+  for (const [, fn] of variants) sample(fn, readError, ITERS / 10);
+  for (let r = 0; r < 7; r++) {
+    for (const [name, fn] of variants) {
+      const v = sample(fn, readError, ITERS);
+      if (!mins.has(name) || v < mins.get(name)!) mins.set(name, v);
+    }
+  }
+  console.log(readError ? "construct + read .error.issues" : "construct + read .success");
+  for (const [name] of variants) console.log(`  ${name.padEnd(30)} ${mins.get(name)!.toFixed(1)} ns`);
+}
+console.log(`sink=${sink}`);

--- a/packages/bench/failure-result-shape.ts
+++ b/packages/bench/failure-result-shape.ts
@@ -28,14 +28,14 @@ function literalAccessors(iss: any[], c: any): any {
       if (!error) {
         error = new Err(iss.map(finalize));
         iss = undefined as any;
-        c = undefined as any;
+        c = undefined;
       }
       return error;
     },
     set error(e: any) {
       error = e;
       iss = undefined as any;
-      c = undefined as any;
+      c = undefined;
     },
   };
 }

--- a/packages/bench/failure-result-shape.ts
+++ b/packages/bench/failure-result-shape.ts
@@ -67,6 +67,47 @@ function sharedDescriptor(iss: any[], c: any): any {
   return r;
 }
 
+// 2b. own accessor + a NON-enumerable slot, both defined in one defineProperties call (spread and Reflect.ownKeys no longer see the slot's value)
+const twoDescs: PropertyDescriptorMap = {
+  [STATE]: { value: undefined, writable: true, enumerable: false, configurable: true },
+  error: sharedDesc,
+};
+function sharedDescriptors(iss: any[], c: any): any {
+  const r: any = { success: false };
+  (twoDescs[STATE as any] as PropertyDescriptor).value = { issues: iss, ctx: c, error: undefined };
+  Object.defineProperties(r, twoDescs);
+  (twoDescs[STATE as any] as PropertyDescriptor).value = undefined;
+  return r;
+}
+
+// 2c. own accessor via the shared descriptor; state in a WeakMap keyed by the result
+const states = new WeakMap<object, { issues: any[] | undefined; ctx: any; error: any }>();
+const weakDesc: PropertyDescriptor = {
+  enumerable: true,
+  configurable: true,
+  get(this: any) {
+    const st = states.get(this)!;
+    if (st.error === undefined) {
+      st.error = new Err(st.issues!.map(finalize));
+      st.issues = undefined;
+      st.ctx = undefined;
+    }
+    return st.error;
+  },
+  set(this: any, e: any) {
+    const st = states.get(this)!;
+    st.error = e;
+    st.issues = undefined;
+    st.ctx = undefined;
+  },
+};
+function weakMapState(iss: any[], c: any): any {
+  const r: any = { success: false };
+  states.set(r, { issues: iss, ctx: c, error: undefined });
+  Object.defineProperty(r, "error", weakDesc);
+  return r;
+}
+
 // 3. prototype accessor (NOT own: changes Object.keys / spread / JSON) — reference only
 class Failure {
   success = false as const;
@@ -120,6 +161,8 @@ function sample(fn: () => any, readError: boolean, iters: number): number {
 const variants: Array<[string, () => any]> = [
   ["literal accessors (shipped)", () => literalAccessors(issues, ctx)],
   ["shared descriptor + slot", () => sharedDescriptor(issues, ctx)],
+  ["defineProperties + hidden slot", () => sharedDescriptors(issues, ctx)],
+  ["shared descriptor + WeakMap", () => weakMapState(issues, ctx)],
   ["prototype accessor (ref)", () => prototypeAccessor(issues, ctx)],
   ["eager object (ref)", () => eager(issues, ctx)],
   ["z.string().safeParse(42)", zodSafeParse],

--- a/packages/bench/memory/compiled-footprint.ts
+++ b/packages/bench/memory/compiled-footprint.ts
@@ -1,0 +1,55 @@
+// Retained heap for ONE compiled schema, each case in its own process: what z.compile adds on top of construction, with and without the compiled issue path. Many identical schemas in one process share their generated source through V8's compilation cache, which hides the per-schema cost `measureStable` would otherwise report, so this spawns a child per case instead. Run under --expose-gc; compare against the same script on the baseline checkout.
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import * as z from "zod";
+import { compile } from "../../zod/src/v4/core/compile.js";
+import { fmtBytes, heapUsed, table } from "./harness.js";
+
+function nested(depth: number, fanout: number): z.ZodType {
+  if (depth === 0) return z.string();
+  const shape: Record<string, z.ZodType> = {};
+  for (let i = 0; i < fanout; i++) shape[`k${i}`] = nested(depth - 1, fanout);
+  return z.object(shape);
+}
+const fiveKey = () => z.object({ a: z.string(), b: z.number(), c: z.boolean(), d: z.string(), e: z.number() });
+const big = () => nested(5, 3);
+
+// `issues: false` is unknown to the baseline compiler, which ignores the option; both rows then read the same there
+const cases: Record<string, () => unknown> = {
+  "5-key constructed": fiveKey,
+  "5-key compiled": () => compile(fiveKey() as never),
+  "5-key compiled, issues:false": () => compile(fiveKey() as never, { issues: false } as never),
+  "243-leaf constructed": big,
+  "243-leaf compiled": () => compile(big() as never),
+  "243-leaf compiled, issues:false": () => compile(big() as never, { issues: false } as never),
+};
+
+const which = process.argv[2];
+if (which) {
+  // child: warm the module state with a schema of a DIFFERENT shape (identical generated source would be served from V8's compilation cache and its string shared), then hold one instance and report the delta. One sample per process; the parent takes the median of several children.
+  const factory = cases[which]!;
+  const sink: unknown[] = [];
+  (globalThis as { __sink?: unknown[] }).__sink = sink;
+  sink.push(compile(z.object({ warm: z.string(), up: z.number() }) as never));
+  sink.length = 0;
+  const before = heapUsed();
+  sink.push(factory());
+  const after = heapUsed();
+  process.stdout.write(String(after - before));
+} else {
+  const self = fileURLToPath(import.meta.url);
+  const rows = Object.keys(cases).map((label) => {
+    const samples: number[] = [];
+    for (let r = 0; r < 5; r++) {
+      const c = spawnSync(process.execPath, ["--expose-gc", "--import", "tsx", "--conditions=@zod/source", self, label], {
+        encoding: "utf8",
+      });
+      if (c.status !== 0) throw new Error(`${label}: ${c.stderr}`);
+      samples.push(Number(c.stdout.trim()));
+    }
+    samples.sort((a, b) => a - b);
+    const bytes = samples[Math.floor(samples.length / 2)]!;
+    return { schema: label, bytes: bytes.toFixed(0), human: fmtBytes(bytes) };
+  });
+  table(rows);
+}

--- a/packages/bench/memory/compiled-footprint.ts
+++ b/packages/bench/memory/compiled-footprint.ts
@@ -14,14 +14,20 @@ function nested(depth: number, fanout: number): z.ZodType {
 const fiveKey = () => z.object({ a: z.string(), b: z.number(), c: z.boolean(), d: z.string(), e: z.number() });
 const big = () => nested(5, 3);
 
-// `issues: false` is unknown to the baseline compiler, which ignores the option; both rows then read the same there
+// the issue parser compiles on the first rejection, so the "rejected once" rows hold what a schema that has failed at least once retains. `issues: false` is unknown to the baseline compiler, which ignores the option; its rows then read like the plain compiled ones there
+const rejected = (schema: z.ZodType) => {
+  schema.safeParse(undefined);
+  return schema;
+};
 const cases: Record<string, () => unknown> = {
   "5-key constructed": fiveKey,
   "5-key compiled": () => compile(fiveKey() as never),
-  "5-key compiled, issues:false": () => compile(fiveKey() as never, { issues: false } as never),
+  "5-key compiled, rejected once": () => rejected(compile(fiveKey() as never)),
+  "5-key compiled, issues:false, rejected once": () => rejected(compile(fiveKey() as never, { issues: false } as never)),
   "243-leaf constructed": big,
   "243-leaf compiled": () => compile(big() as never),
-  "243-leaf compiled, issues:false": () => compile(big() as never, { issues: false } as never),
+  "243-leaf compiled, rejected once": () => rejected(compile(big() as never)),
+  "243-leaf compiled, issues:false, rejected once": () => rejected(compile(big() as never, { issues: false } as never)),
 };
 
 const which = process.argv[2];

--- a/packages/bench/memory/compiled-footprint.ts
+++ b/packages/bench/memory/compiled-footprint.ts
@@ -23,7 +23,8 @@ const cases: Record<string, () => unknown> = {
   "5-key constructed": fiveKey,
   "5-key compiled": () => compile(fiveKey() as never),
   "5-key compiled, rejected once": () => rejected(compile(fiveKey() as never)),
-  "5-key compiled, issues:false, rejected once": () => rejected(compile(fiveKey() as never, { issues: false } as never)),
+  "5-key compiled, issues:false, rejected once": () =>
+    rejected(compile(fiveKey() as never, { issues: false } as never)),
   "243-leaf constructed": big,
   "243-leaf compiled": () => compile(big() as never),
   "243-leaf compiled, rejected once": () => rejected(compile(big() as never)),
@@ -47,9 +48,13 @@ if (which) {
   const rows = Object.keys(cases).map((label) => {
     const samples: number[] = [];
     for (let r = 0; r < 5; r++) {
-      const c = spawnSync(process.execPath, ["--expose-gc", "--import", "tsx", "--conditions=@zod/source", self, label], {
-        encoding: "utf8",
-      });
+      const c = spawnSync(
+        process.execPath,
+        ["--expose-gc", "--import", "tsx", "--conditions=@zod/source", self, label],
+        {
+          encoding: "utf8",
+        }
+      );
       if (c.status !== 0) throw new Error(`${label}: ${c.stderr}`);
       samples.push(Number(c.stdout.trim()));
     }

--- a/packages/bench/memory/compiled-slope.ts
+++ b/packages/bench/memory/compiled-slope.ts
@@ -1,0 +1,43 @@
+// Retained heap PER compiled schema, measured as a slope over many distinct schemas in one process. compiled-footprint.ts holds one instance per process and reports the delta, which also carries one-time costs of whatever the measured schema touched first (lazily compiled compiler functions, prototype members materialized on first read, a regex's first executions); those move the single-instance rows by a few KB between builds while the per-schema cost is unchanged. Distinct key names per schema keep V8's compilation cache from sharing generated source.
+import * as z from "zod";
+import { compile } from "../../zod/src/v4/core/compile.js";
+import { fmtBytes, heapUsed } from "./harness.js";
+
+const fiveKey = (p: string) =>
+  z.object({
+    [`${p}a`]: z.string(),
+    [`${p}b`]: z.number(),
+    [`${p}c`]: z.boolean(),
+    [`${p}d`]: z.string(),
+    [`${p}e`]: z.number(),
+  });
+function nested(depth: number, fanout: number, p: string): z.ZodType {
+  if (depth === 0) return z.string();
+  const shape: Record<string, z.ZodType> = {};
+  for (let i = 0; i < fanout; i++) shape[`${p}${i}`] = nested(depth - 1, fanout, p);
+  return z.object(shape);
+}
+const rejected = (schema: z.ZodType) => {
+  schema.safeParse(undefined);
+  return schema;
+};
+
+const hold: unknown[] = [];
+(globalThis as { __hold?: unknown[] }).__hold = hold;
+
+function slope(label: string, make: (p: string) => unknown, n: number): void {
+  hold.length = 0;
+  // warm-up instances absorb the one-time costs
+  for (let i = 0; i < 3; i++) hold.push(make(`w${i}_`));
+  const before = heapUsed();
+  for (let i = 0; i < n; i++) hold.push(make(`m${i}_`));
+  const per = (heapUsed() - before) / n;
+  console.log(`${label.padEnd(40)} ${fmtBytes(per).padStart(10)} per schema`);
+}
+
+slope("5-key constructed", fiveKey, 50);
+slope("5-key compiled", (p) => compile(fiveKey(p) as never), 50);
+slope("5-key compiled, rejected once", (p) => rejected(compile(fiveKey(p) as never)), 50);
+slope("243-leaf constructed", (p) => nested(5, 3, p), 8);
+slope("243-leaf compiled", (p) => compile(nested(5, 3, p) as never), 8);
+slope("243-leaf compiled, rejected once", (p) => rejected(compile(nested(5, 3, p) as never)), 8);

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -39,13 +39,13 @@ export const $ZodCheck: core.$constructor<$ZodCheck<any>> = /*@__PURE__*/ core.$
 );
 
 /** Default `when` for size-based checks: run only on non-nullish values with a `size`. */
-const _whenHasSize = (payload: schemas.ParsePayload): boolean => {
+export const _whenHasSize = (payload: schemas.ParsePayload): boolean => {
   const val = payload.value;
   return !util.nullish(val) && (val as any).size !== undefined;
 };
 
 /** Default `when` for length-based checks: run only on non-nullish values with a `length`. */
-const _whenHasLength = (payload: schemas.ParsePayload): boolean => {
+export const _whenHasLength = (payload: schemas.ParsePayload): boolean => {
   const val = payload.value;
   return !util.nullish(val) && (val as any).length !== undefined;
 };

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -27,8 +27,8 @@ export type INVALID = typeof INVALID;
 
 // Set on the parse ctx when a compiled wrapper falls back to the runtime, so nested compiled wrappers skip their fast paths for the rest of that parse.
 const FALLBACK_FLAG: unique symbol = Symbol.for("zod.compile.fallback");
-// set on a parse context by a compiled method that already rejected: the wrapper goes straight to the failure path
-const SKIP_FAST = /* @__PURE__ */ Symbol.for("zod.compile.skipfast");
+// raised by a compiled method that already rejected, for the wrapper its runtime method is about to enter: the fast parser has run, go straight to the issue parser. A module flag rather than a parse-context entry, so the fallback takes no context spread and no flag reads; it is consumed synchronously by the first wrapper entered and cleared by the method either way.
+let skipFast = false;
 
 interface CompileFnOptions {
   debug?: boolean | undefined;
@@ -165,22 +165,23 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
     // would push issues with `inst === clone`, producing diverging error
     // messages from the original schema.
     const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): any => {
-      if (
-        ctx?.async ||
-        ctx?.direction === "backward" ||
-        ctx?.skipChecks ||
-        (ctx as Record<symbol, unknown> | undefined)?.[FALLBACK_FLAG]
-      ) {
-        return originalRun(payload, ctx);
-      }
-
-      // A memoized back-edge: only the runtime can close a reference cycle, and a transform on one must raise $ZodCyclicError from its own parse.
-      if (ctx && isBackEdge(ctx, payload.value)) {
-        return originalRun(payload, ctx);
-      }
-
       // a compiled parse/safeParse method that already rejected comes back through here to build the failure; running the fast parser again would only run user callbacks once more
-      if (!(ctx as Record<symbol, unknown> | undefined)?.[SKIP_FAST]) {
+      if (skipFast) skipFast = false;
+      else {
+        if (
+          ctx?.async ||
+          ctx?.direction === "backward" ||
+          ctx?.skipChecks ||
+          (ctx as Record<symbol, unknown> | undefined)?.[FALLBACK_FLAG]
+        ) {
+          return originalRun(payload, ctx);
+        }
+
+        // A memoized back-edge: only the runtime can close a reference cycle, and a transform on one must raise $ZodCyclicError from its own parse.
+        if (ctx && isBackEdge(ctx, payload.value)) {
+          return originalRun(payload, ctx);
+        }
+
         const out = parser(payload.value);
         if (out !== INVALID) {
           payload.value = out;
@@ -214,10 +215,6 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
   }
 }
 
-// parse params spread into the parse context, so the flag rides along to the wrapper
-const SKIP_FAST_PARAMS = { [SKIP_FAST]: true };
-const skipFast = (params: unknown) => (params ? { ...(params as object), [SKIP_FAST]: true } : SKIP_FAST_PARAMS);
-
 function installCompiledUserMethods<T extends SomeType>(target: T, parser: CompiledFn<core.output<T>>): void {
   const targetAny = target as any;
 
@@ -228,7 +225,12 @@ function installCompiledUserMethods<T extends SomeType>(target: T, parser: Compi
       if (out !== INVALID) {
         return { success: true, data: out };
       }
-      return originalSafeParse(data, skipFast(params));
+      skipFast = true;
+      try {
+        return originalSafeParse(data, params);
+      } finally {
+        skipFast = false;
+      }
     };
   }
 
@@ -239,7 +241,12 @@ function installCompiledUserMethods<T extends SomeType>(target: T, parser: Compi
       if (out !== INVALID) {
         return out;
       }
-      return originalParse(data, skipFast(params));
+      skipFast = true;
+      try {
+        return originalParse(data, params);
+      } finally {
+        skipFast = false;
+      }
     };
   }
 }

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -27,7 +27,7 @@ export type INVALID = typeof INVALID;
 
 // Set on the parse ctx when a compiled wrapper falls back to the runtime, so nested compiled wrappers skip their fast paths for the rest of that parse.
 const FALLBACK_FLAG: unique symbol = Symbol.for("zod.compile.fallback");
-// raised by a compiled method that already rejected, naming the schema whose runtime method it is about to enter: the fast parser has run, go straight to the issue parser. Module state rather than a parse-context entry, so the fallback takes no context spread and no flag reads; only that schema's own wrapper consumes it, so a route that reaches a nested wrapper first cannot skip that wrapper's checks, and the method clears it either way.
+// raised by a compiled method that already rejected, naming the schema whose runtime method it is about to enter: the fast parser has run, go straight to the issue parser. Module state rather than a parse-context entry, so the fallback takes no context spread and no flag reads; only that schema's own wrapper consumes it, so a route that reaches a nested wrapper first cannot skip that wrapper's checks, and the method restores whatever it found there, so a re-entrant call from a params getter evaluated on the way in cannot clear an outer signal.
 let skipFastFor: unknown = null;
 // set on the parse context where the issue path hands a subtree to the interpreter, so a compiled wrapper the interpreter reaches inside it skips its own fast pass: user callbacks run at most twice on invalid input
 const SKIP_FAST: unique symbol = Symbol.for("zod.compile.skipfast");
@@ -229,11 +229,12 @@ function installCompiledUserMethods<T extends SomeType>(target: T, parser: Compi
       if (out !== INVALID) {
         return { success: true, data: out };
       }
+      const outer = skipFastFor;
       skipFastFor = target;
       try {
         return originalSafeParse(data, params);
       } finally {
-        skipFastFor = null;
+        skipFastFor = outer;
       }
     };
   }
@@ -245,11 +246,12 @@ function installCompiledUserMethods<T extends SomeType>(target: T, parser: Compi
       if (out !== INVALID) {
         return out;
       }
+      const outer = skipFastFor;
       skipFastFor = target;
       try {
         return originalParse(data, params);
       } finally {
-        skipFastFor = null;
+        skipFastFor = outer;
       }
     };
   }

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -27,8 +27,8 @@ export type INVALID = typeof INVALID;
 
 // Set on the parse ctx when a compiled wrapper falls back to the runtime, so nested compiled wrappers skip their fast paths for the rest of that parse.
 const FALLBACK_FLAG: unique symbol = Symbol.for("zod.compile.fallback");
-// raised by a compiled method that already rejected, for the wrapper its runtime method is about to enter: the fast parser has run, go straight to the issue parser. A module flag rather than a parse-context entry, so the fallback takes no context spread and no flag reads; it is consumed synchronously by the first wrapper entered and cleared by the method either way.
-let skipFast = false;
+// raised by a compiled method that already rejected, naming the schema whose runtime method it is about to enter: the fast parser has run, go straight to the issue parser. Module state rather than a parse-context entry, so the fallback takes no context spread and no flag reads; only that schema's own wrapper consumes it, so a route that reaches a nested wrapper first cannot skip that wrapper's checks, and the method clears it either way.
+let skipFastFor: unknown = null;
 
 interface CompileFnOptions {
   debug?: boolean | undefined;
@@ -166,7 +166,7 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
     // messages from the original schema.
     const wrapped = (payload: ParsePayload, ctx: ParseContextInternal): any => {
       // a compiled parse/safeParse method that already rejected comes back through here to build the failure; running the fast parser again would only run user callbacks once more
-      if (skipFast) skipFast = false;
+      if (skipFastFor === clone) skipFastFor = null;
       else {
         if (
           ctx?.async ||
@@ -225,11 +225,11 @@ function installCompiledUserMethods<T extends SomeType>(target: T, parser: Compi
       if (out !== INVALID) {
         return { success: true, data: out };
       }
-      skipFast = true;
+      skipFastFor = target;
       try {
         return originalSafeParse(data, params);
       } finally {
-        skipFast = false;
+        skipFastFor = null;
       }
     };
   }
@@ -241,11 +241,11 @@ function installCompiledUserMethods<T extends SomeType>(target: T, parser: Compi
       if (out !== INVALID) {
         return out;
       }
-      skipFast = true;
+      skipFastFor = target;
       try {
         return originalParse(data, params);
       } finally {
-        skipFast = false;
+        skipFastFor = null;
       }
     };
   }

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1,4 +1,5 @@
 import type * as checks from "./checks.js";
+import { _whenHasLength, _whenHasSize } from "./checks.js";
 import type * as core from "./core.js";
 import { $ZodAsyncError, config } from "./core.js";
 import { Doc } from "./doc.js";
@@ -1482,33 +1483,45 @@ export function emitIssueIsland(
   return v;
 }
 
-const CHILD_KEYS = ["innerType", "element", "rest", "in", "out", "left", "right", "keyType", "valueType"] as const;
 const runsCallbacks = new WeakMap<object, boolean>();
+type ZodNode = { _zod: { def: unknown } };
 
-// Whether an issue-mode walk of this subtree runs user code that can read its parse payload: a custom check, a `when` predicate, a transform. A lazy stays out because issue mode islands it, and the interpreter hands the island its own payloads.
-export function subtreeRunsCallbacks(schema: SomeType): boolean {
-  const known = runsCallbacks.get(schema);
+// Whether an issue-mode walk of this subtree runs user code that receives its parse payload: a def carrying a user function (`fn`, `transform`) or a `when` other than the guards the size and length checks install themselves. Structural, so a schema or check class this compiler has never met is classified by what its def holds: children are whatever `_zod`-bearing values its def's own data properties reach, directly, in an array, or in a shape. Accessors stay unread, since one can run user code or throw. A lazy's getter is a function, so it stays out; issue mode islands it and the interpreter hands the island its own payloads.
+export function subtreeRunsCallbacks(node: ZodNode): boolean {
+  const known = runsCallbacks.get(node);
   if (known !== undefined) return known;
-  // an assumed answer for a subtree still being scanned
-  runsCallbacks.set(schema, false);
-  const def = schema._zod.def as Record<string, unknown> & { type: string; checks?: unknown[] };
-  let out = def.type === "custom" || def.type === "transform" || !!def.transform;
-  if (!out && def.checks) {
-    out = def.checks.some((c) => {
-      const cdef = (c as { _zod: { def: { check: string; when?: unknown } } })._zod.def;
-      return cdef.check === "custom" || !!cdef.when;
-    });
-  }
+  // an assumed answer for a node still being scanned
+  runsCallbacks.set(node, false);
+  const def = node._zod.def as Record<string, unknown>;
+  // a bare custom check (superRefine, .check(fn)) keeps its user function on `_zod.check`, and "custom" is the one check kind that means user code
+  let out =
+    def.check === "custom" ||
+    typeof def.fn === "function" ||
+    typeof def.transform === "function" ||
+    (typeof def.when === "function" && def.when !== _whenHasSize && def.when !== _whenHasLength);
   if (!out) {
-    const children: unknown[] = [];
-    for (const key of CHILD_KEYS) if (def[key]) children.push(def[key]);
-    if (Array.isArray(def.items)) children.push(...(def.items as unknown[]));
-    if (Array.isArray(def.options)) children.push(...(def.options as unknown[]));
-    if (def.shape) children.push(...Object.values(def.shape as Record<string, unknown>));
-    out = children.some((child) => !!(child as SomeType)?._zod && subtreeRunsCallbacks(child as SomeType));
+    for (const key in def) {
+      const desc = Object.getOwnPropertyDescriptor(def, key);
+      if (desc && !desc.get && reachesCallbacks(desc.value)) {
+        out = true;
+        break;
+      }
+    }
   }
-  runsCallbacks.set(schema, out);
+  runsCallbacks.set(node, out);
   return out;
+}
+
+function reachesCallbacks(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  if ((value as Partial<ZodNode>)._zod) return subtreeRunsCallbacks(value as ZodNode);
+  if (Array.isArray(value)) return value.some(reachesCallbacks);
+  for (const key in value) {
+    const desc = Object.getOwnPropertyDescriptor(value, key);
+    if (desc && !desc.get && (desc.value as Partial<ZodNode> | undefined)?._zod && subtreeRunsCallbacks(desc.value))
+      return true;
+  }
+  return false;
 }
 
 // the child parsed on its own payload: its issues join the parent's with the child's path in front, as handlePropertyResult and the array walk do

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -77,6 +77,8 @@ export interface CompileContext {
   definite: boolean;
   /** Hoisted static issue paths, keyed by their source text. */
   pathConstants?: Map<string, string>;
+  /** Function declarations hoisted above the generated parser, in the factory's scope. */
+  prelude: string[];
 }
 
 // Union of all check types we support in AOT compilation
@@ -261,6 +263,7 @@ export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOpti
     constantCounter: 0,
     varCounter: 0,
     definite: true,
+    prelude: [],
   };
 
   const doc = new Doc(options?.issues ? ["input", "payload", "pctx"] : ["input"]);
@@ -283,15 +286,15 @@ export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOpti
   const constantValues = [INVALID, ...ctx.constants.values()];
 
   const code = doc.content.join("\n");
+  // hoisted subtree and branch functions sit in the factory's scope, next to the constants
+  const prelude = ctx.prelude.length ? `${ctx.prelude.join("\n")}\n` : "";
   const fullCode = options?.debug
-    ? constantNames.length > 0
-      ? `// Constants: ${constantNames.join(", ")}\n${code}`
-      : code
+    ? `${constantNames.length > 0 ? `// Constants: ${constantNames.join(", ")}\n` : ""}${prelude}${code}`
     : "";
 
   const F = Function;
   const params = options?.issues ? "(input, payload, pctx)" : "(input)";
-  const factoryCode = `return ${params} => {\n${code}\n}`;
+  const factoryCode = `${prelude}return ${params} => {\n${code}\n}`;
   let fn: CompiledFn<core.output<T>>;
   try {
     const factory = new F(...constantNames, factoryCode);
@@ -1541,20 +1544,36 @@ export function mergeChildIssues(payload: ParsePayload, child: ParsePayload, pat
 // A subtree whose callbacks could read the payload runs inside one of its own, as the interpreter gives every object property, array element and record value: the callbacks see only the child's issues, with child-relative paths, and the parent takes the issues afterwards. A subtree without callbacks pushes straight into the parent's array with its path prefixed at the site, which is the same result without the payload and the closure.
 function emitIsolatedChild(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string, path: IssuePath): string {
   const mergeConst = addConstant(ctx, mergeChildIssues);
+  const fn = emitBranchFn(ctx, schema);
   const r = newVar(ctx);
-  doc.write(`const ${r} = ((payload) => {`);
-  doc.indented((d) => {
-    d.write(`let _sp;`);
-    const value = compileChildIssues(d, ctx, schema, "payload.value", [], true);
-    d.write(`payload.value = ${value};`);
-    d.write(`return payload;`);
-  });
-  doc.write(`})({ value: ${accessor}, issues: [] });`);
+  doc.write(`const ${r} = ${fn}({ value: ${accessor}, issues: [] }, pctx);`);
   doc.write(`${mergeConst}(payload, ${r}, ${path.length ? pathExpr(ctx, path) : "[]"});`);
   return `${r}.value`;
 }
 
-// Issue-mode counterpart of compileChild: try the native emission, roll back and island on an islandable refusal.
+// A body that parses `payload.value` on a payload of its own — a union branch, an isolated child — hoisted into the factory's scope as `(payload, pctx) => payload` with the value written back, so no closure is allocated per parse. `shared` is true relative to that payload, so a branch pipe's abort flag lands on it.
+export function emitBranchFn(ctx: CompileContext, schema: SomeType): string {
+  const sub = new Doc();
+  const out = compileChildIssues(sub, ctx, schema, "payload.value", [], true);
+  return hoistFn(ctx, "payload, pctx", sub.content, `payload.value = ${out};`, `return payload;`);
+}
+
+function hoistFn(ctx: CompileContext, params: string, body: string[], ...tail: string[]): string {
+  const name = `f${newVar(ctx)}`;
+  ctx.prelude.push(
+    `function ${name}(${params}) {`,
+    `  let _sp;`,
+    ...body.map((line) => `  ${line}`),
+    ...tail.map((line) => `  ${line}`),
+    `}`
+  );
+  return name;
+}
+
+// V8 sizes a function's optimization budget by its bytecode, so one huge issue parser stays unoptimized for thousands of rejections and loses to the interpreter until then; a subtree above this many characters of source becomes a function of its own, which tiers up on its own. Small schemas stay one function and pay no call.
+const HOIST_THRESHOLD = 4000;
+
+// Issue-mode counterpart of compileChild: try the native emission, roll back and island on an islandable refusal. The body generates against a local of its own, detached from the caller's doc, so a large one on a static path can hoist as a function; the rest splices in place.
 export function compileChildIssues(
   doc: Doc,
   ctx: CompileContext,
@@ -1564,23 +1583,39 @@ export function compileChildIssues(
   shared: boolean
 ): string {
   if (!shared && subtreeRunsCallbacks(schema)) return emitIsolatedChild(doc, ctx, schema, accessor, path);
-  const contentLen = doc.content.length;
   const constantCount = ctx.constants.size;
   const constantCounter = ctx.constantCounter;
   const varCounter = ctx.varCounter;
+  const preludeLen = ctx.prelude.length;
+  const local = newVar(ctx);
+  const sub = new Doc();
+  let out: string;
   try {
-    return generateCheckIssues(doc, ctx, schema, accessor, path, shared);
+    out = generateCheckIssues(sub, ctx, schema, local, path, shared);
   } catch (err) {
     if (!(err instanceof ZodCompileUnsupportedError) || !err.islandable) throw err;
-    doc.content.length = contentLen;
     if (ctx.constants.size > constantCount) {
       const trailing = Array.from(ctx.constants.keys()).slice(constantCount);
       for (const k of trailing) ctx.constants.delete(k);
     }
     ctx.constantCounter = constantCounter;
     ctx.varCounter = varCounter;
+    ctx.prelude.length = preludeLen;
     return emitIssueIsland(doc, ctx, schema, accessor, path, shared);
   }
+  const body = sub.content;
+  // a dynamic path element (an array index, a record key) is a variable of the caller's, which a hoisted body could not see
+  if (body.join("\n").length > HOIST_THRESHOLD && path.every((p) => STATIC_PATH_ELEMENT.test(p))) {
+    const r = newVar(ctx);
+    doc.write(
+      `const ${r} = ${hoistFn(ctx, `${local}, payload, pctx`, body, `return ${out};`)}(${accessor}, payload, pctx);`
+    );
+    return r;
+  }
+  doc.write(`const ${local} = ${accessor};`);
+  const pad = " ".repeat(doc.indent * 2);
+  for (const line of body) doc.content.push(pad + line);
+  return out;
 }
 
 /** An issue-mode emitter for one node: writes the node's body against `accessor`, pushing canonical issues (prefixed with `path`) into `payload.issues`, and returns the accessor holding the node's value. `mark` is `payload.issues.length` before the node, present only for an entry that declares `marks`; a pipe also hands back the gate that stops its check chain. */

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -26,6 +26,8 @@ export type INVALID = typeof INVALID;
 
 // Set on the parse ctx when a compiled wrapper falls back to the runtime, so nested compiled wrappers skip their fast paths for the rest of that parse.
 const FALLBACK_FLAG: unique symbol = Symbol.for("zod.compile.fallback");
+// set on a parse context by a compiled method that already rejected: the wrapper goes straight to the failure path
+const SKIP_FAST = /* @__PURE__ */ Symbol.for("zod.compile.skipfast");
 
 interface CompileFnOptions {
   debug?: boolean | undefined;
@@ -131,14 +133,19 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
     const clone = util.clone(schema as any) as T;
 
     type IssueParser = (input: unknown, payload: ParsePayload, pctx: ParseContextInternal) => unknown;
-    let issueParser: IssueParser | null = null;
-    if (options?.issues !== false) {
-      try {
-        issueParser = compileFn(schema, { issues: true }) as unknown as IssueParser;
-      } catch (err) {
-        if (!(err instanceof ZodCompileUnsupportedError || err instanceof ZodCompileAsyncError)) throw err;
+    // Compiled on the first rejection: a schema that never fails never pays for its issue parser, whose source alone can outweigh the schema, and z.compile stays a fast-path-only cost up front. A refusal falls back to the runtime re-parse for good.
+    let issueParser: IssueParser | null | undefined = options?.issues === false ? null : undefined;
+    const issueParserFor = (): IssueParser | null => {
+      if (issueParser === undefined) {
+        try {
+          issueParser = compileFn(schema, { issues: true }) as unknown as IssueParser;
+        } catch (err) {
+          if (!(err instanceof ZodCompileUnsupportedError || err instanceof ZodCompileAsyncError)) throw err;
+          issueParser = null;
+        }
       }
-    }
+      return issueParser;
+    };
 
     // Capture the source-of-truth runtime eagerly. If schema._zod.run is itself a shim installed by global-mode (`__originalRun` set), unwrap past it. Otherwise capturing the live property lazily would let a later self- replacement of schema._zod.run feed our wrapper back into itself.
     const liveRun = schema._zod.run as ((p: ParsePayload, c: ParseContextInternal) => any) & {
@@ -167,14 +174,18 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
         return originalRun(payload, ctx);
       }
 
-      const out = parser(payload.value);
-      if (out !== INVALID) {
-        payload.value = out;
-        return payload;
+      // a compiled parse/safeParse method that already rejected comes back through here to build the failure; running the fast parser again would only run user callbacks once more
+      if (!(ctx as Record<symbol, unknown> | undefined)?.[SKIP_FAST]) {
+        const out = parser(payload.value);
+        if (out !== INVALID) {
+          payload.value = out;
+          return payload;
+        }
       }
       // The issue parser replaces the runtime fallback. `validate` asks for the first failure only (abortEarly); the issue parser walks everything, so that answer still comes from the runtime.
-      if (issueParser && !ctx?.abortEarly) {
-        payload.value = issueParser(payload.value, payload, ctx);
+      const issues = ctx?.abortEarly ? null : issueParserFor();
+      if (issues) {
+        payload.value = issues(payload.value, payload, ctx);
         return payload;
       }
       // Mark this parse as runtime-driven: under global mode every nested schema carries its own compiled wrapper, and without the flag the parent's runtime fallback re-enters each child's fast path, running user callbacks a third time on invalid input.
@@ -185,11 +196,10 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
     (wrapped as { __originalRun?: typeof originalRun }).__originalRun = originalRun;
     clone._zod.bag.fallbackRun = originalRun;
     clone._zod.bag.validator = compileValidator(schema, parser as CompiledFn<unknown>);
-    if (issueParser) clone._zod.bag.issueParser = issueParser;
     clone._zod.run = wrapped;
 
-    // The fast parse/safeParse closures fall back through the source schema's methods. If the source is shim- or wrapper-managed, those methods route into a compiled run and would execute user callbacks a third time on invalid input — the plain method → wrapper path is exactly 2x, so skip. With an issue parser they fall back through the CLONE's own methods, so a rejection lands in the wrapper's issue parser instead of a whole-schema re-parse.
-    if (!liveRun.__originalRun) installCompiledUserMethods(clone, issueParser ? clone : schema, parser);
+    // The fast parse/safeParse closures fall back through the clone's own methods with the skip-fast flag, so a rejection lands in the wrapper's issue parser (or its runtime fallback) without running the fast parser a second time: user callbacks run at most twice on invalid input. If the source is shim-managed, its methods already route into a compiled run, so skip.
+    if (!liveRun.__originalRun) installCompiledUserMethods(clone, parser);
 
     return clone;
   } catch (err) {
@@ -199,33 +209,32 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
   }
 }
 
-function installCompiledUserMethods<T extends SomeType>(
-  target: T,
-  source: T,
-  parser: CompiledFn<core.output<T>>
-): void {
-  const targetAny = target as any;
-  const sourceAny = source as any;
+// parse params spread into the parse context, so the flag rides along to the wrapper
+const SKIP_FAST_PARAMS = { [SKIP_FAST]: true };
+const skipFast = (params: unknown) => (params ? { ...(params as object), [SKIP_FAST]: true } : SKIP_FAST_PARAMS);
 
-  if (typeof sourceAny.safeParse === "function") {
-    const originalSafeParse = sourceAny.safeParse;
+function installCompiledUserMethods<T extends SomeType>(target: T, parser: CompiledFn<core.output<T>>): void {
+  const targetAny = target as any;
+
+  if (typeof targetAny.safeParse === "function") {
+    const originalSafeParse = targetAny.safeParse;
     targetAny.safeParse = (data: unknown, params?: unknown) => {
       const out = parser(data);
       if (out !== INVALID) {
         return { success: true, data: out };
       }
-      return originalSafeParse(data, params);
+      return originalSafeParse(data, skipFast(params));
     };
   }
 
-  if (typeof sourceAny.parse === "function") {
-    const originalParse = sourceAny.parse;
+  if (typeof targetAny.parse === "function") {
+    const originalParse = targetAny.parse;
     targetAny.parse = (data: unknown, params?: unknown) => {
       const out = parser(data);
       if (out !== INVALID) {
         return out;
       }
-      return originalParse(data, params);
+      return originalParse(data, skipFast(params));
     };
   }
 }
@@ -1227,13 +1236,38 @@ export function issueConsts(ctx: CompileContext) {
 
 export const SP_INIT = `(_sp ??= { value: null, issues: payload.issues })`;
 
-// Cold block for a failed leaf type test: re-run the node's runtime parse so it pushes the canonical issue, then prefix. The parse re-evaluates a trivial predicate; the price of never hand-building an issue shape.
+// Cold call for a failed leaf type test: the node's own runtime parse pushes the canonical issue onto the caller's issues array, then the pushed issues get their root-relative path. The parse re-evaluates a trivial predicate; the price of never hand-building an issue shape.
+export function coldParse(
+  value: unknown,
+  parse: (p: ParsePayload, c: ParseContextInternal) => unknown,
+  payload: ParsePayload,
+  pctx: ParseContextInternal | undefined,
+  path?: unknown[]
+): void {
+  const m = payload.issues.length;
+  parse({ value, issues: payload.issues }, pctx as ParseContextInternal);
+  if (path && payload.issues.length > m) prefixIssuesFrom(payload.issues, m, path);
+}
+
+// Cold call for a failed check predicate: the runtime check pushes canonically, the owning schema is stamped, and the pushed issues get their path. The chain's abort gates are recomputed by the caller from the node mark.
+export function coldCheck(
+  value: unknown,
+  check: (p: ParsePayload) => unknown,
+  payload: ParsePayload,
+  owner: unknown,
+  path?: unknown[]
+): void {
+  const m = payload.issues.length;
+  check({ value, issues: payload.issues });
+  util.attachSchema(payload.issues, m, owner as never);
+  if (path && payload.issues.length > m) prefixIssuesFrom(payload.issues, m, path);
+}
+
 export function leafFailBlock(ctx: CompileContext, schema: SomeType, accessor: string, path: IssuePath): string {
-  const { pfx } = issueConsts(ctx);
+  const coldConst = addConstant(ctx, coldParse);
   const parseConst = addConstant(ctx, schema._zod.parse);
-  const m = newVar(ctx);
-  const prefix = path.length ? ` ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);` : "";
-  return `{ ${SP_INIT}.value = ${accessor}; const ${m} = payload.issues.length; ${parseConst}(_sp, pctx);${prefix} }`;
+  const pathArg = path.length ? `, [${path.join(", ")}]` : "";
+  return `${coldConst}(${accessor}, ${parseConst}, payload, pctx${pathArg});`;
 }
 
 interface ChainGate {
@@ -1241,7 +1275,7 @@ interface ChainGate {
   ex: string | null;
 }
 
-// Cold block for a failed check predicate: re-run the runtime check so it pushes canonically, stamp the owning schema, prefix, and update the abort gates. `label` breaks out of the check's remaining hot statements (multi-site checks like url).
+// Cold block for a failed check predicate: `coldCheck` pushes canonically, then the gates are recomputed from the node mark (every issue of this node sits after it, so "aborted since the mark" is exactly the accumulated gate). `label` breaks out of the check's remaining hot statements (multi-site checks like url).
 function checkFailBlock(
   ctx: CompileContext,
   check: { _zod: { check?: unknown } },
@@ -1249,16 +1283,18 @@ function checkFailBlock(
   accessor: string,
   path: IssuePath,
   gate: ChainGate,
-  label: string
+  label: string,
+  nodeMark: string,
+  pre: string
 ): string {
-  const { pfx, abt, eabt, att } = issueConsts(ctx);
+  const { abt, eabt } = issueConsts(ctx);
   const checkFn = (check._zod as { check?: unknown }).check;
   if (typeof checkFn !== "function") throw new ZodCompileUnsupportedError("check without a runtime check function");
+  const coldConst = addConstant(ctx, coldCheck);
   const checkConst = addConstant(ctx, checkFn);
-  const m = newVar(ctx);
-  const prefix = path.length ? ` ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);` : "";
-  const exUpd = gate.ex ? ` if (!${gate.ex}) ${gate.ex} = ${eabt}(payload, ${m});` : "";
-  return `{ ${SP_INIT}.value = ${accessor}; const ${m} = payload.issues.length; ${checkConst}(_sp); ${att}(payload.issues, ${m}, ${ownerConst});${prefix} if (!${gate.ab}) ${gate.ab} = ${abt}(payload, ${m});${exUpd} break ${label}; }`;
+  const pathArg = path.length ? `, [${path.join(", ")}]` : "";
+  const exUpd = gate.ex ? ` ${gate.ex} = ${pre}${eabt}(payload, ${nodeMark});` : "";
+  return `{ ${coldConst}(${accessor}, ${checkConst}, payload, ${ownerConst}${pathArg}); ${gate.ab} = ${pre}${abt}(payload, ${nodeMark});${exUpd} break ${label}; }`;
 }
 
 /**
@@ -1367,7 +1403,7 @@ export function generateChecksIssues(
           });
           d.write(`})();`);
           d.write(
-            `if (${r} === INVALID) ${checkFailBlock(ctx, check as { _zod: { check?: unknown } }, ownerConst, valueVar, path, gate, label)}`
+            `if (${r} === INVALID) ${checkFailBlock(ctx, check as { _zod: { check?: unknown } }, ownerConst, valueVar, path, gate, label, nodeMark, pre)}`
           );
         });
         doc.write(`}`);
@@ -1378,7 +1414,17 @@ export function generateChecksIssues(
         doc.write(`if (${guard}) ${label}: {`);
         doc.indented((d) => {
           const fail = () =>
-            checkFailBlock(ctx, check as { _zod: { check?: unknown } }, ownerConst, valueVar, path, gate, label);
+            checkFailBlock(
+              ctx,
+              check as { _zod: { check?: unknown } },
+              ownerConst,
+              valueVar,
+              path,
+              gate,
+              label,
+              nodeMark,
+              pre
+            );
           const out = emitCheckPredicate(d, ctx, check, valueVar, fail);
           if (out !== valueVar) d.write(`${valueVar} = ${out};`);
         });
@@ -1435,7 +1481,7 @@ export function compileChildIssues(
   }
 }
 
-/** An issue-mode emitter for one node: writes the node's body against `accessor`, pushing canonical issues (prefixed with `path`) into `payload.issues`, and returns the accessor holding the node's value. `mark` is `payload.issues.length` before the node; a pipe also hands back the gate that stops its check chain. */
+/** An issue-mode emitter for one node: writes the node's body against `accessor`, pushing canonical issues (prefixed with `path`) into `payload.issues`, and returns the accessor holding the node's value. `mark` is `payload.issues.length` before the node, present only for an entry that declares `marks`; a pipe also hands back the gate that stops its check chain. */
 export type IssueCodegen = (
   doc: Doc,
   ctx: CompileContext,
@@ -1475,15 +1521,17 @@ function generateCheckIssues(
   const def = schema._zod.def;
 
   // coercion rewrites the value before the type test — the interpreter models it, so island the node
-  const emit = (def as { coerce?: boolean }).coerce ? undefined : emitterFor(schema)?.issues;
+  const entry = (def as { coerce?: boolean }).coerce ? undefined : emitterFor(schema);
+  const emit = entry?.issues;
   if (!emit) return emitIssueIsland(doc, ctx, schema, accessor, path, shared);
 
   const defChecks = (def.checks as unknown[] | undefined) ?? [];
   const isOwnCheck = (schema._zod as { traits?: Set<string> }).traits?.has("$ZodCheck") === true;
   const hasChain = defChecks.length > 0 || isOwnCheck;
 
-  const mark = newVar(ctx);
-  doc.write(`const ${mark} = payload.issues.length;`);
+  // the mark costs a statement per node, so only a node whose chain or emitter reads it takes one
+  const mark = hasChain || entry.marks ? newVar(ctx) : "";
+  if (mark) doc.write(`const ${mark} = payload.issues.length;`);
 
   const out = emit(doc, ctx, schema, accessor, path, shared, mark);
   const value = typeof out === "string" ? out : out.value;

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -29,7 +29,7 @@ export type INVALID = typeof INVALID;
 const FALLBACK_FLAG: unique symbol = Symbol.for("zod.compile.fallback");
 // raised by a compiled method that already rejected, naming the schema whose runtime method it is about to enter: the fast parser has run, go straight to the issue parser. Module state rather than a parse-context entry, so the fallback takes no context spread and no flag reads; only that schema's own wrapper consumes it, so a route that reaches a nested wrapper first cannot skip that wrapper's checks, and the method clears it either way.
 let skipFastFor: unknown = null;
-// set on the parse context once a wrapper's fast pass has failed, so a nested wrapper reached through an island or a cold call skips its own: user callbacks run at most twice on invalid input
+// set on the parse context where the issue path hands a subtree to the interpreter, so a compiled wrapper the interpreter reaches inside it skips its own fast pass: user callbacks run at most twice on invalid input
 const SKIP_FAST: unique symbol = Symbol.for("zod.compile.skipfast");
 
 interface CompileFnOptions {
@@ -192,7 +192,6 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
           }
         }
       }
-      if (ctx) (ctx as Record<symbol, unknown>)[SKIP_FAST] = true;
       // The issue parser replaces the runtime fallback. `validate` asks for the first failure only (abortEarly); the issue parser walks everything, so that answer still comes from the runtime.
       const issues = ctx?.abortEarly ? null : issueParserFor();
       if (issues) {
@@ -1168,7 +1167,9 @@ export function rerunNodeForIssues(
     __originalRun?: (p: ParsePayload, c: ParseContextInternal) => any;
   };
   const run = live.__originalRun ?? live;
-  const r = run({ value, issues: [] }, pctx ?? ({} as ParseContextInternal));
+  const ctx = pctx ?? ({} as ParseContextInternal);
+  (ctx as Record<symbol, unknown>)[SKIP_FAST] = true;
+  const r = run({ value, issues: [] }, ctx);
   if (r && typeof (r as Promise<unknown>).then === "function") throw new $ZodAsyncError();
   if (r.issues.length) payload.issues.push(...r.issues);
   if (shared && r.aborted) payload.aborted = true;
@@ -1215,7 +1216,9 @@ export function pushInvalidKey(
   const live = keyType._zod.run as ((p: ParsePayload, c: ParseContextInternal) => any) & {
     __originalRun?: (p: ParsePayload, c: ParseContextInternal) => any;
   };
-  const r = (live.__originalRun ?? live)({ value: key, issues: [] }, pctx ?? ({} as ParseContextInternal));
+  const ctx = pctx ?? ({} as ParseContextInternal);
+  (ctx as Record<symbol, unknown>)[SKIP_FAST] = true;
+  const r = (live.__originalRun ?? live)({ value: key, issues: [] }, ctx);
   if (r instanceof Promise) throw new Error("Async schemas not supported in object keys currently");
   payload.issues.push({
     code: "invalid_key",

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1486,40 +1486,39 @@ export function emitIssueIsland(
 const runsCallbacks = new WeakMap<object, boolean>();
 type ZodNode = { _zod: { def: unknown } };
 
-// Whether an issue-mode walk of this subtree runs user code that receives its parse payload: a def carrying a user function (`fn`, `transform`) or a `when` other than the guards the size and length checks install themselves. Structural, so a schema or check class this compiler has never met is classified by what its def holds: children are whatever `_zod`-bearing values its def's own data properties reach, directly, in an array, or in a shape. Accessors stay unread, since one can run user code or throw. A lazy's getter is a function, so it stays out; issue mode islands it and the interpreter hands the island its own payloads.
+// Whether an issue-mode walk of this subtree runs user code that receives its parse payload. Three def shapes do: a custom check whose check function is the user's (superRefine, `.check(fn)`: kind "custom" with no value-only `fn` — a refine or a string format keeps its `fn`, which sees the value alone), a `transform`, and a `when` other than the guards the size and length checks install themselves. Structural, so a schema or check class this compiler has never met is classified by what its def holds: children are whatever `_zod`-bearing values the def reaches directly, in an array, or in a shape. A lazy's getter is a function, so it stays out; issue mode islands it and the interpreter hands the island its own payloads.
 export function subtreeRunsCallbacks(node: ZodNode): boolean {
   const known = runsCallbacks.get(node);
   if (known !== undefined) return known;
   // an assumed answer for a node still being scanned
   runsCallbacks.set(node, false);
   const def = node._zod.def as Record<string, unknown>;
-  // a bare custom check (superRefine, .check(fn)) keeps its user function on `_zod.check`, and "custom" is the one check kind that means user code
   let out =
-    def.check === "custom" ||
-    typeof def.fn === "function" ||
+    (def.check === "custom" && typeof def.fn !== "function") ||
     typeof def.transform === "function" ||
     (typeof def.when === "function" && def.when !== _whenHasSize && def.when !== _whenHasLength);
-  if (!out) {
-    for (const key in def) {
-      const desc = Object.getOwnPropertyDescriptor(def, key);
-      if (desc && !desc.get && reachesCallbacks(desc.value)) {
-        out = true;
-        break;
-      }
-    }
-  }
+  if (!out) out = childrenReachCallbacks(def);
   runsCallbacks.set(node, out);
   return out;
 }
 
-function reachesCallbacks(value: unknown): boolean {
-  if (!value || typeof value !== "object") return false;
-  if ((value as Partial<ZodNode>)._zod) return subtreeRunsCallbacks(value as ZodNode);
-  if (Array.isArray(value)) return value.some(reachesCallbacks);
-  for (const key in value) {
-    const desc = Object.getOwnPropertyDescriptor(value, key);
-    if (desc && !desc.get && (desc.value as Partial<ZodNode> | undefined)?._zod && subtreeRunsCallbacks(desc.value))
+// the def's values, one level deep: a node recurses, an array or a shape is scanned for nodes, and anything else (a default value, a regex, a locale map) stays opaque. an accessor is read too — a derived shape is one until its first read, so skipping it would make the answer depend on what was read before — and one that throws counts as callbacks, the conservative answer
+function childrenReachCallbacks(def: object): boolean {
+  for (const key in def) {
+    let value: unknown;
+    try {
+      value = (def as Record<string, unknown>)[key];
+    } catch {
       return true;
+    }
+    if (!value || typeof value !== "object") continue;
+    if ((value as Partial<ZodNode>)._zod) {
+      if (subtreeRunsCallbacks(value as ZodNode)) return true;
+    } else if (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype) {
+      for (const el of Object.values(value)) {
+        if ((el as Partial<ZodNode> | null)?._zod && subtreeRunsCallbacks(el as ZodNode)) return true;
+      }
+    }
   }
   return false;
 }

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -29,6 +29,8 @@ export type INVALID = typeof INVALID;
 const FALLBACK_FLAG: unique symbol = Symbol.for("zod.compile.fallback");
 // raised by a compiled method that already rejected, naming the schema whose runtime method it is about to enter: the fast parser has run, go straight to the issue parser. Module state rather than a parse-context entry, so the fallback takes no context spread and no flag reads; only that schema's own wrapper consumes it, so a route that reaches a nested wrapper first cannot skip that wrapper's checks, and the method clears it either way.
 let skipFastFor: unknown = null;
+// set on the parse context once a wrapper's fast pass has failed, so a nested wrapper reached through an island or a cold call skips its own: user callbacks run at most twice on invalid input
+const SKIP_FAST: unique symbol = Symbol.for("zod.compile.skipfast");
 
 interface CompileFnOptions {
   debug?: boolean | undefined;
@@ -182,12 +184,15 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
           return originalRun(payload, ctx);
         }
 
-        const out = parser(payload.value);
-        if (out !== INVALID) {
-          payload.value = out;
-          return payload;
+        if (!(ctx as Record<symbol, unknown> | undefined)?.[SKIP_FAST]) {
+          const out = parser(payload.value);
+          if (out !== INVALID) {
+            payload.value = out;
+            return payload;
+          }
         }
       }
+      if (ctx) (ctx as Record<symbol, unknown>)[SKIP_FAST] = true;
       // The issue parser replaces the runtime fallback. `validate` asks for the first failure only (abortEarly); the issue parser walks everything, so that answer still comes from the runtime.
       const issues = ctx?.abortEarly ? null : issueParserFor();
       if (issues) {

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1502,14 +1502,20 @@ export function subtreeRunsCallbacks(node: ZodNode): boolean {
   return out;
 }
 
-// the def's values, one level deep: a node recurses, an array or a shape is scanned for nodes, and anything else (a default value, a regex, a locale map) stays opaque. an accessor is read too — a derived shape is one until its first read, so skipping it would make the answer depend on what was read before — and one that throws counts as callbacks, the conservative answer
+// the def's values, one level deep: a node recurses, an array or a shape is scanned for nodes, and anything else (a default value, a regex, a locale map) stays opaque. accessors stay unread — `defaultValue` runs the user's factory — except `shape`, zod's own lazily derived one, which is read so the answer is the same before and after its first read; a shape getter that throws counts as callbacks, the conservative answer
 function childrenReachCallbacks(def: object): boolean {
   for (const key in def) {
+    const desc = Object.getOwnPropertyDescriptor(def, key);
+    if (!desc) continue;
     let value: unknown;
-    try {
-      value = (def as Record<string, unknown>)[key];
-    } catch {
-      return true;
+    if (!desc.get) value = desc.value;
+    else if (key !== "shape") continue;
+    else {
+      try {
+        value = (def as Record<string, unknown>)[key];
+      } catch {
+        return true;
+      }
     }
     if (!value || typeof value !== "object") continue;
     if ((value as Partial<ZodNode>)._zod) {

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1502,20 +1502,28 @@ export function subtreeRunsCallbacks(node: ZodNode): boolean {
   return out;
 }
 
-// the def's values, one level deep: a node recurses, an array or a shape is scanned for nodes, and anything else (a default value, a regex, a locale map) stays opaque. no accessor is invoked — `defaultValue` runs the user's factory — and zod's own lazy shape is read through `rawShape`, which answers from the getter's data without calling it, so the answer is the same before and after the first read; a `shape` accessor a subclass supplied stays unread like any other
+// accessors zod installs on its own defs that hold no callback-bearing child: `defaultValue` runs the user's factory and answers a value; `catchall` (after extend) answers a schema, and a catchall value is a child boundary of its own, so it classifies from its own def
+const INERT_DEF_ACCESSORS = new Set(["defaultValue", "catchall"]);
+
+// the def's values, one level deep: a node recurses, an array or a shape is scanned for nodes, and anything else (a default value, a regex, a locale map) stays opaque. no accessor is invoked: zod's own lazy shape is read through `rawShape`, which answers from the getter's data without calling it, so the answer is the same before and after the first read; any other accessor, on the def or on an entry, counts as callbacks — unread, and on the isolated path, which is safe either way
 function childrenReachCallbacks(def: object): boolean {
   for (const key in def) {
     const desc = Object.getOwnPropertyDescriptor(def, key);
     if (!desc) continue;
-    const value: unknown = desc.get ? (key === "shape" ? util.rawShape(def) : undefined) : desc.value;
+    let value: unknown;
+    if (!desc.get) value = desc.value;
+    else if (key === "shape") value = util.rawShape(def);
+    else if (INERT_DEF_ACCESSORS.has(key)) continue;
+    else return true;
     if (!value || typeof value !== "object") continue;
     if ((value as Partial<ZodNode>)._zod) {
       if (subtreeRunsCallbacks(value as ZodNode)) return true;
     } else if (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype) {
-      // the entries by descriptor too: a plain object in a def can carry accessors of its own
       for (const k of Object.keys(value)) {
         const el = Object.getOwnPropertyDescriptor(value, k);
-        if (el && !el.get && (el.value as Partial<ZodNode> | null)?._zod && subtreeRunsCallbacks(el.value)) return true;
+        if (!el) continue;
+        if (el.get) return true;
+        if ((el.value as Partial<ZodNode> | null)?._zod && subtreeRunsCallbacks(el.value)) return true;
       }
     }
   }

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -74,6 +74,8 @@ export interface CompileContext {
   varCounter: number;
   /** Cleared when a construct can return INVALID for something the interpreter throws on, so `validate` keeps its fallback. */
   definite: boolean;
+  /** Hoisted static issue paths, keyed by their source text. */
+  pathConstants?: Map<string, string>;
 }
 
 // Union of all check types we support in AOT compilation
@@ -1263,10 +1265,37 @@ export function coldCheck(
   if (path && payload.issues.length > m) prefixIssuesFrom(payload.issues, m, path);
 }
 
+const STATIC_PATH_ELEMENT = /^(?:"(?:[^"\\]|\\.)*"|-?\d+)$/;
+
+// Source for a path array that is only read (a cold call's prefix). A path of two or more literals hoists into one shared constant: on a wide schema the literal repeated at every leaf is a large share of the generated issue code, which is retained for the schema's lifetime. Paths carrying a runtime element (an array index, a record key) stay inline.
+export function pathExpr(ctx: CompileContext, path: IssuePath): string {
+  const literal = `[${path.join(", ")}]`;
+  if (path.length < 2 || !path.every((p) => STATIC_PATH_ELEMENT.test(p))) return literal;
+  ctx.pathConstants ??= new Map();
+  const cache = ctx.pathConstants;
+  let name = cache.get(literal);
+  if (!name) {
+    name = addConstant(ctx, JSON.parse(literal));
+    cache.set(literal, name);
+  }
+  return name;
+}
+
+// Source for a path array that lands on an issue, which the caller may mutate: a hoisted constant is copied
+export function pathLiteral(ctx: CompileContext, path: IssuePath): string {
+  const expr = pathExpr(ctx, path);
+  return expr.startsWith("[") ? expr : `${expr}.slice()`;
+}
+
+// the synthetic issue for a required key that is absent when the value schema pushed nothing, as $ZodObject's handlePropertyResult pushes it
+export function pushMissingKey(payload: ParsePayload, path: unknown[]): void {
+  payload.issues.push({ code: "invalid_type", expected: "nonoptional", input: undefined, path: path.slice() } as never);
+}
+
 export function leafFailBlock(ctx: CompileContext, schema: SomeType, accessor: string, path: IssuePath): string {
   const coldConst = addConstant(ctx, coldParse);
   const parseConst = addConstant(ctx, schema._zod.parse);
-  const pathArg = path.length ? `, [${path.join(", ")}]` : "";
+  const pathArg = path.length ? `, ${pathExpr(ctx, path)}` : "";
   return `${coldConst}(${accessor}, ${parseConst}, payload, pctx${pathArg});`;
 }
 
@@ -1292,7 +1321,7 @@ function checkFailBlock(
   if (typeof checkFn !== "function") throw new ZodCompileUnsupportedError("check without a runtime check function");
   const coldConst = addConstant(ctx, coldCheck);
   const checkConst = addConstant(ctx, checkFn);
-  const pathArg = path.length ? `, [${path.join(", ")}]` : "";
+  const pathArg = path.length ? `, ${pathExpr(ctx, path)}` : "";
   const exUpd = gate.ex ? ` ${gate.ex} = ${pre}${eabt}(payload, ${nodeMark});` : "";
   return `{ ${coldConst}(${accessor}, ${checkConst}, payload, ${ownerConst}${pathArg}); ${gate.ab} = ${pre}${abt}(payload, ${nodeMark});${exUpd} break ${label}; }`;
 }
@@ -1367,7 +1396,7 @@ export function generateChecksIssues(
           d.write(`if (payload.issues.length > ${m}) {`);
           d.indented((d2) => {
             d2.write(`${att}(payload.issues, ${m}, ${ownerConst});`);
-            if (path.length) d2.write(`${pfx}(payload.issues, ${m}, [${path.join(", ")}]);`);
+            if (path.length) d2.write(`${pfx}(payload.issues, ${m}, ${pathExpr(ctx, path)});`);
             d2.write(`if (!${gate.ab}) ${gate.ab} = ${abt}(payload, ${m});`);
             if (gate.ex) d2.write(`if (!${gate.ex}) ${gate.ex} = ${eabt}(payload, ${m});`);
           });
@@ -1449,7 +1478,7 @@ export function emitIssueIsland(
   const v = newVar(ctx);
   doc.write(`const ${m} = payload.issues.length;`);
   doc.write(`const ${v} = ${rerunConst}(${schemaConst}, ${accessor}, payload, pctx, ${shared});`);
-  if (path.length) doc.write(`if (payload.issues.length > ${m}) ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);`);
+  if (path.length) doc.write(`if (payload.issues.length > ${m}) ${pfx}(payload.issues, ${m}, ${pathExpr(ctx, path)});`);
   return v;
 }
 

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1176,6 +1176,30 @@ export function unionIssuesForCompiled(
   return input;
 }
 
+// mirrors $ZodRecord's invalid_key push for a key its schema rejects: the key schema re-runs so the nested issues are the interpreter's own, finalized the way the runtime finalizes them
+export function pushInvalidKey(
+  keyType: SomeType,
+  key: PropertyKey,
+  payload: ParsePayload,
+  pctx: ParseContextInternal | undefined,
+  inst: SomeType,
+  path: unknown[]
+): void {
+  const live = keyType._zod.run as ((p: ParsePayload, c: ParseContextInternal) => any) & {
+    __originalRun?: (p: ParsePayload, c: ParseContextInternal) => any;
+  };
+  const r = (live.__originalRun ?? live)({ value: key, issues: [] }, pctx ?? ({} as ParseContextInternal));
+  if (r instanceof Promise) throw new Error("Async schemas not supported in object keys currently");
+  payload.issues.push({
+    code: "invalid_key",
+    origin: "record",
+    issues: r.issues.map((iss: never) => util.finalizeIssue(iss, pctx, config())),
+    input: key,
+    path: [...path, key],
+    inst,
+  } as never);
+}
+
 // mirrors handlePipeResult's stop rule: any issue except unrecognized_keys halts the pipe, continuable or not
 export function pipeStops(issues: unknown[], start: number): boolean {
   for (let i = start; i < issues.length; i++) {

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1,8 +1,8 @@
 import type * as checks from "./checks.js";
 import type * as core from "./core.js";
-import { $ZodAsyncError } from "./core.js";
+import { $ZodAsyncError, config } from "./core.js";
 import { Doc } from "./doc.js";
-import { codegenFor } from "./jit.js";
+import { codegenFor, emitterFor } from "./jit.js";
 import { isBackEdge, isRecursiveSchema } from "./memoizer.js";
 import {
   isValidBase64,
@@ -31,6 +31,8 @@ interface CompileFnOptions {
   debug?: boolean | undefined;
   /** Emit a validator instead of a parser: skip building the output value where nothing reads it. */
   assertOnly?: boolean | undefined;
+  /** Emit an issue-collecting parser: failures push the same raw issues the interpreter pushes instead of returning INVALID. */
+  issues?: boolean | undefined;
 }
 
 type CompiledFn<T> = ((input: unknown) => T | INVALID) & {
@@ -108,6 +110,8 @@ function compileValidator(schema: SomeType, parser: CompiledFn<unknown>): Compil
 export interface CompileOptions {
   /** Throw the refusal instead of returning the schema uncompiled. */
   strict?: boolean | undefined;
+  /** Compile the failure path too (the default): after the fast parser rejects, a second generated parser pushes the interpreter's issues instead of re-parsing through the runtime. `false` keeps the runtime re-parse. */
+  issues?: boolean | undefined;
 }
 
 /**
@@ -125,6 +129,16 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
   try {
     const parser = compileFn(schema);
     const clone = util.clone(schema as any) as T;
+
+    type IssueParser = (input: unknown, payload: ParsePayload, pctx: ParseContextInternal) => unknown;
+    let issueParser: IssueParser | null = null;
+    if (options?.issues !== false) {
+      try {
+        issueParser = compileFn(schema, { issues: true }) as unknown as IssueParser;
+      } catch (err) {
+        if (!(err instanceof ZodCompileUnsupportedError || err instanceof ZodCompileAsyncError)) throw err;
+      }
+    }
 
     // Capture the source-of-truth runtime eagerly. If schema._zod.run is itself a shim installed by global-mode (`__originalRun` set), unwrap past it. Otherwise capturing the live property lazily would let a later self- replacement of schema._zod.run feed our wrapper back into itself.
     const liveRun = schema._zod.run as ((p: ParsePayload, c: ParseContextInternal) => any) & {
@@ -158,6 +172,11 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
         payload.value = out;
         return payload;
       }
+      // The issue parser replaces the runtime fallback. `validate` asks for the first failure only (abortEarly); the issue parser walks everything, so that answer still comes from the runtime.
+      if (issueParser && !ctx?.abortEarly) {
+        payload.value = issueParser(payload.value, payload, ctx);
+        return payload;
+      }
       // Mark this parse as runtime-driven: under global mode every nested schema carries its own compiled wrapper, and without the flag the parent's runtime fallback re-enters each child's fast path, running user callbacks a third time on invalid input.
       if (ctx) (ctx as Record<symbol, unknown>)[FALLBACK_FLAG] = true;
       return originalRun(payload, ctx);
@@ -166,10 +185,11 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
     (wrapped as { __originalRun?: typeof originalRun }).__originalRun = originalRun;
     clone._zod.bag.fallbackRun = originalRun;
     clone._zod.bag.validator = compileValidator(schema, parser as CompiledFn<unknown>);
+    if (issueParser) clone._zod.bag.issueParser = issueParser;
     clone._zod.run = wrapped;
 
-    // The fast parse/safeParse closures fall back through the source schema's methods. If the source is shim- or wrapper-managed, those methods route into a compiled run and would execute user callbacks a third time on invalid input — the plain method → wrapper path is exactly 2x, so skip.
-    if (!liveRun.__originalRun) installCompiledUserMethods(clone, schema, parser);
+    // The fast parse/safeParse closures fall back through the source schema's methods. If the source is shim- or wrapper-managed, those methods route into a compiled run and would execute user callbacks a third time on invalid input — the plain method → wrapper path is exactly 2x, so skip. With an issue parser they fall back through the CLONE's own methods, so a rejection lands in the wrapper's issue parser instead of a whole-schema re-parse.
+    if (!liveRun.__originalRun) installCompiledUserMethods(clone, issueParser ? clone : schema, parser);
 
     return clone;
   } catch (err) {
@@ -231,10 +251,20 @@ export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOpti
     definite: true,
   };
 
-  const doc = new Doc(["input"]);
-  const outputAccessor = generateCheck(doc, ctx, schema, "input", !options?.assertOnly);
-  // In assert mode a root that built nothing has already returned INVALID on every failure, so reaching the end means valid.
-  doc.write(outputAccessor === null ? `return true;` : `return ${outputAccessor};`);
+  const doc = new Doc(options?.issues ? ["input", "payload", "pctx"] : ["input"]);
+  if (options?.issues) {
+    // a root that would compile to a bare self-island is just the interpreter with extra steps — refuse so the wrapper keeps the fallback model instead
+    if ((schema._zod.def as { coerce?: boolean }).coerce || !emitterFor(schema)?.issues) {
+      throw new ZodCompileUnsupportedError(`schema type ${schema._zod.def.type} at the root of an issue-mode compile`);
+    }
+    doc.write(`let _sp;`);
+    const outputAccessor = generateCheckIssues(doc, ctx, schema, "input", [], true);
+    doc.write(`return ${outputAccessor};`);
+  } else {
+    const outputAccessor = generateCheck(doc, ctx, schema, "input", !options?.assertOnly);
+    // In assert mode a root that built nothing has already returned INVALID on every failure, so reaching the end means valid.
+    doc.write(outputAccessor === null ? `return true;` : `return ${outputAccessor};`);
+  }
 
   // Build the function with hoisted constants Always include INVALID as the first constant
   const constantNames = ["INVALID", ...ctx.constants.keys()];
@@ -248,7 +278,8 @@ export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOpti
     : "";
 
   const F = Function;
-  const factoryCode = `return (input) => {\n${code}\n}`;
+  const params = options?.issues ? "(input, payload, pctx)" : "(input)";
+  const factoryCode = `return ${params} => {\n${code}\n}`;
   let fn: CompiledFn<core.output<T>>;
   try {
     const factory = new F(...constantNames, factoryCode);
@@ -356,6 +387,82 @@ const WHEN_DEFAULTED_CHECKS = new Set([
   "length_equals",
 ]);
 
+/** Emits the statement run when a check's predicate fails. Fast mode returns INVALID; issue mode writes a cold block that pushes the canonical issue. Called once per failure site, so implementations may allocate fresh vars. */
+type FailEmitter = () => string;
+const RETURN_INVALID: FailEmitter = () => "return INVALID;";
+
+// Emits the predicate for one non-structural check (everything but custom/overwrite/property/properties), calling `fail()` at each failure site. Returns the accessor holding the post-check value.
+function emitCheckPredicate(
+  doc: Doc,
+  ctx: CompileContext,
+  check: SupportedCheck,
+  accessor: string,
+  fail: FailEmitter
+): string {
+  const def = check._zod.def;
+  switch (def.check) {
+    case "greater_than":
+      generateGreaterThanCheck(doc, ctx, def, accessor, fail);
+      return accessor;
+    case "less_than":
+      generateLessThanCheck(doc, ctx, def, accessor, fail);
+      return accessor;
+    case "multiple_of":
+      generateMultipleOfCheck(doc, ctx, def, accessor, fail);
+      return accessor;
+    case "number_format":
+      generateNumberFormatCheck(doc, def, accessor, fail);
+      return accessor;
+    case "min_length": {
+      const min = numericOperand(def.minimum, "min_length");
+      const len = codePointLengthVar(
+        doc,
+        ctx,
+        accessor,
+        `${accessor}.length >= ${min} && ${accessor}.length < ${def.minimum * 2}`
+      );
+      doc.write(`if (${len} < ${min}) ${fail()}`);
+      return accessor;
+    }
+    case "max_length": {
+      const max = numericOperand(def.maximum, "max_length");
+      const len = codePointLengthVar(doc, ctx, accessor, `${accessor}.length > ${max}`);
+      doc.write(`if (${len} > ${max}) ${fail()}`);
+      return accessor;
+    }
+    case "length_equals": {
+      const exact = numericOperand(def.length, "length_equals");
+      const len = codePointLengthVar(
+        doc,
+        ctx,
+        accessor,
+        `${accessor}.length >= ${exact} && ${accessor}.length <= ${def.length * 2}`
+      );
+      doc.write(`if (${len} !== ${exact}) ${fail()}`);
+      return accessor;
+    }
+    case "min_size":
+      doc.write(`if (${accessor}.size < ${numericOperand(def.minimum, "min_size")}) ${fail()}`);
+      return accessor;
+    case "max_size":
+      doc.write(`if (${accessor}.size > ${numericOperand(def.maximum, "max_size")}) ${fail()}`);
+      return accessor;
+    case "size_equals":
+      doc.write(`if (${accessor}.size !== ${numericOperand(def.size, "size_equals")}) ${fail()}`);
+      return accessor;
+    case "string_format":
+      return generateStringFormatCheck(doc, ctx, def, accessor, fail);
+    case "bigint_format":
+      generateBigIntFormatCheck(doc, def, accessor, fail);
+      return accessor;
+    case "mime_type":
+      generateMimeTypeCheck(doc, ctx, def, accessor, fail);
+      return accessor;
+    default:
+      throw new ZodCompileUnsupportedError(`check type ${(def as { check: string }).check}`);
+  }
+}
+
 export function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
   const schemaChecks = schema._zod.def.checks as SupportedCheck[] | undefined;
   if (!schemaChecks || schemaChecks.length === 0) return accessor;
@@ -370,66 +477,8 @@ export function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, 
       throw new ZodCompileUnsupportedError(`check with a custom "when" condition`);
     }
     switch (def.check) {
-      case "greater_than":
-        generateGreaterThanCheck(doc, ctx, def, currentAccessor);
-        break;
-      case "less_than":
-        generateLessThanCheck(doc, ctx, def, currentAccessor);
-        break;
-      case "multiple_of":
-        generateMultipleOfCheck(doc, ctx, def, currentAccessor);
-        break;
-      case "number_format":
-        generateNumberFormatCheck(doc, def, currentAccessor);
-        break;
-      case "min_length": {
-        const min = numericOperand(def.minimum, "min_length");
-        const len = codePointLengthVar(
-          doc,
-          ctx,
-          currentAccessor,
-          `${currentAccessor}.length >= ${min} && ${currentAccessor}.length < ${def.minimum * 2}`
-        );
-        doc.write(`if (${len} < ${min}) return INVALID;`);
-        break;
-      }
-      case "max_length": {
-        const max = numericOperand(def.maximum, "max_length");
-        const len = codePointLengthVar(doc, ctx, currentAccessor, `${currentAccessor}.length > ${max}`);
-        doc.write(`if (${len} > ${max}) return INVALID;`);
-        break;
-      }
-      case "length_equals": {
-        const exact = numericOperand(def.length, "length_equals");
-        const len = codePointLengthVar(
-          doc,
-          ctx,
-          currentAccessor,
-          `${currentAccessor}.length >= ${exact} && ${currentAccessor}.length <= ${def.length * 2}`
-        );
-        doc.write(`if (${len} !== ${exact}) return INVALID;`);
-        break;
-      }
-      case "min_size":
-        doc.write(`if (${currentAccessor}.size < ${numericOperand(def.minimum, "min_size")}) return INVALID;`);
-        break;
-      case "max_size":
-        doc.write(`if (${currentAccessor}.size > ${numericOperand(def.maximum, "max_size")}) return INVALID;`);
-        break;
-      case "size_equals":
-        doc.write(`if (${currentAccessor}.size !== ${numericOperand(def.size, "size_equals")}) return INVALID;`);
-        break;
-      case "string_format":
-        currentAccessor = generateStringFormatCheck(doc, ctx, def, currentAccessor);
-        break;
       case "custom":
         currentAccessor = generateCustomRefineCheck(doc, ctx, check as CustomCheck, currentAccessor);
-        break;
-      case "bigint_format":
-        generateBigIntFormatCheck(doc, def, currentAccessor);
-        break;
-      case "mime_type":
-        generateMimeTypeCheck(doc, ctx, def, currentAccessor);
         break;
       case "property":
         generatePropertyCheck(doc, ctx, def, currentAccessor);
@@ -444,10 +493,8 @@ export function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, 
         currentAccessor = newAccessor;
         break;
       }
-      default: {
-        void (def satisfies never);
-        throw new ZodCompileUnsupportedError(`check type ${(def as { check: string }).check}`);
-      }
+      default:
+        currentAccessor = emitCheckPredicate(doc, ctx, check, currentAccessor, RETURN_INVALID);
     }
   }
 
@@ -496,64 +543,72 @@ function generateGreaterThanCheck(
   doc: Doc,
   ctx: CompileContext,
   def: checks.$ZodCheckGreaterThanDef,
-  accessor: string
+  accessor: string,
+  fail: FailEmitter = RETURN_INVALID
 ): void {
   const op = def.inclusive ? "<" : "<=";
-  doc.write(`if (${accessor} ${op} ${comparisonOperand(ctx, def.value)}) return INVALID;`);
+  doc.write(`if (${accessor} ${op} ${comparisonOperand(ctx, def.value)}) ${fail()}`);
 }
 
 function generateLessThanCheck(
   doc: Doc,
   ctx: CompileContext,
   def: checks.$ZodCheckLessThanDef,
-  accessor: string
+  accessor: string,
+  fail: FailEmitter = RETURN_INVALID
 ): void {
   const op = def.inclusive ? ">" : ">=";
-  doc.write(`if (${accessor} ${op} ${comparisonOperand(ctx, def.value)}) return INVALID;`);
+  doc.write(`if (${accessor} ${op} ${comparisonOperand(ctx, def.value)}) ${fail()}`);
 }
 
 function generateMultipleOfCheck(
   doc: Doc,
   ctx: CompileContext,
   def: checks.$ZodCheckMultipleOfDef,
-  accessor: string
+  accessor: string,
+  fail: FailEmitter = RETURN_INVALID
 ): void {
   if (typeof def.value === "bigint") {
     // a zero divisor has no compiled form: `x % 0n` throws
     if (def.value === BigInt(0)) throw new ZodCompileUnsupportedError("multiple_of check with a zero divisor");
-    doc.write(`if (${accessor} % ${def.value}n !== 0n) return INVALID;`);
+    doc.write(`if (${accessor} % ${def.value}n !== 0n) ${fail()}`);
   } else {
     // Float `%` has well-known precision issues for sub-integer steps
     // (`1.5 % 0.1`, `2.5e-7 % 1e-7`). Defer to util.floatSafeRemainder so the
     // exact tolerance logic stays in one place — single function call is fine
     // since `multipleOf` runs at most once per number.
     const remainder = addConstant(ctx, util.floatSafeRemainder);
-    doc.write(`if (${remainder}(${accessor}, ${numericOperand(def.value, "multiple_of")}) !== 0) return INVALID;`);
+    doc.write(`if (${remainder}(${accessor}, ${numericOperand(def.value, "multiple_of")}) !== 0) ${fail()}`);
   }
 }
 
-export function generateNumberFormatCheck(doc: Doc, def: checks.$ZodCheckNumberFormatDef, accessor: string): void {
+export function generateNumberFormatCheck(
+  doc: Doc,
+  def: checks.$ZodCheckNumberFormatDef,
+  accessor: string,
+  fail: FailEmitter = RETURN_INVALID
+): void {
   const format = def.format;
   switch (format) {
     case "safeint":
-      doc.write(`if (!Number.isSafeInteger(${accessor})) return INVALID;`);
+      doc.write(`if (!Number.isSafeInteger(${accessor})) ${fail()}`);
       break;
     case "int32":
       doc.write(
-        `if (!Number.isInteger(${accessor}) || ${accessor} < -2147483648 || ${accessor} > 2147483647) return INVALID;`
+        `if (!Number.isInteger(${accessor}) || ${accessor} < -2147483648 || ${accessor} > 2147483647) ${fail()}`
       );
       break;
     case "uint32":
-      doc.write(`if (!Number.isInteger(${accessor}) || ${accessor} < 0 || ${accessor} > 4294967295) return INVALID;`);
+      doc.write(`if (!Number.isInteger(${accessor}) || ${accessor} < 0 || ${accessor} > 4294967295) ${fail()}`);
       break;
     case "float32":
       // Float32 range per util.NUMBER_FORMAT_RANGES
       doc.write(
-        `if (!Number.isFinite(${accessor}) || ${accessor} < -3.4028234663852886e38 || ${accessor} > 3.4028234663852886e38) return INVALID;`
+        `if (!Number.isFinite(${accessor}) || ${accessor} < -3.4028234663852886e38 || ${accessor} > 3.4028234663852886e38) ${fail()}`
       );
       break;
     case "float64":
-      doc.write(`if (!Number.isFinite(${accessor})) return INVALID;`);
+      doc.write(`if (!Number.isFinite(${accessor})) ${fail()}`);
       break;
     default: {
       void (format satisfies never);
@@ -562,15 +617,20 @@ export function generateNumberFormatCheck(doc: Doc, def: checks.$ZodCheckNumberF
   }
 }
 
-function generateBigIntFormatCheck(doc: Doc, def: checks.$ZodCheckBigIntFormatDef, accessor: string): void {
+function generateBigIntFormatCheck(
+  doc: Doc,
+  def: checks.$ZodCheckBigIntFormatDef,
+  accessor: string,
+  fail: FailEmitter = RETURN_INVALID
+): void {
   const format = def.format;
   if (!format) return; // undefined format means no range check
   switch (format) {
     case "int64":
-      doc.write(`if (${accessor} < -9223372036854775808n || ${accessor} > 9223372036854775807n) return INVALID;`);
+      doc.write(`if (${accessor} < -9223372036854775808n || ${accessor} > 9223372036854775807n) ${fail()}`);
       break;
     case "uint64":
-      doc.write(`if (${accessor} < 0n || ${accessor} > 18446744073709551615n) return INVALID;`);
+      doc.write(`if (${accessor} < 0n || ${accessor} > 18446744073709551615n) ${fail()}`);
       break;
     default: {
       void (format satisfies never);
@@ -583,12 +643,13 @@ function generateMimeTypeCheck(
   doc: Doc,
   ctx: CompileContext,
   def: checks.$ZodCheckMimeTypeDef,
-  accessor: string
+  accessor: string,
+  fail: FailEmitter = RETURN_INVALID
 ): void {
   const mimeTypes = def.mime;
   if (mimeTypes && mimeTypes.length > 0) {
     const mimeSet = addConstant(ctx, new Set(mimeTypes));
-    doc.write(`if (!${mimeSet}.has(${accessor}.type)) return INVALID;`);
+    doc.write(`if (!${mimeSet}.has(${accessor}.type)) ${fail()}`);
   }
 }
 
@@ -761,39 +822,40 @@ export function generateStringFormatCheck(
   doc: Doc,
   ctx: CompileContext,
   def: StringFormatDef,
-  accessor: string
+  accessor: string,
+  fail: FailEmitter = RETURN_INVALID
 ): string {
   // Some string formats do runtime validation beyond their advertised pattern. For cheap pure utility checks, hoist the runtime function and call it so the fast path stays correct without cloning the utility logic into codegen.
   const fmt = def.format;
   if (fmt === "base64") {
     const validator = addConstant(ctx, isValidBase64);
-    doc.write(`if (!${validator}(${accessor})) return INVALID;`);
+    doc.write(`if (!${validator}(${accessor})) ${fail()}`);
     return accessor;
   }
   if (fmt === "base64url") {
     const validator = addConstant(ctx, isValidBase64URL);
-    doc.write(`if (!${validator}(${accessor})) return INVALID;`);
+    doc.write(`if (!${validator}(${accessor})) ${fail()}`);
     return accessor;
   }
   if (fmt === "jwt") {
     const validator = addConstant(ctx, isValidJWT);
     const alg = addConstant(ctx, (def as unknown as { alg?: util.JWTAlgorithm }).alg ?? null);
-    doc.write(`if (!${validator}(${accessor}, ${alg})) return INVALID;`);
+    doc.write(`if (!${validator}(${accessor}, ${alg})) ${fail()}`);
     return accessor;
   }
   if (fmt === "ipv6") {
     const validator = addConstant(ctx, isValidIPv6);
-    doc.write(`if (!${validator}(${accessor})) return INVALID;`);
+    doc.write(`if (!${validator}(${accessor})) ${fail()}`);
     return accessor;
   }
   if (fmt === "cidrv6") {
     const validator = addConstant(ctx, isValidCIDRv6);
-    doc.write(`if (!${validator}(${accessor})) return INVALID;`);
+    doc.write(`if (!${validator}(${accessor})) ${fail()}`);
     return accessor;
   }
   if (fmt === "credit_card") {
     const validator = addConstant(ctx, isValidCreditCard);
-    doc.write(`if (!${validator}(${accessor})) return INVALID;`);
+    doc.write(`if (!${validator}(${accessor})) ${fail()}`);
     return accessor;
   }
   const formatDef = def as unknown as { normalize?: boolean; hostname?: unknown; protocol?: unknown };
@@ -811,14 +873,14 @@ export function generateStringFormatCheck(
     const urlVar = newVar(ctx);
     doc.write(`const ${trimVar} = ${accessor}.trim();`);
     doc.write(`const ${urlVar} = ${parseConst}(${trimVar}, ${defConst});`);
-    doc.write(`if (typeof ${urlVar} === "number") return INVALID;`);
+    doc.write(`if (typeof ${urlVar} === "number") ${fail()}`);
     if (formatDef.hostname !== undefined) {
       const hostnameConst = addConstant(ctx, urlHostnameOk);
-      doc.write(`if (!${hostnameConst}(${urlVar}, ${defConst}.hostname)) return INVALID;`);
+      doc.write(`if (!${hostnameConst}(${urlVar}, ${defConst}.hostname)) ${fail()}`);
     }
     if (formatDef.protocol !== undefined) {
       const protocolConst = addConstant(ctx, urlProtocolOk);
-      doc.write(`if (!${protocolConst}(${urlVar}, ${defConst}.protocol)) return INVALID;`);
+      doc.write(`if (!${protocolConst}(${urlVar}, ${defConst}.protocol)) ${fail()}`);
     }
     const outputVar = newVar(ctx);
     const outputExpr = formatDef.normalize ? `${urlVar}.href` : `${addConstant(ctx, stripTabAndNewline)}(${trimVar})`;
@@ -831,7 +893,7 @@ export function generateStringFormatCheck(
   if (customFn) {
     if (isAsyncFunction(customFn)) throw new ZodCompileUnsupportedError(`async string format ${fmt}`);
     const fnConst = addConstant(ctx, customFn);
-    doc.write(`if (!${fnConst}(${accessor})) return INVALID;`);
+    doc.write(`if (!${fnConst}(${accessor})) ${fail()}`);
     return accessor;
   }
 
@@ -839,7 +901,7 @@ export function generateStringFormatCheck(
   if (PATTERN_IS_COMPLETE.has(fmt) && def.pattern) {
     const patternConst = addConstant(ctx, def.pattern);
     doc.write(`${patternConst}.lastIndex = 0;`);
-    doc.write(`if (!${patternConst}.test(${accessor})) return INVALID;`);
+    doc.write(`if (!${patternConst}.test(${accessor})) ${fail()}`);
     return accessor;
   }
 
@@ -849,24 +911,22 @@ export function generateStringFormatCheck(
       // A regex check with a pattern returned above. Reaching here means there is no pattern to test, and accepting unconditionally would pass every input, so hand the schema back to the runtime.
       throw new ZodCompileUnsupportedError("regex format without a pattern");
     case "lowercase":
-      doc.write(`if (${accessor} !== ${accessor}.toLowerCase()) return INVALID;`);
+      doc.write(`if (${accessor} !== ${accessor}.toLowerCase()) ${fail()}`);
       break;
     case "uppercase":
-      doc.write(`if (${accessor} !== ${accessor}.toUpperCase()) return INVALID;`);
+      doc.write(`if (${accessor} !== ${accessor}.toUpperCase()) ${fail()}`);
       break;
     case "includes":
-      doc.write(
-        `if (!${accessor}.includes(${util.esc((def as checks.$ZodCheckIncludesDef).includes)})) return INVALID;`
-      );
+      doc.write(`if (!${accessor}.includes(${util.esc((def as checks.$ZodCheckIncludesDef).includes)})) ${fail()}`);
       break;
     case "starts_with": {
       const prefix = (def as checks.$ZodCheckStartsWithDef).prefix;
-      doc.write(`if (${accessor}.slice(0, ${prefix.length}) !== ${util.esc(prefix)}) return INVALID;`);
+      doc.write(`if (${accessor}.slice(0, ${prefix.length}) !== ${util.esc(prefix)}) ${fail()}`);
       break;
     }
     case "ends_with": {
       const suffix = (def as checks.$ZodCheckEndsWithDef).suffix;
-      doc.write(`if (${accessor}.slice(-${suffix.length}) !== ${util.esc(suffix)}) return INVALID;`);
+      doc.write(`if (${accessor}.slice(-${suffix.length}) !== ${util.esc(suffix)}) ${fail()}`);
       break;
     }
     default: {
@@ -1054,6 +1114,363 @@ export function mayOutputUndefined(schema: SomeType): boolean {
       // any/unknown/undefined/void/default/prefault/transform/custom/lazy/catch
       return true;
   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Issue mode ("apply" codegen): the generated parser pushes the same raw issues the interpreter pushes instead of returning INVALID. Failure sites never hand-build issue objects — they cold-call the hoisted runtime parse/check of the failing node so the canonical issue comes from runtime code, and the generated code owns only the walk plumbing: path prefixes, abort/continue gating, sibling continuation, partial output assembly. Nodes with no native emission are handled by a node-scoped rerun island: the failing subtree runs through its own runtime parser and its issues merge in, which is exact parity at the cost of re-running that subtree's user callbacks (bounded at 2x, the same bound the whole-schema fallback has today).
+//////////////////////////////////////////////////////////////////////////////
+
+// mirrors util.prefixIssues, but from an index and applying a whole path prefix at once — same resulting arrays as the interpreter's per-level unshift
+export function prefixIssuesFrom(issues: unknown[], start: number, path: unknown[]): void {
+  for (let i = start; i < issues.length; i++) {
+    const iss = issues[i] as { path?: unknown[] };
+    iss.path = iss.path ? [...path, ...iss.path] : path.slice();
+  }
+}
+
+// Runs a node through its own runtime parser, merging its issues into the caller's payload — the issue path's escape hatch for constructs it doesn't model natively. A promise means an async member reached a sync parse, which the interpreter answers with a throw. `shared` marks a node whose runtime payload is the caller's own, so the abort flag a pipe or codec sets has to carry across.
+export function rerunNodeForIssues(
+  schema: SomeType,
+  value: unknown,
+  payload: ParsePayload,
+  pctx: ParseContextInternal | undefined,
+  shared: boolean
+): unknown {
+  // unwrap a compiled wrapper or global-mode shim: the island wants the interpreter, and under global mode `_zod.run` is the wrapper whose issue parser is the very code calling this
+  const live = schema._zod.run as ((p: ParsePayload, c: ParseContextInternal) => any) & {
+    __originalRun?: (p: ParsePayload, c: ParseContextInternal) => any;
+  };
+  const run = live.__originalRun ?? live;
+  const r = run({ value, issues: [] }, pctx ?? ({} as ParseContextInternal));
+  if (r && typeof (r as Promise<unknown>).then === "function") throw new $ZodAsyncError();
+  if (r.issues.length) payload.issues.push(...r.issues);
+  if (shared && r.aborted) payload.aborted = true;
+  return r.value;
+}
+
+// mirrors handleUnionResults for the all-branches-failed case: adopt the lone non-aborted branch outright, else aggregate every branch's finalized issues into one invalid_union
+export function unionIssuesForCompiled(
+  inst: SomeType,
+  input: unknown,
+  payload: ParsePayload,
+  results: ParsePayload[],
+  pctx: ParseContextInternal | undefined,
+  shared: boolean
+): unknown {
+  for (const r of results) {
+    if (r.issues.length === 0) return r.value;
+  }
+  const nonaborted = results.filter((r) => !util.aborted(r));
+  if (nonaborted.length === 1) {
+    const r = nonaborted[0]!;
+    payload.issues.push(...r.issues);
+    if (shared && r.aborted) payload.aborted = true;
+    return r.value;
+  }
+  payload.issues.push({
+    code: "invalid_union",
+    input,
+    inst,
+    errors: results.map((result) => result.issues.map((iss) => util.finalizeIssue(iss as never, pctx, config()))),
+  } as never);
+  return input;
+}
+
+// mirrors handlePipeResult's stop rule: any issue except unrecognized_keys halts the pipe, continuable or not
+export function pipeStops(issues: unknown[], start: number): boolean {
+  for (let i = start; i < issues.length; i++) {
+    if ((issues[i] as { code?: string }).code !== "unrecognized_keys") return true;
+  }
+  return false;
+}
+
+// mirrors handleNonOptionalResult's push; kept as a runtime helper so the shape lives in one place on this side
+export function pushNonOptionalIssue(issues: unknown[], input: unknown, inst: unknown): void {
+  (issues as { push: (i: unknown) => void }).push({ code: "invalid_type", expected: "nonoptional", input, inst });
+}
+
+/** JS expressions for the path from the root to the current node — string literals for static keys, variable names for loop indices, constant names for symbols. */
+export type IssuePath = string[];
+
+export function issueConsts(ctx: CompileContext) {
+  return {
+    pfx: addConstant(ctx, prefixIssuesFrom),
+    abt: addConstant(ctx, util.aborted),
+    eabt: addConstant(ctx, util.explicitlyAborted),
+    att: addConstant(ctx, util.attachSchema),
+  };
+}
+
+export const SP_INIT = `(_sp ??= { value: null, issues: payload.issues })`;
+
+// Cold block for a failed leaf type test: re-run the node's runtime parse so it pushes the canonical issue, then prefix. The parse re-evaluates a trivial predicate; the price of never hand-building an issue shape.
+export function leafFailBlock(ctx: CompileContext, schema: SomeType, accessor: string, path: IssuePath): string {
+  const { pfx } = issueConsts(ctx);
+  const parseConst = addConstant(ctx, schema._zod.parse);
+  const m = newVar(ctx);
+  const prefix = path.length ? ` ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);` : "";
+  return `{ ${SP_INIT}.value = ${accessor}; const ${m} = payload.issues.length; ${parseConst}(_sp, pctx);${prefix} }`;
+}
+
+interface ChainGate {
+  ab: string;
+  ex: string | null;
+}
+
+// Cold block for a failed check predicate: re-run the runtime check so it pushes canonically, stamp the owning schema, prefix, and update the abort gates. `label` breaks out of the check's remaining hot statements (multi-site checks like url).
+function checkFailBlock(
+  ctx: CompileContext,
+  check: { _zod: { check?: unknown } },
+  ownerConst: string,
+  accessor: string,
+  path: IssuePath,
+  gate: ChainGate,
+  label: string
+): string {
+  const { pfx, abt, eabt, att } = issueConsts(ctx);
+  const checkFn = (check._zod as { check?: unknown }).check;
+  if (typeof checkFn !== "function") throw new ZodCompileUnsupportedError("check without a runtime check function");
+  const checkConst = addConstant(ctx, checkFn);
+  const m = newVar(ctx);
+  const prefix = path.length ? ` ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);` : "";
+  const exUpd = gate.ex ? ` if (!${gate.ex}) ${gate.ex} = ${eabt}(payload, ${m});` : "";
+  return `{ ${SP_INIT}.value = ${accessor}; const ${m} = payload.issues.length; ${checkConst}(_sp); ${att}(payload.issues, ${m}, ${ownerConst});${prefix} if (!${gate.ab}) ${gate.ab} = ${abt}(payload, ${m});${exUpd} break ${label}; }`;
+}
+
+/**
+ * Issue-mode check chain. Mirrors the runChecks loop in $ZodType.init: a check
+ * runs unless the chain is aborted, a when-carrying check consults its `when`
+ * instead (and skips only on explicit abort), and every failure recomputes the
+ * gates from the issues it pushed. `valueVar` must be a reassignable binding —
+ * overwrite/url/refine rewrite it in place.
+ */
+export function generateChecksIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  valueVar: string,
+  path: IssuePath,
+  nodeMark: string,
+  abOverride: string | null = null
+): void {
+  const defChecks = (schema._zod.def.checks as SupportedCheck[] | undefined) ?? [];
+  const isOwnCheck = (schema._zod as { traits?: Set<string> }).traits?.has("$ZodCheck") === true;
+  const list: SupportedCheck[] = isOwnCheck ? [schema as unknown as SupportedCheck, ...defChecks] : defChecks;
+  if (list.length === 0) return;
+
+  const { pfx, abt, eabt, att } = issueConsts(ctx);
+  const ownerConst = addConstant(ctx, schema);
+  const hasWhen = list.some((c) => {
+    const d = c._zod.def as { when?: unknown; check: string };
+    return !!d.when;
+  });
+
+  const gate: ChainGate = { ab: newVar(ctx), ex: hasWhen ? newVar(ctx) : null };
+  // a stopped pipe reads as aborted (explicitly too) whatever its issues' continue flags say, matching util.aborted's payload.aborted short-circuit on the runtime's returned payload
+  const pre = abOverride ? `${abOverride} || ` : "";
+  doc.write(`let ${gate.ab} = ${pre}(payload.issues.length > ${nodeMark} && ${abt}(payload, ${nodeMark}));`);
+  if (gate.ex)
+    doc.write(`let ${gate.ex} = ${pre}(payload.issues.length > ${nodeMark} && ${eabt}(payload, ${nodeMark}));`);
+
+  for (const check of list) {
+    const def = check._zod.def as { check: string; when?: (p: unknown) => boolean };
+    if (def.when && !WHEN_DEFAULTED_CHECKS.has(def.check)) {
+      throw new ZodCompileUnsupportedError(`check with a custom "when" condition`);
+    }
+    const guard = def.when
+      ? `(!${gate.ab} || (!${gate.ex} && ${addConstant(ctx, def.when)}((${SP_INIT}.value = ${valueVar}, _sp))))`
+      : `!${gate.ab}`;
+
+    switch (def.check) {
+      case "custom": {
+        // the check function runs hot — it IS the user callback, and it pushes its own canonical issue (with the normalizing addIssue for superRefine), so there is no cold re-run and the callback executes exactly once
+        const c = check as CustomCheck;
+        const fn = c._zod.check ?? c._zod.def.fn;
+        if (!fn) throw new ZodCompileUnsupportedError("custom check without a predicate or check function");
+        if (
+          isAsyncFunction(fn) ||
+          (c._zod.def.fn && isAsyncFunction(c._zod.def.fn)) ||
+          (c._zod.check && isAsyncFunction(c._zod.check))
+        ) {
+          throw new ZodCompileAsyncError();
+        }
+        const checkConst = addConstant(ctx, c._zod.check);
+        const throwAsyncConst = addConstant(ctx, throwAsync);
+        const m = newVar(ctx);
+        const r = newVar(ctx);
+        doc.write(`if (${guard}) {`);
+        doc.indented((d) => {
+          d.write(`${SP_INIT}.value = ${valueVar};`);
+          d.write(`const ${m} = payload.issues.length;`);
+          d.write(`const ${r} = ${checkConst}(_sp);`);
+          d.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
+          d.write(`if (payload.issues.length > ${m}) {`);
+          d.indented((d2) => {
+            d2.write(`${att}(payload.issues, ${m}, ${ownerConst});`);
+            if (path.length) d2.write(`${pfx}(payload.issues, ${m}, [${path.join(", ")}]);`);
+            d2.write(`if (!${gate.ab}) ${gate.ab} = ${abt}(payload, ${m});`);
+            if (gate.ex) d2.write(`if (!${gate.ex}) ${gate.ex} = ${eabt}(payload, ${m});`);
+          });
+          d.write(`}`);
+          d.write(`${valueVar} = _sp.value;`);
+        });
+        doc.write(`}`);
+        break;
+      }
+      case "overwrite": {
+        const tx = (check as checks.$ZodCheckOverwrite)._zod.def.tx;
+        if (!tx) throw new ZodCompileUnsupportedError("overwrite check without a transform function");
+        if (isAsyncFunction(tx)) throw new ZodCompileAsyncError();
+        const txConst = addConstant(ctx, tx);
+        doc.write(`if (${guard}) ${valueVar} = ${txConst}(${valueVar});`);
+        break;
+      }
+      case "property":
+      case "properties": {
+        // hot: the fast-mode emission inside an IIFE; cold: re-run the whole check so it pushes canonically (it re-walks its children through the runtime)
+        const r = newVar(ctx);
+        const label = `c${newVar(ctx)}`;
+        doc.write(`if (${guard}) ${label}: {`);
+        doc.indented((d) => {
+          d.write(`const ${r} = (() => {`);
+          d.indented((d2) => {
+            if (def.check === "property") {
+              generatePropertyCheck(d2, ctx, check._zod.def as checks.$ZodCheckPropertyDef, valueVar);
+            } else {
+              generatePropertiesChecks(d2, ctx, check._zod.def as unknown as $ZodPropertiesDef, valueVar, false);
+            }
+            d2.write(`return true;`);
+          });
+          d.write(`})();`);
+          d.write(
+            `if (${r} === INVALID) ${checkFailBlock(ctx, check as { _zod: { check?: unknown } }, ownerConst, valueVar, path, gate, label)}`
+          );
+        });
+        doc.write(`}`);
+        break;
+      }
+      default: {
+        const label = `c${newVar(ctx)}`;
+        doc.write(`if (${guard}) ${label}: {`);
+        doc.indented((d) => {
+          const fail = () =>
+            checkFailBlock(ctx, check as { _zod: { check?: unknown } }, ownerConst, valueVar, path, gate, label);
+          const out = emitCheckPredicate(d, ctx, check, valueVar, fail);
+          if (out !== valueVar) d.write(`${valueVar} = ${out};`);
+        });
+        doc.write(`}`);
+      }
+    }
+  }
+}
+
+export function emitIssueIsland(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath,
+  shared: boolean
+): string {
+  const { pfx } = issueConsts(ctx);
+  const schemaConst = addConstant(ctx, schema);
+  const rerunConst = addConstant(ctx, rerunNodeForIssues);
+  const m = newVar(ctx);
+  const v = newVar(ctx);
+  doc.write(`const ${m} = payload.issues.length;`);
+  doc.write(`const ${v} = ${rerunConst}(${schemaConst}, ${accessor}, payload, pctx, ${shared});`);
+  if (path.length) doc.write(`if (payload.issues.length > ${m}) ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);`);
+  return v;
+}
+
+// Issue-mode counterpart of compileChild: try the native emission, roll back and island on an islandable refusal.
+export function compileChildIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath,
+  shared: boolean
+): string {
+  const contentLen = doc.content.length;
+  const constantCount = ctx.constants.size;
+  const constantCounter = ctx.constantCounter;
+  const varCounter = ctx.varCounter;
+  try {
+    return generateCheckIssues(doc, ctx, schema, accessor, path, shared);
+  } catch (err) {
+    if (!(err instanceof ZodCompileUnsupportedError) || !err.islandable) throw err;
+    doc.content.length = contentLen;
+    if (ctx.constants.size > constantCount) {
+      const trailing = Array.from(ctx.constants.keys()).slice(constantCount);
+      for (const k of trailing) ctx.constants.delete(k);
+    }
+    ctx.constantCounter = constantCounter;
+    ctx.varCounter = varCounter;
+    return emitIssueIsland(doc, ctx, schema, accessor, path, shared);
+  }
+}
+
+/** An issue-mode emitter for one node: writes the node's body against `accessor`, pushing canonical issues (prefixed with `path`) into `payload.issues`, and returns the accessor holding the node's value. `mark` is `payload.issues.length` before the node; a pipe also hands back the gate that stops its check chain. */
+export type IssueCodegen = (
+  doc: Doc,
+  ctx: CompileContext,
+  inst: SomeType,
+  accessor: string,
+  path: IssuePath,
+  shared: boolean,
+  mark: string
+) => string | { value: string; abOverride: string };
+
+/** The issue emitter for a simple-parse leaf: `failCondition` is the inverted type test, or null for a leaf that accepts anything and leaves the work to its check chain. */
+export function leafIssues(
+  failCondition: ((ctx: CompileContext, inst: SomeType, accessor: string) => string | null) | null
+): IssueCodegen {
+  return (doc, ctx, inst, accessor, path) => {
+    const isOwnCheck = (inst._zod as { traits?: Set<string> }).traits?.has("$ZodCheck") === true;
+    // a def-level format with no check trait would silently skip its own validation
+    const anyDef = inst._zod.def as { format?: unknown; check?: unknown; type: string };
+    if (!isOwnCheck && (anyDef.check !== undefined || (anyDef.format !== undefined && anyDef.type !== "literal"))) {
+      throw new ZodCompileUnsupportedError(`def-level format on a non-check ${anyDef.type} schema`);
+    }
+    const cond = failCondition?.(ctx, inst, accessor);
+    if (cond) doc.write(`if (${cond}) ${leafFailBlock(ctx, inst, accessor, path)}`);
+    return accessor;
+  };
+}
+
+// Central issue-mode dispatch. Every native node shares the pattern: take a mark, emit the node body through its class's issue emitter, then run the node's own check chain against the mark — the chain lives HERE (not per node) because any schema type can carry checks. A node whose class has no issue emitter islands, and the rerun covers its checks.
+function generateCheckIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath,
+  shared: boolean
+): string {
+  const def = schema._zod.def;
+
+  // coercion rewrites the value before the type test — the interpreter models it, so island the node
+  const emit = (def as { coerce?: boolean }).coerce ? undefined : emitterFor(schema)?.issues;
+  if (!emit) return emitIssueIsland(doc, ctx, schema, accessor, path, shared);
+
+  const defChecks = (def.checks as unknown[] | undefined) ?? [];
+  const isOwnCheck = (schema._zod as { traits?: Set<string> }).traits?.has("$ZodCheck") === true;
+  const hasChain = defChecks.length > 0 || isOwnCheck;
+
+  const mark = newVar(ctx);
+  doc.write(`const ${mark} = payload.issues.length;`);
+
+  const out = emit(doc, ctx, schema, accessor, path, shared, mark);
+  const value = typeof out === "string" ? out : out.value;
+  const abOverride = typeof out === "string" ? null : out.abOverride;
+
+  if (!hasChain) return value;
+  // the chain mutates its accessor, so alias non-let values
+  const chainVar = newVar(ctx);
+  doc.write(`let ${chainVar} = ${value};`);
+  generateChecksIssues(doc, ctx, schema, chainVar, path, mark, abOverride);
+  return chainVar;
 }
 
 export function isAsyncFunction(fn: unknown): boolean {

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1340,8 +1340,7 @@ export function generateChecksIssues(
   valueVar: string,
   path: IssuePath,
   nodeMark: string,
-  abOverride: string | null,
-  shared: boolean
+  abOverride: string | null = null
 ): void {
   const defChecks = (schema._zod.def.checks as SupportedCheck[] | undefined) ?? [];
   const isOwnCheck = (schema._zod as { traits?: Set<string> }).traits?.has("$ZodCheck") === true;
@@ -1367,10 +1366,8 @@ export function generateChecksIssues(
     if (def.when && !WHEN_DEFAULTED_CHECKS.has(def.check)) {
       throw new ZodCompileUnsupportedError(`check with a custom "when" condition`);
     }
-    // a node the interpreter parses on a payload of its own (an object property, an array element) shows its callbacks only its own issues: a local payload seeded with what this node pushed so far, merged back afterwards. a node on the shared spine hands over the scratch payload, whose issues array is the caller's
-    const ownPayload = `{ value: ${valueVar}, issues: ${nodeMark ? `payload.issues.slice(${nodeMark})` : "[]"} }`;
     const guard = def.when
-      ? `(!${gate.ab} || (!${gate.ex} && ${addConstant(ctx, def.when)}(${shared ? `(${SP_INIT}.value = ${valueVar}, _sp)` : ownPayload})))`
+      ? `(!${gate.ab} || (!${gate.ex} && ${addConstant(ctx, def.when)}((${SP_INIT}.value = ${valueVar}, _sp))))`
       : `!${gate.ab}`;
 
     switch (def.check) {
@@ -1392,23 +1389,10 @@ export function generateChecksIssues(
         const r = newVar(ctx);
         doc.write(`if (${guard}) {`);
         doc.indented((d) => {
-          if (shared) {
-            d.write(`${SP_INIT}.value = ${valueVar};`);
-            d.write(`const ${m} = payload.issues.length;`);
-            d.write(`const ${r} = ${checkConst}(_sp);`);
-            d.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
-          } else {
-            const p = newVar(ctx);
-            const n = newVar(ctx);
-            d.write(`const ${p} = ${ownPayload};`);
-            d.write(`const ${n} = ${p}.issues.length;`);
-            d.write(`const ${r} = ${checkConst}(${p});`);
-            d.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
-            d.write(`const ${m} = payload.issues.length;`);
-            const i = newVar(ctx);
-            d.write(`for (let ${i} = ${n}; ${i} < ${p}.issues.length; ${i}++) payload.issues.push(${p}.issues[${i}]);`);
-            d.write(`${valueVar} = ${p}.value;`);
-          }
+          d.write(`${SP_INIT}.value = ${valueVar};`);
+          d.write(`const ${m} = payload.issues.length;`);
+          d.write(`const ${r} = ${checkConst}(_sp);`);
+          d.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
           d.write(`if (payload.issues.length > ${m}) {`);
           d.indented((d2) => {
             d2.write(`${att}(payload.issues, ${m}, ${ownerConst});`);
@@ -1417,7 +1401,7 @@ export function generateChecksIssues(
             if (gate.ex) d2.write(`if (!${gate.ex}) ${gate.ex} = ${eabt}(payload, ${m});`);
           });
           d.write(`}`);
-          if (shared) d.write(`${valueVar} = _sp.value;`);
+          d.write(`${valueVar} = _sp.value;`);
         });
         doc.write(`}`);
         break;
@@ -1498,6 +1482,59 @@ export function emitIssueIsland(
   return v;
 }
 
+const CHILD_KEYS = ["innerType", "element", "rest", "in", "out", "left", "right", "keyType", "valueType"] as const;
+const runsCallbacks = new WeakMap<object, boolean>();
+
+// Whether an issue-mode walk of this subtree runs user code that can read its parse payload: a custom check, a `when` predicate, a transform. A lazy stays out because issue mode islands it, and the interpreter hands the island its own payloads.
+export function subtreeRunsCallbacks(schema: SomeType): boolean {
+  const known = runsCallbacks.get(schema);
+  if (known !== undefined) return known;
+  // an assumed answer for a subtree still being scanned
+  runsCallbacks.set(schema, false);
+  const def = schema._zod.def as Record<string, unknown> & { type: string; checks?: unknown[] };
+  let out = def.type === "custom" || def.type === "transform" || !!def.transform;
+  if (!out && def.checks) {
+    out = def.checks.some((c) => {
+      const cdef = (c as { _zod: { def: { check: string; when?: unknown } } })._zod.def;
+      return cdef.check === "custom" || !!cdef.when;
+    });
+  }
+  if (!out) {
+    const children: unknown[] = [];
+    for (const key of CHILD_KEYS) if (def[key]) children.push(def[key]);
+    if (Array.isArray(def.items)) children.push(...(def.items as unknown[]));
+    if (Array.isArray(def.options)) children.push(...(def.options as unknown[]));
+    if (def.shape) children.push(...Object.values(def.shape as Record<string, unknown>));
+    out = children.some((child) => !!(child as SomeType)?._zod && subtreeRunsCallbacks(child as SomeType));
+  }
+  runsCallbacks.set(schema, out);
+  return out;
+}
+
+// the child parsed on its own payload: its issues join the parent's with the child's path in front, as handlePropertyResult and the array walk do
+export function mergeChildIssues(payload: ParsePayload, child: ParsePayload, path: unknown[]): void {
+  if (!child.issues.length) return;
+  const m = payload.issues.length;
+  payload.issues.push(...child.issues);
+  if (path.length) prefixIssuesFrom(payload.issues, m, path);
+}
+
+// A subtree whose callbacks could read the payload runs inside one of its own, as the interpreter gives every object property, array element and record value: the callbacks see only the child's issues, with child-relative paths, and the parent takes the issues afterwards. A subtree without callbacks pushes straight into the parent's array with its path prefixed at the site, which is the same result without the payload and the closure.
+function emitIsolatedChild(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string, path: IssuePath): string {
+  const mergeConst = addConstant(ctx, mergeChildIssues);
+  const r = newVar(ctx);
+  doc.write(`const ${r} = ((payload) => {`);
+  doc.indented((d) => {
+    d.write(`let _sp;`);
+    const value = compileChildIssues(d, ctx, schema, "payload.value", [], true);
+    d.write(`payload.value = ${value};`);
+    d.write(`return payload;`);
+  });
+  doc.write(`})({ value: ${accessor}, issues: [] });`);
+  doc.write(`${mergeConst}(payload, ${r}, ${path.length ? pathExpr(ctx, path) : "[]"});`);
+  return `${r}.value`;
+}
+
 // Issue-mode counterpart of compileChild: try the native emission, roll back and island on an islandable refusal.
 export function compileChildIssues(
   doc: Doc,
@@ -1507,6 +1544,7 @@ export function compileChildIssues(
   path: IssuePath,
   shared: boolean
 ): string {
+  if (!shared && subtreeRunsCallbacks(schema)) return emitIsolatedChild(doc, ctx, schema, accessor, path);
   const contentLen = doc.content.length;
   const constantCount = ctx.constants.size;
   const constantCounter = ctx.constantCounter;
@@ -1586,7 +1624,7 @@ function generateCheckIssues(
   // the chain mutates its accessor, so alias non-let values
   const chainVar = newVar(ctx);
   doc.write(`let ${chainVar} = ${value};`);
-  generateChecksIssues(doc, ctx, schema, chainVar, path, mark, abOverride, shared);
+  generateChecksIssues(doc, ctx, schema, chainVar, path, mark, abOverride);
   return chainVar;
 }
 

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1512,8 +1512,10 @@ function childrenReachCallbacks(def: object): boolean {
     if ((value as Partial<ZodNode>)._zod) {
       if (subtreeRunsCallbacks(value as ZodNode)) return true;
     } else if (Array.isArray(value) || Object.getPrototypeOf(value) === Object.prototype) {
-      for (const el of Object.values(value)) {
-        if ((el as Partial<ZodNode> | null)?._zod && subtreeRunsCallbacks(el as ZodNode)) return true;
+      // the entries by descriptor too: a plain object in a def can carry accessors of its own
+      for (const k of Object.keys(value)) {
+        const el = Object.getOwnPropertyDescriptor(value, k);
+        if (el && !el.get && (el.value as Partial<ZodNode> | null)?._zod && subtreeRunsCallbacks(el.value)) return true;
       }
     }
   }

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1340,7 +1340,8 @@ export function generateChecksIssues(
   valueVar: string,
   path: IssuePath,
   nodeMark: string,
-  abOverride: string | null = null
+  abOverride: string | null,
+  shared: boolean
 ): void {
   const defChecks = (schema._zod.def.checks as SupportedCheck[] | undefined) ?? [];
   const isOwnCheck = (schema._zod as { traits?: Set<string> }).traits?.has("$ZodCheck") === true;
@@ -1366,8 +1367,10 @@ export function generateChecksIssues(
     if (def.when && !WHEN_DEFAULTED_CHECKS.has(def.check)) {
       throw new ZodCompileUnsupportedError(`check with a custom "when" condition`);
     }
+    // a node the interpreter parses on a payload of its own (an object property, an array element) shows its callbacks only its own issues: a local payload seeded with what this node pushed so far, merged back afterwards. a node on the shared spine hands over the scratch payload, whose issues array is the caller's
+    const ownPayload = `{ value: ${valueVar}, issues: ${nodeMark ? `payload.issues.slice(${nodeMark})` : "[]"} }`;
     const guard = def.when
-      ? `(!${gate.ab} || (!${gate.ex} && ${addConstant(ctx, def.when)}((${SP_INIT}.value = ${valueVar}, _sp))))`
+      ? `(!${gate.ab} || (!${gate.ex} && ${addConstant(ctx, def.when)}(${shared ? `(${SP_INIT}.value = ${valueVar}, _sp)` : ownPayload})))`
       : `!${gate.ab}`;
 
     switch (def.check) {
@@ -1389,10 +1392,23 @@ export function generateChecksIssues(
         const r = newVar(ctx);
         doc.write(`if (${guard}) {`);
         doc.indented((d) => {
-          d.write(`${SP_INIT}.value = ${valueVar};`);
-          d.write(`const ${m} = payload.issues.length;`);
-          d.write(`const ${r} = ${checkConst}(_sp);`);
-          d.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
+          if (shared) {
+            d.write(`${SP_INIT}.value = ${valueVar};`);
+            d.write(`const ${m} = payload.issues.length;`);
+            d.write(`const ${r} = ${checkConst}(_sp);`);
+            d.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
+          } else {
+            const p = newVar(ctx);
+            const n = newVar(ctx);
+            d.write(`const ${p} = ${ownPayload};`);
+            d.write(`const ${n} = ${p}.issues.length;`);
+            d.write(`const ${r} = ${checkConst}(${p});`);
+            d.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
+            d.write(`const ${m} = payload.issues.length;`);
+            const i = newVar(ctx);
+            d.write(`for (let ${i} = ${n}; ${i} < ${p}.issues.length; ${i}++) payload.issues.push(${p}.issues[${i}]);`);
+            d.write(`${valueVar} = ${p}.value;`);
+          }
           d.write(`if (payload.issues.length > ${m}) {`);
           d.indented((d2) => {
             d2.write(`${att}(payload.issues, ${m}, ${ownerConst});`);
@@ -1401,7 +1417,7 @@ export function generateChecksIssues(
             if (gate.ex) d2.write(`if (!${gate.ex}) ${gate.ex} = ${eabt}(payload, ${m});`);
           });
           d.write(`}`);
-          d.write(`${valueVar} = _sp.value;`);
+          if (shared) d.write(`${valueVar} = _sp.value;`);
         });
         doc.write(`}`);
         break;
@@ -1570,7 +1586,7 @@ function generateCheckIssues(
   // the chain mutates its accessor, so alias non-let values
   const chainVar = newVar(ctx);
   doc.write(`let ${chainVar} = ${value};`);
-  generateChecksIssues(doc, ctx, schema, chainVar, path, mark, abOverride);
+  generateChecksIssues(doc, ctx, schema, chainVar, path, mark, abOverride, shared);
   return chainVar;
 }
 

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -2,8 +2,8 @@ import type * as checks from "./checks.js";
 import type * as core from "./core.js";
 import { $ZodAsyncError } from "./core.js";
 import { Doc } from "./doc.js";
+import { codegenFor } from "./jit.js";
 import { isBackEdge, isRecursiveSchema } from "./memoizer.js";
-import * as regexes from "./regexes.js";
 import {
   isValidBase64,
   isValidBase64URL,
@@ -11,7 +11,6 @@ import {
   isValidCreditCard,
   isValidIPv6,
   isValidJWT,
-  mergeValues,
   parseURLObject,
   stripTabAndNewline,
   urlHostnameOk,
@@ -65,7 +64,7 @@ export class ZodCompileUnsupportedError extends Error {
   }
 }
 
-interface CompileContext {
+export interface CompileContext {
   constants: Map<string, unknown>;
   constantCounter: number;
   varCounter: number;
@@ -265,7 +264,7 @@ export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOpti
   return fn;
 }
 
-function addConstant(ctx: CompileContext, value: unknown): string {
+export function addConstant(ctx: CompileContext, value: unknown): string {
   // Check if we already have this constant
   for (const [name, v] of ctx.constants) {
     if (v === value) return name;
@@ -276,12 +275,12 @@ function addConstant(ctx: CompileContext, value: unknown): string {
 }
 
 /** Hoists a user-supplied callback. Anything the schema's author wrote can throw, and generated code can reject an earlier sibling before ever reaching it, so this clears `definite` — a rejection is then no longer proof that the interpreter would have rejected rather than thrown. */
-function addUserConstant(ctx: CompileContext, fn: unknown): string {
+export function addUserConstant(ctx: CompileContext, fn: unknown): string {
   ctx.definite = false;
   return addConstant(ctx, fn);
 }
 
-function newVar(ctx: CompileContext): string {
+export function newVar(ctx: CompileContext): string {
   return `v${ctx.varCounter++}`;
 }
 
@@ -301,8 +300,8 @@ function runtimeRun(schema: SomeType, value: unknown): unknown {
 // runtime island is emitted instead — the child schema is invoked through
 // `runtimeRun` at parse time and treated as a black box. Anything else thrown
 // propagates (e.g. `ZodCompileAsyncError`).
-function compileChild(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string;
-function compileChild(
+export function compileChild(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string;
+export function compileChild(
   doc: Doc,
   ctx: CompileContext,
   schema: SomeType,
@@ -310,7 +309,7 @@ function compileChild(
   needsValue: boolean
 ): string | null;
 // `null` means the node built no value because nothing reads it. The overloads keep that case out of the 20-odd callers that always want one, so only a caller passing needsValue has to handle it.
-function compileChild(
+export function compileChild(
   doc: Doc,
   ctx: CompileContext,
   schema: SomeType,
@@ -357,7 +356,7 @@ const WHEN_DEFAULTED_CHECKS = new Set([
   "length_equals",
 ]);
 
-function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+export function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
   const schemaChecks = schema._zod.def.checks as SupportedCheck[] | undefined;
   if (!schemaChecks || schemaChecks.length === 0) return accessor;
 
@@ -533,7 +532,7 @@ function generateMultipleOfCheck(
   }
 }
 
-function generateNumberFormatCheck(doc: Doc, def: checks.$ZodCheckNumberFormatDef, accessor: string): void {
+export function generateNumberFormatCheck(doc: Doc, def: checks.$ZodCheckNumberFormatDef, accessor: string): void {
   const format = def.format;
   switch (format) {
     case "safeint":
@@ -594,7 +593,7 @@ function generateMimeTypeCheck(
 }
 
 // asserts each named property in place; children compile assert-only because z.properties never rebuilds its input
-function generatePropertiesChecks(
+export function generatePropertiesChecks(
   doc: Doc,
   ctx: CompileContext,
   def: $ZodPropertiesDef,
@@ -658,12 +657,12 @@ type CustomCheck = {
   _zod: { def: { check: "custom"; fn?: (value: unknown) => boolean }; check?: (payload: unknown) => unknown };
 };
 /** A predicate that hands back a thenable is an async check reached synchronously, and the interpreter throws `$ZodAsyncError` for it. Returning INVALID instead would be a bail-out, and a union reads a bail-out as a rejected branch and answers with a later one — so the throw has to survive into generated code. */
-function throwAsync(): never {
+export function throwAsync(): never {
   throw new $ZodAsyncError();
 }
 
 /** Shared `addIssue` for the spoofed payloads a refine, check or transform receives. Allocating one per call — a fresh closure plus a `this`-bound method on a fresh literal — pinned every payload-allocating schema at ~2.7M ops/sec against 135M for a plain object literal. It captures nothing per call; it only reaches `this.issues`. */
-function pushIssue(this: { issues: unknown[] }, issue: unknown): void {
+export function pushIssue(this: { issues: unknown[] }, issue: unknown): void {
   this.issues.push(issue);
 }
 
@@ -711,7 +710,7 @@ function generateCustomRefineCheck(doc: Doc, ctx: CompileContext, check: CustomC
   throw new ZodCompileUnsupportedError("custom check without a predicate or check function");
 }
 
-type StringFormatDef =
+export type StringFormatDef =
   | checks.$ZodCheckStringFormatDef
   | checks.$ZodCheckRegexDef
   | checks.$ZodCheckLowerCaseDef
@@ -758,7 +757,12 @@ const PATTERN_IS_COMPLETE: Set<string> = new Set([
 ]);
 
 // Returns the accessor holding the (possibly normalized) value after the check — url/normalize formats produce a new value like overwrite does. Never assigns to the incoming accessor: it may be a `const` or a property expression on user input.
-function generateStringFormatCheck(doc: Doc, ctx: CompileContext, def: StringFormatDef, accessor: string): string {
+export function generateStringFormatCheck(
+  doc: Doc,
+  ctx: CompileContext,
+  def: StringFormatDef,
+  accessor: string
+): string {
   // Some string formats do runtime validation beyond their advertised pattern. For cheap pure utility checks, hoist the runtime function and call it so the fast path stays correct without cloning the utility logic into codegen.
   const fmt = def.format;
   if (fmt === "base64") {
@@ -873,56 +877,15 @@ function generateStringFormatCheck(doc: Doc, ctx: CompileContext, def: StringFor
   return accessor;
 }
 
-// Union of all schema types we support in AOT compilation
-type SupportedSchemaType =
-  | "string"
-  | "number"
-  | "boolean"
-  | "bigint"
-  | "symbol"
-  | "undefined"
-  | "null"
-  | "any"
-  | "unknown"
-  | "never"
-  | "void"
-  | "nan"
-  | "date"
-  | "object"
-  | "optional"
-  | "nullable"
-  | "array"
-  | "literal"
-  | "enum"
-  | "readonly"
-  | "success"
-  | "default"
-  | "prefault"
-  | "nonoptional"
-  | "tuple"
-  | "union"
-  | "intersection"
-  | "record"
-  | "map"
-  | "set"
-  | "file"
-  | "template_literal"
-  | "lazy"
-  | "pipe"
-  | "custom"
-  | "properties"
-  | "transform"
-  | "catch";
-
-function generateCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string;
-function generateCheck(
+export function generateCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string;
+export function generateCheck(
   doc: Doc,
   ctx: CompileContext,
   schema: SomeType,
   accessor: string,
   needsValue: boolean
 ): string | null;
-function generateCheck(
+export function generateCheck(
   doc: Doc,
   ctx: CompileContext,
   schema: SomeType,
@@ -930,7 +893,7 @@ function generateCheck(
   needsValue = true
 ): string | null {
   const def = schema._zod.def;
-  const type = def.type as SupportedSchemaType;
+  const type = def.type;
 
   // A coercing schema would compile to the bare type test and reject what it should convert; inside a union that reads as a rejected branch, so refuse at codegen.
   if ((def as { coerce?: boolean }).coerce) {
@@ -939,137 +902,12 @@ function generateCheck(
 
   // A node builds its output when its caller reads one, or when it carries checks of its own, since a check reads what was built. One polarity for the whole walk: this is what the node does, and it is what its children are told they need.
   const buildsValue = needsValue || !!def.checks?.length;
-  let typeAccessor: string | null;
 
-  switch (type) {
-    case "string":
-      typeAccessor = generateStringCheck(doc, ctx, schema, accessor);
-      break;
-    case "number":
-      typeAccessor = generateNumberCheck(doc, schema, accessor);
-      break;
-    case "boolean":
-      typeAccessor = generateBooleanCheck(doc, accessor);
-      break;
-    case "bigint":
-      typeAccessor = generateBigIntCheck(doc, schema, accessor);
-      break;
-    case "symbol":
-      typeAccessor = generateSymbolCheck(doc, accessor);
-      break;
-    case "undefined":
-      typeAccessor = generateUndefinedCheck(doc, accessor);
-      break;
-    case "null":
-      typeAccessor = generateNullCheck(doc, accessor);
-      break;
-    case "any":
-    case "unknown":
-      // No check needed - pass through
-      typeAccessor = accessor;
-      break;
-    case "never":
-      doc.write("return INVALID;");
-      typeAccessor = accessor;
-      break;
-    case "void":
-      typeAccessor = generateVoidCheck(doc, accessor);
-      break;
-    case "nan":
-      typeAccessor = generateNaNCheck(doc, accessor);
-      break;
-    case "date":
-      typeAccessor = generateDateCheck(doc, accessor);
-      break;
-    case "object":
-      typeAccessor = generateObjectCheck(doc, ctx, schema, accessor, buildsValue);
-      break;
-    case "optional":
-      typeAccessor = generateOptionalCheck(doc, ctx, schema, accessor, buildsValue);
-      break;
-    case "nullable":
-      typeAccessor = generateNullableCheck(doc, ctx, schema, accessor, buildsValue);
-      break;
-    case "array":
-      typeAccessor = generateArrayCheck(doc, ctx, schema, accessor, buildsValue);
-      break;
-    case "literal":
-      typeAccessor = generateLiteralCheck(doc, ctx, schema, accessor);
-      break;
-    case "enum":
-      typeAccessor = generateEnumCheck(doc, ctx, schema, accessor);
-      break;
-    case "readonly": {
-      const innerOut = generateWrapperCheck(doc, ctx, schema, accessor);
-      // Runtime freezes the parsed value (schemas.ts handleReadonlyResult).
-      const frozenVar = newVar(ctx);
-      doc.write(`const ${frozenVar} = Object.freeze(${innerOut});`);
-      typeAccessor = frozenVar;
-      break;
-    }
-    case "success":
-      // Runtime output is `issues.length === 0`. The fast path only reaches
-      // here when the inner check passed (failure returns INVALID and the
-      // runtime fallback reproduces the inner issues), so the output is
-      // always `true`.
-      generateWrapperCheck(doc, ctx, schema, accessor);
-      typeAccessor = "true";
-      break;
-    case "default":
-    case "prefault":
-      typeAccessor = generateDefaultCheck(doc, ctx, schema, accessor);
-      break;
-    case "nonoptional":
-      typeAccessor = generateNonOptionalCheck(doc, ctx, schema, accessor);
-      break;
-    case "tuple":
-      typeAccessor = generateTupleCheck(doc, ctx, schema, accessor);
-      break;
-    case "union":
-      typeAccessor = generateUnionCheck(doc, ctx, schema, accessor);
-      break;
-    case "intersection":
-      typeAccessor = generateIntersectionCheck(doc, ctx, schema, accessor);
-      break;
-    case "record":
-      typeAccessor = generateRecordCheck(doc, ctx, schema, accessor);
-      break;
-    case "map":
-      typeAccessor = generateMapCheck(doc, ctx, schema, accessor);
-      break;
-    case "set":
-      typeAccessor = generateSetCheck(doc, ctx, schema, accessor);
-      break;
-    case "file":
-      typeAccessor = generateFileCheck(doc, accessor);
-      break;
-    case "template_literal":
-      typeAccessor = generateTemplateLiteralCheck(doc, ctx, schema, accessor);
-      break;
-    case "lazy":
-      typeAccessor = generateLazyCheck(doc, ctx, schema, accessor);
-      break;
-    case "pipe":
-      typeAccessor = generatePipeCheck(doc, ctx, schema, accessor);
-      break;
-    case "custom":
-      typeAccessor = generateCustomCheck(doc, ctx, schema, accessor);
-      break;
-    case "properties":
-      generatePropertiesChecks(doc, ctx, (schema as $ZodProperties)._zod.def, accessor, true);
-      typeAccessor = accessor;
-      break;
-    case "transform":
-      typeAccessor = generateTransformCheck(doc, ctx, schema, accessor);
-      break;
-    case "catch":
-      typeAccessor = generateCatchCheck(doc, ctx, schema, accessor);
-      break;
-    default: {
-      void (type satisfies never);
-      throw new ZodCompileUnsupportedError(`schema type ${type}`);
-    }
+  const codegen = codegenFor(schema);
+  if (!codegen) {
+    throw new ZodCompileUnsupportedError(`schema type ${type}`);
   }
+  const typeAccessor = codegen(doc, ctx, accessor, buildsValue);
 
   // a node that built nothing has no checks to run: not building requires an empty check list
   if (typeAccessor === null) return null;
@@ -1078,289 +916,12 @@ function generateCheck(
   return generateChecks(doc, ctx, schema, typeAccessor);
 }
 
-function generateStringCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  doc.write(`if (typeof ${accessor} !== "string") return INVALID;`);
-
-  // z.email() carries its format on the def, z.string().email() in def.checks; both route here so the format table has no second copy to drift from.
-  const def = schema._zod.def as unknown as StringFormatDef & { format?: string };
-  if (def.format === undefined) return accessor;
-  return generateStringFormatCheck(doc, ctx, def, accessor);
-}
-
-function generateNumberCheck(doc: Doc, schema: SomeType, accessor: string): string {
-  // Runtime z.number() rejects NaN and ±Infinity. Number.isFinite covers both.
-  doc.write(`if (typeof ${accessor} !== "number" || !Number.isFinite(${accessor})) return INVALID;`);
-
-  // Mini factories like z.int(), z.int32(), z.uint32(), z.float32() bake a number_format check into the schema def itself (not into def.checks). Apply the same constraint here.
-  const def = schema._zod.def as unknown as { check?: string; format?: string };
-  if (def.check === "number_format" && def.format) {
-    generateNumberFormatCheck(doc, { format: def.format } as checks.$ZodCheckNumberFormatDef, accessor);
-  }
-  return accessor;
-}
-
-function generateBooleanCheck(doc: Doc, accessor: string): string {
-  doc.write(`if (typeof ${accessor} !== "boolean") return INVALID;`);
-  return accessor;
-}
-
-function generateBigIntCheck(doc: Doc, schema: SomeType, accessor: string): string {
-  doc.write(`if (typeof ${accessor} !== "bigint") return INVALID;`);
-
-  // Handle bigint format (int64, uint64) directly on the schema def
-  const def = schema._zod.def as unknown as { format?: string };
-  if (def.format) {
-    switch (def.format) {
-      case "int64":
-        doc.write(`if (${accessor} < -9223372036854775808n || ${accessor} > 9223372036854775807n) return INVALID;`);
-        break;
-      case "uint64":
-        doc.write(`if (${accessor} < 0n || ${accessor} > 18446744073709551615n) return INVALID;`);
-        break;
-    }
-  }
-  return accessor;
-}
-
-function generateSymbolCheck(doc: Doc, accessor: string): string {
-  doc.write(`if (typeof ${accessor} !== "symbol") return INVALID;`);
-  return accessor;
-}
-
-function generateUndefinedCheck(doc: Doc, accessor: string): string {
-  doc.write(`if (${accessor} !== undefined) return INVALID;`);
-  return accessor;
-}
-
-function generateNullCheck(doc: Doc, accessor: string): string {
-  doc.write(`if (${accessor} !== null) return INVALID;`);
-  return accessor;
-}
-
-function generateVoidCheck(doc: Doc, accessor: string): string {
-  doc.write(`if (${accessor} !== undefined) return INVALID;`);
-  return accessor;
-}
-
-function generateNaNCheck(doc: Doc, accessor: string): string {
-  doc.write(`if (typeof ${accessor} !== "number" || !Number.isNaN(${accessor})) return INVALID;`);
-  return accessor;
-}
-
-function generateDateCheck(doc: Doc, accessor: string): string {
-  doc.write(`if (!(${accessor} instanceof Date) || Number.isNaN(${accessor}.getTime())) return INVALID;`);
-  return accessor;
-}
-
-function generateObjectCheck(
-  doc: Doc,
-  ctx: CompileContext,
-  schema: SomeType,
-  accessor: string,
-  buildsValue = true
-): string | null {
-  const def = schema._zod.def as unknown as { shape: Record<string, SomeType>; catchall?: SomeType };
-
-  // Check that input is a non-null, non-array object
-  doc.write(
-    `if (typeof ${accessor} !== "object" || ${accessor} === null || Array.isArray(${accessor})) return INVALID;`
-  );
-
-  const shape = def.shape;
-  const keys = Object.keys(shape);
-  const symbolKeys = Object.getOwnPropertySymbols(shape);
-  // a symbol has no source literal, so it is hoisted as a constant; `keys` stays string-only where the emitted code uses `for...in`
-  const allKeys: (string | symbol)[] = symbolKeys.length ? [...keys, ...symbolKeys] : keys;
-  const keyExpr = (k: string | symbol) => (typeof k === "symbol" ? addConstant(ctx, k) : util.esc(k));
-  const propKey = (k: string | symbol) => (typeof k === "symbol" ? `[${keyExpr(k)}]` : util.esc(k));
-  const propShape = shape as Record<string | symbol, SomeType>;
-
-  // `__proto__` as an own shape key can't be expressed in an output object literal (the literal form sets the prototype instead of an own property).
-  if (keys.includes("__proto__")) {
-    throw new ZodCompileUnsupportedError('object shape key "__proto__"');
-  }
-
-  // Map from key to output accessor for that property
-  const propOutputs = new Map<string | symbol, string>();
-
-  // Validate each property and collect output accessors
-  for (const key of allKeys) {
-    const propSchema = propShape[key]!;
-    const kx = keyExpr(key);
-    // Always cache the property read: the runtime reads input[key] exactly once, so a getter must not be re-read by checks or output assembly.
-    const inputVar = newVar(ctx);
-    doc.write(`const ${inputVar} = ${accessor}[${kx}];`);
-
-    if (propSchema._zod.optin !== undefined) {
-      // Any optin rung means the key may be omitted. The runtime runs the property anyway and ignores issues only when the key is genuinely absent, which is what makes exactOptional compositional.
-      const outputVar = newVar(ctx);
-      doc.write(`let ${outputVar} = (() => {`);
-      doc.indented((d) => {
-        const outputAccessor = compileChild(d, ctx, propSchema, inputVar);
-        d.write(`return ${outputAccessor};`);
-      });
-      doc.write(`})();`);
-
-      if (propSchema._zod.optout === "optional") {
-        doc.write(`if (${outputVar} === INVALID) {`);
-        doc.indented((d) => {
-          d.write(`if (${kx} in ${accessor}) return INVALID;`);
-          d.write(`${outputVar} = undefined;`);
-        });
-        doc.write(`}`);
-      } else {
-        doc.write(`if (${outputVar} === INVALID) return INVALID;`);
-      }
-      propOutputs.set(key, outputVar);
-    } else {
-      if (requiresPresenceCheck(propSchema)) {
-        doc.write(`if (!(${kx} in ${accessor})) return INVALID;`);
-      }
-
-      // Generate check and get output accessor
-      const outputAccessor = compileChild(doc, ctx, propSchema, inputVar, buildsValue);
-      if (outputAccessor !== null) propOutputs.set(key, outputAccessor);
-    }
-  }
-
-  // Handle catchall
-  const catchall = def.catchall;
-  let unknownKeysMode: "none" | "passthrough" | "schema" = "none";
-
-  if (catchall) {
-    const catchallType = catchall._zod.def.type;
-
-    if (catchallType === "never") {
-      // Strict: one `for...in`, as the runtime does, so inherited enumerable keys count. An undeclared `__proto__` is reported here and excluded only from the output (#6221); an own-key count would wrongly reject a class instance.
-      const condition = keys.map((k) => `k !== ${util.esc(k)}`).join(" && ") || "true";
-      doc.write(`for (const k in ${accessor}) {`);
-      doc.indented((d) => {
-        d.write(`if (${condition}) return INVALID;`);
-      });
-      doc.write(`}`);
-    } else if ((catchallType === "unknown" || catchallType === "any") && !catchall._zod.def.checks?.length) {
-      unknownKeysMode = "passthrough";
-    } else {
-      unknownKeysMode = "schema";
-    }
-  }
-  // else: strip mode (no catchall) - unknown keys ignored, only include known keys
-
-  // Shape keys in declared order, then unknown keys in for...in order. A middle-rung key is included iff present on the input, else iff its output is not undefined.
-  const outputVar = newVar(ctx);
-  const hasConditionalKeys = allKeys.some((k) => mayOutputUndefined(propShape[k]!) || dropsWhenAbsent(propShape[k]!));
-
-  // Assert mode: every declared key is validated above, so the output literal and the unknown-key copy are pure waste. A `never` catchall already emitted its rejection loop; a schema catchall still has to validate the values it would otherwise have stored.
-  if (!buildsValue) {
-    if (unknownKeysMode === "schema") {
-      const knownSet = keys.length > 0 ? addConstant(ctx, new Set(keys)) : null;
-      doc.write(`for (const k in ${accessor}) {`);
-      doc.indented((d) => {
-        d.write(`if (k === "__proto__") continue;`);
-        if (knownSet) d.write(`if (${knownSet}.has(k)) continue;`);
-        const valVar = newVar(ctx);
-        d.write(`const ${valVar} = ${accessor}[k];`);
-        compileChild(d, ctx, catchall!, valVar, false);
-      });
-      doc.write(`}`);
-    }
-    return null;
-  }
-
-  if (!hasConditionalKeys) {
-    const propLiterals = allKeys.map((k) => `${propKey(k)}: ${propOutputs.get(k)}`).join(", ");
-    doc.write(`const ${outputVar} = { ${propLiterals} };`);
-  } else {
-    doc.write(`const ${outputVar} = {};`);
-    for (const k of allKeys) {
-      const kx = keyExpr(k);
-      const out = propOutputs.get(k);
-      if (dropsWhenAbsent(propShape[k]!)) {
-        doc.write(`if (${kx} in ${accessor}) ${outputVar}[${kx}] = ${out};`);
-      } else if (mayOutputUndefined(propShape[k]!)) {
-        doc.write(`if (${out} !== undefined || ${kx} in ${accessor}) ${outputVar}[${kx}] = ${out};`);
-      } else {
-        doc.write(`${outputVar}[${kx}] = ${out};`);
-      }
-    }
-  }
-
-  if (unknownKeysMode !== "none") {
-    // Unknown keys are written directly into the output after shape keys — for...in (like the runtime) so inherited enumerables participate.
-    const knownSet = keys.length > 0 ? addConstant(ctx, new Set(keys)) : null;
-    doc.write(`for (const k in ${accessor}) {`);
-    doc.indented((d) => {
-      // Skip __proto__: assigning obj["__proto__"] on a plain {} replaces the prototype via the setter rather than adding an own property. Mirrors the runtime catchall fix (#5898).
-      d.write(`if (k === "__proto__") continue;`);
-      if (knownSet) d.write(`if (${knownSet}.has(k)) continue;`);
-      if (unknownKeysMode === "passthrough") {
-        d.write(`${outputVar}[k] = ${accessor}[k];`);
-      } else {
-        const valVar = newVar(ctx);
-        d.write(`const ${valVar} = ${accessor}[k];`);
-        const catchallOut = compileChild(d, ctx, catchall!, valVar);
-        d.write(`${outputVar}[k] = ${catchallOut};`);
-      }
-    });
-    doc.write(`}`);
-  }
-
-  return outputVar;
-}
-
-function generateOptionalCheck(
-  doc: Doc,
-  ctx: CompileContext,
-  schema: SomeType,
-  accessor: string,
-  buildsValue = true
-): string | null {
-  const def = schema._zod.def as unknown as { innerType: SomeType };
-  if (isExactOptional(schema)) {
-    return generateCheck(doc, ctx, def.innerType, accessor, buildsValue);
-  }
-
-  // Same question $ZodOptional asks: only the top rung of the optin ladder substitutes a value for an absent input, so only it is worth running on `undefined`. Every other rung leaves the value intact, which is the skip branch below.
-  if (def.innerType._zod.optin === "defaulted") {
-    const outputVar = newVar(ctx);
-    const branchVar = newVar(ctx);
-    doc.write(`let ${outputVar};`);
-    doc.write(`if (${accessor} === undefined) {`);
-    doc.indented((d) => {
-      d.write(`const ${branchVar} = (() => {`);
-      d.indented((d2) => {
-        const innerOutput = generateCheck(d2, ctx, def.innerType, accessor);
-        d2.write(`return ${innerOutput};`);
-      });
-      d.write(`})();`);
-      d.write(`if (${branchVar} !== INVALID) ${outputVar} = ${branchVar};`);
-    });
-    doc.write(`} else {`);
-    doc.indented((d) => {
-      const innerOutput = generateCheck(d, ctx, def.innerType, accessor);
-      d.write(`${outputVar} = ${innerOutput};`);
-    });
-    doc.write(`}`);
-    return outputVar;
-  }
-
-  const outputVar = buildsValue ? newVar(ctx) : null;
-  if (outputVar) doc.write(`let ${outputVar};`);
-  doc.write(`if (${accessor} !== undefined) {`);
-  doc.indented((d) => {
-    const innerOutput = generateCheck(d, ctx, def.innerType, accessor, buildsValue);
-    if (outputVar && innerOutput !== null) d.write(`${outputVar} = ${innerOutput};`);
-  });
-  doc.write(`}`);
-  return outputVar;
-}
-
-function isExactOptional(schema: SomeType): boolean {
+export function isExactOptional(schema: SomeType): boolean {
   return (schema._zod as { traits?: Set<string> }).traits?.has("$ZodExactOptional") === true;
 }
 
 // A value-level fast path reads an absent key as `undefined`, so z.undefined(), z.any() and unions containing undefined would accept a missing property the runtime rejects.
-function requiresPresenceCheck(schema: SomeType): boolean {
+export function requiresPresenceCheck(schema: SomeType): boolean {
   return schema._zod.optin === undefined && fastPathAcceptsAbsence(schema);
 }
 
@@ -1436,14 +997,14 @@ function fastPathAcceptsAbsence(schema: SomeType): boolean {
 }
 
 /** The middle rung permits absence without supplying anything in its place, so an absent key contributes nothing — mirrors the leading gate in `handlePropertyResult`. */
-function dropsWhenAbsent(schema: SomeType): boolean {
+export function dropsWhenAbsent(schema: SomeType): boolean {
   return schema._zod.optin === "optional" && schema._zod.optout === "optional";
 }
 
 // Whether a schema's success-path output can be `undefined`. Object output
 // assembly gives such props the runtime's value-or-presence inclusion rule;
 // everything else keeps the unconditional object-literal slot.
-function mayOutputUndefined(schema: SomeType): boolean {
+export function mayOutputUndefined(schema: SomeType): boolean {
   const def = schema._zod.def as {
     type: string;
     values?: unknown[];
@@ -1495,753 +1056,10 @@ function mayOutputUndefined(schema: SomeType): boolean {
   }
 }
 
-function generateNullableCheck(
-  doc: Doc,
-  ctx: CompileContext,
-  schema: SomeType,
-  accessor: string,
-  buildsValue = true
-): string | null {
-  const def = schema._zod.def as unknown as { innerType: SomeType };
-  const outputVar = buildsValue ? newVar(ctx) : null;
-  if (outputVar) doc.write(`let ${outputVar} = null;`);
-  doc.write(`if (${accessor} !== null) {`);
-  doc.indented((d) => {
-    const innerOutput = generateCheck(d, ctx, def.innerType, accessor, buildsValue);
-    if (outputVar && innerOutput !== null) d.write(`${outputVar} = ${innerOutput};`);
-  });
-  doc.write(`}`);
-  return outputVar;
-}
-
-function generateArrayCheck(
-  doc: Doc,
-  ctx: CompileContext,
-  schema: SomeType,
-  accessor: string,
-  buildsValue = true
-): string | null {
-  const def = schema._zod.def as unknown as { element: SomeType };
-  doc.write(`if (!Array.isArray(${accessor})) return INVALID;`);
-
-  // Build a new array with validated/transformed elements.
-  const outputVar = buildsValue ? newVar(ctx) : null;
-  const iVar = newVar(ctx);
-  const elemVar = newVar(ctx);
-
-  if (outputVar) doc.write(`const ${outputVar} = new Array(${accessor}.length);`);
-  doc.write(`for (let ${iVar} = 0; ${iVar} < ${accessor}.length; ${iVar}++) {`);
-  doc.indented((d) => {
-    d.write(`const ${elemVar} = ${accessor}[${iVar}];`);
-    const elemOutput = compileChild(d, ctx, def.element, elemVar, buildsValue);
-    if (outputVar && elemOutput !== null) d.write(`${outputVar}[${iVar}] = ${elemOutput};`);
-  });
-  doc.write(`}`);
-
-  return outputVar;
-}
-
-function generateLiteralCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { values: unknown[] };
-  const values = def.values;
-
-  // Anything but a single value goes through Set.has: multi-value so every value participates, empty so nothing does — values[0] would be undefined and compile to an `!== undefined` check that accepts it. Single-value stays inlined for speed.
-  if (values.length !== 1) {
-    const literalSet = addConstant(ctx, new Set(values));
-    doc.write(`if (!${literalSet}.has(${accessor})) return INVALID;`);
-    return accessor;
-  }
-
-  const value = values[0];
-  // `$ZodLiteral` matches with `values.has`, i.e. SameValueZero, so NaN matches itself. `x !== NaN` is true for every input, which would reject everything — hand it to the same Set form the multi-value path uses.
-  if (typeof value === "number" && Number.isNaN(value)) {
-    const literalSet = addConstant(ctx, new Set(values));
-    doc.write(`if (!${literalSet}.has(${accessor})) return INVALID;`);
-    return accessor;
-  }
-  if (typeof value === "string") {
-    doc.write(`if (${accessor} !== ${util.esc(value)}) return INVALID;`);
-  } else if (typeof value === "number" || typeof value === "boolean") {
-    doc.write(`if (${accessor} !== ${value}) return INVALID;`);
-  } else if (value === null) {
-    doc.write(`if (${accessor} !== null) return INVALID;`);
-  } else if (value === undefined) {
-    doc.write(`if (${accessor} !== undefined) return INVALID;`);
-  } else if (typeof value === "bigint") {
-    doc.write(`if (${accessor} !== ${value}n) return INVALID;`);
-  } else {
-    throw new ZodCompileUnsupportedError(`literal type ${typeof value}`);
-  }
-  return accessor;
-}
-
-function generateEnumCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const values = (schema._zod as unknown as { values?: Set<unknown> }).values;
-  // z.partialRecord and friends clear `_zod.values`, leaving no set to test membership against. Throw rather than emit INVALID so a union falls back whole instead of counting a false rejection.
-  if (!values) {
-    throw new ZodCompileUnsupportedError("enum schema without enumerated values");
-  }
-  const enumSet = addConstant(ctx, values);
-  doc.write(`if (!${enumSet}.has(${accessor})) return INVALID;`);
-  return accessor;
-}
-
-function generateWrapperCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { innerType: SomeType };
-  return generateCheck(doc, ctx, def.innerType, accessor);
-}
-
-function generateDefaultCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { innerType: SomeType };
-
-  // `defaultValue` is an accessor on schemas built through the classic/mini
-  // factories and a plain data property on ones rebuilt programmatically
-  // (deepPartial and friends). Read it off the def either way — taking only
-  // `descriptor.get` silently dropped the default for the second kind, so
-  // `.default(v)` compiled to `undefined` instead of `v`.
-  const descriptor = Object.getOwnPropertyDescriptor(schema._zod.def, "defaultValue");
-  const defaultGetter = descriptor
-    ? () => (schema._zod.def as unknown as { defaultValue: unknown }).defaultValue
-    : undefined;
-
-  // prefault differs from default: undefined-input is first replaced with the prefault value, then run through the inner schema.
-  if (schema._zod.def.type === "prefault") {
-    if (!defaultGetter) {
-      return generateCheck(doc, ctx, def.innerType, accessor);
-    }
-    const defaultFn = addConstant(ctx, defaultGetter);
-    const inputVar = newVar(ctx);
-    doc.write(`let ${inputVar} = ${accessor};`);
-    doc.write(`if (${accessor} === undefined) ${inputVar} = ${defaultFn}();`);
-    return generateCheck(doc, ctx, def.innerType, inputVar);
-  }
-
-  const outputVar = newVar(ctx);
-
-  // Default allows undefined (replaces with default value), otherwise validates inner type
-  if (defaultGetter) {
-    const defaultFn = addConstant(ctx, defaultGetter);
-    const cloneFn = addConstant(ctx, util.shallowClone);
-    doc.write(`let ${outputVar};`);
-    doc.write(`if (${accessor} === undefined) {`);
-    doc.indented((d) => {
-      // Shallow-clone the default so callers can mutate the result without affecting subsequent parses (#5855 — also covers Map/Set).
-      d.write(`${outputVar} = ${cloneFn}(${defaultFn}());`);
-    });
-    doc.write(`} else {`);
-    doc.indented((d) => {
-      const innerOutput = generateCheck(d, ctx, def.innerType, accessor);
-      d.write(`${outputVar} = ${innerOutput} === undefined ? ${cloneFn}(${defaultFn}()) : ${innerOutput};`);
-    });
-    doc.write(`}`);
-  } else {
-    doc.write(`let ${outputVar};`);
-    doc.write(`if (${accessor} !== undefined) {`);
-    doc.indented((d) => {
-      const innerOutput = generateCheck(d, ctx, def.innerType, accessor);
-      d.write(`${outputVar} = ${innerOutput};`);
-    });
-    doc.write(`}`);
-  }
-
-  return outputVar;
-}
-
-function generateNonOptionalCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { innerType: SomeType };
-  // The runtime inspects what the inner produced, not what it was given: a catch can turn a defined input into undefined, a default an absent one into a value.
-  const innerOutput = generateCheck(doc, ctx, def.innerType, accessor);
-  const outputVar = newVar(ctx);
-  doc.write(`const ${outputVar} = ${innerOutput};`);
-  doc.write(`if (${outputVar} === undefined) return INVALID;`);
-  return outputVar;
-}
-
-function generateTupleCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { items: SomeType[]; rest: SomeType | null };
-  const items = def.items;
-  const rest = def.rest;
-
-  doc.write(`if (!Array.isArray(${accessor})) return INVALID;`);
-
-  // Mirror the runtime's getTupleOptStart: find the first index where every subsequent slot accepts `undefined` (i.e. is optional on input). Anything shorter than this is too_small; trailing absent slots are legal.
-  const optinStart = getTupleOptStart(items, "optin");
-  const optoutStart = getTupleOptStart(items, "optout");
-
-  // Length bounds
-  if (rest) {
-    // With rest: minimum length is the last required input slot
-    doc.write(`if (${accessor}.length < ${optinStart}) return INVALID;`);
-  } else {
-    // No rest: input must be in [optinStart, items.length]
-    doc.write(`if (${accessor}.length < ${optinStart} || ${accessor}.length > ${items.length}) return INVALID;`);
-  }
-
-  // Build the output in assignment order so absent optional-output tail slots can truncate while default/prefault slots still fill missing positions.
-  const outputVar = newVar(ctx);
-  doc.write(`const ${outputVar} = [];`);
-
-  // Validate and collect each fixed item
-  for (let i = 0; i < items.length; i++) {
-    const itemSchema = items[i]!;
-    if (i >= optoutStart) {
-      doc.write(`if (${outputVar}.length === ${i}) {`);
-      doc.indented((d) => {
-        d.write(`if (${i} < ${accessor}.length) {`);
-        d.indented((d2) => {
-          const elemVar = newVar(ctx);
-          d2.write(`const ${elemVar} = ${accessor}[${i}];`);
-          const elemOutput = compileChild(d2, ctx, itemSchema, elemVar);
-          d2.write(`${outputVar}[${i}] = ${elemOutput};`);
-        });
-        d.write(`} else {`);
-        d.indented((d2) => {
-          // Middle rung: absence supplies nothing in its place, so truncate rather than running the item on `undefined` and keeping what it invents. Mirrors the leading gate in `handleTupleResults`.
-          if (dropsWhenAbsent(itemSchema)) {
-            d2.write(`${outputVar}.length = ${i};`);
-            return;
-          }
-          const elemVar = newVar(ctx);
-          const branchVar = newVar(ctx);
-          d2.write(`const ${elemVar} = undefined;`);
-          d2.write(`const ${branchVar} = (() => {`);
-          d2.indented((d3) => {
-            const elemOutput = compileChild(d3, ctx, itemSchema, elemVar);
-            d3.write(`return ${elemOutput};`);
-          });
-          d2.write(`})();`);
-          d2.write(`if (${branchVar} === INVALID || ${branchVar} === undefined) ${outputVar}.length = ${i};`);
-          d2.write(`else ${outputVar}[${i}] = ${branchVar};`);
-        });
-        d.write(`}`);
-      });
-      doc.write(`}`);
-    } else {
-      const elemVar = newVar(ctx);
-      doc.write(`const ${elemVar} = ${accessor}[${i}];`);
-      const elemOutput = compileChild(doc, ctx, itemSchema, elemVar);
-      doc.write(`${outputVar}[${i}] = ${elemOutput};`);
-    }
-  }
-
-  // Validate and collect rest elements if present
-  if (rest) {
-    const iVar = newVar(ctx);
-    const elemVar = newVar(ctx);
-    doc.write(`for (let ${iVar} = ${items.length}; ${iVar} < ${accessor}.length; ${iVar}++) {`);
-    doc.indented((d) => {
-      d.write(`const ${elemVar} = ${accessor}[${iVar}];`);
-      const elemOutput = compileChild(d, ctx, rest, elemVar);
-      d.write(`${outputVar}[${iVar}] = ${elemOutput};`);
-    });
-    doc.write(`}`);
-  }
-
-  return outputVar;
-}
-
-function getTupleOptStart(items: SomeType[], key: "optin" | "optout"): number {
-  for (let i = items.length - 1; i >= 0; i--) {
-    // Mirrors the runtime: optin is a three-rung ladder so any rung above `undefined` permits an absent slot; optout stays two-valued.
-    const omittable = key === "optin" ? items[i]!._zod.optin !== undefined : items[i]!._zod.optout === "optional";
-    if (!omittable) return i + 1;
-  }
-  return 0;
-}
-
-function generateUnionCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as {
-    options: SomeType[];
-    inclusive?: boolean;
-    discriminator?: string;
-    unionFallback?: boolean;
-  };
-  const options = def.options;
-
-  if (def.discriminator) {
-    return generateDiscriminatedUnionCheck(
-      doc,
-      ctx,
-      def as { options: SomeType[]; discriminator: string; unionFallback?: boolean },
-      accessor
-    );
-  }
-
-  // z.xor requires *exactly one* option to match. Match-counting in the fast path is only sound if every branch is exactly as strict as the runtime — any falsely-rejecting branch silently turns a multi-match rejection into an accept. Force the runtime for this rare combinator.
-  if (def.inclusive === false) {
-    throw new ZodCompileUnsupportedError("exclusive unions (z.xor)");
-  }
-
-  if (options.length === 0) {
-    doc.write("return INVALID;");
-    return accessor;
-  }
-
-  if (options.length === 1) {
-    return generateCheck(doc, ctx, options[0]!, accessor);
-  }
-
-  // Check if all options are bare literals - use Set optimization. A literal option carrying checks (e.g. .refine) must take the general path or the Set would accept values its checks reject.
-  const allLiterals = options.every(
-    (opt) => opt._zod.def.type === "literal" && !(opt._zod.def.checks as unknown[] | undefined)?.length
-  );
-  if (allLiterals) {
-    const values = new Set(options.flatMap((opt) => (opt._zod.def as unknown as { values: unknown[] }).values));
-    const valuesConst = addConstant(ctx, values);
-    doc.write(`if (!${valuesConst}.has(${accessor})) return INVALID;`);
-    return accessor;
-  }
-
-  // General case: try each option until one succeeds Use IIFEs that return the output or INVALID
-  const outputVar = newVar(ctx);
-  doc.write(`let ${outputVar};`);
-
-  for (let i = 0; i < options.length; i++) {
-    const opt = options[i]!;
-
-    if (i === 0) {
-      doc.write(`${outputVar} = (() => {`);
-    } else {
-      doc.write(`if (${outputVar} === INVALID) ${outputVar} = (() => {`);
-    }
-
-    doc.indented((d) => {
-      // Generate check inside IIFE - returns INVALID on failure
-      const branchOutput = generateCheck(d, ctx, opt, accessor);
-      d.write(`return ${branchOutput};`);
-    });
-    doc.write(`})();`);
-  }
-
-  doc.write(`if (${outputVar} === INVALID) return INVALID;`);
-  return outputVar;
-}
-
-function generateDiscriminatedUnionCheck(
-  doc: Doc,
-  ctx: CompileContext,
-  def: { options: SomeType[]; discriminator: string; unionFallback?: boolean },
-  accessor: string
-): string {
-  if (def.unionFallback) {
-    throw new ZodCompileUnsupportedError("discriminated union with unionFallback");
-  }
-
-  if (def.options.length === 0) {
-    doc.write("return INVALID;");
-    return accessor;
-  }
-
-  const discVar = newVar(ctx);
-  const outputVar = newVar(ctx);
-  doc.write(`const ${discVar} = ${accessor}?.[${util.esc(def.discriminator)}];`);
-  doc.write(`let ${outputVar};`);
-
-  let firstBranch = true;
-  const claimed = new Set<util.Primitive>();
-  for (const option of def.options) {
-    const values = option._zod.propValues?.[def.discriminator];
-    if (!values || values.size === 0) {
-      throw new ZodCompileUnsupportedError("discriminated union option without static discriminator values");
-    }
-
-    // Two options claiming one value are not discriminable, and the branch chain below would silently give it to the first. Declining to compile hands that back to the interpreter, whose own map build reports it.
-    for (const value of values) {
-      if (claimed.has(value)) {
-        throw new ZodCompileUnsupportedError(`duplicate discriminator value ${String(value)}`);
-      }
-      claimed.add(value);
-    }
-
-    const conditions = Array.from(values, (value) => literalEquality(ctx, discVar, value));
-    const prefix = firstBranch ? "if" : "else if";
-    doc.write(`${prefix} (${conditions.join(" || ")}) {`);
-    doc.indented((d) => {
-      const branchOutput = generateCheck(d, ctx, option, accessor);
-      d.write(`${outputVar} = ${branchOutput};`);
-    });
-    doc.write(`}`);
-    firstBranch = false;
-  }
-
-  doc.write(`else { return INVALID; }`);
-  return outputVar;
-}
-
-function literalEquality(ctx: CompileContext, accessor: string, value: unknown): string {
-  if (typeof value === "string") return `${accessor} === ${util.esc(value)}`;
-  if (typeof value === "number") {
-    if (Number.isNaN(value)) return `Number.isNaN(${accessor})`;
-    return `${accessor} === ${value}`;
-  }
-  if (typeof value === "boolean") return `${accessor} === ${value}`;
-  if (value === null) return `${accessor} === null`;
-  if (value === undefined) return `${accessor} === undefined`;
-  if (typeof value === "bigint") return `${accessor} === ${value}n`;
-  if (typeof value === "symbol") {
-    const symbolConst = addConstant(ctx, value);
-    return `${accessor} === ${symbolConst}`;
-  }
-  throw new ZodCompileUnsupportedError(`literal discriminator value ${String(value)}`);
-}
-
-function generateIntersectionCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { left: SomeType; right: SomeType };
-  // An unmergeable merge, and a child failing before the merge is even reached, both return INVALID for a case the interpreter answers with a throw.
-  ctx.definite = false;
-  const leftOutput = compileChild(doc, ctx, def.left, accessor);
-  const rightOutput = compileChild(doc, ctx, def.right, accessor);
-
-  // Hoist the runtime merge helper so recursive object/array merge semantics stay in one place. If the merge is invalid, return INVALID and let the runtime fallback construct canonical errors.
-  const mergeConst = addConstant(ctx, mergeValues);
-  const mergedVar = newVar(ctx);
-  doc.write(`const ${mergedVar} = ${mergeConst}(${leftOutput}, ${rightOutput});`);
-  doc.write(`if (!${mergedVar}.valid) return INVALID;`);
-  return `${mergedVar}.data`;
-}
-
-function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { keyType: SomeType; valueType: SomeType };
-
-  // Use util.isPlainObject (rejects Date, Map, Set, class instances, etc.) to match runtime behavior. Hoisted call instead of inline so this stays a single source of truth with the runtime parser.
-  const isPlainObjectConst = addConstant(ctx, util.isPlainObject);
-  doc.write(`if (!${isPlainObjectConst}(${accessor})) return INVALID;`);
-
-  const outputVar = newVar(ctx);
-  const kVar = newVar(ctx);
-  const valVar = newVar(ctx);
-
-  doc.write(`const ${outputVar} = {};`);
-
-  // Exhaustive record. The runtime gates this on `values && !def.partial`, since z.partialRecord keeps its value set but makes every key optional; a loose record passes unrecognized keys through, which the per-key scan cannot express.
-  const recordDef = def as unknown as { mode?: string; partial?: boolean };
-  const keyValues = recordDef.partial ? undefined : (def.keyType._zod as unknown as { values?: Set<unknown> }).values;
-  if (keyValues) {
-    const inputKeys: Array<string | symbol> = [];
-    for (const key of keyValues) {
-      if (!(typeof key === "string" || typeof key === "number" || typeof key === "symbol")) {
-        throw new ZodCompileUnsupportedError(`record key value ${String(key)}`);
-      }
-
-      const inputKey = typeof key === "number" ? key.toString() : key;
-      if (inputKey === "__proto__") {
-        // `out["__proto__"] = v` would hit the prototype setter on the output.
-        throw new ZodCompileUnsupportedError('record key "__proto__"');
-      }
-      inputKeys.push(inputKey);
-
-      const keyConst = addConstant(ctx, key);
-      const outKey = generateCheck(doc, ctx, def.keyType, keyConst);
-      // Read the property once. Passing the raw expression let compileChild validate one read while the output write performed a second, so a getter could hand back a value nothing had checked.
-      const valueVar = newVar(ctx);
-      doc.write(`const ${valueVar} = ${accessor}[${literalPropertyKey(ctx, inputKey)}];`);
-      const valOutput = compileChild(doc, ctx, def.valueType, valueVar);
-      doc.write(`${outputVar}[${outKey}] = ${valOutput};`);
-    }
-
-    // `mode: "loose"` changes only what happens to unrecognized keys, so it belongs here rather than the per-present-key scan. Passing them through matches the runtime, which skips `__proto__`.
-    const knownKeysConst = addConstant(ctx, new Set(inputKeys));
-    doc.write(`for (const ${kVar} in ${accessor}) {`);
-    doc.indented((d) => {
-      d.write(`if (${knownKeysConst}.has(${kVar})) continue;`);
-      if (recordDef.mode === "loose") {
-        d.write(`if (${kVar} !== "__proto__") ${outputVar}[${kVar}] = ${accessor}[${kVar}];`);
-      } else {
-        d.write(`return INVALID;`);
-      }
-    });
-    doc.write(`}`);
-    return outputVar;
-  }
-
-  // The bare-string shortcut below only tests `typeof key === "string"`, so it
-  // is correct exclusively for a `z.string()` carrying nothing else. A string
-  // *format* lives on the def rather than in `checks` — `z.record(z.email(), …)`
-  // reads as a plain string here — and coercion rewrites the key, so both have
-  // to take the general path or the shortcut accepts keys the runtime rejects.
-  const keyDef = def.keyType._zod.def as { type: string; format?: string; coerce?: boolean; checks?: unknown[] };
-  const keyIsBareString =
-    keyDef.type === "string" && keyDef.format === undefined && !keyDef.coerce && (keyDef.checks?.length ?? 0) === 0;
-  if (!keyIsBareString) {
-    // A key schema with no value set is a constraint every key must satisfy
-    // (`z.email()`, `z.string().min(3)`, `z.number()`, a template literal).
-    // The runtime runs it against each own enumerable key and writes the value
-    // under the key it produced, so compile it once and call it per key.
-    const isLoose = (def as { mode?: string }).mode === "loose";
-    // the key compiles in its own context, so carry its verdict out: a key schema that can answer INVALID undecidably makes this validator undecidable too
-    const keyFn = compileFn(def.keyType);
-    if (keyFn.definite === false) ctx.definite = false;
-    const keyFast = addConstant(ctx, keyFn);
-    const numericConst = addConstant(ctx, regexes.number);
-    const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
-    const outKeyVar = newVar(ctx);
-
-    doc.write(`for (const ${kVar} of Reflect.ownKeys(${accessor})) {`);
-    doc.indented((d) => {
-      d.write(`if (${kVar} === "__proto__") continue;`);
-      d.write(`if (!${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
-      d.write(`let ${outKeyVar} = ${keyFast}(${kVar});`);
-      // Numeric-string retry, mirroring the runtime: a key the schema rejects as a string is tried again as a number, so z.record(z.number(), …) matches the numeric keys JavaScript stringified on the way in.
-      d.write(
-        `if (${outKeyVar} === INVALID && typeof ${kVar} === "string" && ${numericConst}.test(${kVar})) ${outKeyVar} = ${keyFast}(Number(${kVar}));`
-      );
-      if (isLoose) {
-        // A loose record keeps a key its schema rejects, copying the value across unvalidated rather than failing the parse.
-        d.write(`if (${outKeyVar} === INVALID) { ${outputVar}[${kVar}] = ${accessor}[${kVar}]; continue; }`);
-      } else {
-        d.write(`if (${outKeyVar} === INVALID) return INVALID;`);
-      }
-      // The guard above tested the input key, but the schema can normalize an ordinary key into __proto__; re-check the one actually written under.
-      d.write(`if (${outKeyVar} === "__proto__") continue;`);
-      // Read once: the raw expression would be evaluated again by the output write below, so an accessor could return an unvalidated second value.
-      const valueVar = newVar(ctx);
-      d.write(`const ${valueVar} = ${accessor}[${kVar}];`);
-      const valOutput = compileChild(d, ctx, def.valueType, valueVar);
-      d.write(`${outputVar}[${outKeyVar}] = ${valOutput};`);
-    });
-    doc.write(`}`);
-    return outputVar;
-  }
-
-  // Plain z.string() keys: iterate enumerable own keys and validate each value. Runtime uses Reflect.ownKeys so symbol keys participate in validation; matching that here prevents silently accepting objects with enumerable Symbol keys under z.record(z.string(), ...).
-  const propIsEnumerable = addConstant(ctx, Object.prototype.propertyIsEnumerable);
-  doc.write(`for (const ${kVar} of Reflect.ownKeys(${accessor})) {`);
-  doc.indented((d) => {
-    d.write(`if (${kVar} === "__proto__") continue;`);
-    d.write(`if (!${propIsEnumerable}.call(${accessor}, ${kVar})) continue;`);
-    d.write(`if (typeof ${kVar} !== "string") return INVALID;`);
-    d.write(`const ${valVar} = ${accessor}[${kVar}];`);
-    const valOutput = compileChild(d, ctx, def.valueType, valVar);
-    d.write(`${outputVar}[${kVar}] = ${valOutput};`);
-  });
-  doc.write(`}`);
-
-  return outputVar;
-}
-
-function literalPropertyKey(ctx: CompileContext, key: string | symbol): string {
-  if (typeof key === "string") return util.esc(key);
-  return addConstant(ctx, key);
-}
-
-function generateMapCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { keyType: SomeType; valueType: SomeType };
-
-  doc.write(`if (!(${accessor} instanceof Map)) return INVALID;`);
-
-  const outputVar = newVar(ctx);
-  const kVar = newVar(ctx);
-  const valVar = newVar(ctx);
-
-  doc.write(`const ${outputVar} = new Map();`);
-  doc.write(`for (const [${kVar}, ${valVar}] of ${accessor}) {`);
-  doc.indented((d) => {
-    const keyOutput = generateCheck(d, ctx, def.keyType, kVar);
-    const valOutput = generateCheck(d, ctx, def.valueType, valVar);
-    d.write(`${outputVar}.set(${keyOutput}, ${valOutput});`);
-  });
-  doc.write(`}`);
-
-  return outputVar;
-}
-
-function generateSetCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { valueType: SomeType };
-
-  doc.write(`if (!(${accessor} instanceof Set)) return INVALID;`);
-
-  const outputVar = newVar(ctx);
-  const valVar = newVar(ctx);
-
-  doc.write(`const ${outputVar} = new Set();`);
-  doc.write(`for (const ${valVar} of ${accessor}) {`);
-  doc.indented((d) => {
-    const valOutput = generateCheck(d, ctx, def.valueType, valVar);
-    d.write(`${outputVar}.add(${valOutput});`);
-  });
-  doc.write(`}`);
-
-  return outputVar;
-}
-
-function generateFileCheck(doc: Doc, accessor: string): string {
-  // Runtime $ZodFile is a bare `instanceof File`, including the implicit global lookup. The previous duck-typed fallback accepted arbitrary {name, size} objects in File-less environments — behavior the runtime never had.
-  doc.write(`if (!(${accessor} instanceof File)) return INVALID;`);
-  return accessor;
-}
-
-function generateTemplateLiteralCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  doc.write(`if (typeof ${accessor} !== "string") return INVALID;`);
-
-  // Template literal schemas have a pre-computed pattern in _zod.pattern
-  const pattern = (schema._zod as unknown as { pattern: RegExp }).pattern;
-  if (pattern) {
-    const patternConst = addConstant(ctx, pattern);
-    doc.write(`${patternConst}.lastIndex = 0;`);
-    doc.write(`if (!${patternConst}.test(${accessor})) return INVALID;`);
-  }
-  return accessor;
-}
-
-function generateLazyCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  // For lazy schemas, we use a cached parser that falls back to runtime Zod parsing This handles recursive schemas correctly by avoiding infinite compilation loops
-  const def = schema._zod.def as unknown as { getter: () => SomeType };
-  const getterConst = addUserConstant(ctx, def.getter);
-  const cacheConst = addConstant(ctx, { parser: null as ((input: unknown) => unknown) | null });
-
-  doc.write(`if (!${cacheConst}.parser) {`);
-  doc.indented((d) => {
-    d.write(`const inner = ${getterConst}();`);
-    d.write(`${cacheConst}.parser = function(input) {`);
-    d.indented((d2) => {
-      // Use runtime Zod parsing - this correctly handles recursive schemas Pass an empty ctx like runtimeRun does — runtime parsers read ctx.skipChecks/ctx.direction unconditionally and crash on undefined.
-      d2.write(`const result = inner._zod.run({ value: input, issues: [] }, {});`);
-      d2.write(`return result.issues.length === 0 ? result.value : INVALID;`);
-    });
-    d.write(`};`);
-  });
-  doc.write(`}`);
-
-  const outputVar = newVar(ctx);
-  doc.write(`const ${outputVar} = ${cacheConst}.parser(${accessor});`);
-  doc.write(`if (${outputVar} === INVALID) return INVALID;`);
-  return outputVar;
-}
-
-function generatePipeCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as {
-    in: SomeType;
-    out: SomeType;
-    transform?: (value: unknown, payload: unknown) => unknown;
-  };
-
-  // Validate input type first
-  const inputOutput = generateCheck(doc, ctx, def.in, accessor);
-
-  if (def.transform) {
-    // Apply transform and validate output. The transform may read its second `payload` argument (codec transforms like z.stringbool() push issues there) so wrap the call in a helper that spoofs a payload. Pushed issues signal INVALID and the wrapper falls back to the runtime, and a plain function handing back a promise answers INVALID too — union parity, but not a decidable rejection at the top level.
-    if (isAsyncFunction(def.transform)) {
-      throw new ZodCompileAsyncError("z.compile: async transforms in pipes are not supported");
-    }
-    const transformFn = def.transform;
-    const helperFn = (value: unknown): unknown => {
-      // `addIssue` has to be here: a transform reporting through it is reporting, not failing. Without it the call threw a TypeError that the old catch swallowed into a fallback, so every ctx.addIssue transform quietly lost its fast path and the real error was never visible.
-      const fakePayload = { value, issues: [] as unknown[], addIssue: pushIssue };
-      // A throw is deliberately not caught. The interpreter lets one propagate out of the whole parse; swallowing it into INVALID turned a thrown error into a merely-rejected union branch, so a later branch answered instead.
-      const result = transformFn(value, fakePayload as any);
-      if (result instanceof Promise) return INVALID;
-      return fakePayload.issues.length === 0 ? result : INVALID;
-    };
-    const helperConst = addUserConstant(ctx, helperFn);
-    const transformedVar = newVar(ctx);
-    doc.write(`const ${transformedVar} = ${helperConst}(${inputOutput});`);
-    doc.write(`if (${transformedVar} === INVALID) return INVALID;`);
-    return generateCheck(doc, ctx, def.out, transformedVar);
-  } else {
-    // No transform - validate output type on same value
-    return generateCheck(doc, ctx, def.out, inputOutput);
-  }
-}
-
-function isAsyncFunction(fn: unknown): boolean {
+export function isAsyncFunction(fn: unknown): boolean {
   return (
     typeof fn === "function" &&
     (fn.constructor.name === "AsyncFunction" ||
       (fn as { [Symbol.toStringTag]?: string })[Symbol.toStringTag] === "AsyncFunction")
   );
-}
-
-function generateCustomCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as { fn?: (value: unknown) => boolean };
-
-  if (def.fn) {
-    // Check for async function
-    if (isAsyncFunction(def.fn)) {
-      throw new ZodCompileAsyncError("z.compile: async custom predicates are not supported");
-    }
-    // Custom schema with a predicate function (e.g. z.instanceof). `isAsyncFunction` above is syntactic, so a plain function returning a promise reaches here, and a promise is truthy — it would read as a pass where the interpreter throws.
-    const fnConst = addUserConstant(ctx, def.fn);
-    const throwAsyncConst = addConstant(ctx, throwAsync);
-    const resVar = newVar(ctx);
-    doc.write(`const ${resVar} = ${fnConst}(${accessor});`);
-    doc.write(`if (${resVar} instanceof Promise) ${throwAsyncConst}();`);
-    doc.write(`if (!${resVar}) return INVALID;`);
-  } else {
-    throw new ZodCompileUnsupportedError("custom schema without a predicate function");
-  }
-  return accessor;
-}
-
-// Runtime helper for a compiled `catch`: runs the inner schema once and returns its value when it succeeded. Anything else — a failure the catch would handle, or an async inner — returns INVALID so the interpreter takes over.
-function runtimeCatch(innerSchema: SomeType, catchValue: () => unknown, value: unknown): unknown {
-  const result = (innerSchema._zod.run as (p: ParsePayload, c: ParseContextInternal) => any)(
-    { value, issues: [] },
-    {} as ParseContextInternal
-  );
-  if (result && typeof (result as Promise<unknown>).then === "function") return INVALID;
-  const r = result as { value: unknown; issues: any[] };
-  if (r.issues.length === 0) return r.value;
-  // Only reached for a catch value that ignores the parse context — codegen refuses the rest — so there are no issues to finalize and nothing here needs the caller's error map.
-  return catchValue();
-}
-
-function generateCatchCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as {
-    innerType: SomeType;
-    catchValue: (ctx: any) => unknown;
-  };
-
-  // An untagged catchValue is a user callback, and one reading `ctx.error` needs the caller's per-parse error map. Catch *succeeds*, so a wrong message there is unobservable — refuse at codegen, and not islandable either, since `runtimeRun` has no context to hand it.
-  if (!(def.catchValue as { [util.CONSTANT_CATCH]?: boolean })[util.CONSTANT_CATCH]) {
-    throw new ZodCompileUnsupportedError("catch with a callback (only a constant catch value compiles)", false);
-  }
-
-  const outputVar = newVar(ctx);
-  doc.write(`let ${outputVar} = (() => {`);
-  doc.indented((d) => {
-    const innerOut = compileChild(d, ctx, def.innerType, accessor);
-    d.write(`return ${innerOut};`);
-  });
-  doc.write(`})();`);
-
-  const innerConst = addConstant(ctx, def.innerType);
-  const catchConst = addUserConstant(ctx, def.catchValue);
-  const catchHelperConst = addConstant(ctx, runtimeCatch);
-  doc.write(`if (${outputVar} === INVALID) {`);
-  doc.indented((d) => {
-    d.write(`${outputVar} = ${catchHelperConst}(${innerConst}, ${catchConst}, ${accessor});`);
-    d.write(`if (${outputVar} === INVALID) return INVALID;`);
-  });
-  doc.write(`}`);
-  return outputVar;
-}
-
-function generateTransformCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
-  const def = schema._zod.def as unknown as {
-    transform: (value: unknown, payload: unknown) => unknown;
-  };
-
-  if (def.transform) {
-    // Check for async transform
-    if (isAsyncFunction(def.transform)) {
-      throw new ZodCompileAsyncError("z.compile: async transforms are not supported");
-    }
-
-    // Create a helper that runs the transform and returns the result or INVALID on error
-    const transformFn = def.transform;
-    const helperFn = (value: unknown): unknown => {
-      const fakePayload = { value, issues: [] as unknown[], addIssue: pushIssue };
-      // As in the pipe helper: a throw propagates, because the interpreter lets it out of the whole parse rather than treating it as a failed branch.
-      const result = transformFn(value, fakePayload);
-      if (result instanceof Promise) return INVALID;
-      return fakePayload.issues.length === 0 ? result : INVALID;
-    };
-    const helperConst = addUserConstant(ctx, helperFn);
-    const outputVar = newVar(ctx);
-    doc.write(`const ${outputVar} = ${helperConst}(${accessor});`);
-    doc.write(`if (${outputVar} === INVALID) return INVALID;`);
-    return outputVar;
-  }
-
-  return accessor;
 }

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1572,6 +1572,7 @@ function hoistFn(ctx: CompileContext, params: string, body: string[], ...tail: s
 
 // V8 sizes a function's optimization budget by its bytecode, so one huge issue parser stays unoptimized for thousands of rejections and loses to the interpreter until then; a subtree above this many characters of source becomes a function of its own, which tiers up on its own. Small schemas stay one function and pay no call.
 const HOIST_THRESHOLD = 4000;
+const IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
 
 // Issue-mode counterpart of compileChild: try the native emission, roll back and island on an islandable refusal. The body generates against a local of its own, detached from the caller's doc, so a large one on a static path can hoist as a function; the rest splices in place.
 export function compileChildIssues(
@@ -1587,7 +1588,8 @@ export function compileChildIssues(
   const constantCounter = ctx.constantCounter;
   const varCounter = ctx.varCounter;
   const preludeLen = ctx.prelude.length;
-  const local = newVar(ctx);
+  // a plain identifier is read in place and doubles as the hoisted function's parameter name; anything else is aliased once
+  const local = IDENTIFIER.test(accessor) ? accessor : newVar(ctx);
   const sub = new Doc();
   let out: string;
   try {
@@ -1612,7 +1614,7 @@ export function compileChildIssues(
     );
     return r;
   }
-  doc.write(`const ${local} = ${accessor};`);
+  if (local !== accessor) doc.write(`const ${local} = ${accessor};`);
   const pad = " ".repeat(doc.indent * 2);
   for (const line of body) doc.content.push(pad + line);
   return out;

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1502,21 +1502,12 @@ export function subtreeRunsCallbacks(node: ZodNode): boolean {
   return out;
 }
 
-// the def's values, one level deep: a node recurses, an array or a shape is scanned for nodes, and anything else (a default value, a regex, a locale map) stays opaque. accessors stay unread — `defaultValue` runs the user's factory — except `shape`, zod's own lazily derived one, which is read so the answer is the same before and after its first read; a shape getter that throws counts as callbacks, the conservative answer
+// the def's values, one level deep: a node recurses, an array or a shape is scanned for nodes, and anything else (a default value, a regex, a locale map) stays opaque. no accessor is invoked — `defaultValue` runs the user's factory — and zod's own lazy shape is read through `rawShape`, which answers from the getter's data without calling it, so the answer is the same before and after the first read; a `shape` accessor a subclass supplied stays unread like any other
 function childrenReachCallbacks(def: object): boolean {
   for (const key in def) {
     const desc = Object.getOwnPropertyDescriptor(def, key);
     if (!desc) continue;
-    let value: unknown;
-    if (!desc.get) value = desc.value;
-    else if (key !== "shape") continue;
-    else {
-      try {
-        value = (def as Record<string, unknown>)[key];
-      } catch {
-        return true;
-      }
-    }
+    const value: unknown = desc.get ? (key === "shape" ? util.rawShape(def) : undefined) : desc.value;
     if (!value || typeof value !== "object") continue;
     if ((value as Partial<ZodNode>)._zod) {
       if (subtreeRunsCallbacks(value as ZodNode)) return true;

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -27,7 +27,7 @@ export type INVALID = typeof INVALID;
 
 // Set on the parse ctx when a compiled wrapper falls back to the runtime, so nested compiled wrappers skip their fast paths for the rest of that parse.
 const FALLBACK_FLAG: unique symbol = Symbol.for("zod.compile.fallback");
-// raised by a compiled method that already rejected, naming the schema whose runtime method it is about to enter: the fast parser has run, go straight to the issue parser. Module state rather than a parse-context entry, so the fallback takes no context spread and no flag reads; only that schema's own wrapper consumes it, so a route that reaches a nested wrapper first cannot skip that wrapper's checks, and the method restores whatever it found there, so a re-entrant call from a params getter evaluated on the way in cannot clear an outer signal.
+// raised by a compiled method that already rejected, naming the schema whose runtime method it is about to enter: the fast parser has run, go straight to the issue parser. Module state rather than a parse-context entry, so the fallback takes no context spread and no flag reads; only that schema's own wrapper consumes it, so a route that reaches a nested wrapper first cannot skip that wrapper's checks, and the method evaluates params getters before raising it and restores whatever it found afterwards, so no other invocation can run between the raise and the consume.
 let skipFastFor: unknown = null;
 // set on the parse context where the issue path hands a subtree to the interpreter, so a compiled wrapper the interpreter reaches inside it skips its own fast pass: user callbacks run at most twice on invalid input
 const SKIP_FAST: unique symbol = Symbol.for("zod.compile.skipfast");
@@ -229,6 +229,8 @@ function installCompiledUserMethods<T extends SomeType>(target: T, parser: Compi
       if (out !== INVALID) {
         return { success: true, data: out };
       }
+      // params are copied here so a getter on them runs now, not between raising the signal and the wrapper consuming it, where a same-schema re-entry would take it
+      if (params) params = { ...(params as object) };
       const outer = skipFastFor;
       skipFastFor = target;
       try {
@@ -246,6 +248,8 @@ function installCompiledUserMethods<T extends SomeType>(target: T, parser: Compi
       if (out !== INVALID) {
         return out;
       }
+      // params are copied here so a getter on them runs now, not between raising the signal and the wrapper consuming it, where a same-schema re-entry would take it
+      if (params) params = { ...(params as object) };
       const outer = skipFastFor;
       skipFastFor = target;
       try {

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -63,6 +63,8 @@ export class ZodCompileAsyncError extends Error {
 export class ZodCompileUnsupportedError extends Error {
   /** Whether a container may absorb this refusal by running the child through the runtime (see `compileChild`). False when running only that node on the runtime is not equivalent to running the whole parse there — a runtime island gets no parse context, so a node that *consumes* issues rather than propagating them would finalize them against the wrong error map and still succeed. */
   readonly islandable: boolean;
+  /** The generated code did not evaluate: a compiler defect, not an unsupported schema. */
+  malformed?: boolean;
 
   constructor(feature: string, islandable = true) {
     super(`z.compile does not support ${feature}; this schema must use the runtime parser`);
@@ -148,6 +150,8 @@ export function compile<T extends SomeType>(schema: T, options?: CompileOptions)
           issueParser = compileFn(schema, { issues: true }) as unknown as IssueParser;
         } catch (err) {
           if (!(err instanceof ZodCompileUnsupportedError || err instanceof ZodCompileAsyncError)) throw err;
+          // malformed generated code is a compiler defect; the silent re-parse would keep every parity test green over it, so strict mode (the global shim's) throws it
+          if (options?.strict && (err as ZodCompileUnsupportedError).malformed) throw err;
           issueParser = null;
         }
       }
@@ -318,7 +322,11 @@ export function compileFn<T extends SomeType>(schema: T, options?: CompileFnOpti
     fn = factory(...constantValues) as CompiledFn<core.output<T>>;
   } catch (err) {
     // Malformed generated code (or a CSP environment rejecting `new Function`) surfaces as a typed error so the global shim falls back to the runtime instead of crashing with a raw SyntaxError/EvalError.
-    throw new ZodCompileUnsupportedError(`this schema (generated code failed to evaluate: ${(err as Error).message})`);
+    const refusal = new ZodCompileUnsupportedError(
+      `this schema (generated code failed to evaluate: ${(err as Error).message})`
+    );
+    refusal.malformed = true;
+    throw refusal;
   }
   if (options?.debug) {
     fn.code = fullCode;

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -251,7 +251,6 @@ const _messageDesc: PropertyDescriptor = {
   enumerable: true,
   configurable: true,
 };
-const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 const _issuesDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 
 /* Prototypes that already carry the lazy `toString`. Seeded with the
@@ -261,12 +260,10 @@ const _installedToString = /* @__PURE__ */ new WeakSet<object>([Object.prototype
 
 const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
   inst.name = "$ZodError";
-  _zodDesc.value = inst._zod;
-  Object.defineProperty(inst, "_zod", _zodDesc);
+  // `_zod` is already non-enumerable: $constructor's init defined it with this same descriptor
   _issuesDesc.value = def;
   Object.defineProperty(inst, "issues", _issuesDesc);
-  // Clear the shared slots; a retained `value` pins the last error's issues.
-  _zodDesc.value = undefined;
+  // Clear the shared slot; a retained `value` pins the last error's issues.
   _issuesDesc.value = undefined;
   Object.defineProperty(inst, "message", _messageDesc);
 

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -843,7 +843,7 @@ function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
   return outputVar;
 }
 
-// Walks the own enumerable keys of a plain object in Reflect.ownKeys order — strings by for-in, then symbols — without materializing the key array, which made that walk 3–6x the cost of the loop it fed. `body` is written once for the string loop and once for the symbol loop unless `onSymbol` replaces the latter.
+// Walks the own enumerable keys of a plain object in Reflect.ownKeys order — strings by for-in, then symbols — without materializing the key array, which made that walk 3–6x the cost of the loop it fed. Both key sets are snapshotted before any value is read and every key is rechecked with propertyIsEnumerable when visited, so a getter that adds, deletes or hides a key mid-walk sees the runtime's verdict; a proxy observes one more descriptor lookup per key than the runtime, from for-in's own enumerability filter. `body` is written once for the string loop and once for the symbol loop unless `onSymbol` replaces the latter.
 function emitOwnKeys(
   doc: Doc,
   ctx: CompileContext,
@@ -852,17 +852,16 @@ function emitOwnKeys(
   body: (d: Doc) => void,
   onSymbol?: string
 ): void {
-  const hasOwnConst = addConstant(ctx, Object.prototype.hasOwnProperty);
   const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
-  doc.write(`for (const ${kVar} in ${accessor}) {`);
-  doc.indented((d) => {
-    d.write(`if (${kVar} === "__proto__" || !${hasOwnConst}.call(${accessor}, ${kVar})) continue;`);
-    body(d);
-  });
-  doc.write(`}`);
   const symsVar = newVar(ctx);
   const iVar = newVar(ctx);
   doc.write(`const ${symsVar} = Object.getOwnPropertySymbols(${accessor});`);
+  doc.write(`for (const ${kVar} in ${accessor}) {`);
+  doc.indented((d) => {
+    d.write(`if (${kVar} === "__proto__" || !${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
+    body(d);
+  });
+  doc.write(`}`);
   doc.write(`for (let ${iVar} = 0; ${iVar} < ${symsVar}.length; ${iVar}++) {`);
   doc.indented((d) => {
     d.write(`const ${kVar} = ${symsVar}[${iVar}];`);

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -25,9 +25,12 @@ import {
   leafIssues,
   mayOutputUndefined,
   newVar,
+  pathExpr,
+  pathLiteral,
   pipeStops,
   pushInvalidKey,
   pushIssue,
+  pushMissingKey,
   pushNonOptionalIssue,
   requiresPresenceCheck,
   throwAsync,
@@ -1121,7 +1124,7 @@ const nonOptionalIssues: IssueCodegen = (doc, ctx, inst, accessor, path, shared,
   const pushConst = addConstant(ctx, pushNonOptionalIssue);
   const instConst = addConstant(ctx, inst);
   const m2 = newVar(ctx);
-  const prefix = path.length ? ` ${pfx}(payload.issues, ${m2}, [${path.join(", ")}]);` : "";
+  const prefix = path.length ? ` ${pfx}(payload.issues, ${m2}, ${pathExpr(ctx, path)});` : "";
   doc.write(
     `if (payload.issues.length === ${mark} && ${v} === undefined) { const ${m2} = payload.issues.length; ${pushConst}(payload.issues, ${v}, ${instConst});${prefix} }`
   );
@@ -1178,7 +1181,7 @@ const transformIssues: IssueCodegen = (doc, ctx, inst, accessor, path, _shared, 
   doc.write(`const ${r} = ${parseConst}(_sp, pctx);`);
   doc.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
   if (path.length) {
-    doc.write(`if (payload.issues.length > ${mark}) ${pfx}(payload.issues, ${mark}, [${path.join(", ")}]);`);
+    doc.write(`if (payload.issues.length > ${mark}) ${pfx}(payload.issues, ${mark}, ${pathExpr(ctx, path)});`);
   }
   const v = newVar(ctx);
   doc.write(`const ${v} = _sp.value;`);
@@ -1361,8 +1364,9 @@ function generateObjectIssues(
       } else if (optin === undefined) {
         const present = newVar(ctx);
         d.write(`const ${present} = ${kx} in ${accessor};`);
+        const missConst = addConstant(ctx, pushMissingKey);
         d.write(
-          `if (!${present} && payload.issues.length === ${mk}) payload.issues.push({ code: "invalid_type", expected: "nonoptional", input: undefined, path: [${childPath.join(", ")}] });`
+          `if (!${present} && payload.issues.length === ${mk}) ${missConst}(payload, ${pathExpr(ctx, childPath)});`
         );
         d.write(`if (${present}) ${out}[${kx}] = ${kv};`);
       } else {
@@ -1386,7 +1390,7 @@ function generateObjectIssues(
         });
         d.write(`}`);
         const instConst = addConstant(ctx, schema);
-        const pathProp = path.length ? `, path: [${path.join(", ")}]` : "";
+        const pathProp = path.length ? `, path: ${pathLiteral(ctx, path)}` : "";
         d.write(
           `if (${unrec}) payload.issues.push({ code: "unrecognized_keys", keys: ${unrec}, input: ${accessor}, inst: ${instConst}, continue: true${pathProp} });`
         );
@@ -1447,7 +1451,7 @@ function generateTupleIssues(
       );
       const instConst = addConstant(ctx, schema);
       const m = newVar(ctx);
-      const pathStmt = path.length ? ` ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);` : "";
+      const pathStmt = path.length ? ` ${pfx}(payload.issues, ${m}, ${pathExpr(ctx, path)});` : "";
       // copied from $ZodTuple.parse's too_big push: the runtime pushes this and keeps walking the items
       d.write(
         `if (${accessor}.length > ${items.length}) { const ${m} = payload.issues.length; payload.issues.push({ code: "too_big", maximum: ${items.length}, inclusive: true, input: ${accessor}, inst: ${instConst}, origin: "array" });${pathStmt} }`
@@ -1648,7 +1652,7 @@ function generateUnionIssues(
     }
     d.write(`const ${m} = payload.issues.length;`);
     d.write(`${v} = ${helperConst}(${instConst}, ${accessor}, payload, ${rsVar}, pctx, ${shared});`);
-    if (path.length) d.write(`if (payload.issues.length > ${m}) ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);`);
+    if (path.length) d.write(`if (payload.issues.length > ${m}) ${pfx}(payload.issues, ${m}, ${pathExpr(ctx, path)});`);
   });
   doc.write(`}`);
   return v;
@@ -1673,7 +1677,7 @@ function generateRecordIssues(
   const keyValues = (def.keyType._zod as unknown as { values?: Set<unknown> }).values;
   const isPlainObjectConst = addConstant(ctx, util.isPlainObject);
   const instConst = addConstant(ctx, schema);
-  const pathProp = path.length ? `, path: [${path.join(", ")}]` : "";
+  const pathProp = path.length ? `, path: ${pathLiteral(ctx, path)}` : "";
   const v = newVar(ctx);
   doc.write(`let ${v} = ${accessor};`);
   doc.write(`if (!${isPlainObjectConst}(${accessor})) ${leafFailBlock(ctx, schema, accessor, path)}`);
@@ -1706,14 +1710,14 @@ function generateRecordIssues(
         d.indented((d2) => {
           d2.write(`const ${outKey} = ${keyFast}(${keyConst});`);
           d2.write(
-            `if (${outKey} === INVALID) { ${badKeyConst}(${keyTypeConst}, ${keyConst}, payload, pctx, ${instConst}, [${path.join(", ")}]); break ${label}; }`
+            `if (${outKey} === INVALID) { ${badKeyConst}(${keyTypeConst}, ${keyConst}, payload, pctx, ${instConst}, ${pathExpr(ctx, path)}); break ${label}; }`
           );
           d2.write(`if (${outKey} === "__proto__") break ${label};`);
           const valueVar = newVar(ctx);
           // the path element is the declared key as declared: a numeric key stays a number, like util.prefixIssues(key, …) in the runtime
-          const pathExpr = typeof key === "number" ? String(key) : literalPropertyKey(ctx, key);
-          d2.write(`const ${valueVar} = ${accessor}[${pathExpr}];`);
-          const val = compileChildIssues(d2, ctx, def.valueType, valueVar, [...path, pathExpr], shared);
+          const keyExpr = typeof key === "number" ? String(key) : literalPropertyKey(ctx, key);
+          d2.write(`const ${valueVar} = ${accessor}[${keyExpr}];`);
+          const val = compileChildIssues(d2, ctx, def.valueType, valueVar, [...path, keyExpr], shared);
           d2.write(`${out}[${outKey}] = ${val};`);
         });
         d.write(`}`);
@@ -1755,7 +1759,7 @@ function generateRecordIssues(
           ? `${out}[${k}] = ${accessor}[${k}];`
           : keyValues
             ? `(${unrec} ??= []).push(${k});`
-            : `${badKeyConst}(${keyTypeConst}, ${k}, payload, pctx, ${instConst}, [${path.join(", ")}]);`;
+            : `${badKeyConst}(${keyTypeConst}, ${k}, payload, pctx, ${instConst}, ${pathExpr(ctx, path)});`;
         d2.write(`if (${outKey} === INVALID) { ${onBadKey} continue; }`);
         // the key schema can normalize an ordinary key into __proto__; re-check the one actually written under
         d2.write(`if (${outKey} === "__proto__") continue;`);

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -1,0 +1,1160 @@
+import type * as checks from "./checks.js";
+import {
+  type CompileContext,
+  INVALID,
+  type StringFormatDef,
+  ZodCompileAsyncError,
+  ZodCompileUnsupportedError,
+  addConstant,
+  addUserConstant,
+  compileChild,
+  compileFn,
+  dropsWhenAbsent,
+  generateCheck,
+  generateNumberFormatCheck,
+  generatePropertiesChecks,
+  generateStringFormatCheck,
+  isAsyncFunction,
+  isExactOptional,
+  mayOutputUndefined,
+  newVar,
+  pushIssue,
+  requiresPresenceCheck,
+  throwAsync,
+} from "./compile.js";
+import type { Doc } from "./doc.js";
+import * as regexes from "./regexes.js";
+import { mergeValues } from "./schemas.js";
+import type { $ZodProperties, ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
+import * as util from "./util.js";
+
+// The compiler, split per core subclass: one fast-path emitter per class, collected in `emitters` at the bottom and resolved by `codegenFor` from the traits an instance recorded, so `generateCheck` in compile.ts never switches on def.type and a schema with no compilable ancestor refuses compilation.
+
+function generateStringCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  doc.write(`if (typeof ${accessor} !== "string") return INVALID;`);
+
+  // z.email() carries its format on the def, z.string().email() in def.checks; both route here so the format table has no second copy to drift from.
+  const def = schema._zod.def as unknown as StringFormatDef & { format?: string };
+  if (def.format === undefined) return accessor;
+  return generateStringFormatCheck(doc, ctx, def, accessor);
+}
+
+function generateNumberCheck(doc: Doc, schema: SomeType, accessor: string): string {
+  // Runtime z.number() rejects NaN and ±Infinity. Number.isFinite covers both.
+  doc.write(`if (typeof ${accessor} !== "number" || !Number.isFinite(${accessor})) return INVALID;`);
+
+  // Mini factories like z.int(), z.int32(), z.uint32(), z.float32() bake a number_format check into the schema def itself (not into def.checks). Apply the same constraint here.
+  const def = schema._zod.def as unknown as { check?: string; format?: string };
+  if (def.check === "number_format" && def.format) {
+    generateNumberFormatCheck(doc, { format: def.format } as checks.$ZodCheckNumberFormatDef, accessor);
+  }
+  return accessor;
+}
+
+function generateBooleanCheck(doc: Doc, accessor: string): string {
+  doc.write(`if (typeof ${accessor} !== "boolean") return INVALID;`);
+  return accessor;
+}
+
+function generateBigIntCheck(doc: Doc, schema: SomeType, accessor: string): string {
+  doc.write(`if (typeof ${accessor} !== "bigint") return INVALID;`);
+
+  // Handle bigint format (int64, uint64) directly on the schema def
+  const def = schema._zod.def as unknown as { format?: string };
+  if (def.format) {
+    switch (def.format) {
+      case "int64":
+        doc.write(`if (${accessor} < -9223372036854775808n || ${accessor} > 9223372036854775807n) return INVALID;`);
+        break;
+      case "uint64":
+        doc.write(`if (${accessor} < 0n || ${accessor} > 18446744073709551615n) return INVALID;`);
+        break;
+    }
+  }
+  return accessor;
+}
+
+function generateSymbolCheck(doc: Doc, accessor: string): string {
+  doc.write(`if (typeof ${accessor} !== "symbol") return INVALID;`);
+  return accessor;
+}
+
+function generateUndefinedCheck(doc: Doc, accessor: string): string {
+  doc.write(`if (${accessor} !== undefined) return INVALID;`);
+  return accessor;
+}
+
+function generateNullCheck(doc: Doc, accessor: string): string {
+  doc.write(`if (${accessor} !== null) return INVALID;`);
+  return accessor;
+}
+
+function generateVoidCheck(doc: Doc, accessor: string): string {
+  doc.write(`if (${accessor} !== undefined) return INVALID;`);
+  return accessor;
+}
+
+function generateNaNCheck(doc: Doc, accessor: string): string {
+  doc.write(`if (typeof ${accessor} !== "number" || !Number.isNaN(${accessor})) return INVALID;`);
+  return accessor;
+}
+
+function generateDateCheck(doc: Doc, accessor: string): string {
+  doc.write(`if (!(${accessor} instanceof Date) || Number.isNaN(${accessor}.getTime())) return INVALID;`);
+  return accessor;
+}
+
+function generateObjectCheck(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  buildsValue = true
+): string | null {
+  const def = schema._zod.def as unknown as { shape: Record<string, SomeType>; catchall?: SomeType };
+
+  // Check that input is a non-null, non-array object
+  doc.write(
+    `if (typeof ${accessor} !== "object" || ${accessor} === null || Array.isArray(${accessor})) return INVALID;`
+  );
+
+  const shape = def.shape;
+  const keys = Object.keys(shape);
+  const symbolKeys = Object.getOwnPropertySymbols(shape);
+  // a symbol has no source literal, so it is hoisted as a constant; `keys` stays string-only where the emitted code uses `for...in`
+  const allKeys: (string | symbol)[] = symbolKeys.length ? [...keys, ...symbolKeys] : keys;
+  const keyExpr = (k: string | symbol) => (typeof k === "symbol" ? addConstant(ctx, k) : util.esc(k));
+  const propKey = (k: string | symbol) => (typeof k === "symbol" ? `[${keyExpr(k)}]` : util.esc(k));
+  const propShape = shape as Record<string | symbol, SomeType>;
+
+  // `__proto__` as an own shape key can't be expressed in an output object literal (the literal form sets the prototype instead of an own property).
+  if (keys.includes("__proto__")) {
+    throw new ZodCompileUnsupportedError('object shape key "__proto__"');
+  }
+
+  // Map from key to output accessor for that property
+  const propOutputs = new Map<string | symbol, string>();
+
+  // Validate each property and collect output accessors
+  for (const key of allKeys) {
+    const propSchema = propShape[key]!;
+    const kx = keyExpr(key);
+    // Always cache the property read: the runtime reads input[key] exactly once, so a getter must not be re-read by checks or output assembly.
+    const inputVar = newVar(ctx);
+    doc.write(`const ${inputVar} = ${accessor}[${kx}];`);
+
+    if (propSchema._zod.optin !== undefined) {
+      // Any optin rung means the key may be omitted. The runtime runs the property anyway and ignores issues only when the key is genuinely absent, which is what makes exactOptional compositional.
+      const outputVar = newVar(ctx);
+      doc.write(`let ${outputVar} = (() => {`);
+      doc.indented((d) => {
+        const outputAccessor = compileChild(d, ctx, propSchema, inputVar);
+        d.write(`return ${outputAccessor};`);
+      });
+      doc.write(`})();`);
+
+      if (propSchema._zod.optout === "optional") {
+        doc.write(`if (${outputVar} === INVALID) {`);
+        doc.indented((d) => {
+          d.write(`if (${kx} in ${accessor}) return INVALID;`);
+          d.write(`${outputVar} = undefined;`);
+        });
+        doc.write(`}`);
+      } else {
+        doc.write(`if (${outputVar} === INVALID) return INVALID;`);
+      }
+      propOutputs.set(key, outputVar);
+    } else {
+      if (requiresPresenceCheck(propSchema)) {
+        doc.write(`if (!(${kx} in ${accessor})) return INVALID;`);
+      }
+
+      // Generate check and get output accessor
+      const outputAccessor = compileChild(doc, ctx, propSchema, inputVar, buildsValue);
+      if (outputAccessor !== null) propOutputs.set(key, outputAccessor);
+    }
+  }
+
+  // Handle catchall
+  const catchall = def.catchall;
+  let unknownKeysMode: "none" | "passthrough" | "schema" = "none";
+
+  if (catchall) {
+    const catchallType = catchall._zod.def.type;
+
+    if (catchallType === "never") {
+      // Strict: one `for...in`, as the runtime does, so inherited enumerable keys count. An undeclared `__proto__` is reported here and excluded only from the output (#6221); an own-key count would wrongly reject a class instance.
+      const condition = keys.map((k) => `k !== ${util.esc(k)}`).join(" && ") || "true";
+      doc.write(`for (const k in ${accessor}) {`);
+      doc.indented((d) => {
+        d.write(`if (${condition}) return INVALID;`);
+      });
+      doc.write(`}`);
+    } else if ((catchallType === "unknown" || catchallType === "any") && !catchall._zod.def.checks?.length) {
+      unknownKeysMode = "passthrough";
+    } else {
+      unknownKeysMode = "schema";
+    }
+  }
+  // else: strip mode (no catchall) - unknown keys ignored, only include known keys
+
+  // Shape keys in declared order, then unknown keys in for...in order. A middle-rung key is included iff present on the input, else iff its output is not undefined.
+  const outputVar = newVar(ctx);
+  const hasConditionalKeys = allKeys.some((k) => mayOutputUndefined(propShape[k]!) || dropsWhenAbsent(propShape[k]!));
+
+  // Assert mode: every declared key is validated above, so the output literal and the unknown-key copy are pure waste. A `never` catchall already emitted its rejection loop; a schema catchall still has to validate the values it would otherwise have stored.
+  if (!buildsValue) {
+    if (unknownKeysMode === "schema") {
+      const knownSet = keys.length > 0 ? addConstant(ctx, new Set(keys)) : null;
+      doc.write(`for (const k in ${accessor}) {`);
+      doc.indented((d) => {
+        d.write(`if (k === "__proto__") continue;`);
+        if (knownSet) d.write(`if (${knownSet}.has(k)) continue;`);
+        const valVar = newVar(ctx);
+        d.write(`const ${valVar} = ${accessor}[k];`);
+        compileChild(d, ctx, catchall!, valVar, false);
+      });
+      doc.write(`}`);
+    }
+    return null;
+  }
+
+  if (!hasConditionalKeys) {
+    const propLiterals = allKeys.map((k) => `${propKey(k)}: ${propOutputs.get(k)}`).join(", ");
+    doc.write(`const ${outputVar} = { ${propLiterals} };`);
+  } else {
+    doc.write(`const ${outputVar} = {};`);
+    for (const k of allKeys) {
+      const kx = keyExpr(k);
+      const out = propOutputs.get(k);
+      if (dropsWhenAbsent(propShape[k]!)) {
+        doc.write(`if (${kx} in ${accessor}) ${outputVar}[${kx}] = ${out};`);
+      } else if (mayOutputUndefined(propShape[k]!)) {
+        doc.write(`if (${out} !== undefined || ${kx} in ${accessor}) ${outputVar}[${kx}] = ${out};`);
+      } else {
+        doc.write(`${outputVar}[${kx}] = ${out};`);
+      }
+    }
+  }
+
+  if (unknownKeysMode !== "none") {
+    // Unknown keys are written directly into the output after shape keys — for...in (like the runtime) so inherited enumerables participate.
+    const knownSet = keys.length > 0 ? addConstant(ctx, new Set(keys)) : null;
+    doc.write(`for (const k in ${accessor}) {`);
+    doc.indented((d) => {
+      // Skip __proto__: assigning obj["__proto__"] on a plain {} replaces the prototype via the setter rather than adding an own property. Mirrors the runtime catchall fix (#5898).
+      d.write(`if (k === "__proto__") continue;`);
+      if (knownSet) d.write(`if (${knownSet}.has(k)) continue;`);
+      if (unknownKeysMode === "passthrough") {
+        d.write(`${outputVar}[k] = ${accessor}[k];`);
+      } else {
+        const valVar = newVar(ctx);
+        d.write(`const ${valVar} = ${accessor}[k];`);
+        const catchallOut = compileChild(d, ctx, catchall!, valVar);
+        d.write(`${outputVar}[k] = ${catchallOut};`);
+      }
+    });
+    doc.write(`}`);
+  }
+
+  return outputVar;
+}
+
+function generateOptionalCheck(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  buildsValue = true
+): string | null {
+  const def = schema._zod.def as unknown as { innerType: SomeType };
+  if (isExactOptional(schema)) {
+    return generateCheck(doc, ctx, def.innerType, accessor, buildsValue);
+  }
+
+  // Same question $ZodOptional asks: only the top rung of the optin ladder substitutes a value for an absent input, so only it is worth running on `undefined`. Every other rung leaves the value intact, which is the skip branch below.
+  if (def.innerType._zod.optin === "defaulted") {
+    const outputVar = newVar(ctx);
+    const branchVar = newVar(ctx);
+    doc.write(`let ${outputVar};`);
+    doc.write(`if (${accessor} === undefined) {`);
+    doc.indented((d) => {
+      d.write(`const ${branchVar} = (() => {`);
+      d.indented((d2) => {
+        const innerOutput = generateCheck(d2, ctx, def.innerType, accessor);
+        d2.write(`return ${innerOutput};`);
+      });
+      d.write(`})();`);
+      d.write(`if (${branchVar} !== INVALID) ${outputVar} = ${branchVar};`);
+    });
+    doc.write(`} else {`);
+    doc.indented((d) => {
+      const innerOutput = generateCheck(d, ctx, def.innerType, accessor);
+      d.write(`${outputVar} = ${innerOutput};`);
+    });
+    doc.write(`}`);
+    return outputVar;
+  }
+
+  const outputVar = buildsValue ? newVar(ctx) : null;
+  if (outputVar) doc.write(`let ${outputVar};`);
+  doc.write(`if (${accessor} !== undefined) {`);
+  doc.indented((d) => {
+    const innerOutput = generateCheck(d, ctx, def.innerType, accessor, buildsValue);
+    if (outputVar && innerOutput !== null) d.write(`${outputVar} = ${innerOutput};`);
+  });
+  doc.write(`}`);
+  return outputVar;
+}
+
+function generateNullableCheck(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  buildsValue = true
+): string | null {
+  const def = schema._zod.def as unknown as { innerType: SomeType };
+  const outputVar = buildsValue ? newVar(ctx) : null;
+  if (outputVar) doc.write(`let ${outputVar} = null;`);
+  doc.write(`if (${accessor} !== null) {`);
+  doc.indented((d) => {
+    const innerOutput = generateCheck(d, ctx, def.innerType, accessor, buildsValue);
+    if (outputVar && innerOutput !== null) d.write(`${outputVar} = ${innerOutput};`);
+  });
+  doc.write(`}`);
+  return outputVar;
+}
+
+function generateArrayCheck(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  buildsValue = true
+): string | null {
+  const def = schema._zod.def as unknown as { element: SomeType };
+  doc.write(`if (!Array.isArray(${accessor})) return INVALID;`);
+
+  // Build a new array with validated/transformed elements.
+  const outputVar = buildsValue ? newVar(ctx) : null;
+  const iVar = newVar(ctx);
+  const elemVar = newVar(ctx);
+
+  if (outputVar) doc.write(`const ${outputVar} = new Array(${accessor}.length);`);
+  doc.write(`for (let ${iVar} = 0; ${iVar} < ${accessor}.length; ${iVar}++) {`);
+  doc.indented((d) => {
+    d.write(`const ${elemVar} = ${accessor}[${iVar}];`);
+    const elemOutput = compileChild(d, ctx, def.element, elemVar, buildsValue);
+    if (outputVar && elemOutput !== null) d.write(`${outputVar}[${iVar}] = ${elemOutput};`);
+  });
+  doc.write(`}`);
+
+  return outputVar;
+}
+
+function generateLiteralCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { values: unknown[] };
+  const values = def.values;
+
+  // Anything but a single value goes through Set.has: multi-value so every value participates, empty so nothing does — values[0] would be undefined and compile to an `!== undefined` check that accepts it. Single-value stays inlined for speed.
+  if (values.length !== 1) {
+    const literalSet = addConstant(ctx, new Set(values));
+    doc.write(`if (!${literalSet}.has(${accessor})) return INVALID;`);
+    return accessor;
+  }
+
+  const value = values[0];
+  // `$ZodLiteral` matches with `values.has`, i.e. SameValueZero, so NaN matches itself. `x !== NaN` is true for every input, which would reject everything — hand it to the same Set form the multi-value path uses.
+  if (typeof value === "number" && Number.isNaN(value)) {
+    const literalSet = addConstant(ctx, new Set(values));
+    doc.write(`if (!${literalSet}.has(${accessor})) return INVALID;`);
+    return accessor;
+  }
+  if (typeof value === "string") {
+    doc.write(`if (${accessor} !== ${util.esc(value)}) return INVALID;`);
+  } else if (typeof value === "number" || typeof value === "boolean") {
+    doc.write(`if (${accessor} !== ${value}) return INVALID;`);
+  } else if (value === null) {
+    doc.write(`if (${accessor} !== null) return INVALID;`);
+  } else if (value === undefined) {
+    doc.write(`if (${accessor} !== undefined) return INVALID;`);
+  } else if (typeof value === "bigint") {
+    doc.write(`if (${accessor} !== ${value}n) return INVALID;`);
+  } else {
+    throw new ZodCompileUnsupportedError(`literal type ${typeof value}`);
+  }
+  return accessor;
+}
+
+function generateEnumCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const values = (schema._zod as unknown as { values?: Set<unknown> }).values;
+  // z.partialRecord and friends clear `_zod.values`, leaving no set to test membership against. Throw rather than emit INVALID so a union falls back whole instead of counting a false rejection.
+  if (!values) {
+    throw new ZodCompileUnsupportedError("enum schema without enumerated values");
+  }
+  const enumSet = addConstant(ctx, values);
+  doc.write(`if (!${enumSet}.has(${accessor})) return INVALID;`);
+  return accessor;
+}
+
+function generateWrapperCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { innerType: SomeType };
+  return generateCheck(doc, ctx, def.innerType, accessor);
+}
+
+function generateDefaultCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { innerType: SomeType };
+
+  // `defaultValue` is an accessor on schemas built through the classic/mini
+  // factories and a plain data property on ones rebuilt programmatically
+  // (deepPartial and friends). Read it off the def either way — taking only
+  // `descriptor.get` silently dropped the default for the second kind, so
+  // `.default(v)` compiled to `undefined` instead of `v`.
+  const descriptor = Object.getOwnPropertyDescriptor(schema._zod.def, "defaultValue");
+  const defaultGetter = descriptor
+    ? () => (schema._zod.def as unknown as { defaultValue: unknown }).defaultValue
+    : undefined;
+
+  // prefault differs from default: undefined-input is first replaced with the prefault value, then run through the inner schema.
+  if (schema._zod.def.type === "prefault") {
+    if (!defaultGetter) {
+      return generateCheck(doc, ctx, def.innerType, accessor);
+    }
+    const defaultFn = addConstant(ctx, defaultGetter);
+    const inputVar = newVar(ctx);
+    doc.write(`let ${inputVar} = ${accessor};`);
+    doc.write(`if (${accessor} === undefined) ${inputVar} = ${defaultFn}();`);
+    return generateCheck(doc, ctx, def.innerType, inputVar);
+  }
+
+  const outputVar = newVar(ctx);
+
+  // Default allows undefined (replaces with default value), otherwise validates inner type
+  if (defaultGetter) {
+    const defaultFn = addConstant(ctx, defaultGetter);
+    const cloneFn = addConstant(ctx, util.shallowClone);
+    doc.write(`let ${outputVar};`);
+    doc.write(`if (${accessor} === undefined) {`);
+    doc.indented((d) => {
+      // Shallow-clone the default so callers can mutate the result without affecting subsequent parses (#5855 — also covers Map/Set).
+      d.write(`${outputVar} = ${cloneFn}(${defaultFn}());`);
+    });
+    doc.write(`} else {`);
+    doc.indented((d) => {
+      const innerOutput = generateCheck(d, ctx, def.innerType, accessor);
+      d.write(`${outputVar} = ${innerOutput} === undefined ? ${cloneFn}(${defaultFn}()) : ${innerOutput};`);
+    });
+    doc.write(`}`);
+  } else {
+    doc.write(`let ${outputVar};`);
+    doc.write(`if (${accessor} !== undefined) {`);
+    doc.indented((d) => {
+      const innerOutput = generateCheck(d, ctx, def.innerType, accessor);
+      d.write(`${outputVar} = ${innerOutput};`);
+    });
+    doc.write(`}`);
+  }
+
+  return outputVar;
+}
+
+function generateNonOptionalCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { innerType: SomeType };
+  // The runtime inspects what the inner produced, not what it was given: a catch can turn a defined input into undefined, a default an absent one into a value.
+  const innerOutput = generateCheck(doc, ctx, def.innerType, accessor);
+  const outputVar = newVar(ctx);
+  doc.write(`const ${outputVar} = ${innerOutput};`);
+  doc.write(`if (${outputVar} === undefined) return INVALID;`);
+  return outputVar;
+}
+
+function generateTupleCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { items: SomeType[]; rest: SomeType | null };
+  const items = def.items;
+  const rest = def.rest;
+
+  doc.write(`if (!Array.isArray(${accessor})) return INVALID;`);
+
+  // Mirror the runtime's getTupleOptStart: find the first index where every subsequent slot accepts `undefined` (i.e. is optional on input). Anything shorter than this is too_small; trailing absent slots are legal.
+  const optinStart = tupleOptStart(items, "optin");
+  const optoutStart = tupleOptStart(items, "optout");
+
+  // Length bounds
+  if (rest) {
+    // With rest: minimum length is the last required input slot
+    doc.write(`if (${accessor}.length < ${optinStart}) return INVALID;`);
+  } else {
+    // No rest: input must be in [optinStart, items.length]
+    doc.write(`if (${accessor}.length < ${optinStart} || ${accessor}.length > ${items.length}) return INVALID;`);
+  }
+
+  // Build the output in assignment order so absent optional-output tail slots can truncate while default/prefault slots still fill missing positions.
+  const outputVar = newVar(ctx);
+  doc.write(`const ${outputVar} = [];`);
+
+  // Validate and collect each fixed item
+  for (let i = 0; i < items.length; i++) {
+    const itemSchema = items[i]!;
+    if (i >= optoutStart) {
+      doc.write(`if (${outputVar}.length === ${i}) {`);
+      doc.indented((d) => {
+        d.write(`if (${i} < ${accessor}.length) {`);
+        d.indented((d2) => {
+          const elemVar = newVar(ctx);
+          d2.write(`const ${elemVar} = ${accessor}[${i}];`);
+          const elemOutput = compileChild(d2, ctx, itemSchema, elemVar);
+          d2.write(`${outputVar}[${i}] = ${elemOutput};`);
+        });
+        d.write(`} else {`);
+        d.indented((d2) => {
+          // Middle rung: absence supplies nothing in its place, so truncate rather than running the item on `undefined` and keeping what it invents. Mirrors the leading gate in `handleTupleResults`.
+          if (dropsWhenAbsent(itemSchema)) {
+            d2.write(`${outputVar}.length = ${i};`);
+            return;
+          }
+          const elemVar = newVar(ctx);
+          const branchVar = newVar(ctx);
+          d2.write(`const ${elemVar} = undefined;`);
+          d2.write(`const ${branchVar} = (() => {`);
+          d2.indented((d3) => {
+            const elemOutput = compileChild(d3, ctx, itemSchema, elemVar);
+            d3.write(`return ${elemOutput};`);
+          });
+          d2.write(`})();`);
+          d2.write(`if (${branchVar} === INVALID || ${branchVar} === undefined) ${outputVar}.length = ${i};`);
+          d2.write(`else ${outputVar}[${i}] = ${branchVar};`);
+        });
+        d.write(`}`);
+      });
+      doc.write(`}`);
+    } else {
+      const elemVar = newVar(ctx);
+      doc.write(`const ${elemVar} = ${accessor}[${i}];`);
+      const elemOutput = compileChild(doc, ctx, itemSchema, elemVar);
+      doc.write(`${outputVar}[${i}] = ${elemOutput};`);
+    }
+  }
+
+  // Validate and collect rest elements if present
+  if (rest) {
+    const iVar = newVar(ctx);
+    const elemVar = newVar(ctx);
+    doc.write(`for (let ${iVar} = ${items.length}; ${iVar} < ${accessor}.length; ${iVar}++) {`);
+    doc.indented((d) => {
+      d.write(`const ${elemVar} = ${accessor}[${iVar}];`);
+      const elemOutput = compileChild(d, ctx, rest, elemVar);
+      d.write(`${outputVar}[${iVar}] = ${elemOutput};`);
+    });
+    doc.write(`}`);
+  }
+
+  return outputVar;
+}
+
+function tupleOptStart(items: SomeType[], key: "optin" | "optout"): number {
+  for (let i = items.length - 1; i >= 0; i--) {
+    // Mirrors the runtime: optin is a three-rung ladder so any rung above `undefined` permits an absent slot; optout stays two-valued.
+    const omittable = key === "optin" ? items[i]!._zod.optin !== undefined : items[i]!._zod.optout === "optional";
+    if (!omittable) return i + 1;
+  }
+  return 0;
+}
+
+function generateUnionCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as {
+    options: SomeType[];
+    inclusive?: boolean;
+    discriminator?: string;
+    unionFallback?: boolean;
+  };
+  const options = def.options;
+
+  if (def.discriminator) {
+    return generateDiscriminatedUnionCheck(
+      doc,
+      ctx,
+      def as { options: SomeType[]; discriminator: string; unionFallback?: boolean },
+      accessor
+    );
+  }
+
+  // z.xor requires *exactly one* option to match. Match-counting in the fast path is only sound if every branch is exactly as strict as the runtime — any falsely-rejecting branch silently turns a multi-match rejection into an accept. Force the runtime for this rare combinator.
+  if (def.inclusive === false) {
+    throw new ZodCompileUnsupportedError("exclusive unions (z.xor)");
+  }
+
+  if (options.length === 0) {
+    doc.write("return INVALID;");
+    return accessor;
+  }
+
+  if (options.length === 1) {
+    return generateCheck(doc, ctx, options[0]!, accessor);
+  }
+
+  // Check if all options are bare literals - use Set optimization. A literal option carrying checks (e.g. .refine) must take the general path or the Set would accept values its checks reject.
+  const allLiterals = options.every(
+    (opt) => opt._zod.def.type === "literal" && !(opt._zod.def.checks as unknown[] | undefined)?.length
+  );
+  if (allLiterals) {
+    const values = new Set(options.flatMap((opt) => (opt._zod.def as unknown as { values: unknown[] }).values));
+    const valuesConst = addConstant(ctx, values);
+    doc.write(`if (!${valuesConst}.has(${accessor})) return INVALID;`);
+    return accessor;
+  }
+
+  // General case: try each option until one succeeds Use IIFEs that return the output or INVALID
+  const outputVar = newVar(ctx);
+  doc.write(`let ${outputVar};`);
+
+  for (let i = 0; i < options.length; i++) {
+    const opt = options[i]!;
+
+    if (i === 0) {
+      doc.write(`${outputVar} = (() => {`);
+    } else {
+      doc.write(`if (${outputVar} === INVALID) ${outputVar} = (() => {`);
+    }
+
+    doc.indented((d) => {
+      // Generate check inside IIFE - returns INVALID on failure
+      const branchOutput = generateCheck(d, ctx, opt, accessor);
+      d.write(`return ${branchOutput};`);
+    });
+    doc.write(`})();`);
+  }
+
+  doc.write(`if (${outputVar} === INVALID) return INVALID;`);
+  return outputVar;
+}
+
+function generateDiscriminatedUnionCheck(
+  doc: Doc,
+  ctx: CompileContext,
+  def: { options: SomeType[]; discriminator: string; unionFallback?: boolean },
+  accessor: string
+): string {
+  if (def.unionFallback) {
+    throw new ZodCompileUnsupportedError("discriminated union with unionFallback");
+  }
+
+  if (def.options.length === 0) {
+    doc.write("return INVALID;");
+    return accessor;
+  }
+
+  const discVar = newVar(ctx);
+  const outputVar = newVar(ctx);
+  doc.write(`const ${discVar} = ${accessor}?.[${util.esc(def.discriminator)}];`);
+  doc.write(`let ${outputVar};`);
+
+  let firstBranch = true;
+  const claimed = new Set<util.Primitive>();
+  for (const option of def.options) {
+    const values = option._zod.propValues?.[def.discriminator];
+    if (!values || values.size === 0) {
+      throw new ZodCompileUnsupportedError("discriminated union option without static discriminator values");
+    }
+
+    // Two options claiming one value are not discriminable, and the branch chain below would silently give it to the first. Declining to compile hands that back to the interpreter, whose own map build reports it.
+    for (const value of values) {
+      if (claimed.has(value)) {
+        throw new ZodCompileUnsupportedError(`duplicate discriminator value ${String(value)}`);
+      }
+      claimed.add(value);
+    }
+
+    const conditions = Array.from(values, (value) => literalEquality(ctx, discVar, value));
+    const prefix = firstBranch ? "if" : "else if";
+    doc.write(`${prefix} (${conditions.join(" || ")}) {`);
+    doc.indented((d) => {
+      const branchOutput = generateCheck(d, ctx, option, accessor);
+      d.write(`${outputVar} = ${branchOutput};`);
+    });
+    doc.write(`}`);
+    firstBranch = false;
+  }
+
+  doc.write(`else { return INVALID; }`);
+  return outputVar;
+}
+
+function literalEquality(ctx: CompileContext, accessor: string, value: unknown): string {
+  if (typeof value === "string") return `${accessor} === ${util.esc(value)}`;
+  if (typeof value === "number") {
+    if (Number.isNaN(value)) return `Number.isNaN(${accessor})`;
+    return `${accessor} === ${value}`;
+  }
+  if (typeof value === "boolean") return `${accessor} === ${value}`;
+  if (value === null) return `${accessor} === null`;
+  if (value === undefined) return `${accessor} === undefined`;
+  if (typeof value === "bigint") return `${accessor} === ${value}n`;
+  if (typeof value === "symbol") {
+    const symbolConst = addConstant(ctx, value);
+    return `${accessor} === ${symbolConst}`;
+  }
+  throw new ZodCompileUnsupportedError(`literal discriminator value ${String(value)}`);
+}
+
+function generateIntersectionCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { left: SomeType; right: SomeType };
+  // An unmergeable merge, and a child failing before the merge is even reached, both return INVALID for a case the interpreter answers with a throw.
+  ctx.definite = false;
+  const leftOutput = compileChild(doc, ctx, def.left, accessor);
+  const rightOutput = compileChild(doc, ctx, def.right, accessor);
+
+  // Hoist the runtime merge helper so recursive object/array merge semantics stay in one place. If the merge is invalid, return INVALID and let the runtime fallback construct canonical errors.
+  const mergeConst = addConstant(ctx, mergeValues);
+  const mergedVar = newVar(ctx);
+  doc.write(`const ${mergedVar} = ${mergeConst}(${leftOutput}, ${rightOutput});`);
+  doc.write(`if (!${mergedVar}.valid) return INVALID;`);
+  return `${mergedVar}.data`;
+}
+
+function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { keyType: SomeType; valueType: SomeType };
+
+  // Use util.isPlainObject (rejects Date, Map, Set, class instances, etc.) to match runtime behavior. Hoisted call instead of inline so this stays a single source of truth with the runtime parser.
+  const isPlainObjectConst = addConstant(ctx, util.isPlainObject);
+  doc.write(`if (!${isPlainObjectConst}(${accessor})) return INVALID;`);
+
+  const outputVar = newVar(ctx);
+  const kVar = newVar(ctx);
+  const valVar = newVar(ctx);
+
+  doc.write(`const ${outputVar} = {};`);
+
+  // Exhaustive record. The runtime gates this on `values && !def.partial`, since z.partialRecord keeps its value set but makes every key optional; a loose record passes unrecognized keys through, which the per-key scan cannot express.
+  const recordDef = def as unknown as { mode?: string; partial?: boolean };
+  const keyValues = recordDef.partial ? undefined : (def.keyType._zod as unknown as { values?: Set<unknown> }).values;
+  if (keyValues) {
+    const inputKeys: Array<string | symbol> = [];
+    for (const key of keyValues) {
+      if (!(typeof key === "string" || typeof key === "number" || typeof key === "symbol")) {
+        throw new ZodCompileUnsupportedError(`record key value ${String(key)}`);
+      }
+
+      const inputKey = typeof key === "number" ? key.toString() : key;
+      if (inputKey === "__proto__") {
+        // `out["__proto__"] = v` would hit the prototype setter on the output.
+        throw new ZodCompileUnsupportedError('record key "__proto__"');
+      }
+      inputKeys.push(inputKey);
+
+      const keyConst = addConstant(ctx, key);
+      const outKey = generateCheck(doc, ctx, def.keyType, keyConst);
+      // Read the property once. Passing the raw expression let compileChild validate one read while the output write performed a second, so a getter could hand back a value nothing had checked.
+      const valueVar = newVar(ctx);
+      doc.write(`const ${valueVar} = ${accessor}[${literalPropertyKey(ctx, inputKey)}];`);
+      const valOutput = compileChild(doc, ctx, def.valueType, valueVar);
+      doc.write(`${outputVar}[${outKey}] = ${valOutput};`);
+    }
+
+    // `mode: "loose"` changes only what happens to unrecognized keys, so it belongs here rather than the per-present-key scan. Passing them through matches the runtime, which skips `__proto__`.
+    const knownKeysConst = addConstant(ctx, new Set(inputKeys));
+    doc.write(`for (const ${kVar} in ${accessor}) {`);
+    doc.indented((d) => {
+      d.write(`if (${knownKeysConst}.has(${kVar})) continue;`);
+      if (recordDef.mode === "loose") {
+        d.write(`if (${kVar} !== "__proto__") ${outputVar}[${kVar}] = ${accessor}[${kVar}];`);
+      } else {
+        d.write(`return INVALID;`);
+      }
+    });
+    doc.write(`}`);
+    return outputVar;
+  }
+
+  // The bare-string shortcut below only tests `typeof key === "string"`, so it
+  // is correct exclusively for a `z.string()` carrying nothing else. A string
+  // *format* lives on the def rather than in `checks` — `z.record(z.email(), …)`
+  // reads as a plain string here — and coercion rewrites the key, so both have
+  // to take the general path or the shortcut accepts keys the runtime rejects.
+  const keyDef = def.keyType._zod.def as { type: string; format?: string; coerce?: boolean; checks?: unknown[] };
+  const keyIsBareString =
+    keyDef.type === "string" && keyDef.format === undefined && !keyDef.coerce && (keyDef.checks?.length ?? 0) === 0;
+  if (!keyIsBareString) {
+    // A key schema with no value set is a constraint every key must satisfy
+    // (`z.email()`, `z.string().min(3)`, `z.number()`, a template literal).
+    // The runtime runs it against each own enumerable key and writes the value
+    // under the key it produced, so compile it once and call it per key.
+    const isLoose = (def as { mode?: string }).mode === "loose";
+    // the key compiles in its own context, so carry its verdict out: a key schema that can answer INVALID undecidably makes this validator undecidable too
+    const keyFn = compileFn(def.keyType);
+    if (keyFn.definite === false) ctx.definite = false;
+    const keyFast = addConstant(ctx, keyFn);
+    const numericConst = addConstant(ctx, regexes.number);
+    const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
+    const outKeyVar = newVar(ctx);
+
+    doc.write(`for (const ${kVar} of Reflect.ownKeys(${accessor})) {`);
+    doc.indented((d) => {
+      d.write(`if (${kVar} === "__proto__") continue;`);
+      d.write(`if (!${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
+      d.write(`let ${outKeyVar} = ${keyFast}(${kVar});`);
+      // Numeric-string retry, mirroring the runtime: a key the schema rejects as a string is tried again as a number, so z.record(z.number(), …) matches the numeric keys JavaScript stringified on the way in.
+      d.write(
+        `if (${outKeyVar} === INVALID && typeof ${kVar} === "string" && ${numericConst}.test(${kVar})) ${outKeyVar} = ${keyFast}(Number(${kVar}));`
+      );
+      if (isLoose) {
+        // A loose record keeps a key its schema rejects, copying the value across unvalidated rather than failing the parse.
+        d.write(`if (${outKeyVar} === INVALID) { ${outputVar}[${kVar}] = ${accessor}[${kVar}]; continue; }`);
+      } else {
+        d.write(`if (${outKeyVar} === INVALID) return INVALID;`);
+      }
+      // The guard above tested the input key, but the schema can normalize an ordinary key into __proto__; re-check the one actually written under.
+      d.write(`if (${outKeyVar} === "__proto__") continue;`);
+      // Read once: the raw expression would be evaluated again by the output write below, so an accessor could return an unvalidated second value.
+      const valueVar = newVar(ctx);
+      d.write(`const ${valueVar} = ${accessor}[${kVar}];`);
+      const valOutput = compileChild(d, ctx, def.valueType, valueVar);
+      d.write(`${outputVar}[${outKeyVar}] = ${valOutput};`);
+    });
+    doc.write(`}`);
+    return outputVar;
+  }
+
+  // Plain z.string() keys: iterate enumerable own keys and validate each value. Runtime uses Reflect.ownKeys so symbol keys participate in validation; matching that here prevents silently accepting objects with enumerable Symbol keys under z.record(z.string(), ...).
+  const propIsEnumerable = addConstant(ctx, Object.prototype.propertyIsEnumerable);
+  doc.write(`for (const ${kVar} of Reflect.ownKeys(${accessor})) {`);
+  doc.indented((d) => {
+    d.write(`if (${kVar} === "__proto__") continue;`);
+    d.write(`if (!${propIsEnumerable}.call(${accessor}, ${kVar})) continue;`);
+    d.write(`if (typeof ${kVar} !== "string") return INVALID;`);
+    d.write(`const ${valVar} = ${accessor}[${kVar}];`);
+    const valOutput = compileChild(d, ctx, def.valueType, valVar);
+    d.write(`${outputVar}[${kVar}] = ${valOutput};`);
+  });
+  doc.write(`}`);
+
+  return outputVar;
+}
+
+function literalPropertyKey(ctx: CompileContext, key: string | symbol): string {
+  if (typeof key === "string") return util.esc(key);
+  return addConstant(ctx, key);
+}
+
+function generateMapCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { keyType: SomeType; valueType: SomeType };
+
+  doc.write(`if (!(${accessor} instanceof Map)) return INVALID;`);
+
+  const outputVar = newVar(ctx);
+  const kVar = newVar(ctx);
+  const valVar = newVar(ctx);
+
+  doc.write(`const ${outputVar} = new Map();`);
+  doc.write(`for (const [${kVar}, ${valVar}] of ${accessor}) {`);
+  doc.indented((d) => {
+    const keyOutput = generateCheck(d, ctx, def.keyType, kVar);
+    const valOutput = generateCheck(d, ctx, def.valueType, valVar);
+    d.write(`${outputVar}.set(${keyOutput}, ${valOutput});`);
+  });
+  doc.write(`}`);
+
+  return outputVar;
+}
+
+function generateSetCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { valueType: SomeType };
+
+  doc.write(`if (!(${accessor} instanceof Set)) return INVALID;`);
+
+  const outputVar = newVar(ctx);
+  const valVar = newVar(ctx);
+
+  doc.write(`const ${outputVar} = new Set();`);
+  doc.write(`for (const ${valVar} of ${accessor}) {`);
+  doc.indented((d) => {
+    const valOutput = generateCheck(d, ctx, def.valueType, valVar);
+    d.write(`${outputVar}.add(${valOutput});`);
+  });
+  doc.write(`}`);
+
+  return outputVar;
+}
+
+function generateFileCheck(doc: Doc, accessor: string): string {
+  // Runtime $ZodFile is a bare `instanceof File`, including the implicit global lookup. The previous duck-typed fallback accepted arbitrary {name, size} objects in File-less environments — behavior the runtime never had.
+  doc.write(`if (!(${accessor} instanceof File)) return INVALID;`);
+  return accessor;
+}
+
+function generateTemplateLiteralCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  doc.write(`if (typeof ${accessor} !== "string") return INVALID;`);
+
+  // Template literal schemas have a pre-computed pattern in _zod.pattern
+  const pattern = (schema._zod as unknown as { pattern: RegExp }).pattern;
+  if (pattern) {
+    const patternConst = addConstant(ctx, pattern);
+    doc.write(`${patternConst}.lastIndex = 0;`);
+    doc.write(`if (!${patternConst}.test(${accessor})) return INVALID;`);
+  }
+  return accessor;
+}
+
+function generateLazyCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  // For lazy schemas, we use a cached parser that falls back to runtime Zod parsing This handles recursive schemas correctly by avoiding infinite compilation loops
+  const def = schema._zod.def as unknown as { getter: () => SomeType };
+  const getterConst = addUserConstant(ctx, def.getter);
+  const cacheConst = addConstant(ctx, { parser: null as ((input: unknown) => unknown) | null });
+
+  doc.write(`if (!${cacheConst}.parser) {`);
+  doc.indented((d) => {
+    d.write(`const inner = ${getterConst}();`);
+    d.write(`${cacheConst}.parser = function(input) {`);
+    d.indented((d2) => {
+      // Use runtime Zod parsing - this correctly handles recursive schemas Pass an empty ctx like runtimeRun does — runtime parsers read ctx.skipChecks/ctx.direction unconditionally and crash on undefined.
+      d2.write(`const result = inner._zod.run({ value: input, issues: [] }, {});`);
+      d2.write(`return result.issues.length === 0 ? result.value : INVALID;`);
+    });
+    d.write(`};`);
+  });
+  doc.write(`}`);
+
+  const outputVar = newVar(ctx);
+  doc.write(`const ${outputVar} = ${cacheConst}.parser(${accessor});`);
+  doc.write(`if (${outputVar} === INVALID) return INVALID;`);
+  return outputVar;
+}
+
+function generatePipeCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as {
+    in: SomeType;
+    out: SomeType;
+    transform?: (value: unknown, payload: unknown) => unknown;
+  };
+
+  // Validate input type first
+  const inputOutput = generateCheck(doc, ctx, def.in, accessor);
+
+  if (def.transform) {
+    // Apply transform and validate output. The transform may read its second `payload` argument (codec transforms like z.stringbool() push issues there) so wrap the call in a helper that spoofs a payload. Pushed issues signal INVALID and the wrapper falls back to the runtime, and a plain function handing back a promise answers INVALID too — union parity, but not a decidable rejection at the top level.
+    if (isAsyncFunction(def.transform)) {
+      throw new ZodCompileAsyncError("z.compile: async transforms in pipes are not supported");
+    }
+    const transformFn = def.transform;
+    const helperFn = (value: unknown): unknown => {
+      // `addIssue` has to be here: a transform reporting through it is reporting, not failing. Without it the call threw a TypeError that the old catch swallowed into a fallback, so every ctx.addIssue transform quietly lost its fast path and the real error was never visible.
+      const fakePayload = { value, issues: [] as unknown[], addIssue: pushIssue };
+      // A throw is deliberately not caught. The interpreter lets one propagate out of the whole parse; swallowing it into INVALID turned a thrown error into a merely-rejected union branch, so a later branch answered instead.
+      const result = transformFn(value, fakePayload as any);
+      if (result instanceof Promise) return INVALID;
+      return fakePayload.issues.length === 0 ? result : INVALID;
+    };
+    const helperConst = addUserConstant(ctx, helperFn);
+    const transformedVar = newVar(ctx);
+    doc.write(`const ${transformedVar} = ${helperConst}(${inputOutput});`);
+    doc.write(`if (${transformedVar} === INVALID) return INVALID;`);
+    return generateCheck(doc, ctx, def.out, transformedVar);
+  } else {
+    // No transform - validate output type on same value
+    return generateCheck(doc, ctx, def.out, inputOutput);
+  }
+}
+
+function generateCustomCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as { fn?: (value: unknown) => boolean };
+
+  if (def.fn) {
+    // Check for async function
+    if (isAsyncFunction(def.fn)) {
+      throw new ZodCompileAsyncError("z.compile: async custom predicates are not supported");
+    }
+    // Custom schema with a predicate function (e.g. z.instanceof). `isAsyncFunction` above is syntactic, so a plain function returning a promise reaches here, and a promise is truthy — it would read as a pass where the interpreter throws.
+    const fnConst = addUserConstant(ctx, def.fn);
+    const throwAsyncConst = addConstant(ctx, throwAsync);
+    const resVar = newVar(ctx);
+    doc.write(`const ${resVar} = ${fnConst}(${accessor});`);
+    doc.write(`if (${resVar} instanceof Promise) ${throwAsyncConst}();`);
+    doc.write(`if (!${resVar}) return INVALID;`);
+  } else {
+    throw new ZodCompileUnsupportedError("custom schema without a predicate function");
+  }
+  return accessor;
+}
+
+// Runtime helper for a compiled `catch`: runs the inner schema once and returns its value when it succeeded. Anything else — a failure the catch would handle, or an async inner — returns INVALID so the interpreter takes over.
+function runtimeCatch(innerSchema: SomeType, catchValue: () => unknown, value: unknown): unknown {
+  const result = (innerSchema._zod.run as (p: ParsePayload, c: ParseContextInternal) => any)(
+    { value, issues: [] },
+    {} as ParseContextInternal
+  );
+  if (result && typeof (result as Promise<unknown>).then === "function") return INVALID;
+  const r = result as { value: unknown; issues: any[] };
+  if (r.issues.length === 0) return r.value;
+  // Only reached for a catch value that ignores the parse context — codegen refuses the rest — so there are no issues to finalize and nothing here needs the caller's error map.
+  return catchValue();
+}
+
+function generateCatchCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as {
+    innerType: SomeType;
+    catchValue: (ctx: any) => unknown;
+  };
+
+  // An untagged catchValue is a user callback, and one reading `ctx.error` needs the caller's per-parse error map. Catch *succeeds*, so a wrong message there is unobservable — refuse at codegen, and not islandable either, since `runtimeRun` has no context to hand it.
+  if (!(def.catchValue as { [util.CONSTANT_CATCH]?: boolean })[util.CONSTANT_CATCH]) {
+    throw new ZodCompileUnsupportedError("catch with a callback (only a constant catch value compiles)", false);
+  }
+
+  const outputVar = newVar(ctx);
+  doc.write(`let ${outputVar} = (() => {`);
+  doc.indented((d) => {
+    const innerOut = compileChild(d, ctx, def.innerType, accessor);
+    d.write(`return ${innerOut};`);
+  });
+  doc.write(`})();`);
+
+  const innerConst = addConstant(ctx, def.innerType);
+  const catchConst = addUserConstant(ctx, def.catchValue);
+  const catchHelperConst = addConstant(ctx, runtimeCatch);
+  doc.write(`if (${outputVar} === INVALID) {`);
+  doc.indented((d) => {
+    d.write(`${outputVar} = ${catchHelperConst}(${innerConst}, ${catchConst}, ${accessor});`);
+    d.write(`if (${outputVar} === INVALID) return INVALID;`);
+  });
+  doc.write(`}`);
+  return outputVar;
+}
+
+function generateTransformCheck(doc: Doc, ctx: CompileContext, schema: SomeType, accessor: string): string {
+  const def = schema._zod.def as unknown as {
+    transform: (value: unknown, payload: unknown) => unknown;
+  };
+
+  if (def.transform) {
+    // Check for async transform
+    if (isAsyncFunction(def.transform)) {
+      throw new ZodCompileAsyncError("z.compile: async transforms are not supported");
+    }
+
+    // Create a helper that runs the transform and returns the result or INVALID on error
+    const transformFn = def.transform;
+    const helperFn = (value: unknown): unknown => {
+      const fakePayload = { value, issues: [] as unknown[], addIssue: pushIssue };
+      // As in the pipe helper: a throw propagates, because the interpreter lets it out of the whole parse rather than treating it as a failed branch.
+      const result = transformFn(value, fakePayload);
+      if (result instanceof Promise) return INVALID;
+      return fakePayload.issues.length === 0 ? result : INVALID;
+    };
+    const helperConst = addUserConstant(ctx, helperFn);
+    const outputVar = newVar(ctx);
+    doc.write(`const ${outputVar} = ${helperConst}(${accessor});`);
+    doc.write(`if (${outputVar} === INVALID) return INVALID;`);
+    return outputVar;
+  }
+
+  return accessor;
+}
+
+type Codegen = (doc: Doc, ctx: CompileContext, inst: SomeType, accessor: string, buildsValue: boolean) => string | null;
+
+// One emitter per core subclass, keyed by the trait name its constructor records. A class without an entry inherits its nearest ancestor's; a class without any compilable ancestor is unsupported. Only `compile()` reads this, so a bundle that never compiles keeps none of it.
+const emitters: Record<string, Codegen> = {
+  $ZodObject: (doc, ctx, inst, accessor, buildsValue) => generateObjectCheck(doc, ctx, inst, accessor, buildsValue),
+  $ZodTuple: (doc, ctx, inst, accessor) => generateTupleCheck(doc, ctx, inst, accessor),
+  $ZodString: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodStringFormat: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodCustomStringFormat: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodEmail: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodGUID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodUUID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodURL: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodEmoji: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodNanoID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodCUID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodCUID2: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodULID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodXID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodKSUID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodISODateTime: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodISODate: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodISOTime: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodISODuration: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodIPv4: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodIPv6: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodCIDRv4: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodCIDRv6: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodBase64: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodBase64URL: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodE164: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodJWT: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodMAC: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodCreditCard: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+  $ZodNumber: (doc, _ctx, inst, accessor) => generateNumberCheck(doc, inst, accessor),
+  $ZodNumberFormat: (doc, _ctx, inst, accessor) => generateNumberCheck(doc, inst, accessor),
+  $ZodBigInt: (doc, _ctx, inst, accessor) => generateBigIntCheck(doc, inst, accessor),
+  $ZodBigIntFormat: (doc, _ctx, inst, accessor) => generateBigIntCheck(doc, inst, accessor),
+  $ZodBoolean: (doc, _ctx, _inst, accessor) => generateBooleanCheck(doc, accessor),
+  $ZodSymbol: (doc, _ctx, _inst, accessor) => generateSymbolCheck(doc, accessor),
+  $ZodUndefined: (doc, _ctx, _inst, accessor) => generateUndefinedCheck(doc, accessor),
+  $ZodNull: (doc, _ctx, _inst, accessor) => generateNullCheck(doc, accessor),
+  $ZodVoid: (doc, _ctx, _inst, accessor) => generateVoidCheck(doc, accessor),
+  $ZodNaN: (doc, _ctx, _inst, accessor) => generateNaNCheck(doc, accessor),
+  $ZodDate: (doc, _ctx, _inst, accessor) => generateDateCheck(doc, accessor),
+  $ZodFile: (doc, _ctx, _inst, accessor) => generateFileCheck(doc, accessor),
+  $ZodAny: (_doc, _ctx, _inst, accessor) => accessor,
+  $ZodUnknown: (_doc, _ctx, _inst, accessor) => accessor,
+  $ZodNever: (doc, _ctx, _inst, accessor) => {
+    doc.write("return INVALID;");
+    return accessor;
+  },
+  $ZodArray: (doc, ctx, inst, accessor, buildsValue) => generateArrayCheck(doc, ctx, inst, accessor, buildsValue),
+  $ZodNullable: (doc, ctx, inst, accessor, buildsValue) => generateNullableCheck(doc, ctx, inst, accessor, buildsValue),
+  $ZodOptional: (doc, ctx, inst, accessor, buildsValue) => generateOptionalCheck(doc, ctx, inst, accessor, buildsValue),
+  $ZodExactOptional: (doc, ctx, inst, accessor, buildsValue) =>
+    generateOptionalCheck(doc, ctx, inst, accessor, buildsValue),
+  $ZodLiteral: (doc, ctx, inst, accessor) => generateLiteralCheck(doc, ctx, inst, accessor),
+  $ZodEnum: (doc, ctx, inst, accessor) => generateEnumCheck(doc, ctx, inst, accessor),
+  $ZodTemplateLiteral: (doc, ctx, inst, accessor) => generateTemplateLiteralCheck(doc, ctx, inst, accessor),
+  $ZodNonOptional: (doc, ctx, inst, accessor) => generateNonOptionalCheck(doc, ctx, inst, accessor),
+  $ZodDefault: (doc, ctx, inst, accessor) => generateDefaultCheck(doc, ctx, inst, accessor),
+  $ZodPrefault: (doc, ctx, inst, accessor) => generateDefaultCheck(doc, ctx, inst, accessor),
+  $ZodUnion: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
+  $ZodDiscriminatedUnion: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
+  $ZodXor: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
+  $ZodIntersection: (doc, ctx, inst, accessor) => generateIntersectionCheck(doc, ctx, inst, accessor),
+  $ZodRecord: (doc, ctx, inst, accessor) => generateRecordCheck(doc, ctx, inst, accessor),
+  $ZodMap: (doc, ctx, inst, accessor) => generateMapCheck(doc, ctx, inst, accessor),
+  $ZodSet: (doc, ctx, inst, accessor) => generateSetCheck(doc, ctx, inst, accessor),
+  $ZodLazy: (doc, ctx, inst, accessor) => generateLazyCheck(doc, ctx, inst, accessor),
+  $ZodPipe: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
+  $ZodCodec: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
+  $ZodPreprocess: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
+  $ZodCustom: (doc, ctx, inst, accessor) => generateCustomCheck(doc, ctx, inst, accessor),
+  $ZodProperties: (doc, ctx, inst, accessor) => {
+    generatePropertiesChecks(doc, ctx, (inst as $ZodProperties)._zod.def, accessor, true);
+    return accessor;
+  },
+  $ZodTransform: (doc, ctx, inst, accessor) => generateTransformCheck(doc, ctx, inst, accessor),
+  $ZodCatch: (doc, ctx, inst, accessor) => generateCatchCheck(doc, ctx, inst, accessor),
+  $ZodReadonly: (doc, ctx, inst, accessor) => {
+    const innerOut = generateWrapperCheck(doc, ctx, inst, accessor);
+    // the runtime freezes the parsed value (handleReadonlyResult)
+    const frozenVar = newVar(ctx);
+    doc.write(`const ${frozenVar} = Object.freeze(${innerOut});`);
+    return frozenVar;
+  },
+  $ZodSuccess: (doc, ctx, inst, accessor) => {
+    // the runtime output is `issues.length === 0`; the fast path only gets here when the inner check passed, so the output is always true
+    generateWrapperCheck(doc, ctx, inst, accessor);
+    return "true";
+  },
+};
+
+/** The AOT emitter for a schema: its own `_zod.codegen` override, else the entry for the most specific trait its constructor recorded. */
+export function codegenFor(
+  schema: SomeType
+): ((doc: Doc, ctx: CompileContext, accessor: string, buildsValue: boolean) => string | null) | undefined {
+  const own = schema._zod.codegen;
+  if (own) return own;
+  // traits are recorded outermost-first, so the first hit is the most specific class
+  for (const trait of schema._zod.traits) {
+    const emit = emitters[trait];
+    if (emit) return (doc, ctx, accessor, buildsValue) => emit(doc, ctx, schema, accessor, buildsValue);
+  }
+  return undefined;
+}

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -800,13 +800,10 @@ function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
     if (keyFn.definite === false) ctx.definite = false;
     const keyFast = addConstant(ctx, keyFn);
     const numericConst = addConstant(ctx, regexes.number);
-    const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
     const outKeyVar = newVar(ctx);
 
-    doc.write(`for (const ${kVar} of Reflect.ownKeys(${accessor})) {`);
-    doc.indented((d) => {
-      d.write(`if (${kVar} === "__proto__") continue;`);
-      d.write(`if (!${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
+    // the body runs once per string key and once per symbol key, since a key schema can accept symbols
+    emitOwnKeys(doc, ctx, accessor, kVar, (d) => {
       d.write(`let ${outKeyVar} = ${keyFast}(${kVar});`);
       // Numeric-string retry, mirroring the runtime: a key the schema rejects as a string is tried again as a number, so z.record(z.number(), …) matches the numeric keys JavaScript stringified on the way in.
       d.write(
@@ -826,24 +823,54 @@ function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
       const valOutput = compileChild(d, ctx, def.valueType, valueVar);
       d.write(`${outputVar}[${outKeyVar}] = ${valOutput};`);
     });
-    doc.write(`}`);
     return outputVar;
   }
 
-  // Plain z.string() keys: iterate enumerable own keys and validate each value. Runtime uses Reflect.ownKeys so symbol keys participate in validation; matching that here prevents silently accepting objects with enumerable Symbol keys under z.record(z.string(), ...).
-  const propIsEnumerable = addConstant(ctx, Object.prototype.propertyIsEnumerable);
-  doc.write(`for (const ${kVar} of Reflect.ownKeys(${accessor})) {`);
-  doc.indented((d) => {
-    d.write(`if (${kVar} === "__proto__") continue;`);
-    d.write(`if (!${propIsEnumerable}.call(${accessor}, ${kVar})) continue;`);
-    d.write(`if (typeof ${kVar} !== "string") return INVALID;`);
-    d.write(`const ${valVar} = ${accessor}[${kVar}];`);
-    const valOutput = compileChild(d, ctx, def.valueType, valVar);
-    d.write(`${outputVar}[${kVar}] = ${valOutput};`);
-  });
-  doc.write(`}`);
+  // Plain z.string() keys: every own enumerable string key's value is validated, and an own enumerable symbol key fails the string key schema, as it does in the runtime's Reflect.ownKeys walk.
+  emitOwnKeys(
+    doc,
+    ctx,
+    accessor,
+    kVar,
+    (d) => {
+      d.write(`const ${valVar} = ${accessor}[${kVar}];`);
+      const valOutput = compileChild(d, ctx, def.valueType, valVar);
+      d.write(`${outputVar}[${kVar}] = ${valOutput};`);
+    },
+    `return INVALID;`
+  );
 
   return outputVar;
+}
+
+// Walks the own enumerable keys of a plain object in Reflect.ownKeys order — strings by for-in, then symbols — without materializing the key array, which made that walk 3–6x the cost of the loop it fed. `body` is written once for the string loop and once for the symbol loop unless `onSymbol` replaces the latter.
+function emitOwnKeys(
+  doc: Doc,
+  ctx: CompileContext,
+  accessor: string,
+  kVar: string,
+  body: (d: Doc) => void,
+  onSymbol?: string
+): void {
+  const hasOwnConst = addConstant(ctx, Object.prototype.hasOwnProperty);
+  const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
+  doc.write(`for (const ${kVar} in ${accessor}) {`);
+  doc.indented((d) => {
+    d.write(`if (${kVar} === "__proto__" || !${hasOwnConst}.call(${accessor}, ${kVar})) continue;`);
+    body(d);
+  });
+  doc.write(`}`);
+  const symsVar = newVar(ctx);
+  const iVar = newVar(ctx);
+  doc.write(`const ${symsVar} = Object.getOwnPropertySymbols(${accessor});`);
+  doc.write(`for (let ${iVar} = 0; ${iVar} < ${symsVar}.length; ${iVar}++) {`);
+  doc.indented((d) => {
+    d.write(`const ${kVar} = ${symsVar}[${iVar}];`);
+    d.write(`if (!${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
+    if (onSymbol) d.write(onSymbol);
+    else body(d);
+  });
+  doc.write(`}`);
 }
 
 function literalPropertyKey(ctx: CompileContext, key: string | symbol): string {

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -1615,31 +1615,20 @@ function generateUnionIssues(
     return v;
   }
 
-  // two-phase: the fast-mode branch attempts decide the match on the hot path; on total failure each branch re-runs as a compiled issue parser against a payload of its own (the interpreter gives branches fresh payloads too), and a helper mirroring handleUnionResults aggregates them
+  // each branch runs as a compiled issue parser against a payload of its own and the walk stops at the first clean branch, like $ZodUnion.parse; a helper mirroring handleUnionResults aggregates the rest. no fast pre-pass here: the outer fast parser already ran the branches once, and a second pass would run every branch callback a third time
   const v = newVar(ctx);
+  const { pfx } = issueConsts(ctx);
+  const helperConst = addConstant(ctx, unionIssuesForCompiled);
+  const instConst = addConstant(ctx, schema);
+  const rsVar = newVar(ctx);
+  const m = newVar(ctx);
+  const label = `u${newVar(ctx)}`;
   doc.write(`let ${v};`);
-  for (let i = 0; i < options.length; i++) {
-    const opt = options[i]!;
-    if (i === 0) {
-      doc.write(`${v} = (() => {`);
-    } else {
-      doc.write(`if (${v} === INVALID) ${v} = (() => {`);
-    }
-    doc.indented((d) => {
-      const branchOutput = generateCheck(d, ctx, opt, accessor);
-      d.write(`return ${branchOutput};`);
-    });
-    doc.write(`})();`);
-  }
-  doc.write(`if (${v} === INVALID) {`);
+  doc.write(`const ${rsVar} = [];`);
+  doc.write(`${label}: {`);
   doc.indented((d) => {
-    const { pfx } = issueConsts(ctx);
-    const helperConst = addConstant(ctx, unionIssuesForCompiled);
-    const instConst = addConstant(ctx, schema);
-    const rsVar = newVar(ctx);
-    const m = newVar(ctx);
-    d.write(`const ${rsVar} = [];`);
-    for (const opt of options) {
+    for (let i = 0; i < options.length; i++) {
+      const opt = options[i]!;
       // the shadowed `payload` and fresh `_sp` confine the branch's pushes to its own local payload, exactly like the interpreter's per-branch payloads; `shared` is true relative to that payload so a branch pipe's abort flag lands on it for the nonaborted filter
       d.write(`${rsVar}.push(((payload) => {`);
       d.indented((d2) => {
@@ -1649,12 +1638,13 @@ function generateUnionIssues(
         d2.write(`return payload;`);
       });
       d.write(`})({ value: ${accessor}, issues: [] }));`);
+      if (i < options.length - 1) d.write(`if (${rsVar}[${i}].issues.length === 0) break ${label};`);
     }
-    d.write(`const ${m} = payload.issues.length;`);
-    d.write(`${v} = ${helperConst}(${instConst}, ${accessor}, payload, ${rsVar}, pctx, ${shared});`);
-    if (path.length) d.write(`if (payload.issues.length > ${m}) ${pfx}(payload.issues, ${m}, ${pathExpr(ctx, path)});`);
   });
   doc.write(`}`);
+  doc.write(`const ${m} = payload.issues.length;`);
+  doc.write(`${v} = ${helperConst}(${instConst}, ${accessor}, payload, ${rsVar}, pctx, ${shared});`);
+  if (path.length) doc.write(`if (payload.issues.length > ${m}) ${pfx}(payload.issues, ${m}, ${pathExpr(ctx, path)});`);
   return v;
 }
 
@@ -1665,7 +1655,7 @@ function generateRecordIssues(
   schema: SomeType,
   accessor: string,
   path: IssuePath,
-  shared: boolean
+  _shared: boolean
 ): string {
   const def = schema._zod.def as unknown as {
     keyType: SomeType;
@@ -1717,7 +1707,7 @@ function generateRecordIssues(
           // the path element is the declared key as declared: a numeric key stays a number, like util.prefixIssues(key, …) in the runtime
           const keyExpr = typeof key === "number" ? String(key) : literalPropertyKey(ctx, key);
           d2.write(`const ${valueVar} = ${accessor}[${keyExpr}];`);
-          const val = compileChildIssues(d2, ctx, def.valueType, valueVar, [...path, keyExpr], shared);
+          const val = compileChildIssues(d2, ctx, def.valueType, valueVar, [...path, keyExpr], false);
           d2.write(`${out}[${outKey}] = ${val};`);
         });
         d.write(`}`);
@@ -1765,7 +1755,7 @@ function generateRecordIssues(
         d2.write(`if (${outKey} === "__proto__") continue;`);
         const valueVar = newVar(ctx);
         d2.write(`const ${valueVar} = ${accessor}[${k}];`);
-        const val = compileChildIssues(d2, ctx, def.valueType, valueVar, [...path, k], shared);
+        const val = compileChildIssues(d2, ctx, def.valueType, valueVar, [...path, k], false);
         d2.write(`${out}[${outKey}] = ${val};`);
       });
       d.write(`}`);

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -26,6 +26,7 @@ import {
   mayOutputUndefined,
   newVar,
   pipeStops,
+  pushInvalidKey,
   pushIssue,
   pushNonOptionalIssue,
   requiresPresenceCheck,
@@ -1660,6 +1661,125 @@ function generateUnionIssues(
   return v;
 }
 
+// Mirrors $ZodRecord.parse. An enumerable key schema walks the declared keys and reports extras as unrecognized; any other key schema is a constraint every own enumerable key must satisfy, with the runtime's numeric-string retry. A rejected key is pushed cold through `pushInvalidKey` (loose keeps it unvalidated, a partial record with enumerable keys counts it as unrecognized); values compile in issue mode so the walk continues past a bad one.
+function generateRecordIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath,
+  shared: boolean
+): string {
+  const def = schema._zod.def as unknown as {
+    keyType: SomeType;
+    valueType: SomeType;
+    mode?: string;
+    partial?: boolean;
+  };
+  const isLoose = def.mode === "loose";
+  const keyValues = (def.keyType._zod as unknown as { values?: Set<unknown> }).values;
+  const isPlainObjectConst = addConstant(ctx, util.isPlainObject);
+  const instConst = addConstant(ctx, schema);
+  const pathProp = path.length ? `, path: [${path.join(", ")}]` : "";
+  const v = newVar(ctx);
+  doc.write(`let ${v} = ${accessor};`);
+  doc.write(`if (!${isPlainObjectConst}(${accessor})) ${leafFailBlock(ctx, schema, accessor, path)}`);
+  doc.write(`else {`);
+  doc.indented((d) => {
+    const out = newVar(ctx);
+    const unrec = newVar(ctx);
+    d.write(`const ${out} = {};`);
+    d.write(`let ${unrec};`);
+    const pushUnrecognized = () =>
+      d.write(
+        `if (${unrec}) payload.issues.push({ code: "unrecognized_keys", input: ${accessor}, inst: ${instConst}, keys: ${unrec}, continue: true${pathProp} });`
+      );
+    if (keyValues && !def.partial) {
+      const keyFast = addConstant(ctx, compileFn(def.keyType));
+      const badKeyConst = addConstant(ctx, pushInvalidKey);
+      const keyTypeConst = addConstant(ctx, def.keyType);
+      const knownKeys: Array<string | symbol> = [];
+      for (const key of keyValues) {
+        if (!(typeof key === "string" || typeof key === "number" || typeof key === "symbol")) {
+          throw new ZodCompileUnsupportedError(`record key value ${String(key)}`);
+        }
+        knownKeys.push(typeof key === "number" ? key.toString() : key);
+        // a declared __proto__ is stripped but is not an unrecognized key
+        if (key === "__proto__") continue;
+        const keyConst = addConstant(ctx, key);
+        const outKey = newVar(ctx);
+        const label = `r${newVar(ctx)}`;
+        d.write(`${label}: {`);
+        d.indented((d2) => {
+          d2.write(`const ${outKey} = ${keyFast}(${keyConst});`);
+          d2.write(
+            `if (${outKey} === INVALID) { ${badKeyConst}(${keyTypeConst}, ${keyConst}, payload, pctx, ${instConst}, [${path.join(", ")}]); break ${label}; }`
+          );
+          d2.write(`if (${outKey} === "__proto__") break ${label};`);
+          const valueVar = newVar(ctx);
+          // the path element is the declared key as declared: a numeric key stays a number, like util.prefixIssues(key, …) in the runtime
+          const pathExpr = typeof key === "number" ? String(key) : literalPropertyKey(ctx, key);
+          d2.write(`const ${valueVar} = ${accessor}[${pathExpr}];`);
+          const val = compileChildIssues(d2, ctx, def.valueType, valueVar, [...path, pathExpr], shared);
+          d2.write(`${out}[${outKey}] = ${val};`);
+        });
+        d.write(`}`);
+      }
+      const knownConst = addConstant(ctx, new Set(knownKeys));
+      const k = newVar(ctx);
+      d.write(`for (const ${k} in ${accessor}) {`);
+      d.indented((d2) => {
+        d2.write(`if (${knownConst}.has(${k})) continue;`);
+        if (isLoose) d2.write(`if (${k} !== "__proto__") ${out}[${k}] = ${accessor}[${k}];`);
+        else d2.write(`(${unrec} ??= []).push(${k});`);
+      });
+      d.write(`}`);
+      pushUnrecognized();
+    } else {
+      const keyDef = def.keyType._zod.def as { type: string; format?: string; coerce?: boolean; checks?: unknown[] };
+      const keyIsBareString =
+        keyDef.type === "string" && keyDef.format === undefined && !keyDef.coerce && (keyDef.checks?.length ?? 0) === 0;
+      const keyFast = keyIsBareString ? null : addConstant(ctx, compileFn(def.keyType));
+      const numericConst = addConstant(ctx, regexes.number);
+      const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
+      const badKeyConst = addConstant(ctx, pushInvalidKey);
+      const keyTypeConst = addConstant(ctx, def.keyType);
+      const k = newVar(ctx);
+      const outKey = newVar(ctx);
+      d.write(`for (const ${k} of Reflect.ownKeys(${accessor})) {`);
+      d.indented((d2) => {
+        d2.write(`if (${k} === "__proto__") continue;`);
+        d2.write(`if (!${propIsEnumerableConst}.call(${accessor}, ${k})) continue;`);
+        if (keyFast) {
+          d2.write(`let ${outKey} = ${keyFast}(${k});`);
+          d2.write(
+            `if (${outKey} === INVALID && typeof ${k} === "string" && ${numericConst}.test(${k})) ${outKey} = ${keyFast}(Number(${k}));`
+          );
+        } else {
+          d2.write(`const ${outKey} = typeof ${k} === "string" ? ${k} : INVALID;`);
+        }
+        const onBadKey = isLoose
+          ? `${out}[${k}] = ${accessor}[${k}];`
+          : keyValues
+            ? `(${unrec} ??= []).push(${k});`
+            : `${badKeyConst}(${keyTypeConst}, ${k}, payload, pctx, ${instConst}, [${path.join(", ")}]);`;
+        d2.write(`if (${outKey} === INVALID) { ${onBadKey} continue; }`);
+        // the key schema can normalize an ordinary key into __proto__; re-check the one actually written under
+        d2.write(`if (${outKey} === "__proto__") continue;`);
+        const valueVar = newVar(ctx);
+        d2.write(`const ${valueVar} = ${accessor}[${k}];`);
+        const val = compileChildIssues(d2, ctx, def.valueType, valueVar, [...path, k], shared);
+        d2.write(`${out}[${outKey}] = ${val};`);
+      });
+      d.write(`}`);
+      pushUnrecognized();
+    }
+    d.write(`${v} = ${out};`);
+  });
+  doc.write(`}`);
+  return v;
+}
+
 type Codegen = (doc: Doc, ctx: CompileContext, inst: SomeType, accessor: string, buildsValue: boolean) => string | null;
 
 /** A core subclass's two emitters: `fast` writes the reject-on-first-failure path, `issues` the path that pushes the interpreter's issues. A class without `issues` islands through the interpreter in issue mode. */
@@ -1885,7 +2005,10 @@ const emitters: Record<string, Emitter> = {
     issues: generateUnionIssues,
   },
   $ZodIntersection: { fast: (doc, ctx, inst, accessor) => generateIntersectionCheck(doc, ctx, inst, accessor) },
-  $ZodRecord: { fast: (doc, ctx, inst, accessor) => generateRecordCheck(doc, ctx, inst, accessor) },
+  $ZodRecord: {
+    fast: (doc, ctx, inst, accessor) => generateRecordCheck(doc, ctx, inst, accessor),
+    issues: generateRecordIssues,
+  },
   $ZodMap: { fast: (doc, ctx, inst, accessor) => generateMapCheck(doc, ctx, inst, accessor) },
   $ZodSet: { fast: (doc, ctx, inst, accessor) => generateSetCheck(doc, ctx, inst, accessor) },
   $ZodLazy: { fast: (doc, ctx, inst, accessor) => generateLazyCheck(doc, ctx, inst, accessor) },

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -2,12 +2,16 @@ import type * as checks from "./checks.js";
 import {
   type CompileContext,
   INVALID,
+  type IssueCodegen,
+  type IssuePath,
+  SP_INIT,
   type StringFormatDef,
   ZodCompileAsyncError,
   ZodCompileUnsupportedError,
   addConstant,
   addUserConstant,
   compileChild,
+  compileChildIssues,
   compileFn,
   dropsWhenAbsent,
   generateCheck,
@@ -16,16 +20,22 @@ import {
   generateStringFormatCheck,
   isAsyncFunction,
   isExactOptional,
+  issueConsts,
+  leafFailBlock,
+  leafIssues,
   mayOutputUndefined,
   newVar,
+  pipeStops,
   pushIssue,
+  pushNonOptionalIssue,
   requiresPresenceCheck,
   throwAsync,
+  unionIssuesForCompiled,
 } from "./compile.js";
 import type { Doc } from "./doc.js";
 import * as regexes from "./regexes.js";
-import { mergeValues } from "./schemas.js";
-import type { $ZodProperties, ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
+import { getTupleOptStart, mergeValues } from "./schemas.js";
+import type { $ZodProperties, $ZodType, ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
 import * as util from "./util.js";
 
 // The compiler, split per core subclass: one fast-path emitter per class, collected in `emitters` at the bottom and resolved by `codegenFor` from the traits an instance recorded, so `generateCheck` in compile.ts never switches on def.type and a schema with no compilable ancestor refuses compilation.
@@ -1050,111 +1060,893 @@ function generateTransformCheck(doc: Doc, ctx: CompileContext, schema: SomeType,
   return accessor;
 }
 
+// ---- issue-mode emitters that are a few lines each; the container ones follow below
+
+const STRING_ISSUES = leafIssues((_ctx, _inst, a) => `typeof ${a} !== "string"`);
+const NUMBER_ISSUES = leafIssues((_ctx, _inst, a) => `typeof ${a} !== "number" || !Number.isFinite(${a})`);
+
+function templateLiteralFail(ctx: CompileContext, inst: SomeType, a: string): string {
+  const pattern = (inst._zod as unknown as { pattern: RegExp }).pattern;
+  if (!pattern) throw new ZodCompileUnsupportedError("template literal without a pattern");
+  const patternConst = addConstant(ctx, pattern);
+  return `typeof ${a} !== "string" || (${patternConst}.lastIndex = 0, !${patternConst}.test(${a}))`;
+}
+
+function enumFail(ctx: CompileContext, inst: SomeType, a: string): string {
+  const values = (inst._zod as unknown as { values?: Set<unknown> }).values;
+  if (!values) throw new ZodCompileUnsupportedError("enum schema without enumerated values");
+  return `!${addConstant(ctx, values)}.has(${a})`;
+}
+
+function literalFail(ctx: CompileContext, inst: SomeType, a: string): string {
+  const values = (inst._zod.def as unknown as { values: unknown[] }).values;
+  if (values.length !== 1 || (typeof values[0] === "number" && Number.isNaN(values[0]))) {
+    return `!${addConstant(ctx, new Set(values))}.has(${a})`;
+  }
+  const value = values[0];
+  if (typeof value === "string") return `${a} !== ${util.esc(value)}`;
+  if (typeof value === "number" || typeof value === "boolean") return `${a} !== ${value}`;
+  if (value === null) return `${a} !== null`;
+  if (value === undefined) return `${a} !== undefined`;
+  if (typeof value === "bigint") return `${a} !== ${value}n`;
+  throw new ZodCompileUnsupportedError(`literal type ${typeof value}`);
+}
+
+// unconditional canonical push; value stays the input, like the interpreter
+const neverIssues: IssueCodegen = (doc, ctx, inst, accessor, path) => {
+  doc.write(leafFailBlock(ctx, inst, accessor, path));
+  return accessor;
+};
+
+const nullableIssues: IssueCodegen = (doc, ctx, inst, accessor, path, shared) => {
+  const inner = (inst._zod.def as unknown as { innerType: SomeType }).innerType;
+  const v = newVar(ctx);
+  doc.write(`let ${v} = null;`);
+  doc.write(`if (${accessor} !== null) {`);
+  doc.indented((d) => {
+    const iv = compileChildIssues(d, ctx, inner, accessor, path, shared);
+    d.write(`${v} = ${iv};`);
+  });
+  doc.write(`}`);
+  return v;
+};
+
+const nonOptionalIssues: IssueCodegen = (doc, ctx, inst, accessor, path, shared, mark) => {
+  const inner = (inst._zod.def as unknown as { innerType: SomeType }).innerType;
+  const { pfx } = issueConsts(ctx);
+  const iv = compileChildIssues(doc, ctx, inner, accessor, path, shared);
+  const v = newVar(ctx);
+  doc.write(`const ${v} = ${iv};`);
+  const pushConst = addConstant(ctx, pushNonOptionalIssue);
+  const instConst = addConstant(ctx, inst);
+  const m2 = newVar(ctx);
+  const prefix = path.length ? ` ${pfx}(payload.issues, ${m2}, [${path.join(", ")}]);` : "";
+  doc.write(
+    `if (payload.issues.length === ${mark} && ${v} === undefined) { const ${m2} = payload.issues.length; ${pushConst}(payload.issues, ${v}, ${instConst});${prefix} }`
+  );
+  return v;
+};
+
+const readonlyIssues: IssueCodegen = (doc, ctx, inst, accessor, path, shared) => {
+  const inner = (inst._zod.def as unknown as { innerType: SomeType }).innerType;
+  const iv = compileChildIssues(doc, ctx, inner, accessor, path, shared);
+  const v = newVar(ctx);
+  doc.write(`const ${v} = Object.freeze(${iv});`);
+  return v;
+};
+
+const successIssues: IssueCodegen = (doc, ctx, inst, accessor, path, shared, mark) => {
+  const inner = (inst._zod.def as unknown as { innerType: SomeType }).innerType;
+  compileChildIssues(doc, ctx, inner, accessor, path, shared);
+  const v = newVar(ctx);
+  doc.write(`const ${v} = payload.issues.length === ${mark};`);
+  return v;
+};
+
+const pipeIssues: IssueCodegen = (doc, ctx, inst, accessor, path, shared, mark) => {
+  const pdef = inst._zod.def as unknown as { in: SomeType; out: SomeType; transform?: unknown };
+  // a transform between the stages runs inside the pipe's own parse; refusing lets the caller island the whole node, checks included
+  if (pdef.transform) throw new ZodCompileUnsupportedError("a pipe with a transform in issue mode");
+  const stopsConst = addConstant(ctx, pipeStops);
+  const iv = compileChildIssues(doc, ctx, pdef.in, accessor, path, shared);
+  const v = newVar(ctx);
+  const stopped = newVar(ctx);
+  doc.write(`let ${v} = ${iv};`);
+  // handlePipeResult: ANY in-stage issue but unrecognized_keys stops the pipe, continuable or not, and marks the payload aborted
+  doc.write(`const ${stopped} = payload.issues.length > ${mark} && ${stopsConst}(payload.issues, ${mark});`);
+  doc.write(`if (!${stopped}) {`);
+  doc.indented((d) => {
+    const ov = compileChildIssues(d, ctx, pdef.out, iv, path, shared);
+    d.write(`${v} = ${ov};`);
+  });
+  doc.write(`}`);
+  if (shared) doc.write(`else payload.aborted = true;`);
+  return { value: v, abOverride: stopped };
+};
+
+// the runtime parse runs the user transform against the shared scratch payload, installing its own normalizing addIssue — canonical issues, callback runs once
+const transformIssues: IssueCodegen = (doc, ctx, inst, accessor, path, _shared, mark) => {
+  const tdef = inst._zod.def as unknown as { transform?: (v: unknown, p: unknown) => unknown };
+  if (!tdef.transform) return accessor;
+  if (isAsyncFunction(tdef.transform)) throw new ZodCompileAsyncError();
+  const { pfx } = issueConsts(ctx);
+  const parseConst = addConstant(ctx, inst._zod.parse);
+  const throwAsyncConst = addConstant(ctx, throwAsync);
+  const r = newVar(ctx);
+  doc.write(`${SP_INIT}.value = ${accessor};`);
+  doc.write(`const ${r} = ${parseConst}(_sp, pctx);`);
+  doc.write(`if (${r} instanceof Promise) ${throwAsyncConst}();`);
+  if (path.length) {
+    doc.write(`if (payload.issues.length > ${mark}) ${pfx}(payload.issues, ${mark}, [${path.join(", ")}]);`);
+  }
+  const v = newVar(ctx);
+  doc.write(`const ${v} = _sp.value;`);
+  return v;
+};
+
+function generateDefaultIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath,
+  shared: boolean
+): string {
+  const def = schema._zod.def as unknown as { innerType: SomeType; type: string };
+  const descriptor = Object.getOwnPropertyDescriptor(schema._zod.def, "defaultValue");
+  const defaultGetter = descriptor
+    ? () => (schema._zod.def as unknown as { defaultValue: unknown }).defaultValue
+    : undefined;
+
+  if (def.type === "prefault") {
+    if (!defaultGetter) return compileChildIssues(doc, ctx, def.innerType, accessor, path, shared);
+    const defaultFn = addConstant(ctx, defaultGetter);
+    const inputVar = newVar(ctx);
+    doc.write(`let ${inputVar} = ${accessor};`);
+    doc.write(`if (${accessor} === undefined) ${inputVar} = ${defaultFn}();`);
+    return compileChildIssues(doc, ctx, def.innerType, inputVar, path, shared);
+  }
+
+  const v = newVar(ctx);
+  doc.write(`let ${v};`);
+  if (defaultGetter) {
+    const defaultFn = addConstant(ctx, defaultGetter);
+    const cloneFn = addConstant(ctx, util.shallowClone);
+    doc.write(`if (${accessor} === undefined) {`);
+    doc.indented((d) => {
+      d.write(`${v} = ${cloneFn}(${defaultFn}());`);
+    });
+    doc.write(`} else {`);
+    doc.indented((d) => {
+      const iv = compileChildIssues(d, ctx, def.innerType, accessor, path, shared);
+      // like handleDefaultResult, the substitution applies whether or not the inner pushed issues
+      d.write(`${v} = ${iv} === undefined ? ${cloneFn}(${defaultFn}()) : ${iv};`);
+    });
+    doc.write(`}`);
+  } else {
+    doc.write(`if (${accessor} !== undefined) {`);
+    doc.indented((d) => {
+      const iv = compileChildIssues(d, ctx, def.innerType, accessor, path, shared);
+      d.write(`${v} = ${iv};`);
+    });
+    doc.write(`}`);
+  }
+  return v;
+}
+
+function generateOptionalIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath,
+  shared: boolean
+): string {
+  const def = schema._zod.def as unknown as { innerType: SomeType };
+  if (isExactOptional(schema)) {
+    return compileChildIssues(doc, ctx, def.innerType, accessor, path, shared);
+  }
+
+  const v = newVar(ctx);
+  doc.write(`let ${v};`);
+  if (def.innerType._zod.optin === "defaulted") {
+    const m = newVar(ctx);
+    doc.write(`if (${accessor} === undefined) {`);
+    doc.indented((d) => {
+      d.write(`const ${m} = payload.issues.length;`);
+      // the substituting branch runs on a payload of its own in the interpreter, so it is never shared
+      const iv = compileChildIssues(d, ctx, def.innerType, accessor, path, false);
+      // handleOptionalResult: a substituting schema that still failed yields undefined and its issues are dropped
+      d.write(`if (payload.issues.length > ${m}) payload.issues.length = ${m};`);
+      d.write(`else ${v} = ${iv};`);
+    });
+    doc.write(`} else {`);
+    doc.indented((d) => {
+      const iv = compileChildIssues(d, ctx, def.innerType, accessor, path, shared);
+      d.write(`${v} = ${iv};`);
+    });
+    doc.write(`}`);
+    return v;
+  }
+
+  doc.write(`if (${accessor} !== undefined) {`);
+  doc.indented((d) => {
+    const iv = compileChildIssues(d, ctx, def.innerType, accessor, path, shared);
+    d.write(`${v} = ${iv};`);
+  });
+  doc.write(`}`);
+  return v;
+}
+
+function generateArrayIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath
+): string {
+  const def = schema._zod.def as unknown as { element: SomeType };
+  const v = newVar(ctx);
+  doc.write(`let ${v} = ${accessor};`);
+  doc.write(`if (!Array.isArray(${accessor})) ${leafFailBlock(ctx, schema, accessor, path)}`);
+  doc.write(`else {`);
+  doc.indented((d) => {
+    const out = newVar(ctx);
+    const iVar = newVar(ctx);
+    const elemVar = newVar(ctx);
+    d.write(`const ${out} = new Array(${accessor}.length);`);
+    d.write(`for (let ${iVar} = 0; ${iVar} < ${accessor}.length; ${iVar}++) {`);
+    d.indented((d2) => {
+      d2.write(`const ${elemVar} = ${accessor}[${iVar}];`);
+      const ev = compileChildIssues(d2, ctx, def.element, elemVar, [...path, iVar], false);
+      // like handleArrayResult, the element's value lands in the output even when it pushed issues
+      d2.write(`${out}[${iVar}] = ${ev};`);
+    });
+    d.write(`}`);
+    d.write(`${v} = ${out};`);
+  });
+  doc.write(`}`);
+  return v;
+}
+
+function generateObjectIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath
+): string {
+  const def = schema._zod.def as unknown as { shape: Record<string, SomeType>; catchall?: SomeType };
+  const shape = def.shape;
+  const keys = Object.keys(shape);
+  const symbolKeys = Object.getOwnPropertySymbols(shape);
+  const allKeys: (string | symbol)[] = symbolKeys.length ? [...keys, ...symbolKeys] : keys;
+  const keyExpr = (k: string | symbol) => (typeof k === "symbol" ? addConstant(ctx, k) : util.esc(k));
+  const propShape = shape as Record<string | symbol, SomeType>;
+  if (keys.includes("__proto__")) {
+    throw new ZodCompileUnsupportedError('object shape key "__proto__"');
+  }
+
+  const v = newVar(ctx);
+  doc.write(`let ${v} = ${accessor};`);
+  doc.write(
+    `if (typeof ${accessor} !== "object" || ${accessor} === null || Array.isArray(${accessor})) ${leafFailBlock(ctx, schema, accessor, path)}`
+  );
+  doc.write(`else {`);
+  doc.indented((d) => {
+    const out = newVar(ctx);
+    d.write(`const ${out} = {};`);
+
+    for (const key of allKeys) {
+      if (key === "__proto__") continue;
+      const propSchema = propShape[key]!;
+      const kx = keyExpr(key);
+      const childPath = [...path, kx];
+      const inputVar = newVar(ctx);
+      const mk = newVar(ctx);
+      d.write(`const ${inputVar} = ${accessor}[${kx}];`);
+      d.write(`const ${mk} = payload.issues.length;`);
+      const kv = compileChildIssues(d, ctx, propSchema, inputVar, childPath, false);
+      const optin = propSchema._zod.optin;
+      const optout = propSchema._zod.optout;
+
+      if (optin !== undefined && optout === "optional") {
+        // absent key + issues: the middle rung discards both, like handlePropertyResult
+        const present = newVar(ctx);
+        d.write(`const ${present} = ${kx} in ${accessor};`);
+        const assignCond = optin === "optional" ? present : `${kv} !== undefined || ${present}`;
+        d.write(`if (payload.issues.length > ${mk} && !${present}) payload.issues.length = ${mk};`);
+        d.write(`else if (${assignCond}) ${out}[${kx}] = ${kv};`);
+      } else if (optin === undefined) {
+        const present = newVar(ctx);
+        d.write(`const ${present} = ${kx} in ${accessor};`);
+        d.write(
+          `if (!${present} && payload.issues.length === ${mk}) payload.issues.push({ code: "invalid_type", expected: "nonoptional", input: undefined, path: [${childPath.join(", ")}] });`
+        );
+        d.write(`if (${present}) ${out}[${kx}] = ${kv};`);
+      } else {
+        d.write(
+          `if (${kv} === undefined) { if (${kx} in ${accessor}) ${out}[${kx}] = undefined; } else ${out}[${kx}] = ${kv};`
+        );
+      }
+    }
+
+    // catchall, mirroring handleCatchall
+    const catchall = def.catchall;
+    if (catchall) {
+      const catchallType = catchall._zod.def.type;
+      if (catchallType === "never") {
+        const condition = keys.map((k) => `k !== ${util.esc(k)}`).join(" && ") || "true";
+        const unrec = newVar(ctx);
+        d.write(`let ${unrec};`);
+        d.write(`for (const k in ${accessor}) {`);
+        d.indented((d2) => {
+          d2.write(`if (${condition}) (${unrec} ??= []).push(k);`);
+        });
+        d.write(`}`);
+        const instConst = addConstant(ctx, schema);
+        const pathProp = path.length ? `, path: [${path.join(", ")}]` : "";
+        d.write(
+          `if (${unrec}) payload.issues.push({ code: "unrecognized_keys", keys: ${unrec}, input: ${accessor}, inst: ${instConst}, continue: true${pathProp} });`
+        );
+      } else if ((catchallType === "unknown" || catchallType === "any") && !catchall._zod.def.checks?.length) {
+        const knownSet = keys.length > 0 ? addConstant(ctx, new Set(keys)) : null;
+        d.write(`for (const k in ${accessor}) {`);
+        d.indented((d2) => {
+          d2.write(`if (k === "__proto__") continue;`);
+          if (knownSet) d2.write(`if (${knownSet}.has(k)) continue;`);
+          d2.write(`${out}[k] = ${accessor}[k];`);
+        });
+        d.write(`}`);
+      } else {
+        const knownSet = keys.length > 0 ? addConstant(ctx, new Set(keys)) : null;
+        d.write(`for (const k in ${accessor}) {`);
+        d.indented((d2) => {
+          d2.write(`if (k === "__proto__") continue;`);
+          if (knownSet) d2.write(`if (${knownSet}.has(k)) continue;`);
+          const valVar = newVar(ctx);
+          d2.write(`const ${valVar} = ${accessor}[k];`);
+          const cv = compileChildIssues(d2, ctx, catchall, valVar, [...path, "k"], false);
+          d2.write(`${out}[k] = ${cv};`);
+        });
+        d.write(`}`);
+      }
+    }
+
+    d.write(`${v} = ${out};`);
+  });
+  doc.write(`}`);
+  return v;
+}
+
+// Mirrors $ZodTuple.parse + handleTupleResults: invalid_type and too_small push-and-return inside the runtime parse (cold call is safe), too_big is hand-built because the runtime pushes it and keeps walking, and the optional-out tail truncates instead of reporting absent-slot issues.
+function generateTupleIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath
+): string {
+  const def = schema._zod.def as unknown as { items: SomeType[]; rest: SomeType | null };
+  const items = def.items;
+  const rest = def.rest;
+  const optinStart = getTupleOptStart(items as unknown as readonly $ZodType[], "optin");
+  const optoutStart = getTupleOptStart(items as unknown as readonly $ZodType[], "optout");
+
+  const { pfx } = issueConsts(ctx);
+  const v = newVar(ctx);
+  doc.write(`let ${v} = ${accessor};`);
+  const label = `t${newVar(ctx)}`;
+  doc.write(`${label}: {`);
+  doc.indented((d) => {
+    d.write(
+      `if (!Array.isArray(${accessor})) { ${trimBlock(leafFailBlock(ctx, schema, accessor, path))} break ${label}; }`
+    );
+    if (!rest) {
+      d.write(
+        `if (${accessor}.length < ${optinStart}) { ${trimBlock(leafFailBlock(ctx, schema, accessor, path))} break ${label}; }`
+      );
+      const instConst = addConstant(ctx, schema);
+      const m = newVar(ctx);
+      const pathStmt = path.length ? ` ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);` : "";
+      // copied from $ZodTuple.parse's too_big push: the runtime pushes this and keeps walking the items
+      d.write(
+        `if (${accessor}.length > ${items.length}) { const ${m} = payload.issues.length; payload.issues.push({ code: "too_big", maximum: ${items.length}, inclusive: true, input: ${accessor}, inst: ${instConst}, origin: "array" });${pathStmt} }`
+      );
+    }
+
+    const out = newVar(ctx);
+    d.write(`const ${out} = [];`);
+    const hasTail = optoutStart < items.length;
+    const trunc = hasTail ? newVar(ctx) : null;
+    if (trunc) d.write(`let ${trunc} = false;`);
+
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]!;
+      if (i < optoutStart) {
+        const el = newVar(ctx);
+        d.write(`const ${el} = ${accessor}[${i}];`);
+        const iv = compileChildIssues(d, ctx, item, el, [...path, `${i}`], false);
+        d.write(`${out}[${i}] = ${iv};`);
+      } else {
+        d.write(`if (!${trunc}) {`);
+        d.indented((d2) => {
+          d2.write(`if (${i} < ${accessor}.length) {`);
+          d2.indented((d3) => {
+            const el = newVar(ctx);
+            d3.write(`const ${el} = ${accessor}[${i}];`);
+            const iv = compileChildIssues(d3, ctx, item, el, [...path, `${i}`], false);
+            d3.write(`${out}[${i}] = ${iv};`);
+          });
+          if (item._zod.optin === "optional") {
+            // absent middle rung: truncate the tail without running the item, like handleTupleResults' early break
+            d2.write(`} else ${trunc} = true;`);
+          } else {
+            d2.write(`} else {`);
+            d2.indented((d3) => {
+              const m = newVar(ctx);
+              d3.write(`const ${m} = payload.issues.length;`);
+              const iv = compileChildIssues(d3, ctx, item, "undefined", [...path, `${i}`], false);
+              // an absent optional-out slot that failed truncates and discards its issues; one that produced a value fills the slot
+              d3.write(`if (payload.issues.length > ${m}) { payload.issues.length = ${m}; ${trunc} = true; }`);
+              d3.write(`else ${out}[${i}] = ${iv};`);
+            });
+            d2.write(`}`);
+          }
+        });
+        d.write(`}`);
+      }
+    }
+
+    if (rest) {
+      const iVar = newVar(ctx);
+      const el = newVar(ctx);
+      d.write(`for (let ${iVar} = ${items.length}; ${iVar} < ${accessor}.length; ${iVar}++) {`);
+      d.indented((d2) => {
+        d2.write(`const ${el} = ${accessor}[${iVar}];`);
+        const iv = compileChildIssues(d2, ctx, rest, el, [...path, iVar], false);
+        d2.write(`${out}[${iVar}] = ${iv};`);
+      });
+      d.write(`}`);
+    }
+
+    // trailing absent optional-out slots that produced undefined truncate, mirroring handleTupleResults' final loop
+    if (items.some((it) => it._zod.optout === "optional")) {
+      const optConst = addConstant(
+        ctx,
+        items.map((it) => it._zod.optout === "optional")
+      );
+      const iVar = newVar(ctx);
+      d.write(`for (let ${iVar} = ${out}.length - 1; ${iVar} >= ${accessor}.length && ${iVar} >= 0; ${iVar}--) {`);
+      d.indented((d2) => {
+        d2.write(`if (${optConst}[${iVar}] && ${out}[${iVar}] === undefined) ${out}.length = ${iVar};`);
+        d2.write(`else break;`);
+      });
+      d.write(`}`);
+    }
+
+    d.write(`${v} = ${out};`);
+  });
+  doc.write(`}`);
+  return v;
+}
+
+// strips the outer braces off a fail block so it can inline before a labeled break
+function trimBlock(block: string): string {
+  return block.slice(1, -1).trim();
+}
+
+function generateUnionIssues(
+  doc: Doc,
+  ctx: CompileContext,
+  schema: SomeType,
+  accessor: string,
+  path: IssuePath,
+  shared: boolean
+): string {
+  const def = schema._zod.def as unknown as {
+    options: SomeType[];
+    inclusive?: boolean;
+    discriminator?: string;
+    unionFallback?: boolean;
+  };
+  const options = def.options;
+
+  // the runtime dispatches on the discriminator and runs the matched option on the SHARED payload, so branch children compile in issue mode directly — no island, no re-walk. Non-object input and a missing discriminator both push-and-return inside the runtime parse, so the cold call is safe. Checked before the xor gate: a discriminated union also carries inclusive: false.
+  if (def.discriminator) {
+    if (def.unionFallback || options.length === 0)
+      throw new ZodCompileUnsupportedError("a union fallback in issue mode");
+    const v = newVar(ctx);
+    const discVar = newVar(ctx);
+    const label = `d${newVar(ctx)}`;
+    doc.write(`let ${v} = ${accessor};`);
+    doc.write(`${label}: {`);
+    doc.indented((d) => {
+      d.write(`if (typeof ${accessor} === "object" && ${accessor} !== null && !Array.isArray(${accessor})) {`);
+      d.indented((d2) => {
+        d2.write(`const ${discVar} = ${accessor}[${util.esc(def.discriminator!)}];`);
+        let firstBranch = true;
+        const claimed = new Set<util.Primitive>();
+        for (const option of options) {
+          const values = option._zod.propValues?.[def.discriminator!];
+          if (!values || values.size === 0) {
+            throw new ZodCompileUnsupportedError("discriminated union option without static discriminator values");
+          }
+          for (const value of values) {
+            if (claimed.has(value)) {
+              throw new ZodCompileUnsupportedError(`duplicate discriminator value ${String(value)}`);
+            }
+            claimed.add(value);
+          }
+          const conditions = Array.from(values, (value) => literalEquality(ctx, discVar, value));
+          const prefix = firstBranch ? "if" : "else if";
+          d2.write(`${prefix} (${conditions.join(" || ")}) {`);
+          d2.indented((d3) => {
+            const bv = compileChildIssues(d3, ctx, option, accessor, path, shared);
+            d3.write(`${v} = ${bv};`);
+            d3.write(`break ${label};`);
+          });
+          d2.write(`}`);
+          firstBranch = false;
+        }
+      });
+      d.write(`}`);
+      d.write(leafFailBlock(ctx, schema, accessor, path));
+    });
+    doc.write(`}`);
+    return v;
+  }
+
+  // xor and unionFallback change match semantics; the interpreter owns them wholesale
+  if (def.inclusive === false || def.unionFallback) {
+    throw new ZodCompileUnsupportedError("an exclusive union in issue mode");
+  }
+  if (options.length === 0) throw new ZodCompileUnsupportedError("an empty union in issue mode");
+  if (options.length === 1) return compileChildIssues(doc, ctx, options[0]!, accessor, path, shared);
+
+  const allLiterals = options.every(
+    (opt) => opt._zod.def.type === "literal" && !(opt._zod.def.checks as unknown[] | undefined)?.length
+  );
+  if (allLiterals) {
+    const values = new Set(options.flatMap((opt) => (opt._zod.def as unknown as { values: unknown[] }).values));
+    const valuesConst = addConstant(ctx, values);
+    const v = newVar(ctx);
+    doc.write(`let ${v} = ${accessor};`);
+    // cold: the union's own parse pushes the canonical invalid_union (its checks stay with the central chain, so no island here)
+    doc.write(`if (!${valuesConst}.has(${accessor})) ${leafFailBlock(ctx, schema, accessor, path)}`);
+    return v;
+  }
+
+  // two-phase: the fast-mode branch attempts decide the match on the hot path; on total failure each branch re-runs as a compiled issue parser against a payload of its own (the interpreter gives branches fresh payloads too), and a helper mirroring handleUnionResults aggregates them
+  const v = newVar(ctx);
+  doc.write(`let ${v};`);
+  for (let i = 0; i < options.length; i++) {
+    const opt = options[i]!;
+    if (i === 0) {
+      doc.write(`${v} = (() => {`);
+    } else {
+      doc.write(`if (${v} === INVALID) ${v} = (() => {`);
+    }
+    doc.indented((d) => {
+      const branchOutput = generateCheck(d, ctx, opt, accessor);
+      d.write(`return ${branchOutput};`);
+    });
+    doc.write(`})();`);
+  }
+  doc.write(`if (${v} === INVALID) {`);
+  doc.indented((d) => {
+    const { pfx } = issueConsts(ctx);
+    const helperConst = addConstant(ctx, unionIssuesForCompiled);
+    const instConst = addConstant(ctx, schema);
+    const rsVar = newVar(ctx);
+    const m = newVar(ctx);
+    d.write(`const ${rsVar} = [];`);
+    for (const opt of options) {
+      // the shadowed `payload` and fresh `_sp` confine the branch's pushes to its own local payload, exactly like the interpreter's per-branch payloads; `shared` is true relative to that payload so a branch pipe's abort flag lands on it for the nonaborted filter
+      d.write(`${rsVar}.push(((payload) => {`);
+      d.indented((d2) => {
+        d2.write(`let _sp;`);
+        const bv = compileChildIssues(d2, ctx, opt, "payload.value", [], true);
+        d2.write(`payload.value = ${bv};`);
+        d2.write(`return payload;`);
+      });
+      d.write(`})({ value: ${accessor}, issues: [] }));`);
+    }
+    d.write(`const ${m} = payload.issues.length;`);
+    d.write(`${v} = ${helperConst}(${instConst}, ${accessor}, payload, ${rsVar}, pctx, ${shared});`);
+    if (path.length) d.write(`if (payload.issues.length > ${m}) ${pfx}(payload.issues, ${m}, [${path.join(", ")}]);`);
+  });
+  doc.write(`}`);
+  return v;
+}
+
 type Codegen = (doc: Doc, ctx: CompileContext, inst: SomeType, accessor: string, buildsValue: boolean) => string | null;
 
+/** A core subclass's two emitters: `fast` writes the reject-on-first-failure path, `issues` the path that pushes the interpreter's issues. A class without `issues` islands through the interpreter in issue mode. */
+interface Emitter {
+  fast: Codegen;
+  issues?: IssueCodegen;
+}
+
 // One emitter per core subclass, keyed by the trait name its constructor records. A class without an entry inherits its nearest ancestor's; a class without any compilable ancestor is unsupported. Only `compile()` reads this, so a bundle that never compiles keeps none of it.
-const emitters: Record<string, Codegen> = {
-  $ZodObject: (doc, ctx, inst, accessor, buildsValue) => generateObjectCheck(doc, ctx, inst, accessor, buildsValue),
-  $ZodTuple: (doc, ctx, inst, accessor) => generateTupleCheck(doc, ctx, inst, accessor),
-  $ZodString: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodStringFormat: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodCustomStringFormat: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodEmail: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodGUID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodUUID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodURL: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodEmoji: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodNanoID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodCUID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodCUID2: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodULID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodXID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodKSUID: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodISODateTime: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodISODate: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodISOTime: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodISODuration: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodIPv4: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodIPv6: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodCIDRv4: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodCIDRv6: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodBase64: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodBase64URL: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodE164: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodJWT: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodMAC: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodCreditCard: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
-  $ZodNumber: (doc, _ctx, inst, accessor) => generateNumberCheck(doc, inst, accessor),
-  $ZodNumberFormat: (doc, _ctx, inst, accessor) => generateNumberCheck(doc, inst, accessor),
-  $ZodBigInt: (doc, _ctx, inst, accessor) => generateBigIntCheck(doc, inst, accessor),
-  $ZodBigIntFormat: (doc, _ctx, inst, accessor) => generateBigIntCheck(doc, inst, accessor),
-  $ZodBoolean: (doc, _ctx, _inst, accessor) => generateBooleanCheck(doc, accessor),
-  $ZodSymbol: (doc, _ctx, _inst, accessor) => generateSymbolCheck(doc, accessor),
-  $ZodUndefined: (doc, _ctx, _inst, accessor) => generateUndefinedCheck(doc, accessor),
-  $ZodNull: (doc, _ctx, _inst, accessor) => generateNullCheck(doc, accessor),
-  $ZodVoid: (doc, _ctx, _inst, accessor) => generateVoidCheck(doc, accessor),
-  $ZodNaN: (doc, _ctx, _inst, accessor) => generateNaNCheck(doc, accessor),
-  $ZodDate: (doc, _ctx, _inst, accessor) => generateDateCheck(doc, accessor),
-  $ZodFile: (doc, _ctx, _inst, accessor) => generateFileCheck(doc, accessor),
-  $ZodAny: (_doc, _ctx, _inst, accessor) => accessor,
-  $ZodUnknown: (_doc, _ctx, _inst, accessor) => accessor,
-  $ZodNever: (doc, _ctx, _inst, accessor) => {
-    doc.write("return INVALID;");
-    return accessor;
+const emitters: Record<string, Emitter> = {
+  $ZodObject: {
+    fast: (doc, ctx, inst, accessor, buildsValue) => generateObjectCheck(doc, ctx, inst, accessor, buildsValue),
+    issues: generateObjectIssues,
   },
-  $ZodArray: (doc, ctx, inst, accessor, buildsValue) => generateArrayCheck(doc, ctx, inst, accessor, buildsValue),
-  $ZodNullable: (doc, ctx, inst, accessor, buildsValue) => generateNullableCheck(doc, ctx, inst, accessor, buildsValue),
-  $ZodOptional: (doc, ctx, inst, accessor, buildsValue) => generateOptionalCheck(doc, ctx, inst, accessor, buildsValue),
-  $ZodExactOptional: (doc, ctx, inst, accessor, buildsValue) =>
-    generateOptionalCheck(doc, ctx, inst, accessor, buildsValue),
-  $ZodLiteral: (doc, ctx, inst, accessor) => generateLiteralCheck(doc, ctx, inst, accessor),
-  $ZodEnum: (doc, ctx, inst, accessor) => generateEnumCheck(doc, ctx, inst, accessor),
-  $ZodTemplateLiteral: (doc, ctx, inst, accessor) => generateTemplateLiteralCheck(doc, ctx, inst, accessor),
-  $ZodNonOptional: (doc, ctx, inst, accessor) => generateNonOptionalCheck(doc, ctx, inst, accessor),
-  $ZodDefault: (doc, ctx, inst, accessor) => generateDefaultCheck(doc, ctx, inst, accessor),
-  $ZodPrefault: (doc, ctx, inst, accessor) => generateDefaultCheck(doc, ctx, inst, accessor),
-  $ZodUnion: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
-  $ZodDiscriminatedUnion: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
-  $ZodXor: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
-  $ZodIntersection: (doc, ctx, inst, accessor) => generateIntersectionCheck(doc, ctx, inst, accessor),
-  $ZodRecord: (doc, ctx, inst, accessor) => generateRecordCheck(doc, ctx, inst, accessor),
-  $ZodMap: (doc, ctx, inst, accessor) => generateMapCheck(doc, ctx, inst, accessor),
-  $ZodSet: (doc, ctx, inst, accessor) => generateSetCheck(doc, ctx, inst, accessor),
-  $ZodLazy: (doc, ctx, inst, accessor) => generateLazyCheck(doc, ctx, inst, accessor),
-  $ZodPipe: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
-  $ZodCodec: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
-  $ZodPreprocess: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
-  $ZodCustom: (doc, ctx, inst, accessor) => generateCustomCheck(doc, ctx, inst, accessor),
-  $ZodProperties: (doc, ctx, inst, accessor) => {
-    generatePropertiesChecks(doc, ctx, (inst as $ZodProperties)._zod.def, accessor, true);
-    return accessor;
+  $ZodTuple: {
+    fast: (doc, ctx, inst, accessor) => generateTupleCheck(doc, ctx, inst, accessor),
+    issues: generateTupleIssues,
   },
-  $ZodTransform: (doc, ctx, inst, accessor) => generateTransformCheck(doc, ctx, inst, accessor),
-  $ZodCatch: (doc, ctx, inst, accessor) => generateCatchCheck(doc, ctx, inst, accessor),
-  $ZodReadonly: (doc, ctx, inst, accessor) => {
-    const innerOut = generateWrapperCheck(doc, ctx, inst, accessor);
-    // the runtime freezes the parsed value (handleReadonlyResult)
-    const frozenVar = newVar(ctx);
-    doc.write(`const ${frozenVar} = Object.freeze(${innerOut});`);
-    return frozenVar;
+  $ZodString: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
   },
-  $ZodSuccess: (doc, ctx, inst, accessor) => {
-    // the runtime output is `issues.length === 0`; the fast path only gets here when the inner check passed, so the output is always true
-    generateWrapperCheck(doc, ctx, inst, accessor);
-    return "true";
+  $ZodStringFormat: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodCustomStringFormat: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodEmail: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodGUID: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodUUID: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodURL: { fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor), issues: STRING_ISSUES },
+  $ZodEmoji: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodNanoID: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodCUID: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodCUID2: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodULID: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodXID: { fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor), issues: STRING_ISSUES },
+  $ZodKSUID: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodISODateTime: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodISODate: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodISOTime: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodISODuration: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodIPv4: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodIPv6: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodCIDRv4: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodCIDRv6: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodBase64: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodBase64URL: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodE164: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodJWT: { fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor), issues: STRING_ISSUES },
+  $ZodMAC: { fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor), issues: STRING_ISSUES },
+  $ZodCreditCard: {
+    fast: (doc, ctx, inst, accessor) => generateStringCheck(doc, ctx, inst, accessor),
+    issues: STRING_ISSUES,
+  },
+  $ZodNumber: { fast: (doc, _ctx, inst, accessor) => generateNumberCheck(doc, inst, accessor), issues: NUMBER_ISSUES },
+  $ZodNumberFormat: {
+    fast: (doc, _ctx, inst, accessor) => generateNumberCheck(doc, inst, accessor),
+    issues: NUMBER_ISSUES,
+  },
+  $ZodBigInt: {
+    fast: (doc, _ctx, inst, accessor) => generateBigIntCheck(doc, inst, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `typeof ${a} !== "bigint"`),
+  },
+  $ZodBigIntFormat: {
+    fast: (doc, _ctx, inst, accessor) => generateBigIntCheck(doc, inst, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `typeof ${a} !== "bigint"`),
+  },
+  $ZodBoolean: {
+    fast: (doc, _ctx, _inst, accessor) => generateBooleanCheck(doc, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `typeof ${a} !== "boolean"`),
+  },
+  $ZodSymbol: {
+    fast: (doc, _ctx, _inst, accessor) => generateSymbolCheck(doc, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `typeof ${a} !== "symbol"`),
+  },
+  $ZodUndefined: {
+    fast: (doc, _ctx, _inst, accessor) => generateUndefinedCheck(doc, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `${a} !== undefined`),
+  },
+  $ZodNull: {
+    fast: (doc, _ctx, _inst, accessor) => generateNullCheck(doc, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `${a} !== null`),
+  },
+  $ZodVoid: {
+    fast: (doc, _ctx, _inst, accessor) => generateVoidCheck(doc, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `${a} !== undefined`),
+  },
+  $ZodNaN: {
+    fast: (doc, _ctx, _inst, accessor) => generateNaNCheck(doc, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `typeof ${a} !== "number" || !Number.isNaN(${a})`),
+  },
+  $ZodDate: {
+    fast: (doc, _ctx, _inst, accessor) => generateDateCheck(doc, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `!(${a} instanceof Date) || Number.isNaN(${a}.getTime())`),
+  },
+  $ZodFile: {
+    fast: (doc, _ctx, _inst, accessor) => generateFileCheck(doc, accessor),
+    issues: leafIssues((_ctx, _inst, a) => `!(${a} instanceof File)`),
+  },
+  $ZodAny: { fast: (_doc, _ctx, _inst, accessor) => accessor, issues: leafIssues(null) },
+  $ZodUnknown: { fast: (_doc, _ctx, _inst, accessor) => accessor, issues: leafIssues(null) },
+  $ZodNever: {
+    fast: (doc, _ctx, _inst, accessor) => {
+      doc.write("return INVALID;");
+      return accessor;
+    },
+    issues: neverIssues,
+  },
+  $ZodArray: {
+    fast: (doc, ctx, inst, accessor, buildsValue) => generateArrayCheck(doc, ctx, inst, accessor, buildsValue),
+    issues: generateArrayIssues,
+  },
+  $ZodNullable: {
+    fast: (doc, ctx, inst, accessor, buildsValue) => generateNullableCheck(doc, ctx, inst, accessor, buildsValue),
+    issues: nullableIssues,
+  },
+  $ZodOptional: {
+    fast: (doc, ctx, inst, accessor, buildsValue) => generateOptionalCheck(doc, ctx, inst, accessor, buildsValue),
+    issues: generateOptionalIssues,
+  },
+  $ZodExactOptional: {
+    fast: (doc, ctx, inst, accessor, buildsValue) => generateOptionalCheck(doc, ctx, inst, accessor, buildsValue),
+    issues: generateOptionalIssues,
+  },
+  $ZodLiteral: {
+    fast: (doc, ctx, inst, accessor) => generateLiteralCheck(doc, ctx, inst, accessor),
+    issues: leafIssues(literalFail),
+  },
+  $ZodEnum: {
+    fast: (doc, ctx, inst, accessor) => generateEnumCheck(doc, ctx, inst, accessor),
+    issues: leafIssues(enumFail),
+  },
+  $ZodTemplateLiteral: {
+    fast: (doc, ctx, inst, accessor) => generateTemplateLiteralCheck(doc, ctx, inst, accessor),
+    issues: leafIssues(templateLiteralFail),
+  },
+  $ZodNonOptional: {
+    fast: (doc, ctx, inst, accessor) => generateNonOptionalCheck(doc, ctx, inst, accessor),
+    issues: nonOptionalIssues,
+  },
+  $ZodDefault: {
+    fast: (doc, ctx, inst, accessor) => generateDefaultCheck(doc, ctx, inst, accessor),
+    issues: generateDefaultIssues,
+  },
+  $ZodPrefault: {
+    fast: (doc, ctx, inst, accessor) => generateDefaultCheck(doc, ctx, inst, accessor),
+    issues: generateDefaultIssues,
+  },
+  $ZodUnion: {
+    fast: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
+    issues: generateUnionIssues,
+  },
+  $ZodDiscriminatedUnion: {
+    fast: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
+    issues: generateUnionIssues,
+  },
+  $ZodXor: {
+    fast: (doc, ctx, inst, accessor) => generateUnionCheck(doc, ctx, inst, accessor),
+    issues: generateUnionIssues,
+  },
+  $ZodIntersection: { fast: (doc, ctx, inst, accessor) => generateIntersectionCheck(doc, ctx, inst, accessor) },
+  $ZodRecord: { fast: (doc, ctx, inst, accessor) => generateRecordCheck(doc, ctx, inst, accessor) },
+  $ZodMap: { fast: (doc, ctx, inst, accessor) => generateMapCheck(doc, ctx, inst, accessor) },
+  $ZodSet: { fast: (doc, ctx, inst, accessor) => generateSetCheck(doc, ctx, inst, accessor) },
+  $ZodLazy: { fast: (doc, ctx, inst, accessor) => generateLazyCheck(doc, ctx, inst, accessor) },
+  $ZodPipe: { fast: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor), issues: pipeIssues },
+  $ZodCodec: { fast: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor), issues: pipeIssues },
+  $ZodPreprocess: {
+    fast: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
+    issues: pipeIssues,
+  },
+  $ZodCustom: {
+    fast: (doc, ctx, inst, accessor) => generateCustomCheck(doc, ctx, inst, accessor),
+    issues: leafIssues(null),
+  },
+  $ZodProperties: {
+    fast: (doc, ctx, inst, accessor) => {
+      generatePropertiesChecks(doc, ctx, (inst as $ZodProperties)._zod.def, accessor, true);
+      return accessor;
+    },
+  },
+  $ZodTransform: {
+    fast: (doc, ctx, inst, accessor) => generateTransformCheck(doc, ctx, inst, accessor),
+    issues: transformIssues,
+  },
+  $ZodCatch: { fast: (doc, ctx, inst, accessor) => generateCatchCheck(doc, ctx, inst, accessor) },
+  $ZodReadonly: {
+    fast: (doc, ctx, inst, accessor) => {
+      const innerOut = generateWrapperCheck(doc, ctx, inst, accessor);
+      // the runtime freezes the parsed value (handleReadonlyResult)
+      const frozenVar = newVar(ctx);
+      doc.write(`const ${frozenVar} = Object.freeze(${innerOut});`);
+      return frozenVar;
+    },
+    issues: readonlyIssues,
+  },
+  $ZodSuccess: {
+    fast: (doc, ctx, inst, accessor) => {
+      // the runtime output is `issues.length === 0`; the fast path only gets here when the inner check passed, so the output is always true
+      generateWrapperCheck(doc, ctx, inst, accessor);
+      return "true";
+    },
+    issues: successIssues,
   },
 };
 
-/** The AOT emitter for a schema: its own `_zod.codegen` override, else the entry for the most specific trait its constructor recorded. */
+/** The emitters for a schema's class: the entry for the most specific trait its constructor recorded. */
+export function emitterFor(schema: SomeType): Emitter | undefined {
+  // traits are recorded outermost-first, so the first hit is the most specific class
+  for (const trait of schema._zod.traits) {
+    const e = emitters[trait];
+    if (e) return e;
+  }
+  return undefined;
+}
+
+/** The fast-path emitter for a schema: its own `_zod.codegen` override, else its class's. */
 export function codegenFor(
   schema: SomeType
 ): ((doc: Doc, ctx: CompileContext, accessor: string, buildsValue: boolean) => string | null) | undefined {
   const own = schema._zod.codegen;
   if (own) return own;
-  // traits are recorded outermost-first, so the first hit is the most specific class
-  for (const trait of schema._zod.traits) {
-    const emit = emitters[trait];
-    if (emit) return (doc, ctx, accessor, buildsValue) => emit(doc, ctx, schema, accessor, buildsValue);
-  }
-  return undefined;
+  const emit = emitterFor(schema)?.fast;
+  if (!emit) return undefined;
+  return (doc, ctx, accessor, buildsValue) => emit(doc, ctx, schema, accessor, buildsValue);
 }

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -14,6 +14,7 @@ import {
   compileChildIssues,
   compileFn,
   dropsWhenAbsent,
+  emitBranchFn,
   generateCheck,
   generateNumberFormatCheck,
   generatePropertiesChecks,
@@ -1629,15 +1630,8 @@ function generateUnionIssues(
   doc.indented((d) => {
     for (let i = 0; i < options.length; i++) {
       const opt = options[i]!;
-      // the shadowed `payload` and fresh `_sp` confine the branch's pushes to its own local payload, exactly like the interpreter's per-branch payloads; `shared` is true relative to that payload so a branch pipe's abort flag lands on it for the nonaborted filter
-      d.write(`${rsVar}.push(((payload) => {`);
-      d.indented((d2) => {
-        d2.write(`let _sp;`);
-        const bv = compileChildIssues(d2, ctx, opt, "payload.value", [], true);
-        d2.write(`payload.value = ${bv};`);
-        d2.write(`return payload;`);
-      });
-      d.write(`})({ value: ${accessor}, issues: [] }));`);
+      // each branch is a hoisted function over a payload of its own, exactly like the interpreter's per-branch payloads
+      d.write(`${rsVar}.push(${emitBranchFn(ctx, opt)}({ value: ${accessor}, issues: [] }, pctx));`);
       if (i < options.length - 1) d.write(`if (${rsVar}[${i}].issues.length === 0) break ${label};`);
     }
   });

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -1786,6 +1786,8 @@ type Codegen = (doc: Doc, ctx: CompileContext, inst: SomeType, accessor: string,
 interface Emitter {
   fast: Codegen;
   issues?: IssueCodegen;
+  /** The issue emitter reads `mark` (the issue count before the node). */
+  marks?: true;
 }
 
 // One emitter per core subclass, keyed by the trait name its constructor records. A class without an entry inherits its nearest ancestor's; a class without any compilable ancestor is unsupported. Only `compile()` reads this, so a bundle that never compiles keeps none of it.
@@ -1983,6 +1985,7 @@ const emitters: Record<string, Emitter> = {
   $ZodNonOptional: {
     fast: (doc, ctx, inst, accessor) => generateNonOptionalCheck(doc, ctx, inst, accessor),
     issues: nonOptionalIssues,
+    marks: true,
   },
   $ZodDefault: {
     fast: (doc, ctx, inst, accessor) => generateDefaultCheck(doc, ctx, inst, accessor),
@@ -2012,11 +2015,20 @@ const emitters: Record<string, Emitter> = {
   $ZodMap: { fast: (doc, ctx, inst, accessor) => generateMapCheck(doc, ctx, inst, accessor) },
   $ZodSet: { fast: (doc, ctx, inst, accessor) => generateSetCheck(doc, ctx, inst, accessor) },
   $ZodLazy: { fast: (doc, ctx, inst, accessor) => generateLazyCheck(doc, ctx, inst, accessor) },
-  $ZodPipe: { fast: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor), issues: pipeIssues },
-  $ZodCodec: { fast: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor), issues: pipeIssues },
+  $ZodPipe: {
+    fast: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
+    issues: pipeIssues,
+    marks: true,
+  },
+  $ZodCodec: {
+    fast: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
+    issues: pipeIssues,
+    marks: true,
+  },
   $ZodPreprocess: {
     fast: (doc, ctx, inst, accessor) => generatePipeCheck(doc, ctx, inst, accessor),
     issues: pipeIssues,
+    marks: true,
   },
   $ZodCustom: {
     fast: (doc, ctx, inst, accessor) => generateCustomCheck(doc, ctx, inst, accessor),
@@ -2031,6 +2043,7 @@ const emitters: Record<string, Emitter> = {
   $ZodTransform: {
     fast: (doc, ctx, inst, accessor) => generateTransformCheck(doc, ctx, inst, accessor),
     issues: transformIssues,
+    marks: true,
   },
   $ZodCatch: { fast: (doc, ctx, inst, accessor) => generateCatchCheck(doc, ctx, inst, accessor) },
   $ZodReadonly: {
@@ -2050,6 +2063,7 @@ const emitters: Record<string, Emitter> = {
       return "true";
     },
     issues: successIssues,
+    marks: true,
   },
 };
 

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -1440,12 +1440,10 @@ function generateTupleIssues(
   const label = `t${newVar(ctx)}`;
   doc.write(`${label}: {`);
   doc.indented((d) => {
-    d.write(
-      `if (!Array.isArray(${accessor})) { ${trimBlock(leafFailBlock(ctx, schema, accessor, path))} break ${label}; }`
-    );
+    d.write(`if (!Array.isArray(${accessor})) { ${leafFailBlock(ctx, schema, accessor, path)} break ${label}; }`);
     if (!rest) {
       d.write(
-        `if (${accessor}.length < ${optinStart}) { ${trimBlock(leafFailBlock(ctx, schema, accessor, path))} break ${label}; }`
+        `if (${accessor}.length < ${optinStart}) { ${leafFailBlock(ctx, schema, accessor, path)} break ${label}; }`
       );
       const instConst = addConstant(ctx, schema);
       const m = newVar(ctx);
@@ -1530,11 +1528,6 @@ function generateTupleIssues(
   });
   doc.write(`}`);
   return v;
-}
-
-// strips the outer braces off a fail block so it can inline before a labeled break
-function trimBlock(block: string): string {
-  return block.slice(1, -1).trim();
 }
 
 function generateUnionIssues(

--- a/packages/zod/src/v4/core/jit.ts
+++ b/packages/zod/src/v4/core/jit.ts
@@ -1487,6 +1487,9 @@ function generateTupleIssues(
 
     const out = newVar(ctx);
     d.write(`const ${out} = [];`);
+    // the interpreter runs the fixed items first but merges their issues last, after the rest elements have pushed theirs; hold them aside across the rest loop so the order matches
+    const held = rest ? newVar(ctx) : null;
+    if (held) d.write(`const ${held} = payload.issues.length;`);
     const hasTail = optoutStart < items.length;
     const trunc = hasTail ? newVar(ctx) : null;
     if (trunc) d.write(`let ${trunc} = false;`);
@@ -1529,6 +1532,8 @@ function generateTupleIssues(
     }
 
     if (rest) {
+      const fixed = newVar(ctx);
+      d.write(`const ${fixed} = payload.issues.length > ${held} ? payload.issues.splice(${held}) : null;`);
       const iVar = newVar(ctx);
       const el = newVar(ctx);
       d.write(`for (let ${iVar} = ${items.length}; ${iVar} < ${accessor}.length; ${iVar}++) {`);
@@ -1538,6 +1543,7 @@ function generateTupleIssues(
         d2.write(`${out}[${iVar}] = ${iv};`);
       });
       d.write(`}`);
+      d.write(`if (${fixed}) payload.issues.push(...${fixed});`);
     }
 
     // trailing absent optional-out slots that produced undefined truncate, mirroring handleTupleResults' final loop
@@ -1798,7 +1804,7 @@ interface Emitter {
 }
 
 // One emitter per core subclass, keyed by the trait name its constructor records. A class without an entry inherits its nearest ancestor's; a class without any compilable ancestor is unsupported. Only `compile()` reads this, so a bundle that never compiles keeps none of it.
-const emitters: Record<string, Emitter> = {
+export const emitters: Record<string, Emitter> = {
   $ZodObject: {
     fast: (doc, ctx, inst, accessor, buildsValue) => generateObjectCheck(doc, ctx, inst, accessor, buildsValue),
     issues: generateObjectIssues,

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1,6 +1,7 @@
 import * as checks from "./checks.js";
 import type { $ZodNumberFormats } from "./checks.js";
 import type { $ZodBigIntFormats } from "./checks.js";
+import type { CompileContext } from "./compile.js";
 import * as core from "./core.js";
 import { Doc } from "./doc.js";
 import type * as errors from "./errors.js";
@@ -121,6 +122,9 @@ export interface _$ZodTypeInternals {
 
   /** @internal Parses input, doesn't run checks. */
   parse(payload: ParsePayload<any>, ctx: ParseContextInternal): util.MaybeAsync<ParsePayload>;
+
+  /** @internal Emits this schema's AOT fast path; overrides the per-subclass emitter in jit.ts. */
+  codegen?(doc: Doc, ctx: CompileContext, accessor: string, buildsValue: boolean): string | null;
 
   /** @internal  Stores identifiers for the set of traits implemented by this schema. */
   traits: Set<string>;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -3044,7 +3044,7 @@ export const $ZodTuple: core.$constructor<$ZodTuple> = /*@__PURE__*/ core.$const
   };
 });
 
-function getTupleOptStart(items: readonly $ZodType[], key: "optin" | "optout") {
+export function getTupleOptStart(items: readonly $ZodType[], key: "optin" | "optout") {
   for (let i = items.length - 1; i >= 0; i--) {
     // optin is a three-rung ladder so any rung above `undefined` permits an absent slot; optout stays two-valued.
     const omittable = key === "optin" ? items[i]._zod.optin !== undefined : items[i]._zod.optout === "optional";

--- a/packages/zod/src/v4/core/tests/compile-differential.test.ts
+++ b/packages/zod/src/v4/core/tests/compile-differential.test.ts
@@ -428,6 +428,26 @@ test("record enum key", () => {
   differential(z.record(z.enum(["a", "b"]), z.number()), [{ a: 1, b: 2 }, { a: 1, c: 3 }, {}]);
 });
 
+test("record issue paths, key modes and bad keys", () => {
+  const sym = Symbol("k");
+  const symInput = { a: 1, [sym]: 2 };
+  // constraint keys: a rejected key is invalid_key (strict), kept (loose), and the numeric retry accepts "1" for a number key
+  differential(z.record(z.string().regex(/^[a-z]+$/), z.number()), [{ ab: 1, A1: 2, cd: "x" }, {}]);
+  differential(z.looseRecord(z.string().regex(/^[a-z]+$/), z.number()), [{ ab: 1, A1: "kept", cd: "x" }]);
+  differential(z.record(z.number(), z.string()), [{ 1: "a", 2: 3, x: "b" }, { 1: "a" }]);
+  // enumerable keys: missing, extra, bad value, declared numeric key, symbol keys
+  differential(z.record(z.enum(["a", "b"]), z.number()), [{ a: 1 }, { a: 1, b: 2, c: 3 }, { a: "x", b: 2 }, symInput]);
+  differential(z.partialRecord(z.enum(["a", "b"]), z.number()), [{ a: 1 }, { a: "x", c: 3 }, {}]);
+  differential(z.looseRecord(z.enum(["a", "b"]), z.number()), [{ a: 1, c: "kept" }, { a: "x" }]);
+  differential(z.record(z.literal([1, 2]), z.string()), [{ 1: "a", 2: "b" }, { 1: 3 }, {}]);
+  // nested: paths through a record into an object and back
+  differential(z.object({ r: z.record(z.string(), z.object({ n: z.number() })) }), [
+    { r: { a: { n: 1 }, b: { n: "x" } } },
+    { r: { a: 1 } },
+    { r: [] },
+  ]);
+});
+
 test("record enum key transform applies to output keys", () => {
   const schema = z.record(
     z.enum(["a", "b"]).transform((key) => (key === "a" ? "x" : "y")),

--- a/packages/zod/src/v4/core/tests/compile-differential.test.ts
+++ b/packages/zod/src/v4/core/tests/compile-differential.test.ts
@@ -95,6 +95,24 @@ function differential(schema: z.ZodType, inputs: unknown[], opts?: { fallbackOk?
       expect(b.error.issues, `issues mismatch for input ${describe(input)}`).toEqual(a.error.issues);
     }
   }
+  // `compiled` above answers a rejection from the generated issue parser; the runtime re-parse fallback is still a supported configuration and must agree too.
+  const fallback = compile(schema, { issues: false });
+  for (const input of inputs) {
+    const at = attempt(() => schema.safeParse(input));
+    const bt = attempt(() => fallback.safeParse(input));
+    expect(
+      bt.threw,
+      `fallback throw mismatch for input ${describe(input)}: runtime ${at.threw ?? "did not throw"}, compiled ${bt.threw ?? "did not throw"}`
+    ).toBe(at.threw);
+    if (at.threw) continue;
+    const a = at.value!;
+    const b = bt.value!;
+    expect(b.success, `fallback success mismatch for input ${describe(input)}`).toBe(a.success);
+    if (a.success && b.success) assertIdentical(b.data, a.data, "$");
+    else if (!a.success && !b.success) {
+      expect(b.error.issues, `fallback issues mismatch for input ${describe(input)}`).toEqual(a.error.issues);
+    }
+  }
   assertUnionSound(schema, inputs);
 }
 

--- a/packages/zod/src/v4/core/tests/compile-generative.test.ts
+++ b/packages/zod/src/v4/core/tests/compile-generative.test.ts
@@ -1,0 +1,428 @@
+import { expect, test } from "vitest";
+
+import * as z from "../../index.js";
+import { compile, compileFn } from "../compile.js";
+
+// Generative differential: random schemas over the emitter-backed node types (plus the occasional island), a valid value for each, single corruptions of that value, and the assertion that the interpreter and the compiled schema agree on the verdict, the output, the issues and how often user callbacks ran. A fixture suite covers the compositions somebody wrote down; this covers the ones nobody did. Seeds are fixed, so a failure names the seed and the schema it built.
+
+function mulberry32(seed: number): () => number {
+  return () => {
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface Gen {
+  schema: z.ZodType;
+  desc: string;
+  valid: () => unknown;
+  // one corruption of a valid value; not always rejected (a loose object absorbs an extra key), and both sides must agree either way
+  corrupt: (v: unknown) => unknown;
+  island: boolean;
+}
+
+interface Ctx {
+  rand: () => number;
+  calls: { n: number };
+}
+
+const pick = <T>(c: Ctx, xs: readonly T[]): T => xs[Math.floor(c.rand() * xs.length)]!;
+const int = (c: Ctx, lo: number, hi: number): number => lo + Math.floor(c.rand() * (hi - lo + 1));
+const JUNK = [42, "x", null, undefined, true, [], {}, -0, Number.NaN] as const;
+
+function leaf(c: Ctx): Gen {
+  switch (int(c, 0, 7)) {
+    case 0: {
+      const min = int(c, 0, 3);
+      return {
+        schema: z.string().min(min),
+        desc: `string.min(${min})`,
+        valid: () => "x".repeat(min + int(c, 0, 2)),
+        corrupt: () => (c.rand() < 0.5 ? 42 : "x".repeat(Math.max(0, min - 1))),
+        island: false,
+      };
+    }
+    case 1:
+      return {
+        schema: z.email(),
+        desc: "email",
+        valid: () => "a@b.co",
+        corrupt: () => (c.rand() < 0.5 ? "nope" : 1),
+        island: false,
+      };
+    case 2: {
+      const lo = int(c, -5, 0);
+      const hi = int(c, 1, 5);
+      return {
+        schema: z.number().int().min(lo).max(hi),
+        desc: `int[${lo},${hi}]`,
+        valid: () => int(c, lo, hi),
+        corrupt: () => pick(c, [hi + 1, lo - 1, 1.5, "1"]),
+        island: false,
+      };
+    }
+    case 3:
+      return {
+        schema: z.boolean(),
+        desc: "boolean",
+        valid: () => c.rand() < 0.5,
+        corrupt: () => pick(c, ["true", 0, null]),
+        island: false,
+      };
+    case 4: {
+      const lit = pick(c, ["a", 1, true] as const);
+      return {
+        schema: z.literal(lit),
+        desc: `literal(${JSON.stringify(lit)})`,
+        valid: () => lit,
+        corrupt: () => pick(c, ["b", 2, false]),
+        island: false,
+      };
+    }
+    case 5:
+      return {
+        schema: z.enum(["a", "b", "c"]),
+        desc: "enum",
+        valid: () => pick(c, ["a", "b", "c"]),
+        corrupt: () => pick(c, ["d", 2, null]),
+        island: false,
+      };
+    case 6:
+      return {
+        schema: z.number().superRefine((v, ctx) => {
+          c.calls.n++;
+          if (v < 0) ctx.addIssue({ code: "custom", message: "negative" });
+        }),
+        desc: "number.superRefine",
+        valid: () => int(c, 0, 9),
+        corrupt: () => pick(c, [-1, "x"]),
+        island: false,
+      };
+    default:
+      return {
+        schema: z.string().transform((s) => {
+          c.calls.n++;
+          return s.length;
+        }),
+        desc: "string.transform",
+        valid: () => "y".repeat(int(c, 0, 3)),
+        corrupt: () => 42,
+        island: false,
+      };
+  }
+}
+
+function wrap(c: Ctx, inner: Gen): Gen {
+  switch (int(c, 0, 4)) {
+    case 0:
+      return {
+        ...inner,
+        schema: inner.schema.optional(),
+        desc: `${inner.desc}.optional`,
+        valid: () => (c.rand() < 0.3 ? undefined : inner.valid()),
+      };
+    case 1:
+      return {
+        ...inner,
+        schema: inner.schema.nullable(),
+        desc: `${inner.desc}.nullable`,
+        valid: () => (c.rand() < 0.3 ? null : inner.valid()),
+      };
+    case 2: {
+      const dflt = inner.valid();
+      return {
+        ...inner,
+        schema: inner.schema.default(dflt as never),
+        desc: `${inner.desc}.default`,
+        valid: () => (c.rand() < 0.3 ? undefined : inner.valid()),
+      };
+    }
+    case 3:
+      return { ...inner, schema: inner.schema.readonly(), desc: `${inner.desc}.readonly` };
+    default:
+      return {
+        ...inner,
+        schema: inner.schema.optional().nonoptional(),
+        desc: `${inner.desc}.optional.nonoptional`,
+        corrupt: (v) => (c.rand() < 0.5 ? undefined : inner.corrupt(v)),
+      };
+  }
+}
+
+function container(c: Ctx, depth: number): Gen {
+  const child = () => gen(c, depth - 1);
+  switch (int(c, 0, 8)) {
+    case 0:
+    case 1: {
+      const n = int(c, 1, 4);
+      const entries = Array.from({ length: n }, (_, i) => [`k${i}`, child(), c.rand() < 0.3] as const);
+      const shape = Object.fromEntries(entries.map(([k, g, opt]) => [k, opt ? g.schema.optional() : g.schema]));
+      const mode = pick(c, ["plain", "strict", "loose", "catchall"] as const);
+      const schema =
+        mode === "strict"
+          ? z.strictObject(shape)
+          : mode === "loose"
+            ? z.looseObject(shape)
+            : mode === "catchall"
+              ? z.object(shape).catchall(z.number())
+              : z.object(shape);
+      const valid = () => {
+        const o: Record<string, unknown> = {};
+        for (const [k, g, opt] of entries) if (!opt || c.rand() < 0.6) o[k] = g.valid();
+        if (mode === "catchall" && c.rand() < 0.5) o.extra = 1;
+        return o;
+      };
+      return {
+        schema,
+        desc: `${mode}{${entries.map(([k, g, opt]) => `${k}${opt ? "?" : ""}:${g.desc}`).join(",")}}`,
+        valid,
+        corrupt: (v) => {
+          if (typeof v !== "object" || v === null) return v;
+          const o = { ...(v as Record<string, unknown>) };
+          const [k, g, opt] = pick(c, entries);
+          switch (int(c, 0, 3)) {
+            case 0:
+              o[k] = g.corrupt(k in o ? o[k] : g.valid());
+              break;
+            case 1:
+              if (opt) o[k] = g.corrupt(g.valid());
+              else delete o[k];
+              break;
+            case 2:
+              o.extra = "e";
+              break;
+            default:
+              return 42;
+          }
+          return o;
+        },
+        island: entries.some(([, g]) => g.island),
+      };
+    }
+    case 2: {
+      const g = child();
+      const min = int(c, 0, 2);
+      return {
+        schema: z.array(g.schema).min(min),
+        desc: `array(${g.desc}).min(${min})`,
+        valid: () => Array.from({ length: min + int(c, 0, 2) }, () => g.valid()),
+        corrupt: (v) => {
+          if (!Array.isArray(v)) return v;
+          const a = [...v];
+          if (a.length && c.rand() < 0.6) a[int(c, 0, a.length - 1)] = g.corrupt(a[0]);
+          else if (min > 0) a.length = min - 1;
+          else return 42;
+          return a;
+        },
+        island: g.island,
+      };
+    }
+    case 3: {
+      const items = Array.from({ length: int(c, 1, 3) }, child);
+      const rest = c.rand() < 0.4 ? child() : null;
+      const schema = rest
+        ? z.tuple(items.map((g) => g.schema) as [z.ZodType, ...z.ZodType[]], rest.schema)
+        : z.tuple(items.map((g) => g.schema) as [z.ZodType, ...z.ZodType[]]);
+      return {
+        schema,
+        desc: `tuple(${items.map((g) => g.desc).join(",")}${rest ? `,...${rest.desc}` : ""})`,
+        valid: () => [
+          ...items.map((g) => g.valid()),
+          ...(rest ? Array.from({ length: int(c, 0, 2) }, () => rest.valid()) : []),
+        ],
+        corrupt: (v) => {
+          if (!Array.isArray(v)) return v;
+          const a = [...v];
+          const i = int(c, 0, items.length - 1);
+          if (c.rand() < 0.6) a[i] = items[i]!.corrupt(a[i]);
+          else if (c.rand() < 0.5) a.push("extra");
+          else a.length = i;
+          return a;
+        },
+        island: items.some((g) => g.island) || !!rest?.island,
+      };
+    }
+    case 4: {
+      const g = child();
+      const enumKeys = c.rand() < 0.4;
+      const schema = enumKeys ? z.record(z.enum(["a", "b"]), g.schema) : z.record(z.string(), g.schema);
+      return {
+        schema,
+        desc: `record(${enumKeys ? "enum" : "string"},${g.desc})`,
+        valid: () =>
+          enumKeys
+            ? { a: g.valid(), b: g.valid() }
+            : Object.fromEntries(Array.from({ length: int(c, 0, 3) }, (_, i) => [`r${i}`, g.valid()])),
+        corrupt: (v) => {
+          if (typeof v !== "object" || v === null) return v;
+          const o = { ...(v as Record<string, unknown>) };
+          const keys = Object.keys(o);
+          if (keys.length && c.rand() < 0.6) o[pick(c, keys)] = g.corrupt(o[keys[0]!]);
+          else if (enumKeys) o.z = g.valid();
+          else return 42;
+          return o;
+        },
+        island: g.island,
+      };
+    }
+    case 5: {
+      const options = Array.from({ length: int(c, 2, 3) }, child);
+      return {
+        schema: z.union(options.map((g) => g.schema) as [z.ZodType, z.ZodType, ...z.ZodType[]]),
+        desc: `union(${options.map((g) => g.desc).join("|")})`,
+        valid: () => pick(c, options).valid(),
+        corrupt: (v) => pick(c, options).corrupt(v),
+        island: options.some((g) => g.island),
+      };
+    }
+    case 6: {
+      const branches = Array.from({ length: int(c, 2, 3) }, (_, i) => [i, child()] as const);
+      return {
+        schema: z.discriminatedUnion(
+          "t",
+          branches.map(([i, g]) => z.object({ t: z.literal(`b${i}`), v: g.schema })) as [
+            z.ZodObject<{ t: z.ZodLiteral<string>; v: z.ZodType }>,
+            ...z.ZodObject<{ t: z.ZodLiteral<string>; v: z.ZodType }>[],
+          ]
+        ),
+        desc: `dunion(${branches.map(([, g]) => g.desc).join("|")})`,
+        valid: () => {
+          const [i, g] = pick(c, branches);
+          return { t: `b${i}`, v: g.valid() };
+        },
+        corrupt: (v) => {
+          if (typeof v !== "object" || v === null) return v;
+          const o = { ...(v as { t: string; v: unknown }) };
+          const branch = branches.find(([i]) => `b${i}` === o.t);
+          if (branch && c.rand() < 0.6) o.v = branch[1].corrupt(o.v);
+          else o.t = "nope";
+          return o;
+        },
+        island: branches.some(([, g]) => g.island),
+      };
+    }
+    case 7: {
+      const min = int(c, 1, 3);
+      return {
+        schema: z.string().pipe(z.string().min(min)),
+        desc: `string.pipe(min(${min}))`,
+        valid: () => "p".repeat(min + int(c, 0, 1)),
+        corrupt: () => (c.rand() < 0.5 ? "p".repeat(min - 1) : 7),
+        island: false,
+      };
+    }
+    default: {
+      // islands: the issue path hands these to the interpreter, and the compiled result still has to agree
+      const g = child();
+      if (c.rand() < 0.5) {
+        return {
+          schema: z.map(z.string(), g.schema),
+          desc: `map(string,${g.desc})`,
+          valid: () => new Map(Array.from({ length: int(c, 0, 2) }, (_, i) => [`m${i}`, g.valid()])),
+          corrupt: (v) => {
+            if (!(v instanceof Map)) return v;
+            const m = new Map(v);
+            if (m.size && c.rand() < 0.7) m.set("m0", g.corrupt(m.get("m0")));
+            else return [];
+            return m;
+          },
+          island: true,
+        };
+      }
+      return {
+        schema: z.set(g.schema),
+        desc: `set(${g.desc})`,
+        valid: () => new Set(Array.from({ length: int(c, 0, 2) }, () => g.valid())),
+        corrupt: (v) => {
+          if (!(v instanceof Set)) return v;
+          const s = new Set(v);
+          if (c.rand() < 0.7) s.add(g.corrupt(g.valid()));
+          else return {};
+          return s;
+        },
+        island: true,
+      };
+    }
+  }
+}
+
+function gen(c: Ctx, depth: number): Gen {
+  if (depth === 0) return leaf(c);
+  const r = c.rand();
+  if (r < 0.25) return leaf(c);
+  if (r < 0.4) return wrap(c, gen(c, depth - 1));
+  return container(c, depth);
+}
+
+function attempt<T>(fn: () => T): { value?: T; threw?: string } {
+  try {
+    return { value: fn() };
+  } catch (err) {
+    return { threw: (err as Error)?.constructor?.name || "Error" };
+  }
+}
+
+function describe(value: unknown): string {
+  return JSON.stringify(value, (_k, v) =>
+    v instanceof Map ? { $map: [...v] } : v instanceof Set ? { $set: [...v] } : v === undefined ? "$undefined" : v
+  );
+}
+
+// own-key order and undefined-valued-vs-absent keys, which toStrictEqual does not see
+function shape(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(shape);
+  if (value && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
+    return Reflect.ownKeys(value).map((k) => [k, shape((value as Record<PropertyKey, unknown>)[k])]);
+  }
+  return value;
+}
+
+const SEEDS = 400;
+
+test("random schemas parse identically through the interpreter and the compiler", () => {
+  // every failing seed is collected, so one run names all of them
+  const failures: string[] = [];
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    try {
+      checkSeed(seed);
+    } catch (err) {
+      failures.push((err as Error).message.split("\n")[0]!);
+    }
+  }
+  expect(failures).toEqual([]);
+});
+
+function checkSeed(seed: number): void {
+  {
+    const c: Ctx = { rand: mulberry32(seed), calls: { n: 0 } };
+    const g = gen(c, 3);
+    const compiled = compile(g.schema);
+    const inputs = [g.valid(), g.corrupt(g.valid()), g.corrupt(g.corrupt(g.valid())), pick(c, JUNK)];
+    for (const input of inputs) {
+      const label = `seed ${seed} ${g.desc} input ${describe(input)}`;
+      c.calls.n = 0;
+      const a = attempt(() => g.schema.safeParse(input));
+      const runtimeCalls = c.calls.n;
+      c.calls.n = 0;
+      const b = attempt(() => compiled.safeParse(input));
+      const compiledCalls = c.calls.n;
+      expect(b.threw, `${label}: throw`).toBe(a.threw);
+      if (a.threw) continue;
+      expect(b.value!.success, `${label}: verdict`).toBe(a.value!.success);
+      if (a.value!.success) {
+        expect(b.value!.data, `${label}: data`).toStrictEqual(a.value!.data);
+        expect(shape(b.value!.data), `${label}: key order`).toEqual(shape(a.value!.data));
+      } else {
+        expect(b.value!.error!.issues, `${label}: issues`).toEqual(a.value!.error!.issues);
+      }
+      // the fast pass runs a callback at most once, the issue pass at most once more
+      expect(compiledCalls, `${label}: callbacks ${compiledCalls} vs ${runtimeCalls}`).toBeLessThanOrEqual(
+        2 * runtimeCalls
+      );
+    }
+    if (!g.island)
+      expect(() => compileFn(g.schema, { issues: true }), `${g.desc}: issue compile refused`).not.toThrow();
+  }
+}

--- a/packages/zod/src/v4/core/tests/compile-generative.test.ts
+++ b/packages/zod/src/v4/core/tests/compile-generative.test.ts
@@ -20,12 +20,19 @@ interface Gen {
   valid: () => unknown;
   // one corruption of a valid value; not always rejected (a loose object absorbs an extra key), and both sides must agree either way
   corrupt: (v: unknown) => unknown;
+  // this node itself is an island; a nested one is absorbed by the parent's issue path and never makes the root refuse
   island: boolean;
 }
 
 interface Ctx {
   rand: () => number;
-  calls: { n: number };
+  // runs per generated callback, so the two-run bound holds for each one rather than for the sum
+  calls: Map<number, number>;
+  nextCallback: number;
+}
+
+function count(c: Ctx, id: number): void {
+  c.calls.set(id, (c.calls.get(id) ?? 0) + 1);
 }
 
 const pick = <T>(c: Ctx, xs: readonly T[]): T => xs[Math.floor(c.rand() * xs.length)]!;
@@ -89,10 +96,11 @@ function leaf(c: Ctx): Gen {
         corrupt: () => pick(c, ["d", 2, null]),
         island: false,
       };
-    case 6:
+    case 6: {
+      const id = c.nextCallback++;
       return {
         schema: z.number().superRefine((v, ctx) => {
-          c.calls.n++;
+          count(c, id);
           if (v < 0) ctx.addIssue({ code: "custom", message: "negative" });
         }),
         desc: "number.superRefine",
@@ -100,10 +108,12 @@ function leaf(c: Ctx): Gen {
         corrupt: () => pick(c, [-1, "x"]),
         island: false,
       };
-    default:
+    }
+    default: {
+      const id = c.nextCallback++;
       return {
         schema: z.string().transform((s) => {
-          c.calls.n++;
+          count(c, id);
           return s.length;
         }),
         desc: "string.transform",
@@ -111,6 +121,7 @@ function leaf(c: Ctx): Gen {
         corrupt: () => 42,
         island: false,
       };
+    }
   }
 }
 
@@ -122,6 +133,7 @@ function wrap(c: Ctx, inner: Gen): Gen {
         schema: inner.schema.optional(),
         desc: `${inner.desc}.optional`,
         valid: () => (c.rand() < 0.3 ? undefined : inner.valid()),
+        island: false,
       };
     case 1:
       return {
@@ -129,6 +141,7 @@ function wrap(c: Ctx, inner: Gen): Gen {
         schema: inner.schema.nullable(),
         desc: `${inner.desc}.nullable`,
         valid: () => (c.rand() < 0.3 ? null : inner.valid()),
+        island: false,
       };
     case 2: {
       const dflt = inner.valid();
@@ -137,16 +150,18 @@ function wrap(c: Ctx, inner: Gen): Gen {
         schema: inner.schema.default(dflt as never),
         desc: `${inner.desc}.default`,
         valid: () => (c.rand() < 0.3 ? undefined : inner.valid()),
+        island: false,
       };
     }
     case 3:
-      return { ...inner, schema: inner.schema.readonly(), desc: `${inner.desc}.readonly` };
+      return { ...inner, schema: inner.schema.readonly(), desc: `${inner.desc}.readonly`, island: false };
     default:
       return {
         ...inner,
         schema: inner.schema.optional().nonoptional(),
         desc: `${inner.desc}.optional.nonoptional`,
         corrupt: (v) => (c.rand() < 0.5 ? undefined : inner.corrupt(v)),
+        island: false,
       };
   }
 }
@@ -198,7 +213,7 @@ function container(c: Ctx, depth: number): Gen {
           }
           return o;
         },
-        island: entries.some(([, g]) => g.island),
+        island: false,
       };
     }
     case 2: {
@@ -216,7 +231,7 @@ function container(c: Ctx, depth: number): Gen {
           else return 42;
           return a;
         },
-        island: g.island,
+        island: false,
       };
     }
     case 3: {
@@ -241,7 +256,7 @@ function container(c: Ctx, depth: number): Gen {
           else a.length = i;
           return a;
         },
-        island: items.some((g) => g.island) || !!rest?.island,
+        island: false,
       };
     }
     case 4: {
@@ -264,7 +279,7 @@ function container(c: Ctx, depth: number): Gen {
           else return 42;
           return o;
         },
-        island: g.island,
+        island: false,
       };
     }
     case 5: {
@@ -274,7 +289,7 @@ function container(c: Ctx, depth: number): Gen {
         desc: `union(${options.map((g) => g.desc).join("|")})`,
         valid: () => pick(c, options).valid(),
         corrupt: (v) => pick(c, options).corrupt(v),
-        island: options.some((g) => g.island),
+        island: false,
       };
     }
     case 6: {
@@ -300,7 +315,7 @@ function container(c: Ctx, depth: number): Gen {
           else o.t = "nope";
           return o;
         },
-        island: branches.some(([, g]) => g.island),
+        island: false,
       };
     }
     case 7: {
@@ -396,18 +411,18 @@ test("random schemas parse identically through the interpreter and the compiler"
 
 function checkSeed(seed: number): void {
   {
-    const c: Ctx = { rand: mulberry32(seed), calls: { n: 0 } };
+    const c: Ctx = { rand: mulberry32(seed), calls: new Map(), nextCallback: 0 };
     const g = gen(c, 3);
     const compiled = compile(g.schema);
     const inputs = [g.valid(), g.corrupt(g.valid()), g.corrupt(g.corrupt(g.valid())), pick(c, JUNK)];
     for (const input of inputs) {
       const label = `seed ${seed} ${g.desc} input ${describe(input)}`;
-      c.calls.n = 0;
+      c.calls.clear();
       const a = attempt(() => g.schema.safeParse(input));
-      const runtimeCalls = c.calls.n;
-      c.calls.n = 0;
+      const runtimeCalls = new Map(c.calls);
+      c.calls.clear();
       const b = attempt(() => compiled.safeParse(input));
-      const compiledCalls = c.calls.n;
+      const compiledCalls = new Map(c.calls);
       expect(b.threw, `${label}: throw`).toBe(a.threw);
       if (a.threw) continue;
       expect(b.value!.success, `${label}: verdict`).toBe(a.value!.success);
@@ -417,10 +432,12 @@ function checkSeed(seed: number): void {
       } else {
         expect(b.value!.error!.issues, `${label}: issues`).toEqual(a.value!.error!.issues);
       }
-      // the fast pass runs a callback at most once, the issue pass at most once more
-      expect(compiledCalls, `${label}: callbacks ${compiledCalls} vs ${runtimeCalls}`).toBeLessThanOrEqual(
-        2 * runtimeCalls
-      );
+      // the fast pass runs a callback at most once, the issue pass at most once more, for each callback on its own
+      for (const [id, n] of compiledCalls) {
+        expect(n, `${label}: callback ${id} ran ${n} vs ${runtimeCalls.get(id) ?? 0}`).toBeLessThanOrEqual(
+          2 * (runtimeCalls.get(id) ?? 0)
+        );
+      }
     }
     if (!g.island)
       expect(() => compileFn(g.schema, { issues: true }), `${g.desc}: issue compile refused`).not.toThrow();

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1789,3 +1789,25 @@ test("compiled issue parsers isolate child payloads and keep unions at two callb
   expect(later.safeParse({ u: "x", k: 1 }).success).toBe(false);
   expect([calls, third]).toEqual([2, 0]);
 });
+
+test("compiling and rejecting never runs a default or prefault factory for a present value", () => {
+  // `defaultValue` is an accessor that runs the factory, so a compile-time scan of the def must not read it
+  let defaults = 0;
+  let prefaults = 0;
+  const schema = z.object({
+    a: z.string().default(() => {
+      defaults++;
+      return "fallback";
+    }),
+    p: z.string().prefault(() => {
+      prefaults++;
+      return "fallback";
+    }),
+    b: z.string(),
+  });
+  const compiled = compile(schema);
+  expect(compiled.safeParse({ a: "present", p: "present", b: 1 }).success).toBe(false);
+  expect([defaults, prefaults]).toEqual([0, 0]);
+  expect(compiled.safeParse({ b: "ok" })).toEqual({ success: true, data: { a: "fallback", p: "fallback", b: "ok" } });
+  expect([defaults, prefaults]).toEqual([1, 1]);
+});

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1721,6 +1721,31 @@ test("compiled issue parsers isolate child payloads and keep unions at two callb
   });
   const seen = compile(sibling).safeParse({ a: 1, b: "ok" });
   expect(!seen.success && seen.error.issues.map((i) => i.code)).toEqual(["invalid_type"]);
+  // the same for a transform
+  const transformed = z.object({
+    a: z.string(),
+    b: z.string().transform((value, ctx) => {
+      if (ctx.issues.length) ctx.addIssue({ code: "custom", message: "saw sibling" });
+      return value;
+    }),
+  });
+  const viaTransform = compile(transformed).safeParse({ a: 1, b: "ok" });
+  expect(!viaTransform.success && viaTransform.error.issues.map((i) => i.code)).toEqual(["invalid_type"]);
+  // and a child's own issues reach its callbacks exactly as the interpreter hands them over: unprefixed, the parent's path added only on the way out
+  const captured: unknown[] = [];
+  const own = z.object({
+    b: z
+      .string()
+      .min(3)
+      .superRefine((_v, ctx) => {
+        captured.push(structuredClone(ctx.issues.map((i) => i.path)));
+      }),
+  });
+  own.safeParse({ b: "x" });
+  const viaOwn = compile(own).safeParse({ b: "x" });
+  expect(!viaOwn.success && viaOwn.error.issues.map((i) => i.path)).toEqual([["b"]]);
+  expect(captured).toHaveLength(2);
+  expect(captured[1]).toEqual(captured[0]);
 
   // a record value's stopped pipe aborts the value, not the record, so the record's own refinement still runs
   const value = z

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1675,32 +1675,56 @@ test("compiled parse methods run user callbacks at most twice on invalid input",
   });
   const compiled = compile(schema);
   // every route to the failure path: the fast method rejects once, then the wrapper builds the issues without a second fast pass
-  const routes: Array<[string, () => unknown, number?]> = [
+  const routes: Array<[string, () => unknown]> = [
     ["safeParse", () => compiled.safeParse({ a: "x" })],
     ["parse", () => expect(() => compiled.parse({ a: "x" })).toThrow()],
     ["safeParse with params", () => compiled.safeParse({ a: "x" }, { error: () => "mapped" })],
     ["z.safeParse", () => z.safeParse(compiled, { a: "x" })],
     ["issues: false", () => compile(schema, { issues: false }).safeParse({ a: "x" })],
-    // a params getter the runtime method evaluates on the way in re-enters the compiled method; the inner call accounts for two runs and must leave the outer signal in place
-    [
-      "re-entering params getter",
-      () =>
-        compiled.safeParse(
-          { a: "x" },
-          {
-            get error() {
-              compiled.safeParse({ a: "x" });
-              return () => undefined;
-            },
-          }
-        ),
-      4,
-    ],
   ];
-  for (const [name, run, expected = 2] of routes) {
+  for (const [name, run] of routes) {
     refines = 0;
     run();
-    expect(refines, name).toBe(expected);
+    expect(refines, name).toBe(2);
+  }
+  // a params getter runs while the outer invocation is between its fast pass and its failure path; a re-entry from it, through the instance method or the standalone function, is its own invocation with its own two runs, in both issue modes
+  for (const opts of [undefined, { issues: false }] as const) {
+    const events: string[] = [];
+    const tracing = compile(
+      z.string().refine((v) => {
+        events.push(v);
+        return false;
+      }),
+      opts as never
+    );
+    for (const [name, inner] of [
+      ["method", () => tracing.safeParse("inner")],
+      ["standalone", () => z.safeParse(tracing, "inner")],
+    ] as const) {
+      for (const outer of [
+        () =>
+          tracing.safeParse("outer", {
+            get error() {
+              inner();
+              return () => undefined;
+            },
+          }),
+        () =>
+          expect(() =>
+            tracing.parse("outer", {
+              get error() {
+                inner();
+                return () => undefined;
+              },
+            })
+          ).toThrow(),
+      ]) {
+        events.length = 0;
+        outer();
+        // order differs under global compilation, where the outer invocation has no compiled method and its fast pass runs after the params spread
+        expect([...events].sort(), `${name} ${JSON.stringify(opts)}`).toEqual(["inner", "inner", "outer", "outer"]);
+      }
+    }
   }
   // the params still reach the failure path
   const mapped = compiled.safeParse({ a: "x" }, { error: () => "mapped" });

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1658,3 +1658,30 @@ test("strict is per-call, so a supported schema compiles either way", () => {
     invalid(aot, { a: 1, b: 1 });
   }
 });
+
+test("compiled parse methods run user callbacks at most twice on invalid input", () => {
+  let refines = 0;
+  const schema = z.object({
+    a: z.string().refine(() => {
+      refines++;
+      return false;
+    }),
+  });
+  const compiled = compile(schema);
+  // every route to the failure path: the fast method rejects once, then the wrapper builds the issues without a second fast pass
+  const routes: Array<[string, () => unknown]> = [
+    ["safeParse", () => compiled.safeParse({ a: "x" })],
+    ["parse", () => expect(() => compiled.parse({ a: "x" })).toThrow()],
+    ["safeParse with params", () => compiled.safeParse({ a: "x" }, { error: () => "mapped" })],
+    ["z.safeParse", () => z.safeParse(compiled, { a: "x" })],
+    ["issues: false", () => compile(schema, { issues: false }).safeParse({ a: "x" })],
+  ];
+  for (const [name, run] of routes) {
+    refines = 0;
+    run();
+    expect(refines, name).toBe(2);
+  }
+  // the params still reach the failure path
+  const mapped = compiled.safeParse({ a: "x" }, { error: () => "mapped" });
+  expect(!mapped.success && mapped.error.issues[0]!.message).toBe("mapped");
+});

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1737,6 +1737,51 @@ test("compiled records walk own enumerable keys without Reflect.ownKeys", () => 
   expect(emailKeys.parse({ "a@b.co": 1 })).toEqual({ "a@b.co": 1 });
   expect(emailKeys.safeParse({ "a@b.co": 1, [sym]: 2 }).success).toBe(false);
   expect(compile(z.record(z.number(), z.string())).parse({ 1: "a" })).toEqual({ 1: "a" });
+  // keys are snapshotted before any value is read and rechecked when visited, like the runtime's Reflect.ownKeys walk: a getter that adds a key mid-walk is not visited, one that hides a later key skips it
+  const mutating = (effect: (o: Record<PropertyKey, unknown>) => void) => {
+    const o: Record<PropertyKey, unknown> = {};
+    Object.defineProperty(o, "a", {
+      enumerable: true,
+      get() {
+        effect(o);
+        return 1;
+      },
+    });
+    o.b = 2;
+    return o;
+  };
+  const both = z.record(z.union([z.string(), z.symbol()]), z.number());
+  for (const [schema, effect] of [
+    [
+      both,
+      (o: Record<PropertyKey, unknown>) => {
+        o[sym] = 2;
+      },
+    ],
+    [
+      z.record(z.string(), z.number()),
+      (o: Record<PropertyKey, unknown>) => {
+        o[sym] = "bad";
+      },
+    ],
+    [
+      z.record(z.string(), z.number()),
+      (o: Record<PropertyKey, unknown>) => {
+        o.z = "bad";
+      },
+    ],
+    [
+      z.record(z.string(), z.number()),
+      (o: Record<PropertyKey, unknown>) => Object.defineProperty(o, "b", { enumerable: false }),
+    ],
+  ] as const) {
+    const expected = schema.safeParse(mutating(effect));
+    const actual = compile(schema).safeParse(mutating(effect));
+    expect(actual.success).toBe(expected.success);
+    if (expected.success)
+      expect(Reflect.ownKeys(actual.data as object)).toEqual(Reflect.ownKeys(expected.data as object));
+    else expect(actual.error!.issues).toEqual(expected.error!.issues);
+  }
 });
 
 test("wide issue parsers split into hoisted per-subtree functions", () => {

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1710,3 +1710,57 @@ test("issue parsers compile natively for every emitter-backed shape", () => {
     expect(() => compileFn(schema, { issues: true }), name).not.toThrow();
   }
 });
+
+test("compiled issue parsers isolate child payloads and keep unions at two callback runs", () => {
+  // a property's superRefine sees only its own issues, like the interpreter's per-property payload
+  const sibling = z.object({
+    a: z.string(),
+    b: z.string().superRefine((_v, ctx) => {
+      if (ctx.issues.length) ctx.addIssue({ code: "custom", message: "saw sibling" });
+    }),
+  });
+  const seen = compile(sibling).safeParse({ a: 1, b: "ok" });
+  expect(!seen.success && seen.error.issues.map((i) => i.code)).toEqual(["invalid_type"]);
+
+  // a record value's stopped pipe aborts the value, not the record, so the record's own refinement still runs
+  const value = z
+    .string()
+    .refine(() => false)
+    .pipe(z.string());
+  const rec = z.record(z.string(), value).refine(() => false);
+  const compiledRec = compile(rec).safeParse({ a: "x" });
+  const runtimeRec = rec.safeParse({ a: "x" });
+  expect(!compiledRec.success && compiledRec.error.issues).toEqual(!runtimeRec.success && runtimeRec.error.issues);
+
+  // a failing union runs each branch callback once in the fast parser and once in the issue parser, never a third time
+  let calls = 0;
+  const failing = () => {
+    calls++;
+    return false;
+  };
+  const passing = () => {
+    calls++;
+    return true;
+  };
+  const union = compile(z.union([z.string().refine(failing), z.number()]));
+  union.safeParse("x");
+  expect(calls).toBe(2);
+  // and inside the issue parser a matching branch ends the walk, like $ZodUnion.parse: a sibling failure forces the issue walk, the second branch matches, the third never runs
+  let third = 0;
+  calls = 0;
+  const later = compile(
+    z.object({
+      u: z.union([
+        z.number(),
+        z.string().refine(passing),
+        z.string().refine(() => {
+          third++;
+          return true;
+        }),
+      ]),
+      k: z.string(),
+    })
+  );
+  expect(later.safeParse({ u: "x", k: 1 }).success).toBe(false);
+  expect([calls, third]).toEqual([2, 0]);
+});

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1854,6 +1854,16 @@ test("compiling and rejecting never runs a default or prefault factory for a pre
   const withMeta = new Custom({ type: "string", metadata } as never);
   expect(compile(z.object({ withMeta, bad: z.string() })).safeParse({ withMeta: "ok", bad: 1 }).success).toBe(false);
   expect(reads).toBe(0);
+  // an unread accessor that does hold a callback lands on the isolated path anyway: the check behind it sees only its own issues
+  const check = z.string().superRefine((_v, ctx) => {
+    if (ctx.issues.length) ctx.addIssue({ code: "custom", message: "saw sibling" });
+  })._zod.def.checks![0];
+  const checks: unknown[] = [];
+  Object.defineProperty(checks, "0", { enumerable: true, get: () => check });
+  checks.length = 1;
+  const behindAccessor = z.object({ a: z.string(), b: new Custom({ type: "string", checks } as never) });
+  const viaAccessor = compile(behindAccessor).safeParse({ a: 1, b: "ok" });
+  expect(!viaAccessor.success && viaAccessor.error.issues.map((i) => i.code)).toEqual(["invalid_type"]);
   // while a pick() shape, lazy until its first read, still classifies the callback behind it
   const picked = z.object({ c: z.string().superRefine(() => {}), d: z.number() }).pick({ c: true });
   expect(Object.getOwnPropertyDescriptor(picked._zod.def, "shape")?.get).toBeDefined();

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1843,6 +1843,17 @@ test("compiling and rejecting never runs a default or prefault factory for a pre
   );
   expect(compile(z.object({ withRaw, bad: z.string() })).safeParse({ withRaw: "ok", bad: 1 }).success).toBe(false);
   expect(reads).toBe(0);
+  // nor an accessor nested in a plain object a custom def carries
+  const metadata = Object.defineProperty({}, "nested", {
+    enumerable: true,
+    get() {
+      reads++;
+      throw new Error("nested getter ran");
+    },
+  });
+  const withMeta = new Custom({ type: "string", metadata } as never);
+  expect(compile(z.object({ withMeta, bad: z.string() })).safeParse({ withMeta: "ok", bad: 1 }).success).toBe(false);
+  expect(reads).toBe(0);
   // while a pick() shape, lazy until its first read, still classifies the callback behind it
   const picked = z.object({ c: z.string().superRefine(() => {}), d: z.number() }).pick({ c: true });
   expect(Object.getOwnPropertyDescriptor(picked._zod.def, "shape")?.get).toBeDefined();

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 
 import * as z from "../../index.js";
-import { ZodCompileAsyncError, ZodCompileUnsupportedError, compile } from "../compile.js";
+import { ZodCompileAsyncError, ZodCompileUnsupportedError, compile, compileFn } from "../compile.js";
 import { $ZodAsyncError } from "../core.js";
 
 // Differential helper: assert compiled schema matches the original on a value.
@@ -1684,4 +1684,29 @@ test("compiled parse methods run user callbacks at most twice on invalid input",
   // the params still reach the failure path
   const mapped = compiled.safeParse({ a: "x" }, { error: () => "mapped" });
   expect(!mapped.success && mapped.error.issues[0]!.message).toBe("mapped");
+});
+
+test("issue parsers compile natively for every emitter-backed shape", () => {
+  // a refused issue compile falls back to the runtime re-parse silently, so parity tests stay green while the shape quietly loses its compiled issues; the tuple emitter shipped that way once
+  const shapes: Record<string, z.ZodType> = {
+    tuple: z.tuple([z.string(), z.number()]),
+    tupleRest: z.tuple([z.string()], z.number()),
+    tupleOptional: z.tuple([z.string(), z.number().optional()]),
+    nestedTuple: z.object({ t: z.array(z.tuple([z.string()])) }),
+    object: z.object({ a: z.string() }),
+    array: z.array(z.number()),
+    union: z.union([z.string(), z.number()]),
+    discriminated: z.discriminatedUnion("t", [z.object({ t: z.literal("a") }), z.object({ t: z.literal("b") })]),
+    record: z.record(z.string(), z.number()),
+    wrappers: z.string().default("x").nullable().optional().nonoptional(),
+    checked: z.string().min(2),
+    pipe: z.string().pipe(z.string().min(1)),
+    readonly: z.array(z.string()).readonly(),
+    enumeration: z.enum(["a", "b"]),
+    literal: z.literal("a"),
+    never: z.never(),
+  };
+  for (const [name, schema] of Object.entries(shapes)) {
+    expect(() => compileFn(schema, { issues: true }), name).not.toThrow();
+  }
 });

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1675,17 +1675,32 @@ test("compiled parse methods run user callbacks at most twice on invalid input",
   });
   const compiled = compile(schema);
   // every route to the failure path: the fast method rejects once, then the wrapper builds the issues without a second fast pass
-  const routes: Array<[string, () => unknown]> = [
+  const routes: Array<[string, () => unknown, number?]> = [
     ["safeParse", () => compiled.safeParse({ a: "x" })],
     ["parse", () => expect(() => compiled.parse({ a: "x" })).toThrow()],
     ["safeParse with params", () => compiled.safeParse({ a: "x" }, { error: () => "mapped" })],
     ["z.safeParse", () => z.safeParse(compiled, { a: "x" })],
     ["issues: false", () => compile(schema, { issues: false }).safeParse({ a: "x" })],
+    // a params getter the runtime method evaluates on the way in re-enters the compiled method; the inner call accounts for two runs and must leave the outer signal in place
+    [
+      "re-entering params getter",
+      () =>
+        compiled.safeParse(
+          { a: "x" },
+          {
+            get error() {
+              compiled.safeParse({ a: "x" });
+              return () => undefined;
+            },
+          }
+        ),
+      4,
+    ],
   ];
-  for (const [name, run] of routes) {
+  for (const [name, run, expected = 2] of routes) {
     refines = 0;
     run();
-    expect(refines, name).toBe(2);
+    expect(refines, name).toBe(expected);
   }
   // the params still reach the failure path
   const mapped = compiled.safeParse({ a: "x" }, { error: () => "mapped" });

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1830,6 +1830,19 @@ test("compiling and rejecting never runs a default or prefault factory for a pre
   const withGetter = compile(z.object({ child, bad: z.string() }));
   expect(withGetter.safeParse({ child: "ok", bad: 1 }).success).toBe(false);
   expect(reads).toBe(0);
+  // nor is an accessor hung on a foreign getter function under the name of zod's own `raw`
+  const foreignGetter = () => ({});
+  Object.defineProperty(foreignGetter, "raw", {
+    get() {
+      reads++;
+      throw new Error("raw getter ran");
+    },
+  });
+  const withRaw = new Custom(
+    Object.defineProperty({ type: "string" }, "shape", { get: foreignGetter, enumerable: true }) as never
+  );
+  expect(compile(z.object({ withRaw, bad: z.string() })).safeParse({ withRaw: "ok", bad: 1 }).success).toBe(false);
+  expect(reads).toBe(0);
   // while a pick() shape, lazy until its first read, still classifies the callback behind it
   const picked = z.object({ c: z.string().superRefine(() => {}), d: z.number() }).pick({ c: true });
   expect(Object.getOwnPropertyDescriptor(picked._zod.def, "shape")?.get).toBeDefined();

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1717,6 +1717,28 @@ test("issue parsers compile natively for every emitter-backed shape", () => {
   }
 });
 
+test("compiled records walk own enumerable keys without Reflect.ownKeys", () => {
+  // for-in plus hasOwn sees the same keys as the runtime's Reflect.ownKeys walk: inherited enumerables are skipped, symbols fail a string key schema but pass a symbol one, and the numeric-string retry still applies
+  const sym = Symbol("s");
+  const bare = compile(z.record(z.string(), z.number()));
+  const inherited = Object.assign(Object.create({ proto: 1 }), { a: 1 });
+  expect(bare.parse(inherited)).toEqual({ a: 1 });
+  const symbolic = { a: 1, [sym]: 2 };
+  expect(bare.safeParse(symbolic).error!.issues).toEqual(
+    z.record(z.string(), z.number()).safeParse(symbolic).error!.issues
+  );
+  expect(bare.safeParse({ a: 1, b: "x" }).error!.issues).toEqual(
+    z.record(z.string(), z.number()).safeParse({ a: 1, b: "x" }).error!.issues
+  );
+  const symKeys = compile(z.record(z.symbol(), z.number()));
+  expect(symKeys.parse({ [sym]: 2 })).toEqual({ [sym]: 2 });
+  expect(symKeys.safeParse({ a: 1 }).success).toBe(false);
+  const emailKeys = compile(z.record(z.email(), z.number()));
+  expect(emailKeys.parse({ "a@b.co": 1 })).toEqual({ "a@b.co": 1 });
+  expect(emailKeys.safeParse({ "a@b.co": 1, [sym]: 2 }).success).toBe(false);
+  expect(compile(z.record(z.number(), z.string())).parse({ 1: "a" })).toEqual({ 1: "a" });
+});
+
 test("wide issue parsers split into hoisted per-subtree functions", () => {
   // one huge function stays unoptimized for thousands of rejections and loses to the interpreter until then; a subtree over the size threshold becomes a function of its own, small schemas stay one function, and union branches are hoisted rather than closed over per parse
   const nested = (depth: number): z.ZodType =>

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1690,6 +1690,19 @@ test("compiled parse methods run user callbacks at most twice on invalid input",
   // the params still reach the failure path
   const mapped = compiled.safeParse({ a: "x" }, { error: () => "mapped" });
   expect(!mapped.success && mapped.error.issues[0]!.message).toBe("mapped");
+  // a compiled schema reached through an island's runtime parse is a nested wrapper on the same context; it must not run its own fast pass again
+  const inner = compile(schema);
+  const outer = compile(z.object({ m: z.map(z.string(), inner) }));
+  const bad = { m: new Map([["k", { a: "x" }]]) };
+  for (const [name, run] of [
+    ["island via safeParse", () => outer.safeParse(bad)],
+    ["island via parse", () => expect(() => outer.parse(bad)).toThrow()],
+    ["island via _zod.run", () => outer._zod.run({ value: bad, issues: [] }, { async: false } as never)],
+  ] as const) {
+    refines = 0;
+    run();
+    expect(refines, name).toBe(2);
+  }
 });
 
 test("issue parsers compile natively for every emitter-backed shape", () => {

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1,7 +1,13 @@
 import { expect, test } from "vitest";
 
 import * as z from "../../index.js";
-import { ZodCompileAsyncError, ZodCompileUnsupportedError, compile, compileFn } from "../compile.js";
+import {
+  ZodCompileAsyncError,
+  ZodCompileUnsupportedError,
+  compile,
+  compileFn,
+  subtreeRunsCallbacks,
+} from "../compile.js";
 import { $ZodAsyncError } from "../core.js";
 
 // Differential helper: assert compiled schema matches the original on a value.
@@ -1810,4 +1816,22 @@ test("compiling and rejecting never runs a default or prefault factory for a pre
   expect([defaults, prefaults]).toEqual([0, 0]);
   expect(compiled.safeParse({ b: "ok" })).toEqual({ success: true, data: { a: "fallback", p: "fallback", b: "ok" } });
   expect([defaults, prefaults]).toEqual([1, 1]);
+
+  // a `shape` accessor a subclass supplies is not zod's lazy shape and stays unread too
+  let reads = 0;
+  const Custom = class extends z.ZodString {};
+  const child = new Custom({
+    type: "string",
+    get shape() {
+      reads++;
+      throw new Error("shape");
+    },
+  } as never);
+  const withGetter = compile(z.object({ child, bad: z.string() }));
+  expect(withGetter.safeParse({ child: "ok", bad: 1 }).success).toBe(false);
+  expect(reads).toBe(0);
+  // while a pick() shape, lazy until its first read, still classifies the callback behind it
+  const picked = z.object({ c: z.string().superRefine(() => {}), d: z.number() }).pick({ c: true });
+  expect(Object.getOwnPropertyDescriptor(picked._zod.def, "shape")?.get).toBeDefined();
+  expect(subtreeRunsCallbacks(picked)).toBe(true);
 });

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1717,6 +1717,43 @@ test("issue parsers compile natively for every emitter-backed shape", () => {
   }
 });
 
+test("wide issue parsers split into hoisted per-subtree functions", () => {
+  // one huge function stays unoptimized for thousands of rejections and loses to the interpreter until then; a subtree over the size threshold becomes a function of its own, small schemas stay one function, and union branches are hoisted rather than closed over per parse
+  const nested = (depth: number): z.ZodType =>
+    depth === 0
+      ? z.string()
+      : z.object({
+          k0: nested(depth - 1),
+          k1: nested(depth - 1),
+          k2: nested(depth - 1),
+          k3: nested(depth - 1),
+          k4: nested(depth - 1),
+        });
+  const wide = nested(3);
+  const fns = (schema: z.ZodType) =>
+    compileFn(schema, { issues: true, debug: true }).code!.match(/^function fv\d+\(/gm) ?? [];
+  expect(fns(wide).length).toBeGreaterThan(1);
+  expect(fns(z.object({ a: z.string() }))).toEqual([]);
+  expect(fns(z.union([z.string(), z.number()]))).toHaveLength(2);
+  const fill = (depth: number, leaf: unknown): any =>
+    depth === 0
+      ? leaf
+      : {
+          k0: fill(depth - 1, leaf),
+          k1: fill(depth - 1, leaf),
+          k2: fill(depth - 1, leaf),
+          k3: fill(depth - 1, leaf),
+          k4: fill(depth - 1, leaf),
+        };
+  const bad = fill(3, "x");
+  bad.k0.k0.k0 = 1;
+  bad.k2.k4 = null;
+  delete bad.k4.k4.k4;
+  const compiled = compile(wide);
+  expect(compiled.safeParse(bad).error!.issues).toEqual(wide.safeParse(bad).error!.issues);
+  expect(compiled.safeParse(fill(3, "x"))).toEqual(wide.safeParse(fill(3, "x")));
+});
+
 test("compiled issue parsers isolate child payloads and keep unions at two callback runs", () => {
   // a property's superRefine sees only its own issues, like the interpreter's per-property payload
   const sibling = z.object({

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -9,6 +9,7 @@ import {
   subtreeRunsCallbacks,
 } from "../compile.js";
 import { $ZodAsyncError } from "../core.js";
+import { emitters } from "../jit.js";
 
 // Differential helper: assert compiled schema matches the original on a value.
 function expectMatch(schema: z.ZodType, value: unknown) {
@@ -1742,6 +1743,35 @@ test("compiled parse methods run user callbacks at most twice on invalid input",
     run();
     expect(refines, name).toBe(2);
   }
+});
+
+test("strict compilation surfaces malformed issue code instead of the silent runtime re-parse", () => {
+  // a refused issue compile falls back to the interpreter, so a syntax error in an emitter keeps every parity test green; strict mode, which the global shim uses, throws it
+  const string = emitters.$ZodString!;
+  const issues = string.issues;
+  string.issues = ((doc: { write(line: string): void }) => {
+    doc.write("this is not javascript");
+    return "input";
+  }) as never;
+  try {
+    expect(() => compile(z.string(), { strict: true }).safeParse(42)).toThrow(ZodCompileUnsupportedError);
+    const lenient = compile(z.string()).safeParse(42);
+    expect(!lenient.success && lenient.error.issues.map((i) => i.code)).toEqual(["invalid_type"]);
+  } finally {
+    string.issues = issues as never;
+  }
+});
+
+test("a rest tuple reports its fixed items' issues after the rest elements', like the interpreter", () => {
+  // the interpreter runs the fixed items first but merges their results last; found by the generative suite, invisible to every fixture with one failing element
+  const schema = z.tuple([z.string(), z.object({ a: z.string() })], z.number());
+  const bad = [1, { a: 2 }, "x", "y"];
+  expect(
+    compile(schema)
+      .safeParse(bad)
+      .error!.issues.map((i) => i.path)
+  ).toEqual([[2], [3], [0], [1, "a"]]);
+  expect(compile(schema).safeParse(bad).error!.issues).toEqual(schema.safeParse(bad).error!.issues);
 });
 
 test("issue parsers compile natively for every emitter-backed shape", () => {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -964,13 +964,18 @@ export function finalizeIssue(
       unwrapMessage(config.localeError?.(iss)) ??
       "Invalid input");
 
-  const { inst: _inst, schema: _schema, continue: _continue, input: _input, ...rest } = iss as any;
-  rest.path ??= [];
-  rest.message = message;
-  if (ctx?.reportInput) {
-    rest.input = _input;
+  // an explicit copy beats object rest with excluded keys, which v8 routes through a generic runtime call
+  const full: any = {};
+  for (const k in iss) {
+    if (k === "inst" || k === "schema" || k === "continue" || k === "input") continue;
+    full[k] = (iss as any)[k];
   }
-  return rest;
+  full.path ??= [];
+  full.message = message;
+  if (ctx?.reportInput) {
+    full.input = iss.input;
+  }
+  return full;
 }
 
 export function getSizableOrigin(input: any): "set" | "map" | "file" | "unknown" {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -390,7 +390,10 @@ export interface ShapeGetter {
  */
 export function rawShape(def: any): Record<PropertyKey, any> | undefined {
   const desc = Object.getOwnPropertyDescriptor(def, "shape");
-  return desc?.get ? (desc.get as ShapeGetter).raw : desc?.value;
+  if (!desc?.get) return desc?.value;
+  // zod's own getter carries `raw` as data; a foreign getter's `raw` could be an accessor, and reading it would break the no-invocation promise
+  const raw = Object.getOwnPropertyDescriptor(desc.get, "raw");
+  return raw && !raw.get ? raw.value : undefined;
 }
 
 // where a builder reads its source's keys and descriptors, resolving only a shape a def answers for itself. A shape resolves by object spread, so only its enumerable keys are ever part of it.


### PR DESCRIPTION
`z.compile` now produces issues itself on invalid input instead of re-parsing through the interpreter, and the compiler is decomposed into per-subclass emitters in `core/jit.ts`.

**How it works.** Every emitter owns a fast generator and, where one exists, an issue generator. `compile()` builds the fast parser up front and the issue parser lazily on the first rejection, so a schema that never fails pays nothing for it. Failure sites never hand-build issues: a failed predicate calls the node's own runtime `parse` or `check` cold, so the issue shapes cannot drift from the interpreter's; codegen owns only the walk — path prefixes, abort gates, sibling continuation, partial output, the pipe stop rule. Anything without a native emitter (intersection, map, set, lazy, catch, codecs, coercion, xor) runs as an island through its own interpreter run. `{ issues: false }` keeps today's runtime re-parse, and `z.validate` still stops at the first failure.

**Why a table and not JIT constructors.** The `tuple-jit` branch had classic construct `$ZodXJIT` twins. Measured, that retains the whole compiler in every classic bundle (+5.7 KB gz on a bundle that never calls `z.compile`) and leaves mini's `z.compile` compiling nothing, which is presumably why bf7f5632 reverted it. Here classic and mini construct the plain core classes as before; `emitterFor(schema)` resolves the most specific recorded trait against the table only inside `compile()`, and a per-instance `_zod.codegen` override still wins.

**Parity.** The differential suite asserts deep-equal `error.issues` between the interpreter and the compiled parser on every fixture, and the compile-mode project re-runs the entire corpus under global compilation with issue mode on. Two additions close the holes that left: generated issue code that fails to evaluate is now a loud failure under strict mode (the global shim's), where before it fell back to the runtime re-parse and kept every parity test green over a broken emitter; and a seeded generative differential builds random schemas over every emitter-backed node type and the islands, corrupts valid values, and asserts the interpreter and the compiled schema agree on verdict, output, key order, issues and callback counts across 400 seeds. Its first run found that a rest tuple's fixed-item issues come after the rest elements' in the interpreter and came first from the compiler; fixed and pinned. 8,130 tests green.

**Three axes.**

- Bundle (gz, esbuild `--minify`): bundles that never call `z.compile` are unchanged (classic-object 25,459 → 25,487, mini-object 4,669 → 4,662). Bundles that do: classic-object 32,753 → 39,202 (+6.4 KB), mini-object 14,038 → 20,502 (+6.4 KB). If that is too much for compiler users who never read issues, the emitters can move behind their own entry; `issues: false` is already the runtime switch.
- Memory (retained per schema, measured as a slope over distinct schemas): unchanged until the first rejection (5-key compiled 15 KB, 243-leaf compiled 551 KB, same as main's compiler). A schema that has rejected once retains its issue parser: 5-key 15 → 18 KB, 243-leaf 551 → 724 KB. Generated issue code was cut 45% from the prototype (243-leaf: 237 → 131 KB of source); the remainder is bytecode.
- Runtime: the valid path is byte-identical to main's fast path. Failing parses: the compiled walk is 3–6x the interpreter's on nested objects, arrays and tuples. Wide schemas needed one more piece: V8 sizes a function's optimization budget by its bytecode, so the 243-leaf issue parser as one 131 KB function ran unoptimized for thousands of rejections and lost to the interpreter until then. Subtrees over a size threshold are now hoisted into functions of their own (union branches and isolated children too, which also drops a closure allocation per parse), and the 243-leaf failing parse goes from 3.5 µs to 1.0–1.3 µs at peak, 8–11x the interpreter, with the first 2,000 rejections costing the same as the interpreter instead of 2x. Small shapes were at or below 1x until two more pieces: a compiled `safeParse` that rejected re-entered its runtime method through a symbol-keyed params object, paying a context spread and six flag reads in the wrapper, so the methods now raise a module flag the wrapper consumes on entry (5-key object 1.08 → 1.20x, object union 0.95 → 1.03x); and the record fast path materialized every key through `Reflect.ownKeys`, now a for-in over a symbol snapshot taken before any value is read, with the same per-key enumerability recheck as the runtime (two valid keys 259 → ~90 ns, about 3x the interpreter; a proxy input sees one more descriptor lookup per key than it does from the interpreter). What is left on small shapes is the result object in `failure()` — a CPU profile puts it at 38% of self time on both paths — which is a public-shape question, not a codegen one; a bare `z.string()` stays at ~0.87x on a failing parse because that parse is the interpreter's own leaf parse cold-called plus dispatch.

Failing `safeParse` on a quiet machine (load 5–7, interleaved, min of 7 fixed-iteration rounds), interpreter vs `z.compile(s, { issues: false })` (today's runtime re-parse) vs compiled issues:

| shape | interpreter | `issues: false` | compiled issues |
| --- | --- | --- | --- |
| string | 238 ns | 272 (0.87x) | 254 (0.93x) |
| object-5key | 357 | 463 (0.77x) | 307 (1.16x) |
| nested-3deep | 408 | 571 (0.71x) | 352 (1.16x) |
| array-20 | 597 | 682 (0.88x) | 386 (1.55x) |
| tuple-4 | 482 | 545 (0.88x) | 336 (1.43x) |
| union-3obj | 1,465 | 1,197 (1.22x) | 1,312 (1.12x) |
| discunion-3 | 362 | 425 (0.85x) | 332 (1.09x) |
| leaf-243 | 11,463 | 10,229 (1.12x) | 3,862 (2.97x, 12x once tiered up) |

The compiled walk itself is 2–4x the interpreter's on containers (nested 100 vs 205 ns, array 143 vs 418, tuple 100 vs 204) and at parity on unions, where both sides spend the time finalizing per-branch issues; the rest of each row is the result object.

Two mode-invariant cuts rode along, both contract-neutral (every own-property descriptor of the error classes was diffed against main): `finalizeIssue` copies with a loop instead of object rest (139 → 99 ns), and the `$ZodError` initializer no longer redefines `_zod` with a descriptor `$constructor` had already applied (`new ZodError` 403 → 335 ns).

Follows on from #6538 and #6544.
