### PR TITLE
fix(compile): unwind the doc indent when a child generator throws

### DIFF
--- a/packages/zod/src/v4/core/doc.ts
+++ b/packages/zod/src/v4/core/doc.ts
@@ -12,10 +12,14 @@ export class Doc {
     this.closed = closed;
   }
 
+  // the compiler catches a child's throw and keeps writing into this doc, so the indent has to unwind with it
   indented(fn: (doc: Doc) => void) {
     this.indent += 1;
-    fn(this);
-    this.indent -= 1;
+    try {
+      fn(this);
+    } finally {
+      this.indent -= 1;
+    }
   }
 
   write(fn: ModeWriter): void;

--- a/packages/zod/src/v4/core/tests/compile.test.ts
+++ b/packages/zod/src/v4/core/tests/compile.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 
 import * as z from "../../index.js";
-import { ZodCompileAsyncError, ZodCompileUnsupportedError, compile } from "../compile.js";
+import { ZodCompileAsyncError, ZodCompileUnsupportedError, compile, compileFn } from "../compile.js";
 import { $ZodAsyncError } from "../core.js";
 
 // Differential helper: assert compiled schema matches the original on a value.
@@ -1349,6 +1349,29 @@ test("runtime island inside array element", () => {
   const aot = compile(z.array(z.xor([z.string(), z.number()])));
   expect(valid(aot, ["a", 1, "b"])).toEqual(["a", 1, "b"]);
   invalid(aot, ["a", true]);
+});
+
+test("an island thrown from inside an indented block leaves the indent level alone", () => {
+  // nullable opens an indented block, coerce throws inside it, and the property islands the pair — two of them so a leak compounds
+  const schema = z.object({ a: z.coerce.number().nullable(), b: z.coerce.number().nullable(), tail: z.string() });
+  expect(compileFn(schema, { debug: true }).code).toMatchInlineSnapshot(`
+    "// Constants: INVALID, c0, c1, c2
+    if (typeof input !== "object" || input === null || Array.isArray(input)) return INVALID;
+    const v0 = input["a"];
+    if (!("a" in input)) return INVALID;
+    const v1 = c1(c0, v0);
+    if (v1 === INVALID) return INVALID;
+    const v2 = input["b"];
+    if (!("b" in input)) return INVALID;
+    const v3 = c1(c2, v2);
+    if (v3 === INVALID) return INVALID;
+    const v4 = input["tail"];
+    if (typeof v4 !== "string") return INVALID;
+    const v5 = { "a": v1, "b": v3, "tail": v4 };
+    return v5;"
+  `);
+  expectMatch(schema, { a: "1", b: null, tail: "x" });
+  expectMatch(schema, { a: "nope", b: null, tail: "x" });
 });
 
 test("url string-format check never assigns to its accessor", () => {


### PR DESCRIPTION
`Doc.indented` decremented the indent level after the callback returned, so a child generator that threw left it raised. `compileChild` catches `ZodCompileUnsupportedError`, rolls back the emitted content and the constant/var counters, and emits a runtime island instead — but the indent was never part of that rollback. Every line after an island got written one level deeper, and each further island added another, so a schema with N islands emitted O(N²) leading spaces. Nothing reads that whitespace, but `new Function` retains the source, so it is live memory.

Moving the decrement into a `finally` is the whole fix. It belongs in `Doc` rather than at the call site: the throw unwinds through whichever `indented` frames it was under, so the ~30 call sites in `compile.ts` would each need the same wrapper otherwise.

On a 162-branch discriminated union with 324 `z.coerce.number()` islands:

| | before | after |
| --- | --- | --- |
| generated source | 976 KB (90% whitespace) | 103 KB (4.6%) |
| retained heap per compiled fn | 1.01 MB | 162 KB |
| `compileFn` | 4.8 ms | 3.9 ms |

Dedented, the generated code is character-identical before and after, so nothing on the parse path moves. Bundle cost is +10 gzipped bytes on a classic `z.object` fixture, and zero on the mini fixtures and the classic string/boolean ones.

The source and retained-heap figures come from [`packages/bench/memory/indent-leak.ts`](https://github.com/colinhacks/zod/blob/main/packages/bench/memory/indent-leak.ts), which restores the pre-fix `indented` onto the prototype so the comparison stays runnable. The commit message carries an earlier, lower pair for retained heap: that measurement compiled one schema repeatedly, and V8's compilation cache shares generated source between byte-identical compiles.

Reported with a working branch by @aaronhipple.

Closes #6561
