### PR TITLE
ci: release only on workflow_dispatch behind the npm environment

### DIFF
--- a/.claude/skills/security-advisory/SKILL.md
+++ b/.claude/skills/security-advisory/SKILL.md
@@ -49,7 +49,7 @@ So the fix is not a follow-up to the triage. It is a step inside it, and it come
 - **Judge the candidates against the whole defect, not the reported symptom.** A patch that fixes the one function in the PoC while three sibling call sites keep the bug is partial. Build a behavior matrix of the cases that matter, run it against `main` and against each candidate patch, and let that table pick the winner. This is also how you catch a patch that trades a crash for silent data loss.
 - **Extend the base rather than starting over**, and preserve the contributor's commits — AGENTS.md covers pushing to a contributor's head ref.
 - **Run what CI runs** before pushing, then confirm CI itself is green.
-- **Do not bump a version and do not cut a release.** Landing on `main` is the goal. Release timing on a security fix is Colin's, and on this repo a version bump is the one irreversible action.
+- **Do not bump a version and do not cut a release.** Landing on `main` is the goal. Release timing on a security fix is Colin's, and on this repo dispatching the release workflow is the one irreversible action.
 
 Only once the fix is merged do you write the comment, and the comment names the merge commit and the PR.
 

--- a/.claude/skills/security-advisory/SKILL.md
+++ b/.claude/skills/security-advisory/SKILL.md
@@ -49,7 +49,7 @@ So the fix is not a follow-up to the triage. It is a step inside it, and it come
 - **Judge the candidates against the whole defect, not the reported symptom.** A patch that fixes the one function in the PoC while three sibling call sites keep the bug is partial. Build a behavior matrix of the cases that matter, run it against `main` and against each candidate patch, and let that table pick the winner. This is also how you catch a patch that trades a crash for silent data loss.
 - **Extend the base rather than starting over**, and preserve the contributor's commits — AGENTS.md covers pushing to a contributor's head ref.
 - **Run what CI runs** before pushing, then confirm CI itself is green.
-- **Do not bump a version and do not cut a release.** Landing on `main` is the goal. Release timing on a security fix is Colin's, and on this repo dispatching the release workflow is the one irreversible action.
+- **Do not bump a version and do not cut a release.** Landing on `main` is the goal. Release timing on a security fix is Colin's, and on this repo approving the release workflow's `npm` environment is the one irreversible action.
 
 Only once the fix is merged do you write the comment, and the comment names the merge commit and the PR.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,55 +2,18 @@
 
 name: Release on npm
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "packages/zod/package.json"
-      - "packages/mini/package.json"
-      - ".github/workflows/release.yml"
-  # back-publish @zod/mini at an x.y.z that zod already shipped without it; the peer floor becomes ^x.y.0
+  # a version bump on main publishes nothing by itself; a maintainer runs `gh workflow run release.yml` and approves the npm environment
   workflow_dispatch:
     inputs:
       mini_version:
-        description: "Publish @zod/mini at this x.y.z (must be an existing zod version)"
-        required: true
+        description: "Leave empty to release what is on main. Set an x.y.z that zod already shipped to back-publish @zod/mini at that version; the peer floor becomes ^x.y.0"
+        required: false
         type: string
+        default: ""
 
 jobs:
-  version_changed:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      changed: ${{ steps.version.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - uses: nubjs/setup-nub@47e5e7393d50f4e9544ddaf756aa277972afba2d # v0
-        with:
-          nub-version: "0.8.3"
-      - id: version
-        env:
-          BASE_SHA: ${{ github.event.before }}
-        run: |
-          git cat-file -e "$BASE_SHA^{commit}"
-          changed=false
-          for package in zod mini; do
-            if ! git cat-file -e "$BASE_SHA:packages/$package/package.json" 2>/dev/null; then
-              changed=true
-              continue
-            fi
-            before=$(git show "$BASE_SHA:packages/$package/package.json" | nub --node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).version')
-            after=$(nub --node -p "require('./packages/$package/package.json').version")
-            if [ "$before" != "$after" ]; then changed=true; fi
-          done
-          echo "changed=$changed" >> "$GITHUB_OUTPUT"
-
   test-node:
-    if: github.event_name == 'push'
+    if: inputs.mini_version == ''
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -79,7 +42,7 @@ jobs:
       - run: nub run --filter @zod/integration test:all
 
   lint:
-    if: github.event_name == 'push'
+    if: inputs.mini_version == ''
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -97,7 +60,7 @@ jobs:
       - run: nub run lint:check
 
   check-circular:
-    if: github.event_name == 'push'
+    if: inputs.mini_version == ''
     runs-on: ubuntu-latest
     name: Check for circular dependencies
     steps:
@@ -111,9 +74,11 @@ jobs:
       - run: nub run check:circular
 
   build_and_publish:
-    if: github.event_name == 'push' && needs.version_changed.outputs.changed == 'true'
-    needs: [version_changed, test-node, lint, check-circular]
+    if: inputs.mini_version == ''
+    needs: [test-node, lint, check-circular]
     runs-on: ubuntu-latest
+    # a required reviewer approves every publish, and the environment only deploys main; npm's trusted publishers are bound to it so no other branch or workflow can publish
+    environment: npm
     # 6h is GitHub's hard cap for a hosted runner, not a tunable. The two npm waits below share it, so neither can have the whole thing; a stall that outlives them needs the wait moved to its own job rather than a larger number here.
     timeout-minutes: 360
     permissions:
@@ -261,8 +226,9 @@ jobs:
       - run: nub run check:lockstep --wait
 
   backpublish_mini:
-    if: github.event_name == 'workflow_dispatch'
+    if: inputs.mini_version != ''
     runs-on: ubuntu-latest
+    environment: npm
     timeout-minutes: 360
     permissions:
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Key commands:
 - When you've modified a PR (or opened/closed/commented on one), include the PR URL liberally in summary messages — at minimum once at the end of any reply that touched it
 - When creating a PR, do not include a separate test plan section in the body. Link to any relevant issues under discussion, and use the same copywriting guidelines from "Commenting on issues and PRs": concise maintainer voice, prose over templates, and validation details only when they are material to the reader.
 - Format validators (`z.iso.*`, `z.email()`, `z.url()`, `z.uuid()`, …) are deliberately narrower than the specs they're named after. "The spec allows X" is not a reason to accept X — see "Format validators: spec compliance is not the bar" below.
-- NEVER bump the version in `packages/zod/package.json` (or any package's `package.json`), and NEVER run `gh workflow run release.yml`. A version bump on `main` publishes nothing by itself; the dispatch plus an approval in the `npm` environment is what publishes, and that is the one irreversible action in this repo. If a version bump is genuinely needed, ask first.
+- NEVER bump the version in `packages/zod/package.json` (or any package's `package.json`), and NEVER run `gh workflow run release.yml`. A version bump on `main` publishes nothing by itself, and a dispatched run can be cancelled; the approval in the `npm` environment is what publishes, and that is the one irreversible action in this repo. If a version bump is genuinely needed, ask first.
 
 ## The three axes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Key commands:
 - When you've modified a PR (or opened/closed/commented on one), include the PR URL liberally in summary messages — at minimum once at the end of any reply that touched it
 - When creating a PR, do not include a separate test plan section in the body. Link to any relevant issues under discussion, and use the same copywriting guidelines from "Commenting on issues and PRs": concise maintainer voice, prose over templates, and validation details only when they are material to the reader.
 - Format validators (`z.iso.*`, `z.email()`, `z.url()`, `z.uuid()`, …) are deliberately narrower than the specs they're named after. "The spec allows X" is not a reason to accept X — see "Format validators: spec compliance is not the bar" below.
-- NEVER bump the version in `packages/zod/package.json` (or any package's `package.json`). A version bump is the only thing that triggers a release; everything else (including direct pushes to `main`) is recoverable until that happens. If a version bump is genuinely needed, ask first.
+- NEVER bump the version in `packages/zod/package.json` (or any package's `package.json`), and NEVER run `gh workflow run release.yml`. A version bump on `main` publishes nothing by itself; the dispatch plus an approval in the `npm` environment is what publishes, and that is the one irreversible action in this repo. If a version bump is genuinely needed, ask first.
 
 ## The three axes
 
@@ -86,7 +86,7 @@ If you touch that machinery, three things bite:
 
 ## Cutting a release
 
-Only do this when the user explicitly asks. Pushing a version bump to `main` triggers `.github/workflows/release.yml`, which publishes to npm + JSR and creates a `v<version>` GitHub release. There is no undo.
+Only do this when the user explicitly asks. A release is two deliberate steps: push the version bump to `main`, then dispatch `.github/workflows/release.yml` and approve its `npm` environment. The workflow publishes to npm + JSR and creates a `v<version>` GitHub release. There is no undo.
 
 Five files must be bumped together — `nub run check:semver` runs in pre-commit and `prepublishOnly`, and will fail the commit if they disagree:
 
@@ -106,9 +106,15 @@ git checkout main && git pull
 git add packages/zod/package.json packages/zod/jsr.json packages/zod/src/v4/core/versions.ts packages/mini/package.json packages/mini/jsr.json
 git commit -m "<x.y.z>"   # commit message is just the version, e.g. "4.4.3"
 git push origin main
+
+# Then start the release from any machine signed into gh, and approve it when the run pauses on the npm environment.
+gh workflow run release.yml
+gh run watch   # pick the "Release on npm" run
 ```
 
-The release workflow runs on changes under `packages/zod/package.json`, `packages/mini/package.json` or the workflow file itself, but publishing requires a changed package version. Tooling-only edits do not publish. Nub publishes `zod` with npm trusted publishing and provenance, then the workflow tags and releases it and publishes `@zod/mini` to npm and JSR last. Watch the Actions tab to confirm `build_and_publish` succeeds.
+Nothing publishes on push. The dispatch runs the test, lint and circular-dependency gates, then `build_and_publish` waits in the `npm` environment until colinhacks or joeltg approves it (the Actions run page, or `gh api -X POST repos/colinhacks/zod/actions/runs/<run-id>/pending_deployments -F 'environment_ids[]=21517757301' -f state=approved -f comment=ok`). Nub publishes `zod` with npm trusted publishing and provenance, then the workflow tags and releases it and publishes `@zod/mini` to npm and JSR last. Every publish step skips a version that is already on its registry, so a dispatch with no version bump, or a second dispatch of the same version, is harmless. Watch the Actions tab to confirm `build_and_publish` succeeds.
+
+The `npm` environment is what makes the dispatch the only publish path: it deploys `main` only and requires a reviewer, and the npm trusted publishers for `zod` and `@zod/mini` are bound to it, so a workflow on another branch cannot mint a publish token. Keep `actions: write` out of every bot workflow, because a `GITHUB_TOKEN` cannot trigger a push workflow but can trigger a `workflow_dispatch`.
 
 To publish `@zod/mini` at a version zod already shipped without it, dispatch the same workflow; it publishes only the scoped package, with the peer floor set to that minor:
 


### PR DESCRIPTION
A version bump on `main` no longer publishes anything. The release workflow now runs only on `gh workflow run release.yml`, and the publish job waits in a new `npm` environment for colinhacks or joeltg to approve it. The environment deploys `main` only. The `@zod/mini` back-publish rides the same dispatch through the now-optional `mini_version` input.

The environment is already created on the repo. The npm trusted publishers for `zod` and `@zod/mini` still need to be bound to it on npmjs.com; until then the branch policy is enforced by the workflow file alone.

Every publish step already skips a version that is on its registry, so a dispatch without a bump is a no-op. `AGENTS.md` documents the new procedure and the approval command.
