### PR TITLE
fix(v4): defer recursive object index inference

### DIFF
--- a/packages/zod/src/v4/classic/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/recursive-types.test.ts
@@ -1,6 +1,42 @@
 import { expect, expectTypeOf, test } from "vitest";
 import { z } from "zod/v4";
 
+test("recursive object schema type aliases", () => {
+  type ObjectField = z.ZodObject<{ [k: string]: ObjectField }>;
+  type MixedField = z.ZodString | z.ZodObject<{ [k: string]: MixedField }>;
+  expectTypeOf<ObjectField>().toExtend<z.ZodType>();
+  expectTypeOf<MixedField>().toExtend<z.ZodType>();
+
+  type ObjectValue = { [k: string]: ObjectValue };
+  type MixedValue = string | { [k: string]: MixedValue };
+  expectTypeOf<z.input<ObjectField>>().toEqualTypeOf<ObjectValue>();
+  expectTypeOf<z.output<ObjectField>>().toEqualTypeOf<ObjectValue>();
+  expectTypeOf<z.input<MixedField>>().toEqualTypeOf<MixedValue>();
+  expectTypeOf<z.output<MixedField>>().toEqualTypeOf<MixedValue>();
+
+  const schema: MixedField = z.object({ name: z.string(), nested: z.object({ name: z.string() }) });
+  expect(schema.parse({ name: "a", nested: { name: "b", extra: true } })).toEqual({
+    name: "a",
+    nested: { name: "b" },
+  });
+  expect(schema.safeParse({ name: "a", nested: { name: 123 } }).success).toBe(false);
+
+  type CoreField = z.core.$ZodString<string> | z.core.$ZodObject<{ [k: string]: CoreField }>;
+  expectTypeOf<z.input<CoreField>>().toEqualTypeOf<MixedValue>();
+  expectTypeOf<z.output<CoreField>>().toEqualTypeOf<MixedValue>();
+});
+
+test("recursive object aliases preserve distinct input and output", () => {
+  type Field = z.ZodPipe<z.ZodString, z.ZodTransform<number, string>> | z.ZodObject<{ [k: string]: Field }>;
+  type Input = string | { [k: string]: Input };
+  type Output = number | { [k: string]: Output };
+  expectTypeOf<z.input<Field>>().toEqualTypeOf<Input>();
+  expectTypeOf<z.output<Field>>().toEqualTypeOf<Output>();
+  const schema: Field = z.object({ nested: z.object({ length: z.string().transform((s) => s.length) }) });
+  expect(schema.parse({ nested: { length: "abc" } })).toEqual({ nested: { length: 3 } });
+  expect(schema.safeParse({ nested: { length: 3 } }).success).toBe(false);
+});
+
 test("recursion with z.lazy", () => {
   const data = {
     name: "I",

--- a/packages/zod/src/v4/classic/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/classic/tests/recursive-types.test.ts
@@ -37,6 +37,15 @@ test("recursive object aliases preserve distinct input and output", () => {
   expect(schema.safeParse({ nested: { length: 3 } }).success).toBe(false);
 });
 
+test("indexed object inference preserves string keys", () => {
+  type Indexed = z.ZodObject<Record<string, z.ZodString>>;
+  type Recursive = z.ZodObject<Record<string, Recursive>>;
+  expectTypeOf<keyof z.input<Indexed>>().toEqualTypeOf<string>();
+  expectTypeOf<keyof z.output<Indexed>>().toEqualTypeOf<string>();
+  expectTypeOf<keyof z.input<Recursive>>().toEqualTypeOf<string>();
+  expectTypeOf<keyof z.output<Recursive>>().toEqualTypeOf<string>();
+});
+
 test("recursion with z.lazy", () => {
   const data = {
     name: "I",

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1893,7 +1893,7 @@ type OptionalInSchema = { _zod: { optin: "optional" | "defaulted" } };
 export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<string, unknown>> = string extends keyof T
   ? util.IsAny<T[keyof T]> extends true
     ? Record<string, unknown>
-    : { [k: string]: core.output<T[keyof T]> }
+    : { [k in string]: core.output<T[keyof T]> }
   : keyof (T & Extra) extends never
     ? Record<string, never>
     : util.Prettify<
@@ -1937,7 +1937,7 @@ export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<st
 export type $InferObjectInput<T extends $ZodLooseShape, Extra extends Record<string, unknown>> = string extends keyof T
   ? util.IsAny<T[keyof T]> extends true
     ? Record<string, unknown>
-    : { [k: string]: core.input<T[keyof T]> }
+    : { [k in string]: core.input<T[keyof T]> }
   : keyof (T & Extra) extends never
     ? Record<string, never>
     : util.Prettify<

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1893,7 +1893,7 @@ type OptionalInSchema = { _zod: { optin: "optional" | "defaulted" } };
 export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<string, unknown>> = string extends keyof T
   ? util.IsAny<T[keyof T]> extends true
     ? Record<string, unknown>
-    : Record<string, core.output<T[keyof T]>>
+    : { [k: string]: core.output<T[keyof T]> }
   : keyof (T & Extra) extends never
     ? Record<string, never>
     : util.Prettify<
@@ -1937,7 +1937,7 @@ export type $InferObjectOutput<T extends $ZodLooseShape, Extra extends Record<st
 export type $InferObjectInput<T extends $ZodLooseShape, Extra extends Record<string, unknown>> = string extends keyof T
   ? util.IsAny<T[keyof T]> extends true
     ? Record<string, unknown>
-    : Record<string, core.input<T[keyof T]>>
+    : { [k: string]: core.input<T[keyof T]> }
   : keyof (T & Extra) extends never
     ? Record<string, never>
     : util.Prettify<

--- a/packages/zod/src/v4/mini/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/mini/tests/recursive-types.test.ts
@@ -8,6 +8,8 @@ test("recursive object schema type aliases", () => {
   type Value = string | { [k: string]: Value };
   expectTypeOf<z.input<ObjectField>>().toEqualTypeOf<ObjectValue>();
   expectTypeOf<z.output<ObjectField>>().toEqualTypeOf<ObjectValue>();
+  expectTypeOf<keyof z.input<ObjectField>>().toEqualTypeOf<string>();
+  expectTypeOf<keyof z.output<ObjectField>>().toEqualTypeOf<string>();
   expectTypeOf<z.input<Field>>().toEqualTypeOf<Value>();
   expectTypeOf<z.output<Field>>().toEqualTypeOf<Value>();
   const schema: Field = z.object({ nested: z.object({ name: z.string() }) });

--- a/packages/zod/src/v4/mini/tests/recursive-types.test.ts
+++ b/packages/zod/src/v4/mini/tests/recursive-types.test.ts
@@ -1,6 +1,20 @@
 import { expect, expectTypeOf, test } from "vitest";
 import { z } from "zod/mini";
 
+test("recursive object schema type aliases", () => {
+  type ObjectField = z.ZodMiniObject<{ [k: string]: ObjectField }>;
+  type Field = z.ZodMiniString<string> | z.ZodMiniObject<{ [k: string]: Field }>;
+  type ObjectValue = { [k: string]: ObjectValue };
+  type Value = string | { [k: string]: Value };
+  expectTypeOf<z.input<ObjectField>>().toEqualTypeOf<ObjectValue>();
+  expectTypeOf<z.output<ObjectField>>().toEqualTypeOf<ObjectValue>();
+  expectTypeOf<z.input<Field>>().toEqualTypeOf<Value>();
+  expectTypeOf<z.output<Field>>().toEqualTypeOf<Value>();
+  const schema: Field = z.object({ nested: z.object({ name: z.string() }) });
+  expect(schema.parse({ nested: { name: "a", extra: true } })).toEqual({ nested: { name: "a" } });
+  expect(schema.safeParse({ nested: { name: 123 } }).success).toBe(false);
+});
+
 test("recursion with z.lazy", () => {
   const data = {
     name: "I",


### PR DESCRIPTION
Use inline mapped types for object input/output inference so TypeScript can defer recursive value types instead of eagerly instantiating `Record`. The mapped spelling preserves the existing `string` key domain.

This fixes the plain recursive `ZodObject` alias and its union with `ZodString`. It does not fix recursive `ZodUnion`, array/tuple inference, or the wrapper cases in #4611, so #6015 should stay open. Refs #6015.

Regression coverage includes classic, core, and mini, with distinct input/output types through transform leaves and explicit key-domain assertions. All 8,216 tests pass on TypeScript 5.5, 6, and 7. Generated runtime JavaScript and classic/mini bundles are unchanged.
