### PR TITLE
fix(v4): stop the memoizer from pinning a finished parse

### DIFF
--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -1,3 +1,5 @@
+import v8 from "node:v8";
+import vm from "node:vm";
 import { expect, test } from "vitest";
 import * as z from "zod/v4";
 
@@ -959,4 +961,34 @@ test("parses a factory-built recursive schema through z.lazy", () => {
 
   const out = z.object({ root: Node() }).parse({ root: { id: 1, child: { id: 2, child: undefined } } });
   expect(out.root.child.id).toBe(2);
+});
+
+test("a finished parse pins nothing on the schema", async () => {
+  // es2020 is the target, and its lib predates WeakRef
+  type Weak<T extends object> = { deref(): T | undefined };
+  const { WeakRef: Weak } = globalThis as unknown as { WeakRef: new <T extends object>(target: T) => Weak<T> };
+  // vitest carries no --expose-gc, so reach the collector the way node's own tests do
+  v8.setFlagsFromString("--expose-gc");
+  const gc = vm.runInNewContext("gc") as () => void;
+
+  const Node: any = z.object({
+    id: z.number(),
+    get next() {
+      return z.optional(Node);
+    },
+  });
+
+  const ref = ((): Weak<object> => {
+    const input = { id: 1, next: { id: 2, next: undefined } };
+    Node.parse(input);
+    return new Weak(input);
+  })();
+
+  for (let attempt = 0; attempt < 10 && ref.deref(); attempt++) {
+    // the input stays on the stack until a macrotask boundary
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    gc();
+  }
+
+  expect(ref.deref()).toBeUndefined();
 });

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -16,9 +16,10 @@ interface Entry {
 }
 
 interface State {
-  buckets: Map<$ZodType, Map<object, Entry>>;
+  /** Weak throughout because `attach` caches a bucket on the schema instance, which outlives the parse. */
+  buckets: WeakMap<$ZodType, WeakMap<object, Entry>>;
   /** Nodes a back-edge resolved to before they finished. */
-  backEdges: Set<object> | undefined;
+  backEdges: WeakSet<object> | undefined;
 }
 
 /** Keyed off the context object every schema in one parse call already shares. */
@@ -199,17 +200,17 @@ export function isRecursiveSchema(inst: $ZodType): boolean {
   return isRecursive(inst, new Set(), true) !== NONE;
 }
 
-function bucketFor(state: State, inst: $ZodType): Map<object, Entry> {
+function bucketFor(state: State, inst: $ZodType): WeakMap<object, Entry> {
   let bucket = state.buckets.get(inst);
   if (!bucket) {
-    bucket = new Map();
+    bucket = new WeakMap();
     state.buckets.set(inst, bucket);
   }
   return bucket;
 }
 
 // Set immediately before delegating to core and cleared immediately after, so `alloc` registers only for a visit this module is driving.
-let handoff: Map<object, Entry> | undefined;
+let handoff: WeakMap<object, Entry> | undefined;
 
 // Allocated but unfinished entries. `alloc` and the matching pop both happen in the synchronous part of a parse, so they nest even when children are async, and one stack serves every schema.
 const open: Entry[] = [];
@@ -242,9 +243,9 @@ const memo: $ZodMemoizer = {
   attach(inst) {
     let isRecursiveInst: boolean | undefined;
     let rechecked = false;
-    // `bucket` memoized for one parse; a recursive schema is re-entered many times and its bucket never changes
+    // a recursive schema is re-entered many times per parse and its bucket never changes
     let lastCtx: object | undefined;
-    let lastBucket: Map<object, Entry> | undefined;
+    let lastBucket: WeakMap<object, Entry> | undefined;
 
     // Wraps `parse` in a deferred so it sees the container's final parse. Core's own deferred copies `parse` into `run` when there are no checks, and it ran first, so `run` is patched to match; with checks, `run` reads `parse` dynamically.
     inst._zod.deferred ??= [];
@@ -270,11 +271,11 @@ const memo: $ZodMemoizer = {
 
         let state = (ctx as WithState)[STATE];
         if (!state) {
-          state = { buckets: new Map(), backEdges: undefined };
+          state = { buckets: new WeakMap(), backEdges: undefined };
           (ctx as WithState)[STATE] = state;
         }
 
-        let bucket: Map<object, Entry>;
+        let bucket: WeakMap<object, Entry>;
         if (lastCtx === ctx) {
           bucket = lastBucket!;
         } else {
@@ -291,7 +292,7 @@ const memo: $ZodMemoizer = {
           } else {
             // Still being parsed: its own checks cover it, so skip them here.
             payload.memo = true;
-            state.backEdges ??= new Set();
+            state.backEdges ??= new WeakSet();
             state.backEdges.add(hit.value as object);
           }
           return payload;


### PR DESCRIPTION
Fixes #6557.

A recursive schema held the entire input and output graph of its last parse until the next parse replaced it. The memoizer caches the current parse context and its bucket on the schema instance, so a re-entered container skips a lookup — but nothing ever clears that slot, and it outlives the parse. One long-lived schema therefore pinned every object the parse touched, across every schema in it. Reported as an 8 GiB OOM on a repo-wide ESLint run that completed on 4.4.3.

The buckets only ever need `get` and `set`, and the back-edge set only needs `add` and `has`. Making the parse state weak throughout leaves the fast path exactly as it is and lets the graph go.

### Measurements

| axis | main | this PR |
| --- | ---: | ---: |
| retained after one parse | 10.1 MB | 2.2 MB |
| recursive parse, object + array | 5694/s | 5354/s (−6.0%) |
| recursive parse, self-referential object | 10607/s | 9873/s (−6.9%) |
| bundle, classic | 21560 B gz | 21564 B gz |
| bundle, mini | 3710 B gz | 3710 B gz |

Retention is a `WeakRef` probe plus a heap measurement over one parse of a 29k-node tree, with the input dropped and GC forced. The 2.2 MB residual is `WeakMap` table capacity rather than live data — the input collects, and the next parse of the same schema replaces the tables.

Throughput is medians of 8 interleaved rounds, fixed iteration count with `gc()` between samples. The cost lands only on schemas that can re-enter themselves; the memoizer takes its own wrapper back off every other schema on first parse. Load average was 9–13 during the runs, so treat the magnitudes as approximate — the ordering held across every round.

The regression test asserts the parsed input is collectable. It reaches the collector through `v8.setFlagsFromString`, the way the existing release-the-parsed-input test in `error.test.ts` already does, so no test config changes.

### Alternatives

Deleting the fast path, as the issue proposes, removes the retention completely but measured 13–17% slower on the same two shapes. Scoping it to the parse state, proposed later in the thread, recovers the speed only when a single container re-enters itself; on an object holding an array of itself the slot thrashes and it is no better than deleting the cache.

Reported by @alexvoedi, with alternative benchmarks from @0jaspahwa in the thread.
