### PR TITLE
Fix undefined prefault outputs and object keys

### DIFF
--- a/packages/zod/src/v4/classic/tests/prefault.test.ts
+++ b/packages/zod/src/v4/classic/tests/prefault.test.ts
@@ -1,6 +1,76 @@
 import { expect, expectTypeOf, test } from "vitest";
 import { z } from "zod/v4";
 
+test.each([false, true])("undefined prefault preserves object keys (jitless: %s)", async (jitless) => {
+  const previous = z.config().jitless;
+  z.config({ jitless });
+  try {
+    let calls = 0;
+    const field = z.union([z.string(), z.undefined()]).prefault(() => {
+      calls++;
+      return undefined;
+    });
+    const schema = z.object({ a: field });
+    expectTypeOf<z.output<typeof field>>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<z.input<typeof schema>>().toEqualTypeOf<{ a?: string | undefined }>();
+    expectTypeOf<z.output<typeof schema>>().toEqualTypeOf<{ a: string | undefined }>();
+    expect(schema.parse({})).toStrictEqual({ a: undefined });
+    expect(calls).toBe(1);
+    expect(schema.parse({ a: undefined })).toStrictEqual({ a: undefined });
+    expect(calls).toBe(2);
+    expect(await schema.parseAsync({})).toStrictEqual({ a: undefined });
+    expect(calls).toBe(3);
+    expect(schema.parse({ a: "value" })).toStrictEqual({ a: "value" });
+    expect(schema.safeParse({ a: 123 }).success).toBe(false);
+    expect(calls).toBe(3);
+
+    const literal = z.prefault(z.string().optional(), undefined);
+    expect(z.core.compileFn(z.object({ a: literal }))({})).toStrictEqual({ a: undefined });
+    for (const wrapped of [literal, literal.readonly(), literal.nullable(), z.lazy(() => literal)]) {
+      expect(z.object({ a: wrapped }).parse({})).toStrictEqual({ a: undefined });
+    }
+    expect(z.object({ a: literal.optional() }).parse({})).toStrictEqual({});
+    expect(z.object({ a: literal.optional() }).parse({ a: undefined })).toStrictEqual({ a: undefined });
+    expect(z.tuple([literal]).parse([])).toStrictEqual([undefined]);
+  } finally {
+    z.config({ jitless: previous });
+  }
+});
+
+test("prefault preserves transformed undefined output", async () => {
+  const field = z
+    .string()
+    .transform(() => undefined)
+    .prefault("fallback");
+  expectTypeOf<z.output<typeof field>>().toEqualTypeOf<undefined>();
+  expect(field.parse(undefined)).toBeUndefined();
+  const schema = z.object({ a: field, optional: z.string().optional() });
+  expectTypeOf<z.output<typeof schema>>().toEqualTypeOf<{ a: undefined; optional?: string | undefined }>();
+  expect(schema.parse({})).toStrictEqual({ a: undefined });
+  expect(z.core.compileFn(schema)({})).toStrictEqual({ a: undefined });
+  expect(z.compile(schema).parse({})).toStrictEqual({ a: undefined });
+  expect(
+    await z
+      .object({
+        a: z
+          .string()
+          .transform(async () => undefined)
+          .prefault("fallback"),
+      })
+      .parseAsync({})
+  ).toStrictEqual({ a: undefined });
+  expect(
+    z
+      .object({
+        a: z
+          .string()
+          .prefault("fallback")
+          .transform(() => undefined),
+      })
+      .parse({})
+  ).toStrictEqual({ a: undefined });
+});
+
 test("basic prefault", () => {
   const a = z.prefault(z.string().trim(), "  default  ");
   expect(a).toBeInstanceOf(z.ZodPrefault);

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -1270,9 +1270,9 @@ function generateObjectCheck(
   }
   // else: strip mode (no catchall) - unknown keys ignored, only include known keys
 
-  // Shape keys in declared order, then unknown keys in for...in order. A middle-rung key is included iff present on the input, else iff its output is not undefined.
+  // defaulted required outputs keep their keys even when undefined
   const outputVar = newVar(ctx);
-  const hasConditionalKeys = allKeys.some((k) => mayOutputUndefined(propShape[k]!) || dropsWhenAbsent(propShape[k]!));
+  const hasConditionalKeys = allKeys.some((k) => mayOmitUndefined(propShape[k]!) || dropsWhenAbsent(propShape[k]!));
 
   // Assert mode: every declared key is validated above, so the output literal and the unknown-key copy are pure waste. A `never` catchall already emitted its rejection loop; a schema catchall still has to validate the values it would otherwise have stored.
   if (!buildsValue) {
@@ -1301,7 +1301,7 @@ function generateObjectCheck(
       const out = propOutputs.get(k);
       if (dropsWhenAbsent(propShape[k]!)) {
         doc.write(`if (${kx} in ${accessor}) ${outputVar}[${kx}] = ${out};`);
-      } else if (mayOutputUndefined(propShape[k]!)) {
+      } else if (mayOmitUndefined(propShape[k]!)) {
         doc.write(`if (${out} !== undefined || ${kx} in ${accessor}) ${outputVar}[${kx}] = ${out};`);
       } else {
         doc.write(`${outputVar}[${kx}] = ${out};`);
@@ -1464,9 +1464,11 @@ function dropsWhenAbsent(schema: SomeType): boolean {
   return schema._zod.optin === "optional" && schema._zod.optout === "optional";
 }
 
-// Whether a schema's success-path output can be `undefined`. Object output
-// assembly gives such props the runtime's value-or-presence inclusion rule;
-// everything else keeps the unconditional object-literal slot.
+function mayOmitUndefined(schema: SomeType): boolean {
+  return (schema._zod.optin !== "defaulted" || schema._zod.optout === "optional") && mayOutputUndefined(schema);
+}
+
+// whether a schema's success-path output can be undefined
 function mayOutputUndefined(schema: SomeType): boolean {
   const def = schema._zod.def as {
     type: string;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -1983,7 +1983,7 @@ function handlePropertyResult(
   }
 
   if (result.value === undefined) {
-    if (isPresent) {
+    if (isPresent || (optin === "defaulted" && !isOptionalOut)) {
       (final.value as any)[key] = undefined;
     }
   } else {
@@ -2314,16 +2314,16 @@ export const $ZodObjectJIT: core.$constructor<$ZodObject> = /*@__PURE__*/ core.$
           doc.write(`
         if (${id}.issues.length) {${prefixStr(id, k)}
         }
-        
-        if (${id}.value === undefined) {
-          if (${isPresent}) {
-            newResult[${k}] = undefined;
-          }
-        } else {
+      `);
+          if (optin === "defaulted") {
+            doc.write(`newResult[${k}] = ${id}.value;`);
+          } else {
+            doc.write(`
+        if (${id}.value !== undefined || ${isPresent}) {
           newResult[${k}] = ${id}.value;
         }
-
       `);
+          }
         }
       }
 
@@ -4077,7 +4077,7 @@ export interface $ZodPrefaultDef<T extends SomeType = $ZodType> extends $ZodType
 }
 
 export interface $ZodPrefaultInternals<T extends SomeType = $ZodType>
-  extends $ZodTypeInternals<util.NoUndefined<core.output<T>>, core.input<T> | undefined> {
+  extends $ZodTypeInternals<core.output<T>, core.input<T> | undefined> {
   def: $ZodPrefaultDef<T>;
   optin: "defaulted";
   optout?: "optional" | undefined;

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1597,7 +1597,7 @@ export const ZodMiniPrefault: core.$constructor<ZodMiniPrefault> = /*@__PURE__*/
 // @__NO_SIDE_EFFECTS__
 export function prefault<T extends SomeType>(
   innerType: T,
-  defaultValue: util.NoUndefined<core.input<T>> | (() => util.NoUndefined<core.input<T>>)
+  defaultValue: core.input<T> | (() => core.input<T>)
 ): ZodMiniPrefault<T> {
   return new ZodMiniPrefault({
     type: "prefault",

--- a/packages/zod/src/v4/mini/tests/index.test.ts
+++ b/packages/zod/src/v4/mini/tests/index.test.ts
@@ -165,6 +165,28 @@ test("z.iso.duration", () => {
   expect(z.safeParse(b, d2).success).toEqual(false);
 });
 
+test("z.prefault preserves undefined output", async () => {
+  const field = z.prefault(z.union([z.string(), z.undefined()]), () => undefined);
+  const schema = z.object({ a: field });
+  expectTypeOf<z.output<typeof field>>().toEqualTypeOf<string | undefined>();
+  expectTypeOf<z.output<typeof schema>>().toEqualTypeOf<{ a: string | undefined }>();
+  expect(z.parse(schema, {})).toStrictEqual({ a: undefined });
+  expect(z.parse(schema, { a: undefined })).toStrictEqual({ a: undefined });
+  expect(z.parse(schema, { a: "value" })).toStrictEqual({ a: "value" });
+  expect(z.safeParse(schema, { a: 123 }).success).toBe(false);
+  expect(await z.parseAsync(schema, {})).toStrictEqual({ a: undefined });
+  expect(z.parse(z.object({ a: z.prefault(z.optional(z.string()), undefined) }), {})).toStrictEqual({ a: undefined });
+  const transformed = z.prefault(
+    z.pipe(
+      z.string(),
+      z.transform(() => undefined)
+    ),
+    "fallback"
+  );
+  expectTypeOf<z.output<typeof transformed>>().toEqualTypeOf<undefined>();
+  expect(z.parse(z.object({ a: transformed }), {})).toStrictEqual({ a: undefined });
+});
+
 test("z.undefined", () => {
   const a = z.undefined();
   expect(z.parse(a, undefined)).toEqual(undefined);


### PR DESCRIPTION
Fixes #6585.

Preserve `undefined` in prefault output types and retain missing object keys when a defaulted field has required output. This also fixes transforms that return `undefined` after receiving a defined prefault. Mini now accepts the same prefault inputs as Classic.

The object change uses existing optionality metadata across interpreted, JIT, and compiled parsing. Optional output fields still omit absent keys. Regression tests cover types, callbacks, wrappers, transforms, async parsing, and direct compiled output.

Retained schema memory is unchanged. The gzipped object fixture grows by 6 bytes for Classic and 14 bytes for Mini; boolean fixtures are unchanged. Local runtime samples were rejected because the host was saturated, so no performance claim is made.
