### PR TITLE
Make z.properties() a check again

### DIFF
--- a/packages/docs/content/api.mdx
+++ b/packages/docs/content/api.mdx
@@ -2352,19 +2352,9 @@ type OkResponse = z.infer<typeof okResponse>;
 // => Response & { status: number; redirected: false }
 ```
 
-The underlying `z.properties()` is a standalone schema. It asserts the named properties in place and returns its input untouched — unlike `z.object()`, it never builds a new object, so prototypes, unlisted keys, and object identity survive. Schemas inside the shape are validated but their results are discarded, so a transform or a default never changes the parsed value.
+The check asserts each property in place. Unlike `z.object()`, it never builds a new object, so prototypes, unlisted keys, and object identity survive. Schemas inside the shape are validated but their results are discarded, so a transform or a default never changes the parsed value.
 
-```ts
-const Named = z.properties({ name: z.string() });
-
-class Dog {
-  constructor(public name: string) {}
-}
-const rex = new Dog("Rex");
-Named.parse(rex); // => rex (the same instance)
-```
-
-Spreading into `.check()` works too: `z.instanceof(Response).check(...z.properties({ ... }))`. As a check it asserts on whatever the base schema produced, so `z.string().check(...z.properties({ length: z.number().min(3) }))` reads a string's length; as a standalone schema it expects an object.
+The underlying `z.properties()` is a check, so it spreads into `.check()` too: `z.instanceof(Response).check(...z.properties({ ... }))`. It asserts on whatever the base schema produced, so `z.string().check(...z.properties({ length: z.number().min(3) }))` reads a string's length.
 
 ## Refinements
 

--- a/packages/treeshake/bundle-size.test.ts
+++ b/packages/treeshake/bundle-size.test.ts
@@ -42,13 +42,15 @@ const CEILINGS: Record<string, number> = {
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
-  "zod-mini-boolean": 3088,
+  // Lowered by the measured −17 / −16 / −16 from making z.properties() a check again: the symbol-key loop in `util.members` and the memoizer's callable arm left with the schema role. Measured 3044 / 3418 / 4629 locally plus 18 headroom; the object ceiling had been overtaken to zero headroom on main, so its number moves up by two while the bundle moves down.
+  "zod-mini-boolean": 3062,
   // Also carries the code-point string length scan: `.min`/`.max`/`.length` on a string pulls in the surrogate walk.
   // Also carries the Standard Schema issue bag: a failing `~standard.validate` parses with a plain issue holder instead of constructing a ZodError. Measured 2974 / 3455 / 4540 locally plus 28 headroom.
   // Also carries the lazy `safeParse` error: a getter and a setter on the failing result, and the async wrapper that keeps a sync throw a rejection. Measured 3021 / 3497 / 4581 locally plus 18 headroom.
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
   // Lowered by the measured −105 when checks stopped writing metadata into the bag at attach time: the string length/format closures and the per-instance bounded regex left every string bundle, and the template literal now derives its own part patterns.
-  "zod-mini-string": 3462,
+  // Lowered by the measured −17 / −16 / −16 from making z.properties() a check again: the symbol-key loop in `util.members` and the memoizer's callable arm left with the schema role. Measured 3044 / 3418 / 4629 locally plus 18 headroom; the object ceiling had been overtaken to zero headroom on main, so its number moves up by two while the bundle moves down.
+  "zod-mini-string": 3436,
   // Also carries the construction-time discriminator check, which writes a WeakMap entry from `$ZodObject`, so every bundle containing `z.object` pays for it whether or not it builds a discriminated union.
   // Also carries the declared symbol keys from #6448: `normalizeDef` collects the shape's own symbols and the parse loop walks them. Almost none of that is the `Reflect.ownKeys` conversions — reverting all eight of them measures a byte larger.
   // Also carries the memoizer seam from #6482: each container init reads `globalConfig.memoizer` and calls `attach`, which is what lets `zod/mini` opt into cycle support. Measured 4512 locally but 4533 on CI — the gzip stream differs across zlib builds — so the headroom rides on the CI number.
@@ -57,7 +59,8 @@ const CEILINGS: Record<string, number> = {
   // Also carries the symbol-key loop in `util.members`, which is what installs `$ZodProperties`'s `Symbol.iterator` on its prototype, and the memoizer's shared reference predicate. Measured 3036 / 3516 / 4611 locally plus 18 headroom.
   // Also carries the guards `validate` parses under: an `aborted` check in each container loop, and two early exits in the generated object parser. Only a bundle containing a container pays — boolean is byte-identical to main and string measures three bytes smaller — so this ceiling rises by the measured +76 and the other two do not move. Measured 4696 locally plus 18 headroom.
   // Lowered by the measured −69 for the same bag strip: the string and number inits no longer carry pattern derivation or attach-time metadata writes.
-  "zod-mini-object": 4645,
+  // Lowered by the measured −17 / −16 / −16 from making z.properties() a check again: the symbol-key loop in `util.members` and the memoizer's callable arm left with the schema role. Measured 3044 / 3418 / 4629 locally plus 18 headroom; the object ceiling had been overtaken to zero headroom on main, so its number moves up by two while the bundle moves down.
+  "zod-mini-object": 4647,
 };
 
 /**

--- a/packages/zod/src/v4/classic/checks.ts
+++ b/packages/zod/src/v4/classic/checks.ts
@@ -21,6 +21,7 @@ export {
   _startsWith as startsWith,
   _endsWith as endsWith,
   _property as property,
+  _properties as properties,
   _mime as mime,
   _overwrite as overwrite,
   _normalize as normalize,

--- a/packages/zod/src/v4/classic/schemas.ts
+++ b/packages/zod/src/v4/classic/schemas.ts
@@ -2791,28 +2791,6 @@ export const ZodCustom: core.$constructor<ZodCustom> = /*@__PURE__*/ core.$const
   inst._zod.processJSONSchema = (ctx, json, params) => processors.customProcessor(inst, ctx, json, params);
 });
 
-// ZodProperties
-export interface ZodProperties<Shape extends core.$ZodShape = core.$ZodShape>
-  extends _ZodType<core.$ZodPropertiesInternals<Shape>>,
-    core.$ZodProperties<Shape> {
-  "~standard": ZodStandardSchemaWithJSON<this>;
-}
-export const ZodProperties: core.$constructor<ZodProperties> = /*@__PURE__*/ core.$constructor(
-  "ZodProperties",
-  (inst, def) => {
-    _ensureDefaultMemoizer();
-    core.$ZodProperties.init(inst, def);
-    ZodType.init(inst, def);
-  }
-);
-
-export function properties<Shape extends core.$ZodShape>(
-  shape: Shape,
-  params?: string | core.$ZodPropertiesParams
-): ZodProperties<Shape> {
-  return core._properties(ZodProperties, shape, params) as any;
-}
-
 // custom checks
 export function check<O = unknown>(fn: core.CheckFn<O>): core.$ZodCheck<O> {
   const ch = new core.$ZodCheck({
@@ -2860,7 +2838,7 @@ type ZodInstanceOfParams = core.Params<
 export interface ZodInstanceOf<T = unknown> extends ZodCustom<T, T> {
   properties<Shape extends core.$ZodShape>(
     shape: Shape,
-    params?: string | core.$ZodPropertiesParams
+    params?: string | core.$ZodCheckPropertiesParams
   ): ZodInstanceOf<T & core.$InferObjectInput<Shape, {}>>;
 }
 export const ZodInstanceOf: core.$constructor<ZodInstanceOf> = /*@__PURE__*/ core.$constructor(
@@ -2869,9 +2847,9 @@ export const ZodInstanceOf: core.$constructor<ZodInstanceOf> = /*@__PURE__*/ cor
     ZodCustom.init(inst, def);
   },
   {
-    properties(shape: core.$ZodShape, params?: string | core.$ZodPropertiesParams) {
+    properties(shape: core.$ZodShape, params?: string | core.$ZodCheckPropertiesParams) {
       // asserts in place, so the narrowed output type is truthful without a wrapper
-      return this.check(properties(shape, params)) as any;
+      return this.check(core._properties(shape, params)) as any;
     },
   }
 );

--- a/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
+++ b/packages/zod/src/v4/classic/tests/cyclic-data.test.ts
@@ -924,17 +924,8 @@ test("a deferred edge stops being assumed a cycle once the graph resolves", () =
   expect(z.core.isRecursiveSchema(Cyclic)).toBe(true);
 });
 
-// `z.object` resolves its shape by spread, so a non-enumerable key is no part of it; `z.properties` reads every own key, so one there is still parsed and can still close a cycle
-test("a non-enumerable key counts for z.properties and not for z.object", () => {
-  const props = (enumerable: boolean) => {
-    const shape: Record<string, any> = { id: z.number() };
-    const P = z.properties(shape);
-    Object.defineProperty(shape, "next", { value: z.lazy(() => z.optional(P)), enumerable, configurable: true });
-    return P;
-  };
-  expect(z.core.isRecursiveSchema(props(true) as any)).toBe(true);
-  expect(z.core.isRecursiveSchema(props(false) as any)).toBe(true);
-
+// `z.object` resolves its shape by spread, so a non-enumerable key is no part of it
+test("a non-enumerable key does not count for z.object", () => {
   const object = (enumerable: boolean) => {
     const shape: Record<string, any> = { id: z.number() };
     const O: any = z.object(shape);

--- a/packages/zod/src/v4/classic/tests/firstparty.test.ts
+++ b/packages/zod/src/v4/classic/tests/firstparty.test.ts
@@ -80,8 +80,6 @@ test("first party switch", () => {
       break;
     case "file":
       break;
-    case "properties":
-      break;
     case "lazy":
       break;
     case "function":
@@ -171,8 +169,6 @@ test("$ZodSchemaTypes", () => {
     case "file":
       break;
     case "lazy":
-      break;
-    case "properties":
       break;
     case "function":
       break;

--- a/packages/zod/src/v4/classic/tests/instanceof.test.ts
+++ b/packages/zod/src/v4/classic/tests/instanceof.test.ts
@@ -90,7 +90,7 @@ test("z.properties", () => {
     expect(obj.safeParse(input).error!.issues.map((i) => [i.code, i.path])).toEqual([["invalid_type", []]]);
   }
 
-  // Known looseness versus the longhand, pinned so it stays deliberate: the schema-as-check is typed over the whole shape, and `$ZodCheckInternals.check()` is a method, so TypeScript compares it bivariantly and accepts a check type that is a subtype of the target. Naming a key the target lacks therefore compiles here and fails at parse time, where the equivalent chain of `z.property()` calls rejects it outright.
+  // Known looseness versus the longhand, pinned so it stays deliberate: the check is typed over the whole shape, and `$ZodCheckInternals.check()` is a method, so TypeScript compares it bivariantly and accepts a check type that is a subtype of the target. Naming a key the target lacks therefore compiles here and fails at parse time, where the equivalent chain of `z.property()` calls rejects it outright.
   z.object({ a: z.string() }).check(...z.properties({ a: z.literal("x"), b: z.literal("y") }));
   expect(
     z

--- a/packages/zod/src/v4/classic/tests/properties.test.ts
+++ b/packages/zod/src/v4/classic/tests/properties.test.ts
@@ -1,25 +1,15 @@
 import { expect, expectTypeOf, test } from "vitest";
 import * as z from "zod/v4";
 
-test("z.properties is a schema", () => {
-  const p = z.properties({ a: z.literal("x"), b: z.literal("y") });
+test("z.properties is a check", () => {
+  const s = z.object({ a: z.string(), b: z.string() }).check(z.properties({ a: z.literal("x"), b: z.literal("y") }));
 
-  expectTypeOf<z.infer<typeof p>>().toEqualTypeOf<{ a: "x"; b: "y" }>();
+  // asserts in place: extra keys pass, and every failing key reports
+  expect(s.safeParse({ a: "x", b: "y", extra: 1 }).success).toBe(true);
+  expect(s.safeParse({ a: "!", b: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"], ["b"]]);
 
-  // asserts in place: the parse returns the input identity, extra keys pass
-  const ok = { a: "x", b: "y", extra: 1 };
-  expect(p.parse(ok)).toBe(ok);
-
-  // every failing key reports
-  expect(p.safeParse({ a: "!", b: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"], ["b"]]);
-
-  // as a schema it is the type gate and infers an object shape, so a primitive is a type error
-  for (const input of [null, undefined, 5, "abc"]) {
-    expect(p.safeParse(input).error!.issues.map((i) => [i.code, i.path])).toEqual([["invalid_type", []]]);
-  }
-
-  // as a check the base already typed the value, so the properties are asserted on whatever it produced — a string's length, as z.property() does
-  const long = z.string().check(...z.properties({ length: z.number().min(3) }));
+  // the base already typed the value, so the properties are asserted on whatever it produced — a string's length, as z.property() does
+  const long = z.string().check(z.properties({ length: z.number().min(3) }));
   expect(long.parse("abc")).toBe("abc");
   expect(long.safeParse("ab").error!.issues.map((i) => i.path)).toEqual([["length"]]);
   expect(
@@ -29,27 +19,17 @@ test("z.properties is a schema", () => {
       .error!.issues.map((i) => i.path)
   ).toEqual([["length"]]);
 
-  // an optional key may be absent
-  const opt = z.properties({ a: z.string().optional() });
-  expect(opt.safeParse({}).success).toBe(true);
-  expectTypeOf<z.infer<typeof opt>>().toEqualTypeOf<{ a?: string | undefined }>();
+  // not a schema
+  // @ts-expect-error a check has no parse of its own
+  z.properties({ a: z.string() }).parse;
 });
 
 test("z.properties discards transformed output", () => {
   // asserts and never writes back, exactly as z.property() behaves; a nested object schema rebuilds its output even without transforms, so identity cannot distinguish the two
-  const p = z.properties({ a: z.string().transform((s) => s.toUpperCase()) });
+  const s = z.any().check(z.properties({ a: z.string().transform((s) => s.toUpperCase()) }));
   const input = { a: "hi" };
-  expect(p.parse(input)).toBe(input);
+  expect(s.parse(input)).toBe(input);
   expect(input.a).toBe("hi");
-});
-
-test("z.properties narrows through intersection", () => {
-  const httpsUrl = z.instanceof(URL).and(z.properties({ protocol: z.literal("https:") }));
-  expectTypeOf<z.infer<typeof httpsUrl>>().toEqualTypeOf<URL & { protocol: "https:" }>();
-
-  const u = new URL("https://example.com");
-  expect(httpsUrl.parse(u)).toBe(u);
-  expect(httpsUrl.safeParse(new URL("http://example.com")).success).toBe(false);
 });
 
 test("z.instanceof().properties()", () => {
@@ -65,38 +45,23 @@ test("z.instanceof().properties()", () => {
   expectTypeOf<z.infer<typeof chained>>().toEqualTypeOf<URL & { protocol: "https:" } & { port: "" }>();
   expect(chained.safeParse(u).success).toBe(true);
   expect(chained.safeParse(new URL("https://example.com:8443")).error!.issues.map((i) => i.path)).toEqual([["port"]]);
+
+  // nothing is written back, so the narrowing is over the shape's input side
+  const W = z.instanceof(URL).properties({ search: z.string().transform((s) => s.length) });
+  expectTypeOf<z.infer<typeof W>>().toEqualTypeOf<URL & { search: string }>();
 });
 
 test("z.properties spreads into .check()", () => {
-  // the pre-4.6 array call sites: the schema yields itself from Symbol.iterator
+  // the 4.5 array call sites: the check yields itself from Symbol.iterator
   const p = z.properties({ a: z.literal("x") });
-  const spread = [...p];
-  expect(spread).toEqual([p]);
+  expect([...p]).toEqual([p]);
 
   const s = z.object({ a: z.string() }).check(...z.properties({ a: z.literal("x") }));
   expect(s.safeParse({ a: "x" }).success).toBe(true);
   expect(s.safeParse({ a: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"]]);
 });
 
-test("z.properties JSON Schema", () => {
-  const p = z.properties({ a: z.string(), b: z.number().optional() });
-  expect(z.toJSONSchema(p)).toEqual({
-    $schema: "https://json-schema.org/draft/2020-12/schema",
-    type: "object",
-    properties: { a: { type: "string" }, b: { type: "number" } },
-    required: ["a"],
-  });
-});
-
-test("z.properties compiles", () => {
-  const p = z.properties({ a: z.literal("x"), b: z.literal("y") });
-  const compiled = z.compile(p);
-  const ok = { a: "x", b: "y", extra: 1 };
-  expect(compiled.parse(ok)).toBe(ok);
-  expect(compiled.safeParse({ a: "!", b: "!" }).error!.issues.map((i) => i.path)).toEqual([["a"], ["b"]]);
-  expect(compiled.safeParse(null).error!.issues.map((i) => [i.code, i.path])).toEqual([["invalid_type", []]]);
-
-  // nested in a container
+test("z.properties compiles inside a container", () => {
   const outer = z.compile(z.object({ url: z.instanceof(URL).properties({ protocol: z.literal("https:") }) }));
   expect(outer.safeParse({ url: new URL("http://example.com") }).error!.issues.map((i) => i.path)).toEqual([
     ["url", "protocol"],
@@ -104,43 +69,28 @@ test("z.properties compiles", () => {
 });
 
 test("z.properties async", async () => {
-  const p = z.properties({ a: z.string().refine(async (s) => s.length > 1) });
+  const s = z.any().check(z.properties({ a: z.string().refine(async (s) => s.length > 1) }));
   const ok = { a: "hi" };
-  await expect(p.parseAsync(ok)).resolves.toBe(ok);
-  const bad = await p.safeParseAsync({ a: "!" });
+  await expect(s.parseAsync(ok)).resolves.toBe(ok);
+  const bad = await s.safeParseAsync({ a: "!" });
   expect(bad.error!.issues.map((i) => i.path)).toEqual([["a"]]);
-});
-
-test("z.properties infers the input side", () => {
-  // nothing is written back, so an output-typed inference would lie for every shape entry whose output differs from its input
-  const withDefault = z.properties({ a: z.string().default("x") });
-  expectTypeOf<z.infer<typeof withDefault>>().toEqualTypeOf<{ a?: string | undefined }>();
-  expect(withDefault.parse({})).toEqual({});
-
-  const withTransform = z.properties({ a: z.string().transform((s) => s.length) });
-  expectTypeOf<z.infer<typeof withTransform>>().toEqualTypeOf<{ a: string }>();
-  expect(withTransform.parse({ a: "hi" })).toEqual({ a: "hi" });
-
-  // a plain schema has the same input and output, so the documented narrowing is unchanged
-  const W = z.instanceof(URL).properties({ protocol: z.literal("https:") });
-  expectTypeOf<z.infer<typeof W>>().toEqualTypeOf<URL & { protocol: "https:" }>();
 });
 
 test("z.properties validates symbol keys", () => {
   const sym = Symbol("tag");
-  const p = z.properties({ [sym]: z.string() });
-  expect(p.safeParse({ [sym]: "ok" }).success).toBe(true);
-  expect(p.safeParse({ [sym]: 123 }).error!.issues.map((i) => i.path)).toEqual([[sym]]);
+  const s = z.any().check(z.properties({ [sym]: z.string() }));
+  expect(s.safeParse({ [sym]: "ok" }).success).toBe(true);
+  expect(s.safeParse({ [sym]: 123 }).error!.issues.map((i) => i.path)).toEqual([[sym]]);
   expect(
     z
-      .compile(p)
+      .compile(s)
       .safeParse({ [sym]: 123 })
       .error!.issues.map((i) => i.path)
   ).toEqual([[sym]]);
 });
 
 test("z.properties compiled and interpreted agree on a nullish value", () => {
-  // a base that permits null reaches the check role with one; the compiled property read must not throw where the runtime reports an issue
+  // a base that permits null reaches the check with one; the compiled property read must not throw where the runtime reports an issue
   const s = z.any().check(...z.properties({ a: z.string() }));
   const expected = [["invalid_type", []]];
   expect(s.safeParse(null).error!.issues.map((i) => [i.code, i.path])).toEqual(expected);
@@ -153,73 +103,20 @@ test("z.properties compiled and interpreted agree on a nullish value", () => {
 });
 
 test("z.properties with a custom when refuses to compile", () => {
-  // `when` is not publicly settable, since it gates a check inside the run loop and means nothing to a parsed schema. A hand-built def can still carry one, and compiling it must refuse rather than run the shape unconditionally: a union branch compiles to its own IIFE, so a wrong rejection is absorbed as a branch failure with no fallback.
-  const p = new z.core.$ZodProperties({
-    type: "properties",
-    check: "properties",
-    shape: { a: z.literal("x") },
-    when: () => false,
-  });
-  const s = z.union([p as unknown as z.ZodType, z.object({ b: z.string() })]);
+  // `when` is not publicly settable, since it gates the assertion inside the run loop. A hand-built def can still carry one, and compiling it must refuse rather than run the shape unconditionally: a union branch compiles to its own IIFE, so a wrong rejection is absorbed as a branch failure with no fallback.
+  const p = new z.core.$ZodCheckProperties({ check: "properties", shape: { a: z.literal("x") }, when: () => false });
+  const s = z.union([z.any().check(p), z.object({ b: z.string() })]);
   const input = { a: "wrong", b: "hello" };
   expect(z.compile(s).safeParse(input)).toEqual(s.safeParse(input));
-});
-
-test("z.properties parses cyclic input", () => {
-  // the input is its own output, so it registers as its own memo entry; without that a cycle re-enters forever
-  const Node: z.ZodType<{ id: string; next?: unknown }> = z.lazy(() =>
-    z.properties({ id: z.string(), next: Node.optional() })
-  );
-  const cyclic: Record<string, unknown> = { id: "a" };
-  cyclic.next = cyclic;
-  expect(Node.parse(cyclic)).toBe(cyclic);
-  expect(z.compile(Node).parse(cyclic)).toBe(cyclic);
-
-  // the cycle guard must not swallow a real failure further down
-  expect(Node.safeParse({ id: "a", next: { id: 1 } }).error!.issues.map((i) => i.path)).toEqual([["next", "id"]]);
-});
-
-test("z.properties asserts forward while encoding", () => {
-  // both sides declare the shape's input type, so encoding must still check the value against it; running the children backward would encode them and reject that type
-  const codec = z.codec(z.string(), z.number(), { decode: (s) => Number(s), encode: (n) => String(n) });
-  const p = z.properties({ a: codec, b: z.string().transform((s) => s.length) });
-  const value = { a: "1", b: "hi" };
-  expect(z.decode(p, value)).toBe(value);
-  expect(z.encode(p, value)).toBe(value);
-  expect(z.safeEncode(p, { a: 1, b: "hi" } as never).error!.issues.map((i) => i.path)).toEqual([["a"]]);
-});
-
-test("z.properties parses a cyclic callable", () => {
-  // property reads work on a function too, so the cycle guard has to recognize one as a reference
-  const Fn: z.ZodType<{ self?: unknown }> = z.lazy(() => z.properties({ self: Fn.optional() }));
-  const fn = (() => {}) as unknown as Record<string, unknown>;
-  fn.self = fn;
-  expect(Fn.parse(fn)).toBe(fn);
 });
 
 test("z.properties survives shape mutation", () => {
   // key and schema are snapshotted together; caching one and reading the other live paired a stale key with a missing schema
   const shape: Record<string, z.ZodType> = { a: z.string() };
-  const p = z.properties(shape);
-  expect(p.safeParse({ a: "x" }).success).toBe(true);
+  const s = z.any().check(z.properties(shape));
+  expect(s.safeParse({ a: "x" }).success).toBe(true);
   delete shape.a;
-  expect(p.safeParse({ a: "x" }).success).toBe(true);
+  expect(s.safeParse({ a: "x" }).success).toBe(true);
   shape.b = z.string();
-  expect(p.safeParse({ a: "x" }).success).toBe(true);
-});
-
-test("z.properties JSON Schema describes the input side", () => {
-  // the parsed value is the input, so a defaulted key that stays absent must not be required of the output either
-  const p = z.properties({ a: z.string().default("x") });
-  expect(p.parse({})).toEqual({});
-  expect(z.toJSONSchema(p, { io: "output" })).toEqual({
-    $schema: "https://json-schema.org/draft/2020-12/schema",
-    type: "object",
-    properties: { a: { default: "x", type: "string" } },
-  });
-
-  // an output mode emission for a transforming child would describe a value this schema never returns
-  const t = z.properties({ a: z.string().transform((s) => s.length) });
-  expect(() => z.toJSONSchema(t, { io: "output" })).toThrow(/cannot be represented/);
-  expect(z.toJSONSchema(t, { io: "input" })).toMatchObject({ properties: { a: { type: "string" } }, required: ["a"] });
+  expect(s.safeParse({ a: "x" }).success).toBe(true);
 });

--- a/packages/zod/src/v4/core/api.ts
+++ b/packages/zod/src/v4/core/api.ts
@@ -1144,16 +1144,13 @@ export function _property<K extends string, T extends schemas.$ZodType>(
   });
 }
 
-// `when` is omitted: it gates a check inside the run loop, so it means nothing when this is parsed as a schema, and honoring it in one role only would diverge silently
-export type $ZodPropertiesParams = CheckTypeParams<schemas.$ZodProperties, "shape" | "when">;
+export type $ZodCheckPropertiesParams = CheckParams<checks.$ZodCheckProperties, "shape" | "when">;
 // @__NO_SIDE_EFFECTS__
 export function _properties<Shape extends schemas.$ZodShape>(
-  Class: util.SchemaClass<schemas.$ZodProperties>,
   shape: Shape,
-  params?: string | $ZodPropertiesParams
-): schemas.$ZodProperties<Shape> {
-  return new Class({
-    type: "properties",
+  params?: string | $ZodCheckPropertiesParams
+): checks.$ZodCheckProperties<Shape> {
+  return new checks.$ZodCheckProperties({
     check: "properties",
     shape,
     ...util.normalizeParams(params),

--- a/packages/zod/src/v4/core/checks.ts
+++ b/packages/zod/src/v4/core/checks.ts
@@ -1000,7 +1000,7 @@ export const $ZodCheckEndsWith: core.$constructor<$ZodCheckEndsWith> = /*@__PURE
 function handleCheckPropertyResult(
   result: schemas.ParsePayload<unknown>,
   payload: schemas.ParsePayload<unknown>,
-  property: string
+  property: string | symbol
 ) {
   if (result.issues.length) {
     payload.issues.push(...util.prefixIssues(property, result.issues));
@@ -1041,6 +1041,66 @@ export const $ZodCheckProperty: core.$constructor<$ZodCheckProperty> = /*@__PURE
 
       handleCheckPropertyResult(result, payload, def.property);
       return;
+    };
+  }
+);
+
+/////////////////////////////////////
+/////    $ZodCheckProperties    /////
+/////////////////////////////////////
+export interface $ZodCheckPropertiesDef<Shape extends schemas.$ZodShape = schemas.$ZodShape> extends $ZodCheckDef {
+  check: "properties";
+  shape: Shape;
+}
+
+// typed over the input side, since each child's result is discarded; a literal widens to its primitive so spreading over a `string` property still type-checks (#6520)
+export type $ZodCheckPropertiesInput<Shape extends schemas.$ZodShape = schemas.$ZodShape> = {
+  -readonly [k in keyof Shape]: util.Widen<core.input<Shape[k]>>;
+};
+
+export interface $ZodCheckPropertiesInternals<Shape extends schemas.$ZodShape = schemas.$ZodShape>
+  extends $ZodCheckInternals<$ZodCheckPropertiesInput<Shape>> {
+  def: $ZodCheckPropertiesDef<Shape>;
+  issc: errors.$ZodIssue;
+}
+
+export interface $ZodCheckProperties<Shape extends schemas.$ZodShape = schemas.$ZodShape>
+  extends $ZodCheck<$ZodCheckPropertiesInput<Shape>> {
+  _zod: $ZodCheckPropertiesInternals<Shape>;
+  // yields the check itself, so `.check(...z.properties(shape))` spread call sites keep working
+  [Symbol.iterator](): Iterator<this>;
+}
+
+export const $ZodCheckProperties: core.$constructor<$ZodCheckProperties> = /*@__PURE__*/ core.$constructor(
+  "$ZodCheckProperties",
+  (inst, def) => {
+    $ZodCheck.init(inst, def);
+    util.hide(inst, Symbol.iterator, function* () {
+      yield inst;
+    });
+
+    // key and schema snapshotted together: reading one live and the other cached lets a later mutation of the caller's shape object pair a stale key with a missing schema
+    let entries!: [string | symbol, schemas.$ZodType][];
+    inst._zod.check = (payload) => {
+      // the base schema already typed the value, so only a nullish one is rejected here: the properties read on a primitive too, matching z.property() on a string's length
+      if (payload.value == null) {
+        payload.issues.push({ expected: "object", code: "invalid_type", input: payload.value, inst });
+        return undefined;
+      }
+      entries ??= Reflect.ownKeys(def.shape).map((key) => [key, (def.shape as any)[key] as schemas.$ZodType]);
+      const input = payload.value as any;
+      let proms: Promise<any>[] | undefined;
+      for (const [key, schema] of entries) {
+        const result = schema._zod.run({ value: input[key], issues: [] }, {});
+        if (result instanceof Promise) {
+          proms ??= [];
+          proms.push(result.then((result) => handleCheckPropertyResult(result, payload, key)));
+        } else {
+          handleCheckPropertyResult(result, payload, key);
+        }
+      }
+      if (proms) return Promise.all(proms).then(() => undefined);
+      return undefined;
     };
   }
 );

--- a/packages/zod/src/v4/core/compile.ts
+++ b/packages/zod/src/v4/core/compile.ts
@@ -18,7 +18,7 @@ import {
   urlHostnameOk,
   urlProtocolOk,
 } from "./schemas.js";
-import type { $ZodProperties, $ZodPropertiesDef, ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
+import type { ParseContextInternal, ParsePayload, SomeType } from "./schemas.js";
 import * as util from "./util.js";
 
 /** @internal Sentinel the compiled fast path returns when validation fails. */
@@ -89,7 +89,7 @@ type SupportedCheck =
   | checks.$ZodCheckLengthEquals
   | checks.$ZodCheckStringFormat
   | checks.$ZodCheckProperty
-  | $ZodProperties
+  | checks.$ZodCheckProperties
   | checks.$ZodCheckMimeType
   | checks.$ZodCheckOverwrite
   | { _zod: { def: { check: "custom"; fn?: (value: unknown) => boolean }; check?: (payload: unknown) => unknown } };
@@ -455,7 +455,7 @@ function generateChecks(doc: Doc, ctx: CompileContext, schema: SomeType, accesso
         generatePropertyCheck(doc, ctx, def, currentAccessor);
         break;
       case "properties":
-        generatePropertiesChecks(doc, ctx, def, currentAccessor, false);
+        generatePropertiesChecks(doc, ctx, def, currentAccessor);
         break;
       case "overwrite": {
         // Overwrite transforms the value - create new variable for transformed result
@@ -616,20 +616,15 @@ function generateMimeTypeCheck(
 function generatePropertiesChecks(
   doc: Doc,
   ctx: CompileContext,
-  def: $ZodPropertiesDef,
-  accessor: string,
-  schemaRole: boolean
+  def: checks.$ZodCheckPropertiesDef,
+  accessor: string
 ): void {
-  // a custom `when` gates the assertion at runtime; inside a union a wrongly-run branch is absorbed as a branch failure rather than falling back, so refuse at codegen the way the check role does
+  // a custom `when` gates the assertion at runtime; inside a union a wrongly-run branch is absorbed as a branch failure rather than falling back, so refuse at codegen
   if (def.when) {
     throw new ZodCompileUnsupportedError(`check with a custom "when" condition`);
   }
-  // matches the runtime gate for whichever role this is: a schema rejects a primitive outright, a check only a nullish value
-  doc.write(
-    schemaRole
-      ? `if (${accessor} === null || (typeof ${accessor} !== "object" && typeof ${accessor} !== "function")) return INVALID;`
-      : `if (${accessor} == null) return INVALID;`
-  );
+  // matches the runtime gate: the base schema already typed the value, so only a nullish one is rejected
+  doc.write(`if (${accessor} == null) return INVALID;`);
   const shape = def.shape as Record<string | symbol, SomeType>;
   for (const key of Reflect.ownKeys(shape)) {
     // a symbol has no source literal, so it is hoisted as a constant
@@ -934,7 +929,6 @@ type SupportedSchemaType =
   | "lazy"
   | "pipe"
   | "custom"
-  | "properties"
   | "transform"
   | "catch";
 
@@ -1078,10 +1072,6 @@ function generateCheck(
       break;
     case "custom":
       typeAccessor = generateCustomCheck(doc, ctx, schema, accessor);
-      break;
-    case "properties":
-      generatePropertiesChecks(doc, ctx, (schema as $ZodProperties)._zod.def, accessor, true);
-      typeAccessor = accessor;
       break;
     case "transform":
       typeAccessor = generateTransformCheck(doc, ctx, schema, accessor);

--- a/packages/zod/src/v4/core/json-schema-processors.ts
+++ b/packages/zod/src/v4/core/json-schema-processors.ts
@@ -16,7 +16,6 @@ import {
   finalize,
   handleUnrepresentable,
   initializeContext,
-  isTransforming,
   processSchema,
 } from "./to-json-schema.js";
 import { BIGINT_FORMAT_RANGES, NUMBER_FORMAT_RANGES, assignProp, getEnumValues } from "./util.js";
@@ -481,54 +480,6 @@ export const objectProcessor: Processor<schemas.$ZodObject> = (schema, ctx, _jso
   }
 };
 
-// asserts named properties in place and passes everything else through, so no additionalProperties constraint is emitted
-export const propertiesProcessor: Processor<schemas.$ZodProperties> = (schema, ctx, _json, params) => {
-  const json = _json as JSONSchema.ObjectSchema;
-  const def = schema._zod.def;
-
-  // dropping a symbol key silently would emit a schema that asserts less than this one does
-  if (
-    Object.getOwnPropertySymbols(def.shape).length &&
-    handleUnrepresentable(schema, ctx, json, params, "Symbol keys cannot be represented in JSON Schema")
-  ) {
-    return;
-  }
-
-  // the parsed value is the input, so an output-mode emission would describe a transformed value this schema never returns
-  if (ctx.io === "output") {
-    for (const key in def.shape) {
-      if (
-        isTransforming(def.shape[key]!) &&
-        handleUnrepresentable(
-          schema,
-          ctx,
-          json,
-          params,
-          `z.properties() returns its input, so the output of a transforming schema at key "${key}" cannot be represented in JSON Schema`
-        )
-      ) {
-        return;
-      }
-    }
-  }
-
-  json.type = "object";
-  json.properties = {};
-  for (const key in def.shape) {
-    assignProp(
-      json.properties,
-      key,
-      processSchema(def.shape[key]!, ctx as any, {
-        ...params,
-        path: [...params.path, "properties", key],
-      })
-    );
-  }
-  // input-side optionality in both modes: the parsed value is the input, so a defaulted key that stays absent must not be required of the output either
-  const required = Object.keys(def.shape).filter((key) => inputOptin(def.shape[key]!) === undefined);
-  if (required.length > 0) json.required = required;
-};
-
 export const unionProcessor: Processor<schemas.$ZodUnion> = (schema, ctx, json, params) => {
   const def = schema._zod.def as schemas.$ZodUnionDef;
   // Exclusive unions (inclusive === false) use oneOf (exactly one match) instead of anyOf (one or more matches). This includes both z.xor() and discriminated unions
@@ -904,7 +855,6 @@ export const allProcessors: Record<string, Processor<any>> = {
   file: fileProcessor,
   success: successProcessor,
   custom: customProcessor,
-  properties: propertiesProcessor,
   function: functionProcessor,
   transform: transformProcessor,
   map: mapProcessor,

--- a/packages/zod/src/v4/core/memoizer.ts
+++ b/packages/zod/src/v4/core/memoizer.ts
@@ -28,9 +28,9 @@ type WithState = { [STATE]?: State };
 
 const NO_ISSUES: errors.$ZodRawIssue[] = [];
 
-// a value a cycle can close through; callables count, since z.properties asserts on one
+// a value a cycle can close through
 function isRef(value: unknown): value is object {
-  return value !== null && (typeof value === "object" || typeof value === "function");
+  return value !== null && typeof value === "object";
 }
 
 // Receivers prefix paths in place, so the cache and every hand-out need their own copies.
@@ -90,9 +90,6 @@ function isRecursive(inst: $ZodType, stack: Set<object>, resolve: boolean): Answ
       check(def.catchall);
       break;
     }
-    case "properties":
-      merge(shape(def.shape, false));
-      break;
     case "array":
       check(def.element);
       break;

--- a/packages/zod/src/v4/core/schemas.ts
+++ b/packages/zod/src/v4/core/schemas.ts
@@ -96,8 +96,7 @@ export interface $ZodTypeDef {
     | "promise"
     | "lazy"
     | "function"
-    | "custom"
-    | "properties";
+    | "custom";
   error?: errors.$ZodErrorMap<never> | undefined;
   checks?: checks.$ZodCheck<never>[];
 }
@@ -5096,101 +5095,6 @@ function handleRefineResult(result: unknown, payload: ParsePayload, input: unkno
   }
 }
 
-////////////////////////////////////////
-////////////////////////////////////////
-//////////                    //////////
-//////////  $ZodProperties    //////////
-//////////                    //////////
-////////////////////////////////////////
-////////////////////////////////////////
-export interface $ZodPropertiesDef<Shape extends $ZodShape = $ZodShape> extends $ZodTypeDef, checks.$ZodCheckDef {
-  type: "properties";
-  check: "properties";
-  shape: Shape;
-}
-
-// both sides infer the INPUT type: the shape is asserted and its results discarded, so a default, catch or transform inside it would make an output-typed inference a lie. The check side widens a literal to its primitive, so spreading over a `string` property still type-checks (#6520).
-export interface $ZodPropertiesInternals<Shape extends $ZodShape = $ZodShape>
-  extends $ZodTypeInternals<$InferObjectInput<Shape, {}>, $InferObjectInput<Shape, {}>>,
-    checks.$ZodCheckInternals<{ -readonly [k in keyof Shape]: util.Widen<core.input<Shape[k]>> }> {
-  def: $ZodPropertiesDef<Shape>;
-  isst: errors.$ZodIssueInvalidType;
-  issc: errors.$ZodIssue;
-}
-
-export interface $ZodProperties<Shape extends $ZodShape = $ZodShape> extends $ZodType {
-  _zod: $ZodPropertiesInternals<Shape>;
-  // yields the schema itself, so pre-4.6 `.check(...z.properties(shape))` spread call sites keep working
-  [Symbol.iterator](): Iterator<this>;
-}
-
-// asserts in place: the child result's value is discarded, matching z.property(), because a nested object or array schema rebuilds its output even when nothing transformed
-function handlePropertiesResult(result: ParsePayload, payload: ParsePayload, key: string | symbol): void {
-  if (result.issues.length) {
-    payload.issues.push(...util.prefixIssues(key, result.issues));
-  }
-}
-
-export const $ZodProperties: core.$constructor<$ZodProperties> = /*@__PURE__*/ core.$constructor(
-  "$ZodProperties",
-  (inst, def) => {
-    // $ZodType.init prepends an instance that already carries the $ZodCheck trait to its own `checks`, which would run the shape a second time and cost the parse context. Initializing the check trait after it keeps the schema role in `parse`, where the context arrives.
-    $ZodType.init(inst, def);
-    checks.$ZodCheck.init(inst, def);
-
-    const memo = core.globalConfig.memoizer;
-    memo?.attach(inst);
-
-    // key and schema snapshotted together: reading one live and the other cached lets a later mutation of the caller's shape object pair a stale key with a missing schema
-    let entries!: [string | symbol, $ZodType][];
-    const runShape = (payload: ParsePayload, ctx: ParseContextInternal): util.MaybeAsync<void> => {
-      entries ??= Reflect.ownKeys(def.shape).map((key) => [key, (def.shape as any)[key] as $ZodType]);
-      const input = payload.value as any;
-      let proms: Promise<any>[] | undefined;
-      for (const [key, schema] of entries) {
-        const result = schema._zod.run({ value: input[key], issues: [] }, ctx);
-        if (result instanceof Promise) {
-          proms ??= [];
-          proms.push(result.then((result) => handlePropertiesResult(result, payload, key)));
-        } else {
-          handlePropertiesResult(result, payload, key);
-        }
-      }
-      if (proms) return Promise.all(proms).then(() => undefined);
-      return undefined;
-    };
-
-    inst._zod.parse = (payload, ctx) => {
-      const input = payload.value;
-      // as a schema this is the type gate, and it infers an object shape, so a primitive is a type error. A function passes: its properties read like any other object's, and z.instanceof allows one.
-      if (input === null || (typeof input !== "object" && typeof input !== "function")) {
-        payload.issues.push({ expected: "object", code: "invalid_type", input, inst });
-        return payload;
-      }
-      // both sides declare the shape's input type, so the assertion runs forward in either direction; encoding the children backward would reject the very type this schema claims to take
-      if (ctx.direction === "backward") ctx = { ...ctx, direction: "forward" };
-      // the input is its own output here, so it registers as its own memo entry: a cycle re-entering this node hits the bucket instead of recursing forever
-      if (memo) memo.alloc(inst, payload, input, ctx);
-      const result = runShape(payload, ctx);
-      return result instanceof Promise ? result.then(() => payload) : payload;
-    };
-
-    // as a check the base schema already typed the value, so this only asserts the properties — which read on a primitive too, matching z.property() on a string's length. It gets no context of its own, so a cycle through a spread schema is not tracked.
-    inst._zod.check = (payload) => {
-      if (payload.value == null) {
-        payload.issues.push({ expected: "object", code: "invalid_type", input: payload.value, inst });
-        return undefined;
-      }
-      return runShape(payload, {});
-    };
-  },
-  {
-    *[Symbol.iterator]() {
-      yield this;
-    },
-  }
-);
-
 export type $ZodTypes =
   | $ZodString
   | $ZodNumber
@@ -5223,7 +5127,6 @@ export type $ZodTypes =
   | $ZodPrefault
   | $ZodTemplateLiteral
   | $ZodCustom
-  | $ZodProperties
   | $ZodTransform
   | $ZodNonOptional
   | $ZodReadonly

--- a/packages/zod/src/v4/core/to-json-schema.ts
+++ b/packages/zod/src/v4/core/to-json-schema.ts
@@ -757,7 +757,7 @@ export function finalize<T extends schemas.$ZodType>(
   }
 }
 
-export function isTransforming(
+function isTransforming(
   _schema: schemas.$ZodType,
   _ctx?: {
     seen: Set<schemas.$ZodType>;

--- a/packages/zod/src/v4/core/util.ts
+++ b/packages/zod/src/v4/core/util.ts
@@ -1125,10 +1125,6 @@ export function members(proto: object, table: object): void {
     // a method materializes bound on first read, which is what keeps a detached member working: `const opt = schema.optional; opt()`
     else defineBound(proto, key, desc.value);
   }
-  // for..in sees no symbol keys, so well-known members like Symbol.iterator install here
-  for (const sym of Object.getOwnPropertySymbols(table)) {
-    defineBound(proto, sym, (table as any)[sym]);
-  }
 }
 
 /** Shadows a prototype member with an own value, so a getter that builds from the instance runs once. */

--- a/packages/zod/src/v4/core/visit.ts
+++ b/packages/zod/src/v4/core/visit.ts
@@ -158,17 +158,6 @@ export function visit(schema: schemas.SomeType, fnOrHandlers: VisitFn | VisitHan
         const { _cachedInner, ...rest } = def;
         return clone(s, { ...rest, getter: () => run(original()) });
       }
-      case "properties": {
-        const oldShape = def.shape as Record<string | symbol, AnyZod>;
-        let changed = false;
-        const newShape: Record<string | symbol, AnyZod> = {};
-        for (const k of Reflect.ownKeys(oldShape)) {
-          const mapped = run(oldShape[k]!);
-          if (mapped !== oldShape[k]) changed = true;
-          newShape[k] = mapped;
-        }
-        return changed ? clone(s, { ...def, shape: newShape }) : s;
-      }
       // A leaf by choice: `parts` are regex fragments, not data positions.
       case "template_literal":
       // Leaves.

--- a/packages/zod/src/v4/mini/checks.ts
+++ b/packages/zod/src/v4/mini/checks.ts
@@ -23,6 +23,7 @@ export {
   _startsWith as startsWith,
   _endsWith as endsWith,
   _property as property,
+  _properties as properties,
   _mime as mime,
   _overwrite as overwrite,
   _normalize as normalize,

--- a/packages/zod/src/v4/mini/schemas.ts
+++ b/packages/zod/src/v4/mini/schemas.ts
@@ -1866,25 +1866,6 @@ export const ZodMiniCustom: core.$constructor<ZodMiniCustom> = /*@__PURE__*/ cor
   }
 );
 
-// ZodMiniProperties
-export interface ZodMiniProperties<Shape extends core.$ZodShape = core.$ZodShape>
-  extends _ZodMiniType<core.$ZodPropertiesInternals<Shape>>,
-    core.$ZodProperties<Shape> {}
-export const ZodMiniProperties: core.$constructor<ZodMiniProperties> = /*@__PURE__*/ core.$constructor(
-  "ZodMiniProperties",
-  (inst, def) => {
-    core.$ZodProperties.init(inst, def);
-    ZodMiniType.init(inst, def);
-  }
-);
-
-export function properties<Shape extends core.$ZodShape>(
-  shape: Shape,
-  params?: string | core.$ZodPropertiesParams
-): ZodMiniProperties<Shape> {
-  return core._properties(ZodMiniProperties, shape, params) as any;
-}
-
 // custom checks
 // @__NO_SIDE_EFFECTS__
 export function check<O = unknown>(fn: core.CheckFn<O>, params?: string | core.$ZodCustomParams): core.$ZodCheck<O> {


### PR DESCRIPTION
Reverts the schema role that #6536 gave `z.properties()`. It is a check again, as in 4.5: it spreads into `.check()`, and `z.instanceof().properties()` stays as sugar over it. The standalone form is gone — `z.properties(shape).parse()`, `z.infer` of it, `z.toJSONSchema()` and `z.compile()` of it, and the cycle tracking only the schema role had.

The schema form was a trap with transforms. A transform inside the shape ran and was discarded, so the parsed value and the inferred type were both the input side, and writing the result back is not an option for the objects the feature exists for: assigning to a getter-only property such as `Response.status` throws. As a check, "the value is never changed" is what a check already means.

What stays: every failing key reports, symbol keys, the `params` argument, and compile support. The check now lives next to `$ZodCheckProperty` as `$ZodCheckProperties` and installs its `Symbol.iterator` as an own property, so the symbol-key loop in `util.members` and the memoizer's callable arm go with the schema role. The API reference drops the standalone paragraph; the 4.6 post already led with the method.

Bundle, gzipped from the built package: mini −17 / −16 / −16 on boolean / string / object, classic −35 / −38 / −44, the named import −447. Runtime and memory: the check body is the same code moved, construction pays one `Object.defineProperty` per `z.properties()` call, and each check instance carries one extra own property.

This removes an API that shipped in 4.6.0.
