### PR TITLE
perf(compile): for-in record walk, cheaper issue finalization, and a generative compile differential

### DIFF
--- a/packages/bench/error-construction-breakdown.ts
+++ b/packages/bench/error-construction-breakdown.ts
@@ -1,0 +1,83 @@
+// Where the time goes when a caller reads `.error` on a failing safeParse: finalizeIssue per issue, the ZodError construction, and the plain Error baseline. Fixed iterations, gc between samples, min of 7 interleaved rounds.
+import * as z from "zod";
+import * as core from "../zod/src/v4/core/index.js";
+import * as util from "../zod/src/v4/core/util.js";
+
+declare global {
+  var gc: undefined | (() => void);
+}
+if (!globalThis.gc) {
+  console.error("run with --expose-gc");
+  process.exit(1);
+}
+
+const inst = z.string();
+const raw = () => ({ code: "invalid_type", expected: "string", input: 42, inst }) as unknown as core.$ZodRawIssue;
+const ctx = { async: false } as core.ParseContextInternal;
+const finalized = util.finalizeIssue(raw(), ctx, core.config());
+const finalizedList = [finalized];
+
+let sink = 0;
+function sample(fn: () => unknown, iters: number): number {
+  globalThis.gc!();
+  const t0 = process.hrtime.bigint();
+  for (let i = 0; i < iters; i++) if (fn()) sink++;
+  return Number(process.hrtime.bigint() - t0) / iters;
+}
+
+// candidate finalizeIssue bodies, same output: object rest (shipped) vs an explicit copy loop
+const SKIP = new Set(["inst", "schema", "continue", "input"]);
+function finalizeLoop(iss: any, c: any, cfg: any): any {
+  const traits: Set<string> | undefined = iss.inst?._zod?.traits;
+  if (traits?.has("$ZodType")) {
+    if (traits.has("$ZodCheck")) iss.schema ??= iss.inst;
+    else iss.schema = iss.inst;
+  }
+  const schemaError = iss.schema !== iss.inst ? iss.schema?._zod.def?.error : undefined;
+  const message = iss.message
+    ? iss.message
+    : (util.unwrapMessage(iss.inst?._zod.def?.error?.(iss)) ??
+      util.unwrapMessage(schemaError?.(iss)) ??
+      util.unwrapMessage(c?.error?.(iss)) ??
+      util.unwrapMessage(cfg.customError?.(iss)) ??
+      util.unwrapMessage(cfg.localeError?.(iss)) ??
+      "Invalid input");
+  const out: any = {};
+  for (const k in iss) if (!SKIP.has(k)) out[k] = iss[k];
+  out.path ??= [];
+  out.message = message;
+  if (c?.reportInput) out.input = iss.input;
+  return out;
+}
+const localeError = core.config().localeError!;
+
+const variants: Array<[string, () => unknown]> = [
+  ["finalizeIssue: copy loop variant", () => finalizeLoop(raw(), ctx, core.config())],
+  ["localeError(raw) alone", () => localeError(raw() as never)],
+  [
+    "object rest of a raw issue",
+    () => {
+      const { inst: _i, schema: _s, continue: _c, input: _n, ...rest } = raw() as any;
+      return rest;
+    },
+  ],
+  ["finalizeIssue(one raw issue)", () => util.finalizeIssue(raw(), ctx, core.config())],
+  ["config() alone", () => core.config()],
+  ["new Error('x')", () => new Error("x")],
+  ["new core.$ZodRealError([issue])", () => new core.$ZodRealError(finalizedList)],
+  ["new z.ZodError([issue]) (classic)", () => new z.ZodError(finalizedList)],
+  ["new z.ZodError + read .issues", () => new z.ZodError(finalizedList).issues],
+  ["new z.ZodError + read .message", () => new z.ZodError(finalizedList).message.length],
+  ["safeParse(42).error.issues.length", () => (inst.safeParse(42) as any).error.issues.length],
+];
+const ITERS = 300_000;
+const mins = new Map<string, number>();
+for (const [, fn] of variants) sample(fn, ITERS / 10);
+for (let r = 0; r < 7; r++) {
+  for (const [name, fn] of variants) {
+    const v = sample(fn, ITERS);
+    if (!mins.has(name) || v < mins.get(name)!) mins.set(name, v);
+  }
+}
+for (const [name] of variants) console.log(`${name.padEnd(38)} ${mins.get(name)!.toFixed(1)} ns`);
+console.log(`sink=${sink}`);

--- a/packages/bench/error-construction-breakdown.ts
+++ b/packages/bench/error-construction-breakdown.ts
@@ -25,7 +25,7 @@ function sample(fn: () => unknown, iters: number): number {
   return Number(process.hrtime.bigint() - t0) / iters;
 }
 
-// candidate finalizeIssue bodies, same output: object rest (shipped) vs an explicit copy loop
+// candidate finalizeIssue bodies, same output: object rest (main before #6567) vs a for-in copy loop; the shipped body walks Object.keys so inherited keys stay out
 const SKIP = new Set(["inst", "schema", "continue", "input"]);
 function finalizeLoop(iss: any, c: any, cfg: any): any {
   const traits: Set<string> | undefined = iss.inst?._zod?.traits;

--- a/packages/bench/memory/compiled-slope.ts
+++ b/packages/bench/memory/compiled-slope.ts
@@ -1,0 +1,43 @@
+// Retained heap PER compiled schema, measured as a slope over many distinct schemas in one process. compiled-footprint.ts holds one instance per process and reports the delta, which also carries one-time costs of whatever the measured schema touched first (lazily compiled compiler functions, prototype members materialized on first read, a regex's first executions); those move the single-instance rows by a few KB between builds while the per-schema cost is unchanged. Distinct key names per schema keep V8's compilation cache from sharing generated source.
+import * as z from "zod";
+import { compile } from "../../zod/src/v4/core/compile.js";
+import { fmtBytes, heapUsed } from "./harness.js";
+
+const fiveKey = (p: string) =>
+  z.object({
+    [`${p}a`]: z.string(),
+    [`${p}b`]: z.number(),
+    [`${p}c`]: z.boolean(),
+    [`${p}d`]: z.string(),
+    [`${p}e`]: z.number(),
+  });
+function nested(depth: number, fanout: number, p: string): z.ZodType {
+  if (depth === 0) return z.string();
+  const shape: Record<string, z.ZodType> = {};
+  for (let i = 0; i < fanout; i++) shape[`${p}${i}`] = nested(depth - 1, fanout, p);
+  return z.object(shape);
+}
+const rejected = (schema: z.ZodType) => {
+  schema.safeParse(undefined);
+  return schema;
+};
+
+const hold: unknown[] = [];
+(globalThis as { __hold?: unknown[] }).__hold = hold;
+
+function slope(label: string, make: (p: string) => unknown, n: number): void {
+  hold.length = 0;
+  // warm-up instances absorb the one-time costs
+  for (let i = 0; i < 3; i++) hold.push(make(`w${i}_`));
+  const before = heapUsed();
+  for (let i = 0; i < n; i++) hold.push(make(`m${i}_`));
+  const per = (heapUsed() - before) / n;
+  console.log(`${label.padEnd(40)} ${fmtBytes(per).padStart(10)} per schema`);
+}
+
+slope("5-key constructed", fiveKey, 50);
+slope("5-key compiled", (p) => compile(fiveKey(p) as never), 50);
+slope("5-key compiled, rejected once", (p) => rejected(compile(fiveKey(p) as never)), 50);
+slope("243-leaf constructed", (p) => nested(5, 3, p), 8);
+slope("243-leaf compiled", (p) => compile(nested(5, 3, p) as never), 8);
+slope("243-leaf compiled, rejected once", (p) => rejected(compile(nested(5, 3, p) as never)), 8);

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -42,13 +42,13 @@ const CEILINGS: Record<string, number> = {
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
-  "zod-mini-boolean": 3054,
+  "zod-mini-boolean": 3088,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
   // Lowered by the measured −105 when checks stopped writing metadata into the bag at attach time: the string length/format closures and the per-instance bounded regex left every string bundle, and the template literal now derives its own part patterns.
-  "zod-mini-string": 3429,
+  "zod-mini-string": 3462,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
   // Also carries the memoizer seam from #6482: each container init reads `globalConfig.memoizer` and calls `attach`, which is what lets `zod/mini` opt into cycle support. Measured 4512 locally but 4533 on CI — the gzip stream differs across zlib builds — so the headroom rides on the CI number.

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1080,3 +1080,15 @@ describe("safeParse builds the error on first read", () => {
     }
   });
 });
+
+test("a finalized issue copies the raw issue's own keys only", () => {
+  const proto = { inherited: true };
+  const schema = z.string().check((ctx) => {
+    const raw = Object.create(proto);
+    Object.assign(raw, { code: "custom", message: "own", input: ctx.value, extra: 1 });
+    ctx.issues.push(raw);
+  });
+  const issue = schema.safeParse("x").error!.issues[0];
+  expect(issue).toStrictEqual({ code: "custom", message: "own", path: [], extra: 1 });
+  expect("inherited" in issue).toBe(false);
+});

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1091,4 +1091,12 @@ test("a finalized issue copies the raw issue's own keys only", () => {
   const issue = schema.safeParse("x").error!.issues[0];
   expect(issue).toStrictEqual({ code: "custom", message: "own", path: [], extra: 1 });
   expect("inherited" in issue).toBe(false);
+  // an own __proto__ key, as JSON.parse produces, neither swaps the prototype nor survives
+  const parsed = z.string().check((ctx) => {
+    ctx.issues.push(JSON.parse('{"code":"custom","message":"json","__proto__":{"polluted":true}}'));
+  });
+  const fromJson = parsed.safeParse("x").error!.issues[0];
+  expect(Object.getPrototypeOf(fromJson)).toBe(Object.prototype);
+  expect(Object.prototype.hasOwnProperty.call(fromJson, "__proto__")).toBe(false);
+  expect("polluted" in fromJson).toBe(false);
 });

--- a/packages/zod/src/v4/classic/tests/error.test.ts
+++ b/packages/zod/src/v4/classic/tests/error.test.ts
@@ -1091,6 +1091,12 @@ test("a finalized issue copies the raw issue's own keys only", () => {
   const issue = schema.safeParse("x").error!.issues[0];
   expect(issue).toStrictEqual({ code: "custom", message: "own", path: [], extra: 1 });
   expect("inherited" in issue).toBe(false);
+  // own symbol-keyed fields are not copied either; nothing in zod produces one and the walk stays a string-key walk
+  const sym = Symbol("meta");
+  const symbolic = z.string().check((ctx) => {
+    ctx.issues.push({ code: "custom", message: "sym", input: ctx.value, [sym]: 1 } as never);
+  });
+  expect(Object.getOwnPropertySymbols(symbolic.safeParse("x").error!.issues[0])).toEqual([]);
   // an own __proto__ key, as JSON.parse produces, neither swaps the prototype nor survives
   const parsed = z.string().check((ctx) => {
     ctx.issues.push(JSON.parse('{"code":"custom","message":"json","__proto__":{"polluted":true}}'));

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1973,13 +1973,10 @@ function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
     if (keyFn.definite === false) ctx.definite = false;
     const keyFast = addConstant(ctx, keyFn);
     const numericConst = addConstant(ctx, regexes.number);
-    const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
     const outKeyVar = newVar(ctx);
 
-    doc.write(`for (const ${kVar} of Reflect.ownKeys(${accessor})) {`);
-    doc.indented((d) => {
-      d.write(`if (${kVar} === "__proto__") continue;`);
-      d.write(`if (!${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
+    // the body runs once per string key and once per symbol key, since a key schema can accept symbols
+    emitOwnKeys(doc, ctx, accessor, kVar, (d) => {
       d.write(`let ${outKeyVar} = ${keyFast}(${kVar});`);
       // Numeric-string retry, mirroring the runtime: a key the schema rejects as a string is tried again as a number, so z.record(z.number(), …) matches the numeric keys JavaScript stringified on the way in.
       d.write(
@@ -1999,24 +1996,53 @@ function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
       const valOutput = compileChild(d, ctx, def.valueType, valueVar);
       d.write(`${outputVar}[${outKeyVar}] = ${valOutput};`);
     });
-    doc.write(`}`);
     return outputVar;
   }
 
-  // Plain z.string() keys: iterate enumerable own keys and validate each value. Runtime uses Reflect.ownKeys so symbol keys participate in validation; matching that here prevents silently accepting objects with enumerable Symbol keys under z.record(z.string(), ...).
-  const propIsEnumerable = addConstant(ctx, Object.prototype.propertyIsEnumerable);
-  doc.write(`for (const ${kVar} of Reflect.ownKeys(${accessor})) {`);
-  doc.indented((d) => {
-    d.write(`if (${kVar} === "__proto__") continue;`);
-    d.write(`if (!${propIsEnumerable}.call(${accessor}, ${kVar})) continue;`);
-    d.write(`if (typeof ${kVar} !== "string") return INVALID;`);
-    d.write(`const ${valVar} = ${accessor}[${kVar}];`);
-    const valOutput = compileChild(d, ctx, def.valueType, valVar);
-    d.write(`${outputVar}[${kVar}] = ${valOutput};`);
-  });
-  doc.write(`}`);
+  // Plain z.string() keys: every own enumerable string key's value is validated, and an own enumerable symbol key fails the string key schema, as it does in the runtime's Reflect.ownKeys walk.
+  emitOwnKeys(
+    doc,
+    ctx,
+    accessor,
+    kVar,
+    (d) => {
+      d.write(`const ${valVar} = ${accessor}[${kVar}];`);
+      const valOutput = compileChild(d, ctx, def.valueType, valVar);
+      d.write(`${outputVar}[${kVar}] = ${valOutput};`);
+    },
+    `return INVALID;`
+  );
 
   return outputVar;
+}
+
+// Walks the own enumerable keys of a plain object in Reflect.ownKeys order — strings by for-in, then symbols — without materializing the key array, which made that walk 3–6x the cost of the loop it fed. Both key sets are snapshotted before any value is read and every key is rechecked with propertyIsEnumerable when visited, so a getter that adds, deletes or hides a key mid-walk sees the runtime's verdict; a proxy observes one more descriptor lookup per key than the runtime, from for-in's own enumerability filter. `body` is written once for the string loop and once for the symbol loop unless `onSymbol` replaces the latter.
+function emitOwnKeys(
+  doc: Doc,
+  ctx: CompileContext,
+  accessor: string,
+  kVar: string,
+  body: (d: Doc) => void,
+  onSymbol?: string
+): void {
+  const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
+  const symsVar = newVar(ctx);
+  const iVar = newVar(ctx);
+  doc.write(`const ${symsVar} = Object.getOwnPropertySymbols(${accessor});`);
+  doc.write(`for (const ${kVar} in ${accessor}) {`);
+  doc.indented((d) => {
+    d.write(`if (${kVar} === "__proto__" || !${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
+    body(d);
+  });
+  doc.write(`}`);
+  doc.write(`for (let ${iVar} = 0; ${iVar} < ${symsVar}.length; ${iVar}++) {`);
+  doc.indented((d) => {
+    d.write(`const ${kVar} = ${symsVar}[${iVar}];`);
+    d.write(`if (!${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
+    if (onSymbol) d.write(onSymbol);
+    else body(d);
+  });
+  doc.write(`}`);
 }
 
 function literalPropertyKey(ctx: CompileContext, key: string | symbol): string {

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -2016,7 +2016,7 @@ function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
   return outputVar;
 }
 
-// Walks the own enumerable keys of a plain object in Reflect.ownKeys order — strings from Object.keys, then symbols — instead of Reflect.ownKeys, whose accumulator made that walk 3–6x the cost of the loop it fed. Both key sets are snapshotted before any value is read and every key is rechecked with propertyIsEnumerable when visited, so a getter that adds, deletes or hides a key mid-walk sees the runtime's verdict; for-in was faster still but enumerates the prototype chain after the own keys, so a getter that shadowed an inherited enumerable name mid-walk leaked the new key. `body` is written once for the string loop and once for the symbol loop unless `onSymbol` replaces the latter.
+// Walks the own enumerable keys of a plain object in Reflect.ownKeys order — strings from getOwnPropertyNames, then symbols — instead of Reflect.ownKeys, whose accumulator made that walk 3–6x the cost of the loop it fed. Both snapshots are taken before any value is read and every key is rechecked with propertyIsEnumerable when visited, exactly the runtime's walk, so a getter that adds, deletes, hides or reveals a key mid-walk sees the runtime's verdict; for-in and Object.keys were no faster and each lost a case (for-in enumerates the prototype chain after the own keys, Object.keys drops a key that is non-enumerable at snapshot time). `body` is written once for the string loop and once for the symbol loop unless `onSymbol` replaces the latter.
 function emitOwnKeys(
   doc: Doc,
   ctx: CompileContext,
@@ -2030,7 +2030,7 @@ function emitOwnKeys(
   const keysVar = newVar(ctx);
   const iVar = newVar(ctx);
   doc.write(`const ${symsVar} = Object.getOwnPropertySymbols(${accessor});`);
-  doc.write(`const ${keysVar} = Object.keys(${accessor});`);
+  doc.write(`const ${keysVar} = Object.getOwnPropertyNames(${accessor});`);
   doc.write(`for (let ${iVar} = 0; ${iVar} < ${keysVar}.length; ${iVar}++) {`);
   doc.indented((d) => {
     d.write(`const ${kVar} = ${keysVar}[${iVar}];`);

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -2016,7 +2016,7 @@ function generateRecordCheck(doc: Doc, ctx: CompileContext, schema: SomeType, ac
   return outputVar;
 }
 
-// Walks the own enumerable keys of a plain object in Reflect.ownKeys order — strings by for-in, then symbols — without materializing the key array, which made that walk 3–6x the cost of the loop it fed. Both key sets are snapshotted before any value is read and every key is rechecked with propertyIsEnumerable when visited, so a getter that adds, deletes or hides a key mid-walk sees the runtime's verdict; a proxy observes one more descriptor lookup per key than the runtime, from for-in's own enumerability filter. `body` is written once for the string loop and once for the symbol loop unless `onSymbol` replaces the latter.
+// Walks the own enumerable keys of a plain object in Reflect.ownKeys order — strings from Object.keys, then symbols — instead of Reflect.ownKeys, whose accumulator made that walk 3–6x the cost of the loop it fed. Both key sets are snapshotted before any value is read and every key is rechecked with propertyIsEnumerable when visited, so a getter that adds, deletes or hides a key mid-walk sees the runtime's verdict; for-in was faster still but enumerates the prototype chain after the own keys, so a getter that shadowed an inherited enumerable name mid-walk leaked the new key. `body` is written once for the string loop and once for the symbol loop unless `onSymbol` replaces the latter.
 function emitOwnKeys(
   doc: Doc,
   ctx: CompileContext,
@@ -2027,10 +2027,13 @@ function emitOwnKeys(
 ): void {
   const propIsEnumerableConst = addConstant(ctx, Object.prototype.propertyIsEnumerable);
   const symsVar = newVar(ctx);
+  const keysVar = newVar(ctx);
   const iVar = newVar(ctx);
   doc.write(`const ${symsVar} = Object.getOwnPropertySymbols(${accessor});`);
-  doc.write(`for (const ${kVar} in ${accessor}) {`);
+  doc.write(`const ${keysVar} = Object.keys(${accessor});`);
+  doc.write(`for (let ${iVar} = 0; ${iVar} < ${keysVar}.length; ${iVar}++) {`);
   doc.indented((d) => {
+    d.write(`const ${kVar} = ${keysVar}[${iVar}];`);
     d.write(`if (${kVar} === "__proto__" || !${propIsEnumerableConst}.call(${accessor}, ${kVar})) continue;`);
     body(d);
   });

--- a/packages/zod/src/v4/core/errors.ts
+++ b/packages/zod/src/v4/core/errors.ts
@@ -251,7 +251,6 @@ const _messageDesc: PropertyDescriptor = {
   enumerable: true,
   configurable: true,
 };
-const _zodDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 const _issuesDesc: PropertyDescriptor = { value: undefined, enumerable: false };
 
 /* Prototypes that already carry the lazy `toString`. Seeded with the
@@ -261,12 +260,10 @@ const _installedToString = /* @__PURE__ */ new WeakSet<object>([Object.prototype
 
 const initializer = (inst: $ZodError, def: $ZodIssue[]): void => {
   inst.name = "$ZodError";
-  _zodDesc.value = inst._zod;
-  Object.defineProperty(inst, "_zod", _zodDesc);
+  // `_zod` is already non-enumerable: $constructor's init defined it with this same descriptor
   _issuesDesc.value = def;
   Object.defineProperty(inst, "issues", _issuesDesc);
-  // Clear the shared slots; a retained `value` pins the last error's issues.
-  _zodDesc.value = undefined;
+  // Clear the shared slot; a retained `value` pins the last error's issues.
   _issuesDesc.value = undefined;
   Object.defineProperty(inst, "message", _messageDesc);
 

--- a/packages/zod/src/v4/core/tests/compile-generative.test.ts
+++ b/packages/zod/src/v4/core/tests/compile-generative.test.ts
@@ -432,11 +432,12 @@ function checkSeed(seed: number): void {
       } else {
         expect(b.value!.error!.issues, `${label}: issues`).toEqual(a.value!.error!.issues);
       }
-      // the fast pass runs a callback at most once, the runtime re-parse at most once more, for each callback on its own
-      for (const [id, n] of compiledCalls) {
-        expect(n, `${label}: callback ${id} ran ${n} vs ${runtimeCalls.get(id) ?? 0}`).toBeLessThanOrEqual(
-          2 * (runtimeCalls.get(id) ?? 0)
-        );
+      // every callback the interpreter reaches, the compiled schema reaches too; the fast pass runs it at most once and the runtime re-parse at most once more
+      for (const id of new Set([...compiledCalls.keys(), ...runtimeCalls.keys()])) {
+        const n = compiledCalls.get(id) ?? 0;
+        const r = runtimeCalls.get(id) ?? 0;
+        expect(n, `${label}: callback ${id} ran ${n} vs ${r}`).toBeGreaterThanOrEqual(r);
+        expect(n, `${label}: callback ${id} ran ${n} vs ${r}`).toBeLessThanOrEqual(2 * r);
       }
     }
     expect(() => compileFn(g.schema), `${g.desc}: compile refused`).not.toThrow();

--- a/packages/zod/src/v4/core/tests/compile-generative.test.ts
+++ b/packages/zod/src/v4/core/tests/compile-generative.test.ts
@@ -1,0 +1,444 @@
+import { expect, test } from "vitest";
+
+import * as z from "../../index.js";
+import { compile, compileFn } from "../compile.js";
+
+// Generative differential: random schemas over the compiled node types, a valid value for each, single corruptions of that value, and the assertion that the interpreter and the compiled schema agree on the verdict, the output, the issues and how often user callbacks ran. A fixture suite covers the compositions somebody wrote down; this covers the ones nobody did. Seeds are fixed, so a failure names the seed and the schema it built.
+
+function mulberry32(seed: number): () => number {
+  return () => {
+    seed = (seed + 0x6d2b79f5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface Gen {
+  schema: z.ZodType;
+  desc: string;
+  valid: () => unknown;
+  // one corruption of a valid value; not always rejected (a loose object absorbs an extra key), and both sides must agree either way
+  corrupt: (v: unknown) => unknown;
+  // this node itself has no fast emitter and compiles through the runtime
+  island: boolean;
+}
+
+interface Ctx {
+  rand: () => number;
+  // runs per generated callback, so the two-run bound holds for each one rather than for the sum
+  calls: Map<number, number>;
+  nextCallback: number;
+}
+
+function count(c: Ctx, id: number): void {
+  c.calls.set(id, (c.calls.get(id) ?? 0) + 1);
+}
+
+const pick = <T>(c: Ctx, xs: readonly T[]): T => xs[Math.floor(c.rand() * xs.length)]!;
+const int = (c: Ctx, lo: number, hi: number): number => lo + Math.floor(c.rand() * (hi - lo + 1));
+const JUNK = [42, "x", null, undefined, true, [], {}, -0, Number.NaN] as const;
+
+function leaf(c: Ctx): Gen {
+  switch (int(c, 0, 7)) {
+    case 0: {
+      const min = int(c, 0, 3);
+      return {
+        schema: z.string().min(min),
+        desc: `string.min(${min})`,
+        valid: () => "x".repeat(min + int(c, 0, 2)),
+        corrupt: () => (c.rand() < 0.5 ? 42 : "x".repeat(Math.max(0, min - 1))),
+        island: false,
+      };
+    }
+    case 1:
+      return {
+        schema: z.email(),
+        desc: "email",
+        valid: () => "a@b.co",
+        corrupt: () => (c.rand() < 0.5 ? "nope" : 1),
+        island: false,
+      };
+    case 2: {
+      const lo = int(c, -5, 0);
+      const hi = int(c, 1, 5);
+      return {
+        schema: z.number().int().min(lo).max(hi),
+        desc: `int[${lo},${hi}]`,
+        valid: () => int(c, lo, hi),
+        corrupt: () => pick(c, [hi + 1, lo - 1, 1.5, "1"]),
+        island: false,
+      };
+    }
+    case 3:
+      return {
+        schema: z.boolean(),
+        desc: "boolean",
+        valid: () => c.rand() < 0.5,
+        corrupt: () => pick(c, ["true", 0, null]),
+        island: false,
+      };
+    case 4: {
+      const lit = pick(c, ["a", 1, true] as const);
+      return {
+        schema: z.literal(lit),
+        desc: `literal(${JSON.stringify(lit)})`,
+        valid: () => lit,
+        corrupt: () => pick(c, ["b", 2, false]),
+        island: false,
+      };
+    }
+    case 5:
+      return {
+        schema: z.enum(["a", "b", "c"]),
+        desc: "enum",
+        valid: () => pick(c, ["a", "b", "c"]),
+        corrupt: () => pick(c, ["d", 2, null]),
+        island: false,
+      };
+    case 6: {
+      const id = c.nextCallback++;
+      return {
+        schema: z.number().superRefine((v, ctx) => {
+          count(c, id);
+          if (v < 0) ctx.addIssue({ code: "custom", message: "negative" });
+        }),
+        desc: "number.superRefine",
+        valid: () => int(c, 0, 9),
+        corrupt: () => pick(c, [-1, "x"]),
+        island: false,
+      };
+    }
+    default: {
+      const id = c.nextCallback++;
+      return {
+        schema: z.string().transform((s) => {
+          count(c, id);
+          return s.length;
+        }),
+        desc: "string.transform",
+        valid: () => "y".repeat(int(c, 0, 3)),
+        corrupt: () => 42,
+        island: false,
+      };
+    }
+  }
+}
+
+function wrap(c: Ctx, inner: Gen): Gen {
+  switch (int(c, 0, 4)) {
+    case 0:
+      return {
+        ...inner,
+        schema: inner.schema.optional(),
+        desc: `${inner.desc}.optional`,
+        valid: () => (c.rand() < 0.3 ? undefined : inner.valid()),
+        island: false,
+      };
+    case 1:
+      return {
+        ...inner,
+        schema: inner.schema.nullable(),
+        desc: `${inner.desc}.nullable`,
+        valid: () => (c.rand() < 0.3 ? null : inner.valid()),
+        island: false,
+      };
+    case 2: {
+      const dflt = inner.valid();
+      return {
+        ...inner,
+        schema: inner.schema.default(dflt as never),
+        desc: `${inner.desc}.default`,
+        valid: () => (c.rand() < 0.3 ? undefined : inner.valid()),
+        island: false,
+      };
+    }
+    case 3:
+      return { ...inner, schema: inner.schema.readonly(), desc: `${inner.desc}.readonly`, island: false };
+    default:
+      return {
+        ...inner,
+        schema: inner.schema.optional().nonoptional(),
+        desc: `${inner.desc}.optional.nonoptional`,
+        corrupt: (v) => (c.rand() < 0.5 ? undefined : inner.corrupt(v)),
+        island: false,
+      };
+  }
+}
+
+function container(c: Ctx, depth: number): Gen {
+  const child = () => gen(c, depth - 1);
+  switch (int(c, 0, 8)) {
+    case 0:
+    case 1: {
+      const n = int(c, 1, 4);
+      const entries = Array.from({ length: n }, (_, i) => [`k${i}`, child(), c.rand() < 0.3] as const);
+      const shape = Object.fromEntries(entries.map(([k, g, opt]) => [k, opt ? g.schema.optional() : g.schema]));
+      const mode = pick(c, ["plain", "strict", "loose", "catchall"] as const);
+      const schema =
+        mode === "strict"
+          ? z.strictObject(shape)
+          : mode === "loose"
+            ? z.looseObject(shape)
+            : mode === "catchall"
+              ? z.object(shape).catchall(z.number())
+              : z.object(shape);
+      const valid = () => {
+        const o: Record<string, unknown> = {};
+        for (const [k, g, opt] of entries) if (!opt || c.rand() < 0.6) o[k] = g.valid();
+        if (mode === "catchall" && c.rand() < 0.5) o.extra = 1;
+        return o;
+      };
+      return {
+        schema,
+        desc: `${mode}{${entries.map(([k, g, opt]) => `${k}${opt ? "?" : ""}:${g.desc}`).join(",")}}`,
+        valid,
+        corrupt: (v) => {
+          if (typeof v !== "object" || v === null) return v;
+          const o = { ...(v as Record<string, unknown>) };
+          const [k, g, opt] = pick(c, entries);
+          switch (int(c, 0, 3)) {
+            case 0:
+              o[k] = g.corrupt(k in o ? o[k] : g.valid());
+              break;
+            case 1:
+              if (opt) o[k] = g.corrupt(g.valid());
+              else delete o[k];
+              break;
+            case 2:
+              o.extra = "e";
+              break;
+            default:
+              return 42;
+          }
+          return o;
+        },
+        island: false,
+      };
+    }
+    case 2: {
+      const g = child();
+      const min = int(c, 0, 2);
+      return {
+        schema: z.array(g.schema).min(min),
+        desc: `array(${g.desc}).min(${min})`,
+        valid: () => Array.from({ length: min + int(c, 0, 2) }, () => g.valid()),
+        corrupt: (v) => {
+          if (!Array.isArray(v)) return v;
+          const a = [...v];
+          if (a.length && c.rand() < 0.6) a[int(c, 0, a.length - 1)] = g.corrupt(a[0]);
+          else if (min > 0) a.length = min - 1;
+          else return 42;
+          return a;
+        },
+        island: false,
+      };
+    }
+    case 3: {
+      const items = Array.from({ length: int(c, 1, 3) }, child);
+      const rest = c.rand() < 0.4 ? child() : null;
+      const schema = rest
+        ? z.tuple(items.map((g) => g.schema) as [z.ZodType, ...z.ZodType[]], rest.schema)
+        : z.tuple(items.map((g) => g.schema) as [z.ZodType, ...z.ZodType[]]);
+      return {
+        schema,
+        desc: `tuple(${items.map((g) => g.desc).join(",")}${rest ? `,...${rest.desc}` : ""})`,
+        valid: () => [
+          ...items.map((g) => g.valid()),
+          ...(rest ? Array.from({ length: int(c, 0, 2) }, () => rest.valid()) : []),
+        ],
+        corrupt: (v) => {
+          if (!Array.isArray(v)) return v;
+          const a = [...v];
+          const i = int(c, 0, items.length - 1);
+          if (c.rand() < 0.6) a[i] = items[i]!.corrupt(a[i]);
+          else if (c.rand() < 0.5) a.push("extra");
+          else a.length = i;
+          return a;
+        },
+        island: false,
+      };
+    }
+    case 4: {
+      const g = child();
+      const enumKeys = c.rand() < 0.4;
+      const schema = enumKeys ? z.record(z.enum(["a", "b"]), g.schema) : z.record(z.string(), g.schema);
+      return {
+        schema,
+        desc: `record(${enumKeys ? "enum" : "string"},${g.desc})`,
+        valid: () =>
+          enumKeys
+            ? { a: g.valid(), b: g.valid() }
+            : Object.fromEntries(Array.from({ length: int(c, 0, 3) }, (_, i) => [`r${i}`, g.valid()])),
+        corrupt: (v) => {
+          if (typeof v !== "object" || v === null) return v;
+          const o = { ...(v as Record<string, unknown>) };
+          const keys = Object.keys(o);
+          if (keys.length && c.rand() < 0.6) o[pick(c, keys)] = g.corrupt(o[keys[0]!]);
+          else if (enumKeys) o.z = g.valid();
+          else return 42;
+          return o;
+        },
+        island: false,
+      };
+    }
+    case 5: {
+      const options = Array.from({ length: int(c, 2, 3) }, child);
+      return {
+        schema: z.union(options.map((g) => g.schema) as [z.ZodType, z.ZodType, ...z.ZodType[]]),
+        desc: `union(${options.map((g) => g.desc).join("|")})`,
+        valid: () => pick(c, options).valid(),
+        corrupt: (v) => pick(c, options).corrupt(v),
+        island: false,
+      };
+    }
+    case 6: {
+      const branches = Array.from({ length: int(c, 2, 3) }, (_, i) => [i, child()] as const);
+      return {
+        schema: z.discriminatedUnion(
+          "t",
+          branches.map(([i, g]) => z.object({ t: z.literal(`b${i}`), v: g.schema })) as [
+            z.ZodObject<{ t: z.ZodLiteral<string>; v: z.ZodType }>,
+            ...z.ZodObject<{ t: z.ZodLiteral<string>; v: z.ZodType }>[],
+          ]
+        ),
+        desc: `dunion(${branches.map(([, g]) => g.desc).join("|")})`,
+        valid: () => {
+          const [i, g] = pick(c, branches);
+          return { t: `b${i}`, v: g.valid() };
+        },
+        corrupt: (v) => {
+          if (typeof v !== "object" || v === null) return v;
+          const o = { ...(v as { t: string; v: unknown }) };
+          const branch = branches.find(([i]) => `b${i}` === o.t);
+          if (branch && c.rand() < 0.6) o.v = branch[1].corrupt(o.v);
+          else o.t = "nope";
+          return o;
+        },
+        island: false,
+      };
+    }
+    case 7: {
+      const min = int(c, 1, 3);
+      return {
+        schema: z.string().pipe(z.string().min(min)),
+        desc: `string.pipe(min(${min}))`,
+        valid: () => "p".repeat(min + int(c, 0, 1)),
+        corrupt: () => (c.rand() < 0.5 ? "p".repeat(min - 1) : 7),
+        island: false,
+      };
+    }
+    default: {
+      // map and set: the compiled result still has to agree
+      const g = child();
+      if (c.rand() < 0.5) {
+        return {
+          schema: z.map(z.string(), g.schema),
+          desc: `map(string,${g.desc})`,
+          valid: () => new Map(Array.from({ length: int(c, 0, 2) }, (_, i) => [`m${i}`, g.valid()])),
+          corrupt: (v) => {
+            if (!(v instanceof Map)) return v;
+            const m = new Map(v);
+            if (m.size && c.rand() < 0.7) m.set("m0", g.corrupt(m.get("m0")));
+            else return [];
+            return m;
+          },
+          island: true,
+        };
+      }
+      return {
+        schema: z.set(g.schema),
+        desc: `set(${g.desc})`,
+        valid: () => new Set(Array.from({ length: int(c, 0, 2) }, () => g.valid())),
+        corrupt: (v) => {
+          if (!(v instanceof Set)) return v;
+          const s = new Set(v);
+          if (c.rand() < 0.7) s.add(g.corrupt(g.valid()));
+          else return {};
+          return s;
+        },
+        island: true,
+      };
+    }
+  }
+}
+
+function gen(c: Ctx, depth: number): Gen {
+  if (depth === 0) return leaf(c);
+  const r = c.rand();
+  if (r < 0.25) return leaf(c);
+  if (r < 0.4) return wrap(c, gen(c, depth - 1));
+  return container(c, depth);
+}
+
+function attempt<T>(fn: () => T): { value?: T; threw?: string } {
+  try {
+    return { value: fn() };
+  } catch (err) {
+    return { threw: (err as Error)?.constructor?.name || "Error" };
+  }
+}
+
+function describe(value: unknown): string {
+  return JSON.stringify(value, (_k, v) =>
+    v instanceof Map ? { $map: [...v] } : v instanceof Set ? { $set: [...v] } : v === undefined ? "$undefined" : v
+  );
+}
+
+// own-key order and undefined-valued-vs-absent keys, which toStrictEqual does not see
+function shape(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(shape);
+  if (value && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
+    return Reflect.ownKeys(value).map((k) => [k, shape((value as Record<PropertyKey, unknown>)[k])]);
+  }
+  return value;
+}
+
+const SEEDS = 400;
+
+test("random schemas parse identically through the interpreter and the compiler", () => {
+  // every failing seed is collected, so one run names all of them
+  const failures: string[] = [];
+  for (let seed = 1; seed <= SEEDS; seed++) {
+    try {
+      checkSeed(seed);
+    } catch (err) {
+      failures.push((err as Error).message.split("\n")[0]!);
+    }
+  }
+  expect(failures).toEqual([]);
+});
+
+function checkSeed(seed: number): void {
+  {
+    const c: Ctx = { rand: mulberry32(seed), calls: new Map(), nextCallback: 0 };
+    const g = gen(c, 3);
+    const compiled = compile(g.schema);
+    const inputs = [g.valid(), g.corrupt(g.valid()), g.corrupt(g.corrupt(g.valid())), pick(c, JUNK)];
+    for (const input of inputs) {
+      const label = `seed ${seed} ${g.desc} input ${describe(input)}`;
+      c.calls.clear();
+      const a = attempt(() => g.schema.safeParse(input));
+      const runtimeCalls = new Map(c.calls);
+      c.calls.clear();
+      const b = attempt(() => compiled.safeParse(input));
+      const compiledCalls = new Map(c.calls);
+      expect(b.threw, `${label}: throw`).toBe(a.threw);
+      if (a.threw) continue;
+      expect(b.value!.success, `${label}: verdict`).toBe(a.value!.success);
+      if (a.value!.success) {
+        expect(b.value!.data, `${label}: data`).toStrictEqual(a.value!.data);
+        expect(shape(b.value!.data), `${label}: key order`).toEqual(shape(a.value!.data));
+      } else {
+        expect(b.value!.error!.issues, `${label}: issues`).toEqual(a.value!.error!.issues);
+      }
+      // the fast pass runs a callback at most once, the runtime re-parse at most once more, for each callback on its own
+      for (const [id, n] of compiledCalls) {
+        expect(n, `${label}: callback ${id} ran ${n} vs ${runtimeCalls.get(id) ?? 0}`).toBeLessThanOrEqual(
+          2 * (runtimeCalls.get(id) ?? 0)
+        );
+      }
+    }
+    expect(() => compileFn(g.schema), `${g.desc}: compile refused`).not.toThrow();
+  }
+}

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1658,3 +1658,70 @@ test("strict is per-call, so a supported schema compiles either way", () => {
     invalid(aot, { a: 1, b: 1 });
   }
 });
+
+test("compiled records walk own enumerable keys without Reflect.ownKeys", () => {
+  // for-in plus hasOwn sees the same keys as the runtime's Reflect.ownKeys walk: inherited enumerables are skipped, symbols fail a string key schema but pass a symbol one, and the numeric-string retry still applies
+  const sym = Symbol("s");
+  const bare = compile(z.record(z.string(), z.number()));
+  const inherited = Object.assign(Object.create({ proto: 1 }), { a: 1 });
+  expect(bare.parse(inherited)).toEqual({ a: 1 });
+  const symbolic = { a: 1, [sym]: 2 };
+  expect(bare.safeParse(symbolic).error!.issues).toEqual(
+    z.record(z.string(), z.number()).safeParse(symbolic).error!.issues
+  );
+  expect(bare.safeParse({ a: 1, b: "x" }).error!.issues).toEqual(
+    z.record(z.string(), z.number()).safeParse({ a: 1, b: "x" }).error!.issues
+  );
+  const symKeys = compile(z.record(z.symbol(), z.number()));
+  expect(symKeys.parse({ [sym]: 2 })).toEqual({ [sym]: 2 });
+  expect(symKeys.safeParse({ a: 1 }).success).toBe(false);
+  const emailKeys = compile(z.record(z.email(), z.number()));
+  expect(emailKeys.parse({ "a@b.co": 1 })).toEqual({ "a@b.co": 1 });
+  expect(emailKeys.safeParse({ "a@b.co": 1, [sym]: 2 }).success).toBe(false);
+  expect(compile(z.record(z.number(), z.string())).parse({ 1: "a" })).toEqual({ 1: "a" });
+  // keys are snapshotted before any value is read and rechecked when visited, like the runtime's Reflect.ownKeys walk: a getter that adds a key mid-walk is not visited, one that hides a later key skips it
+  const mutating = (effect: (o: Record<PropertyKey, unknown>) => void) => {
+    const o: Record<PropertyKey, unknown> = {};
+    Object.defineProperty(o, "a", {
+      enumerable: true,
+      get() {
+        effect(o);
+        return 1;
+      },
+    });
+    o.b = 2;
+    return o;
+  };
+  const both = z.record(z.union([z.string(), z.symbol()]), z.number());
+  for (const [schema, effect] of [
+    [
+      both,
+      (o: Record<PropertyKey, unknown>) => {
+        o[sym] = 2;
+      },
+    ],
+    [
+      z.record(z.string(), z.number()),
+      (o: Record<PropertyKey, unknown>) => {
+        o[sym] = "bad";
+      },
+    ],
+    [
+      z.record(z.string(), z.number()),
+      (o: Record<PropertyKey, unknown>) => {
+        o.z = "bad";
+      },
+    ],
+    [
+      z.record(z.string(), z.number()),
+      (o: Record<PropertyKey, unknown>) => Object.defineProperty(o, "b", { enumerable: false }),
+    ],
+  ] as const) {
+    const expected = schema.safeParse(mutating(effect));
+    const actual = compile(schema).safeParse(mutating(effect));
+    expect(actual.success).toBe(expected.success);
+    if (expected.success)
+      expect(Reflect.ownKeys(actual.data as object)).toEqual(Reflect.ownKeys(expected.data as object));
+    else expect(actual.error!.issues).toEqual(expected.error!.issues);
+  }
+});

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1660,7 +1660,7 @@ test("strict is per-call, so a supported schema compiles either way", () => {
 });
 
 test("compiled records walk own enumerable keys without Reflect.ownKeys", () => {
-  // for-in plus hasOwn sees the same keys as the runtime's Reflect.ownKeys walk: inherited enumerables are skipped, symbols fail a string key schema but pass a symbol one, and the numeric-string retry still applies
+  // an Object.keys snapshot plus a per-key recheck sees the same keys as the runtime's Reflect.ownKeys walk: inherited enumerables are skipped, symbols fail a string key schema but pass a symbol one, and the numeric-string retry still applies
   const sym = Symbol("s");
   const bare = compile(z.record(z.string(), z.number()));
   const inherited = Object.assign(Object.create({ proto: 1 }), { a: 1 });
@@ -1724,4 +1724,19 @@ test("compiled records walk own enumerable keys without Reflect.ownKeys", () => 
       expect(Reflect.ownKeys(actual.data as object)).toEqual(Reflect.ownKeys(expected.data as object));
     else expect(actual.error!.issues).toEqual(expected.error!.issues);
   }
+  // a getter that defines an own key under an inherited enumerable name mid-walk: the snapshot predates it, so neither walk visits it, and a union that accepts the record cannot be corrected by a fallback
+  const shadowing = () => {
+    const o = Object.create({ z: 0 });
+    Object.defineProperty(o, "a", {
+      enumerable: true,
+      get() {
+        Object.defineProperty(o, "z", { value: 2, enumerable: true });
+        return 1;
+      },
+    });
+    return o;
+  };
+  const inUnion = z.union([z.record(z.string(), z.number()), z.any()]);
+  expect(compile(inUnion).parse(shadowing())).toStrictEqual(inUnion.parse(shadowing()));
+  expect(compile(inUnion).parse(shadowing())).toStrictEqual({ a: 1 });
 });

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1660,7 +1660,7 @@ test("strict is per-call, so a supported schema compiles either way", () => {
 });
 
 test("compiled records walk own enumerable keys without Reflect.ownKeys", () => {
-  // an Object.keys snapshot plus a per-key recheck sees the same keys as the runtime's Reflect.ownKeys walk: inherited enumerables are skipped, symbols fail a string key schema but pass a symbol one, and the numeric-string retry still applies
+  // a getOwnPropertyNames snapshot plus a per-key recheck sees the same keys as the runtime's Reflect.ownKeys walk: inherited enumerables are skipped, symbols fail a string key schema but pass a symbol one, and the numeric-string retry still applies
   const sym = Symbol("s");
   const bare = compile(z.record(z.string(), z.number()));
   const inherited = Object.assign(Object.create({ proto: 1 }), { a: 1 });
@@ -1739,4 +1739,20 @@ test("compiled records walk own enumerable keys without Reflect.ownKeys", () => 
   const inUnion = z.union([z.record(z.string(), z.number()), z.any()]);
   expect(compile(inUnion).parse(shadowing())).toStrictEqual(inUnion.parse(shadowing()));
   expect(compile(inUnion).parse(shadowing())).toStrictEqual({ a: 1 });
+  // a key that is non-enumerable at snapshot time and revealed by an earlier getter is in the snapshot and passes the recheck, like the runtime
+  const revealing = () => {
+    const o: Record<string, unknown> = {};
+    Object.defineProperty(o, "a", {
+      enumerable: true,
+      get() {
+        Object.defineProperty(o, "b", { enumerable: true });
+        return 1;
+      },
+    });
+    Object.defineProperty(o, "b", { value: 2, enumerable: false, configurable: true });
+    return o;
+  };
+  const plain = z.record(z.string(), z.number());
+  expect(compile(plain).parse(revealing())).toStrictEqual(plain.parse(revealing()));
+  expect(compile(plain).parse(revealing())).toStrictEqual({ a: 1, b: 2 });
 });

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -964,13 +964,18 @@ export function finalizeIssue(
       unwrapMessage(config.localeError?.(iss)) ??
       "Invalid input");
 
-  const { inst: _inst, schema: _schema, continue: _continue, input: _input, ...rest } = iss as any;
-  rest.path ??= [];
-  rest.message = message;
-  if (ctx?.reportInput) {
-    rest.input = _input;
+  // an explicit copy beats object rest with excluded keys, which v8 routes through a generic runtime call
+  const full: any = {};
+  for (const k in iss) {
+    if (k === "inst" || k === "schema" || k === "continue" || k === "input") continue;
+    full[k] = (iss as any)[k];
   }
-  return rest;
+  full.path ??= [];
+  full.message = message;
+  if (ctx?.reportInput) {
+    full.input = iss.input;
+  }
+  return full;
 }
 
 export function getSizableOrigin(input: any): "set" | "map" | "file" | "unknown" {

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -964,9 +964,9 @@ export function finalizeIssue(
       unwrapMessage(config.localeError?.(iss)) ??
       "Invalid input");
 
-  // an explicit copy beats object rest with excluded keys, which v8 routes through a generic runtime call
+  // an explicit own-key copy beats object rest with excluded keys, which v8 routes through a generic runtime call; Object.keys rather than for-in so an issue pushed with a prototype does not leak inherited keys
   const full: any = {};
-  for (const k in iss) {
+  for (const k of Object.keys(iss)) {
     if (k === "inst" || k === "schema" || k === "continue" || k === "input") continue;
     full[k] = (iss as any)[k];
   }

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -964,10 +964,10 @@ export function finalizeIssue(
       unwrapMessage(config.localeError?.(iss)) ??
       "Invalid input");
 
-  // an explicit own-key copy beats object rest with excluded keys, which v8 routes through a generic runtime call; Object.keys rather than for-in so an issue pushed with a prototype does not leak inherited keys
+  // an explicit own-key copy beats object rest with excluded keys, which v8 routes through a generic runtime call; Object.keys rather than for-in so an issue pushed with a prototype does not leak inherited keys, and an own __proto__ key is dropped rather than assigned through the setter
   const full: any = {};
   for (const k of Object.keys(iss)) {
-    if (k === "inst" || k === "schema" || k === "continue" || k === "input") continue;
+    if (k === "inst" || k === "schema" || k === "continue" || k === "input" || k === "__proto__") continue;
     full[k] = (iss as any)[k];
   }
   full.path ??= [];


### PR DESCRIPTION
The mode-independent half of #6559, which I'm closing in favor of this. `z.compile` keeps today's runtime re-parse on invalid input; what lands here is the part of that branch that helps regardless of how issues get built.

**Record fast path.** The compiled record walked keys through `Reflect.ownKeys` with a `propertyIsEnumerable` call per key, 154 ns on two keys before any value was checked. It now snapshots the string keys with `getOwnPropertyNames` and the symbol keys with `getOwnPropertySymbols` before any value is read, and rechecks each key's enumerability when it is visited, which is the runtime's `Reflect.ownKeys` walk exactly, order included: a getter that adds, deletes, hides or reveals a key mid-walk gets the runtime's verdict. Pullfrog took two cheaper snapshots off the table on the way here (for-in enumerates the prototype chain after the own keys, `Object.keys` drops a key that is non-enumerable at snapshot time) and both are pinned. Two valid keys 259 → ~106 ns against the interpreter's 214, ten keys 971 → ~496 against 864. A proxy input sees two `ownKeys` traps instead of the interpreter's one; that is the one accepted difference.

**Cheaper issue finalization.** `finalizeIssue` copies the raw issue's own keys with a loop over `Object.keys` instead of object rest with excluded keys, which V8 routes through a generic runtime call (175 → 147 ns in-process; a for-in walk was faster still but also copied inherited enumerable keys off an issue pushed as a class instance, which Copilot caught). Two deliberate differences from object rest: an own `__proto__` key on a raw issue, as `JSON.parse` produces, is dropped rather than assigned through the setter, the same as the record walk already does; and own symbol-keyed fields are not copied, since nothing in zod produces one and reading `getOwnPropertySymbols` on every issue would cost an allocation per issue plus bytes in every bundle to preserve a case that JSON serialization drops anyway; both are pinned. And the `$ZodError` initializer no longer redefines `_zod` with the descriptor `$constructor` already applied (`new ZodError` 403 → 335 ns). Every own-property descriptor of `ZodError`, `ZodRealError`, `$ZodError` and `$ZodRealError` was dumped on both revisions and is identical.

**Harness.** A seeded generative differential builds random schemas over the compiled node types, corrupts valid values, and asserts the interpreter and the compiled schema agree on verdict, output, key order, issues and per-callback run counts across 400 seeds (every callback the interpreter reaches, the compiled schema reaches at least once and at most twice), reporting every failing seed at once. The fixture suites only cover the compositions somebody wrote down; this is what caught the rest-tuple issue order divergence on the other branch. A memory bench measures retained bytes per compiled schema as a slope over distinct schemas, since a single-instance delta also carries one-time costs of whatever the schema touched first.

**Three axes.** Bundle (gz, esbuild `--minify`): classic-object+compile 32,978 → 33,032 (+54 B), mini-object+compile 13,963 → 14,036 (+73 B); bundles that never call `z.compile` move by 10 B or less, all of it the finalization loop; the `zod-mini-boolean` and `zod-mini-string` ceilings in the bundle-size test are re-measured for it. Memory: retained bytes per compiled schema unchanged (5-key 15 KB, 243-leaf 551 KB on the slope bench). Runtime: valid-path record parses about 2.4x faster as above, valid path otherwise byte-identical; a failing `safeParse` through the compiled fallback sits within 5% of the interpreter on every shape measured (string, flat and nested objects, arrays, tuples, unions) and at 0.90x on records, where the walk before the failing key is the difference.
