### PR TITLE
docs: reconcile the sponsor listings with active sponsorships

### DIFF
--- a/packages/docs-v3/home.md
+++ b/packages/docs-v3/home.md
@@ -201,6 +201,22 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
       </p>
       <p></p>
     </td>
+    <td align="center">
+      <p></p>
+      <p>
+      <a href="https://trigger.dev/?utm_source=zod">
+        <picture height="80px">
+          <source media="(prefers-color-scheme: dark)" srcset="https://avatars.githubusercontent.com/u/95297378?s=400&v=4">
+          <img alt="Trigger.dev logo" height="80px" src="https://avatars.githubusercontent.com/u/95297378?s=400&v=4">
+        </picture>
+      </a>
+      <br  />
+      Build and deploy fully-managed AI agents and workflows
+      <br/>
+      <a href="https://trigger.dev/?utm_source=zod" style="text-decoration:none;">trigger.dev</a>
+      </p>
+      <p></p>
+    </td>
   </tr>
 </table>
 
@@ -213,100 +229,16 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
     <td align="center">
       <p></p>
       <p>
-      <a href="https://www.courier.com/?utm_source=zod&utm_campaign=osssponsors">
-        <picture height="62px">
-          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/6b09506a-78de-47e8-a8c1-792efe31910a">
-          <img alt="Courier logo" height="62px" src="https://github.com/user-attachments/assets/6b09506a-78de-47e8-a8c1-792efe31910a">
+      <a href="https://zernio.com/?utm_source=zod">
+        <picture height="48px">
+          <source media="(prefers-color-scheme: dark)" srcset="https://zernio.com/brand/logo-white.svg">
+          <img alt="Zernio" height="48px" src="https://zernio.com/brand/logo-primary.svg">
         </picture>
       </a>
       <br  />
-      The API platform for sending notifications
+      Social APIs for developers and AI agents
       <br/>
-      <a href="https://www.courier.com/?utm_source=zod&utm_campaign=osssponsors" style="text-decoration:none;">courier.com</a>
-      </p>
-      <p></p>
-    </td>
-    <td align="center">
-      <p></p>
-      <p>
-      <a href="https://liblab.com/?utm_source=zod">
-        <picture height="62px">
-          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/34dfa1a2-ce94-46f4-8902-fbfac3e1a9bc">
-          <img alt="LibLab" height="62px" src="https://github.com/user-attachments/assets/3de0b617-5137-49c4-b72d-a033cbe602d8">
-        </picture>
-      </a>
-      <br  />
-      Generate better SDKs for your APIs
-      <br/>
-      <a href="https://liblab.com/?utm_source=zod" style="text-decoration:none;">liblab.com</a>
-      </p>
-      <p></p>
-    </td>
-  </tr>
-  <tr>
-    <td align="center">
-      <p></p>
-      <p>
-      <a href="https://neon.tech">
-        <picture height="68px">
-          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/83b4b1b1-a9ab-4ae5-a632-56d282f0c444">
-          <img alt="Neon" height="68px" src="https://github.com/user-attachments/assets/b5799fc8-81ff-4053-a1c3-b29adf85e7a1">
-        </picture>
-      </a>
-      <br  />
-      Serverless Postgres — Ship faster
-      <br/>
-      <a href="https://neon.tech" style="text-decoration:none;">neon.tech</a>
-      </p>
-      <p></p>
-    </td>
-    <td align="center">
-      <p></p>
-      <p>
-      <a href="https://retool.com/?utm_source=github&utm_medium=referral&utm_campaign=zod">
-        <picture height="45px">
-          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/colinhacks/zod/assets/3084745/ac65013f-aeb4-48dd-a2ee-41040b69cbe6">
-          <img alt="Retool" height="45px" src="https://github.com/colinhacks/zod/assets/3084745/5ef4c11b-efeb-4495-90a8-41b83f798600">
-        </picture>
-      </a>
-      <br  />
-      Build AI apps and workflows with <a href="https://retool.com/products/ai?utm_source=github&utm_medium=referral&utm_campaign=zod">Retool AI</a>
-      <br/>
-      <a href="https://retool.com/?utm_source=github&utm_medium=referral&utm_campaign=zod" style="text-decoration:none;">retool.com</a>
-      </p>
-      <p></p>
-    </td>
-  </tr>
-  <tr>
-    <td align="center">
-      <p></p>
-      <p>
-      <a href="https://stainless.com">
-        <picture height="45px">
-          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/colinhacks/zod/assets/3084745/f20759c1-3e51-49d0-a31e-bbc43abec665">
-          <img alt="stainless" height="45px" src="https://github.com/colinhacks/zod/assets/3084745/e9444e44-d991-4bba-a697-dbcfad608e47">
-        </picture>
-      </a>
-      <br  />
-      Generate best-in-class SDKs
-      <br/>
-      <a href="https://stainless.com" style="text-decoration:none;">stainless.com</a>
-      </p>
-      <p></p>
-    </td>
-    <td align="center">
-      <p></p>
-      <p>
-      <a href="https://speakeasy.com/editor?utm_source=zod+docs">
-        <picture height="40px">
-          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/colinhacks/zod/assets/3084745/b1d86601-c7fb-483c-9927-5dc24ce8b737">
-          <img alt="speakeasy" height="40px" src="https://github.com/colinhacks/zod/assets/3084745/647524a4-22bb-4199-be70-404207a5a2b5">
-        </picture>
-      </a>
-      <br  />
-      SDKs & Terraform providers for your API
-      <br/>
-      <a href="https://speakeasy.com/?utm_source=zod+docs" style="text-decoration:none;">speakeasy.com</a>
+      <a href="https://zernio.com/?utm_source=zod" style="text-decoration:none;">zernio.com</a>
       </p>
       <p></p>
     </td>
@@ -320,9 +252,9 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
 <table align="center" style="justify-content: center;align-items: center;display: flex;">
   <tr>
     <td align="center">
-      <img src="https://avatars.githubusercontent.com/u/72055470?s=200&v=4" height="50px;" alt="Nitric" />
+      <img src="https://avatars.githubusercontent.com/u/176449348?s=200&v=4" height="50px;" alt="Subtotal" />
       <br />
-      <a style="text-decoration:none;" href="https://nitric.io/" target="_blank">Nitric</a>
+      <a style="text-decoration:none;" href="https://www.subtotal.com/?utm_source=zod" target="_blank">Subtotal</a>
     </td>
     <td align="center">
       <img src="https://avatars.githubusercontent.com/u/89474619?s=200&v=4" height="50px;" alt="PropelAuth" />
@@ -330,20 +262,9 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
       <a style="text-decoration:none;" href="https://www.propelauth.com/" target="_blank">PropelAuth</a>
     </td>
     <td align="center">
-      <img src="https://avatars.githubusercontent.com/u/80861386?s=200&v=4" height="50px;" alt="Cerbos" />
-      <br />
-      <a style="text-decoration:none;" href="https://cerbos.dev/" target="_blank">Cerbos</a>
-    </td>
-    <td align="center">
       <img src="https://avatars.githubusercontent.com/u/301879?s=200&v=4" height="50px;" alt="Scalar.com logo" />
       <br />
       <a style="text-decoration:none;" href="https://scalar.com/" target="_blank">Scalar</a>
-    </td>
-    </tr><tr>
-    <td align="center">
-      <img src="https://avatars.githubusercontent.com/u/95297378?s=200&v=4" height="50px;" alt="Trigger.dev logo" />
-      <br />
-      <a style="text-decoration:none;" href="https://trigger.dev" target="_blank">Trigger.dev</a>
     </td>
     <td align="center">
       <img src="https://avatars.githubusercontent.com/u/125754?s=200&v=4" height="50px;" alt="Transloadit logo" />
@@ -351,26 +272,12 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
       <a style="text-decoration:none;" href="https://transloadit.com/?utm_source=zod&utm_medium=refe
     rral&utm_campaign=sponsorship&utm_content=github" target="_blank">Transloadit</a>
     </td>
-    <td align="center">
-      <img src="https://avatars.githubusercontent.com/u/107880645?s=200&v=4" height="50px;" alt="Infisical logo" />
-      <br />
-      <a style="text-decoration:none;" href="https://infisical.com" target="_blank">Infisical</a>
-    </td>
+  </tr>
+  <tr>
     <td align="center">
       <img src="https://avatars.githubusercontent.com/u/91036480?s=200&v=4" height="50px;" alt="Whop logo" />
       <br />
       <a style="text-decoration:none;" href="https://whop.com/" target="_blank">Whop</a>
-    </td>
-    </tr><tr>
-    <td align="center">
-      <img src="https://avatars.githubusercontent.com/u/36402888?s=200&v=4" height="50px;" alt="CryptoJobsList logo" />
-      <br />
-      <a style="text-decoration:none;" href="https://cryptojobslist.com/" target="_blank">CryptoJobsList</a>
-    </td>
-    <td align="center">
-      <img src="https://avatars.githubusercontent.com/u/70170949?s=200&v=4" height="50px;" alt="Plain logo" />
-      <br />
-      <a style="text-decoration:none;" href="https://plain.com/" target="_blank">Plain.</a>
     </td>
     <td align="center">
       <img src="https://avatars.githubusercontent.com/u/78935958?s=200&v=4" height="50px;" alt="Inngest logo" />
@@ -382,16 +289,22 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
       <br />
       <a style="text-decoration:none;" href="https://storyblok.com/" target="_blank">Storyblok</a>
     </td>
-    </tr><tr>
     <td align="center">
       <img src="https://avatars.githubusercontent.com/u/16199997?s=200&v=4" height="50px;" alt="Mux logo" />
       <br />
       <a style="text-decoration:none;" href="https://mux.link/zod" target="_blank">Mux</a>
     </td>
+  </tr>
+  <tr>
     <td align="center">
       <img src="https://avatars.githubusercontent.com/u/76428554?s=200&v=4" height="50px;" alt="Cybozu logo" />
       <br />
       <a style="text-decoration:none;" href="https://cybozu.co.jp/index.html" target="_blank">Cybozu</a>
+    </td>
+    <td align="center">
+      <img src="https://avatars.githubusercontent.com/u/117220588?s=200&v=4" height="50px;" alt="9thCO" />
+      <br />
+      <a style="text-decoration:none;" href="https://www.9thco.com/?utm_source=zod" target="_blank">9thCO</a>
     </td>
   </tr>
 </table>
@@ -403,60 +316,23 @@ Sponsorship at any level is appreciated and encouraged. If you built a paid prod
 <table align="center" style="justify-content: center;align-items: center;display: flex;">
   <tr>
     <td align="center">
-      <a href="https://www.val.town/">
-        <picture width="100%" height="40px">
-          <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/36961d2e-d92e-42af-9031-a41885ece5f4">
-          <img alt="val town logo" src="https://github.com/user-attachments/assets/95305fc4-4da6-4bf8-aea4-bae8f5893e5d" height="40px">
-        </picture>
-      </a>
-    </td>
-    <td align="center">
       <a href="https://www.route4me.com/">
         <img src="https://avatars.githubusercontent.com/u/7936820?s=200&v=4" height="40px;" alt="route4me logo" />
       </a>
     </td>
     <td align="center">
-      <a href="https://encore.dev">
-        <img src="https://github.com/colinhacks/zod/assets/3084745/5ad94e73-cd34-4957-9979-37da85fcf9cd" height="40px;" alt="Encore.dev logo" />
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://www.replay.io/">
-        <img src="https://avatars.githubusercontent.com/u/60818315?s=200&v=4" height="40px;" alt="Replay.io logo" />
-      </a>
-    </td>
-  </tr>
-  <tr>
-    <td align="center">
-      <a href="https://www.numeric.io">
-        <img src="https://i.imgur.com/kTiLtZt.png" height="40px;" alt="Numeric logo" />
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://marcatopartners.com">
-        <img src="https://avatars.githubusercontent.com/u/84106192?s=200&v=4" height="40px;" alt="Marcato Partners" />
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://interval.com">
-        <img src="https://avatars.githubusercontent.com/u/67802063?s=200&v=4" height="40px;" alt="" />
-      </a>
-    </td>
-    <td align="center">
-      <a href="https://seasoned.cc">
-        <img src="https://avatars.githubusercontent.com/u/33913103?s=200&v=4" height="40px;" alt="" />
-      </a>
-    </td>
-  </tr>
-  <tr>
-    <td align="center">
-      <a href="https://www.bamboocreative.nz/">
-        <img src="https://avatars.githubusercontent.com/u/41406870?v=4" height="40px;" alt="Bamboo Creative logo" />
-      </a>
-    </td>
-    <td align="center">
       <a href="https://github.com/jasonLaster">
         <img src="https://avatars.githubusercontent.com/u/254562?v=4" height="40px;" alt="Jason Laster" />
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://convex.dev/?utm_source=zod">
+        <img src="https://avatars.githubusercontent.com/u/81530787?s=200&v=4" height="40px;" alt="Convex logo" />
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://n8n.io/?utm_source=zod">
+        <img src="https://avatars.githubusercontent.com/u/104988782?s=200&v=4" height="40px;" alt="n8n logo" />
       </a>
     </td>
   </tr>

--- a/packages/docs/components/bronze.tsx
+++ b/packages/docs/components/bronze.tsx
@@ -7,12 +7,6 @@ export const Bronze = () => {
       href: "https://github.com/jasonLaster",
     },
     {
-      name: "Clipboard",
-      logoSrc: "https://avatars.githubusercontent.com/u/28880063?s=200&v=4",
-      url: "clipboardhealth.com/engineering",
-      href: "https://www.clipboardhealth.com/engineering",
-    },
-    {
       name: "Convex",
       logoSrc: "https://avatars.githubusercontent.com/u/81530787?s=200&v=4",
       url: "convex.dev",

--- a/packages/docs/components/gold.tsx
+++ b/packages/docs/components/gold.tsx
@@ -19,33 +19,16 @@ export const Gold = () => {
       url: "zernio.com",
       href: "https://zernio.com/?utm_source=zod",
     },
-    {
-      name: "Neon",
-      description: "Serverless Postgres — Ship faster",
-      logoDark: "https://github.com/user-attachments/assets/83b4b1b1-a9ab-4ae5-a632-56d282f0c444",
-      logoLight: "https://github.com/user-attachments/assets/b5799fc8-81ff-4053-a1c3-b29adf85e7a1",
-      url: "neon.tech",
-      href: "https://neon.tech",
-    },
-    {
-      name: "Stainless",
-      description: "Generate best-in-class SDKs",
-      logoDark: "https://github.com/colinhacks/zod/assets/3084745/f20759c1-3e51-49d0-a31e-bbc43abec665",
-      logoLight: "https://github.com/colinhacks/zod/assets/3084745/e9444e44-d991-4bba-a697-dbcfad608e47",
-      logoClassName: "h-12",
-      url: "stainlessapi.com",
-      href: "https://stainlessapi.com",
-    },
   ];
 
   return (
     <div className="max-w-4xl mt-4">
       <div className="border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 rounded-md">
-        <div className="grid grid-cols-1 sm:grid-cols-2">
+        <div className={`grid grid-cols-1 ${companies.length > 1 ? "sm:grid-cols-2" : ""}`}>
           {companies.map((company) => (
             <div
               key={company.name}
-              className="p-4 flex flex-col items-center border-b border-r border-gray-200 dark:border-gray-700 last:border-b-0 "
+              className="p-4 flex flex-col items-center border-b border-r border-gray-200 dark:border-gray-700 last:border-b-0 last:border-r-0"
             >
               <a href={company.href} target="_blank" rel="noopener noreferrer" className="my-0! border-none">
                 <img

--- a/packages/docs/components/platinum.tsx
+++ b/packages/docs/components/platinum.tsx
@@ -16,6 +16,14 @@ export const Platinum = () => {
       url: "coderabbit.ai",
       href: "https://www.coderabbit.ai/",
     },
+    {
+      name: "Trigger.dev",
+      description: "Build and deploy fully-managed AI agents and workflows",
+      logoDark: "https://avatars.githubusercontent.com/u/95297378?s=400&v=4",
+      logoLight: "https://avatars.githubusercontent.com/u/95297378?s=400&v=4",
+      url: "trigger.dev",
+      href: "https://trigger.dev/?utm_source=zod",
+    },
   ];
 
   return (

--- a/packages/docs/components/silver.tsx
+++ b/packages/docs/components/silver.tsx
@@ -1,34 +1,16 @@
 export const Silver = () => {
   const companies = [
     {
-      name: "Sanity",
-      logoSrc: "https://avatars.githubusercontent.com/u/17177659?s=200&v=4",
-      url: "sanity.io",
-      href: "https://www.sanity.io/",
-    },
-    {
       name: "Subtotal",
       logoSrc: "https://avatars.githubusercontent.com/u/176449348?s=200&v=4",
       url: "subtotal.com",
       href: "https://www.subtotal.com/?utm_source=zod",
     },
     {
-      name: "Nitric",
-      logoSrc: "https://avatars.githubusercontent.com/u/72055470?s=200&v=4",
-      url: "nitric.io",
-      href: "https://nitric.io/",
-    },
-    {
       name: "PropelAuth",
       logoSrc: "https://avatars.githubusercontent.com/u/89474619?s=200&v=4",
       url: "propelauth.com",
       href: "https://www.propelauth.com/",
-    },
-    {
-      name: "Cerbos",
-      logoSrc: "https://avatars.githubusercontent.com/u/80861386?s=200&v=4",
-      url: "cerbos.dev",
-      href: "https://cerbos.dev/",
     },
     {
       name: "Scalar",
@@ -47,18 +29,6 @@ export const Silver = () => {
       logoSrc: "https://avatars.githubusercontent.com/u/91036480?s=200&v=4",
       url: "whop.com",
       href: "https://whop.com/",
-    },
-    {
-      name: "CryptoJobsList",
-      logoSrc: "https://avatars.githubusercontent.com/u/36402888?s=200&v=4",
-      url: "cryptojobslist.com",
-      href: "https://cryptojobslist.com/",
-    },
-    {
-      name: "Plain",
-      logoSrc: "https://avatars.githubusercontent.com/u/70170949?s=200&v=4",
-      url: "plain.com",
-      href: "https://plain.com/",
     },
     {
       name: "Inngest",
@@ -89,12 +59,6 @@ export const Silver = () => {
       logoSrc: "https://avatars.githubusercontent.com/u/117220588?s=200&v=4",
       url: "9thco.com",
       href: "https://www.9thco.com/?utm_source=zod",
-    },
-    {
-      name: "Ferry Health",
-      logoSrc: "https://avatars.githubusercontent.com/u/158637456?s=200&v=4",
-      url: "ferry.health",
-      href: "https://ferry.health/?utm_source=zod",
     },
   ];
 


### PR DESCRIPTION
Brings both sponsor listings in line with the active GitHub sponsorships.

Removed from zod.dev, none of them sponsoring. Cancellation dates come from the sponsor activity feed; the active list is the ground truth, because a cancellation on its own doesn't mean churn — CodeRabbit and Storyblok both cancelled and re-subscribed on annual terms.

| Tier | Sponsor | Cancelled |
| --- | --- | --- |
| Gold | Neon | 2026-07-05 |
| Gold | Stainless | 2026-06-20 |
| Silver | Crypto Jobs List | 2026-09-08 |
| Silver | Nitric | 2026-09-08 |
| Silver | Cerbos | 2026-09-05 |
| Silver | Plain | 2026-07-21 |
| Silver | Ferry Health | 2026-06-01 |
| Silver | Sanity | never recurring — two one-time payments, last 2026-01-26 |
| Bronze | Clipboard | 2026-04-30 |

The other two commits:

- **Trigger.dev joins Platinum.** They opened a $999/mo sponsorship on 2026-09-08, having lapsed in 2024 and been pruned from Silver in 7391be88. That price is the platinum point — CodeRabbit was on it when added to the tier in c6a0ca3d, and the tiers below are $499 (Neon and Stainless, both Gold) and $249 (PropelAuth, 9thCO, Subtotal, all Silver). Uses their GitHub org mark, since they publish no light/dark wordmark pair.
- **The Zod 3 roster is 19 entries out of date.** `v3.zod.dev` serves `packages/docs-v3/home.md`, and it still advertised Courier, LibLab, Retool, Speakeasy, Infisical, Val Town, Encore, Replay, Numeric, Marcato Partners, Interval, Seasoned and Bamboo Creative alongside the nine above — its entire Gold tier was inactive. All 19 are gone. Zernio joins Gold so the tier isn't empty, Subtotal and 9thCO join Silver, Convex and n8n join Bronze, and Trigger.dev moves to Platinum. The two English pages now list the same sponsors at the same tiers, except that Route4Me stays on the Zod 3 page — they sponsor actively but have never been on the current one. Every kept entry's markup is untouched; only the row grouping is regenerated.

Two that look cancelled but aren't, and stay: Zernio has no GitHub Sponsors record at all, so it bills through the other channel; Cybozu points its logo at the `cybozu-sponsorship` account while the active sponsorship sits under `cybozu`.

Gold on zod.dev is down to one entry, so its grid stays single-column below two sponsors and the last cell drops its right border. Otherwise the lone card strands a divider down the middle.

The Korean and Chinese Zod 3 pages keep their own, older rosters. The Korean one still lists Clerk as Platinum and the Chinese one lists Astro and Trip, so they are snapshots of a different era rather than maintained listings.

One thing worth watching: CodeRabbit dropped from $999 to $499 in May and has a pending change dated 2026-09-04. Every other pending change in the feed was followed by a cancellation within a month.
