### PR TITLE
fix: preserve unique tags with defaulted discriminators

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2018,6 +2018,8 @@ z.getDiscriminatedOption(MyResult, "pending"); // ❌ not a declared discriminat
 
 The option is returned as-is, so `.shape` and the other object methods keep working.
 
+If multiple options accept an absent discriminator, looking up `undefined` throws an ambiguity error. Their unique explicit tags remain retrievable.
+
 ## Intersections
 
 Intersection types (`A & B`) represent a logical "AND". 

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -740,6 +740,26 @@ test("encode with codec discriminator", () => {
   expect(encoded).toEqual({ type: 1, value: "hello" });
 });
 
+test("nested encoding does not select a sibling from forward discriminator values", async () => {
+  const tag = (value: "a" | "b") =>
+    z.codec(z.literal(value).default(value), z.undefined(), {
+      decode: () => undefined,
+      encode: () => value,
+    });
+  const inner = z.discriminatedUnion("type", [
+    z.object({ type: tag("a"), value: z.literal("a") }),
+    z.object({ type: tag("b"), value: z.literal("b") }),
+  ]);
+  const outer = z.discriminatedUnion("type", [inner, z.object({ type: z.undefined(), value: z.string() })]);
+  for (const value of ["a", "b"] as const) {
+    const input = { type: undefined, value };
+    const expected = { type: value, value };
+    expect(z.encode(inner, input)).toEqual(expected);
+    expect(z.encode(outer, input)).toEqual(expected);
+    expect(await z.encodeAsync(outer, input)).toEqual(expected);
+  }
+});
+
 test("getDiscriminatedOption", () => {
   const fruit = z.object({ type: z.literal("fruit"), seeds: z.boolean() });
   const veg = z.object({ type: z.literal("vegetable"), leafy: z.boolean() });
@@ -892,6 +912,7 @@ test("non-undefined discriminator collisions remain schema errors", () => {
   for (const tag of [z.literal("a").default("a"), z.literal(["a", "b"]), z.literal("a").nullable()]) {
     const schema = z.discriminatedUnion("type", [z.object({ type: tag }), z.object({ type: tag })]);
     expect(() => schema.safeParse({ type: "a" })).toThrow(/Duplicate discriminator value/);
+    expect(() => z.encode(schema, { type: "a" })).toThrow(/Duplicate discriminator value/);
     expect(() => z.getDiscriminatedOption(schema, "a")).toThrow(/Duplicate discriminator value/);
   }
   const nullable = z.discriminatedUnion("type", [

--- a/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
+++ b/packages/zod/src/v4/classic/tests/discriminated-unions.test.ts
@@ -811,9 +811,14 @@ test.each(["__proto__", "constructor", "toString", "hasOwnProperty", "valueOf"])
   }
 );
 
-// An omittable discriminator reads back as undefined at the lookup, exactly as TypeScript sees it: `{ k?: "a" } | { k?: "c" }` does not narrow on `k === undefined`.
 test("an omittable discriminator claims undefined", () => {
-  const omittable = [z.exactOptional(z.literal("a")), z.optional(z.literal("a")), z.literal("a").default("a")];
+  const omittable = [
+    z.exactOptional(z.literal("a")),
+    z.optional(z.literal("a")),
+    z.literal("a").default("a"),
+    z.literal("a").prefault("a"),
+    z.literal("a").catch("a"),
+  ];
   for (const k of omittable) {
     expect(z.object({ k })._zod.propValues.k).toEqual(new Set(["a", undefined]));
   }
@@ -827,10 +832,90 @@ test("an omittable discriminator claims undefined", () => {
   expect(z.union(options).safeParse({ x: "s" }).success).toEqual(true);
   expect(z.discriminatedUnion("k", options).safeParse({ k: "b", y: 1 }).success).toEqual(true);
 
-  // two options omit the key: both claim undefined, so they are not discriminable on it
+  // ambiguous absence does not prevent explicit tags from routing
   for (const k of omittable) {
-    expect(() =>
-      z.discriminatedUnion("k", [z.object({ k }), z.object({ k: z.exactOptional(z.literal("c")) })]).parse({})
-    ).toThrow(/Duplicate discriminator value "undefined"/);
+    const schema = z.discriminatedUnion("k", [z.object({ k }), z.object({ k: z.exactOptional(z.literal("c")) })]);
+    expect(schema.parse({ k: "a" })).toEqual({ k: "a" });
+    expect(schema.parse({ k: "c" })).toEqual({ k: "c" });
+    expect(schema.safeParse({}).success).toBe(false);
   }
+});
+
+test("defaulted discriminators preserve tagged parsing without guessing a member", async () => {
+  const a = z.object({ type: z.literal("a").default("a"), x: z.number().positive() });
+  const b = z.object({ type: z.literal("b").default("b"), y: z.string() });
+  const c = z.object({ type: z.literal("c").default("c"), z: z.boolean() });
+  for (const options of [
+    [a, b, c],
+    [c, b, a],
+  ] as const) {
+    const schema = z.discriminatedUnion("type", options);
+    for (const input of [a.parse({ x: 1 }), b.parse({ y: "s" }), c.parse({ z: true })]) {
+      expect(schema.parse(input)).toEqual(input);
+      expect((await schema.safeParseAsync(input)).success).toBe(true);
+    }
+    for (const input of [{ x: 1, y: "s", z: true }, { type: undefined }, { type: "other" }, { type: "a", x: -1 }]) {
+      expect(schema.safeParse(input).success).toBe(false);
+      expect((await schema.safeParseAsync(input)).success).toBe(false);
+    }
+    const result = schema.safeParse({});
+    expect(result.error?.issues[0]).toMatchObject({
+      code: "invalid_union",
+      path: ["type"],
+      options: options.map((o) => o.shape.type.unwrap().value),
+    });
+    expect(z.getDiscriminatedOption(schema, "a")).toBe(a);
+  }
+  const unique = z.discriminatedUnion("type", [a, b.safeExtend({ type: b.shape.type.unwrap() })]);
+  expect(unique.parse({ x: 1 })).toEqual({ type: "a", x: 1 });
+});
+
+test("undefined collisions are value-based and discriminator lookup rejects ambiguity", () => {
+  const a = z.object({ type: z.literal("a").optional() });
+  const absent = z.object({ type: z.undefined() });
+  for (const options of [
+    [a, absent],
+    [absent, a],
+    [absent, absent, a],
+  ] as const) {
+    const schema = z.discriminatedUnion("type", options);
+    expect(schema.parse({ type: "a" })).toEqual({ type: "a" });
+    expect(schema.safeParse({}).success).toBe(false);
+    expect(() => z.getDiscriminatedOption(schema, undefined)).toThrow('Ambiguous discriminator value "undefined"');
+  }
+  const unique = z.discriminatedUnion("type", [absent, z.object({ type: z.literal("a") })]);
+  expect(unique.parse({ type: undefined })).toEqual({ type: undefined });
+  expect(z.getDiscriminatedOption(unique, undefined)).toBe(absent);
+});
+
+test("non-undefined discriminator collisions remain schema errors", () => {
+  for (const tag of [z.literal("a").default("a"), z.literal(["a", "b"]), z.literal("a").nullable()]) {
+    const schema = z.discriminatedUnion("type", [z.object({ type: tag }), z.object({ type: tag })]);
+    expect(() => schema.safeParse({ type: "a" })).toThrow(/Duplicate discriminator value/);
+    expect(() => z.getDiscriminatedOption(schema, "a")).toThrow(/Duplicate discriminator value/);
+  }
+  const nullable = z.discriminatedUnion("type", [
+    z.object({ type: z.literal("a").nullable() }),
+    z.object({ type: z.literal("b").nullable() }),
+  ]);
+  expect(() => nullable.safeParse({ type: "a" })).toThrow('Duplicate discriminator value "null"');
+});
+
+test("nested defaulted unions only advertise routable discriminator values", () => {
+  const a = z.object({ type: z.literal("a").default("a"), group: z.literal("inner") });
+  const b = z.object({ type: z.literal("b").default("b"), group: z.literal("inner") });
+  const inner = z.discriminatedUnion("type", [a, b]);
+  const c = z.object({ type: z.literal("c").default("c"), group: z.literal("outer") });
+  expect(inner._zod.propValues.type).toEqual(new Set(["a", "b"]));
+  for (const schema of [
+    z.discriminatedUnion("type", [z.lazy(() => inner), c]),
+    z.discriminatedUnion("group", [inner, c]),
+  ]) {
+    expect(schema.parse({ type: "a", group: "inner" })).toEqual({ type: "a", group: "inner" });
+    expect(schema.parse({ group: "outer" })).toEqual({ type: "c", group: "outer" });
+    expect(schema.safeParse({ group: "inner" }).success).toBe(false);
+  }
+  const fallback = z.discriminatedUnion("type", [a, b], { unionFallback: true });
+  expect(fallback._zod.propValues.type.has(undefined)).toBe(true);
+  expect(fallback.parse({ group: "inner" })).toEqual({ type: "a", group: "inner" });
 });

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1869,7 +1869,7 @@ function generateDiscriminatedUnionCheck(
       throw new ZodCompileUnsupportedError("discriminated union option without static discriminator values");
     }
 
-    // Two options claiming one value are not discriminable, and the branch chain below would silently give it to the first. Declining to compile hands that back to the interpreter, whose own map build reports it.
+    // let the interpreter handle collisions instead of compiling first-match dispatch
     for (const value of values) {
       if (claimed.has(value)) {
         throw new ZodCompileUnsupportedError(`duplicate discriminator value ${String(value)}`);

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2600,7 +2600,7 @@ export interface $ZodDiscriminatedUnionInternals<
   def: $ZodDiscriminatedUnionDef<Options, Disc>;
   propValues: util.PropValues;
   bag: util.LoosePartial<{
-    optionsMap: Map<util.Primitive, $ZodType>;
+    optionsMap: Map<util.Primitive, $ZodType | null>;
   }>;
 }
 
@@ -2633,15 +2633,31 @@ export function getDiscriminatedOption<
   const internals = union._zod;
   let map = internals.bag.optionsMap;
   if (!map) {
-    map = new Map();
-    const { options, discriminator } = internals.def;
-    for (const option of options as unknown as readonly $ZodType[]) {
-      // First declaration wins, matching the order the parse path resolves a duplicate in.
-      for (const v of option._zod.propValues?.[discriminator] ?? []) if (!map.has(v)) map.set(v, option);
-    }
+    map = discriminatorMap(internals.def);
     internals.bag.optionsMap = map;
   }
-  return map.get(value as util.Primitive) as any;
+  const option = map.get(value as util.Primitive);
+  if (option === null) throw new Error(`Ambiguous discriminator value "${String(value)}"`);
+  return option as any;
+}
+
+function discriminatorMap(def: $ZodDiscriminatedUnionDef<readonly SomeType[]>): Map<util.Primitive, $ZodType | null> {
+  const map = new Map<util.Primitive, $ZodType | null>();
+  for (const option of def.options as readonly $ZodType[]) {
+    const values = option._zod.propValues?.[def.discriminator];
+    if (!values || values.size === 0)
+      throw new Error(`Invalid discriminated union option at index "${def.options.indexOf(option)}"`);
+    for (const value of values) {
+      if (map.has(value)) {
+        if (value !== undefined) throw new Error(`Duplicate discriminator value "${String(value)}"`);
+        // keep the collision marked so a later member cannot reclaim it
+        map.set(value, null);
+      } else {
+        map.set(value, option);
+      }
+    }
+  }
+  return map;
 }
 
 export interface $ZodDiscriminatedUnion<
@@ -2661,10 +2677,12 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
     const _super = inst._zod.parse;
     util.defineLazyInternal(inst, "propValues", (zod) => {
       const propValues: util.PropValues = {};
+      let undefinedCount = 0;
       for (const option of zod.def.options) {
         const pv = option._zod.propValues;
         if (!pv || Object.keys(pv).length === 0)
           throw new Error(`Invalid discriminated union option at index "${zod.def.options.indexOf(option)}"`);
+        if (pv[zod.def.discriminator]?.has(undefined)) undefinedCount++;
         for (const [k, v] of Object.entries(pv!)) {
           if (!Object.prototype.hasOwnProperty.call(propValues, k)) {
             util.assignProp(propValues, k, new Set());
@@ -2674,6 +2692,7 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
           }
         }
       }
+      if (!zod.def.unionFallback && undefinedCount > 1) propValues[zod.def.discriminator]?.delete(undefined);
       return propValues;
     });
 
@@ -2685,22 +2704,7 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
       }
     });
 
-    const disc = util.cached(() => {
-      const opts = def.options;
-      const map: Map<util.Primitive, $ZodType> = new Map();
-      for (const o of opts) {
-        const values = o._zod.propValues?.[def.discriminator];
-        if (!values || values.size === 0)
-          throw new Error(`Invalid discriminated union option at index "${def.options.indexOf(o)}"`);
-        for (const v of values) {
-          if (map.has(v)) {
-            throw new Error(`Duplicate discriminator value "${String(v)}"`);
-          }
-          map.set(v, o);
-        }
-      }
-      return map;
-    });
+    const disc = util.cached(() => discriminatorMap(def));
 
     inst._zod.parse = (payload, ctx) => {
       const input = payload.value;
@@ -2733,7 +2737,7 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
         errors: [],
         note: "No matching discriminator",
         discriminator: def.discriminator,
-        options: Array.from(disc.value.keys()),
+        options: Array.from(disc.value.keys()).filter((value) => disc.value.get(value) !== null),
         input,
         path: [def.discriminator],
         inst,

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -2624,7 +2624,7 @@ export type $DiscriminatedOption<Options extends readonly SomeType[], Disc exten
     : never;
 }[number];
 
-/** Returns the option of `union` whose discriminator claims `value`. */
+/** Returns the option whose discriminator claims `value`, or throws if ambiguous. */
 export function getDiscriminatedOption<
   Options extends readonly SomeType[],
   Disc extends string,
@@ -2719,8 +2719,10 @@ export const $ZodDiscriminatedUnion: core.$constructor<$ZodDiscriminatedUnion> =
         return payload;
       }
 
-      const opt = disc.value.get(input?.[def.discriminator] as any);
-      if (opt) {
+      const value = input?.[def.discriminator];
+      const opt = disc.value.get(value as util.Primitive);
+      // forward metadata cannot choose an encoder for an absent tag
+      if (opt && (value !== undefined || ctx.direction !== "backward")) {
         return opt._zod.run(payload, ctx) as any;
       }
 


### PR DESCRIPTION
Preserve explicitly tagged parsing when multiple discriminated-union members have defaulted tags. A shared map builder marks colliding `undefined` values as ambiguous; missing tags fail validation, while unique tags retain direct dispatch. Other duplicate values remain schema errors.

There are no schema-type checks, wrapper walks, new options, or new instance properties. The lookup helper uses the same map builder and rejects ambiguous lookup. Nested unions omit an unroutable `undefined` from their discriminator metadata; backward encoding of `undefined` uses the existing union fallback so forward-only metadata cannot select the wrong sibling. Defined tags retain their encoding fast path. The compiler keeps its existing interpreter fallback for collisions rather than introducing a second dispatch policy.

Local build, lint, resolution, integration, and the full suite pass, including 8,243 tests on each of TypeScript 5.5.4, 6.0.3, and 7.0.2. Plain-Node ESM/CJS probes pass for both classic and Mini. The encoding regression has synchronous and asynchronous coverage, and the API reference documents ambiguous lookup.

| Measurement | Base → change |
| --- | --- |
| Parse, median of ten process minima | 38.06 → 38.44 ns (+1.0%) |
| Defined-tag encode, median of ten process minima | 48.21 → 48.03 ns (-0.4%) |
| Construction, median of ten process minima | 802.6 → 804.1 ns (+0.2%) |
| Classic discriminated-union fixture, gzip | 21,159 → 21,248 B (+89 B) |
| Mini discriminated-union fixture, gzip | 5,238 → 5,339 B (+101 B) |
| Classic / Mini object-only fixtures | unchanged |
| Fresh two-member union, retained heap | 9,136 → 9,136 B in repeated isolated measurements |
| Shared-member union, unparsed / parsed | approximately 921 / 1,098 B on both revisions |

Runtime measurements on `f1f96bea` use ten interleaved rounds, alternating which revision runs first, fixed iteration counts, and GC between samples. Host load stayed at 5.44–6.10; no meaningful runtime regression was observed. Earlier high-load timing samples were discarded. The initial broad memory run also showed a +288 B union result that did not reproduce in two isolated comparisons; the 500-resource catalogue remained approximately 38.53 MiB on both revisions.

Closes #6577.
